### PR TITLE
Configure SQL user and pass in ZMON worker

### DIFF
--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -44,6 +44,16 @@ spec:
               value: zmon:queue:default/16
             - name: WORKER_REDIS_SERVERS
               value: zmon-redis:6379
+            - name: WORKER_PLUGIN_SQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: zmon-worker
+                  key: sql-user
+            - name: WORKER_PLUGIN_SQL_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: zmon-worker
+                  key: sql-pass
 
             - name: OAUTH2_ACCESS_TOKEN_URL
               value: https://token.services.auth.zalando.com/oauth2/access_token?realm=/services

--- a/cluster/manifests/zmon-worker/secret.yaml
+++ b/cluster/manifests/zmon-worker/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: zmon-worker
+  namespace: kube-system
+type: Opaque
+data:
+  sql-user: {{ .ConfigItems.zmon_worker_plugin_sql_user }}
+  sql-pass: {{ .ConfigItems.zmon_worker_plugin_sql_pass }}


### PR DESCRIPTION
Configures sql user and pass for ZMON worker.

Things to note:

* Since the values are stored in a secret it will not update the pods when the secret is updated
* Being stored in a secret also means we have to base64 encode the password before encrypting it and storing it in the cluster-registry.