### PR TITLE
Bump hyperkube to v1.6.6_coreos.1

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -74,7 +74,7 @@ coreos:
       runtime: true
       content: |
         [Service]
-        Environment=KUBELET_IMAGE_TAG=v1.6.6_coreos.0
+        Environment=KUBELET_IMAGE_TAG=v1.6.6_coreos.1
         Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
         Environment="RKT_RUN_ARGS=--insecure-options=image \
         --uuid-file-save=/var/run/kubelet-pod.uuid \
@@ -132,7 +132,7 @@ coreos:
         --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
         --mount=volume=kube,target=/etc/kubernetes \
         --net=host \
-        registry.opensource.zalan.do/teapot/hyperkube:v1.6.6_coreos.0 \
+        registry.opensource.zalan.do/teapot/hyperkube:v1.6.6_coreos.1 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           drain $(hostname) \
@@ -223,14 +223,14 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-proxy
-          version: v1.6.6_coreos.0
+          version: v1.6.6_coreos.1
         annotations:
           rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
       spec:
         hostNetwork: true
         containers:
         - name: kube-proxy
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.6.6_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.6.6_coreos.1
           command:
           - /hyperkube
           - proxy
@@ -270,7 +270,7 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-apiserver
-          version: v1.6.6_coreos.0
+          version: v1.6.6_coreos.1
         annotations:
           kubernetes-log-watcher/scalyr-parser: |
             [{"container": "webhook", "parser": "json-structured-log"}]
@@ -278,7 +278,7 @@ write_files:
         hostNetwork: true
         containers:
         - name: kube-apiserver
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.6.6_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.6.6_coreos.1
           command:
           - /hyperkube
           - apiserver
@@ -408,11 +408,11 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-controller-manager
-          version: v1.6.6_coreos.0
+          version: v1.6.6_coreos.1
       spec:
         containers:
         - name: kube-controller-manager
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.6.6_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.6.6_coreos.1
           command:
           - /hyperkube
           - controller-manager
@@ -469,12 +469,12 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-scheduler
-          version: v1.6.6_coreos.0
+          version: v1.6.6_coreos.1
       spec:
         hostNetwork: true
         containers:
         - name: kube-scheduler
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.6.6_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.6.6_coreos.1
           command:
           - /hyperkube
           - scheduler

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -65,7 +65,7 @@ coreos:
       runtime: true
       content: |
         [Service]
-        Environment=KUBELET_IMAGE_TAG=v1.6.6_coreos.0
+        Environment=KUBELET_IMAGE_TAG=v1.6.6_coreos.1
         Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
         Environment="RKT_RUN_ARGS=--insecure-options=image \
         --uuid-file-save=/var/run/kubelet-pod.uuid \
@@ -127,7 +127,7 @@ coreos:
         --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
         --mount=volume=kube,target=/etc/kubernetes \
         --net=host \
-        registry.opensource.zalan.do/teapot/hyperkube:v1.6.6_coreos.0 \
+        registry.opensource.zalan.do/teapot/hyperkube:v1.6.6_coreos.1 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
           drain $(hostname) \
@@ -188,14 +188,14 @@ write_files:
           namespace: kube-system
           labels:
             application: kube-proxy
-            version: v1.6.6_coreos.0
+            version: v1.6.6_coreos.1
           annotations:
             rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
         spec:
           hostNetwork: true
           containers:
           - name: kube-proxy
-            image: registry.opensource.zalan.do/teapot/hyperkube:v1.6.6_coreos.0
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.6.6_coreos.1
             command:
             - /hyperkube
             - proxy


### PR DESCRIPTION
Coreos pushed a new hyperkube image v1.6.6_coreos.1

The previous v1.6.6 version has this as the kubernetes version v1.6.6+coreos.0-dirty so I assume they cleaned it up :D