### PR TITLE
slow down daemonset upgrader

### DIFF
--- a/cluster/manifests/daemonupgrader/deployment.yaml
+++ b/cluster/manifests/daemonupgrader/deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: daemonupgrader
-        image: registry.opensource.zalan.do/teapot/k8s-daemonupgradecontroller:8264ca0
+        image: registry.opensource.zalan.do/teapot/k8s-daemonupgradecontroller:c90ffa1
         resources:
           limits:
             cpu: 200m

--- a/cluster/manifests/daemonupgrader/deployment.yaml
+++ b/cluster/manifests/daemonupgrader/deployment.yaml
@@ -22,7 +22,10 @@ spec:
     spec:
       containers:
       - name: daemonupgrader
-        image: registry.opensource.zalan.do/teapot/k8s-daemonupgradecontroller:c90ffa1
+        image: registry.opensource.zalan.do/teapot/k8s-daemonupgradecontroller:5c21c97
+        env:
+        - name: HOTLOOP_DELAY
+          value: 60
         resources:
           limits:
             cpu: 200m


### PR DESCRIPTION
The new custom build registry.opensource.zalan.do/teapot/k8s-daemonupgradecontroller:c90ffa1 will wait 60s for each daemonset before deleting the next one.