### PR TITLE
Pre-generate SSH authorized_keys

### DIFF
--- a/cluster/update-authorized-keys.sh
+++ b/cluster/update-authorized-keys.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Helper script to update the authorized_keys section in the user data
+
+ADMIN_USERS='''
+ahartmann
+hjacobs
+jmussler
+mkerk
+mlarsen
+mlinkhorst
+rdifazio
+sszuecs
+ytussupbekov
+'''
+
+for file in userdata-*.yaml; do
+    echo "Updating ${file}.."
+    new_file=${file}.tmp
+    echo '#cloud-config' > $new_file
+    echo 'ssh_authorized_keys:' >> $new_file
+    for uid in $ADMIN_USERS; do
+        key=$(/usr/bin/curl -s https://even.stups.zalan.do/public-keys/$uid/sshkey.pub)
+        echo "  - '$key'" >> $new_file
+    done
+    cat $file | awk '/^coreos:/ { p=1 } p==1 { print }' >> $new_file
+    mv $new_file $file
+done

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -1,6 +1,14 @@
 #cloud-config
 ssh_authorized_keys:
-  - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCpzwYq1DHpE45uNin32k3KchWGHSPjGgpDrrl7d9fiP6ByIhhkeG/0sHqy9MC5r5OOsBwjlUlVZv1fZv42ei9tv94qeHL9vIMLeYGSeZLF+iqYGJAGTOMViptJb1K3OdBk6s/+nJCIA4agbKOh3E4f+EdxUMOA/rllx3dBtFv8LE2CAAFH0g5b5nGdHbOyLCI1qeG54q7zpKK/oJxWoHBSNSekVlQV0/i9DelFfOf2W6r+ugXD4h5msL9doHvpqnq0xcjJ+nc9u1FE9BwkjfgIZEmb9mDMaBUIqtEJ2TzwP3aQ+RPCmPqMGiC2/FmCnY1imhGjX13H00o1/j9Qvj/j9i7D6hNVi7/zom+yail+W6E/s1wWmkAI4yLq0VAt9M4F860m464UFUpkBw0IFzYvsyA/OoB7Az6R36ilHZ4EhCTvbP2AH5OYzE68w0+8E28Xb3cet7PSUO1qZ9DrfMzHxbiZduCgn+GgdJ5QUMiel2X8e8+7J72JBzjbvwkx5qFGRgnKI1TAhxO50LQfWerB1ND21DMYldiqTqkmyKtxsn9pZiK0QHl31Q01gUJVnHprMzj5fvMe4EH4cCB4qeddKjUQYo5javV6yL7WQB4igdQF3gLy1EC1DoC5y/3BGjMJVSDAS8rHk/o+ATpJRJvhH8fK8Es+4x68vHU0tIDoZw== cardno:000604137982"
+  - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC8yXjMX812gbdUsosLvIA/zPrRZI+iOKo8Igq7eiwRTeJKxIkRd2vxDGDfqzCnMhUPPgLW7YM0FWt1u8ZTlXyL4fv1KZuYMRF+27GuU2b/IKu4JYlHDDHrvKCr9tyKb+YVPrAfzi2xVRTGGZG6GRmAiDw8HSUFdejuDLIropAFQu9gAow9aiuQG6kmxZK8qdwIu03eZhuUHCRySCPbusjO+I2JEyVa7lM+P1zt2znDwXsdGjTzHE7NSu5z/VHzho3STWolBm5Vk8uLNYKhjs0eiw/FXV5t+c08Y3JA1LwjAmfOBS23ERSHMG8I3EVSnB9utrdLXejwFAV/jY+Dl2QX9o8brFePBe26MbSg9udD0yfrVz4HEG6NigK6sSx97Zs0lcaSwvjJsnp/J3B1IQMlNRLJGQ7WxM9H2rtoMmD7/iPdADevehEui8C9iaADk6j8AWtN0SJbccSvidrFXW7eH/YSYW394rk8Cl1xBk2RORv3OGVy/RNVt6/Pk/BzvqKf3RvKlbvbFZsWeBSZHDAKeer7001g8HmKV7c8fnDsxIU9Ro3aeWpsX1rQ/jzH1an2deXzVDX1Xbm80VmL5M53dr4w2ZiF5uEIODEUr2nssvl6fhdnaXmbO0vsIyOVawl8mkQ7CBsW06Q+kNs7iDvwVmoG/DD0k4i86La2TBpGvQ== andre.hartmann@zalando.de'
+  - 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAt8djQXfn5U7H85oDzuZRfRONF+jVqn3Mp9t3tnBrJdKyTccfDovq1sekzEdOFdmj74yfS8bzaIO9pDUczy6j5k2MtDCoRnzAO6KZc46jMJ2GjhLArUuHLjmAw2r9LotZ30LEIEvJdmUI7mDlPMczv381PghyM8+DsYv62UrfjDiOsZ4EVkYnztQlO3ntNE16RFNj4fbfErQz67kmw0lB8C6bAf0RuRmvXzB7xRMplmknQnLusoURmySKdZM0GUe0VY6fmqOsgzHVLoEs1m82V8QK1ac/1DSHA91v50MbpCjTVLaRhjR8nmhWBedlhb6j5ClZdAQ8iwyyWC1MFQuvKw== henning@zalando.de'
+  - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDIgO42Rr98DRo4N86Uk4cqHcnbA0iPhL7/DQXRNs+o2vfnfoTVNQiyfq8XzScb+pRJpiq2wW2OthMVRUJsiO4PECw7avYAi0M8cyCsu+ZUoIeMlu+TssWA00GZgdKcQKyCoyLlGbPu2z4GpM9tX+7ASMbMuk6fpm6n9af1YbTm2eqKKXpHDJO+aex3WCj1VyQpCgCD4zquGRy8JRSiQ+QGyGZHIzWWpo3Lc1xGqSQu6L3h4RMrwtZNOjMr/xxxnApOQjBLr70Q8MlYnAhXrIyLjNOaMabMKVxDEltrvN2rCWfN/DFyRi4c5GiDKk1/lwlfO9dRieUqXm9J670PWhwx jan.mussler@zalando.de'
+  - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDOjGGBqrWGdbh0yfkBRE04IbdiAP2TJ2RXnfnp3OV8Lw+jg7cUqeZA5l2vIhFd2ctKPd5OGE3K/A6xCK3hFV9V01oYbH8S3IvrhyA+VjBG0d/ZgTm6GCrlE4XeAt9/ourBSxrrE04lfO786dhLsGEOa5WvvSG3Z/6BhyC/1e5Bd37nnWB363fjAsbg1UgSPr99QZQ5l2mSxN4i2IpJjULBWpLvrJLLJzzl67aaVhDjdtggEU+pMsOoRpDuJ46cYMMDvBI9gyyal2G1aIkqu9iejt1bly53Th2ZAiXecXxEh4K3a5H/Czf70vpCzXQiG1OuZRD1PaSpqw4+zzcizZdX matthias@zalando.de'
+  - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCs4NhH7uwlnklYYlV1GP57XX9NHYgXNv0njfEVowR1jFSKiMdEUtPKz5lOAeDtKpck9HyjxVOTSutNOIBZkkgN/FgkcpNbc59nIO4ELUzipkJivuYNO1lDAjCQi1qwYo+uksiNfcsao9mn7nd9Rh1g8TXYv95TSvml9v/Dolmanm1qj6OkbDw1xIurnNsoCjdxCWwSRGNja4r+PQc8pi+1xpdUBEvn40CeBdU7b/hZnv/BM9FIKSsVlIwMR2i/Co2rxCKo9B3q4dmdQ/2C1QczINVpPQcNUMuiljJFMXvT7dgfNsnUBe8vFuoPgqohJ/m8AiKZZOyoRNiCuELnKLRKqxosDmJz47Y0YiYgZk9jpnmt+x1fwqhY2R85F7W4RybpX3AFL1jOqOT2lE+idkhyeFq/pPoAiPvUcpQSmL9AwlrG6cPklTJZW+dUzH/W6kNlgl/T6hnMn4Mu+IljG08Iyb/HBdmOX+uRq5wdF8lI9Zjzlwg+j7HMa3p1O7MNwpSJVjVXkhUXH0WrFrK2JkwgXokIWvu0o+lajYOmXRQeGCyVybg06WFCzOXnK2toVucFMuAGoM0NkthAnodZCk+xXLNrtHOYagpdJ/x/Q88vuDsZr7IG0NvgX/OCq1a5lpnIydCe+tABNNKcRaOuOLbDYVgUaeVzIXyJjRYu5ZN/JQ== mikkel.larsen@zalando.de'
+  - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAEAQCry4lt7DKc4yQpWIsvIIzWlBYBJifhX+1BZueb8jXpeVyiqL4U4S/XyR4QPRvIxB5JY1rc1y/Mo6+J6XpbhIfSJROMSaFWcsisRj2/lmvrU9RmhSefpQgB04qQcXejy6WqCyYYQSUwwbbObmq/mFZLt4iMI3J5oDyN5Fg5+8JXb4udDZQLJuH7qIkt+MZuy8v7HtSK03lEmDlAm14D9zndFEfSDfituUk/X/K5N7Li6dGYf4JLqIuX5yf2HoNyCCDrtUm9E/pUvBxrnPEtALBuMf8hd+hgNhJmiX2sZgSQHV9XhYLlNUshw+uZ7YVFOaYi3OQUn5pJVKFuxF5LftsXWl1xlFRy7SS2Vf5emMBXOmVTcDKFIghpojtsmsq53lvu2YSBZ6BJP2cqgD5HLw3xgqn6uzYaJCbCdiJZsGQ7Gly/fShR0ebOuvbumJpxegCE54pps3icwhvEhqbWhTv+z/zuvH1z5rqod1+GvrH6kjA80+cjv56zgLR77EHXnhwrTsDgb5KWm9Qktl/bbfnrYzT889/4gzE+3IO/RBHgM12aAHFCc1G9Kp/25iEK/2b3t6Qw1sikNo/0BRD4Y1CakTXtZOvp7nNOCZSAUY0PXsrKF82sDWIgccgeiNebxS1ESU0JQVDzzKZ/HmOP5fCRFC3nQnZtk/5/nj6iRiH22gcRl77Cv3k7MpX9MnpVE5Duk7VL0wnVQ8xJ7mNbUSzadsyJHbvBjfsWL2C+s6LC0ApAVBXekcymvkqP7nZwPj8XCrN0nWhBBGym6VUwDdLI9dedWd3XJrhgmbmc74xOhYHTTNVpiuHpYNb90G+0O/GHWaAY76fg4YvR+OwZVbPu8a36EhYMuzsNEshzwnAxh/1PHrGH7X2aHc+E37f5/hTL9QArqdiIhqt0iMCXMF89mlNlQ8oC6FgmaFlMub4fX7Sy6tkzl3W9pqQvAVlFxvCQ2zApYYsMwJDgwQRkxCX0ohzDYKvnFXLHGi3M+mKZQfDEe2KNOJaB8vBc3G0veTiH3fnveB/NtmsvYiBBQn+Z/Ftiezb8ApnE6GJofKBVA+ijCO4eKyYOuozik+oKJ4F2wLnDZM2rRJU/uxZhGrg50cPv62Hszhc3m3WGLMHJ9lntK1mDpZds6xbF4DccsE81Of11hZnTE8sookAKRt1FIL+kZd564JWaD9iM3SQuTXdCK/46Ms+Dmr5/MCMlGSNyRw52OZ1m1R5s+yMDBddGwMf5xh6s5Mh2G9bODETueEDPlYNiQCQw5Rx19ZT/W/CaaPswTYPYIgAQNXg8XnWzdKDCTqZ2z6LMwfyEAgaHIPoubLPVKk0iPWYnS2BpfrxdeG/DeywDVf2GEgnkdaVD martin.linkhorst@zalando.de'
+  - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCuFg0sZtpORWFESaGFnDHYPDG2mYAEsg3pz2yvLn8L2U4b+clIqzQyMjjnze/syB979hVxAucb5A7YR8s7jPIcHUsTcLdGJUNATxiYSdReFj+6ki+6vk01zf9fTVrmAy39SYMi0hSicyMpQL7ur1osnqZ/OEq7+m/qJD6dQ5KpSMVr72kcdXqObEGxIKwPSJlyZ2df1UoMxuslLeGzovuNfngFMTpE7K6A1Nuysn0Vm4EIJ1/UC1nADbTsRexpwCD/7ZanS349RGhGA7SLeXKwSEejL6IkaMF6mWyy4+IWeKraSogw73oM9Quyzq72AwZos4WTb61DVWcRaRXj0D1/ raffaele.di.fazio@zalando.de'
+  - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqAikaHsZWMuJvKZphZPZG0fnKMvVCRfBAbIS6e0Y+YqM0PfsWgB5e4f5TrbisQHdKopbfZVwYIaV/NegEuinrYPKC7t2ese/HjxgjHR95zHOcDP19Cbo+xeyH8zbRd9K3iRSyCUSMNRw5NL6zN8JOSl12m8QWQA4hTjFTmt870fIT4RLxu9qGlbQipUm57E/SotsNC41MQ/PsLQzOAviKrkS1rei2vzRHzAcjz1Z7GT5oH+dFVUC66kKa0XWDvq+VtkRVoLvS2chrIPCgESeeZAyOKyiOoyJxFFFiMVK48MWDBBIYTIsHE0qs/RwBi9+8lQGiHK5Rpk2djcloO0c7 sandor.szuecs@zalando.de'
+  - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCa6Sj76tQ/nyCbkAd5zL/ZPhH+4lfuBT7fFXfamRnIiA3LVXp5/0R8vhvXOYL5Q6uclr5n8sJD1IcwpYTkQrV+u7+PKnbBJZjYDgsbcDr843jzDHhJOzWiKpB5fFcu4Ll5pYVyXq3CgsTuNKBUCnQJEtx7WLRBAFoHZuicp9IjfXfyEVclcKvlGfWBFnidaSCrv2MKKCfqYwif8bY1PSnDYaqsqCrptZkzvuFlcewtsp2t12W760LiZlAB8RRM9SE5DdTYqyeLB2NymI0JecFM+yW/p3bRp6NZt63w9N/IqjQw5aJwAJfEzrb2dVKlr9y7TXyKZPfElvzPEsujTZBOTZs4uRfTMdPsAJj8qB/hNvdIfaFLn9KNQvzhwOjk8zjYU5NhZMUu5T8VBby8tcg9DLFfIqLJxoD1E1UHkOXCIuA3jhF6zre2d6cUeLmatsuOmd2OYeAcy9s3GOOjn/zCpIZ9k5eDLaWKwBgNFnNVznWdOgpd5BaY5PE1wS6655/po7hEngE3KWaNcmHV7AuQteozWYNNbIZy78UZ2p9LDm7v78BP5UNy834kSOu8MUQN2hNJ9hZ4x0MI2F6nmDKxqxAfkH9LBQ3Mf6FfJsV0+GSrLnI0mvmBcZp9/LOwcBAjf9MyHN3IcFbTxiQATaj7rXnYoBi88g9l4lQObiBNXQ== yerken.tussupbekov@zalando.de'
 coreos:
   update:
     reboot-strategy: "off"
@@ -118,17 +126,6 @@ coreos:
         [Install]
         WantedBy=multi-user.target
 
-    - name: install-ssh-keys.service
-      command: start
-      enable: true
-      content: |
-        [Unit]
-        Description=install personal SSH keys
-
-        [Service]
-        Type=oneshot
-        ExecStart=/opt/bin/install-ssh-keys
-
     - name: install-microscope.service
       command: start
       runtime: true
@@ -218,18 +215,6 @@ write_files:
       cd /opt
       curl -O https://test.docker.com/builds/Linux/x86_64/docker-1.13.0-rc2.tgz
       tar xzf docker-1.13.0-rc2.tgz
-
-
-
-  - path: /opt/bin/install-ssh-keys
-    permissions: 0700
-    owner: root:root
-    content: |
-      #!/bin/bash -e
-      for uid in mabdelhameed hjacobs mkerk sszuecs rdifazio mlinkhorst mlarsen tsarnowski lmineiro aryszka apfeiffer ytussupbekov; do
-          /usr/bin/curl -s https://even.stups.zalan.do/public-keys/$uid/sshkey.pub -o /home/core/.ssh/authorized_keys.d/$uid
-      done
-      /usr/bin/update-ssh-keys
 
   - path: /etc/kubernetes/cni/docker_opts_cni.env
     content: |

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -1,6 +1,14 @@
 #cloud-config
 ssh_authorized_keys:
-  - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCpzwYq1DHpE45uNin32k3KchWGHSPjGgpDrrl7d9fiP6ByIhhkeG/0sHqy9MC5r5OOsBwjlUlVZv1fZv42ei9tv94qeHL9vIMLeYGSeZLF+iqYGJAGTOMViptJb1K3OdBk6s/+nJCIA4agbKOh3E4f+EdxUMOA/rllx3dBtFv8LE2CAAFH0g5b5nGdHbOyLCI1qeG54q7zpKK/oJxWoHBSNSekVlQV0/i9DelFfOf2W6r+ugXD4h5msL9doHvpqnq0xcjJ+nc9u1FE9BwkjfgIZEmb9mDMaBUIqtEJ2TzwP3aQ+RPCmPqMGiC2/FmCnY1imhGjX13H00o1/j9Qvj/j9i7D6hNVi7/zom+yail+W6E/s1wWmkAI4yLq0VAt9M4F860m464UFUpkBw0IFzYvsyA/OoB7Az6R36ilHZ4EhCTvbP2AH5OYzE68w0+8E28Xb3cet7PSUO1qZ9DrfMzHxbiZduCgn+GgdJ5QUMiel2X8e8+7J72JBzjbvwkx5qFGRgnKI1TAhxO50LQfWerB1ND21DMYldiqTqkmyKtxsn9pZiK0QHl31Q01gUJVnHprMzj5fvMe4EH4cCB4qeddKjUQYo5javV6yL7WQB4igdQF3gLy1EC1DoC5y/3BGjMJVSDAS8rHk/o+ATpJRJvhH8fK8Es+4x68vHU0tIDoZw== cardno:000604137982"
+  - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC8yXjMX812gbdUsosLvIA/zPrRZI+iOKo8Igq7eiwRTeJKxIkRd2vxDGDfqzCnMhUPPgLW7YM0FWt1u8ZTlXyL4fv1KZuYMRF+27GuU2b/IKu4JYlHDDHrvKCr9tyKb+YVPrAfzi2xVRTGGZG6GRmAiDw8HSUFdejuDLIropAFQu9gAow9aiuQG6kmxZK8qdwIu03eZhuUHCRySCPbusjO+I2JEyVa7lM+P1zt2znDwXsdGjTzHE7NSu5z/VHzho3STWolBm5Vk8uLNYKhjs0eiw/FXV5t+c08Y3JA1LwjAmfOBS23ERSHMG8I3EVSnB9utrdLXejwFAV/jY+Dl2QX9o8brFePBe26MbSg9udD0yfrVz4HEG6NigK6sSx97Zs0lcaSwvjJsnp/J3B1IQMlNRLJGQ7WxM9H2rtoMmD7/iPdADevehEui8C9iaADk6j8AWtN0SJbccSvidrFXW7eH/YSYW394rk8Cl1xBk2RORv3OGVy/RNVt6/Pk/BzvqKf3RvKlbvbFZsWeBSZHDAKeer7001g8HmKV7c8fnDsxIU9Ro3aeWpsX1rQ/jzH1an2deXzVDX1Xbm80VmL5M53dr4w2ZiF5uEIODEUr2nssvl6fhdnaXmbO0vsIyOVawl8mkQ7CBsW06Q+kNs7iDvwVmoG/DD0k4i86La2TBpGvQ== andre.hartmann@zalando.de'
+  - 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAt8djQXfn5U7H85oDzuZRfRONF+jVqn3Mp9t3tnBrJdKyTccfDovq1sekzEdOFdmj74yfS8bzaIO9pDUczy6j5k2MtDCoRnzAO6KZc46jMJ2GjhLArUuHLjmAw2r9LotZ30LEIEvJdmUI7mDlPMczv381PghyM8+DsYv62UrfjDiOsZ4EVkYnztQlO3ntNE16RFNj4fbfErQz67kmw0lB8C6bAf0RuRmvXzB7xRMplmknQnLusoURmySKdZM0GUe0VY6fmqOsgzHVLoEs1m82V8QK1ac/1DSHA91v50MbpCjTVLaRhjR8nmhWBedlhb6j5ClZdAQ8iwyyWC1MFQuvKw== henning@zalando.de'
+  - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDIgO42Rr98DRo4N86Uk4cqHcnbA0iPhL7/DQXRNs+o2vfnfoTVNQiyfq8XzScb+pRJpiq2wW2OthMVRUJsiO4PECw7avYAi0M8cyCsu+ZUoIeMlu+TssWA00GZgdKcQKyCoyLlGbPu2z4GpM9tX+7ASMbMuk6fpm6n9af1YbTm2eqKKXpHDJO+aex3WCj1VyQpCgCD4zquGRy8JRSiQ+QGyGZHIzWWpo3Lc1xGqSQu6L3h4RMrwtZNOjMr/xxxnApOQjBLr70Q8MlYnAhXrIyLjNOaMabMKVxDEltrvN2rCWfN/DFyRi4c5GiDKk1/lwlfO9dRieUqXm9J670PWhwx jan.mussler@zalando.de'
+  - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDOjGGBqrWGdbh0yfkBRE04IbdiAP2TJ2RXnfnp3OV8Lw+jg7cUqeZA5l2vIhFd2ctKPd5OGE3K/A6xCK3hFV9V01oYbH8S3IvrhyA+VjBG0d/ZgTm6GCrlE4XeAt9/ourBSxrrE04lfO786dhLsGEOa5WvvSG3Z/6BhyC/1e5Bd37nnWB363fjAsbg1UgSPr99QZQ5l2mSxN4i2IpJjULBWpLvrJLLJzzl67aaVhDjdtggEU+pMsOoRpDuJ46cYMMDvBI9gyyal2G1aIkqu9iejt1bly53Th2ZAiXecXxEh4K3a5H/Czf70vpCzXQiG1OuZRD1PaSpqw4+zzcizZdX matthias@zalando.de'
+  - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCs4NhH7uwlnklYYlV1GP57XX9NHYgXNv0njfEVowR1jFSKiMdEUtPKz5lOAeDtKpck9HyjxVOTSutNOIBZkkgN/FgkcpNbc59nIO4ELUzipkJivuYNO1lDAjCQi1qwYo+uksiNfcsao9mn7nd9Rh1g8TXYv95TSvml9v/Dolmanm1qj6OkbDw1xIurnNsoCjdxCWwSRGNja4r+PQc8pi+1xpdUBEvn40CeBdU7b/hZnv/BM9FIKSsVlIwMR2i/Co2rxCKo9B3q4dmdQ/2C1QczINVpPQcNUMuiljJFMXvT7dgfNsnUBe8vFuoPgqohJ/m8AiKZZOyoRNiCuELnKLRKqxosDmJz47Y0YiYgZk9jpnmt+x1fwqhY2R85F7W4RybpX3AFL1jOqOT2lE+idkhyeFq/pPoAiPvUcpQSmL9AwlrG6cPklTJZW+dUzH/W6kNlgl/T6hnMn4Mu+IljG08Iyb/HBdmOX+uRq5wdF8lI9Zjzlwg+j7HMa3p1O7MNwpSJVjVXkhUXH0WrFrK2JkwgXokIWvu0o+lajYOmXRQeGCyVybg06WFCzOXnK2toVucFMuAGoM0NkthAnodZCk+xXLNrtHOYagpdJ/x/Q88vuDsZr7IG0NvgX/OCq1a5lpnIydCe+tABNNKcRaOuOLbDYVgUaeVzIXyJjRYu5ZN/JQ== mikkel.larsen@zalando.de'
+  - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAEAQCry4lt7DKc4yQpWIsvIIzWlBYBJifhX+1BZueb8jXpeVyiqL4U4S/XyR4QPRvIxB5JY1rc1y/Mo6+J6XpbhIfSJROMSaFWcsisRj2/lmvrU9RmhSefpQgB04qQcXejy6WqCyYYQSUwwbbObmq/mFZLt4iMI3J5oDyN5Fg5+8JXb4udDZQLJuH7qIkt+MZuy8v7HtSK03lEmDlAm14D9zndFEfSDfituUk/X/K5N7Li6dGYf4JLqIuX5yf2HoNyCCDrtUm9E/pUvBxrnPEtALBuMf8hd+hgNhJmiX2sZgSQHV9XhYLlNUshw+uZ7YVFOaYi3OQUn5pJVKFuxF5LftsXWl1xlFRy7SS2Vf5emMBXOmVTcDKFIghpojtsmsq53lvu2YSBZ6BJP2cqgD5HLw3xgqn6uzYaJCbCdiJZsGQ7Gly/fShR0ebOuvbumJpxegCE54pps3icwhvEhqbWhTv+z/zuvH1z5rqod1+GvrH6kjA80+cjv56zgLR77EHXnhwrTsDgb5KWm9Qktl/bbfnrYzT889/4gzE+3IO/RBHgM12aAHFCc1G9Kp/25iEK/2b3t6Qw1sikNo/0BRD4Y1CakTXtZOvp7nNOCZSAUY0PXsrKF82sDWIgccgeiNebxS1ESU0JQVDzzKZ/HmOP5fCRFC3nQnZtk/5/nj6iRiH22gcRl77Cv3k7MpX9MnpVE5Duk7VL0wnVQ8xJ7mNbUSzadsyJHbvBjfsWL2C+s6LC0ApAVBXekcymvkqP7nZwPj8XCrN0nWhBBGym6VUwDdLI9dedWd3XJrhgmbmc74xOhYHTTNVpiuHpYNb90G+0O/GHWaAY76fg4YvR+OwZVbPu8a36EhYMuzsNEshzwnAxh/1PHrGH7X2aHc+E37f5/hTL9QArqdiIhqt0iMCXMF89mlNlQ8oC6FgmaFlMub4fX7Sy6tkzl3W9pqQvAVlFxvCQ2zApYYsMwJDgwQRkxCX0ohzDYKvnFXLHGi3M+mKZQfDEe2KNOJaB8vBc3G0veTiH3fnveB/NtmsvYiBBQn+Z/Ftiezb8ApnE6GJofKBVA+ijCO4eKyYOuozik+oKJ4F2wLnDZM2rRJU/uxZhGrg50cPv62Hszhc3m3WGLMHJ9lntK1mDpZds6xbF4DccsE81Of11hZnTE8sookAKRt1FIL+kZd564JWaD9iM3SQuTXdCK/46Ms+Dmr5/MCMlGSNyRw52OZ1m1R5s+yMDBddGwMf5xh6s5Mh2G9bODETueEDPlYNiQCQw5Rx19ZT/W/CaaPswTYPYIgAQNXg8XnWzdKDCTqZ2z6LMwfyEAgaHIPoubLPVKk0iPWYnS2BpfrxdeG/DeywDVf2GEgnkdaVD martin.linkhorst@zalando.de'
+  - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCuFg0sZtpORWFESaGFnDHYPDG2mYAEsg3pz2yvLn8L2U4b+clIqzQyMjjnze/syB979hVxAucb5A7YR8s7jPIcHUsTcLdGJUNATxiYSdReFj+6ki+6vk01zf9fTVrmAy39SYMi0hSicyMpQL7ur1osnqZ/OEq7+m/qJD6dQ5KpSMVr72kcdXqObEGxIKwPSJlyZ2df1UoMxuslLeGzovuNfngFMTpE7K6A1Nuysn0Vm4EIJ1/UC1nADbTsRexpwCD/7ZanS349RGhGA7SLeXKwSEejL6IkaMF6mWyy4+IWeKraSogw73oM9Quyzq72AwZos4WTb61DVWcRaRXj0D1/ raffaele.di.fazio@zalando.de'
+  - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqAikaHsZWMuJvKZphZPZG0fnKMvVCRfBAbIS6e0Y+YqM0PfsWgB5e4f5TrbisQHdKopbfZVwYIaV/NegEuinrYPKC7t2ese/HjxgjHR95zHOcDP19Cbo+xeyH8zbRd9K3iRSyCUSMNRw5NL6zN8JOSl12m8QWQA4hTjFTmt870fIT4RLxu9qGlbQipUm57E/SotsNC41MQ/PsLQzOAviKrkS1rei2vzRHzAcjz1Z7GT5oH+dFVUC66kKa0XWDvq+VtkRVoLvS2chrIPCgESeeZAyOKyiOoyJxFFFiMVK48MWDBBIYTIsHE0qs/RwBi9+8lQGiHK5Rpk2djcloO0c7 sandor.szuecs@zalando.de'
+  - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCa6Sj76tQ/nyCbkAd5zL/ZPhH+4lfuBT7fFXfamRnIiA3LVXp5/0R8vhvXOYL5Q6uclr5n8sJD1IcwpYTkQrV+u7+PKnbBJZjYDgsbcDr843jzDHhJOzWiKpB5fFcu4Ll5pYVyXq3CgsTuNKBUCnQJEtx7WLRBAFoHZuicp9IjfXfyEVclcKvlGfWBFnidaSCrv2MKKCfqYwif8bY1PSnDYaqsqCrptZkzvuFlcewtsp2t12W760LiZlAB8RRM9SE5DdTYqyeLB2NymI0JecFM+yW/p3bRp6NZt63w9N/IqjQw5aJwAJfEzrb2dVKlr9y7TXyKZPfElvzPEsujTZBOTZs4uRfTMdPsAJj8qB/hNvdIfaFLn9KNQvzhwOjk8zjYU5NhZMUu5T8VBby8tcg9DLFfIqLJxoD1E1UHkOXCIuA3jhF6zre2d6cUeLmatsuOmd2OYeAcy9s3GOOjn/zCpIZ9k5eDLaWKwBgNFnNVznWdOgpd5BaY5PE1wS6655/po7hEngE3KWaNcmHV7AuQteozWYNNbIZy78UZ2p9LDm7v78BP5UNy834kSOu8MUQN2hNJ9hZ4x0MI2F6nmDKxqxAfkH9LBQ3Mf6FfJsV0+GSrLnI0mvmBcZp9/LOwcBAjf9MyHN3IcFbTxiQATaj7rXnYoBi88g9l4lQObiBNXQ== yerken.tussupbekov@zalando.de'
 coreos:
   update:
     reboot-strategy: "off"
@@ -115,21 +123,6 @@ coreos:
         [Install]
         WantedBy=multi-user.target
 
-    - name: install-ssh-keys.service
-      enable: true
-      content: |
-        [Unit]
-        Description=install personal SSH keys
-        Before=kubelet.service
-
-        [Service]
-        Type=oneshot
-        RemainAfterExit=yes
-        ExecStart=/opt/bin/install-ssh-keys
-
-        [Install]
-        RequiredBy=kubelet.service
-
     - name: install-microscope.service
       command: start
       runtime: true
@@ -161,16 +154,6 @@ write_files:
     content: |
       DOCKER_OPT_BIP=""
       DOCKER_OPT_IPMASQ=""
-
-  - path: /opt/bin/install-ssh-keys
-    permissions: 0700
-    owner: root:root
-    content: |
-      #!/bin/bash -e
-      for uid in hjacobs mkerk sszuecs rdifazio mlinkhorst mlarsen tsarnowski lmineiro aryszka apfeiffer; do
-          /usr/bin/curl https://even.stups.zalan.do/public-keys/$uid/sshkey.pub -o /home/core/.ssh/authorized_keys.d/$uid
-      done
-      /usr/bin/update-ssh-keys
 
   - path: /opt/bin/host-rkt
     permissions: 0755


### PR DESCRIPTION
To avoid a runtime dependency to Even. Removed some non-authorized users and added 24x7 support users.