### PR TITLE
kube2iam v0.5.0

### DIFF
--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube2iam
-    version: v0.4.1
+    version: v0.5.1
 spec:
   selector:
     matchLabels:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: kube2iam
-        version: v0.4.1
+        version: v0.5.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -25,7 +25,7 @@ spec:
         operator: Exists
       hostNetwork: true
       containers:
-      - image: registry.opensource.zalan.do/teapot/kube2iam:0.4.1
+      - image: registry.opensource.zalan.do/teapot/kube2iam:0.5.1
         name: kube2iam
         args:
         - "--base-role-arn=arn:aws:iam::{{ getAWSAccountID .InfrastructureAccount }}:role/"

--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube2iam
-    version: v0.5.1
+    version: v0.5.0
 spec:
   selector:
     matchLabels:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: kube2iam
-        version: v0.5.1
+        version: v0.5.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -25,7 +25,7 @@ spec:
         operator: Exists
       hostNetwork: true
       containers:
-      - image: registry.opensource.zalan.do/teapot/kube2iam:0.5.1
+      - image: registry.opensource.zalan.do/teapot/kube2iam:0.5.0
         name: kube2iam
         args:
         - --auto-discover-base-arn

--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       - image: registry.opensource.zalan.do/teapot/kube2iam:0.5.1
         name: kube2iam
         args:
-        - "--base-role-arn=arn:aws:iam::{{ getAWSAccountID .InfrastructureAccount }}:role/"
+        - --auto-discover-base-arn
         - --verbose
         ports:
         - containerPort: 8181


### PR DESCRIPTION
Upgrade kube2iam to https://github.com/jtblin/kube2iam/releases/tag/0.5.1

Uses the new flag to automatically discover the base ARN: https://github.com/jtblin/kube2iam/issues/13