### PR TITLE
kube-aws-autoscaler

### DIFF
--- a/cluster/manifests/cluster-autoscaler/deployment.yaml
+++ b/cluster/manifests/cluster-autoscaler/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: cluster-autoscaler
-    version: v0.3.2
+    version: v0.2
 spec:
   replicas: 1
   selector:
@@ -15,30 +15,19 @@ spec:
     metadata:
       labels:
         application: cluster-autoscaler
-        version: v0.3.2
+        version: v0.2
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
         iam.amazonaws.com/role: "{{ .LocalID }}-app-autoscaler"
     spec:
       containers:
-        - image: registry.opensource.zalan.do/teapot/aws-k8s-cluster-autoscaler:0.3.2
+        - image: registry.opensource.zalan.do/teapot/kube-aws-autoscaler:0.2
           name: cluster-autoscaler
           resources:
             limits:
-              cpu: 250m
-              memory: 500Mi
+              cpu: 200m
+              memory: 100Mi
             requests:
-              cpu: 100m
+              cpu: 50m
               memory: 50Mi
-          command:
-            - ./cluster-autoscaler
-            - --v=9
-            - --cloud-provider=aws
-            - --skip-nodes-with-local-storage=false
-            - --leader-elect=false
-            - --scale-down-unneeded-time=45m0s
-          env:
-            - name: AWS_REGION
-              value: {{ .Region }}
-          imagePullPolicy: "Always"


### PR DESCRIPTION
Replace the contrib/cluster-autoscaler with [kube-aws-autoscaler](https://github.com/hjacobs/kube-aws-autoscaler). This is not necessarily the final solution, but it improves the current situation:

* we are already running `kube-aws-autoscaler` (deployed manually to `default` namespace) in all clusters, but it currently "competes" with `contrib/cluster-autoscaler`, i.e. it does most of the scaling, but at some point `contrib/cluster-autoscaler` might decide to scale down (as it does not incorporate any buffer) and  `kube-aws-autoscaler` will scale up one minute later again
* it applies a 10% resource buffer, i.e. it ensures that always at least 10% of the requested resources are free --- this prevents deployments from waiting on cluster scaling (the situation we observed before with  `contrib/cluster-autoscaler`)
* it quickly scales down (but at most one node at a time) which helps "recovering" from our CLM node update loop (scaling up by one instance every time)
* it's completely "deterministic" as it simply calculates the required number of nodes from the given resource requests, see https://github.com/hjacobs/kube-aws-autoscaler#how-it-works for details on the algorithm
