### PR TITLE
Update skipper to include traffic switching support

### DIFF
--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.9.26
+    version: v0.9.37
     component: ingress
 spec:
   selector:
@@ -18,7 +18,7 @@ spec:
       name: skipper-ingress
       labels:
         application: skipper-ingress
-        version: v0.9.26
+        version: v0.9.37
         component: ingress
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -36,7 +36,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/teapot/skipper:v0.9.26
+        image: registry.opensource.zalan.do/teapot/skipper:v0.9.37
         ports:
         - name: ingress-port
           containerPort: 9999


### PR DESCRIPTION
This adds support for the ingress annotation `zalando.org/backend-weights` which was implemented in https://github.com/zalando/skipper/pull/330