### PR TITLE
add CronJob to delete completed jobs after one hour

### DIFF
--- a/cluster/manifests/kube-job-cleaner/cronjob.yaml
+++ b/cluster/manifests/kube-job-cleaner/cronjob.yaml
@@ -2,6 +2,7 @@ apiVersion: batch/v2alpha1
 kind: CronJob
 metadata:
   name: kube-job-cleaner
+  namespace: kube-system
   labels:
     application: kube-job-cleaner
     version: "0.1"

--- a/cluster/manifests/kube-job-cleaner/cronjob.yaml
+++ b/cluster/manifests/kube-job-cleaner/cronjob.yaml
@@ -1,0 +1,29 @@
+apiVersion: batch/v2alpha1
+kind: CronJob
+metadata:
+  name: kube-job-cleaner
+  labels:
+    application: kube-job-cleaner
+    version: "0.1"
+spec:
+  schedule: "17 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            application: kube-job-cleaner
+            version: "0.1"
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: cleaner
+            # delete all completed jobs after one hour
+            image: registry.opensource.zalan.do/teapot/kube-job-cleaner:cd3
+            resources:
+              limits:
+                cpu: 100m
+                memory: 100Mi
+              requests:
+                cpu: 50m
+                memory: 50Mi


### PR DESCRIPTION
* add CronJob triggering every hour (17 minutes after full hour)
* delete all completed jobs after one hour
* internal CI/CD pipeline for [kube-job-cleaner](https://github.com/hjacobs/kube-job-cleaner) exists