### PR TITLE
Merge to alpha

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ Kubernetes on AWS
 
 **WORK IN PROGRESS**
 
-This repo contains configuration templates to provision Kubernetes_ clusters on AWS using Cloud Formation and CoreOS_.
+This repo contains configuration templates to provision Kubernetes_ clusters on AWS using Cloud Formation and `CoreOS Container Linux`_.
 
 **Consider this as alpha quality**. Many values are hardcoded, and currently we're focusing on solving our own, specific/Zalando use case.
 However, **we are open to ideas from the community at large about potentially turning this idea into a project that provides universal/general value to others**.
@@ -65,7 +65,7 @@ Directory Structure
 
 
 .. _Kubernetes: http://kubernetes.io
-.. _CoreOS: https://coreos.com/
+.. _CoreOS Container Linux: https://coreos.com/os/docs/latest
 .. _kube-aws: https://github.com/coreos/coreos-kubernetes/tree/master/multi-node/aws
 .. _Senza Cloud Formation tool: https://github.com/zalando-stups/senza
 .. _OAuth Token Info: http://planb.readthedocs.io/en/latest/intro.html#token-info

--- a/cluster/manifests/default-limits/limits.yaml
+++ b/cluster/manifests/default-limits/limits.yaml
@@ -10,7 +10,7 @@ spec:
         cpu: "100m"
         memory: 100Mi
       default:
-        cpu: "1000m"
+        cpu: "3000m"
         memory: 1Gi
       max:
         cpu: "16"

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: app-ingress-controller
-    version: v0.1.0-2-g0755a45
+    version: v0.1.0-14-gaaaa9f7
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: app-ingress-controller
-        version: v0.1.0-2-g0755a45
+        version: v0.1.0-14-gaaaa9f7
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-aws-ingress-controller:v0.1.0-11-gda4eda5
+        image: registry.opensource.zalan.do/teapot/kube-aws-ingress-controller:v0.1.0-14-gaaaa9f7
         env:
         - name: AWS_REGION
           value: {{ .Region }}

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: app-ingress-controller
-    version: v0.1.0-14-gaaaa9f7
+    version: v0.1.1
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: app-ingress-controller
-        version: v0.1.0-14-gaaaa9f7
+        version: v0.1.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-aws-ingress-controller:v0.1.0-14-gaaaa9f7
+        image: registry.opensource.zalan.do/teapot/kube-aws-ingress-controller:v0.1.1
         env:
         - name: AWS_REGION
           value: {{ .Region }}

--- a/cluster/manifests/mate/deployment.yaml
+++ b/cluster/manifests/mate/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: mate
-    version: v0.6.1
+    version: v0.6.2
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: mate
-        version: v0.6.1
+        version: v0.6.2
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: mate
-        image: registry.opensource.zalan.do/teapot/mate:v0.6.1
+        image: registry.opensource.zalan.do/teapot/mate:v0.6.2
         env:
         - name: AWS_REGION
           value: {{ .Region }}
@@ -32,6 +32,7 @@ spec:
         - --kubernetes-format={{`{{ .Name }}-{{ .Namespace }}`}}.{{ .ConfigItems.mate_hosted_zone }}.
         - --consumer=aws
         - --aws-record-group-id={{ .LocalID }}
+        - --debug
         resources:
           limits:
             cpu: 200m

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -399,6 +399,7 @@ Resources:
     Properties:
       GroupDescription: {Ref: 'AWS::StackName'}
       SecurityGroupIngress:
+      - {CidrIp: 0.0.0.0/0, FromPort: 80, IpProtocol: tcp, ToPort: 80}
       - {CidrIp: 0.0.0.0/0, FromPort: 443, IpProtocol: tcp, ToPort: 443}
       VpcId: "{{ AccountInfo.VpcID }}"
       Tags:

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -75,7 +75,7 @@ coreos:
       runtime: true
       content: |
         [Service]
-        Environment=KUBELET_VERSION=v1.5.3_coreos.0
+        Environment=KUBELET_VERSION=v1.5.4_coreos.0
         Environment=KUBELET_ACI=docker://registry.opensource.zalan.do/teapot/hyperkube
         Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf \
         --insecure-options=image \
@@ -133,7 +133,7 @@ coreos:
         --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
         --mount=volume=kube,target=/etc/kubernetes \
         --net=host \
-        registry.opensource.zalan.do/teapot/hyperkube:v1.5.3_coreos.0 \
+        registry.opensource.zalan.do/teapot/hyperkube:v1.5.4_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           drain $(hostname) \
@@ -231,14 +231,14 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-proxy
-          version: v1.5.3_coreos.0
+          version: v1.5.4_coreos.0
         annotations:
           rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
       spec:
         hostNetwork: true
         containers:
         - name: kube-proxy
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.5.3_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.5.4_coreos.0
           command:
           - /hyperkube
           - proxy
@@ -278,12 +278,12 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-apiserver
-          version: v1.5.3_coreos.0
+          version: v1.5.4_coreos.0
       spec:
         hostNetwork: true
         containers:
         - name: kube-apiserver
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.5.3_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.5.4_coreos.0
           command:
           - /hyperkube
           - apiserver
@@ -410,11 +410,11 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-controller-manager
-          version: v1.5.3_coreos.0
+          version: v1.5.4_coreos.0
       spec:
         containers:
         - name: kube-controller-manager
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.5.3_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.5.4_coreos.0
           command:
           - /hyperkube
           - controller-manager
@@ -469,12 +469,12 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-scheduler
-          version: v1.5.3_coreos.0
+          version: v1.5.4_coreos.0
       spec:
         hostNetwork: true
         containers:
         - name: kube-scheduler
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.5.3_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.5.4_coreos.0
           command:
           - /hyperkube
           - scheduler

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -337,7 +337,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.7
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.7-gd803898
           name: webhook
           ports:
           - containerPort: 8081

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -337,7 +337,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.7-2-gd803898
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.8
           name: webhook
           ports:
           - containerPort: 8081

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -337,7 +337,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.7-gd803898
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.7-2-gd803898
           name: webhook
           ports:
           - containerPort: 8081

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -66,7 +66,7 @@ coreos:
       runtime: true
       content: |
         [Service]
-        Environment=KUBELET_VERSION=v1.5.3_coreos.0
+        Environment=KUBELET_VERSION=v1.5.4_coreos.0
         Environment=KUBELET_ACI=docker://registry.opensource.zalan.do/teapot/hyperkube
         Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf \
         --insecure-options=image \
@@ -128,7 +128,7 @@ coreos:
         --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
         --mount=volume=kube,target=/etc/kubernetes \
         --net=host \
-        registry.opensource.zalan.do/teapot/hyperkube:v1.5.3_coreos.0 \
+        registry.opensource.zalan.do/teapot/hyperkube:v1.5.4_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
           drain $(hostname) \
@@ -186,14 +186,14 @@ write_files:
           namespace: kube-system
           labels:
             application: kube-proxy
-            version: v1.5.3_coreos.0
+            version: v1.5.4_coreos.0
           annotations:
             rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
         spec:
           hostNetwork: true
           containers:
           - name: kube-proxy
-            image: registry.opensource.zalan.do/teapot/hyperkube:v1.5.3_coreos.0
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.5.4_coreos.0
             command:
             - /hyperkube
             - proxy


### PR DESCRIPTION
This will:
- deploy Kubernetes to v1.5.4 
- update ingress controller such that http to http redirects are automatically deployed
- fix mate canonical zone id
- fix the webhook such that the default account in non kube-system namespaces have read access to the apiserver
- instance limits are raised from 1 Core to 3 Cores
