### PR TITLE
kube2iam v0.4.1

### DIFF
--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube2iam
-    version: v0.3.0
+    version: v0.4.1
 spec:
   selector:
     matchLabels:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: kube2iam
-        version: v0.3.0
+        version: v0.4.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -25,7 +25,7 @@ spec:
         operator: Exists
       hostNetwork: true
       containers:
-      - image: registry.opensource.zalan.do/teapot/kube2iam:0.3.0
+      - image: registry.opensource.zalan.do/teapot/kube2iam:0.4.1
         name: kube2iam
         args:
         - "--base-role-arn=arn:aws:iam::{{ getAWSAccountID .InfrastructureAccount }}:role/"


### PR DESCRIPTION
Latest release of kube2iam: https://github.com/jtblin/kube2iam/compare/0.3.0...0.4.1

There are sadly no official release notes for newer releases than 0.3.0: https://github.com/jtblin/kube2iam/issues/64