### PR TITLE
Always use strings for envars

### DIFF
--- a/cluster/manifests/daemonupgrader/deployment.yaml
+++ b/cluster/manifests/daemonupgrader/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         image: registry.opensource.zalan.do/teapot/k8s-daemonupgradecontroller:5c21c97
         env:
         - name: HOTLOOP_DELAY
-          value: 60
+          value: "60"
         resources:
           limits:
             cpu: 200m


### PR DESCRIPTION
Envars always need to be strings :)

Otherwise kubectl will complain:

```
error: unable to decode "STDIN": [pos 527]: json: expect char '"' but got char '6' 
FATA[0025] exit status 1: error: unable to decode "STDIN": [pos 527]: json: expect char '"' but got char
```