### PR TITLE
Don't schedule skipper on master nodes

### DIFF
--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -23,6 +23,13 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: master
+                operator: DoesNotExist
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists


### PR DESCRIPTION
This uses node anti-affinity to ensure the skipper daemonset pods are not scheduled on master nodes. Since no traffic is going to the pods it doesn't make sense to have them running there. (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature)

I think eventually taints/tolerations is a better approach for these kind of things, but as of 1.6 there is no way, afaik, to prevent other non-system pods from being scheduled on master nodes if we use taints.