### PR TITLE
Feature add kube-state-metrics to check cluster state from zmon 

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -818,10 +818,8 @@ write_files:
       apiVersion: v1
       kind: Service
       metadata:
-        name: apiserver-svc
+        name: apiserver-svc-ro
         namespace: kube-system
-        labels:
-          application: kube-apiserver-ro
       spec:
         type: ClusterIP
         ports:
@@ -854,7 +852,7 @@ write_files:
               command:
               - /kube-state-metrics
               - --port=8080
-              - --apiserver=http://apiserver-svc.kube-system.svc.cluster.local
+              - --apiserver=http://apiserver-svc-ro.kube-system.svc.cluster.local
 
   - path: /srv/kubernetes/manifests/services/kube-state-metrics.yaml
     content: |

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -342,6 +342,9 @@ write_files:
               value: stups_deployment-controller-ui=Administrator
         - name: nginx
           image: registry.opensource.zalan.do/teapot/nginx:1.11.5
+          ports:
+          - containerPort: 8082
+            hostPort: 8082
           volumeMounts:
           - name: config-volume
             mountPath: /etc/nginx

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -842,7 +842,8 @@ write_files:
         template:
           metadata:
             labels:
-              app: kube-state-metrics
+              application: kube-state-metrics
+              version: v0.3.3
           spec:
             containers:
             - image: registry.opensource.zalan.do/teapot/kube-state-metrics:v0.3.3
@@ -870,7 +871,8 @@ write_files:
           protocol: TCP
           targetPort: 8080
         selector:
-          app: kube-state-metrics
+          application: kube-state-metrics
+          version: v0.3.3
 
   - path: /srv/kubernetes/manifests/daemonsets/prometheus-node-exporter.yaml
     content: |

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -362,25 +362,6 @@ write_files:
             path: /etc/kubernetes/nginx
           name: config-volume
 
-  - path: /etc/kubernetes/manifests/kube-apiserver-readonly-svc.yaml
-    content: |
-      apiVersion: v1
-      kind: Service
-      metadata:
-        name: apiserver-svc
-        namespace: kube-system
-        labels:
-          application: kube-apiserver-ro
-      spec:
-        type: ClusterIP
-        ports:
-          - port: 80
-            protocol: TCP
-            targetPort: 8082
-        selector:
-          application: kube-apiserver
-          version: v1.4.5_coreos.0
-
   - path: /etc/kubernetes/manifests/kube-controller-manager.yaml
     content: |
       apiVersion: v1
@@ -831,6 +812,65 @@ write_files:
               args:
               - kubectl
               - proxy
+
+  - path: /srv/kubernetes/manifests/services/kube-apiserver-readonly-svc.yaml
+    content: |
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: apiserver-svc
+        namespace: kube-system
+        labels:
+          application: kube-apiserver-ro
+      spec:
+        type: ClusterIP
+        ports:
+          - port: 80
+            protocol: TCP
+            targetPort: 8082
+        selector:
+          application: kube-apiserver
+          version: v1.4.5_coreos.0
+
+  - path: /srv/kubernetes/manifests/deployments/kube-state-metrics.yaml
+    content: |
+      apiVersion: extensions/v1beta1
+      kind: Deployment
+      metadata:
+        name: kube-state-metrics
+        namespace: kube-system
+      spec:
+        replicas: 1
+        template:
+          metadata:
+            labels:
+              app: kube-state-metrics
+          spec:
+            containers:
+            - image: registry.opensource.zalan.do/teapot/kube-state-metrics:v0.3.3
+              name: kube-state-metrics
+              ports:
+              - containerPort: 8080
+              command:
+              - /kube-state-metrics
+              - --port=8080
+              - --apiserver=http://apiserver-svc.kube-system.svc.cluster.local
+
+  - path: /srv/kubernetes/manifests/services/kube-state-metrics.yaml
+    content: |
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: kube-state-metrics
+        namespace: kube-system
+      spec:
+        type: LoadBalancer
+        ports:
+        - port: 80
+          protocol: TCP
+          targetPort: 8080
+        selector:
+          app: kube-state-metrics
 
   - path: /srv/kubernetes/manifests/daemonsets/prometheus-node-exporter.yaml
     content: |

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -342,9 +342,6 @@ write_files:
               value: stups_deployment-controller-ui=Administrator
         - name: nginx
           image: registry.opensource.zalan.do/teapot/nginx:1.11.5
-          ports:
-          - containerPort: 8082
-            hostPort: 8082
           volumeMounts:
           - name: config-volume
             mountPath: /etc/nginx

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -362,6 +362,25 @@ write_files:
             path: /etc/kubernetes/nginx
           name: config-volume
 
+  - path: /etc/kubernetes/manifests/kube-apiserver-readonly-svc.yaml
+    content: |
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: apiserver-svc
+        namespace: kube-system
+        labels:
+          application: kube-apiserver-ro
+      spec:
+        type: ClusterIP
+        ports:
+          - port: 80
+            protocol: TCP
+            targetPort: 8082
+        selector:
+          application: kube-apiserver
+          version: v1.4.5_coreos.0
+
   - path: /etc/kubernetes/manifests/kube-controller-manager.yaml
     content: |
       apiVersion: v1

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -813,22 +813,6 @@ write_files:
               - kubectl
               - proxy
 
-  - path: /srv/kubernetes/manifests/services/kube-apiserver-readonly-svc.yaml
-    content: |
-      apiVersion: v1
-      kind: Service
-      metadata:
-        name: kubernetes-ro
-        namespace: kube-system
-      spec:
-        type: ClusterIP
-        ports:
-          - port: 80
-            protocol: TCP
-            targetPort: 8082
-        selector:
-          application: kube-apiserver
-
   - path: /srv/kubernetes/manifests/deployments/kube-state-metrics.yaml
     content: |
       apiVersion: extensions/v1beta1
@@ -852,7 +836,6 @@ write_files:
               command:
               - /kube-state-metrics
               - --port=8080
-              - --apiserver=http://kubernetes-ro.kube-system.svc.cluster.local
 
   - path: /srv/kubernetes/manifests/services/kube-state-metrics.yaml
     content: |

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -818,7 +818,7 @@ write_files:
       apiVersion: v1
       kind: Service
       metadata:
-        name: apiserver-svc-ro
+        name: kubernetes-ro
         namespace: kube-system
       spec:
         type: ClusterIP
@@ -852,7 +852,7 @@ write_files:
               command:
               - /kube-state-metrics
               - --port=8080
-              - --apiserver=http://apiserver-svc-ro.kube-system.svc.cluster.local
+              - --apiserver=http://kubernetes-ro.kube-system.svc.cluster.local
 
   - path: /srv/kubernetes/manifests/services/kube-state-metrics.yaml
     content: |

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -828,7 +828,6 @@ write_files:
             targetPort: 8082
         selector:
           application: kube-apiserver
-          version: v1.4.5_coreos.0
 
   - path: /srv/kubernetes/manifests/deployments/kube-state-metrics.yaml
     content: |
@@ -872,7 +871,6 @@ write_files:
           targetPort: 8080
         selector:
           application: kube-state-metrics
-          version: v0.3.3
 
   - path: /srv/kubernetes/manifests/daemonsets/prometheus-node-exporter.yaml
     content: |

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -863,6 +863,8 @@ write_files:
       metadata:
         name: kube-state-metrics
         namespace: kube-system
+        annotations:
+          service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
       spec:
         type: LoadBalancer
         ports:

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -817,6 +817,9 @@ write_files:
       metadata:
         name: kube-state-metrics
         namespace: kube-system
+        labels:
+          application: kube-state-metrics
+          version: v0.3.3
       spec:
         replicas: 1
         template:


### PR DESCRIPTION
zmon needs kube-state-metrics on a predictable url

* kube-state-metrics is exposed as service type LoadBalancer for zmon
* deploy kube-state-metrics 
  * kube-state-metrics uses kube-apiserver-readonly-svc with a predictable clusterIP
  * kube-apiserver-readonly exposes 8082 to be a target of kube-apiserver-readonly-svc