### PR TITLE
Update log-watcher and zmon-agent

### DIFF
--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: logging-agent
-    version: v0.10
+    version: v0.14
     component: logging
 spec:
   selector:
@@ -18,7 +18,7 @@ spec:
       name: logging-agent
       labels:
         application: logging-agent
-        version: v0.10
+        version: v0.14
         component: logging
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -53,7 +53,7 @@ spec:
           mountPath: /mnt/scalyr-checkpoint
       containers:
       - name: log-watcher
-        image: registry.opensource.zalan.do/eagleeye/kubernetes-log-watcher:0.13
+        image: registry.opensource.zalan.do/eagleeye/kubernetes-log-watcher:0.14
         env:
         - name: CLUSTER_NODE_NAME
           valueFrom:

--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: "kube-system"
   labels:
     application: "zmon-agent"
-    version: "v0.1"
+    version: "v0.1-a21"
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: "zmon-agent"
-        version: "v0.1"
+        version: "v0.1-a21"
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
         scheduler.alpha.kubernetes.io/critical-pod: ''

--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         operator: Exists
       containers:
         - name: zmon-agent
-          image: "registry.opensource.zalan.do/zmon/zmon-agent-core:0.1-a20"
+          image: "registry.opensource.zalan.do/zmon/zmon-agent-core:0.1-a21"
           resources:
             limits:
               cpu: 100m


### PR DESCRIPTION
Changes:

**Log-watcher (0.14)**
- Drop constraint on application and version labels (could be enabled via ``WATCHER_STRICT_LABELS``) https://github.com/zalando-incubator/kubernetes-log-watcher/pull/39

**ZMON-agent (0.1-a21)**
- Add postgresql_cluster entity type https://github.com/zalando-zmon/zmon-agent-core/pull/10
