### PR TITLE
increase write rate 10 times

### DIFF
--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -73,9 +73,9 @@ spec:
         - name: WATCHER_SCALYR_JOURNALD
           value: "true"
         - name: WATCHER_SCALYR_JOURNALD_WRITE_RATE
-          value: "20000"
+          value: "200000"
         - name: WATCHER_SCALYR_JOURNALD_WRITE_BURST
-          value: "300000"
+          value: "3000000"
 
         resources:
           limits:


### PR DESCRIPTION
I didn't get any new ```.... Warning, skipped writing 10 log lines due to limit set by `monitor_log_write_rate` option...``` with this value.

please test carefully