### PR TITLE
Bugfix/skipper

### DIFF
--- a/cluster/manifests/daemonupgrader/deployment.yaml
+++ b/cluster/manifests/daemonupgrader/deployment.yaml
@@ -16,6 +16,9 @@ spec:
       labels:
         application: daemonupgrader
         version: 8264ca0
+      annotations:
+        daemonset.kubernetes.io/strategyType: RollingUpdate
+        daemonset.kubernetes.io/maxUnavailable: "1"
     spec:
       containers:
       - name: daemonupgrader

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -28,11 +28,13 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.9.8
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.9.8a
         ports:
         - name: ingress-port
           containerPort: 9999
           hostPort: 9999
+        command:
+          - /usr/bin/skipper
         args:
           - "-application-log-level=DEBUG"
           - "-kubernetes-url=http://localhost:8001"

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -28,13 +28,11 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.9.8a
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.9.9
         ports:
         - name: ingress-port
           containerPort: 9999
           hostPort: 9999
-        command:
-          - /usr/bin/skipper
         args:
           - "-application-log-level=DEBUG"
           - "-kubernetes-url=http://localhost:8001"

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.1.1
+    version: v0.9.9
     component: ingress
   annotations:
     daemonset.kubernetes.io/strategyType: RollingUpdate
@@ -19,7 +19,7 @@ spec:
       name: skipper-ingress
       labels:
         application: skipper-ingress
-        version: v0.1.1
+        version: v0.9.9
         component: ingress
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -34,6 +34,7 @@ spec:
           containerPort: 9999
           hostPort: 9999
         args:
+          - "skipper"
           - "-application-log-level=DEBUG"
           - "-kubernetes-url=http://localhost:8001"
           - "-address=:9999"

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/teapot/skipper:v0.1.1
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.9.8
         ports:
         - name: ingress-port
           containerPort: 9999


### PR DESCRIPTION
Bump skipper to upstream version v0.9.8a and fix command path which we set before ourselves in our Dockerfile.
Please do not merge before 2017-02-23 and validating our test cluster.