### PR TITLE
Add scalyr read key to zmon-worker manifest

### DIFF
--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -46,6 +46,8 @@ spec:
               value: zmon:queue:default/16
             - name: WORKER_REDIS_SERVERS
               value: zmon-redis:6379
+            - name: WORKER_PLUGIN_SCALYR_READ_KEY
+              value: "{{ .ConfigItems.scalyr_read_key }}"
             - name: WORKER_PLUGIN_SQL_USER
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Changes:

- Update ``zmon-worker`` manifest to include ``SCALYR_READ_KEY`` to allow zmon checks read access from the cluster scalyr account.

Note: Depends on ``"{{ .ConfigItems.scalyr_read_key }}"``