### PR TITLE
remove obsolete imagePullSecret

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -35,5 +35,3 @@ spec:
         - --txt-owner-id={{ .Region }}:{{ .LocalID }}
         - --compatibility=mate # remove when we switched to the new annotations
         - --debug # remove when we are sure external-dns can be trusted
-      imagePullSecrets:
-        - name: pierone.stups.zalan.do


### PR DESCRIPTION
External DNS is in OSS registry, so we need no credentials to pull from Docker registry :smile: 