### PR TITLE
Add imagePullSecret for private external-dns sidecar

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -44,3 +44,5 @@ spec:
         args:
         - --source-txt-label=mate:{{ .LocalID }}
         - --target-txt-label=heritage=external-dns,external-dns/owner={{ .Region }}:{{ .LocalID }}
+      imagePullSecrets:
+        - name: pierone.stups.zalan.do


### PR DESCRIPTION
Makes sure the pod can become ready even if it's scheduled before secretary has attached the `imagePullSecret` to the serviceaccount.