### PR TITLE
Handle systemd deps more reliable

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -93,14 +93,12 @@ coreos:
       command: start
       runtime: true
       content: |
-        [Unit]
-        Requires=kubelet.service docker.service
-        After=kubelet.service docker.service
-
         [Service]
         Type=simple
         StartLimitInterval=0
         Restart=on-failure
+        ExecStartPre=systemctl is-active docker.service
+        ExecStartPre=systemctl is-active kubelet.service
         ExecStartPre=/usr/bin/curl http://127.0.0.1:8080/version
         ExecStart=/opt/bin/install-kube-system
 


### PR DESCRIPTION
Sometimes the download from quay.io is so slow that `flanneld.service`
will be restarted by systemd. If this happens at the same time
`install-kube-system.service` is started then systemd will see a failing
dependency chain (docker.service -> flanneld.service) and will not try
to restart `install-kube-system.service`, effectively not installing the
expected k8s pods (heapster, dashboard, etc.).

This patch fixes the issue by handling the dependency check in
`ExecStartPre` allowing for a restart if it fails the first times.