### PR TITLE
expose skipper-ingress monitor port 

### DIFF
--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -33,6 +33,9 @@ spec:
         - name: ingress-port
           containerPort: 9999
           hostPort: 9999
+        - name: monitor-port
+          containerPort: 9911
+          hostPort: 9911
         args:
           - "skipper"
           - "-application-log-level=DEBUG"


### PR DESCRIPTION
To create checks/metrics from our monitoring systems we need to expose the monitoring port to the kubernetes cluster.