### PR TITLE
Disable anonymous-auth

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -308,6 +308,7 @@ write_files:
           - --authorization-webhook-config-file=/etc/kubernetes/config/authz.yaml
           - --runtime-config=authorization.k8s.io/v1beta1=true
           - --feature-gates=AllAlpha=true
+          - --anonymous-auth=false
           livenessProbe:
             httpGet:
               host: 127.0.0.1


### PR DESCRIPTION
Set `--anonymous-auth=false` on the API server to block anonymous access to `/api` `/healthz` etc.