### PR TITLE
Add zmon-agent PostgreSQL secrets configuration to deployment.yaml

### DIFF
--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         operator: Exists
       containers:
         - name: zmon-agent
-          image: "registry.opensource.zalan.do/zmon/zmon-agent-core:0.1-a19"
+          image: "registry.opensource.zalan.do/zmon/zmon-agent-core:0.1-a20"
           resources:
             limits:
               cpu: 100m

--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -50,6 +50,17 @@ spec:
             - name: ZMON_AGENT_KUBERNETES_CLUSTER_ALIAS
               value: "{{ .Alias }}"
 
+            - name: ZMON_AGENT_POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: zmon-worker
+                  key: sql-user
+            - name: ZMON_AGENT_POSTGRES_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: zmon-worker
+                  key: sql-pass
+
             - name: OAUTH2_ACCESS_TOKEN_URL
               value: https://token.services.auth.zalando.com/oauth2/access_token?realm=/services
             - name: CREDENTIALS_DIR


### PR DESCRIPTION
We "steal" the username and password from zmon-worker secret.  This is going
to work, but we might want to create a separate secret (and user) later.