### PR TITLE
Alpha to beta

### DIFF
--- a/cluster/manifests/cluster-autoscaler/config-playground.yaml
+++ b/cluster/manifests/cluster-autoscaler/config-playground.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-autoscaler-playground
+  namespace: kube-system
+data:
+  # do not provision any "spare" nodes for Playground
+  BUFFER_SPARE_NODES: "0"

--- a/cluster/manifests/cluster-autoscaler/config-production.yaml
+++ b/cluster/manifests/cluster-autoscaler/config-production.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-autoscaler-production
+  namespace: kube-system
+data:
+  BUFFER_SPARE_NODES: "1"

--- a/cluster/manifests/cluster-autoscaler/config-test.yaml
+++ b/cluster/manifests/cluster-autoscaler/config-test.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-autoscaler-test
+  namespace: kube-system
+data:
+  # do not provision any "spare" nodes for test/staging clusters
+  BUFFER_SPARE_NODES: "0"

--- a/cluster/manifests/cluster-autoscaler/deployment.yaml
+++ b/cluster/manifests/cluster-autoscaler/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: cluster-autoscaler
-    version: v0.7
+    version: v0.8
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: cluster-autoscaler
-        version: v0.7
+        version: v0.8
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-autoscaler"
@@ -24,7 +24,7 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       containers:
-        - image: registry.opensource.zalan.do/teapot/kube-aws-autoscaler:0.7
+        - image: registry.opensource.zalan.do/teapot/kube-aws-autoscaler:0.8
           name: cluster-autoscaler
           resources:
             limits:

--- a/cluster/manifests/cluster-autoscaler/deployment.yaml
+++ b/cluster/manifests/cluster-autoscaler/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: cluster-autoscaler
-    version: v0.8
+    version: v0.9
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: cluster-autoscaler
-        version: v0.8
+        version: v0.9
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-autoscaler"
@@ -24,12 +24,17 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       containers:
-        - image: registry.opensource.zalan.do/teapot/kube-aws-autoscaler:0.8
-          name: cluster-autoscaler
-          resources:
-            limits:
-              cpu: 200m
-              memory: 300Mi
-            requests:
-              cpu: 50m
-              memory: 100Mi
+      - name: cluster-autoscaler
+        image: registry.opensource.zalan.do/teapot/kube-aws-autoscaler:0.9
+        envFrom:
+        - configMapRef:
+            # load buffer settings from ConfigMap e.g. to set spare nodes to zero for test environments
+            name: cluster-autoscaler-{{ .Environment }}
+            optional: true
+        resources:
+          limits:
+            cpu: 200m
+            memory: 300Mi
+          requests:
+            cpu: 50m
+            memory: 100Mi

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: external-dns
-    version: v0.3.0-alpha.5
+    version: v0.3.0-beta.0
 spec:
   strategy:
     type: Recreate
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: external-dns
-        version: v0.3.0-alpha.5
+        version: v0.3.0-beta.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
@@ -26,20 +26,16 @@ spec:
          operator: Exists
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.3.0-alpha.5
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.3.0-beta.0
         args:
-        - --in-cluster
         - --source=service
         - --source=ingress
         - --provider=aws
-        - --registry=txt
-        - --record-owner-id={{ .Region }}:{{ .LocalID }}
-        - --dry-run=false
-        - --debug
-        - --domain=
-        - --zone=""
-        - --compatibility=mate
         - --policy=upsert-only # remove when we are sure external-dns can be trusted
+        - --registry=txt
+        - --txt-owner-id={{ .Region }}:{{ .LocalID }}
+        - --compatibility=mate # remove when we switched to the new annotations
+        - --debug # remove when we are sure external-dns can be trusted
       - name: external-dns-migration
         image: pierone.stups.zalan.do/teapot/external-dns-migration:v0.1.2
         args:

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: external-dns
-    version: v0.3.0-beta.0
+    version: v0.3.0-beta.2
 spec:
   strategy:
     type: Recreate
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: external-dns
-        version: v0.3.0-beta.0
+        version: v0.3.0-beta.2
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
@@ -26,20 +26,14 @@ spec:
          operator: Exists
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.3.0-beta.0
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.3.0-beta.2
         args:
         - --source=service
         - --source=ingress
         - --provider=aws
-        - --policy=upsert-only # remove when we are sure external-dns can be trusted
         - --registry=txt
         - --txt-owner-id={{ .Region }}:{{ .LocalID }}
         - --compatibility=mate # remove when we switched to the new annotations
         - --debug # remove when we are sure external-dns can be trusted
-      - name: external-dns-migration
-        image: pierone.stups.zalan.do/teapot/external-dns-migration:v0.1.2
-        args:
-        - --source-txt-label=mate:{{ .LocalID }}
-        - --target-txt-label=heritage=external-dns,external-dns/owner={{ .Region }}:{{ .LocalID }}
       imagePullSecrets:
         - name: pierone.stups.zalan.do

--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube2iam
-    version: v0.5.0
+    version: v0.5.2
 spec:
   selector:
     matchLabels:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: kube2iam
-        version: v0.5.0
+        version: v0.5.2
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -25,7 +25,7 @@ spec:
         operator: Exists
       hostNetwork: true
       containers:
-      - image: registry.opensource.zalan.do/teapot/kube2iam:0.5.0
+      - image: registry.opensource.zalan.do/teapot/kube2iam:0.5.2
         name: kube2iam
         args:
         - --auto-discover-base-arn

--- a/cluster/manifests/secretary/deployment.yaml
+++ b/cluster/manifests/secretary/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: secretary
-    version: v0.3.0
+    version: v0.3.1
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: secretary
-        version: v0.3.0
+        version: v0.3.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-secretary"
@@ -25,7 +25,7 @@ spec:
         operator: Exists
       containers:
       - name: secretary
-        image: registry.opensource.zalan.do/teapot/secretary:v0.3.0
+        image: registry.opensource.zalan.do/teapot/secretary:v0.3.1
         args:
         - --all-namespaces
         - --service-account=default

--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         operator: Exists
       containers:
         - name: zmon-agent
-          image: "registry.opensource.zalan.do/zmon/zmon-agent-core:0.1-a19"
+          image: "registry.opensource.zalan.do/zmon/zmon-agent-core:0.1-a20"
           resources:
             limits:
               cpu: 100m

--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -50,6 +50,17 @@ spec:
             - name: ZMON_AGENT_KUBERNETES_CLUSTER_ALIAS
               value: "{{ .Alias }}"
 
+            - name: ZMON_AGENT_POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: zmon-worker
+                  key: sql-user
+            - name: ZMON_AGENT_POSTGRES_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: zmon-worker
+                  key: sql-pass
+
             - name: OAUTH2_ACCESS_TOKEN_URL
               value: https://token.services.auth.zalando.com/oauth2/access_token?realm=/services
             - name: CREDENTIALS_DIR

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -356,6 +356,8 @@ Resources:
       - {CidrIp: 172.31.0.0/16, FromPort: 9100, IpProtocol: tcp, ToPort: 9100}
       # allow checking kubelet healthz port from within the VPC
       - {CidrIp: 172.31.0.0/16, FromPort: 10248, IpProtocol: tcp, ToPort: 10248}
+      # allow default service NodePort range
+      - {CidrIp: 172.31.0.0/16, FromPort: 30000, IpProtocol: tcp, ToPort: 32767}
       Tags:
         - Key: "KubernetesCluster"
           Value: kubernetes

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -241,35 +241,6 @@ Resources:
           Version: '2012-10-17'
         PolicyName: root
     Type: AWS::IAM::Role
-  MateIAMRole:
-    Properties:
-      RoleName: "{{SenzaInfo.StackName}}-{{SenzaInfo.StackVersion}}-app-mate"
-      AssumeRolePolicyDocument:
-        Statement:
-        - Action: ['sts:AssumeRole']
-          Effect: Allow
-          Principal:
-            Service: [ec2.amazonaws.com]
-        - Action: ['sts:AssumeRole']
-          Effect: Allow
-          Principal:
-            AWS:
-              Fn::Join:
-                - ""
-                -
-                  - arn:aws:iam::{{ AccountInfo.AccountID }}:role/
-                  -
-                    Ref: WorkerIAMRole
-        Version: '2012-10-17'
-      Path: /
-      Policies:
-      - PolicyDocument:
-          Statement:
-          - {Action: 'route53:*', Effect: Allow, Resource: '*'}
-          - {Action: 'elasticloadbalancing:DescribeLoadBalancers', Effect: Allow, Resource: '*'}
-          Version: '2012-10-17'
-        PolicyName: root
-    Type: AWS::IAM::Role
   IngressControllerIAMRole:
     Properties:
       RoleName: "{{SenzaInfo.StackName}}-{{SenzaInfo.StackVersion}}-app-ingr-ctrl"

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -340,7 +340,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.10
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.11
           name: webhook
           ports:
           - containerPort: 8081

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -427,6 +427,7 @@ write_files:
           - --root-ca-file=/etc/kubernetes/ssl/ca.pem
           - --cloud-provider=aws
           - --feature-gates=AllAlpha=true
+          - --cloud-config=/etc/kubernetes/cloud-config.ini
           resources:
             limits:
               cpu: 200m
@@ -599,6 +600,11 @@ write_files:
                 "isDefaultGateway": true
             }
         }
+
+  - path: /etc/kubernetes/cloud-config.ini
+    content: |
+      [global]
+      DisableSecurityGroupIngress = true
 
   - path: /home/core/.toolboxrc
     owner: core

--- a/docs/admin-guide/kubernetes-in-production.rst
+++ b/docs/admin-guide/kubernetes-in-production.rst
@@ -76,11 +76,11 @@ There is no official way of implementing Ingress on AWS. We decided to create a 
 We use Skipper_ as our HTTP proxy to route based on Host header and path. Skipper is running as a ``DaemonSet`` on all worker nodes for convenient AWS ASG integration (new nodes are automatically registered in the ALB's Target Group).
 Skipper directly comes with a Kubernetes data client to automatically update its routes periodically.
 
-Mate_ is automatically configuring the Ingress hosts as DNS records in Route53 for us.
+`External DNS`_ is automatically configuring the Ingress hosts as DNS records in Route53 for us.
 
 .. _Kube AWS Ingress Controller: https://github.com/zalando-incubator/kube-ingress-aws-controller
 .. _Skipper: https://github.com/zalando/skipper
-.. _Mate: https://github.com/zalando-incubator/mate
+.. _External DNS: https://github.com/kubernetes-incubator/external-dns
 
 Resources
 =========

--- a/docs/user-guide/tls-termination.rst
+++ b/docs/user-guide/tls-termination.rst
@@ -123,40 +123,8 @@ doesn't match the served certificate.
 DNS records
 ===========
 
-For convenience we create alias DNS entries for your service so you don't have
-to use the arbitrary ELB endpoints. The DNS name that is generated is based on
-your service's name, namespace, and the cluster's domain.
-
-The generated DNS name's format is:
-
-.. code-block:: go
-
-    {serviceName}-{serviceNamespace}.{teamName}.zalan.do
-
-For the service above this results in the following DNS name:
-
-.. code-block:: go
-
-    nginx-default.hackweek.zalan.do
-
-Verify that this works with ``curl``. If you've chosen the right certificate ARN
-you won't get any certificate warning.
-
-.. code-block:: bash
-
-    $ curl https://nginx-default.hackweek.zalan.do
-    <!DOCTYPE html>
-    <html>
-    <head>
-    <title>Welcome to nginx!</title>
-    ...
-    </body>
-    </html>
-
-Customizing the DNS name
-------------------------
-
-However, if you're not happy with the default DNS name you can change it by
+For convenience you can assign a DNS name for your service so you don't have
+to use the arbitrary ELB endpoints. The DNS name can be specified by
 adding an additional annotation to your service containing the desired dns name.
 
 .. code-block:: yaml
@@ -166,7 +134,7 @@ adding an additional annotation to your service containing the desired dns name.
     metadata:
       name: nginx
       annotations:
-        zalando.org/dnsname: my-nginx.hackweek.zalan.do
+        external-dns.alpha.kubernetes.io/hostname: my-nginx.playground.zalan.do
     spec:
       ...
 
@@ -179,7 +147,7 @@ Make sure it works:
 
 .. code-block:: bash
 
-    $ curl https://my-nginx.hackweek.zalan.do
+    $ curl https://my-nginx.playground.zalan.do
     <!DOCTYPE html>
     <html>
     <head>
@@ -199,7 +167,7 @@ For reference, the full service description should look like this:
       annotations:
         service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:eu-central-1:some-account-id:certificate/some-cert-id
         service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
-        zalando.org/dnsname: my-nginx.hackweek.zalan.do
+        external-dns.alpha.kubernetes.io/hostname: my-nginx.playground.zalan.do
     spec:
       type: LoadBalancer
       ports:
@@ -208,8 +176,6 @@ For reference, the full service description should look like this:
       selector:
         app: nginx
 
-*Special note to Zalando Hackweek cluster users: We will provide you with the correct
-ARN for the Hackweek cluster DNS zone.*
 
 Common pitfalls
 ===============

--- a/docs/user-guide/zalando-iam.rst
+++ b/docs/user-guide/zalando-iam.rst
@@ -31,16 +31,17 @@ The ``PlatformCredentialsSet`` resource allows application owners to declare nee
     spec:
        application: my-app
        tokens:
-         full-access:
-           privileges:
+         full-access: # token name
+           privileges: # privileges/scopes for the token.
              # All zalando-specific privileges start with namespace com.zalando, following pattern <namespace>::<privilege>
+             # the privileges/scopes you define here should match those you define for your application in yourturn.
              - com.zalando::foobar.write
              - com.zalando::acme.full
-         read-only:
-           privileges:
+         read-only: # token name
+           privileges: # privileges/scopes for the token.
              - com.zalando::foobar.read
        clients:
-         employee:
+         employee: # client name
            # the allowed grant type, see https://tools.ietf.org/html/rfc6749
            # options: authorization-code, implicit, resource-owner-password-credentials, client-credentials
            # (values directly reference RFC section titles)
@@ -52,7 +53,14 @@ The ``PlatformCredentialsSet`` resource allows application owners to declare nee
            # redirection URI as described in https://tools.ietf.org/html/rfc6749#section-2
            redirectUri: https://example.org/auth/callback
 
-The declared credentials will automatically be provided as a secret with the same name.
+The declared credentials will automatically be provided as a secret with the
+same name.
+
+Following this example you would get a token called ``full-access`` with the
+privileges ``com.zalando::foobar.write`` and ``com.zalando::acme.full``, a
+token called ``read-only`` with privileges ``com.zalando::foobar.read`` and a
+client named ``employee`` which uses ``authorization-code`` grant under realm
+``users``.
 
 
 Secrets


### PR DESCRIPTION
Align alpha and beta.

* Bump kube2iam to v0.5.2
* Update autoscaler to v0.9
* External DNS 0.3 (https://github.com/kubernetes-incubator/external-dns/issues/168): remove migration, remove safety flag, remove Mate IAM role
* Allow more ELBs (fixes #195)
* Bump Secretary version (small race condition fix)
* Bump webhook (logging, error handling)
* Pass postgres credentials to ZMON-agent (and bump agent to 0.1-a20)