### PR TITLE
determine nodes to update by labels

### DIFF
--- a/cluster/cluster.py
+++ b/cluster/cluster.py
@@ -369,7 +369,8 @@ def get_instances_to_update(asg_name, desired_user_data, desired_node_labels, co
 @click.option('--max-worker-nodes', default=10, type=int, help='Maximum number of nodes in the worker ASG')
 @click.option('--node-labels', type=str, default='', help='Labels to assign to each node')
 @click.option('--scalyr-access-key', type=str, required=True, help='Secret for the logging agent')
-def update(stack_name, version, dry_run, force, instance_type, master_nodes, worker_nodes, postpone, min_worker_nodes, max_worker_nodes, node_labels, scalyr_access_key):
+def update(stack_name, version, dry_run, force, instance_type, master_nodes, worker_nodes, postpone, min_worker_nodes, max_worker_nodes, node_labels,
+           scalyr_access_key):
     '''
     Update Kubernetes cluster
     '''

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -103,6 +103,7 @@ coreos:
         --register-schedulable=false \
         --allow-privileged \
         --node-labels=master=true \
+        --node-labels={{NODE_LABELS}} \
         --pod-manifest-path=/etc/kubernetes/manifests \
         --cluster_dns=10.3.0.10 \
         --cluster_domain=cluster.local \

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -97,6 +97,7 @@ coreos:
         --rkt-path=/usr/bin/rkt \
         --register-node \
         --allow-privileged \
+        --node-labels={{NODE_LABELS}} \
         --pod-manifest-path=/etc/kubernetes/manifests \
         --cluster_dns=10.3.0.10 \
         --cluster_domain=cluster.local \


### PR DESCRIPTION
This allows passing node labels to cluster.py which are added to all nodes.

---

*This issue used to modify the rolling update behaviour to consider node labels. This is not beneficial and postponed for now. For reference, see the text below and find the commits in the history.*

**Determine nodes to update by labels**

EARLY VERSION: Pretty much done but needs some testing. I would love to get a review @mikkeloscar @hjacobs @ideahitme for any obvious mistakes.

This allows passing node labels to each node of the cluster. Node labels can then be used to determine which nodes need to be updated during a cluster update.

The rolling update process looks for nodes that either have old userdata *or* different values for the labels specified on `cluster.py update`. Initial labels can also be set on `cluster.py create`. When providing no labels it should behave as before.

It makes `cluster.py update` re-entrant so it can be called again if a cluster update was interrupted. On each run it can make some progress until the entire cluster is updated instead of going into an endless loop like now.

Note: it's still not perfectly equal to an uninterrupted run (the ASGs' desired capacity is increased with each run and might not be reduced later, but that should be fixed by the autoscaler eventually).