### PR TITLE
add PlatformCredentialsSet as ThirdPartyResource

### DIFF
--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -24,7 +24,7 @@ SenzaComponents:
       Type: Senza::CoreosAutoConfiguration
       PublicOnly: true # use all public subnets
       DefineParameters: false # skip CF template parameter definition
-      ReleaseChannel: alpha # see https://coreos.com/os/docs/latest/switching-channels.html
+      ReleaseChannel: beta # see https://coreos.com/os/docs/latest/switching-channels.html
   - MasterLoadBalancer:
       Type: Senza::WeightedDnsElasticLoadBalancer
       HTTPPort: 443

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -24,7 +24,7 @@ SenzaComponents:
       Type: Senza::CoreosAutoConfiguration
       PublicOnly: true # use all public subnets
       DefineParameters: false # skip CF template parameter definition
-      ReleaseChannel: beta # see https://coreos.com/os/docs/latest/switching-channels.html
+      ReleaseChannel: alpha # see https://coreos.com/os/docs/latest/switching-channels.html
   - MasterLoadBalancer:
       Type: Senza::WeightedDnsElasticLoadBalancer
       HTTPPort: 443

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -1063,6 +1063,17 @@ write_files:
       parameters:
         type: gp2
 
+  - path: /srv/kubernetes/manifests/thirdpartyresources/platform-i-a-m-credentials.yaml
+    content: |
+      apiVersion: extensions/v1beta1
+      kind: ThirdPartyResource
+      metadata:
+        # NOTE: dashes are needed to get proper PlatformIAMCredentials name
+        name: platform-i-a-m-credentials.zalando.org
+      description: "A specification to declare needed OAuth credentials (tokens, clients)"
+      versions:
+      - version: v1
+
   - path: /etc/kubernetes/nginx/nginx.conf
     content: |
       user nginx;

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -1063,14 +1063,14 @@ write_files:
       parameters:
         type: gp2
 
-  - path: /srv/kubernetes/manifests/thirdpartyresources/platform-i-a-m-credentials.yaml
+  - path: /srv/kubernetes/manifests/thirdpartyresources/platform-credentials-set.yaml
     content: |
       apiVersion: extensions/v1beta1
       kind: ThirdPartyResource
       metadata:
-        # NOTE: dashes are needed to get proper PlatformIAMCredentials name
-        name: platform-i-a-m-credentials.zalando.org
-      description: "A specification to declare needed OAuth credentials (tokens, clients)"
+        # NOTE: dashes are needed to get proper PlatformCredentialsSet name
+        name: platform-credentials-set.zalando.org
+      description: "A specification to declare needed OAuth credentials (tokens, clients) for the Zalando Platform IAM system"
       versions:
       - name: v1
 

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -1072,7 +1072,7 @@ write_files:
         name: platform-i-a-m-credentials.zalando.org
       description: "A specification to declare needed OAuth credentials (tokens, clients)"
       versions:
-      - version: v1
+      - name: v1
 
   - path: /etc/kubernetes/nginx/nginx.conf
     content: |

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -1032,7 +1032,7 @@ write_files:
                   fieldRef:
                     fieldPath: spec.nodeName
               - name: APPDYNAMICS_AGENT_ACCOUNT_ACCESS_KEY
-                value: {{APPDYNAMICS_ACCESS_KEY}}
+                value: "{{APPDYNAMICS_ACCESS_KEY}}"
               - name: APPDYNAMICS_AGENT_ACCOUNT_NAME
                 value: testing
               - name: APPDYNAMICS_ACCOUNT_GLOBALNAME


### PR DESCRIPTION
The PlatformCredentialsSet resource allows application owners to declare needed OAuth credentials.

```yaml
apiVersion: "zalando.org/v1"
kind: PlatformCredentialsSet
metadata:
   name: my-app-credentials
spec:
   application: my-app
   tokens:
     full-access:
       privileges:
         - foobar.write
         - acme.full
     read-only:
       privileges:
         - foobar.read
   clients:
     employee:
       # the allowed grant type, see https://tools.ietf.org/html/rfc6749
       # options: authorization-code, implicit, resource-owner-password-credentials, client-credentials
       # (values directly reference RFC section titles)
       grant: authorization-code
       realm: employees
```
The declared credentials will automatically be provided as a secret with the same name.

