### PR TITLE
Bump of mem limits for apiserver

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -354,10 +354,10 @@ write_files:
           resources:
             requests:
               cpu: 100m
-              memory: 200Mi
+              memory: 500Mi
             limits:
               cpu: 200m
-              memory: 500Mi
+              memory: 1Gi
         - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.0
           name: webhook
           ports:

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -446,10 +446,10 @@ write_files:
           resources:
             limits:
               cpu: 200m
-              memory: 200Mi
+              memory: 500Mi
             requests:
               cpu: 100m
-              memory: 100Mi
+              memory: 200Mi
           livenessProbe:
             httpGet:
               host: 127.0.0.1


### PR DESCRIPTION
This is needed not to get them OOMkilled, this will probably just give us some time to breathe before we have a better solution. 