### PR TITLE
kube-aws-autoscaler v0.9: no spare nodes for test and support >50 nodes

### DIFF
--- a/cluster/manifests/cluster-autoscaler/config-playground.yaml
+++ b/cluster/manifests/cluster-autoscaler/config-playground.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-autoscaler-playground
+  namespace: kube-system
+data:
+  # do not provision any "spare" nodes for Playground
+  BUFFER_SPARE_NODES: "0"

--- a/cluster/manifests/cluster-autoscaler/config-production.yaml
+++ b/cluster/manifests/cluster-autoscaler/config-production.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-autoscaler-production
+  namespace: kube-system
+data:
+  BUFFER_SPARE_NODES: "1"

--- a/cluster/manifests/cluster-autoscaler/config-test.yaml
+++ b/cluster/manifests/cluster-autoscaler/config-test.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-autoscaler-test
+  namespace: kube-system
+data:
+  # do not provision any "spare" nodes for test/staging clusters
+  BUFFER_SPARE_NODES: "0"

--- a/cluster/manifests/cluster-autoscaler/deployment.yaml
+++ b/cluster/manifests/cluster-autoscaler/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: cluster-autoscaler
-    version: v0.7
+    version: v0.8
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: cluster-autoscaler
-        version: v0.7
+        version: v0.8
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-autoscaler"
@@ -24,7 +24,7 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       containers:
-        - image: registry.opensource.zalan.do/teapot/kube-aws-autoscaler:0.7
+        - image: registry.opensource.zalan.do/teapot/kube-aws-autoscaler:0.8
           name: cluster-autoscaler
           resources:
             limits:

--- a/cluster/manifests/cluster-autoscaler/deployment.yaml
+++ b/cluster/manifests/cluster-autoscaler/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: cluster-autoscaler
-    version: v0.8
+    version: v0.9
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: cluster-autoscaler
-        version: v0.8
+        version: v0.9
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-autoscaler"
@@ -24,12 +24,17 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       containers:
-        - image: registry.opensource.zalan.do/teapot/kube-aws-autoscaler:0.8
-          name: cluster-autoscaler
-          resources:
-            limits:
-              cpu: 200m
-              memory: 300Mi
-            requests:
-              cpu: 50m
-              memory: 100Mi
+      - name: cluster-autoscaler
+        image: registry.opensource.zalan.do/teapot/kube-aws-autoscaler:0.9
+        envFrom:
+        - configMapRef:
+            # load buffer settings from ConfigMap e.g. to set spare nodes to zero for test environments
+            name: cluster-autoscaler-{{ .Environment }}
+            optional: true
+        resources:
+          limits:
+            cpu: 200m
+            memory: 300Mi
+          requests:
+            cpu: 50m
+            memory: 100Mi


### PR DESCRIPTION
Version bump to https://github.com/hjacobs/kube-aws-autoscaler/releases/tag/0.9:

* Fix a problem we don't really have (yet): supporting more than 50 nodes (@ichekrygin found this issue.., see https://github.com/hjacobs/kube-aws-autoscaler/issues/25)
* Change the resource buffer via environment specific ConfigMap (required https://github.com/hjacobs/kube-aws-autoscaler/issues/27) to set number of spare nodes to zero for test/staging clusters (saves costs :moneybag:)