### PR TITLE
update gerry to v0.0.9

### DIFF
--- a/cluster/manifests/secretary/deployment.yaml
+++ b/cluster/manifests/secretary/deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: gerry
-        image: registry.opensource.zalan.do/teapot/gerry:v0.0.8
+        image: registry.opensource.zalan.do/teapot/gerry:v0.0.9
         args:
         - /meta/credentials
         - --application-id=secretary

--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -57,7 +57,7 @@ spec:
               readOnly: true
 
         - name: gerry
-          image: registry.opensource.zalan.do/teapot/gerry:v0.0.8
+          image: registry.opensource.zalan.do/teapot/gerry:v0.0.9
           args:
             - /meta/credentials
             - --application-id=secretary

--- a/cluster/manifests/zmon-aws-agent/deployment.yaml
+++ b/cluster/manifests/zmon-aws-agent/deployment.yaml
@@ -44,7 +44,7 @@ spec:
               readOnly: true
 
         - name: gerry
-          image: registry.opensource.zalan.do/teapot/gerry:v0.0.8
+          image: registry.opensource.zalan.do/teapot/gerry:v0.0.9
           args:
             - /meta/credentials
             - --application-id=secretary

--- a/cluster/manifests/zmon-scheduler/deployment.yaml
+++ b/cluster/manifests/zmon-scheduler/deployment.yaml
@@ -90,7 +90,7 @@ spec:
               readOnly: true
 
         - name: gerry
-          image: registry.opensource.zalan.do/teapot/gerry:v0.0.8
+          image: registry.opensource.zalan.do/teapot/gerry:v0.0.9
           args:
             - /meta/credentials
             - --application-id=secretary

--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -66,7 +66,7 @@ spec:
               readOnly: true
 
         - name: gerry
-          image: registry.opensource.zalan.do/teapot/gerry:v0.0.8
+          image: registry.opensource.zalan.do/teapot/gerry:v0.0.9
           args:
             - /meta/credentials
             - --application-id=secretary

--- a/docs/user-guide/example-credentials.rst
+++ b/docs/user-guide/example-credentials.rst
@@ -54,7 +54,7 @@ In this example the AWS access role for the S3 bucket is called ``myapp-iam-role
                   mountPath: /meta/credentials
                   readOnly: true
             - name: gerry
-              image: registry.opensource.zalan.do/teapot/gerry:v0.0.8
+              image: registry.opensource.zalan.do/teapot/gerry:v0.0.9
               args:
                 - /meta/credentials
                 - --application-id=myapp
@@ -83,7 +83,7 @@ The next important part is the ``gerry`` *sidecar*.
 .. code-block:: yaml
 
     - name: gerry
-      image: registry.opensource.zalan.do/teapot/gerry:v0.0.8
+      image: registry.opensource.zalan.do/teapot/gerry:v0.0.9
       args:
         - /meta/credentials
         - --application-id=myapp


### PR DESCRIPTION
allows to omit the `s3://` prefix for gerry.