### PR TITLE
update secretary to v0.2.0

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -781,7 +781,7 @@ write_files:
         namespace: kube-system
         labels:
           application: secretary
-          version: v0.1.1
+          version: v0.2.0
       spec:
         replicas: 1
         selector:
@@ -791,7 +791,7 @@ write_files:
           metadata:
             labels:
               application: secretary
-              version: v0.1.1
+              version: v0.2.0
             annotations:
               scheduler.alpha.kubernetes.io/critical-pod: ''
               scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
@@ -809,7 +809,7 @@ write_files:
                 name: credentials
                 readOnly: false
             - name: secretary
-              image: registry.opensource.zalan.do/teapot/secretary:v0.1.1
+              image: registry.opensource.zalan.do/teapot/secretary:v0.2.0
               args:
               - --all-namespaces
               - --service-account=default
@@ -821,14 +821,6 @@ write_files:
               - mountPath: /meta/credentials
                 name: credentials
                 readOnly: true
-            - name: kubectl
-              image: registry.opensource.zalan.do/teapot/hyperkube:pr-cp_zalando.pr-37302
-              command:
-              - /hyperkube
-              args:
-              - kubectl
-              - proxy
-              - --port=8080
             volumes:
             - name: credentials
               emptyDir:


### PR DESCRIPTION
secretary `v0.2.0` doesn't require the `hyperkube` sidecar anymore