### PR TITLE
correctly use compatibility flag

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: external-dns
-    version: v0.3.0-alpha.4
+    version: v0.3.0-alpha.5
 spec:
   strategy:
     type: Recreate
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: external-dns
-        version: v0.3.0-alpha.4
+        version: v0.3.0-alpha.5
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -26,7 +26,7 @@ spec:
          operator: Exists
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.3.0-alpha.4
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.3.0-alpha.5
         args:
         - --in-cluster
         - --source=service
@@ -38,7 +38,7 @@ spec:
         - --debug
         - --domain=
         - --zone=""
-        - --compatibility # change this to string later to --compatibility=mate, when this flag value will become a string type
+        - --compatibility=mate
         - --policy=upsert-only # remove when we are sure external-dns can be trusted
       - name: external-dns-migration
         image: pierone.stups.zalan.do/teapot/external-dns-migration:v0.1.2


### PR DESCRIPTION
this already changed to a string in `alpha.4`. I wonder how this worked.