### PR TITLE
webhook: Allow readonly access to non-resource paths

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -380,7 +380,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 500Mi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:6669b4b
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.0
           name: webhook
           ports:
           - containerPort: 8081


### PR DESCRIPTION
Allow readOnly access to non-resource paths like `/apis`.