### PR TITLE
ingress controller with health period of 10s

### DIFF
--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: app-ingress-controller
-    version: v0.2.0
+    version: v0.2.0-14-g459b9ef
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: app-ingress-controller
-        version: v0.2.0
+        version: v0.2.0-14-g459b9ef
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-aws-ingress-controller:v0.2.0
+        image: registry.opensource.zalan.do/teapot/kube-aws-ingress-controller:v0.2.0-14-g459b9ef
         env:
         - name: AWS_REGION
           value: {{ .Region }}


### PR DESCRIPTION
Set ALB health period to 10s to become unhealthy within default pod grace period (30s).

See https://github.com/zalando-incubator/kube-ingress-aws-controller/pull/48