### PR TITLE
allow multiple flannels to use the same etcd

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -7,6 +7,7 @@ coreos:
   flannel:
     interface: $private_ipv4
     etcd_endpoints: http://$private_ipv4:2379
+    etcd_prefix: /{{STACK_VERSION}}/coreos.com/network
   etcd2:
     discovery-srv: {{ETCD_DISCOVERY_DOMAIN}}
     proxy: on
@@ -74,7 +75,7 @@ coreos:
           content: |
             [Service]
             ExecStartPre=/usr/bin/etcdctl \
-            --endpoint=http://localhost:2379 set /coreos.com/network/config \
+            --endpoint=http://localhost:2379 set /{{STACK_VERSION}}/coreos.com/network/config \
             '{ "Network": "10.2.0.0/16", "Backend": {"Type": "vxlan"}}'
     - name: kubelet.service
       command: start

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -7,6 +7,7 @@ coreos:
   flannel:
     interface: $private_ipv4
     etcd_endpoints: http://$private_ipv4:2379
+    etcd_prefix: /{{STACK_VERSION}}/coreos.com/network
   etcd2:
     discovery-srv: {{ETCD_DISCOVERY_DOMAIN}}
     proxy: on


### PR DESCRIPTION
clusters in our AWS account share the same etcd cluster to store flannel's network config.

This leads to many unrelated nodes to fight over a subnet as well as terminated clusters to leave lots of garbage and claimed subnets. Now we hit the limit of 256 and flannel won't come up anymore.

This puts each cluster's flannel config under a separate prefix in etcd.

Note: becomes obsolete with a config map backend for flannel.