### PR TITLE
securityContext missing for node_exporter

### DIFF
--- a/cluster/manifests/prometheus-node-exporter/daemonset.yaml
+++ b/cluster/manifests/prometheus-node-exporter/daemonset.yaml
@@ -39,5 +39,7 @@ spec:
           requests:
             cpu: 25m
             memory: 25Mi
+        securityContext:
+          privileged: true
       hostNetwork: true
       hostPID: true


### PR DESCRIPTION
node exporter needs to use the privileged psp, otherwise it has no access to hostNetwork