### PR TITLE
Upgrade kube2iam to 0.6.0 and add liveness and readiness probes

### DIFF
--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube2iam
-    version: v0.5.2
+    version: v0.6.0
 spec:
   selector:
     matchLabels:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: kube2iam
-        version: v0.5.2
+        version: v0.6.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -25,7 +25,7 @@ spec:
         operator: Exists
       hostNetwork: true
       containers:
-      - image: registry.opensource.zalan.do/teapot/kube2iam:0.5.2
+      - image: registry.opensource.zalan.do/teapot/kube2iam:0.6.0
         name: kube2iam
         args:
         - --auto-discover-base-arn
@@ -36,6 +36,16 @@ spec:
           name: http
         securityContext:
           privileged: true
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8181
+          timeoutSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8181
+          timeoutSeconds: 1
         resources:
           limits:
             cpu: 100m

--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -40,12 +40,12 @@ spec:
           httpGet:
             path: /healthz
             port: 8181
-          timeoutSeconds: 1
+          timeoutSeconds: 3
         readinessProbe:
           httpGet:
             path: /healthz
             port: 8181
-          timeoutSeconds: 1
+          timeoutSeconds: 3
         resources:
           limits:
             cpu: 100m

--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -36,11 +36,6 @@ spec:
           name: http
         securityContext:
           privileged: true
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8181
-          timeoutSeconds: 3
         readinessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
This bumps kube2iam to version 0.6.0 which includes `/healthz` endpoint, thus I'm adding liveness and readiness probes.

https://github.com/jtblin/kube2iam/releases/tag/0.6.0