### PR TITLE
Stability fixes: memory limit, job cleanup

### DIFF
--- a/cluster/manifests/cluster-autoscaler/deployment.yaml
+++ b/cluster/manifests/cluster-autoscaler/deployment.yaml
@@ -27,7 +27,7 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 100Mi
+              memory: 300Mi
             requests:
               cpu: 50m
-              memory: 50Mi
+              memory: 100Mi

--- a/cluster/manifests/kube-job-cleaner/cronjob.yaml
+++ b/cluster/manifests/kube-job-cleaner/cronjob.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-job-cleaner
-    version: "0.1"
+    version: "0.2"
 spec:
   schedule: "17 * * * *"
   jobTemplate:
@@ -14,13 +14,13 @@ spec:
         metadata:
           labels:
             application: kube-job-cleaner
-            version: "0.1"
+            version: "0.2"
         spec:
           restartPolicy: OnFailure
           containers:
           - name: cleaner
             # delete all completed jobs after one hour
-            image: registry.opensource.zalan.do/teapot/kube-job-cleaner:cd3
+            image: registry.opensource.zalan.do/teapot/kube-job-cleaner:0.2
             resources:
               limits:
                 cpu: 100m


### PR DESCRIPTION
* autoscaler had not enough memory for clusters with large number of pods (such as pods not being cleaned up :smirk: )
* job cleanup now deletes pods explicitly and also deletes failed pods: https://github.com/hjacobs/kube-job-cleaner/releases/tag/0.2