### PR TITLE
change skipper docker image url

### DIFF
--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -36,7 +36,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/teapot/skipper:v0.9.37
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.9.49-1-gd2a3df5
         ports:
         - name: ingress-port
           containerPort: 9999


### PR DESCRIPTION
build image is now compliant and use cdp build