### PR TITLE
deploy local multi-tenant tokeninfo with introspection

### DIFF
--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -185,9 +185,7 @@ Resources:
       - PolicyDocument:
           Statement:
           - {Action: 'ec2:Describe*', Effect: Allow, Resource: '*'}
-          - {Action: 'autoscaling:Describe*', Effect: Allow, Resource: '*'}
-          - {Action: 'autoscaling:SetDesiredCapacity', Effect: Allow, Resource: '*'}
-          - {Action: 'autoscaling:TerminateInstanceInAutoScalingGroup', Effect: Allow, Resource: '*'}
+          - {Action: 'autoscaling:*', Effect: Allow, Resource: '*'}
           Version: '2012-10-17'
         PolicyName: root
     Type: AWS::IAM::Role

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -323,7 +323,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: pierone.stups.zalan.do/teapot/k8s-authnz-webhook:v0.1.11-15-g686ead1
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.2.0
           name: webhook
           ports:
           - containerPort: 8081
@@ -358,7 +358,7 @@ write_files:
             - name: USER_GROUPS
               value: stups_autobahn=Administrator,stups_deployment-controller-ui=ReadOnly,credentials-provider=Administrator,credprov-kube-ops-view-read-only-token=ReadOnly,credprov-cluster-lifecycle-manager-cluster-rw-token=Administrator,credprov-cluster-lifecycle-manager-test-cluster-rw-token=Administrator,credprov-cdp-controller-cluster-token=PowerUser
             - name: BUSINESS_PARTNER_IDS
-              value: {{BUSINESS_PARTNER_IDS}}
+              value: {{ APISERVER_BUSINESS_PARTNER_IDS }}
           volumeMounts:
           - mountPath: /etc/kubernetes/config
             name: kubernetes-configs

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -354,13 +354,47 @@ write_files:
             - name: CLUSTER_ID
               value: {{WEBHOOK_ID}}
             - name: TOKENINFO_URL
-              value: https://info.services.auth.zalando.com/oauth2/tokeninfo
+              value: http://127.0.0.1:9021/oauth2/introspect
             - name: USER_GROUPS
               value: stups_autobahn=Administrator,stups_deployment-controller-ui=ReadOnly,credentials-provider=Administrator,credprov-kube-ops-view-read-only-token=ReadOnly,credprov-cluster-lifecycle-manager-cluster-rw-token=Administrator,credprov-cluster-lifecycle-manager-test-cluster-rw-token=Administrator,credprov-cdp-controller-cluster-token=PowerUser
           volumeMounts:
           - mountPath: /etc/kubernetes/config
             name: kubernetes-configs
             readOnly: true
+        - image: pierone.stups.zalan.do/foundation/platform-iam-tokeninfo:46fa3a9
+          name: tokeninfo
+          ports:
+            - containerPort: 9021
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 9021
+            periodSeconds: 3
+            failureThreshold: 2
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 9021
+            periodSeconds: 3
+            failureThreshold: 2
+          resources:
+            limits:
+              cpu: 4000m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 20Mi
+          env:
+            - name: OPENID_PROVIDER_CONFIGURATION_URL
+              value: https://identity.zalando.com/.well-known/openid-configuration
+            - name: REVOCATION_PROVIDER_URL
+              value: https://planb-revocation.greendale-questionmark.zalan.do/revocations
+            - name: REVOCATION_HASHING_SALT
+              value: {{REVOCATION_HASHING_SALT}}
+            - name: BUSINESS_PARTNERS
+              value: ""
+            - name: ENABLE_INTROSPECTION
+              value: "true"
         - name: nginx
           image: registry.opensource.zalan.do/teapot/nginx:1.11.5
           resources:

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -361,7 +361,7 @@ write_files:
           - mountPath: /etc/kubernetes/config
             name: kubernetes-configs
             readOnly: true
-        - image: registry.opensource.zalan.do/foundation/platform-iam-tokeninfo:c7c7988
+        - image: registry.opensource.zalan.do/foundation/platform-iam-tokeninfo:4feeb5a
           name: tokeninfo
           ports:
             - containerPort: 9021
@@ -387,10 +387,6 @@ write_files:
           env:
             - name: OPENID_PROVIDER_CONFIGURATION_URL
               value: https://identity.zalando.com/.well-known/openid-configuration
-            - name: REVOCATION_PROVIDER_URL
-              value: https://planb-revocation.greendale-questionmark.zalan.do/revocations
-            - name: REVOCATION_HASHING_SALT
-              value: {{ REVOCATION_HASHING_SALT }}
             - name: ENABLE_INTROSPECTION
               value: "true"
         - name: nginx

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -323,7 +323,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.14
+        - image: pierone.stups.zalan.do/teapot/k8s-authnz-webhook:v0.1.11-15-g686ead1
           name: webhook
           ports:
           - containerPort: 8081
@@ -357,6 +357,8 @@ write_files:
               value: http://127.0.0.1:9021/oauth2/introspect
             - name: USER_GROUPS
               value: stups_autobahn=Administrator,stups_deployment-controller-ui=ReadOnly,credentials-provider=Administrator,credprov-kube-ops-view-read-only-token=ReadOnly,credprov-cluster-lifecycle-manager-cluster-rw-token=Administrator,credprov-cluster-lifecycle-manager-test-cluster-rw-token=Administrator,credprov-cdp-controller-cluster-token=PowerUser
+            - name: BUSINESS_PARTNER_IDS
+              value: {{BUSINESS_PARTNER_IDS}}
           volumeMounts:
           - mountPath: /etc/kubernetes/config
             name: kubernetes-configs

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -361,7 +361,7 @@ write_files:
           - mountPath: /etc/kubernetes/config
             name: kubernetes-configs
             readOnly: true
-        - image: registry.opensource.zalan.do/foundation/platform-iam-tokeninfo:46fa3a9
+        - image: registry.opensource.zalan.do/foundation/platform-iam-tokeninfo:c7c7988
           name: tokeninfo
           ports:
             - containerPort: 9021
@@ -390,9 +390,7 @@ write_files:
             - name: REVOCATION_PROVIDER_URL
               value: https://planb-revocation.greendale-questionmark.zalan.do/revocations
             - name: REVOCATION_HASHING_SALT
-              value: {{REVOCATION_HASHING_SALT}}
-            - name: BUSINESS_PARTNERS
-              value: ""
+              value: {{ REVOCATION_HASHING_SALT }}
             - name: ENABLE_INTROSPECTION
               value: "true"
         - name: nginx

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -353,7 +353,7 @@ write_files:
               value: https://users.auth.zalando.com
             - name: CLUSTER_ID
               value: {{WEBHOOK_ID}}
-            - name: TOKENINFO_URL
+            - name: TOKEN_INTROSPECTION_URL
               value: http://127.0.0.1:9021/oauth2/introspect
             - name: USER_GROUPS
               value: stups_autobahn=Administrator,stups_deployment-controller-ui=ReadOnly,credentials-provider=Administrator,credprov-kube-ops-view-read-only-token=ReadOnly,credprov-cluster-lifecycle-manager-cluster-rw-token=Administrator,credprov-cluster-lifecycle-manager-test-cluster-rw-token=Administrator,credprov-cdp-controller-cluster-token=PowerUser

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -361,7 +361,7 @@ write_files:
           - mountPath: /etc/kubernetes/config
             name: kubernetes-configs
             readOnly: true
-        - image: pierone.stups.zalan.do/foundation/platform-iam-tokeninfo:46fa3a9
+        - image: registry.opensource.zalan.do/foundation/platform-iam-tokeninfo:46fa3a9
           name: tokeninfo
           ports:
             - containerPort: 9021


### PR DESCRIPTION
This deploys the new token introspection endpoint as a sidecar to the webhook.
* [x] make revocation optional or securely add the value
* [x] change the webhook to deal with the request/response bodies
* [x] reference webhook version that's compatible (https://github.bus.zalan.do/teapot/k8s-authnz-webhook/pull/76)

related PRs
* https://github.com/zalando-incubator/kubernetes-on-aws/pull/456 <= this
* https://github.bus.zalan.do/teapot/k8s-authnz-webhook/pull/76
* https://github.bus.zalan.do/teapot/aws-account-creator/pull/41

/cc @vroldanbet 