### PR TITLE
enable host header based metrics

### DIFF
--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -40,6 +40,7 @@ spec:
           - "-kubernetes-in-cluster"
           - "-address=:9999"
           - "-proxy-preserve-host"
+          - "-serve-host-metrics"
         resources:
           limits:
             cpu: 200m


### PR DESCRIPTION
To enable teams to check their own applications, which are backends for skipper we have to enable http host header based metrics in skipper.