### PR TITLE
some minor improvements

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -801,7 +801,7 @@ write_files:
           spec:
             containers:
             - name: mate
-              image: registry.opensource.zalan.do/teapot/mate:v0.0.4-34-gf2f1dd2
+              image: registry.opensource.zalan.do/teapot/mate:v0.0.5
               args:
               - --producer=kubernetes
               - --kubernetes-domain=HOSTED_ZONE.

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -478,7 +478,7 @@ write_files:
             version: v19
             kubernetes.io/cluster-service: "true"
         spec:
-          replicas: 1
+          replicas: 2
           selector:
             k8s-app: kube-dns
             version: v19


### PR DESCRIPTION
* tagged version of mate (support `--no-sync`)
* run two copies of dns server as done by gke