### PR TITLE
Fix e2e tests for v1.5

### DIFF
--- a/e2e/test-cluster.py
+++ b/e2e/test-cluster.py
@@ -33,7 +33,8 @@ def get_containers(url, token):
 @click.command()
 @click.argument('url')
 @click.option('--token')
-def main(url, token):
+@click.option('--retries', default=90, type=int, help="Number of retries when waiting for containers to be ready.")
+def main(url, token, retries):
 
     run_id = ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(8))
     info('Starting test run {}..'.format(run_id))
@@ -41,7 +42,7 @@ def main(url, token):
     all_containers_ready = False
 
     with Action('Waiting for all containers to be ready..') as act:
-        for i in range(60):
+        for i in range(retries):
             containers = get_containers(url, token)
             ready = True
             for name in EXPECTED_CONTAINERS:

--- a/e2e/test-cluster.py
+++ b/e2e/test-cluster.py
@@ -33,7 +33,7 @@ def get_containers(url, token):
 @click.command()
 @click.argument('url')
 @click.option('--token')
-@click.option('--retries', default=90, type=int, help="Number of retries when waiting for containers to be ready.")
+@click.option('--retries', default=120, type=int, help="Number of retries when waiting for containers to be ready.")
 def main(url, token, retries):
 
     run_id = ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(8))

--- a/e2e/tests/helpers.py
+++ b/e2e/tests/helpers.py
@@ -6,7 +6,7 @@ from clickclick import Action
 
 DEPLOYMENTS_PATH = '/apis/extensions/v1beta1/namespaces/e2e/deployments'
 SERVICES_PATH = '/api/v1/namespaces/e2e/services'
-PETSET_PATH = '/apis/apps/v1alpha1/namespaces/e2e/petsets'
+STATEFULSET_PATH = '/apis/apps/v1beta1/namespaces/e2e/statefulsets'
 SECRET_PATH = '/api/v1/namespaces/e2e/secrets'
 ENDPOINT_PATH = '/api/v1/namespaces/e2e/endpoints'
 POD_PATH = '/api/v1/namespaces/e2e/pods'
@@ -50,7 +50,7 @@ def wait_for_pod(name, url, token, timeout=100):
         while time.time() < cut_off:
             response = requests.get(url + POD_PATH + '/{}'.format(name), headers={'Authorization': 'Bearer {}'.format(token)})
             data = response.json()
-            if data.get('status', {}).get('phase') == 'Running':
+            if response.status_code != 404 and data.get('status', {}).get('phase') == 'Running':
                 available = True
                 break
             time.sleep(2)

--- a/e2e/tests/test_volumes.py
+++ b/e2e/tests/test_volumes.py
@@ -1,6 +1,6 @@
 from clickclick import fatal_error
 
-from .helpers import PETSET_PATH, SECRET_PATH, create_resource, wait_for_pod
+from .helpers import STATEFULSET_PATH, SECRET_PATH, create_resource, wait_for_pod
 
 
 def test_volumes(run_id, url, token):
@@ -102,7 +102,7 @@ spec:
         requests:
           storage: 5Gi
 '''
-    create_resource(manifest, url + PETSET_PATH, token)
+    create_resource(manifest, url + STATEFULSET_PATH, token)
 
     for i in range(3):
         available = wait_for_pod('spilodemo-{}'.format(i), url, token)

--- a/e2e/tests/test_volumes.py
+++ b/e2e/tests/test_volumes.py
@@ -23,8 +23,8 @@ data:
     create_resource(secret_manifest, url + SECRET_PATH, token)
 
     manifest = '''
-apiVersion: apps/v1alpha1
-kind: PetSet
+apiVersion: apps/v1beta1
+kind: StatefulSet
 metadata:
   name: &cluster_name spilodemo
   labels:
@@ -38,8 +38,6 @@ spec:
       labels:
         application: spilo
         spilo-cluster: *cluster_name
-      annotations:
-        pod.alpha.kubernetes.io/initialized: "true"
     spec:
       containers:
       - name: *cluster_name


### PR DESCRIPTION
Makes the e2e tests work with kubernetes 1.5 (petset -> statefulset) and increases the default timeout a bit.