### PR TITLE
allow write access to s3

### DIFF
--- a/cluster/etcd-cluster.yaml
+++ b/cluster/etcd-cluster.yaml
@@ -100,3 +100,11 @@ Resources:
             - route53:ListResourceRecordSets
             - route53:GetChange
             Resource: [ "*" ]
+      - PolicyName: AmazonS3EtcdBackupWrite
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+          - Effect: Allow
+            Action:
+            - s3:PutObject
+            Resource: [ "arn:aws:s3:::teapot-etcd-backup" ]


### PR DESCRIPTION
allow write access to arn:aws:s3:::teapot-etcd-backup to enable backup to s3 from etcd hosts