### PR TITLE
bump of webhook to include metrics

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -340,7 +340,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.8
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.9
           name: webhook
           ports:
           - containerPort: 8081


### PR DESCRIPTION
This includes metrics, exposed on `:7979/metrics`. 

