### PR TITLE
Scale down agent. Change filter to kubernetes entities only.

### DIFF
--- a/cluster/manifests/zmon-aws-agent/deployment.yaml
+++ b/cluster/manifests/zmon-aws-agent/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     application: "zmon-aws-agent"
     version: "v0.1"
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       application: zmon-aws-agent

--- a/cluster/manifests/zmon-scheduler/deployment.yaml
+++ b/cluster/manifests/zmon-scheduler/deployment.yaml
@@ -68,7 +68,7 @@ spec:
               value: "6379"
 
             - name: SCHEDULER_ENTITY_BASE_FILTER_STR
-              value: '[{"infrastructure_account":"{{ .InfrastructureAccount }}","region":"{{ .Region }}"}]'
+              value: '[{"infrastructure_account":"{{ .InfrastructureAccount }}","region":"{{ .Region }}", "kube_cluster":"{{ .ID }}"}]'
             - name: SCHEDULER_INSTANT_EVAL_HTTP_URL
               value: https://data-service.zmon.zalan.do/api/v1/instant-evaluations/kube-cluster[{{ .InfrastructureAccount }}:{{ .Region }}]/
             - name: SCHEDULER_TRIAL_RUN_HTTP_URL


### PR DESCRIPTION
 - Scale down AWS agent
 - Change filter for kube entities only