### PR TITLE
allow write access for credentials-provider

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -415,7 +415,7 @@ write_files:
             - name: TOKENINFO_URL
               value: https://info.services.auth.zalando.com/oauth2/tokeninfo
             - name: USER_GROUPS
-              value: stups_deployment-controller-ui=Administrator
+              value: stups_deployment-controller-ui=Administrator,credentials-provider=Administrator
         - name: nginx
           image: registry.opensource.zalan.do/teapot/nginx:1.11.5
           resources:


### PR DESCRIPTION
#183: the CredentialsProvider needs to have read/write access:

* reading `PlatformCredentialsSet` TPRs
* writing `Secret` resources

We need to restrict access to the above resources in the future, this PR just uses "Administrator" for now.