### PR TITLE
Feature/multi region etcd

### DIFF
--- a/cluster/etcd-cluster.yaml
+++ b/cluster/etcd-cluster.yaml
@@ -41,6 +41,8 @@ SenzaInfo:
   - InstanceCount:
       Description: Instance number in ASG
       Default: 5
+  - EtcdS3Backup:
+      Description: AWS S3 Bucket to backup ETCD to
   StackName: etcd-cluster
 Resources:
   EtcdSecurityGroup:
@@ -111,3 +113,12 @@ Resources:
             - route53:ListResourceRecordSets
             - route53:GetChange
             Resource: "*"
+      - PolicyName: AmazonS3EtcdBackupWrite
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+          - Effect: Allow
+            Action:
+            - s3:PutObject
+            Resource: [ "arn:aws:s3:::{{Arguments.EtcdS3Backup}}/*" ]
+

--- a/cluster/etcd-cluster.yaml
+++ b/cluster/etcd-cluster.yaml
@@ -1,15 +1,9 @@
-SenzaInfo:
-  StackName: etcd-cluster
-  Parameters:
-  - HostedZone:
-      Description: AWS Hosted Zone to work with
-  - EtcdS3Backup:
-      Description: AWS S3 Bucket to backup ETCD to
-
 SenzaComponents:
 - Configuration:
     Type: Senza::StupsAutoConfiguration
+    PublicOnly: true
 - AppServer:
+    AssociatePublicIpAddress: true
     IamRoles:
     - Ref: EtcdRole
     InstanceType: m3.medium
@@ -22,20 +16,32 @@ SenzaComponents:
         2379: 2379
         2380: 2380
       runtime: Docker
-      source: registry.opensource.zalan.do/acid/etcd-cluster:3.0.12-p12
+      source: registry.opensource.zalan.do/acid/multiregion-etcd-cluster:3.0.15-p6
       environment:
         HOSTED_ZONE: '{{Arguments.HostedZone}}'
+        ACTIVE_REGIONS: '{{Arguments.ActiveRegions}}'
       mounts:
         /home/etcd:
           partition: none
           filesystem: tmpfs
           erase_on_boot: false
           options: size=3g
+      appdynamics_application: 'etcd-cluster-{{Arguments.version}}'
     Type: Senza::TaupageAutoScalingGroup
     AutoScaling:
-      Minimum: 3
-      Maximum: 3
-      MetricType: CPU
+      Minimum: "{{Arguments.InstanceCount}}"
+      Maximum: "{{Arguments.InstanceCount}}"
+SenzaInfo:
+  Parameters:
+  - HostedZone:
+      Description: AWS Hosted Zone to work with
+  - ActiveRegions:
+      Description: Multi-Region-Cluster? Active/Deployed regions.
+      Default: eu-west-1,eu-central-1
+  - InstanceCount:
+      Description: Instance number in ASG
+      Default: 5
+  StackName: etcd-cluster
 Resources:
   EtcdSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -45,15 +51,15 @@ Resources:
       - IpProtocol: tcp
         FromPort: 22
         ToPort: 22
-        CidrIp: 0.0.0.0/0
+        CidrIp: 172.16.0.0/12
       - IpProtocol: tcp
         FromPort: 9100
         ToPort: 9100
-        CidrIp: 0.0.0.0/0
+        CidrIp: 172.16.0.0/12
       - IpProtocol: tcp
         FromPort: 2379
         ToPort: 2380
-        CidrIp: 0.0.0.0/0
+        CidrIp: 172.16.0.0/12
   EtcdIngressMembers:
     Type: "AWS::EC2::SecurityGroupIngress"
     Properties:
@@ -85,7 +91,10 @@ Resources:
           Version: "2012-10-17"
           Statement:
           - Effect: Allow
-            Action: ec2:Describe*
+            Action:
+              - ec2:Describe*
+              - ec2:AuthorizeSecurityGroupIngress
+              - ec2:RevokeSecurityGroupIngress
             Resource: "*"
           - Effect: Allow
             Action: autoscaling:Describe*
@@ -101,12 +110,4 @@ Resources:
             - route53:GetHostedZone
             - route53:ListResourceRecordSets
             - route53:GetChange
-            Resource: [ "*" ]
-      - PolicyName: AmazonS3EtcdBackupWrite
-        PolicyDocument:
-          Version: "2012-10-17"
-          Statement:
-          - Effect: Allow
-            Action:
-            - s3:PutObject
-            Resource: [ "arn:aws:s3:::{{Arguments.EtcdS3Backup}}/*" ]
+            Resource: "*"


### PR DESCRIPTION
Based on https://raw.githubusercontent.com/zalando/stups-etcd-cluster/multiregion-cluster/etcd-cluster-multiregion.yaml @CyberDem0n and me created a new etcd-cluster.yaml.
Known issues are that Kubernetes apiserver can not access the 2nd region, which we consider as ok.
If we really have to do a region failover we could also boostrap Kubernetes masters and worker nodes.