### PR TITLE
#239 define default requests for "default" namespace

### DIFF
--- a/cluster/manifests/default-limits/limits.yaml
+++ b/cluster/manifests/default-limits/limits.yaml
@@ -9,3 +9,6 @@ spec:
       defaultRequest:
         cpu: "100m"
         memory: 100Mi
+      default:
+        cpu: "1000m"
+        memory: 1Gi

--- a/cluster/manifests/default-limits/limits.yaml
+++ b/cluster/manifests/default-limits/limits.yaml
@@ -1,0 +1,11 @@
+apiVersion: "v1"
+kind: "LimitRange"
+metadata:
+  name: "limits"
+  namespace: default
+spec:
+  limits:
+    - type: "Container"
+      defaultRequest:
+        cpu: "100m"
+        memory: 100Mi


### PR DESCRIPTION
Define some reasonable defaults. This will not limit users, but it makes sure that all pods have at least 100m CPU and 100Mi memory requested (important for scheduler) and also some sane memory limit (1Gi). All values can be overwritten by users in the pod spec.

