### PR TITLE
Remove redundant api flag

### DIFF
--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -138,7 +138,6 @@ write_files:
             command:
             - /hyperkube
             - proxy
-            - --master=API_SERVER
             - --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml
             - --feature-gates=AllAlpha=true
             - --v=2


### PR DESCRIPTION
Flag is not needed since the api server is already configured in the
kubeconfig.