### PR TITLE
Kube node drainer

### DIFF
--- a/cluster/manifests/cluster-autoscaler/deployment.yaml
+++ b/cluster/manifests/cluster-autoscaler/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: cluster-autoscaler
-    version: v0.2
+    version: v0.3-3
 spec:
   replicas: 1
   selector:
@@ -15,14 +15,14 @@ spec:
     metadata:
       labels:
         application: cluster-autoscaler
-        version: v0.2
+        version: v0.3-3
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
         iam.amazonaws.com/role: "{{ .LocalID }}-app-autoscaler"
     spec:
       containers:
-        - image: registry.opensource.zalan.do/teapot/kube-aws-autoscaler:0.2
+        - image: registry.opensource.zalan.do/teapot/kube-aws-autoscaler:0.3-3-g56f0ca4
           name: cluster-autoscaler
           resources:
             limits:

--- a/cluster/manifests/cluster-autoscaler/deployment.yaml
+++ b/cluster/manifests/cluster-autoscaler/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: cluster-autoscaler
-    version: v0.3-3
+    version: v0.4
 spec:
   replicas: 1
   selector:
@@ -15,14 +15,14 @@ spec:
     metadata:
       labels:
         application: cluster-autoscaler
-        version: v0.3-3
+        version: v0.4
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
         iam.amazonaws.com/role: "{{ .LocalID }}-app-autoscaler"
     spec:
       containers:
-        - image: registry.opensource.zalan.do/teapot/kube-aws-autoscaler:0.3-3-g56f0ca4
+        - image: registry.opensource.zalan.do/teapot/kube-aws-autoscaler:0.4
           name: cluster-autoscaler
           resources:
             limits:

--- a/cluster/manifests/cluster-autoscaler/deployment.yaml
+++ b/cluster/manifests/cluster-autoscaler/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: cluster-autoscaler
-    version: v0.4
+    version: v0.5
 spec:
   replicas: 1
   selector:
@@ -15,14 +15,14 @@ spec:
     metadata:
       labels:
         application: cluster-autoscaler
-        version: v0.4
+        version: v0.5
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
         iam.amazonaws.com/role: "{{ .LocalID }}-app-autoscaler"
     spec:
       containers:
-        - image: registry.opensource.zalan.do/teapot/kube-aws-autoscaler:0.4
+        - image: registry.opensource.zalan.do/teapot/kube-aws-autoscaler:0.5
           name: cluster-autoscaler
           resources:
             limits:

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -210,6 +210,7 @@ Resources:
           - {Action: 'ec2:Describe*', Effect: Allow, Resource: '*'}
           - {Action: 'autoscaling:DescribeAutoScalingGroups', Effect: Allow, Resource: '*'}
           - {Action: 'autoscaling:DescribeAutoScalingInstances', Effect: Allow, Resource: '*'}
+          - {Action: 'autoscaling:DescribeScalingActivities', Effect: Allow, Resource: '*'}
           - {Action: 'autoscaling:SetDesiredCapacity', Effect: Allow, Resource: '*'}
           - {Action: 'autoscaling:TerminateInstanceInAutoScalingGroup', Effect: Allow, Resource: '*'}
           Version: '2012-10-17'

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -34,7 +34,7 @@ SenzaComponents:
       Type: Senza::CoreosAutoConfiguration
       PublicOnly: true # use all public subnets
       DefineParameters: false # skip CF template parameter definition
-      ReleaseChannel: stable # see https://coreos.com/os/docs/latest/switching-channels.html
+      ReleaseChannel: alpha # see https://coreos.com/os/docs/latest/switching-channels.html
   - MasterLoadBalancer:
       Type: Senza::WeightedDnsElasticLoadBalancer
       HTTPPort: 443

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -36,10 +36,10 @@ coreos:
             After=flanneld.service
             [Service]
             EnvironmentFile=/etc/kubernetes/cni/docker_opts_cni.env
-        - name: 50-logging.conf
+        - name: 60-dockeropts.conf
           content: |
             [Service]
-            Environment="DOCKER_OPTS=--log-opt=max-file=2 --log-opt=max-size=50m"
+            Environment="DOCKER_OPTS=--iptables=false --log-opt=max-file=2 --log-opt=max-size=50m"
 
     - name: flanneld.service
       drop-ins:

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -27,42 +27,7 @@ coreos:
       command: start
       runtime: true
 
-    - name: install-docker.service
-      command: start
-      runtime: true
-      content: |
-        [Service]
-        Type=oneshot
-        ExecStart=/opt/bin/install-docker
-
     - name: docker.service
-      content: |
-        [Unit]
-        Description=Docker Application Container Engine
-        Documentation=http://docs.docker.com
-        After=install-docker docker.socket early-docker.target network.target
-        Requires=install-docker docker.socket early-docker.target
-
-        [Service]
-        EnvironmentFile=-/run/flannel_docker_opts.env
-        EnvironmentFile=/etc/profile.env
-        MountFlags=slave
-        ExecStart=/opt/docker/dockerd --host=fd:// $DOCKER_OPTS $DOCKER_CGROUPS $DOCKER_OPT_BIP $DOCKER_OPT_MTU $DOCKER_OPT_IPMASQ
-        LimitNOFILE=1048576
-        # Having non-zero Limit*s causes performance problems due to accounting overhead
-        # in the kernel. We recommend using cgroups to do container-local accounting.
-        LimitNPROC=infinity
-        LimitCORE=infinity
-        # Uncomment TasksMax if your systemd version supports .
-        # Only systemd 226 and above support this version.
-        TasksMax=infinity
-        TimeoutStartSec=0
-        # set delegate yes so that systemd does not reset the cgroups of docker containers
-        Delegate=yes
-
-        [Install]
-        WantedBy=multi-user.target
-
       drop-ins:
         - name: 40-flannel.conf
           content: |
@@ -74,7 +39,7 @@ coreos:
         - name: 50-logging.conf
           content: |
             [Service]
-            Environment="DOCKER_OPTS=--debug --log-opt=max-file=2 --log-opt=max-size=50m"
+            Environment="DOCKER_OPTS=--log-opt=max-file=2 --log-opt=max-size=50m"
 
     - name: flanneld.service
       drop-ins:
@@ -139,21 +104,6 @@ coreos:
 
 write_files:
 
-  - path: "/etc/profile.env"
-    content: |
-      PATH="/opt/docker:/usr/sbin:$PATH"
-
-
-  - path: "/opt/bin/install-docker"
-    permissions: 0700
-    owner: root:root
-    content: |
-      #!/bin/bash -e
-      cd /opt
-      curl -O https://test.docker.com/builds/Linux/x86_64/docker-1.13.0-rc2.tgz
-      tar xzf docker-1.13.0-rc2.tgz
-
-
   - path: /etc/kubernetes/kubeconfig
     permissions: "0644"
     owner: core
@@ -206,15 +156,6 @@ write_files:
           cluster: authz-webhook
           user: authz-webhook-client
         name: authz-webhook
-
-  - path: /opt/bin/install-docker
-    permissions: 0700
-    owner: root:root
-    content: |
-      #!/bin/bash -e
-      cd /opt
-      curl -O https://test.docker.com/builds/Linux/x86_64/docker-1.13.0-rc2.tgz
-      tar xzf docker-1.13.0-rc2.tgz
 
   - path: /etc/kubernetes/cni/docker_opts_cni.env
     content: |

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -93,6 +93,36 @@ coreos:
         [Install]
         WantedBy=multi-user.target
 
+    - name: kube-node-drainer.service
+      enable: true
+      command: start
+      runtime: true
+      content: |
+        [Unit]
+        Description=drain this k8s node to make running pods time to gracefully shut down before stopping kubelet
+        Requires=docker.service
+        After=docker.service
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=true
+        ExecStart=/bin/true
+        TimeoutStopSec=120s
+        ExecStop=/bin/sh -c '/usr/bin/rkt run \
+        --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
+        --mount=volume=kube,target=/etc/kubernetes \
+        --net=host \
+        registry.opensource.zalan.do/teapot/hyperkube:v1.5.2_coreos.0 \
+          --exec=/kubectl -- \
+          --kubeconfig=/etc/kubernetes/kubeconfig \
+          drain $(hostname) \
+          --ignore-daemonsets \
+          --delete-local-data \
+          --force'
+
+        [Install]
+        WantedBy=multi-user.target
+
     - name: install-microscope.service
       command: start
       runtime: true

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -84,7 +84,9 @@ coreos:
         --require-kubeconfig \
         --cloud-provider=aws \
         --low-diskspace-threshold-mb=1000 \
-        --feature-gates=AllAlpha=true
+        --feature-gates=AllAlpha=true \
+        --system-reserved=cpu=100m,memory=164Mi \
+        --kube-reserved=cpu=100m,memory=282Mi
         Restart=always
         RestartSec=10
 

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -36,10 +36,10 @@ coreos:
             After=flanneld.service
             [Service]
             EnvironmentFile=/etc/kubernetes/cni/docker_opts_cni.env
-        - name: 50-logging.conf
+        - name: 60-dockeropts.conf
           content: |
             [Service]
-            Environment="DOCKER_OPTS=--log-opt=max-file=2 --log-opt=max-size=50m"
+            Environment="DOCKER_OPTS=--iptables=false --log-opt=max-file=2 --log-opt=max-size=50m"
 
     - name: kubelet.service
       command: start

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -81,7 +81,9 @@ coreos:
         --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \
         --cloud-provider=aws \
         --low-diskspace-threshold-mb=1000 \
-        --feature-gates=AllAlpha=true
+        --feature-gates=AllAlpha=true \
+        --system-reserved=cpu=100m,memory=164Mi \
+        --kube-reserved=cpu=100m,memory=282Mi
         Restart=always
         RestartSec=10
         [Install]

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -94,13 +94,14 @@ coreos:
       content: |
         [Unit]
         Description=drain this k8s node to make running pods time to gracefully shut down before stopping kubelet
-        After=multi-user.target
+        Requires=docker.service
+        After=docker.service
 
         [Service]
         Type=oneshot
         RemainAfterExit=true
         ExecStart=/bin/true
-        TimeoutStopSec=30s
+        TimeoutStopSec=40s
         ExecStop=/bin/sh -c '/usr/bin/rkt run \
         --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
         --mount=volume=kube,target=/etc/kubernetes \

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -27,43 +27,7 @@ coreos:
       command: start
       runtime: true
 
-
-    - name: install-docker.service
-      command: start
-      runtime: true
-      content: |
-        [Service]
-        Type=oneshot
-        ExecStart=/opt/bin/install-docker
-
     - name: docker.service
-      content: |
-        [Unit]
-        Description=Docker Application Container Engine
-        Documentation=http://docs.docker.com
-        After=install-docker docker.socket early-docker.target network.target
-        Requires=install-docker docker.socket early-docker.target
-
-        [Service]
-        EnvironmentFile=-/run/flannel_docker_opts.env
-        EnvironmentFile=/etc/profile.env
-        MountFlags=slave
-        ExecStart=/opt/docker/dockerd --host=fd:// $DOCKER_OPTS $DOCKER_CGROUPS $DOCKER_OPT_BIP $DOCKER_OPT_MTU $DOCKER_OPT_IPMASQ
-        LimitNOFILE=1048576
-        # Having non-zero Limit*s causes performance problems due to accounting overhead
-        # in the kernel. We recommend using cgroups to do container-local accounting.
-        LimitNPROC=infinity
-        LimitCORE=infinity
-        # Uncomment TasksMax if your systemd version supports .
-        # Only systemd 226 and above support this version.
-        TasksMax=infinity
-        TimeoutStartSec=0
-        # set delegate yes so that systemd does not reset the cgroups of docker containers
-        Delegate=yes
-
-        [Install]
-        WantedBy=multi-user.target
-
       drop-ins:
         - name: 40-flannel.conf
           content: |
@@ -165,19 +129,6 @@ coreos:
 
 
 write_files:
-
-  - path: "/etc/profile.env"
-    content: |
-      PATH="/opt/docker:/usr/sbin:$PATH"
-
-  - path: "/opt/bin/install-docker"
-    permissions: 0700
-    owner: root:root
-    content: |
-      #!/bin/bash -e
-      cd /opt
-      curl -O https://test.docker.com/builds/Linux/x86_64/docker-1.13.0-rc2.tgz
-      tar xzf docker-1.13.0-rc2.tgz
 
   - path: /etc/kubernetes/cni/docker_opts_cni.env
     content: |

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -123,6 +123,35 @@ coreos:
         [Install]
         WantedBy=multi-user.target
 
+    - name: kube-node-drainer.service
+      enable: true
+      command: start
+      runtime: true
+      content: |
+        [Unit]
+        Description=drain this k8s node to make running pods time to gracefully shut down before stopping kubelet
+        After=multi-user.target
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=true
+        ExecStart=/bin/true
+        TimeoutStopSec=30s
+        ExecStop=/bin/sh -c '/usr/bin/rkt run \
+        --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
+        --mount=volume=kube,target=/etc/kubernetes \
+        --net=host \
+        registry.opensource.zalan.do/teapot/hyperkube:v1.5.2_coreos.0 \
+          --exec=/kubectl -- \
+          --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
+          drain $(hostname) \
+          --ignore-daemonsets \
+          --delete-local-data \
+          --force'
+
+        [Install]
+        WantedBy=multi-user.target
+
     - name: install-microscope.service
       command: start
       runtime: true

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -103,7 +103,7 @@ coreos:
         Type=oneshot
         RemainAfterExit=true
         ExecStart=/bin/true
-        TimeoutStopSec=40s
+        TimeoutStopSec=120s
         ExecStop=/bin/sh -c '/usr/bin/rkt run \
         --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
         --mount=volume=kube,target=/etc/kubernetes \


### PR DESCRIPTION
Fixes #133 and #167.

* call `kubectl drain` before stopping Docker daemon in shutdown sequence
* use Docker 1.13 included in CoreOS alpha

Uses snippet from `kube-aws` for node draining: https://github.com/coreos/kube-aws/blob/9c77168c060e6584f871973f8a1a287f90137264/config/templates/cloud-config-worker#L164

I haven't found issues yet regarding Docker 1.13 and `iptables` as it was mentioned here: https://twitter.com/jbeda/status/826969113801093121

