### PR TITLE
enable PodSecurityPolicy

### DIFF
--- a/cluster/cluster.py
+++ b/cluster/cluster.py
@@ -400,7 +400,7 @@ def longest_grace_period(node_name: str, config: dict):
     pods = resp.json()
     grace_period = 0
     if not pods:
-        print("resp:", resp)
+        warning("Response does not contain valid json {}", resp)
         return grace_period
     for pod in pods["items"]:
         grace_period = max(pod["spec"]["terminationGracePeriodSeconds"], grace_period)

--- a/cluster/cluster.py
+++ b/cluster/cluster.py
@@ -396,8 +396,12 @@ def longest_grace_period(node_name: str, config: dict):
     """
     headers = {"Authorization": "Bearer {}".format(config["worker_shared_secret"])}
     params = {"fieldSelector": "spec.nodeName={}".format(node_name)}
-    pods = requests.get(config["api_server"] + "/api/v1/pods", params=params, headers=headers, timeout=5).json()
+    resp = requests.get(config["api_server"] + "/api/v1/pods", params=params, headers=headers, timeout=5)
+    pods = resp.json()
     grace_period = 0
+    if not pods:
+        print("resp:", resp)
+        return grace_period
     for pod in pods["items"]:
         grace_period = max(pod["spec"]["terminationGracePeriodSeconds"], grace_period)
     return grace_period

--- a/cluster/manifests/psp/pod_security_policy.yaml
+++ b/cluster/manifests/psp/pod_security_policy.yaml
@@ -33,4 +33,10 @@ spec:
   supplementalGroups:
     rule: RunAsAny
   volumes:
-  - '*'
+  - emptyDir
+  - awsElasticBlockStore
+  - secret
+  - persistentVolumeClaim
+  - downwardAPI
+  - configMap
+

--- a/cluster/manifests/psp/pod_security_policy.yaml
+++ b/cluster/manifests/psp/pod_security_policy.yaml
@@ -9,7 +9,7 @@ spec:
   hostNetwork: true
   hostPorts:
   - max: 10000
-    min: 1025
+    min: 50
   runAsUser:
     rule: RunAsAny
   seLinux:

--- a/cluster/manifests/psp/pod_security_policy.yaml
+++ b/cluster/manifests/psp/pod_security_policy.yaml
@@ -7,6 +7,9 @@ spec:
     rule: RunAsAny
   privileged: true
   hostNetwork: true
+  hostPorts:
+  - max: 10000
+    min: 1025
   runAsUser:
     rule: RunAsAny
   seLinux:
@@ -31,4 +34,3 @@ spec:
     rule: RunAsAny
   volumes:
   - '*'
-

--- a/cluster/manifests/psp/pod_security_policy.yaml
+++ b/cluster/manifests/psp/pod_security_policy.yaml
@@ -6,6 +6,7 @@ spec:
   fsGroup:
     rule: RunAsAny
   privileged: true
+  hostNetwork: true
   runAsUser:
     rule: RunAsAny
   seLinux:

--- a/cluster/manifests/psp/pod_security_policy.yaml
+++ b/cluster/manifests/psp/pod_security_policy.yaml
@@ -1,0 +1,33 @@
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: privileged
+spec:
+  fsGroup:
+    rule: RunAsAny
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+---
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: restricted
+spec:
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -316,11 +316,11 @@ write_files:
           - --service-cluster-ip-range=10.3.0.0/24
           - --secure-port=443
           - --advertise-address=$private_ipv4
-          - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota
+          - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,PodSecurityPolicy
           - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
           - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
           - --service-account-key-file=/etc/kubernetes/ssl/apiserver-key.pem
-          - --runtime-config=extensions/v1beta1/networkpolicies=true,batch/v2alpha1=true
+          - --runtime-config=extensions/v1beta1/networkpolicies=true,batch/v2alpha1=true,extensions/v1beta1/podsecuritypolic=true
           - --authentication-token-webhook-config-file=/etc/kubernetes/config/authn.yaml
           - --cloud-provider=aws
           - --authorization-mode=Webhook

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -358,7 +358,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.0-1-g6cf3a23-dirty
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.0-2-gd5a8738-dirty
           name: webhook
           ports:
           - containerPort: 8081

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -358,7 +358,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.0
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.0-1-g6cf3a23-dirty
           name: webhook
           ports:
           - containerPort: 8081

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -354,7 +354,7 @@ write_files:
           resources:
             requests:
               cpu: 100m
-              memory: 500Mi
+              memory: 200Mi
             limits:
               cpu: 200m
               memory: 1Gi
@@ -449,7 +449,7 @@ write_files:
               memory: 500Mi
             requests:
               cpu: 100m
-              memory: 200Mi
+              memory: 100Mi
           livenessProbe:
             httpGet:
               host: 127.0.0.1

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -358,7 +358,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.0-3-g7e9fb0d-dirty
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.0-6-g372fc9f
           name: webhook
           ports:
           - containerPort: 8081

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -320,7 +320,7 @@ write_files:
           - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
           - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
           - --service-account-key-file=/etc/kubernetes/ssl/apiserver-key.pem
-          - --runtime-config=extensions/v1beta1/networkpolicies=true,batch/v2alpha1=true,extensions/v1beta1/podsecuritypolic=true
+          - --runtime-config=extensions/v1beta1/networkpolicies=true,batch/v2alpha1=true,extensions/v1beta1/podsecuritypolicy=true
           - --authentication-token-webhook-config-file=/etc/kubernetes/config/authn.yaml
           - --cloud-provider=aws
           - --authorization-mode=Webhook

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -358,7 +358,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.0-6-g372fc9f
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.1
           name: webhook
           ports:
           - containerPort: 8081

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -358,7 +358,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.0-2-gd5a8738-dirty
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.0-3-g7e9fb0d-dirty
           name: webhook
           ports:
           - containerPort: 8081


### PR DESCRIPTION
This can be used for a discussion on what kind of PSP we want to have.

This PR shows how to enable PSP and use a hack in the webhook to disallow PowerUsers to create privileged containers. The webhook will only allow restricted PODs for PowerUsers.