### PR TITLE
Align db-alpha branch with alpha

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ Kubernetes on AWS
 
 **WORK IN PROGRESS**
 
-This repo contains configuration templates to provision Kubernetes_ clusters on AWS using Cloud Formation and CoreOS_.
+This repo contains configuration templates to provision Kubernetes_ clusters on AWS using Cloud Formation and `CoreOS Container Linux`_.
 
 **Consider this as alpha quality**. Many values are hardcoded, and currently we're focusing on solving our own, specific/Zalando use case.
 However, **we are open to ideas from the community at large about potentially turning this idea into a project that provides universal/general value to others**.
@@ -65,7 +65,7 @@ Directory Structure
 
 
 .. _Kubernetes: http://kubernetes.io
-.. _CoreOS: https://coreos.com/
+.. _CoreOS Container Linux: https://coreos.com/os/docs/latest
 .. _kube-aws: https://github.com/coreos/coreos-kubernetes/tree/master/multi-node/aws
 .. _Senza Cloud Formation tool: https://github.com/zalando-stups/senza
 .. _OAuth Token Info: http://planb.readthedocs.io/en/latest/intro.html#token-info

--- a/cluster/manifests/default-limits/limits.yaml
+++ b/cluster/manifests/default-limits/limits.yaml
@@ -10,7 +10,7 @@ spec:
         cpu: "100m"
         memory: 100Mi
       default:
-        cpu: "1000m"
+        cpu: "3000m"
         memory: 1Gi
       max:
         cpu: "16"

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: app-ingress-controller
-    version: v0.1.0-2-g0755a45
+    version: v0.1.0-14-gaaaa9f7
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: app-ingress-controller
-        version: v0.1.0-2-g0755a45
+        version: v0.1.0-14-gaaaa9f7
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-aws-ingress-controller:v0.1.0-11-gda4eda5
+        image: registry.opensource.zalan.do/teapot/kube-aws-ingress-controller:v0.1.0-14-gaaaa9f7
         env:
         - name: AWS_REGION
           value: {{ .Region }}

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: app-ingress-controller
-    version: v0.1.0-14-gaaaa9f7
+    version: v0.1.1
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: app-ingress-controller
-        version: v0.1.0-14-gaaaa9f7
+        version: v0.1.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-aws-ingress-controller:v0.1.0-14-gaaaa9f7
+        image: registry.opensource.zalan.do/teapot/kube-aws-ingress-controller:v0.1.1
         env:
         - name: AWS_REGION
           value: {{ .Region }}

--- a/cluster/manifests/mate/deployment.yaml
+++ b/cluster/manifests/mate/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: mate
-    version: v0.6.1
+    version: v0.6.2
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: mate
-        version: v0.6.1
+        version: v0.6.2
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: mate
-        image: registry.opensource.zalan.do/teapot/mate:v0.6.1
+        image: registry.opensource.zalan.do/teapot/mate:v0.6.2
         env:
         - name: AWS_REGION
           value: {{ .Region }}
@@ -32,6 +32,7 @@ spec:
         - --kubernetes-format={{`{{ .Name }}-{{ .Namespace }}`}}.{{ .ConfigItems.mate_hosted_zone }}.
         - --consumer=aws
         - --aws-record-group-id={{ .LocalID }}
+        - --debug
         resources:
           limits:
             cpu: 200m

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.9.15a
+    version: v0.9.19
     component: ingress
   annotations:
     daemonset.kubernetes.io/strategyType: RollingUpdate
@@ -19,7 +19,7 @@ spec:
       name: skipper-ingress
       labels:
         application: skipper-ingress
-        version: v0.9.15a
+        version: v0.9.19
         component: ingress
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -28,7 +28,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.9.15a
+        image: registry.opensource.zalan.do/teapot/skipper:v0.9.19
         ports:
         - name: ingress-port
           containerPort: 9999

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -40,6 +40,7 @@ spec:
           - "-kubernetes-in-cluster"
           - "-address=:9999"
           - "-proxy-preserve-host"
+          - "-serve-host-metrics"
         resources:
           limits:
             cpu: 200m

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -399,6 +399,7 @@ Resources:
     Properties:
       GroupDescription: {Ref: 'AWS::StackName'}
       SecurityGroupIngress:
+      - {CidrIp: 0.0.0.0/0, FromPort: 80, IpProtocol: tcp, ToPort: 80}
       - {CidrIp: 0.0.0.0/0, FromPort: 443, IpProtocol: tcp, ToPort: 443}
       VpcId: "{{ AccountInfo.VpcID }}"
       Tags:

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -75,7 +75,7 @@ coreos:
       runtime: true
       content: |
         [Service]
-        Environment=KUBELET_VERSION=v1.5.2_coreos.0
+        Environment=KUBELET_VERSION=v1.5.3_coreos.0
         Environment=KUBELET_ACI=docker://registry.opensource.zalan.do/teapot/hyperkube
         Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf \
         --insecure-options=image \
@@ -133,7 +133,7 @@ coreos:
         --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
         --mount=volume=kube,target=/etc/kubernetes \
         --net=host \
-        registry.opensource.zalan.do/teapot/hyperkube:v1.5.2_coreos.0 \
+        registry.opensource.zalan.do/teapot/hyperkube:v1.5.3_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           drain $(hostname) \
@@ -231,14 +231,14 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-proxy
-          version: v1.5.2_coreos.0
+          version: v1.5.3_coreos.0
         annotations:
           rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
       spec:
         hostNetwork: true
         containers:
         - name: kube-proxy
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.5.2_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.5.3_coreos.0
           command:
           - /hyperkube
           - proxy
@@ -278,12 +278,12 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-apiserver
-          version: v1.5.2_coreos.0
+          version: v1.5.3_coreos.0
       spec:
         hostNetwork: true
         containers:
         - name: kube-apiserver
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.5.2_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.5.3_coreos.0
           command:
           - /hyperkube
           - apiserver
@@ -410,11 +410,11 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-controller-manager
-          version: v1.5.2_coreos.0
+          version: v1.5.3_coreos.0
       spec:
         containers:
         - name: kube-controller-manager
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.5.2_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.5.3_coreos.0
           command:
           - /hyperkube
           - controller-manager
@@ -469,12 +469,12 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-scheduler
-          version: v1.5.2_coreos.0
+          version: v1.5.3_coreos.0
       spec:
         hostNetwork: true
         containers:
         - name: kube-scheduler
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.5.2_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.5.3_coreos.0
           command:
           - /hyperkube
           - scheduler

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -75,7 +75,7 @@ coreos:
       runtime: true
       content: |
         [Service]
-        Environment=KUBELET_VERSION=v1.5.3_coreos.0
+        Environment=KUBELET_VERSION=v1.5.4_coreos.0
         Environment=KUBELET_ACI=docker://registry.opensource.zalan.do/teapot/hyperkube
         Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf \
         --insecure-options=image \
@@ -133,7 +133,7 @@ coreos:
         --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
         --mount=volume=kube,target=/etc/kubernetes \
         --net=host \
-        registry.opensource.zalan.do/teapot/hyperkube:v1.5.3_coreos.0 \
+        registry.opensource.zalan.do/teapot/hyperkube:v1.5.4_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           drain $(hostname) \
@@ -231,14 +231,14 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-proxy
-          version: v1.5.3_coreos.0
+          version: v1.5.4_coreos.0
         annotations:
           rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
       spec:
         hostNetwork: true
         containers:
         - name: kube-proxy
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.5.3_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.5.4_coreos.0
           command:
           - /hyperkube
           - proxy
@@ -278,12 +278,12 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-apiserver
-          version: v1.5.3_coreos.0
+          version: v1.5.4_coreos.0
       spec:
         hostNetwork: true
         containers:
         - name: kube-apiserver
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.5.3_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.5.4_coreos.0
           command:
           - /hyperkube
           - apiserver
@@ -410,11 +410,11 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-controller-manager
-          version: v1.5.3_coreos.0
+          version: v1.5.4_coreos.0
       spec:
         containers:
         - name: kube-controller-manager
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.5.3_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.5.4_coreos.0
           command:
           - /hyperkube
           - controller-manager
@@ -469,12 +469,12 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-scheduler
-          version: v1.5.3_coreos.0
+          version: v1.5.4_coreos.0
       spec:
         hostNetwork: true
         containers:
         - name: kube-scheduler
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.5.3_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.5.4_coreos.0
           command:
           - /hyperkube
           - scheduler

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -337,7 +337,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.6
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.7
           name: webhook
           ports:
           - containerPort: 8081
@@ -360,13 +360,9 @@ write_files:
             requests:
               cpu: 50m
               memory: 50Mi
+          args:
+            - --tokens-file=/etc/kubernetes/config/tokenfile.csv
           env:
-            - name: SHARED_SECRET
-              value: {{WORKER_SHARED_SECRET}}
-            - name: CONTROLLER_MANAGER_SECRET
-              value: {{CONTROLLER_MANAGER_SECRET}}
-            - name: WEBHOOK_ADDRESS
-              value: :8081
             - name: USERS_API_URL
               value: https://users.auth.zalando.com
             - name: CLUSTER_ID
@@ -375,6 +371,10 @@ write_files:
               value: https://info.services.auth.zalando.com/oauth2/tokeninfo
             - name: USER_GROUPS
               value: stups_autobahn=Administrator,stups_deployment-controller-ui=ReadOnly,credentials-provider=Administrator,credprov-kube-ops-view-read-only-token=ReadOnly,credprov-cluster-lifecycle-manager-cluster-rw-token=Administrator,credprov-cluster-lifecycle-manager-test-cluster-rw-token=Administrator
+          volumeMounts:
+          - mountPath: /etc/kubernetes/config
+            name: kubernetes-configs
+            readOnly: true
         - name: nginx
           image: registry.opensource.zalan.do/teapot/nginx:1.11.5
           resources:
@@ -577,6 +577,11 @@ write_files:
       - name: kube-controller-manager
         user:
           token: {{CONTROLLER_MANAGER_SECRET}}
+
+  - path: /etc/kubernetes/config/tokenfile.csv
+    content: |
+      {{WORKER_SHARED_SECRET}},kubelet,kubelet
+      {{CONTROLLER_MANAGER_SECRET}},kube-controller-manager,kube-controller-manager
 
   - path: /etc/kubernetes/ssl/ca.pem
     encoding: gzip+base64

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -337,7 +337,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.7
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.7-gd803898
           name: webhook
           ports:
           - containerPort: 8081

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -337,7 +337,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.7-2-gd803898
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.8
           name: webhook
           ports:
           - containerPort: 8081

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -337,7 +337,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.7-gd803898
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.7-2-gd803898
           name: webhook
           ports:
           - containerPort: 8081

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -66,7 +66,7 @@ coreos:
       runtime: true
       content: |
         [Service]
-        Environment=KUBELET_VERSION=v1.5.3_coreos.0
+        Environment=KUBELET_VERSION=v1.5.4_coreos.0
         Environment=KUBELET_ACI=docker://registry.opensource.zalan.do/teapot/hyperkube
         Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf \
         --insecure-options=image \
@@ -128,7 +128,7 @@ coreos:
         --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
         --mount=volume=kube,target=/etc/kubernetes \
         --net=host \
-        registry.opensource.zalan.do/teapot/hyperkube:v1.5.3_coreos.0 \
+        registry.opensource.zalan.do/teapot/hyperkube:v1.5.4_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
           drain $(hostname) \
@@ -186,14 +186,14 @@ write_files:
           namespace: kube-system
           labels:
             application: kube-proxy
-            version: v1.5.3_coreos.0
+            version: v1.5.4_coreos.0
           annotations:
             rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
         spec:
           hostNetwork: true
           containers:
           - name: kube-proxy
-            image: registry.opensource.zalan.do/teapot/hyperkube:v1.5.3_coreos.0
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.5.4_coreos.0
             command:
             - /hyperkube
             - proxy

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -66,7 +66,7 @@ coreos:
       runtime: true
       content: |
         [Service]
-        Environment=KUBELET_VERSION=v1.5.2_coreos.0
+        Environment=KUBELET_VERSION=v1.5.3_coreos.0
         Environment=KUBELET_ACI=docker://registry.opensource.zalan.do/teapot/hyperkube
         Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf \
         --insecure-options=image \
@@ -128,7 +128,7 @@ coreos:
         --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
         --mount=volume=kube,target=/etc/kubernetes \
         --net=host \
-        registry.opensource.zalan.do/teapot/hyperkube:v1.5.2_coreos.0 \
+        registry.opensource.zalan.do/teapot/hyperkube:v1.5.3_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
           drain $(hostname) \
@@ -186,14 +186,14 @@ write_files:
           namespace: kube-system
           labels:
             application: kube-proxy
-            version: v1.5.2_coreos.0
+            version: v1.5.3_coreos.0
           annotations:
             rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
         spec:
           hostNetwork: true
           containers:
           - name: kube-proxy
-            image: registry.opensource.zalan.do/teapot/hyperkube:v1.5.2_coreos.0
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.5.3_coreos.0
             command:
             - /hyperkube
             - proxy


### PR DESCRIPTION
Aligns `db-alpha` branch with `alpha`.

Among other fixes, this brings in kubernetes v1.5.4 which should fix the EBS volume device naming/mounting issues experienced in the DB cluster.

https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG.md#v154

/cc @Jan-M