### PR TITLE
Add standard storageclass

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -1004,6 +1004,16 @@ write_files:
             imagePullSecrets:
             - name: pierone.stups.zalan.do
 
+  - path: /srv/kubernetes/manifests/storageclasses/standard.yaml
+    content: |
+      apiVersion: storage.k8s.io/v1beta1
+      kind: StorageClass
+      metadata:
+        name: standard
+      provisioner: kubernetes.io/aws-ebs
+      parameters:
+        type: gp2
+
   - path: /etc/kubernetes/nginx/nginx.conf
     content: |
       user nginx;


### PR DESCRIPTION
This adds a standard storageclass which can be used by users.

We still need to figure out what classes we really need, but for now I think this is enough.

http://kubernetes.io/docs/user-guide/persistent-volumes/#storageclasses