### PR TITLE
only run flake8 on Travis (fixed failing builds)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,9 @@
 [tox]
 envlist=flake8
 
+[tox:travis]
+3.5=flake8
+
 [testenv:flake8]
 deps=flake8
 commands=flake8


### PR DESCRIPTION
The [`tox-travis` plugin](https://pypi.python.org/pypi/tox-travis) automatically sets the env for tox according to Travis Python version, but we just want to run flake8 for now.