### PR TITLE
Bump kube2iam to v0.6.1

### DIFF
--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube2iam
-    version: v0.6.0
+    version: v0.6.1
 spec:
   selector:
     matchLabels:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: kube2iam
-        version: v0.6.0
+        version: v0.6.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -25,7 +25,7 @@ spec:
         operator: Exists
       hostNetwork: true
       containers:
-      - image: registry.opensource.zalan.do/teapot/kube2iam:0.6.0
+      - image: registry.opensource.zalan.do/teapot/kube2iam:0.6.1
         name: kube2iam
         args:
         - --auto-discover-base-arn


### PR DESCRIPTION
Minor release: https://github.com/jtblin/kube2iam/releases/tag/0.6.1