### PR TITLE
make kubectl apply work with daemonsets

### DIFF
--- a/cluster/manifests/daemonupgrader/deployment.yaml
+++ b/cluster/manifests/daemonupgrader/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: daemonupgrader
+  namespace: kube-system
+  labels:
+    application: daemonupgrader
+    version: 8264ca0
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      application: daemonupgrader
+  template:
+    metadata:
+      labels:
+        application: daemonupgrader
+        version: 8264ca0
+    spec:
+      containers:
+      - name: daemonupgrader
+        image: pierone.stups.zalan.do/teapot/k8s-daemonupgradecontroller:8264ca0
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 50m
+            memory: 25Mi

--- a/cluster/manifests/daemonupgrader/deployment.yaml
+++ b/cluster/manifests/daemonupgrader/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: daemonupgrader
-        image: pierone.stups.zalan.do/teapot/k8s-daemonupgradecontroller:8264ca0
+        image: registry.opensource.zalan.do/teapot/k8s-daemonupgradecontroller:8264ca0
         resources:
           limits:
             cpu: 200m

--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     application: kube2iam
     version: v0.3.0
+  annotations:
+    daemonset.kubernetes.io/strategyType: RollingUpdate
+    daemonset.kubernetes.io/maxUnavailable: "1"
 spec:
   selector:
     matchLabels:

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -7,6 +7,9 @@ metadata:
     application: logging-agent
     version: v0.10
     component: logging
+  annotations:
+    daemonset.kubernetes.io/strategyType: RollingUpdate
+    daemonset.kubernetes.io/maxUnavailable: "1"
 spec:
   selector:
     matchLabels:

--- a/cluster/manifests/prometheus-node-exporter/daemonset.yaml
+++ b/cluster/manifests/prometheus-node-exporter/daemonset.yaml
@@ -7,6 +7,9 @@ metadata:
     version: v0.12.0
     component: node-exporter
   namespace: kube-system
+  annotations:
+    daemonset.kubernetes.io/strategyType: RollingUpdate
+    daemonset.kubernetes.io/maxUnavailable: "1"
 spec:
   selector:
     matchLabels:

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -7,6 +7,9 @@ metadata:
     application: skipper-ingress
     version: v0.1.1
     component: ingress
+  annotations:
+    daemonset.kubernetes.io/strategyType: RollingUpdate
+    daemonset.kubernetes.io/maxUnavailable: "1"
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
This deploys Mirantis' `daemonupgradecontroller` controller and annotates daemonsets to opt-in to being managed by it.

It looks for outdated pods of a daemon set (via `podTemplateHash` annotations) and kills them one by one.

Note: This may not be enough to have a smooth upgrade for skipper.