### PR TITLE
Remove hosted zone from senza definition and add NodePool tag to ASGs

### DIFF
--- a/cluster/cluster.py
+++ b/cluster/cluster.py
@@ -284,7 +284,7 @@ def create(stack_name, version, dry_run, instance_type, master_nodes, worker_nod
                                'MasterNodes={}'.format(master_nodes), 'WorkerNodes={}'.format(worker_nodes),
                                'MinimumWorkerNodes={}'.format(min_worker_nodes),
                                'MaximumWorkerNodes={}'.format(max_worker_nodes),
-                               'APIServerHostName={}'.format(variables['api_server']),
+                               'HostedZone={}'.format(variables['hosted_zone']),
                                'InstanceType={}'.format(instance_type), 'ClusterID={}'.format(variables['cluster_id'])])
         # wait up to 15m for stack to be created
         subprocess.check_call(['senza', 'wait', '--timeout=900', stack_name, version])
@@ -364,7 +364,7 @@ def update(stack_name, version, dry_run, force, instance_type, master_nodes, wor
                                'MasterNodes={}'.format(master_nodes), 'WorkerNodes={}'.format(worker_nodes),
                                'MinimumWorkerNodes={}'.format(min_worker_nodes),
                                'MaximumWorkerNodes={}'.format(max_worker_nodes),
-                               'APIServerHostName={}'.format(variables['api_server']),
+                               'HostedZone={}'.format(variables['hosted_zone']),
                                'InstanceType={}'.format(instance_type), 'ClusterID={}'.format(variables['cluster_id'])])
         # wait for CF update to complete..
         subprocess.check_call(['senza', 'wait', '--timeout=600', stack_name, version])

--- a/cluster/cluster.py
+++ b/cluster/cluster.py
@@ -280,6 +280,8 @@ def create(stack_name, version, dry_run, instance_type, master_nodes, worker_nod
     if not dry_run:
         subprocess.check_call(['senza', 'create', 'senza-definition.yaml', version, 'StackName={}'.format(stack_name),
                                'UserDataMaster={}'.format(userdata_master), 'UserDataWorker={}'.format(userdata_worker), 'KmsKey=*',
+                               'MasterNodePoolName=master-default',
+                               'WorkerNodePoolName=worker-default',
                                'MasterNodes={}'.format(master_nodes), 'WorkerNodes={}'.format(worker_nodes),
                                'MinimumWorkerNodes={}'.format(min_worker_nodes),
                                'MaximumWorkerNodes={}'.format(max_worker_nodes),
@@ -358,6 +360,8 @@ def update(stack_name, version, dry_run, force, instance_type, master_nodes, wor
         subprocess.check_call(['senza', 'update', 'senza-definition.yaml', version, 'StackName={}'.format(stack_name),
                                'UserDataMaster={}'.format(user_data_master),
                                'UserDataWorker={}'.format(user_data_worker), 'KmsKey=*',
+                               'MasterNodePoolName=master-default',
+                               'WorkerNodePoolName=worker-default',
                                'MasterNodes={}'.format(master_nodes), 'WorkerNodes={}'.format(worker_nodes),
                                'MinimumWorkerNodes={}'.format(min_worker_nodes),
                                'MaximumWorkerNodes={}'.format(max_worker_nodes),

--- a/cluster/cluster.py
+++ b/cluster/cluster.py
@@ -283,7 +283,7 @@ def create(stack_name, version, dry_run, instance_type, master_nodes, worker_nod
                                'MasterNodes={}'.format(master_nodes), 'WorkerNodes={}'.format(worker_nodes),
                                'MinimumWorkerNodes={}'.format(min_worker_nodes),
                                'MaximumWorkerNodes={}'.format(max_worker_nodes),
-                               'HostedZone={}'.format(variables['hosted_zone']),
+                               'APIServerHostName={}'.format(variables['api_server']),
                                'InstanceType={}'.format(instance_type), 'ClusterID={}'.format(variables['cluster_id'])])
         # wait up to 15m for stack to be created
         subprocess.check_call(['senza', 'wait', '--timeout=900', stack_name, version])
@@ -361,7 +361,7 @@ def update(stack_name, version, dry_run, force, instance_type, master_nodes, wor
                                'MasterNodes={}'.format(master_nodes), 'WorkerNodes={}'.format(worker_nodes),
                                'MinimumWorkerNodes={}'.format(min_worker_nodes),
                                'MaximumWorkerNodes={}'.format(max_worker_nodes),
-                               'HostedZone={}'.format(variables['hosted_zone']),
+                               'APIServerHostName={}'.format(variables['api_server']),
                                'InstanceType={}'.format(instance_type), 'ClusterID={}'.format(variables['cluster_id'])])
         # wait for CF update to complete..
         subprocess.check_call(['senza', 'wait', '--timeout=600', stack_name, version])

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -22,8 +22,8 @@ SenzaInfo:
           Description: "Type of instance"
       - ClusterID:
           Description: "ID of the cluster"
-      - APIServerHostName:
-          Description: "API Server host name"
+      - HostedZone:
+          Description: "Hosted DNS zone"
       - MasterNodePoolName:
           Description: "Name of the master node pool (ASG)"
       - WorkerNodePoolName:
@@ -51,8 +51,8 @@ SenzaComponents:
           LoadBalancerPort: 443
       ConnectionSettings:
         IdleTimeout: 300
-      VersionDomain: "{{ Arguments.APIServerHostName }}"
-      MainDomain: "{{ Arguments.APIServerHostName }}"
+      VersionDomain: "{{SenzaInfo.StackName}}-{{SenzaInfo.StackVersion}}.{{Arguments.HostedZone}}"
+      MainDomain: "{{SenzaInfo.StackName}}.{{Arguments.HostedZone}}"
       Tags:
         - Key: "KubernetesCluster"
           Value: kubernetes

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -22,8 +22,8 @@ SenzaInfo:
           Description: "Type of instance"
       - ClusterID:
           Description: "ID of the cluster"
-      - HostedZone:
-          Description: "Hosted DNS zone"
+      - APIServerHostName:
+          Description: "API Server host name"
 
 SenzaComponents:
   - Configuration:
@@ -47,8 +47,8 @@ SenzaComponents:
           LoadBalancerPort: 443
       ConnectionSettings:
         IdleTimeout: 300
-      VersionDomain: "{{SenzaInfo.StackName}}-{{SenzaInfo.StackVersion}}.{{Arguments.HostedZone}}"
-      MainDomain: "{{SenzaInfo.StackName}}.{{Arguments.HostedZone}}"
+      VersionDomain: "{{ Arguments.APIServerHostName }}"
+      # MainDomain: "{{ Arguments.APIServerHostName }}"
       Tags:
         - Key: "KubernetesCluster"
           Value: kubernetes

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -24,6 +24,10 @@ SenzaInfo:
           Description: "ID of the cluster"
       - APIServerHostName:
           Description: "API Server host name"
+      - MasterNodePoolName:
+          Description: "Name of the master node pool (ASG)"
+      - WorkerNodePoolName:
+          Description: "Name of the worker node pool (ASG)"
 
 SenzaComponents:
   - Configuration:
@@ -48,7 +52,6 @@ SenzaComponents:
       ConnectionSettings:
         IdleTimeout: 300
       VersionDomain: "{{ Arguments.APIServerHostName }}"
-      # MainDomain: "{{ Arguments.APIServerHostName }}"
       Tags:
         - Key: "KubernetesCluster"
           Value: kubernetes
@@ -82,6 +85,8 @@ SenzaComponents:
           Value: kubernetes
         - Key: "ClusterID"
           Value: "{{ Arguments.ClusterID }}"
+        - Key: "NodePool"
+          Value: "{{ Arguments.MasterNodePoolName }}"
   - WorkerAutoScaling:
       Type: Senza::AutoScalingGroup
       InstanceType: "{{ Arguments.InstanceType }}"
@@ -110,6 +115,8 @@ SenzaComponents:
           Value: kubernetes
         - Key: "ClusterID"
           Value: "{{ Arguments.ClusterID }}"
+        - Key: "NodePool"
+          Value: "{{ Arguments.WorkerNodePoolName }}"
   - WorkerLoadBalancer:
       Type: Senza::ElasticLoadBalancer
       NameSuffix: worker

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -52,6 +52,7 @@ SenzaComponents:
       ConnectionSettings:
         IdleTimeout: 300
       VersionDomain: "{{ Arguments.APIServerHostName }}"
+      MainDomain: "{{ Arguments.APIServerHostName }}"
       Tags:
         - Key: "KubernetesCluster"
           Value: kubernetes

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -378,7 +378,7 @@ write_files:
             - name: TOKENINFO_URL
               value: https://info.services.auth.zalando.com/oauth2/tokeninfo
             - name: USER_GROUPS
-              value: stups_autobahn=Administrator,stups_deployment-controller-ui=ReadOnly,credentials-provider=Administrator,credprov-kube-ops-view-read-only-token=ReadOnly,credprov-cluster-lifecycle-manager-cluster-rw-token=Administrator
+              value: stups_autobahn=Administrator,stups_deployment-controller-ui=ReadOnly,credentials-provider=Administrator,credprov-kube-ops-view-read-only-token=ReadOnly,credprov-cluster-lifecycle-manager-cluster-rw-token=Administrator,credprov-cluster-lifecycle-manager-test-cluster-rw-token=Administrator
         - name: nginx
           image: registry.opensource.zalan.do/teapot/nginx:1.11.5
           resources:


### PR DESCRIPTION
These are the changes required for getting rid of cluster.py in the CLM.

This removes the need for constructing the apiserver url from the hosted zone and instead passes the apiserver url directly to the senza definition.

It also introduces `NodePool` tags on the autoscaling groups (master and worker) so it's possible to lookup the ASG by the tagged node pool name. Currently the node pool names are just hardcoded in cluster.py so it's still compatible. I can also pass these values in flags if you prefer.