### PR TITLE
Set custom log parsers

### DIFF
--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -22,6 +22,8 @@ spec:
         component: ingress
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
+        kubernetes-log-watcher/scalyr-parser: |
+          [{"container": "skipper-ingress", "parser": "skipper-access-log"}]
     spec:
       affinity:
         nodeAffinity:

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -271,6 +271,9 @@ write_files:
         labels:
           application: kube-apiserver
           version: v1.6.6_coreos.0
+        annotations:
+          kubernetes-log-watcher/scalyr-parser: |
+            [{"container": "webhook", "parser": "json-structured-log"}]
       spec:
         hostNetwork: true
         containers:


### PR DESCRIPTION
Define custom scalyr log parsers for skipper and webhook.

This will allow us to create custom parsers to make it much easier to query requests in skipper, and make it easier to inspect the webhook logs e.g. to get information about number of unique users pr day/week/month.