### PR TITLE
create system service account 

### DIFF
--- a/cluster/manifests/heapster/deployment.yaml
+++ b/cluster/manifests/heapster/deployment.yaml
@@ -23,6 +23,7 @@ spec:
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
+      serviceAccountName: system
       containers:
         - image: gcr.io/google_containers/heapster:v1.3.0
           name: heapster

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
     spec:
+      serviceAccountName: system
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/cluster/manifests/kube-dns/depl-kube-dns-autoscaler.yaml
+++ b/cluster/manifests/kube-dns/depl-kube-dns-autoscaler.yaml
@@ -20,6 +20,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      serviceAccountName: system
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/cluster/manifests/kube-dns/depl-kube-dns.yaml
+++ b/cluster/manifests/kube-dns/depl-kube-dns.yaml
@@ -27,6 +27,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      serviceAccountName: system
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/cluster/manifests/kube-job-cleaner/cronjob.yaml
+++ b/cluster/manifests/kube-job-cleaner/cronjob.yaml
@@ -16,6 +16,7 @@ spec:
             application: kube-job-cleaner
             version: "0.3"
         spec:
+          serviceAccountName: system
           restartPolicy: OnFailure
           containers:
           - name: cleaner

--- a/cluster/manifests/kube-system-system/sa.yaml
+++ b/cluster/manifests/kube-system-system/sa.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+imagePullSecrets:
+- name: pierone.stups.zalan.do
+metadata:
+  name: system
+  namespace: kube-system

--- a/cluster/manifests/secretary/deployment.yaml
+++ b/cluster/manifests/secretary/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-secretary"
     spec:
+      serviceAccountName: system
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -332,7 +332,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.12-3-g9b76041
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.14
           name: webhook
           ports:
           - containerPort: 8081

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -332,7 +332,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.12-2-g5ebfe2c
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.12-3-g9b76041
           name: webhook
           ports:
           - containerPort: 8081

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -339,7 +339,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.12
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.12-2-g5ebfe2c
           name: webhook
           ports:
           - containerPort: 8081
@@ -427,6 +427,7 @@ write_files:
           - --cloud-provider=aws
           - --feature-gates=AllAlpha=true
           - --cloud-config=/etc/kubernetes/cloud-config.ini
+          - --use-service-account-credentials=true
           resources:
             limits:
               cpu: 200m


### PR DESCRIPTION
This restricts access for the `default` service account in the kube system namespace. It also creates a `system` SA in order to allow high privileged access. This also enables the "use-service-account-credentials" for the controller manager. 

NOTE: the webhook version is only temporary to allow e2e tests. 