### PR TITLE
Make kube-state-metrics service type clusterIP

### DIFF
--- a/cluster/manifests/kube-state-metrics/service.yaml
+++ b/cluster/manifests/kube-state-metrics/service.yaml
@@ -3,10 +3,8 @@ kind: Service
 metadata:
   name: kube-state-metrics
   namespace: kube-system
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   ports:
   - port: 80
     protocol: TCP


### PR DESCRIPTION
Since we have ZMON in the clusters there is no longer a need for exposing `kube-state-metrics` through an internal elb.

This changes the service to type `ClusterIP`.

This will cause problems on update because you can't change a `LoadBalancer` service to `ClusterIP` :X I do think however that it would be feasable to go to every cluster and delete the service manually for this update unless someone has a better proposal?