### PR TITLE
#278 set reasonable max CPU/memory

### DIFF
--- a/cluster/manifests/default-limits/limits.yaml
+++ b/cluster/manifests/default-limits/limits.yaml
@@ -12,3 +12,6 @@ spec:
       default:
         cpu: "1000m"
         memory: 1Gi
+      max:
+        cpu: "16"
+        memory: 64Gi


### PR DESCRIPTION
Set maximum resource requests/limits to "reasonable" values. This prevents users from accidentally requesting more than they need e.g. by mixing up units ("m" vs "Mi").

Fixes #278.

