### PR TITLE
Enable Operator serviceaccount access to storageclasses

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -339,7 +339,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.11
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.12
           name: webhook
           ports:
           - containerPort: 8081


### PR DESCRIPTION
Updates the webhook to allow Operator serviceAccount access to read/write storageclasses.