### PR TITLE
use CF to reduce API calls to AWS

### DIFF
--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: app-ingress-controller
-    version: v0.2.2
+    version: v0.3.0
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: app-ingress-controller
-        version: v0.2.2
+        version: v0.3.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
@@ -25,7 +25,7 @@ spec:
         operator: Exists
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-aws-ingress-controller:v0.2.2
+        image: registry.opensource.zalan.do/teapot/kube-aws-ingress-controller:v0.3.0
         env:
         - name: AWS_REGION
           value: {{ .Region }}

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -272,21 +272,17 @@ Resources:
           - {Action: 'autoscaling:DetachLoadBalancers', Effect: Allow, Resource: '*'}
           - {Action: 'autoscaling:DetachLoadBalancerTargetGroups', Effect: Allow, Resource: '*'}
           - {Action: 'autoscaling:AttachLoadBalancerTargetGroups', Effect: Allow, Resource: '*'}
-          - {Action: 'elasticloadbalancing:DescribeLoadBalancers', Effect: Allow, Resource: '*'}
-          - {Action: 'elasticloadbalancing:CreateLoadBalancer', Effect: Allow, Resource: '*'}
-          - {Action: 'elasticloadbalancing:DeleteLoadBalancer', Effect: Allow, Resource: '*'}
-          - {Action: 'elasticloadbalancing:DescribeListeners', Effect: Allow, Resource: '*'}
-          - {Action: 'elasticloadbalancing:CreateListener', Effect: Allow, Resource: '*'}
-          - {Action: 'elasticloadbalancing:DeleteListener', Effect: Allow, Resource: '*'}
-          - {Action: 'elasticloadbalancing:DescribeTags', Effect: Allow, Resource: '*'}
-          - {Action: 'elasticloadbalancing:CreateTargetGroup', Effect: Allow, Resource: '*'}
-          - {Action: 'elasticloadbalancing:DeleteTargetGroup', Effect: Allow, Resource: '*'}
           - {Action: 'ec2:DescribeInstances', Effect: Allow, Resource: '*'}
           - {Action: 'ec2:DescribeSubnets', Effect: Allow, Resource: '*'}
           - {Action: 'ec2:DescribeSecurityGroups', Effect: Allow, Resource: '*'}
           - {Action: 'ec2:DescribeRouteTables', Effect: Allow, Resource: '*'}
           - {Action: 'iam:GetServerCertificate', Effect: Allow, Resource: '*'}
           - {Action: 'iam:ListServerCertificates', Effect: Allow, Resource: '*'}
+          - {Action: 'cloudformation:Get*', Effect: Allow, Resource: '*'}
+          - {Action: 'cloudformation:Describe*', Effect: Allow, Resource: '*'}
+          - {Action: 'cloudformation:List*', Effect: Allow, Resource: '*'}
+          - {Action: 'cloudformation:Create*', Effect: Allow, Resource: '*'}
+          - {Action: 'cloudformation:Delete*', Effect: Allow, Resource: '*'}
           Version: '2012-10-17'
         PolicyName: root
     Type: AWS::IAM::Role

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -272,26 +272,9 @@ Resources:
           - {Action: 'autoscaling:DetachLoadBalancers', Effect: Allow, Resource: '*'}
           - {Action: 'autoscaling:DetachLoadBalancerTargetGroups', Effect: Allow, Resource: '*'}
           - {Action: 'autoscaling:AttachLoadBalancerTargetGroups', Effect: Allow, Resource: '*'}
-          - {Action: 'elasticloadbalancing:DescribeLoadBalancers', Effect: Allow, Resource: '*'}
-          - {Action: 'elasticloadbalancing:CreateLoadBalancer', Effect: Allow, Resource: '*'}
-          - {Action: 'elasticloadbalancing:DeleteLoadBalancer', Effect: Allow, Resource: '*'}
-          - {Action: 'elasticloadbalancing:DescribeListeners', Effect: Allow, Resource: '*'}
-          - {Action: 'elasticloadbalancing:CreateListener', Effect: Allow, Resource: '*'}
-          - {Action: 'elasticloadbalancing:DeleteListener', Effect: Allow, Resource: '*'}
-          - {Action: 'elasticloadbalancing:DescribeTags', Effect: Allow, Resource: '*'}
-          - {Action: 'elasticloadbalancing:CreateTargetGroup', Effect: Allow, Resource: '*'}
-          - {Action: 'elasticloadbalancing:DeleteTargetGroup', Effect: Allow, Resource: '*'}
-          - {Action: 'elasticloadbalancing:DescribeTargetGroups', Effect: Allow, Resource: '*'}
-          - {Action: 'elasticloadbalancingv2:DescribeLoadBalancers', Effect: Allow, Resource: '*'}
-          - {Action: 'elasticloadbalancingv2:CreateLoadBalancer', Effect: Allow, Resource: '*'}
-          - {Action: 'elasticloadbalancingv2:DeleteLoadBalancer', Effect: Allow, Resource: '*'}
-          - {Action: 'elasticloadbalancingv2:DescribeListeners', Effect: Allow, Resource: '*'}
-          - {Action: 'elasticloadbalancingv2:CreateListener', Effect: Allow, Resource: '*'}
-          - {Action: 'elasticloadbalancingv2:DeleteListener', Effect: Allow, Resource: '*'}
-          - {Action: 'elasticloadbalancingv2:DescribeTags', Effect: Allow, Resource: '*'}
-          - {Action: 'elasticloadbalancingv2:CreateTargetGroup', Effect: Allow, Resource: '*'}
-          - {Action: 'elasticloadbalancingv2:DeleteTargetGroup', Effect: Allow, Resource: '*'}
-          - {Action: 'elasticloadbalancingv2:DescribeTargetGroups', Effect: Allow, Resource: '*'}
+          - {Action: 'cloudformation:*', Effect: Allow, Resource: '*'}
+          - {Action: 'elasticloadbalancing:*', Effect: Allow, Resource: '*'}
+          - {Action: 'elasticloadbalancingv2:*', Effect: Allow, Resource: '*'}
           - {Action: 'ec2:DescribeInstances', Effect: Allow, Resource: '*'}
           - {Action: 'ec2:DescribeSubnets', Effect: Allow, Resource: '*'}
           - {Action: 'ec2:DescribeSecurityGroups', Effect: Allow, Resource: '*'}
@@ -299,11 +282,6 @@ Resources:
           - {Action: 'ec2:DescribeVpcs', Effect: Allow, Resource: '*'}
           - {Action: 'iam:GetServerCertificate', Effect: Allow, Resource: '*'}
           - {Action: 'iam:ListServerCertificates', Effect: Allow, Resource: '*'}
-          - {Action: 'cloudformation:Get*', Effect: Allow, Resource: '*'}
-          - {Action: 'cloudformation:Describe*', Effect: Allow, Resource: '*'}
-          - {Action: 'cloudformation:List*', Effect: Allow, Resource: '*'}
-          - {Action: 'cloudformation:Create*', Effect: Allow, Resource: '*'}
-          - {Action: 'cloudformation:Delete*', Effect: Allow, Resource: '*'}
           Version: '2012-10-17'
         PolicyName: root
     Type: AWS::IAM::Role

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -272,10 +272,31 @@ Resources:
           - {Action: 'autoscaling:DetachLoadBalancers', Effect: Allow, Resource: '*'}
           - {Action: 'autoscaling:DetachLoadBalancerTargetGroups', Effect: Allow, Resource: '*'}
           - {Action: 'autoscaling:AttachLoadBalancerTargetGroups', Effect: Allow, Resource: '*'}
+          - {Action: 'elasticloadbalancing:DescribeLoadBalancers', Effect: Allow, Resource: '*'}
+          - {Action: 'elasticloadbalancing:CreateLoadBalancer', Effect: Allow, Resource: '*'}
+          - {Action: 'elasticloadbalancing:DeleteLoadBalancer', Effect: Allow, Resource: '*'}
+          - {Action: 'elasticloadbalancing:DescribeListeners', Effect: Allow, Resource: '*'}
+          - {Action: 'elasticloadbalancing:CreateListener', Effect: Allow, Resource: '*'}
+          - {Action: 'elasticloadbalancing:DeleteListener', Effect: Allow, Resource: '*'}
+          - {Action: 'elasticloadbalancing:DescribeTags', Effect: Allow, Resource: '*'}
+          - {Action: 'elasticloadbalancing:CreateTargetGroup', Effect: Allow, Resource: '*'}
+          - {Action: 'elasticloadbalancing:DeleteTargetGroup', Effect: Allow, Resource: '*'}
+          - {Action: 'elasticloadbalancing:DescribeTargetGroups', Effect: Allow, Resource: '*'}
+          - {Action: 'elasticloadbalancingv2:DescribeLoadBalancers', Effect: Allow, Resource: '*'}
+          - {Action: 'elasticloadbalancingv2:CreateLoadBalancer', Effect: Allow, Resource: '*'}
+          - {Action: 'elasticloadbalancingv2:DeleteLoadBalancer', Effect: Allow, Resource: '*'}
+          - {Action: 'elasticloadbalancingv2:DescribeListeners', Effect: Allow, Resource: '*'}
+          - {Action: 'elasticloadbalancingv2:CreateListener', Effect: Allow, Resource: '*'}
+          - {Action: 'elasticloadbalancingv2:DeleteListener', Effect: Allow, Resource: '*'}
+          - {Action: 'elasticloadbalancingv2:DescribeTags', Effect: Allow, Resource: '*'}
+          - {Action: 'elasticloadbalancingv2:CreateTargetGroup', Effect: Allow, Resource: '*'}
+          - {Action: 'elasticloadbalancingv2:DeleteTargetGroup', Effect: Allow, Resource: '*'}
+          - {Action: 'elasticloadbalancingv2:DescribeTargetGroups', Effect: Allow, Resource: '*'}
           - {Action: 'ec2:DescribeInstances', Effect: Allow, Resource: '*'}
           - {Action: 'ec2:DescribeSubnets', Effect: Allow, Resource: '*'}
           - {Action: 'ec2:DescribeSecurityGroups', Effect: Allow, Resource: '*'}
           - {Action: 'ec2:DescribeRouteTables', Effect: Allow, Resource: '*'}
+          - {Action: 'ec2:DescribeVpcs', Effect: Allow, Resource: '*'}
           - {Action: 'iam:GetServerCertificate', Effect: Allow, Resource: '*'}
           - {Action: 'iam:ListServerCertificates', Effect: Allow, Resource: '*'}
           - {Action: 'cloudformation:Get*', Effect: Allow, Resource: '*'}


### PR DESCRIPTION
To reduce AWS API calls we use now kube-aws-ingress-controller in version v0.3.0. 
We have to manually cleaning up AWS ALBs after traffic switching and watch out for DNS entries and kube-external-dns changes