### PR TITLE
Update ingress controller to version with http listener

### DIFF
--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: app-ingress-controller
-    version: v0.1.0-2-g0755a45
+    version: v0.1.0-14-gaaaa9f7
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: app-ingress-controller
-        version: v0.1.0-2-g0755a45
+        version: v0.1.0-14-gaaaa9f7
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-aws-ingress-controller:v0.1.0-11-gda4eda5
+        image: registry.opensource.zalan.do/teapot/kube-aws-ingress-controller:v0.1.0-14-gaaaa9f7
         env:
         - name: AWS_REGION
           value: {{ .Region }}

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: app-ingress-controller
-    version: v0.1.0-14-gaaaa9f7
+    version: v0.1.1
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: app-ingress-controller
-        version: v0.1.0-14-gaaaa9f7
+        version: v0.1.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-aws-ingress-controller:v0.1.0-14-gaaaa9f7
+        image: registry.opensource.zalan.do/teapot/kube-aws-ingress-controller:v0.1.1
         env:
         - name: AWS_REGION
           value: {{ .Region }}

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -399,6 +399,7 @@ Resources:
     Properties:
       GroupDescription: {Ref: 'AWS::StackName'}
       SecurityGroupIngress:
+      - {CidrIp: 0.0.0.0/0, FromPort: 80, IpProtocol: tcp, ToPort: 80}
       - {CidrIp: 0.0.0.0/0, FromPort: 443, IpProtocol: tcp, ToPort: 443}
       VpcId: "{{ AccountInfo.VpcID }}"
       Tags:


### PR DESCRIPTION
This updates the ingress controller to also add an HTTP listener to the ALBs it creates: https://github.com/zalando-incubator/kube-ingress-aws-controller/pull/28

I will test this branch in my own cluster and make a proper tag before this is ready for merge.