### PR TITLE
Fix quote in wrong place

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -82,9 +82,9 @@ coreos:
         --volume dns,kind=host,source=/etc/resolv.conf \
         --mount volume=dns,target=/etc/resolv.conf \
         --volume var-log,kind=host,source=/var/log \
-        --mount volume=var-log,target=/var/log" \
+        --mount volume=var-log,target=/var/log \
         --volume var-lib-cni,kind=host,source=/var/lib/cni \
-        --mount volume=var-lib-cni,target=/var/lib/cni
+        --mount volume=var-lib-cni,target=/var/lib/cni"
         ExecStartPre=/usr/bin/mkdir -p /var/log/containers
         ExecStartPre=/bin/mkdir -p /var/lib/cni
         ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -75,9 +75,9 @@ coreos:
         --volume hosts,kind=host,source=/etc/hosts \
         --mount volume=hosts,target=/etc/hosts \
         --volume var-log,kind=host,source=/var/log \
-        --mount volume=var-log,target=/var/log" \
+        --mount volume=var-log,target=/var/log \
         --volume var-lib-cni,kind=host,source=/var/lib/cni \
-        --mount volume=var-lib-cni,target=/var/lib/cni
+        --mount volume=var-lib-cni,target=/var/lib/cni"
         ExecStartPre=/usr/bin/mkdir -p /var/log/containers
         ExecStartPre=/bin/mkdir -p /var/lib/cni
         ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid


### PR DESCRIPTION
#418 introduced a small bug because a `"` was in the wrong place.

It didn't cause any problems because the `--mount volume=var-lib-cni` was just ignored by systemd.