### PR TITLE
update ingress controller to v0.2.2

### DIFF
--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: app-ingress-controller
-    version: v0.2.1
+    version: v0.2.2
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: app-ingress-controller
-        version: v0.2.1
+        version: v0.2.2
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
@@ -25,7 +25,7 @@ spec:
         operator: Exists
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-aws-ingress-controller:v0.2.1
+        image: registry.opensource.zalan.do/teapot/kube-aws-ingress-controller:v0.2.2
         env:
         - name: AWS_REGION
           value: {{ .Region }}


### PR DESCRIPTION
* Create :7979/metrics endpoint to serve metrics from all client http calls to external APIs (AWS/Kubernetes) https://github.com/zalando-incubator/kube-ingress-aws-controller/pull/52