### PR TITLE
Increased delay to consider node as unneeded

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -1162,6 +1162,7 @@ write_files:
                   - --cloud-provider=aws
                   - --skip-nodes-with-local-storage=false
                   - --leader-elect=false
+                  - --scale-down-unneeded-time=45m0s
                 env:
                   - name: AWS_REGION
                     value: {{REGION}}


### PR DESCRIPTION
Straight from the CLI flags: 

````
--scale-down-unneeded-time=10m0s: How long the node should be unneeded before it is eligible for scale down
````
In GCP, we pay the first 10 minutes and then per minute. In AWS we pay per hour, so it makes no sense to drop an unused node too early (the default is 10 minutes as per CLI flag) as we might need it shortly after, thus wasting money. 