### PR TITLE
Bump kube2iam to 0.6.2

### DIFF
--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube2iam
-    version: v0.6.1
+    version: v0.6.2
 spec:
   selector:
     matchLabels:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: kube2iam
-        version: v0.6.1
+        version: v0.6.2
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -25,7 +25,7 @@ spec:
         operator: Exists
       hostNetwork: true
       containers:
-      - image: registry.opensource.zalan.do/teapot/kube2iam:0.6.1
+      - image: registry.opensource.zalan.do/teapot/kube2iam:0.6.2
         name: kube2iam
         args:
         - --auto-discover-base-arn


### PR DESCRIPTION
New kube2iam release: https://github.com/jtblin/kube2iam/releases/tag/0.6.2