### PR TITLE
Replace etcd2 proxy with etcd3 gateway

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -24,7 +24,7 @@ coreos:
           content: |
             [Service]
             Environment="ETCD_IMAGE_TAG=v3.1.6"
-            Environment="ETCD_OPTS=gateway start --listen-addr=127.0.0.1:2379 --endpoints={{ etcd_endpoints }}"
+            Environment="ETCD_OPTS=gateway start --listen-addr=127.0.0.1:2379 --endpoints={{ ETCD_ENDPOINTS }}"
 
     - name: docker.service
       drop-ins:
@@ -289,9 +289,9 @@ write_files:
           - --bind-address=0.0.0.0
           - --insecure-bind-address=0.0.0.0
           - --etcd-servers=http://127.0.0.1:2379
-          - --etcd-prefix={{ apiserver_etcd_prefix }}
-          - --storage-backend={{ apiserver_storage_backend }}
-          - --storage-media-type={{ apiserver_storage_media_type }}
+          - --etcd-prefix={{ APISERVER_ETCD_PREFIX }}
+          - --storage-backend={{ APISERVER_STORAGE_BACKEND }}
+          - --storage-media-type={{ APISERVER_STORAGE_MEDIA_TYPE }}
           - --allow-privileged=true
           - --service-cluster-ip-range=10.3.0.0/24
           - --secure-port=443

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -14,18 +14,17 @@ coreos:
     reboot-strategy: "off"
   flannel:
     interface: $private_ipv4
-    etcd_endpoints: http://$private_ipv4:2379
-  etcd2:
-    discovery-srv: {{ETCD_DISCOVERY_DOMAIN}}
-    proxy: on
-    advertise-client-urls: http://$private_ipv4:2379
-    initial-advertise-peer-urls: http://$private_ipv4:2380
-    listen-client-urls: http://0.0.0.0:2379
-    listen-peer-urls: http://0.0.0.0:2380
+    etcd_endpoints: http://127.0.0.1:2379
   units:
-    - name: etcd2.service
+    - name: etcd-member.service
       command: start
-      runtime: true
+      enable: true
+      drop-ins:
+        - name: 40-etcd-gateway.conf
+          content: |
+            [Service]
+            Environment="ETCD_IMAGE_TAG=v3.1.6"
+            Environment="ETCD_OPTS=gateway start --listen-addr=127.0.0.1:2379 --endpoints={{ etcd_endpoints }}"
 
     - name: docker.service
       drop-ins:
@@ -289,10 +288,10 @@ write_files:
           - apiserver
           - --bind-address=0.0.0.0
           - --insecure-bind-address=0.0.0.0
-          - --etcd-servers=http://localhost:2379
-          - --etcd-prefix=/registry-{{STACK_VERSION}}
-          - --storage-backend=etcd2
-          - --storage-media-type=application/json
+          - --etcd-servers=http://127.0.0.1:2379
+          - --etcd-prefix={{ apiserver_etcd_prefix }}
+          - --storage-backend={{ apiserver_storage_backend }}
+          - --storage-media-type={{ apiserver_storage_media_type }}
           - --allow-privileged=true
           - --service-cluster-ip-range=10.3.0.0/24
           - --secure-port=443

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -14,18 +14,17 @@ coreos:
     reboot-strategy: "off"
   flannel:
     interface: $private_ipv4
-    etcd_endpoints: http://$private_ipv4:2379
-  etcd2:
-    discovery-srv: {{ETCD_DISCOVERY_DOMAIN}}
-    proxy: on
-    advertise-client-urls: http://$private_ipv4:2379
-    initial-advertise-peer-urls: http://$private_ipv4:2380
-    listen-client-urls: http://0.0.0.0:2379
-    listen-peer-urls: http://0.0.0.0:2380
+    etcd_endpoints: http://127.0.0.1:2379
   units:
-    - name: etcd2.service
+    - name: etcd-member.service
       command: start
-      runtime: true
+      enable: true
+      drop-ins:
+        - name: 40-etcd-gateway.conf
+          content: |
+            [Service]
+            Environment="ETCD_IMAGE_TAG=v3.1.6"
+            Environment="ETCD_OPTS=gateway start --listen-addr=127.0.0.1:2379 --endpoints={{ etcd_endpoints }}"
 
     - name: docker.service
       drop-ins:

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -24,7 +24,7 @@ coreos:
           content: |
             [Service]
             Environment="ETCD_IMAGE_TAG=v3.1.6"
-            Environment="ETCD_OPTS=gateway start --listen-addr=127.0.0.1:2379 --endpoints={{ etcd_endpoints }}"
+            Environment="ETCD_OPTS=gateway start --listen-addr=127.0.0.1:2379 --endpoints={{ ETCD_ENDPOINTS }}"
 
     - name: docker.service
       drop-ins:


### PR DESCRIPTION
Replaces the default etcd2 proxy with the etcd3 gateway
(etcd-member.service). This makes it possible to later switch to etcd3
while still being etcd2 compatible.

Using etcd gateway should also fix the issues we have seen where the etcd2 proxy doesn't re-resolve the hostnames of the etcd cluster after the members has been updated.

etcd version is set to v3.1.6 because the default version included in
coreos stable (v3.0.10) doesn't correctly signal systemd, making the unit
hang (https://github.com/coreos/etcd/commit/01dd60c0f774886193310180b6d62f47f11a0c24).

This also changes the apiserver flags etcd-prefix, storage-backend and
storage-media-type to be configured through template variables. This
enables different storage configuration for different clusters (pending
change in CLM).