### PR TITLE
Install kube2iam iptables rules on nodes

### DIFF
--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -28,15 +28,7 @@ spec:
         name: kube2iam
         args:
         - "--base-role-arn=arn:aws:iam::{{ getAWSAccountID .InfrastructureAccount }}:role/"
-        - --iptables=true
-        - --host-ip=$(HOST_IP)
         - --verbose
-        - --host-interface=cni0
-        env:
-        - name: HOST_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
         ports:
         - containerPort: 8181
           hostPort: 8181

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -49,6 +49,27 @@ coreos:
             ExecStartPre=/usr/bin/etcdctl \
             --endpoint=http://localhost:2379 set /coreos.com/network/config \
             '{ "Network": "10.2.0.0/16", "Backend": {"Type": "vxlan"}}'
+
+    - name: kube2iam-iptables.service
+      command: start
+      runtime: true
+      content: |
+        [Service]
+        Type=oneshot
+        ExecStart=/usr/sbin/iptables \
+          --append PREROUTING \
+          --protocol tcp \
+          --destination 169.254.169.254 \
+          --dport 80 \
+          --in-interface cni0 \
+          --match tcp \
+          --jump DNAT \
+          --table nat \
+          --to-destination $private_ipv4:8181
+
+        [Install]
+        WantedBy=multi-user.target
+
     - name: kubelet.service
       command: start
       runtime: true

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -41,6 +41,26 @@ coreos:
             [Service]
             Environment="DOCKER_OPTS=--log-opt=max-file=2 --log-opt=max-size=50m"
 
+    - name: kube2iam-iptables.service
+      command: start
+      runtime: true
+      content: |
+        [Service]
+        Type=oneshot
+        ExecStart=/usr/sbin/iptables \
+          --append PREROUTING \
+          --protocol tcp \
+          --destination 169.254.169.254 \
+          --dport 80 \
+          --in-interface cni0 \
+          --match tcp \
+          --jump DNAT \
+          --table nat \
+          --to-destination $private_ipv4:8181
+
+        [Install]
+        WantedBy=multi-user.target
+
     - name: kubelet.service
       command: start
       runtime: true


### PR DESCRIPTION
Creates iptables rule for kube2iam on node startup to prevent other pods
from getting access to the node IAM role if it is started before
kube2iam.

Fix #291 