### PR TITLE
#62 wait for Cloud Formation SUCCESS signal

### DIFF
--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -7,7 +7,7 @@ SenzaInfo:
       - UserDataMaster:
           Description: "User data of master"
       - UserDataWorker:
-          Description: "User data of master"
+          Description: "User data of worker"
       - KmsKey:
           Description: "ARN of KMS key to decrypt secrets"
       - MasterNodes:
@@ -110,7 +110,7 @@ SenzaComponents:
          Minimum: "{{ Arguments.MinimumWorkerNodes}}"
          Maximum: "{{ Arguments.MaximumWorkerNodes}}"
          DesiredCapacity: "{{ Arguments.WorkerNodes }}"
-         SuccessRequires: "0 within 15m"
+         SuccessRequires: "1 within 15m"
       Tags:
         - Key: "KubernetesCluster"
           Value: kubernetes

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -214,13 +214,6 @@ write_files:
       DOCKER_OPT_BIP=""
       DOCKER_OPT_IPMASQ=""
 
-  - path: /opt/bin/host-rkt
-    permissions: 0755
-    owner: root:root
-    content: |
-      #!/bin/sh
-      exec nsenter -m -u -i -n -p -t 1 -- /usr/bin/rkt "$@"
-
   - path: /etc/kubernetes/manifests/kube-proxy.yaml
     content: |
       apiVersion: v1

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -149,19 +149,23 @@ coreos:
         Type=oneshot
         ExecStart=/usr/bin/docker pull registry.opensource.zalan.do/teapot/microscope:v0.0.4
 
+    - name: cfn-signal.service
+      command: start
+      runtime: true
+      content: |
+        [Service]
+        Type=oneshot
+        ExecStart=/usr/bin/docker run registry.opensource.zalan.do/teapot/cfn-signal:1.4-4 {{LOCAL_ID}} WorkerAutoScaling 0
+
+        [Install]
+        WantedBy=multi-user.target
+
 write_files:
 
   - path: /etc/kubernetes/cni/docker_opts_cni.env
     content: |
       DOCKER_OPT_BIP=""
       DOCKER_OPT_IPMASQ=""
-
-  - path: /opt/bin/host-rkt
-    permissions: 0755
-    owner: root:root
-    content: |
-      #!/bin/sh
-      exec nsenter -m -u -i -n -p -t 1 -- /usr/bin/rkt "$@"
 
   - path: /etc/kubernetes/ssl/worker.pem
     encoding: gzip+base64


### PR DESCRIPTION
Fixes #62: wait for Cloud Formation SUCCESS signal (send by `cfn-signal` script, similar to Taupage).

* add `cfn-signal` service on worker nodes (Docker image was built from https://github.com/hjacobs/docker-aws-cfn-signal)
* wait for at least 1 success signal within 15 minutes
* remove `host-rkt` (not used as we are using Docker runtime)

