### PR TITLE
Fix etcdctl command

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -34,8 +34,9 @@ coreos:
         - name: 10-etcd.conf
           content: |
             [Service]
-            ExecStartPre=/usr/bin/etcdctl --endpoint=http://localhost:2379 \
--             set /coreos.com/network/config '{ "Network": "10.2.0.0/16", "Backend" : {"Type" : "vxlan"}}'
+            ExecStartPre=/usr/bin/etcdctl \
+            --endpoint=http://localhost:2379 set /coreos.com/network/config \
+            '{ "Network": "10.2.0.0/16", "Backend": {"Type": "vxlan"}}'
     - name: kubelet.service
       command: start
       runtime: true


### PR DESCRIPTION
#4 introduced a stray dash in the cloud config causing the master node to not come up.

This fixes it.