### PR TITLE
update mate to v0.5.0

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -880,7 +880,7 @@ write_files:
         namespace: kube-system
         labels:
           application: mate
-          version: v0.3.2
+          version: v0.5.0
       spec:
         replicas: 1
         selector:
@@ -890,7 +890,7 @@ write_files:
           metadata:
             labels:
               application: mate
-              version: v0.3.2
+              version: v0.5.0
             annotations:
               scheduler.alpha.kubernetes.io/critical-pod: ''
               scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
@@ -898,7 +898,7 @@ write_files:
           spec:
             containers:
             - name: mate
-              image: registry.opensource.zalan.do/teapot/mate:v0.3.2
+              image: registry.opensource.zalan.do/teapot/mate:v0.5.0
               env:
               - name: AWS_REGION
                 value: {{REGION}}


### PR DESCRIPTION
updates mate to a version that crashes less and supports paginated responses from aws.