### PR TITLE
Fetch hyperkube from pierone instead of quay.io

### DIFF
--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -14,11 +14,11 @@ SenzaInfo:
 Mappings:
   Images:
     eu-central-1:
-        # latest image can be found on https://coreos.com/dist/aws/aws-stable.json
-        LatestCoreOSImage: ami-1809f077
+        # latest image can be found on https://coreos.com/dist/aws/aws-beta.json
+        LatestCoreOSImage: ami-b10ff6de
     eu-west-1:
-        # latest image can be found on https://coreos.com/dist/aws/aws-stable.json
-        LatestCoreOSImage: ami-a94c02da
+        # latest image can be found on https://coreos.com/dist/aws/aws-beta.json
+        LatestCoreOSImage: ami-925719e1
 
 SenzaComponents:
   - Configuration:

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -43,8 +43,9 @@ coreos:
       content: |
         [Service]
         Environment=KUBELET_VERSION=v1.4.4_coreos.0
-        Environment=KUBELET_ACI=quay.io/coreos/hyperkube
+        Environment=KUBELET_ACI=docker://registry.opensource.zalan.do/teapot/hyperkube
         Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf \
+        --insecure-options=image \
         --mount volume=dns,target=/etc/resolv.conf \
         --volume rkt,kind=host,source=/opt/bin/host-rkt \
         --mount volume=rkt,target=/usr/bin/rkt \
@@ -266,7 +267,7 @@ write_files:
           hostNetwork: true
           containers:
           - name: kube-proxy
-            image: quay.io/coreos/hyperkube:v1.4.4_coreos.0
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.4.4_coreos.0
             command:
             - /hyperkube
             - proxy
@@ -301,7 +302,7 @@ write_files:
         hostNetwork: true
         containers:
         - name: kube-apiserver
-          image: quay.io/coreos/hyperkube:v1.4.4_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.4.4_coreos.0
           command:
           - /hyperkube
           - apiserver
@@ -397,7 +398,7 @@ write_files:
       spec:
         containers:
         - name: kube-controller-manager
-          image: quay.io/coreos/hyperkube:v1.4.4_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.4.4_coreos.0
           command:
           - /hyperkube
           - controller-manager
@@ -444,7 +445,7 @@ write_files:
         hostNetwork: true
         containers:
         - name: kube-scheduler
-          image: quay.io/coreos/hyperkube:v1.4.4_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.4.4_coreos.0
           command:
           - /hyperkube
           - scheduler
@@ -773,7 +774,7 @@ write_files:
                 name: credentials
                 readOnly: true
             - name: kubectl
-              image: quay.io/coreos/hyperkube:v1.4.4_coreos.0
+              image: registry.opensource.zalan.do/teapot/hyperkube:v1.4.4_coreos.0
               command:
               - /hyperkube
               args:
@@ -809,7 +810,7 @@ write_files:
               - --aws-hosted-zone=HOSTED_ZONE.
               - --no-sync
             - name: kubectl
-              image: quay.io/coreos/hyperkube:v1.4.4_coreos.0
+              image: registry.opensource.zalan.do/teapot/hyperkube:v1.4.4_coreos.0
               command:
               - /hyperkube
               args:

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -35,8 +35,9 @@ coreos:
       content: |
         [Service]
         Environment=KUBELET_VERSION=v1.4.4_coreos.0
-        Environment=KUBELET_ACI=quay.io/coreos/hyperkube
+        Environment=KUBELET_ACI=docker://registry.opensource.zalan.do/teapot/hyperkube
         Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf \
+        --insecure-options=image \
         --mount volume=dns,target=/etc/resolv.conf \
         --volume hosts,kind=host,source=/etc/hosts \
         --mount volume=hosts,target=/etc/hosts \
@@ -175,7 +176,7 @@ write_files:
           hostNetwork: true
           containers:
           - name: kube-proxy
-            image: quay.io/coreos/hyperkube:v1.4.4_coreos.0
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.4.4_coreos.0
             command:
             - /hyperkube
             - proxy


### PR DESCRIPTION
Note this also switches to coreos beta channel which has a `rkt` version
compatible with pierone.