### PR TITLE
rename kube-secretary to just secretary

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -739,7 +739,7 @@ write_files:
               image: registry.opensource.zalan.do/teapot/gerry:v0.0.7
               args:
               - /meta/credentials
-              - --application-id=kube-secretary
+              - --application-id=secretary
               - --mint-bucket=s3://{{MINT_BUCKET}}
               volumeMounts:
               - mountPath: /meta/credentials


### PR DESCRIPTION
to be consistent with the reset of the application ids