### PR TITLE
allow kube-ops-view ReadOnly access

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -415,7 +415,7 @@ write_files:
             - name: TOKENINFO_URL
               value: https://info.services.auth.zalando.com/oauth2/tokeninfo
             - name: USER_GROUPS
-              value: stups_autobahn=Administrator,stups_deployment-controller-ui=ReadOnly,credentials-provider=Administrator
+              value: stups_autobahn=Administrator,stups_deployment-controller-ui=ReadOnly,credentials-provider=Administrator,credprov-kube-ops-view-read-only-token=ReadOnly
         - name: nginx
           image: registry.opensource.zalan.do/teapot/nginx:1.11.5
           resources:


### PR DESCRIPTION
To allow the ["Kubernetes Operational View" dashboard](https://github.com/hjacobs/kube-ops-view) read-only access to the API server.