### PR TITLE
Dev to alpha

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,9 +16,10 @@ Configuration in this repository initially was based on kube-aws_, but now depen
 * Cluster Lifecycle Manager to provision the cluster's Cloud Formation stack and apply Kubernetes manifests for system components
 * Authnz Webhook to validate OAuth tokens and authorize access
 
-We plan to release all required components to the community in Q1/2017.
+We plan to release all required components to the community in Q2/2017.
 
-Please see our `Running Kubernetes in Production on AWS document`_ for details on the setup.
+Please watch our meetup talk `"Kubernetes on AWS at Europe's Leading Online Fashion Platform" on YouTube`_ to learn how we run Kubernetes on AWS in production.
+See our `Running Kubernetes in Production on AWS document`_ for details on the setup.
 
 
 Features
@@ -73,3 +74,4 @@ Directory Structure
 .. _kube2iam: https://github.com/jtblin/kube2iam
 .. _kube-aws-autoscaler: https://github.com/hjacobs/kube-aws-autoscaler
 .. _Running Kubernetes in Production on AWS document: https://kubernetes-on-aws.readthedocs.io/en/latest/admin-guide/kubernetes-in-production.html
+.. _"Kubernetes on AWS at Europe's Leading Online Fashion Platform" on YouTube: https://www.youtube.com/watch?time_continue=2671&v=XmnhzEoengI

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: app-ingress-controller
-    version: v0.2.0
+    version: v0.2.0-14-g459b9ef
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: app-ingress-controller
-        version: v0.2.0
+        version: v0.2.0-14-g459b9ef
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-aws-ingress-controller:v0.2.0
+        image: registry.opensource.zalan.do/teapot/kube-aws-ingress-controller:v0.2.0-14-g459b9ef
         env:
         - name: AWS_REGION
           value: {{ .Region }}

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.9.19
+    version: v0.9.26
     component: ingress
   annotations:
     daemonset.kubernetes.io/strategyType: RollingUpdate
@@ -19,7 +19,7 @@ spec:
       name: skipper-ingress
       labels:
         application: skipper-ingress
-        version: v0.9.19
+        version: v0.9.26
         component: ingress
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -28,7 +28,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/teapot/skipper:v0.9.19
+        image: registry.opensource.zalan.do/teapot/skipper:v0.9.26
         ports:
         - name: ingress-port
           containerPort: 9999

--- a/docs/admin-guide/kubernetes-in-production.rst
+++ b/docs/admin-guide/kubernetes-in-production.rst
@@ -2,6 +2,13 @@
 Running Kubernetes in Production
 ================================
 
+.. Tip::
+
+    Start by watching our meetup talk `"Kubernetes on AWS at Europe's Leading Online Fashion Platform" on YouTube`_ (slides_) to learn how we run Kubernetes on AWS in production.
+
+.. _"Kubernetes on AWS at Europe's Leading Online Fashion Platform" on YouTube: https://www.youtube.com/watch?time_continue=2671&v=XmnhzEoengI
+.. _slides: https://www.slideshare.net/try_except_/kubernetes-on-aws-at-europes-leading-online-fashion-platform
+
 This document should briefly describe our learnings in Zalando Tech while running Kubernetes on AWS in production. As we just recently started to migrate to Kubernetes, we consider ourselves far from being experts in the field. This document is shared in the hope that others in the community can benefit from our learnings.
 
 Context


### PR DESCRIPTION
* handle `TERM` signal in Skipper
* change health check period of ALB Target Group to 10s (instead of default 30s)

=> node shutdown should now be graceful (tested manually by deleting `skipper-ingress` pod and watching AWS TargetGroup health state)
