### PR TITLE
add compatibility mode and upsert only policy

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -37,8 +37,8 @@ spec:
         - --dry-run=false 
         - --domain=
         - --zone=""
-        - --compatibility
-        - --policy=upsert-only
+        - --compatibility # change this to string later to --compatibility=mate, when this flag value will become a string type
+        - --policy=upsert-only # remove when we are sure external-dns can be trusted
       - name: external-dns-migration
         image: pierone.stups.zalan.do/teapot/external-dns-migration:v0.1.2
         args:

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -37,6 +37,8 @@ spec:
         - --dry-run=false 
         - --domain=
         - --zone=""
+        - --compatibility
+        - --policy=upsert-only
       - name: external-dns-migration
         image: pierone.stups.zalan.do/teapot/external-dns-migration:v0.1.2
         args:


### PR DESCRIPTION
add compatibility mode and upsert only policy

`--compatibility true` enables external-dns consider mate annotations `zalando.org/dnsname` to figure out the needed dnsname. It is only needed for services[type=LoadBalancer]. 
`--policy=upsert-only`will only create/update records as needed. If ingress/service is deleted, corresponding dns record will still exist. Adding this flag to make sure that this `alpha` release of external-dns functions as expected in a more sophisticated environment with multiple hosted-zones. Will be removed once we are sure. 