### PR TITLE
Update Skipper to v0.1.1

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -1022,7 +1022,7 @@ write_files:
         namespace: kube-system
         labels:
           application: skipper-ingress
-          version: v0.1.0
+          version: v0.1.1
           component: ingress
       spec:
         selector:
@@ -1033,7 +1033,7 @@ write_files:
             name: skipper-ingress
             labels:
               application: skipper-ingress
-              version: v0.1.0
+              version: v0.1.1
               component: ingress
             annotations:
               scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -1042,7 +1042,7 @@ write_files:
             hostNetwork: true
             containers:
             - name: skipper-ingress
-              image: registry.opensource.zalan.do/teapot/skipper:v0.1.0
+              image: registry.opensource.zalan.do/teapot/skipper:v0.1.1
               ports:
               - name: ingress-port
                 containerPort: 9999


### PR DESCRIPTION
Fix Skipper returning "Internal Server Error" instead of "Service Unavailable", see https://github.com/zalando/skipper/issues/241