### PR TITLE
fix SG for ELBs

### DIFF
--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -356,6 +356,8 @@ Resources:
       - {CidrIp: 172.31.0.0/16, FromPort: 9100, IpProtocol: tcp, ToPort: 9100}
       # allow checking kubelet healthz port from within the VPC
       - {CidrIp: 172.31.0.0/16, FromPort: 10248, IpProtocol: tcp, ToPort: 10248}
+      # allow default service NodePort range
+      - {CidrIp: 172.31.0.0/16, FromPort: 30000, IpProtocol: tcp, ToPort: 32767}
       Tags:
         - Key: "KubernetesCluster"
           Value: kubernetes

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -427,6 +427,7 @@ write_files:
           - --root-ca-file=/etc/kubernetes/ssl/ca.pem
           - --cloud-provider=aws
           - --feature-gates=AllAlpha=true
+          - --cloud-config=/etc/kubernetes/cloud-config.ini
           resources:
             limits:
               cpu: 200m
@@ -599,6 +600,11 @@ write_files:
                 "isDefaultGateway": true
             }
         }
+
+  - path: /etc/kubernetes/cloud-config.ini
+    content: |
+      [global]
+      DisableSecurityGroupIngress = true
 
   - path: /home/core/.toolboxrc
     owner: core


### PR DESCRIPTION
use static SG to allow all local VPC IPs including ELBs to access worker ASG nodePorts

for reference there is a CloudConfig struct which can be configure with --cloud-config params on the controller-manager:
https://github.com/kubernetes/kubernetes/blob/master/pkg/cloudprovider/providers/aws/aws.go\#L386-L426