### PR TITLE
add kube-dns-metrics

### DIFF
--- a/cluster/manifests/kube-dns-metrics-bash/deployment.yaml
+++ b/cluster/manifests/kube-dns-metrics-bash/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kube-dns-metrics-bash
+  namespace: kube-system
+  labels:
+    application: kube-dns-metrics-bash
+    version: v0.0.4
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      application: kube-dns-metrics-bash
+  template:
+    metadata:
+      labels:
+        application: kube-dns-metrics-bash
+        version: v0.0.4
+    spec:
+      containers:
+        - image: pierone.stups.zalan.do/teapot/kube-dns-metrics-bash:v0.0.4
+          name: kube-dns-metrics-bash
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+            requests:
+              cpu: 25m
+              memory: 25Mi
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+          ports:
+            - containerPort: 8080

--- a/cluster/manifests/kube-dns-metrics-bash/deployment.yaml
+++ b/cluster/manifests/kube-dns-metrics-bash/deployment.yaml
@@ -36,3 +36,6 @@ spec:
             timeoutSeconds: 3
           ports:
             - containerPort: 8080
+      imagePullSecrets:
+        - name: pierone.stups.zalan.do
+

--- a/cluster/manifests/kube-dns-metrics/deployment.yaml
+++ b/cluster/manifests/kube-dns-metrics/deployment.yaml
@@ -37,3 +37,5 @@ spec:
           ports:
             - containerPort: 8080
             - containerPort: 9000
+      imagePullSecrets:
+        - name: pierone.stups.zalan.do

--- a/cluster/manifests/kube-dns-metrics/deployment.yaml
+++ b/cluster/manifests/kube-dns-metrics/deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kube-dns-metrics
+  namespace: kube-system
+  labels:
+    application: kube-dns-metrics
+    version: v1.0.0
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      application: kube-dns-metrics
+  template:
+    metadata:
+      labels:
+        application: kube-dns-metrics
+        version: v1.0.0
+    spec:
+      containers:
+        - image: pierone.stups.zalan.do/teapot/kube-dns-metrics:v1.0.0
+          name: kube-dns-metrics
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+            requests:
+              cpu: 25m
+              memory: 25Mi
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+          ports:
+            - containerPort: 8080
+            - containerPort: 9000


### PR DESCRIPTION
add kube-dns-metrics deployment which does dns queries every 10s and expose metrics calculated over the last 60s