### PR TITLE
ELB-unhealthy nodes should not be terminated

### DIFF
--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -69,6 +69,7 @@ SenzaComponents:
          - {Ref: MasterIAMRole}
       ElasticLoadBalancer: MasterLoadBalancer
       HealthCheckGracePeriod: 480 # give master node up to 8 min to start up
+      HealthCheckType: EC2
       AssociatePublicIpAddress: true
       UserData: "{{ Arguments.UserDataMaster }}"
       AutoScaling:
@@ -96,6 +97,7 @@ SenzaComponents:
          - {Ref: WorkerIAMRole}
       ElasticLoadBalancer: WorkerLoadBalancer
       HealthCheckGracePeriod: 480 # give worker node up to 8 min to start up
+      HealthCheckType: EC2
       AssociatePublicIpAddress: true
       UserData: "{{ Arguments.UserDataWorker }}"
       AutoScaling:

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -375,6 +375,8 @@ Resources:
       - {CidrIp: 0.0.0.0/0, FromPort: 22, IpProtocol: tcp, ToPort: 22}
       - {CidrIp: 172.31.0.0/16, FromPort: 9999, IpProtocol: tcp, ToPort: 9999}
       - {CidrIp: 172.31.0.0/16, FromPort: 9100, IpProtocol: tcp, ToPort: 9100}
+      # allow checking kubelet healthz port from within the VPC
+      - {CidrIp: 172.31.0.0/16, FromPort: 10248, IpProtocol: tcp, ToPort: 10248}
       Tags:
         - Key: "KubernetesCluster"
           Value: kubernetes


### PR DESCRIPTION
Do not use ELB health check for ASGs: http://docs.stups.io/en/latest/components/senza.html#senza-taupageautoscalinggroup

This prevents nodes from getting terminated on ELB health check failure.