### PR TITLE
revert s3 prefix

### DIFF
--- a/cluster/manifests/secretary/deployment.yaml
+++ b/cluster/manifests/secretary/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         args:
         - /meta/credentials
         - --application-id=secretary
-        - --mint-bucket={{.ConfigItems.gerry_mint_bucket}}
+        - --mint-bucket=s3://{{.ConfigItems.gerry_mint_bucket}}
         volumeMounts:
         - mountPath: /meta/credentials
           name: credentials


### PR DESCRIPTION
no idea why it ends up here: https://github.bus.zalan.do/teapot/gerry/blob/master/downloaders/downloaders.go#L47-L49

but it does when removing the prefix.