### PR TITLE
Tuned parameters for kubelet and docker.

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -28,6 +28,12 @@ coreos:
             After=flanneld.service
             [Service]
             EnvironmentFile=/etc/kubernetes/cni/docker_opts_cni.env
+        - name: docker.conf
+          content: |
+            [Service]
+            ExecStart=
+            ExecStart=/usr/bin/docker daemon --log-opt max-file=2  --log-opt max-size=50m
+
 
     - name: flanneld.service
       drop-ins:
@@ -54,7 +60,8 @@ coreos:
         --volume stage,kind=host,source=/tmp \
         --mount volume=stage,target=/tmp \
         --volume var-log,kind=host,source=/var/log \
-        --mount volume=var-log,target=/var/log"
+        --mount volume=var-log,target=/var/log" \
+        --low-diskspace-threshold-mb=1000 \
         ExecStartPre=/usr/bin/mkdir -p /var/log/containers
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
         --cni-conf-dir=/etc/kubernetes/cni/net.d \

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -60,8 +60,7 @@ coreos:
         --volume stage,kind=host,source=/tmp \
         --mount volume=stage,target=/tmp \
         --volume var-log,kind=host,source=/var/log \
-        --mount volume=var-log,target=/var/log" \
-        --low-diskspace-threshold-mb=1000 \
+        --mount volume=var-log,target=/var/log"
         ExecStartPre=/usr/bin/mkdir -p /var/log/containers
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
         --cni-conf-dir=/etc/kubernetes/cni/net.d \
@@ -77,6 +76,7 @@ coreos:
         --kubeconfig=/etc/kubernetes/kubeconfig \
         --require-kubeconfig \
         --cloud-provider=aws \
+        --low-diskspace-threshold-mb=1000 \
         --feature-gates=AllAlpha=true
         Restart=always
         RestartSec=10


### PR DESCRIPTION
- logrotation (docker opt)
- kubelet low diskspace threshold to 1 GB

Params are for the moment pretty much arbitrary and will need to be
tuned further.