### PR TITLE
hostPID is needed for PSPs

### DIFF
--- a/cluster/manifests/psp/pod_security_policy.yaml
+++ b/cluster/manifests/psp/pod_security_policy.yaml
@@ -6,6 +6,7 @@ spec:
   fsGroup:
     rule: RunAsAny
   privileged: true
+  hostPID: true
   hostNetwork: true
   hostPorts:
   - max: 10000
@@ -39,4 +40,3 @@ spec:
   - persistentVolumeClaim
   - downwardAPI
   - configMap
-


### PR DESCRIPTION
missing item in PSP was hostPID to get prometheus-node-exporter running