### PR TITLE
remove hardcoded s3:// prefix

### DIFF
--- a/cluster/manifests/secretary/deployment.yaml
+++ b/cluster/manifests/secretary/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         args:
         - /meta/credentials
         - --application-id=secretary
-        - --mint-bucket=s3://{{.ConfigItems.gerry_mint_bucket}}
+        - --mint-bucket={{.ConfigItems.gerry_mint_bucket}}
         volumeMounts:
         - mountPath: /meta/credentials
           name: credentials


### PR DESCRIPTION
gerry defaults to s3://, so we do not have to change anything else and we easily support other cloud providers.