### PR TITLE
Upgrade log-watcher version to 0.13

### DIFF
--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -53,7 +53,7 @@ spec:
           mountPath: /mnt/scalyr-checkpoint
       containers:
       - name: log-watcher
-        image: registry.opensource.zalan.do/eagleeye/kubernetes-log-watcher:0.12
+        image: registry.opensource.zalan.do/eagleeye/kubernetes-log-watcher:0.13
         env:
         - name: CLUSTER_NODE_NAME
           valueFrom:


### PR DESCRIPTION
Changes:

- Upgrade ``log-watcher`` to 0.13
- Supporting custom Scalyr parsers via pod annotations