### PR TITLE
fix: env vars should be strings

### DIFF
--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -73,9 +73,9 @@ spec:
         - name: WATCHER_SCALYR_JOURNALD
           value: "true"
         - name: WATCHER_SCALYR_JOURNALD_WRITE_RATE
-          value: 20000
+          value: "20000"
         - name: WATCHER_SCALYR_JOURNALD_WRITE_BURST
-          value: 300000
+          value: "300000"
 
         resources:
           limits:


### PR DESCRIPTION
Kubernetes env vars need to be strings...