### PR TITLE
change the default cpu.limit to 3 cores

### DIFF
--- a/cluster/manifests/default-limits/limits.yaml
+++ b/cluster/manifests/default-limits/limits.yaml
@@ -10,7 +10,7 @@ spec:
         cpu: "100m"
         memory: 100Mi
       default:
-        cpu: "1000m"
+        cpu: "3000m"
         memory: 1Gi
       max:
         cpu: "16"


### PR DESCRIPTION
1 core was not very nice for people not setting any CPU limits (e.g. JVM start up takes advantage of multiple threads)