### PR TITLE
change the default cpu.limit to 3 cores

### DIFF
--- a/cluster/manifests/default-limits/limits.yaml
+++ b/cluster/manifests/default-limits/limits.yaml
@@ -10,7 +10,7 @@ spec:
         cpu: "100m"
         memory: 100Mi
       default:
-        cpu: "1000m"
+        cpu: "3000m"
         memory: 1Gi
       max:
         cpu: "16"


### PR DESCRIPTION
Set CPU limit to 3 also for `alpha` channel.