### PR TITLE
Use static worker node name

### DIFF
--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -102,6 +102,7 @@ Resources:
     Type: AWS::IAM::Role
   WorkerIAMRole:
     Properties:
+      RoleName: "{{SenzaInfo.StackName}}-{{SenzaInfo.StackVersion}}-worker"
       AssumeRolePolicyDocument:
         Statement:
         - Action: ['sts:AssumeRole']


### PR DESCRIPTION
Uses 'static' name for worker IAM role so it's easy to reference when
creating roles that should be delegated to nodes through kube2iam.