### PR TITLE
[wip] add mate to kube stack

### DIFF
--- a/cluster/create-stack.sh
+++ b/cluster/create-stack.sh
@@ -15,6 +15,6 @@ key_arn=$(aws kms create-key --description "Kubernetes cluster $cluster $ver" | 
 aws kms create-alias --alias-name "alias/${cluster}-${ver}" --target-key-id "$key_arn"
 token=$(cat /dev/urandom | LC_ALL=C tr -dc _A-Z-a-z-0-9- | head -c 64)
 # TODO: encrypt fixed token with KMS
-userdata_master=$(cat userdata-master.yaml|sed -e s/STACK_VERSION/$ver/ -e s/ETCD_DISCOVERY_DOMAIN/$etcd_discovery_domain/ -e s,API_SERVER,$api_server, -e s/WORKER_SHARED_SECRET/$token/|gzip|base64 -w 0)
-userdata_worker=$(cat userdata-worker.yaml|sed -e s/STACK_VERSION/$ver/ -e s/ETCD_DISCOVERY_DOMAIN/$etcd_discovery_domain/ -e s,API_SERVER,$api_server, -e s/WORKER_SHARED_SECRET/$token/|gzip|base64 -w 0)
+userdata_master=$(cat userdata-master.yaml|sed -e s/STACK_VERSION/$ver/ -e s/ETCD_DISCOVERY_DOMAIN/$etcd_discovery_domain/ -e s,API_SERVER,$api_server, -e s/WORKER_SHARED_SECRET/$token/ -e s/HOSTED_ZONE/$hosted_zone/ |gzip|base64 )
+userdata_worker=$(cat userdata-worker.yaml|sed -e s/STACK_VERSION/$ver/ -e s/ETCD_DISCOVERY_DOMAIN/$etcd_discovery_domain/ -e s,API_SERVER,$api_server, -e s/WORKER_SHARED_SECRET/$token/|gzip|base64 )
 senza create senza-definition.yaml $ver UserDataMaster="$userdata_master" UserDataWorker="$userdata_worker" KmsKey="$key_arn"

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -122,6 +122,7 @@ Resources:
           - {Action: 'ec2:AttachVolume', Effect: Allow, Resource: '*'}
           - {Action: 'ec2:DetachVolume', Effect: Allow, Resource: '*'}
           - {Action: 'kms:Decrypt', Effect: Allow, Resource: '{{ Arguments.KmsKey }}'}
+          - {Action: 'route53:*', Effect: Allow, Resource: '*'}
           - Action: ['ecr:GetAuthorizationToken', 'ecr:BatchCheckLayerAvailability',
               'ecr:GetDownloadUrlForLayer', 'ecr:GetRepositoryPolicy', 'ecr:DescribeRepositories',
               'ecr:ListImages', 'ecr:BatchGetImage']

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -748,7 +748,7 @@ write_files:
                 name: credentials
                 readOnly: true
             - name: kubectl
-              image: quay.io/coreos/hyperkube:v1.3.6_coreos.0
+              image: quay.io/coreos/hyperkube:v1.3.9_coreos.0
               command:
               - /hyperkube
               args:
@@ -784,7 +784,7 @@ write_files:
               - --aws-hosted-zone=HOSTED_ZONE.
               - --no-sync
             - name: kubectl
-              image: quay.io/coreos/hyperkube:v1.3.6_coreos.0
+              image: quay.io/coreos/hyperkube:v1.3.9_coreos.0
               command:
               - /hyperkube
               args:

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -776,7 +776,7 @@ write_files:
           spec:
             containers:
             - name: mate
-              image: pierone.stups.zalan.do/teapot/mate:v0.0.4-32-g0af5e78
+              image: registry.opensource.zalan.do/teapot/mate:v0.0.4-34-gf2f1dd2
               args:
               - --producer=kubernetes
               - --kubernetes-domain=HOSTED_ZONE.

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -776,12 +776,12 @@ write_files:
           spec:
             containers:
             - name: mate
-              image: pierone.stups.zalan.do/teapot/mate:v0.0.4-31-gebb7747
+              image: pierone.stups.zalan.do/teapot/mate:v0.0.4-32-g0af5e78
               args:
               - --producer=kubernetes
-              - --kubernetes-domain=mate.teapot.zalan.do.
+              - --kubernetes-domain=HOSTED_ZONE.
               - --consumer=aws
-              - --aws-hosted-zone=mate.teapot.zalan.do.
+              - --aws-hosted-zone=HOSTED_ZONE.
               - --no-sync
             - name: kubectl
               image: quay.io/coreos/hyperkube:v1.3.6_coreos.0

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -42,7 +42,7 @@ coreos:
       runtime: true
       content: |
         [Service]
-        Environment=KUBELET_VERSION=v1.4.0_coreos.2
+        Environment=KUBELET_VERSION=v1.4.3_coreos.0
         Environment=KUBELET_ACI=quay.io/coreos/hyperkube
         Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf \
         --mount volume=dns,target=/etc/resolv.conf \
@@ -251,7 +251,7 @@ write_files:
           hostNetwork: true
           containers:
           - name: kube-proxy
-            image: quay.io/coreos/hyperkube:v1.4.0_coreos.2
+            image: quay.io/coreos/hyperkube:v1.4.3_coreos.0
             command:
             - /hyperkube
             - proxy
@@ -285,7 +285,7 @@ write_files:
         hostNetwork: true
         containers:
         - name: kube-apiserver
-          image: quay.io/coreos/hyperkube:v1.4.0_coreos.2
+          image: quay.io/coreos/hyperkube:v1.4.3_coreos.0
           command:
           - /hyperkube
           - apiserver
@@ -372,7 +372,7 @@ write_files:
       spec:
         containers:
         - name: kube-controller-manager
-          image: quay.io/coreos/hyperkube:v1.4.0_coreos.2
+          image: quay.io/coreos/hyperkube:v1.4.3_coreos.0
           command:
           - /hyperkube
           - controller-manager
@@ -419,7 +419,7 @@ write_files:
         hostNetwork: true
         containers:
         - name: kube-scheduler
-          image: quay.io/coreos/hyperkube:v1.4.0_coreos.2
+          image: quay.io/coreos/hyperkube:v1.4.3_coreos.0
           command:
           - /hyperkube
           - scheduler
@@ -748,7 +748,7 @@ write_files:
                 name: credentials
                 readOnly: true
             - name: kubectl
-              image: quay.io/coreos/hyperkube:v1.3.9_coreos.0
+              image: quay.io/coreos/hyperkube:v1.4.3_coreos.0
               command:
               - /hyperkube
               args:
@@ -784,7 +784,7 @@ write_files:
               - --aws-hosted-zone=HOSTED_ZONE.
               - --no-sync
             - name: kubectl
-              image: quay.io/coreos/hyperkube:v1.3.9_coreos.0
+              image: quay.io/coreos/hyperkube:v1.4.3_coreos.0
               command:
               - /hyperkube
               args:

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -178,6 +178,10 @@ write_files:
       -d"$(cat /srv/kubernetes/manifests/secretary-de.yaml)" \
       "http://127.0.0.1:8080/apis/extensions/v1beta1/namespaces/kube-system/deployments"
 
+      /usr/bin/curl  -H "Content-Type: application/yaml" -XPOST \
+      -d"$(cat /srv/kubernetes/manifests/mate-de.yaml)" \
+      "http://127.0.0.1:8080/apis/extensions/v1beta1/namespaces/kube-system/deployments"
+
       for manifest in {kube-dns,heapster,kube-dashboard}-svc.yaml;do
           /usr/bin/curl  -H "Content-Type: application/yaml" -XPOST \
           -d"$(cat /srv/kubernetes/manifests/$manifest)" \
@@ -756,6 +760,36 @@ write_files:
               emptyDir:
                 medium: Memory # share a tmpfs between the two containers
 
+  - path: /srv/kubernetes/manifests/mate-de.yaml
+    content: |
+      apiVersion: extensions/v1beta1
+      kind: Deployment
+      metadata:
+        name: mate
+        namespace: kube-system
+      spec:
+        replicas: 1
+        template:
+          metadata:
+            labels:
+              app: mate
+          spec:
+            containers:
+            - name: mate
+              image: pierone.stups.zalan.do/teapot/mate:v0.0.4-31-gebb7747
+              args:
+              - --producer=kubernetes
+              - --kubernetes-domain=mate.teapot.zalan.do.
+              - --consumer=aws
+              - --aws-hosted-zone=mate.teapot.zalan.do.
+              - --no-sync
+            - name: kubectl
+              image: quay.io/coreos/hyperkube:v1.3.6_coreos.0
+              command:
+              - /hyperkube
+              args:
+              - kubectl
+              - proxy
 
   - path: /etc/kubernetes/ssl/ca.pem
     encoding: gzip+base64
@@ -778,4 +812,3 @@ write_files:
                 "isDefaultGateway": true
             }
         }
-

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -34,7 +34,7 @@ coreos:
       runtime: true
       content: |
         [Service]
-        Environment=KUBELET_VERSION=v1.4.0_coreos.2
+        Environment=KUBELET_VERSION=v1.4.3_coreos.0
         Environment=KUBELET_ACI=quay.io/coreos/hyperkube
         Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf \
         --mount volume=dns,target=/etc/resolv.conf \
@@ -175,7 +175,7 @@ write_files:
           hostNetwork: true
           containers:
           - name: kube-proxy
-            image: quay.io/coreos/hyperkube:v1.4.0_coreos.2
+            image: quay.io/coreos/hyperkube:v1.4.3_coreos.0
             command:
             - /hyperkube
             - proxy

--- a/hack/render_userdata.go
+++ b/hack/render_userdata.go
@@ -34,7 +34,7 @@ var values = struct {
 	ServiceCIDR:        "10.3.0.0/24",
 	K8sVer:             "v1.4.0",
 	HyperkubeImageRepo: "gcr.io/google_containers/hyperkube-amd64",
-	// K8sVer:             "v1.4.0_coreos.2",
+	// K8sVer:             "v1.4.3_coreos.0",
 	// HyperkubeImageRepo: "quay.io/coreos/hyperkube",
 	K8sNetworkPlugin: "cni",
 	ContainerRuntime: "docker",


### PR DESCRIPTION
**work in progress**

this adds mate by default to the stack 

discussion needed:
* opensource mate?
* hosted zone needs to be configured correctly
* `--no-sync` is the default but explicitly defined for clarity
* `route:53*` policy stuff must obviously be tweaked