### PR TITLE
Update logging-agent, zmon-worker and zmon-agent

### DIFF
--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -24,24 +24,56 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
+        pod.beta.kubernetes.io/init-containers: '[
+          {
+            "name": "init-scalyr-config",
+            "image": "busybox",
+            "imagePullPolicy": "IfNotPresent",
+            "command": ["sh", "-c"],
+            "args": [
+              "if [ ! -f /mnt/scalyr/agent.json ]; then
+                echo {
+                  \\\"import_vars\\\": [\\\"WATCHER_SCALYR_API_KEY\\\", \\\"WATCHER_CLUSTER_ID\\\"],
+                  \\\"server_attributes\\\": {\\\"serverHost\\\": \\\"\\$WATCHER_CLUSTER_ID\\\"},
+                  \\\"implicit_agent_process_metrics_monitor\\\": false,
+                  \\\"implicit_metric_monitor\\\": false,
+                  \\\"api_key\\\": \\\"\\$WATCHER_SCALYR_API_KEY\\\",
+                  \\\"monitors\\\": [],
+                  \\\"logs\\\": []
+                  } > /mnt/scalyr/agent.json;
+                  echo Updated agent.json to inital configuration;
+              fi
+              && cat /mnt/scalyr/agent.json;
+              test -f /mnt/scalyr-checkpoint/checkpoints.json && ls -lah /mnt/scalyr-checkpoint/checkpoints.json && cat /mnt/scalyr-checkpoint/checkpoints.json"
+            ],
+            "volumeMounts": [
+              {
+                "name": "scalyr-config",
+                "mountPath": "/mnt/scalyr"
+              },
+              {
+                "name": "scalyr-checkpoint",
+                "mountPath": "/mnt/scalyr-checkpoint"
+              }
+            ]
+          }
+        ]'
     spec:
       containers:
       - name: log-watcher
-        image: registry.opensource.zalan.do/eagleeye/kubernetes-log-watcher:0.11
+        image: registry.opensource.zalan.do/eagleeye/kubernetes-log-watcher:0.12
         env:
         - name: CLUSTER_NODE_NAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
 
-        - name: WATCHER_KUBERNETES_UPDATE_CERTIFICATES
-          value: "true"
-        - name: WATCHER_CLUSTER_ID
-          value: "{{ .ID }}"
         - name: WATCHER_AGENTS
           value: scalyr
         - name: WATCHER_SCALYR_API_KEY
           value: "{{ .ConfigItems.scalyr_access_key }}"
+        - name: WATCHER_CLUSTER_ID
+          value: "{{ .ID }}"
         - name: WATCHER_SCALYR_DEST_PATH
           value: /mnt/scalyr-logs
         - name: WATCHER_SCALYR_CONFIG_PATH
@@ -66,10 +98,10 @@ spec:
           readOnly: false
         - name: scalyr-config
           mountPath: /mnt/scalyr-config
-          readOnly: false
 
       - name: scalyr-agent
-        image: registry.opensource.zalan.do/eagleeye/scalyr-agent:0.1
+
+        image: registry.opensource.zalan.do/eagleeye/scalyr-agent:0.2
 
         env:
         # Note: added for scalyr-config-base, but not needed by the scalyr-agent itself.
@@ -85,6 +117,8 @@ spec:
         - name: scalyr-logs
           mountPath: /mnt/scalyr-logs
           readOnly: true
+        - name: scalyr-checkpoint
+          mountPath: /var/lib/scalyr-agent-2
         - name: scalyr-config
           mountPath: /etc/scalyr-agent-2/
           readOnly: true
@@ -109,12 +143,15 @@ spec:
         hostPath:
           path: /var/log/journal
 
-      - name: scalyr-logs
-        emptyDir: {}
+      - name: scalyr-checkpoint
+        hostPath:
+          path: /var/lib/scalyr-agent
 
       - name: scalyr-config
-        configMap:
-          name: scalyr-config-base
-          items:
-            - key: scalyr.config
-              path: agent.json
+        hostPath:
+          path: /etc/scalyr-agent
+
+      - name: scalyr-logs
+        hostPath:
+          path: /var/log/scalyr-agent
+

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -44,7 +44,7 @@ spec:
                   echo Updated agent.json to inital configuration;
               fi
               && cat /mnt/scalyr/agent.json;
-              test -f /mnt/scalyr-checkpoint/checkpoints.json && ls -lah /mnt/scalyr-checkpoint/checkpoints.json && cat /mnt/scalyr-checkpoint/checkpoints.json"
+              test -f /mnt/scalyr-checkpoint/checkpoints.json && ls -lah /mnt/scalyr-checkpoint/checkpoints.json && cat /mnt/scalyr-checkpoint/checkpoints.json || true;"
             ],
             "volumeMounts": [
               {

--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: zmon-agent
-          image: "registry.opensource.zalan.do/zmon/zmon-agent-core:0.1-a18"
+          image: "registry.opensource.zalan.do/zmon/zmon-agent-core:0.1-a19"
           resources:
             limits:
               cpu: 100m
@@ -45,6 +45,8 @@ spec:
 
             - name: ZMON_AGENT_KUBERNETES_CLUSTER_ID
               value: "{{ .ID }}"
+            - name: ZMON_AGENT_KUBERNETES_CLUSTER_ALIAS
+              value: "{{ .Alias }}"
 
             - name: OAUTH2_ACCESS_TOKEN_URL
               value: https://token.services.auth.zalando.com/oauth2/access_token?realm=/services

--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: zmon-worker
-          image: "pierone.stups.zalan.do/stups/zmon-worker:zv199"
+          image: "pierone.stups.zalan.do/stups/zmon-worker:zv200"
           resources:
             limits:
               cpu: 500m

--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: zmon-worker
-          image: "pierone.stups.zalan.do/stups/zmon-worker:zv197"
+          image: "pierone.stups.zalan.do/stups/zmon-worker:zv199"
           resources:
             limits:
               cpu: 500m


### PR DESCRIPTION
Changes:

**logging-agent**
- Updated scalyr-agent with ``copy_from_start`` option.
- Persist scalyr-agent ``checkpoints`` file to avoid log duplication.
- Drop dependency on ``ConfigMap`` for initial scalyr config and use ``initContainer`` instead.
- Update log-watcher manifest with modified volume types (``hostPath`` iso ``emptyDir``).
- Update log-watcher with adjusted rate limits for Journald and more debug info.

https://github.com/zalando-incubator/kubernetes-log-watcher/issues/28
https://github.com/zalando-incubator/kubernetes-log-watcher/issues/30
https://github.com/zalando-incubator/kubernetes-log-watcher/issues/31
https://github.com/scalyr/scalyr-agent-2/issues/48

**zmon-worker**
- Add support kubernetes wrapper

https://github.com/zalando-zmon/zmon-worker/issues/203

**zmon-agent**
- Add Cluster Alias to entities.

https://github.com/zalando-zmon/zmon-agent-core/issues/2