### PR TITLE
Update kube-aws-autoscaler to add extra spare nodes

### DIFF
--- a/cluster/manifests/cluster-autoscaler/deployment.yaml
+++ b/cluster/manifests/cluster-autoscaler/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: cluster-autoscaler
-    version: v0.5
+    version: v0.7
 spec:
   replicas: 1
   selector:
@@ -15,14 +15,14 @@ spec:
     metadata:
       labels:
         application: cluster-autoscaler
-        version: v0.5
+        version: v0.7
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
         iam.amazonaws.com/role: "{{ .LocalID }}-app-autoscaler"
     spec:
       containers:
-        - image: registry.opensource.zalan.do/teapot/kube-aws-autoscaler:0.5
+        - image: registry.opensource.zalan.do/teapot/kube-aws-autoscaler:0.7
           name: cluster-autoscaler
           resources:
             limits:


### PR DESCRIPTION
Updates `kube-aws-autoscaler` from v0.5 to [v0.7](https://github.com/hjacobs/kube-aws-autoscaler/releases/tag/0.7). Changes are:

* provision 1 extra spare node per ASG/AZ by default
* add timestamp to log output (important to make `kubectl logs` readable)
* ignore master nodes by default (master ASG usually does not need any autoscaling)

Example log output with v0.7 (no master ASG, timestamps):

```
2017-03-03 18:53:05,667 INFO: kube-1-WorkerAutoScaling-15OS9AZERKV8L/eu-central-1a:                       CPU     MEMORY       PODS
2017-03-03 18:53:05,667 INFO: kube-1-WorkerAutoScaling-15OS9AZERKV8L/eu-central-1a: requested:            2.5     4360Mi         32
2017-03-03 18:53:05,667 INFO: kube-1-WorkerAutoScaling-15OS9AZERKV8L/eu-central-1a: with buffer:          2.9     4996Mi         45
2017-03-03 18:53:05,667 INFO: kube-1-WorkerAutoScaling-15OS9AZERKV8L/eu-central-1a: weakest node:         1.8     7541Mi        110
2017-03-03 18:53:05,667 INFO: kube-1-WorkerAutoScaling-15OS9AZERKV8L/eu-central-1a: overprovision:        1.1    10721Mi        188
2017-03-03 18:53:05,667 INFO: kube-1-WorkerAutoScaling-15OS9AZERKV8L/eu-central-1a: => 3 nodes required (current: 2)
2017-03-03 18:53:05,667 INFO: kube-1-WorkerAutoScaling-15OS9AZERKV8L/eu-central-1b:                       CPU     MEMORY       PODS
2017-03-03 18:53:05,667 INFO: kube-1-WorkerAutoScaling-15OS9AZERKV8L/eu-central-1b: requested:            3.8     6313Mi         50
2017-03-03 18:53:05,668 INFO: kube-1-WorkerAutoScaling-15OS9AZERKV8L/eu-central-1b: with buffer:          4.4     7144Mi         65
2017-03-03 18:53:05,668 INFO: kube-1-WorkerAutoScaling-15OS9AZERKV8L/eu-central-1b: weakest node:         1.8     7541Mi        110
2017-03-03 18:53:05,668 INFO: kube-1-WorkerAutoScaling-15OS9AZERKV8L/eu-central-1b: overprovision:        1.6    16309Mi        280
2017-03-03 18:53:05,668 INFO: kube-1-WorkerAutoScaling-15OS9AZERKV8L/eu-central-1b: => 4 nodes required (current: 3)
2017-03-03 18:53:05,705 INFO: Changing desired capacity for ASG kube-1-WorkerAutoScaling-15OS9AZERKV8L from 5 to 7..

