### PR TITLE
Add internal ELB for readonly API Server

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -428,6 +428,8 @@ write_files:
           volumeMounts:
           - name: config-volume
             mountPath: /etc/nginx
+          ports:
+          - containerPort: 8082
         volumes:
         - hostPath:
             path: /etc/kubernetes/ssl
@@ -530,6 +532,24 @@ write_files:
               port: 10251
             initialDelaySeconds: 15
             timeoutSeconds: 15
+
+  - path: /srv/kubernetes/manifests/services/kubernetes-readonly.yaml
+    content: |
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: kubernetes-readonly
+        namespace: kube-system
+        annotations:
+          service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
+      spec:
+        type: LoadBalancer
+        ports:
+        - port: 80
+          protocol: TCP
+          targetPort: 8082
+        selector:
+          application: kube-apiserver
 
   - path: /srv/kubernetes/manifests/deployments/kube-dns.yaml
     content: |
@@ -974,10 +994,7 @@ write_files:
       metadata:
         name: kube-state-metrics
         namespace: kube-system
-        annotations:
-          service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
       spec:
-        type: LoadBalancer
         ports:
         - port: 80
           protocol: TCP

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -761,7 +761,10 @@ write_files:
           application: heapster
           kubernetes.io/cluster-service: "true"
           kubernetes.io/name: "Heapster"
+        annotations:
+          service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
       spec:
+        type: LoadBalancer
         ports:
           - port: 80
             targetPort: 8082
@@ -994,7 +997,10 @@ write_files:
       metadata:
         name: kube-state-metrics
         namespace: kube-system
+        annotations:
+          service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
       spec:
+        type: LoadBalancer
         ports:
         - port: 80
           protocol: TCP


### PR DESCRIPTION
Creates internal ELB for kube-apiserver on the readonly port (8082).

Makes it possible to create ZMON checks that only run once for each
cluster instead of multiple times in case of multiple master nodes.

This also makes the internal ELB for `kube-state-metrics` somewhat obsolete since
this can now be proxied through the API server.

Proxying would work like this:

```
GET http://internal-elb/api/v1/proxy/namespaces/kube-system/services/kube-state-metrics/
```

Once ZMON is running inside the cluster and can access the in-cluster service URLs then this wouldn't be needed anymore.