### PR TITLE
expose dashboard to the outside

### DIFF
--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -307,9 +307,9 @@ Resources:
         PolicyName: root
     Type: AWS::IAM::Role
 
-  KubeDashboardIAMRole:
+  KubeDashboardProxyIAMRole:
     Properties:
-      RoleName: "{{SenzaInfo.StackName}}-{{SenzaInfo.StackVersion}}-app-kube-dashboard"
+      RoleName: "{{SenzaInfo.StackName}}-{{SenzaInfo.StackVersion}}-app-kube-dashboard-proxy"
       AssumeRolePolicyDocument:
         Statement:
         - Action: ['sts:AssumeRole']
@@ -333,7 +333,7 @@ Resources:
           Version: '2012-10-17'
           Statement:
           - Action: "s3:GetObject"
-            Resource: "arn:aws:s3:::{{ AccountInfo.MintBucket }}/{{SenzaInfo.StackName}}-{{SenzaInfo.StackVersion}}-dashboard/*"
+            Resource: "arn:aws:s3:::{{ AccountInfo.MintBucket }}/{{SenzaInfo.StackName}}-{{SenzaInfo.StackVersion}}-dashboard-proxy/*"
             Effect: Allow
         PolicyName: AllowMintRead
     Type: AWS::IAM::Role

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -307,6 +307,37 @@ Resources:
         PolicyName: root
     Type: AWS::IAM::Role
 
+  KubeDashboardIAMRole:
+    Properties:
+      RoleName: "{{SenzaInfo.StackName}}-{{SenzaInfo.StackVersion}}-app-kube-dashboard"
+      AssumeRolePolicyDocument:
+        Statement:
+        - Action: ['sts:AssumeRole']
+          Effect: Allow
+          Principal:
+            Service: [ec2.amazonaws.com]
+        - Action: ['sts:AssumeRole']
+          Effect: Allow
+          Principal:
+            AWS:
+              Fn::Join:
+                - ""
+                -
+                  - arn:aws:iam::{{ AccountInfo.AccountID }}:role/
+                  -
+                    Ref: WorkerIAMRole
+        Version: '2012-10-17'
+      Path: /
+      Policies:
+      - PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Action: "s3:GetObject"
+            Resource: "arn:aws:s3:::{{ AccountInfo.MintBucket }}/{{SenzaInfo.StackName}}-{{SenzaInfo.StackVersion}}-dashboard/*"
+            Effect: Allow
+        PolicyName: AllowMintRead
+    Type: AWS::IAM::Role
+
   MasterSecurityGroup:
     Properties:
       GroupDescription: {Ref: 'AWS::StackName'}

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -773,37 +773,8 @@ write_files:
             annotations:
               scheduler.alpha.kubernetes.io/critical-pod: ''
               scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
-              iam.amazonaws.com/role: {{STACK_NAME}}-{{STACK_VERSION}}-app-kube-dashboard
           spec:
             containers:
-            - name: employeelogind
-              image: pierone.stups.zalan.do/teapot/employeelogind:0457e10
-              args:
-              - -backend=http://127.0.0.1:9090
-              env:
-              - name: CREDENTIALS_DIR
-                value: /meta/credentials
-              - name: SESSION_ENCRYPTION_KEY
-                valueFrom:
-                  secretKeyRef:
-                    name: kube-dashboard-config
-                    key: session.key
-              ports:
-              - containerPort: 3030
-              volumeMounts:
-              - mountPath: /meta/credentials
-                name: credentials
-                readOnly: true
-            - name: gerry
-              image: registry.opensource.zalan.do/teapot/gerry:v0.0.7
-              args:
-              - /meta/credentials
-              - --application-id={{STACK_NAME}}-{{STACK_VERSION}}-dashboard
-              - --mint-bucket=s3://{{MINT_BUCKET}}
-              volumeMounts:
-              - mountPath: /meta/credentials
-                name: credentials
-                readOnly: false
             - name: kubernetes-dashboard
               image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.5.0
               resources:
@@ -821,12 +792,6 @@ write_files:
                   port: 9090
                 initialDelaySeconds: 30
                 timeoutSeconds: 30
-            volumes:
-            - name: credentials
-              emptyDir:
-                medium: Memory
-            imagePullSecrets:
-            - name: pierone.stups.zalan.do
 
   - path: /srv/kubernetes/manifests/services/kube-dashboard.yaml
     content: |
@@ -838,23 +803,98 @@ write_files:
         labels:
           application: kubernetes-dashboard
           kubernetes.io/cluster-service: "true"
+      spec:
+        selector:
+          application: kubernetes-dashboard
+        ports:
+        - port: 80
+          targetPort: 9090
+
+  - path: /srv/kubernetes/manifests/deployments/kubernetes-dashboard-proxy.yaml
+    content: |
+      apiVersion: extensions/v1beta1
+      kind: Deployment
+      metadata:
+        name: kubernetes-dashboard-proxy
+        namespace: kube-system
+        labels:
+          application: kubernetes-dashboard-proxy
+          version: "0457e10"
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            application: kubernetes-dashboard-proxy
+        template:
+          metadata:
+            labels:
+              application: kubernetes-dashboard-proxy
+              version: "0457e10"
+            annotations:
+              iam.amazonaws.com/role: {{STACK_NAME}}-{{STACK_VERSION}}-app-kube-dashboard-proxy
+          spec:
+            containers:
+            - name: employeelogind
+              image: pierone.stups.zalan.do/teapot/employeelogind:0457e10
+              args:
+              - -backend=http://kubernetes-dashboard.kube-system.svc.cluster.local
+              env:
+              - name: CREDENTIALS_DIR
+                value: /meta/credentials
+              - name: SESSION_ENCRYPTION_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: kubernetes-dashboard-proxy-config
+                    key: session.key
+              ports:
+              - containerPort: 3030
+              volumeMounts:
+              - mountPath: /meta/credentials
+                name: credentials
+                readOnly: true
+            - name: gerry
+              image: registry.opensource.zalan.do/teapot/gerry:v0.0.7
+              args:
+              - /meta/credentials
+              - --application-id={{STACK_NAME}}-{{STACK_VERSION}}-dashboard-proxy
+              - --mint-bucket=s3://{{MINT_BUCKET}}
+              volumeMounts:
+              - mountPath: /meta/credentials
+                name: credentials
+                readOnly: false
+            volumes:
+            - name: credentials
+              emptyDir:
+                medium: Memory
+            imagePullSecrets:
+            - name: pierone.stups.zalan.do
+
+  - path: /srv/kubernetes/manifests/services/kubernetes-dashboard-proxy.yaml
+    content: |
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: kubernetes-dashboard-proxy
+        namespace: kube-system
+        labels:
+          application: kubernetes-dashboard-proxy
         annotations:
           service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:eu-central-1:{{ACCOUNT_ID}}:certificate/{{CERTIFICATE_ID}}
           zalando.org/dnsname: {{STACK_NAME}}-{{STACK_VERSION}}-dashboard.{{HOSTED_ZONE}}
       spec:
         type: LoadBalancer
         selector:
-          application: kubernetes-dashboard
+          application: kubernetes-dashboard-proxy
         ports:
         - port: 443
           targetPort: 3030
 
-  - path: /srv/kubernetes/manifests/deployments/kube-dashboard-config.yaml
+  - path: /srv/kubernetes/manifests/deployments/kubernetes-dashboard-proxy-config.yaml
     content: |
       apiVersion: v1
       kind: Secret
       metadata:
-        name: kube-dashboard-config
+        name: kubernetes-dashboard-proxy-config
         namespace: kube-system
       type: Opaque
       data:

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -773,8 +773,37 @@ write_files:
             annotations:
               scheduler.alpha.kubernetes.io/critical-pod: ''
               scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
+              iam.amazonaws.com/role: {{STACK_NAME}}-{{STACK_VERSION}}-app-kube-dashboard
           spec:
             containers:
+            - name: employeelogind
+              image: pierone.stups.zalan.do/teapot/employeelogind:0457e10
+              args:
+              - -backend=http://127.0.0.1:9090
+              env:
+              - name: CREDENTIALS_DIR
+                value: /meta/credentials
+              - name: SESSION_ENCRYPTION_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: kube-dashboard-config
+                    key: session.key
+              ports:
+              - containerPort: 3030
+              volumeMounts:
+              - mountPath: /meta/credentials
+                name: credentials
+                readOnly: true
+            - name: gerry
+              image: registry.opensource.zalan.do/teapot/gerry:v0.0.7
+              args:
+              - /meta/credentials
+              - --application-id={{STACK_NAME}}-{{STACK_VERSION}}-dashboard
+              - --mint-bucket=s3://{{MINT_BUCKET}}
+              volumeMounts:
+              - mountPath: /meta/credentials
+                name: credentials
+                readOnly: false
             - name: kubernetes-dashboard
               image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.5.0
               resources:
@@ -792,6 +821,12 @@ write_files:
                   port: 9090
                 initialDelaySeconds: 30
                 timeoutSeconds: 30
+            volumes:
+            - name: credentials
+              emptyDir:
+                medium: Memory
+            imagePullSecrets:
+            - name: pierone.stups.zalan.do
 
   - path: /srv/kubernetes/manifests/services/kube-dashboard.yaml
     content: |
@@ -803,12 +838,27 @@ write_files:
         labels:
           application: kubernetes-dashboard
           kubernetes.io/cluster-service: "true"
+        annotations:
+          service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:eu-central-1:{{ACCOUNT_ID}}:certificate/{{CERTIFICATE_ID}}
+          zalando.org/dnsname: {{STACK_NAME}}-{{STACK_VERSION}}-dashboard.{{HOSTED_ZONE}}
       spec:
+        type: LoadBalancer
         selector:
           application: kubernetes-dashboard
         ports:
-        - port: 80
-          targetPort: 9090
+        - port: 443
+          targetPort: 3030
+
+  - path: /srv/kubernetes/manifests/deployments/kube-dashboard-config.yaml
+    content: |
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: kube-dashboard-config
+        namespace: kube-system
+      type: Opaque
+      data:
+        session.key: "{{SESSION_KEY}}"
 
   - path: /srv/kubernetes/manifests/deployments/secretary.yaml
     content: |


### PR DESCRIPTION
first working version of an exposed dashboard. couple of open questions though:

* makes dashboard availabe at a specific url per cluster: e.g. check out https://kube-aws-test-linki53-dashboard.teapot.zalan.do/
  * since the goal is one cluster per account, should this rather be sth. like https://dashboard.hackweek.zalan.do?
* requires the certificate id for the exposed https endpoint
  * maybe we should infer this somehow?
* generates a random cookie secret for employeelogind
  * even on update if not provided, so everybody gets logged out. is that ok for now?
* requires a specific kio app for the dashboard
  * with platform IAM we may be able to avoid this?
* allows read and write for anybody whose authenticated
  * could be fixed by putting the dashboard under a read-only service account

this is a first full fledged working version. lot's of dependencies and a manual step (create kio app). good for hackweek i guess but really not so nice for after that.

please provide some feedback.

