### PR TITLE
kube-job-cleaner v0.3

### DIFF
--- a/cluster/manifests/kube-job-cleaner/cronjob.yaml
+++ b/cluster/manifests/kube-job-cleaner/cronjob.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-job-cleaner
-    version: "0.2"
+    version: "0.3"
 spec:
   schedule: "17 * * * *"
   jobTemplate:
@@ -14,13 +14,13 @@ spec:
         metadata:
           labels:
             application: kube-job-cleaner
-            version: "0.2"
+            version: "0.3"
         spec:
           restartPolicy: OnFailure
           containers:
           - name: cleaner
             # delete all completed jobs after one hour
-            image: registry.opensource.zalan.do/teapot/kube-job-cleaner:0.2
+            image: registry.opensource.zalan.do/teapot/kube-job-cleaner:0.3
             resources:
               limits:
                 cpu: 100m


### PR DESCRIPTION
CDP was spamming our cluster with jobs/pods in "weird" states (container create failed etc). This PR updates the job cleaner to https://github.com/hjacobs/kube-job-cleaner/releases/tag/0.3 to clean up more stuff.

Example pod status (current state "waiting") which was not cleaned up, but will be cleaned up with the new version:

```
status:
  conditions:
  - lastProbeTime: null
    lastTransitionTime: 2017-04-11T14:44:23Z
    status: "True"
    type: Initialized
  - lastProbeTime: null
    lastTransitionTime: 2017-04-11T14:44:23Z
    message: 'containers with unready status: [smoke-test]'
    reason: ContainersNotReady
    status: "False"
    type: Ready
  - lastProbeTime: null
    lastTransitionTime: 2017-04-11T14:44:23Z
    status: "True"
    type: PodScheduled
  containerStatuses:
  - containerID: docker://1f45eca6a31cf92ba6fa3f3fd19dbd229290f9da98005e48119252bb25371322
    image: pierone.stups.zalan.do/ci/cdp-controller-smoketest:2
    imageID: docker-pullable://pierone.stups.zalan.do/ci/cdp-controller-smoketest@sha256:4167a9fafc2149daaf7aa68a369a16d41d525a6338bbdd993ba3722eeaf0101d
    lastState:
      terminated:
        containerID: docker://1f45eca6a31cf92ba6fa3f3fd19dbd229290f9da98005e48119252bb25371322
        exitCode: 127
        finishedAt: 2017-04-11T14:44:23Z
        message: 'invalid header field value "oci runtime error: container_linux.go:247:
          starting container process caused \"exec: \\\"\\\": executable file not
          found in $PATH\"\n"'
        reason: ContainerCannotRun
        startedAt: null
    name: smoke-test
    ready: false
    restartCount: 0
    state:
      waiting:
        message: Start Container Failed
        reason: 'rpc error: code = 2 desc = failed to start container "1f45eca6a31cf92ba6fa3f3fd19dbd229290f9da98005e48119252bb25371322":
          Error response from daemon: {"message":"invalid header field value \"oci
          runtime error: container_linux.go:247: starting container process caused
          \\\"exec: \\\\\\\"\\\\\\\": executable file not found in $PATH\\\"\\n\""}'
  hostIP: 172.31.7.103
  phase: Failed
  podIP: 10.2.94.43
  qosClass: Burstable
  startTime: 2017-04-11T14:44:23Z
