### PR TITLE
chore(external-dns): bump version to v0.3.0-beta.0

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: external-dns
-    version: v0.3.0-alpha.5
+    version: v0.3.0-beta.0
 spec:
   strategy:
     type: Recreate
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: external-dns
-        version: v0.3.0-alpha.5
+        version: v0.3.0-beta.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
@@ -26,20 +26,16 @@ spec:
          operator: Exists
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.3.0-alpha.5
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.3.0-beta.0
         args:
-        - --in-cluster
         - --source=service
         - --source=ingress
         - --provider=aws
-        - --registry=txt
-        - --record-owner-id={{ .Region }}:{{ .LocalID }}
-        - --dry-run=false
-        - --debug
-        - --domain=
-        - --zone=""
-        - --compatibility=mate
         - --policy=upsert-only # remove when we are sure external-dns can be trusted
+        - --registry=txt
+        - --txt-owner-id={{ .Region }}:{{ .LocalID }}
+        - --compatibility=mate # remove when we switched to the new annotations
+        - --debug # remove when we are sure external-dns can be trusted
       - name: external-dns-migration
         image: pierone.stups.zalan.do/teapot/external-dns-migration:v0.1.2
         args:


### PR DESCRIPTION
bumps version of ExternalDNS to v0.3.0-beta.0