### PR TITLE
bump version of ingress controller to v0.3.5

### DIFF
--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         operator: Exists
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-aws-ingress-controller:v0.3.4
+        image: registry.opensource.zalan.do/teapot/kube-aws-ingress-controller:v0.3.5
         env:
         - name: AWS_REGION
           value: {{ .Region }}


### PR DESCRIPTION
This includes updated dependencies as specified in https://github.com/zalando-incubator/kube-ingress-aws-controller/pull/62 