### PR TITLE
allow instance type to be configured

### DIFF
--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -12,6 +12,8 @@ SenzaInfo:
           Description: "ARN of KMS key to decrypt secrets"
       - WorkerNodes:
           Description: "Number of worker nodes"
+      - InstanceType:
+          Description: "Type of instance"
 
 Mappings:
   Images:
@@ -65,7 +67,7 @@ SenzaComponents:
           Value: kubernetes
   - WorkerAutoScaling:
       Type: Senza::AutoScalingGroup
-      InstanceType: t2.micro
+      InstanceType: "{{ Arguments.InstanceType }}"
       Image: LatestCoreOSImage
       SecurityGroups:
          - {Ref: WorkerSecurityGroup}


### PR DESCRIPTION
worker instance type can be configured with this

on create:
* provide optional flag `--instance-type` to specify instance type of worker nodes (defaults to `t2.micro`)

on update:
* provide optional flag `--instance-type` to change instance type of worker nodes (defaults to `current` which results in whatever type the workers currently have)
* if cloud-config didn't change one has to use the `--force` flag to trigger the update