### PR TITLE
Dev to alpha

### DIFF
--- a/cluster/manifests/heapster/deployment.yaml
+++ b/cluster/manifests/heapster/deployment.yaml
@@ -23,6 +23,7 @@ spec:
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
+      serviceAccountName: system
       containers:
         - image: gcr.io/google_containers/heapster:v1.3.0
           name: heapster

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         operator: Exists
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-aws-ingress-controller:v0.3.4
+        image: registry.opensource.zalan.do/teapot/kube-aws-ingress-controller:v0.3.5
         env:
         - name: AWS_REGION
           value: {{ .Region }}

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
     spec:
+      serviceAccountName: system
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/cluster/manifests/kube-dns/depl-kube-dns-autoscaler.yaml
+++ b/cluster/manifests/kube-dns/depl-kube-dns-autoscaler.yaml
@@ -20,6 +20,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      serviceAccountName: system
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/cluster/manifests/kube-dns/depl-kube-dns.yaml
+++ b/cluster/manifests/kube-dns/depl-kube-dns.yaml
@@ -27,6 +27,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      serviceAccountName: system
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/cluster/manifests/kube-job-cleaner/cronjob.yaml
+++ b/cluster/manifests/kube-job-cleaner/cronjob.yaml
@@ -16,6 +16,7 @@ spec:
             application: kube-job-cleaner
             version: "0.3"
         spec:
+          serviceAccountName: system
           restartPolicy: OnFailure
           containers:
           - name: cleaner

--- a/cluster/manifests/kube-system-system/sa.yaml
+++ b/cluster/manifests/kube-system-system/sa.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+imagePullSecrets:
+- name: pierone.stups.zalan.do
+metadata:
+  name: system
+  namespace: kube-system

--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube2iam
-    version: v0.6.0
+    version: v0.6.1
 spec:
   selector:
     matchLabels:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: kube2iam
-        version: v0.6.0
+        version: v0.6.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -25,7 +25,7 @@ spec:
         operator: Exists
       hostNetwork: true
       containers:
-      - image: registry.opensource.zalan.do/teapot/kube2iam:0.6.0
+      - image: registry.opensource.zalan.do/teapot/kube2iam:0.6.1
         name: kube2iam
         args:
         - --auto-discover-base-arn

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: logging-agent
-    version: v0.14
+    version: v0.15
     component: logging
 spec:
   selector:
@@ -18,7 +18,7 @@ spec:
       name: logging-agent
       labels:
         application: logging-agent
-        version: v0.14
+        version: v0.15
         component: logging
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -53,7 +53,7 @@ spec:
           mountPath: /mnt/scalyr-checkpoint
       containers:
       - name: log-watcher
-        image: registry.opensource.zalan.do/eagleeye/kubernetes-log-watcher:0.14
+        image: registry.opensource.zalan.do/eagleeye/kubernetes-log-watcher:0.15
         env:
         - name: CLUSTER_NODE_NAME
           valueFrom:
@@ -72,6 +72,10 @@ spec:
           value: /mnt/scalyr-config/agent.json
         - name: WATCHER_SCALYR_JOURNALD
           value: "true"
+        - name: WATCHER_SCALYR_JOURNALD_WRITE_RATE
+          value: 20000
+        - name: WATCHER_SCALYR_JOURNALD_WRITE_BURST
+          value: 300000
 
         resources:
           limits:

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -73,9 +73,9 @@ spec:
         - name: WATCHER_SCALYR_JOURNALD
           value: "true"
         - name: WATCHER_SCALYR_JOURNALD_WRITE_RATE
-          value: 20000
+          value: "20000"
         - name: WATCHER_SCALYR_JOURNALD_WRITE_BURST
-          value: 300000
+          value: "300000"
 
         resources:
           limits:

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -73,9 +73,9 @@ spec:
         - name: WATCHER_SCALYR_JOURNALD
           value: "true"
         - name: WATCHER_SCALYR_JOURNALD_WRITE_RATE
-          value: "20000"
+          value: "200000"
         - name: WATCHER_SCALYR_JOURNALD_WRITE_BURST
-          value: "300000"
+          value: "3000000"
 
         resources:
           limits:

--- a/cluster/manifests/secretary/deployment.yaml
+++ b/cluster/manifests/secretary/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-secretary"
     spec:
+      serviceAccountName: system
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: "kube-system"
   labels:
     application: "zmon-agent"
-    version: "v0.1-a23"
+    version: "v0.1-a24"
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: "zmon-agent"
-        version: "v0.1-a21"
+        version: "v0.1-a24"
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -25,7 +25,7 @@ spec:
         operator: Exists
       containers:
         - name: zmon-agent
-          image: "registry.opensource.zalan.do/zmon/zmon-agent-core:0.1-a23"
+          image: "registry.opensource.zalan.do/zmon/zmon-agent-core:0.1-a24"
           resources:
             limits:
               cpu: 100m

--- a/cluster/manifests/zmon-worker/secret.yaml
+++ b/cluster/manifests/zmon-worker/secret.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: kube-system
 type: Opaque
 data:
-  sql-user: {{ .ConfigItems.zmon_worker_plugin_sql_user | base64 }}
-  sql-pass: {{ .ConfigItems.zmon_worker_plugin_sql_pass | base64 }}
+  sql-user: "{{ .ConfigItems.zmon_worker_plugin_sql_user | base64 }}"
+  sql-pass: "{{ .ConfigItems.zmon_worker_plugin_sql_pass | base64 }}"

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -517,6 +517,9 @@ Resources:
             - Action: "s3:GetObject"
               Resource: "arn:aws:s3:::{{ AccountInfo.MintBucket }}/secretary/*"
               Effect: Allow
+            - {Action: 'sqs:GetQueueAttributes', Effect: Allow, Resource: '*'}
+            - {Action: 'sqs:ListDeadLetterSourceQueues', Effect: Allow, Resource: '*'}
+            - {Action: 'sqs:ListQueues', Effect: Allow, Resource: '*'}            
           Version: '2012-10-17'
         PolicyName: root
     Type: AWS::IAM::Role

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -7,7 +7,7 @@ SenzaInfo:
       - UserDataMaster:
           Description: "User data of master"
       - UserDataWorker:
-          Description: "User data of master"
+          Description: "User data of worker"
       - KmsKey:
           Description: "ARN of KMS key to decrypt secrets"
       - MasterNodes:
@@ -110,7 +110,7 @@ SenzaComponents:
          Minimum: "{{ Arguments.MinimumWorkerNodes}}"
          Maximum: "{{ Arguments.MaximumWorkerNodes}}"
          DesiredCapacity: "{{ Arguments.WorkerNodes }}"
-         SuccessRequires: "0 within 15m"
+         SuccessRequires: "1 within 15m"
       Tags:
         - Key: "KubernetesCluster"
           Value: kubernetes

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -101,9 +101,6 @@ SenzaComponents:
          - {Ref: WorkerSecurityGroup}
       IamRoles:
          - {Ref: WorkerIAMRole}
-      ElasticLoadBalancer: WorkerLoadBalancer
-      HealthCheckGracePeriod: 480 # give worker node up to 8 min to start up
-      HealthCheckType: EC2
       AssociatePublicIpAddress: true
       UserData: "{{ Arguments.UserDataWorker }}"
       AutoScaling:
@@ -118,25 +115,6 @@ SenzaComponents:
           Value: "{{ Arguments.ClusterID }}"
         - Key: "NodePool"
           Value: "{{ Arguments.WorkerNodePoolName }}"
-  - WorkerLoadBalancer:
-      Type: Senza::ElasticLoadBalancer
-      NameSuffix: worker
-      HTTPPort: 10248
-      HealthCheckPath: /healthz
-      HealthCheckPort: 10248
-      Listeners:
-        - PolicyNames: []
-          Protocol: HTTP
-          InstanceProtocol: HTTP
-          InstancePort: 10248
-          LoadBalancerPort: 10248
-      Tags:
-        - Key: "KubernetesCluster"
-          Value: kubernetes
-        - Key: "ClusterID"
-          Value: "{{ Arguments.ClusterID }}"
-      SecurityGroups:
-        - {Ref: WorkerLoadBalancerSecurityGroup}
 
 Resources:
   MasterIAMRole:
@@ -373,27 +351,6 @@ Resources:
           Value: "{{ Arguments.ClusterID }}"
     Type: AWS::EC2::SecurityGroup
 
-  WorkerLoadBalancerSecurityGroup:
-    Properties:
-      GroupDescription: {Ref: 'AWS::StackName'}
-      SecurityGroupIngress:
-      - {CidrIp: 0.0.0.0/0, FromPort: -1, IpProtocol: icmp, ToPort: -1}
-      VpcId: "{{ AccountInfo.VpcID }}"
-      Tags:
-        - Key: "ClusterID"
-          Value: "{{ Arguments.ClusterID }}"
-    Type: AWS::EC2::SecurityGroup
-  WorkerSecurityGroupFromLoadBalancerHealthCheck:
-    Properties:
-      FromPort: 10248
-      GroupId: {Ref: WorkerSecurityGroup}
-      IpProtocol: tcp
-      SourceSecurityGroupId: {Ref: WorkerLoadBalancerSecurityGroup}
-      ToPort: 10248
-      Tags:
-        - Key: "ClusterID"
-          Value: "{{ Arguments.ClusterID }}"
-    Type: AWS::EC2::SecurityGroupIngress
   MasterSecurityGroupIngressFromWorker:
     Properties:
       FromPort: 443

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -332,7 +332,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.12-3-g9b76041
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.14
           name: webhook
           ports:
           - containerPort: 8081

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -332,7 +332,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.12-2-g5ebfe2c
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.12-3-g9b76041
           name: webhook
           ports:
           - containerPort: 8081

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -214,13 +214,6 @@ write_files:
       DOCKER_OPT_BIP=""
       DOCKER_OPT_IPMASQ=""
 
-  - path: /opt/bin/host-rkt
-    permissions: 0755
-    owner: root:root
-    content: |
-      #!/bin/sh
-      exec nsenter -m -u -i -n -p -t 1 -- /usr/bin/rkt "$@"
-
   - path: /etc/kubernetes/manifests/kube-proxy.yaml
     content: |
       apiVersion: v1

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -332,7 +332,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.12
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.13
           name: webhook
           ports:
           - containerPort: 8081

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -339,7 +339,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.12
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.12-2-g5ebfe2c
           name: webhook
           ports:
           - containerPort: 8081
@@ -427,6 +427,7 @@ write_files:
           - --cloud-provider=aws
           - --feature-gates=AllAlpha=true
           - --cloud-config=/etc/kubernetes/cloud-config.ini
+          - --use-service-account-credentials=true
           resources:
             limits:
               cpu: 200m

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -149,19 +149,23 @@ coreos:
         Type=oneshot
         ExecStart=/usr/bin/docker pull registry.opensource.zalan.do/teapot/microscope:v0.0.4
 
+    - name: cfn-signal.service
+      command: start
+      runtime: true
+      content: |
+        [Service]
+        Type=oneshot
+        ExecStart=/usr/bin/docker run registry.opensource.zalan.do/teapot/cfn-signal:1.4-4 {{LOCAL_ID}} WorkerAutoScaling 0
+
+        [Install]
+        WantedBy=multi-user.target
+
 write_files:
 
   - path: /etc/kubernetes/cni/docker_opts_cni.env
     content: |
       DOCKER_OPT_BIP=""
       DOCKER_OPT_IPMASQ=""
-
-  - path: /opt/bin/host-rkt
-    permissions: 0755
-    owner: root:root
-    content: |
-      #!/bin/sh
-      exec nsenter -m -u -i -n -p -t 1 -- /usr/bin/rkt "$@"
 
   - path: /etc/kubernetes/ssl/worker.pem
     encoding: gzip+base64


### PR DESCRIPTION
* enables --use-service-account-credentials=true flag for kube-controller-manager, meaning all controller loops use service accounts
* bump webhook to support kube-controller-manager service-accounts
* use cfn-signal and changed CF for Worker nodes to fix worker node bootstrapping problems
* fix: sqs permission