### PR TITLE
Revert "chore(*): update gerry to v0.0.6"

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -698,7 +698,7 @@ write_files:
           spec:
             containers:
             - name: gerry
-              image: registry.opensource.zalan.do/teapot/gerry:v0.0.6
+              image: registry.opensource.zalan.do/teapot/gerry:v0.0.5
               args:
               - /meta/credentials
               - --application-id=kube-secretary

--- a/docs/user-guide/example-credentials.rst
+++ b/docs/user-guide/example-credentials.rst
@@ -34,7 +34,7 @@ access role for the S3 bucket is called ``myapp-iam-role`` (See also
                   mountPath: /meta/credentials
                   readOnly: true
             - name: gerry
-              image: registry.opensource.zalan.do/teapot/gerry:v0.0.6
+              image: registry.opensource.zalan.do/teapot/gerry:v0.0.5
               args:
                 - /meta/credentials
                 - --application-id=myapp
@@ -63,7 +63,7 @@ The next important part is the ``gerry`` *sidecar*.
 .. code-block:: yaml
 
     - name: gerry
-      image: registry.opensource.zalan.do/teapot/gerry:v0.0.6
+      image: registry.opensource.zalan.do/teapot/gerry:v0.0.5
       args:
         - /meta/credentials
         - --application-id=myapp


### PR DESCRIPTION
```
I1110 14:15:49.858933       1 downloaders.go:42] Bucket name indicates a region, using '--region=eu-central-1'.
F1110 14:15:50.096722       1 main.go:54] Error rotating client credentials for 'kube-secretary': Failed to move credentials to /meta/credentials/client.json: rename /tmp/gerry-106052673 /meta/credentials/client.json: invalid cross-device link
```