### PR TITLE
expose skipper-ingress monitor port to create checks from zmon

### DIFF
--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -330,6 +330,7 @@ Resources:
       - {CidrIp: 0.0.0.0/0, FromPort: 22, IpProtocol: tcp, ToPort: 22}
       - {CidrIp: 172.31.0.0/16, FromPort: 8082, IpProtocol: tcp, ToPort: 8082}
       - {CidrIp: 172.31.0.0/16, FromPort: 9100, IpProtocol: tcp, ToPort: 9100}
+      - {CidrIp: 172.31.0.0/16, FromPort: 9911, IpProtocol: tcp, ToPort: 9911}
       Tags:
         - Key: "KubernetesCluster"
           Value: kubernetes


### PR DESCRIPTION
We have to allow access from all ec2 instances to skipper monitoring port incoming to master stack.