### PR TITLE
Make sure secret values are quoted

### DIFF
--- a/cluster/manifests/zmon-worker/secret.yaml
+++ b/cluster/manifests/zmon-worker/secret.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: kube-system
 type: Opaque
 data:
-  sql-user: {{ .ConfigItems.zmon_worker_plugin_sql_user | base64 }}
-  sql-pass: {{ .ConfigItems.zmon_worker_plugin_sql_pass | base64 }}
+  sql-user: "{{ .ConfigItems.zmon_worker_plugin_sql_user | base64 }}"
+  sql-pass: "{{ .ConfigItems.zmon_worker_plugin_sql_pass | base64 }}"


### PR DESCRIPTION
This ensures that empty values for the config items result in an empty string value rather than a `null` value.

Fixes an issue were the data values are not returned when they are both `null` when using etcd3.