### PR TITLE
#18 dynamic mint bucket, use "kube-secretary" app

### DIFF
--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -103,7 +103,7 @@ Resources:
           Version: '2012-10-17'
           Statement:
           - Action: "s3:GetObject"
-            Resource: "arn:aws:s3:::zalando-stups-mint-170858875137-eu-central-1/k8s-authnz-webhook/*"
+            Resource: "arn:aws:s3:::{{ AccountInfo.MintBucket }}/kube-secretary/*"
             Effect: Allow
         PolicyName: AllowMintRead
     Type: AWS::IAM::Role
@@ -136,7 +136,7 @@ Resources:
           Version: '2012-10-17'
           Statement:
           - Action: "s3:GetObject"
-            Resource: "arn:aws:s3:::zalando-stups-mint-170858875137-eu-central-1/k8s-authnz-webhook/*"
+            Resource: "arn:aws:s3:::{{ AccountInfo.MintBucket }}/kube-secretary/*"
             Effect: Allow
         PolicyName: AllowMintRead
     Type: AWS::IAM::Role

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -753,8 +753,8 @@ write_files:
               image: registry.opensource.zalan.do/teapot/gerry:v0.0.5
               args:
               - /meta/credentials
-              - --application-id=k8s-authnz-webhook
-              - --mint-bucket=s3://zalando-stups-mint-170858875137-eu-central-1
+              - --application-id=kube-secretary
+              - --mint-bucket=s3://MINT_BUCKET
               volumeMounts:
               - mountPath: /meta/credentials
                 name: credentials


### PR DESCRIPTION
Fixes #18:
* use the mint bucket of the current AWS account.
* use "kube-secretary" Kio app

Missing: automatic registration of mint bucket in Kio