### PR TITLE
Pass hostedZone from cluster.py

### DIFF
--- a/cluster/cluster.py
+++ b/cluster/cluster.py
@@ -282,6 +282,7 @@ def create(stack_name, version, dry_run, instance_type, master_nodes, worker_nod
                                'MasterNodes={}'.format(master_nodes), 'WorkerNodes={}'.format(worker_nodes),
                                'MinimumWorkerNodes={}'.format(min_worker_nodes),
                                'MaximumWorkerNodes={}'.format(max_worker_nodes),
+                               'HostedZone={}'.format(variables['hosted_zone']),
                                'InstanceType={}'.format(instance_type), 'ClusterID={}'.format(variables['cluster_id'])])
         # wait up to 15m for stack to be created
         subprocess.check_call(['senza', 'wait', '--timeout=900', stack_name, version])
@@ -364,6 +365,7 @@ def update(stack_name, version, dry_run, force, instance_type, master_nodes, wor
                                'MasterNodes={}'.format(master_nodes), 'WorkerNodes={}'.format(worker_nodes),
                                'MinimumWorkerNodes={}'.format(min_worker_nodes),
                                'MaximumWorkerNodes={}'.format(max_worker_nodes),
+                               'HostedZone={}'.format(variables['hosted_zone']),
                                'InstanceType={}'.format(instance_type), 'ClusterID={}'.format(variables['cluster_id'])])
         # wait for CF update to complete..
         subprocess.check_call(['senza', 'wait', '--timeout=600', stack_name, version])

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -22,6 +22,8 @@ SenzaInfo:
           Description: "Type of instance"
       - ClusterID:
           Description: "ID of the cluster"
+      - HostedZone:
+          Description: "Hosted DNS zone"
 
 SenzaComponents:
   - Configuration:
@@ -45,6 +47,8 @@ SenzaComponents:
           LoadBalancerPort: 443
       ConnectionSettings:
         IdleTimeout: 300
+      VersionDomain: "{{SenzaInfo.StackName}}-{{SenzaInfo.StackVersion}}.{{Arguments.HostedZone}}"
+      MainDomain: "{{SenzaInfo.StackName}}.{{Arguments.HostedZone}}"
       Tags:
         - Key: "KubernetesCluster"
           Value: kubernetes


### PR DESCRIPTION
This passes the hostedZone to senza from cluster.py instead of letting
senza find it. This way senza won't prompt the user for a hosted zone
selection in case there is more than one.