### PR TITLE
Integrate ZMON in kubernetes cluster

### DIFF
--- a/cluster/cluster.py
+++ b/cluster/cluster.py
@@ -131,6 +131,7 @@ def get_cluster_variables(stack_name: str, version: str, node_labels: str, worke
         'mint_bucket': mint_bucket,
         'etcd_bucket': etcd_bucket,
         'account_id': get_account_id(),
+        'account_alias': get_account_alias(),
         'region': get_region(),
         'node_labels': node_labels,
     }

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -226,7 +226,7 @@ write_files:
     owner: root:root
     content: |
       #!/bin/bash -e
-      for uid in hjacobs mkerk sszuecs rdifazio mlinkhorst mlarsen tsarnowski lmineiro aryszka apfeiffer ytussupbekov; do
+      for uid in mabdelhameed hjacobs mkerk sszuecs rdifazio mlinkhorst mlarsen tsarnowski lmineiro aryszka apfeiffer ytussupbekov; do
           /usr/bin/curl -s https://even.stups.zalan.do/public-keys/$uid/sshkey.pub -o /home/core/.ssh/authorized_keys.d/$uid
       done
       /usr/bin/update-ssh-keys
@@ -535,7 +535,6 @@ write_files:
           - /rescheduler
           args:
           - --running-in-cluster=false
-
 
   - path: /etc/kubernetes/nginx/nginx.conf
     content: |


### PR DESCRIPTION
- worker
- scheduler
- agent
- redis

Notes:
- Tested with ``t2.medium``

TBD:
- Using ``zmon-worker`` OS image, due to failure while pulling private registry image on ``kube-system``
- That lead to transferring all private env variables to the manifests, which pollutes ``userdata-master`` and complicates CLI args

For ref, the following private env variables were needed:
- {{ZMON_MAIL_HOST}}
- {{ZMON_MAIL_SENDER}}
- {{ZMON_MAIL_USER}}
- {{ZMON_MAIL_PASSWORD}}
- {{ZMON_HIPCHAT_URL}}
- {{ZMON_NOTIFICATIONS_SERVICE_KEY}}
- {{ZMON_PUSH_KEY}}
- {{ZMON_PAGERDUTY_KEY}}
- {{ZMON_OPSGENIE_KEY}}

Possible solutions:
- Workaround for private registry image pulling failure?
- Pass args to ``cluster create`` & ``cluster update`` (imho complex and error prone)
- Pass ZMON args as ``yaml`` config file.
- Separate ZMON as standalone deployment.
- ... ?