### PR TITLE
Start install-ssh-keys early

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -77,14 +77,6 @@ coreos:
         [Install]
         WantedBy=multi-user.target
 
-    - name: install-kube-system.service
-      command: start
-      runtime: true
-      content: |
-        [Service]
-        Type=oneshot
-        ExecStart=/opt/bin/install-kube-system
-
     - name: install-ssh-keys.service
       command: start
       enable: true
@@ -95,6 +87,14 @@ coreos:
         [Service]
         Type=oneshot
         ExecStart=/opt/bin/install-ssh-keys
+
+    - name: install-kube-system.service
+      command: start
+      runtime: true
+      content: |
+        [Service]
+        Type=oneshot
+        ExecStart=/opt/bin/install-kube-system
 
 write_files:
   - path: /etc/kubernetes/kubeconfig


### PR DESCRIPTION
Coreos runs `coreos-cloudinit` to start each systemd service
sequentially and waits for service to be started before starting the
next one. This means that the `install-kube-system.service` blocks
`install-ssh-keys.service` until the API server is up.

Solution is to start the `install-ssh-keys.service` before
`install-kube-system.service`.