### PR TITLE
Use new coreos stable release

### DIFF
--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -20,11 +20,11 @@ SenzaInfo:
 Mappings:
   Images:
     eu-central-1:
-        # latest image can be found on https://coreos.com/dist/aws/aws-beta.json
-        LatestCoreOSImage: ami-b10ff6de
+        # latest image can be found on https://coreos.com/dist/aws/aws-stable.json
+        LatestCoreOSImage: ami-27877c48
     eu-west-1:
-        # latest image can be found on https://coreos.com/dist/aws/aws-beta.json
-        LatestCoreOSImage: ami-925719e1
+        # latest image can be found on https://coreos.com/dist/aws/aws-stable.json
+        LatestCoreOSImage: ami-7ddc960e
 
 SenzaComponents:
   - Configuration:

--- a/hack/Vagrantfile
+++ b/hack/Vagrantfile
@@ -8,7 +8,7 @@ require 'yaml'
 
 Vagrant.require_version ">= 1.6.0"
 
-$update_channel = "beta"
+$update_channel = "stable"
 $controller_count = 1
 $controller_vm_memory = 2048
 $worker_count = 1


### PR DESCRIPTION
Previous beta version was promoted to stable:
https://coreos.com/releases/#1185.3.0

It includes a compatible `rkt` version which was the reason we used beta
before.