### PR TITLE
[WIP] Use RBAC for authorization

### DIFF
--- a/cluster/manifests/heapster/deployment.yaml
+++ b/cluster/manifests/heapster/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         version: v1.5.4
     spec:
       priorityClassName: system-cluster-critical
-      serviceAccountName: system
+      serviceAccountName: heapster
       containers:
         - image: registry.opensource.zalan.do/teapot/heapster:v1.5.4
           name: heapster

--- a/cluster/manifests/heapster/rbac.yaml
+++ b/cluster/manifests/heapster/rbac.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: heapster
+  namespace: kube-system
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: heapster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:heapster
+subjects:
+- kind: ServiceAccount
+  name: heapster
+  namespace: kube-system

--- a/cluster/manifests/kube-dns/rbac.yaml
+++ b/cluster/manifests/kube-dns/rbac.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-dns
+  namespace: kube-system
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: kube-dns-autoscaler
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: system:kube-dns-autoscaler
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list"]
+  - apiGroups: [""]
+    resources: ["replicationcontrollers/scale"]
+    verbs: ["get", "update"]
+  - apiGroups: ["extensions"]
+    resources: ["deployments/scale", "replicasets/scale"]
+    verbs: ["get", "update"]
+# Remove the configmaps rule once below issue is fixed:
+# kubernetes-incubator/cluster-proportional-autoscaler#16
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: system:kube-dns-autoscaler
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+subjects:
+  - kind: ServiceAccount
+    name: kube-dns-autoscaler
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: system:kube-dns-autoscaler
+  apiGroup: rbac.authorization.k8s.io

--- a/cluster/manifests/kube-state-metrics/deployment.yaml
+++ b/cluster/manifests/kube-state-metrics/deployment.yaml
@@ -18,6 +18,7 @@ spec:
         version: v1.3.0
     spec:
       priorityClassName: system-cluster-critical
+      serviceAccountName: kube-state-metrics
       containers:
       - image: registry.opensource.zalan.do/teapot/kube-state-metrics:v1.3.0
         name: kube-state-metrics

--- a/cluster/manifests/kube-state-metrics/rbac.yaml
+++ b/cluster/manifests/kube-state-metrics/rbac.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-state-metrics
+  namespace: kube-system
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:monitor
+subjects:
+- kind: ServiceAccount
+  name: kube-state-metrics
+  namespace: kube-system

--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -19,6 +19,7 @@ spec:
         version: master-6
     spec:
       priorityClassName: system-node-critical
+      serviceAccountName: system
       tolerations:
       - operator: Exists
         effect: NoSchedule

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -23,6 +23,7 @@ spec:
         component: logging
     spec:
       priorityClassName: system-node-critical
+      serviceAccountName: system
       tolerations:
       - operator: Exists
         effect: NoSchedule

--- a/cluster/manifests/prometheus-node-exporter/daemonset.yaml
+++ b/cluster/manifests/prometheus-node-exporter/daemonset.yaml
@@ -22,6 +22,7 @@ spec:
         component: node-exporter
     spec:
       priorityClassName: system-node-critical
+      serviceAccountName: system
       tolerations:
       - operator: Exists
         effect: NoSchedule

--- a/cluster/manifests/roles/billing-binding.yaml
+++ b/cluster/manifests/roles/billing-binding.yaml
@@ -1,0 +1,13 @@
+# TODO review if view role is too much
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: billing
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- kind: Group
+  name: business-partner:cloudyn:com.zalando::billing-information.read
+  apiGroup: rbac.authorization.k8s.io

--- a/cluster/manifests/roles/kube-proxy-kubelet-binding.yaml
+++ b/cluster/manifests/roles/kube-proxy-kubelet-binding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kube-proxy-kubelet
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:node-proxier
+subjects:
+- kind: User
+  name: kubelet
+  apiGroup: rbac.authorization.k8s.io

--- a/cluster/manifests/roles/kube-system-system-binding.yaml
+++ b/cluster/manifests/roles/kube-system-system-binding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: system
+  namespace: kube-system

--- a/cluster/manifests/roles/kube-system-view-binding.yaml
+++ b/cluster/manifests/roles/kube-system-view-binding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kube-system-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: kube-system

--- a/cluster/manifests/roles/kubelet-binding.yaml
+++ b/cluster/manifests/roles/kubelet-binding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kubelet
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:node
+subjects:
+- kind: User
+  name: kubelet
+  apiGroup: rbac.authorization.k8s.io

--- a/cluster/manifests/roles/kubelet-psp-role-bindings.yaml
+++ b/cluster/manifests/roles/kubelet-psp-role-bindings.yaml
@@ -1,0 +1,32 @@
+# Gives kubelet user access to use retricted and privileged psps in kube-system.
+# This is needed to allow kubelet to create mirror pods
+# TODO: remove these roles if/when introducing tls-bootstrap/node identities.
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: privileged-psp-kubelet
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: privileged-psp
+subjects:
+- kind: User
+  name: kubelet
+  apiGroup: rbac.authorization.k8s.io
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: restricted-psp-kubelet
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: restricted-psp
+subjects:
+- kind: User
+  name: kubelet
+  apiGroup: rbac.authorization.k8s.io
+  namespace: kube-system

--- a/cluster/manifests/roles/operator-bindings.yaml
+++ b/cluster/manifests/roles/operator-bindings.yaml
@@ -1,0 +1,25 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: operator-edit
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edit
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: operator-privileged-psp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: privileged-psp
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: default

--- a/cluster/manifests/roles/poweruser-binding.yaml
+++ b/cluster/manifests/roles/poweruser-binding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: poweruser
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edit
+subjects:
+- kind: Group
+  name: PowerUser
+  apiGroup: rbac.authorization.k8s.io

--- a/cluster/manifests/roles/priviliged_psp_cluster_role.yaml
+++ b/cluster/manifests/roles/priviliged_psp_cluster_role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: privileged-psp
+rules:
+- apiGroups:
+  - extensions
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - privileged
+  verbs:
+  - use

--- a/cluster/manifests/roles/priviliged_psp_kube-system_role_binding.yaml
+++ b/cluster/manifests/roles/priviliged_psp_kube-system_role_binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: privileged-psp
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: privileged-psp
+subjects:
+- kind: ServiceAccount
+  name: system
+  namespace: kube-system

--- a/cluster/manifests/roles/readonly-binding.yaml
+++ b/cluster/manifests/roles/readonly-binding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: readonly
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- kind: Group
+  name: ReadOnly
+  apiGroup: rbac.authorization.k8s.io

--- a/cluster/manifests/roles/restricted_psp_cluster_role.yaml
+++ b/cluster/manifests/roles/restricted_psp_cluster_role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: restricted-psp
+rules:
+- apiGroups:
+  - extensions
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - restricted
+  verbs:
+  - use

--- a/cluster/manifests/roles/restricted_psp_cluster_role_binding.yaml
+++ b/cluster/manifests/roles/restricted_psp_cluster_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: restricted-psp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: restricted-psp
+subjects:
+- kind: Group
+  name: system:serviceaccounts
+  apiGroup: rbac.authorization.k8s.io

--- a/cluster/manifests/roles/view-node-role.yaml
+++ b/cluster/manifests/roles/view-node-role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: view-node
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -25,6 +25,7 @@ spec:
           [{"container": "skipper-ingress", "parser": "skipper-access-log"}]
     spec:
       priorityClassName: system-node-critical
+      serviceAccountName: system
       tolerations:
       - key: dedicated
         operator: Exists

--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
     spec:
       priorityClassName: visibility-zmon
+      serviceAccountName: zmon
       initContainers:
       - name: gerry-init
         image: registry.opensource.zalan.do/teapot/gerry:v0.0.14
@@ -40,7 +41,6 @@ spec:
           - name: credentials
             mountPath: /meta/credentials
             readOnly: false
-
       containers:
         - name: zmon-agent
           image: "pierone.stups.zalan.do/zmon/zmon-agent-core:0.1-a57-zv2"

--- a/cluster/manifests/zmon-agent/rbac.yaml
+++ b/cluster/manifests/zmon-agent/rbac.yaml
@@ -1,0 +1,114 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: zmon
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: system:monitor
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - persistentvolumeclaims
+  - pods
+  - replicationcontrollers
+  - replicationcontrollers/scale
+  - serviceaccounts
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - bindings
+  - events
+  - limitranges
+  - namespaces/status
+  - pods/log
+  - pods/status
+  - replicationcontrollers/status
+  - resourcequotas
+  - resourcequotas/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - deployments/scale
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  - scheduledjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - deployments/scale
+  - ingresses
+  - replicasets
+  - replicasets/scale
+  - replicationcontrollers/scale
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: zmon
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:monitor
+subjects:
+- kind: ServiceAccount
+  name: zmon
+  namespace: kube-system

--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
     spec:
       priorityClassName: visibility-zmon
+      serviceAccountName: zmon
       initContainers:
       - name: gerry-init
         image: registry.opensource.zalan.do/teapot/gerry:v0.0.14
@@ -39,7 +40,6 @@ spec:
           - name: credentials
             mountPath: /meta/credentials
             readOnly: false
-
       containers:
         - name: zmon-worker
           image: "pierone.stups.zalan.do/zmon/zmon-worker:v201-zv247"

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -314,8 +314,9 @@ storage:
             - --authentication-token-webhook-config-file=/etc/kubernetes/config/authn.yaml
             - --authentication-token-webhook-cache-ttl=10s
             - --cloud-provider=aws
-            - --authorization-mode=Webhook
-            - --authorization-webhook-config-file=/etc/kubernetes/config/authz.yaml
+            - --authorization-mode=RBAC
+            # - --authorization-mode=Webhook
+            # - --authorization-webhook-config-file=/etc/kubernetes/config/authz.yaml
             - --admission-control-config-file=/etc/kubernetes/config/image-policy-webhook.yaml
             - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true
             - --anonymous-auth=false
@@ -333,6 +334,8 @@ storage:
             - --requestheader-username-headers=X-Remote-User
             - --proxy-client-cert-file=/etc/kubernetes/ssl/proxy-client.pem
             - --proxy-client-key-file=/etc/kubernetes/ssl/proxy-client-key.pem
+            # TODO: remove - view RBAC denies
+            - --v=2
             livenessProbe:
               httpGet:
                 host: 127.0.0.1
@@ -420,7 +423,7 @@ storage:
               - name: TOKEN_INTROSPECTION_URL
                 value: http://127.0.0.1:9021/oauth2/introspect
               - name: USER_GROUPS
-                value: credentials-provider=Administrator,credprov-kube-ops-view-read-only-token=ReadOnly,credprov-cluster-lifecycle-manager-cluster-rw-token=Administrator,stups_cluster-lifecycle-manager=Administrator,credprov-cluster-lifecycle-manager-test-cluster-rw-token=Administrator,credprov-cdp-controller-cluster-token=PowerUser,credprov-api-discovery-k8s-cluster-read-only-token=ReadOnly,stups_zmon-zmon=ReadOnly,stups_kube-resource-report=ReadOnly
+                value: credentials-provider=system:masters,credprov-kube-ops-view-read-only-token=ReadOnly,stups_cluster-lifecycle-manager=system:masters,credprov-cdp-controller-cluster-token=PowerUser,credprov-api-discovery-k8s-cluster-read-only-token=ReadOnly,stups_zmon-zmon=ReadOnly,stups_kube-resource-report=ReadOnly
               - name: BUSINESS_PARTNER_IDS
                 value: {{ .Cluster.ConfigItems.apiserver_business_partner_ids }}
             volumeMounts:
@@ -658,7 +661,7 @@ storage:
             token: ${token}
         EOF
 
-        echo "${token},kube-controller-manager,kube-controller-manager" >> /etc/kubernetes/config/tokenfile.csv
+        echo "${token},system:kube-controller-manager,system:kube-controller-manager" >> /etc/kubernetes/config/tokenfile.csv
 
   - filesystem: root
     path: /etc/kubernetes/config/tokenfile.csv
@@ -744,7 +747,7 @@ storage:
             users: ["system:apiserver"]
           # don't audit any kube-controller-manager events
           - level: None
-            users: ["kube-controller-manager"]
+            users: ["system:kube-controller-manager"]
           # Don't audit events from system users in kube-system
           - level: None
             userGroups: ["system:serviceaccounts:kube-system"]


### PR DESCRIPTION
Initial effort to replace authz part of our webhook with RBAC while being
compatible with the current expectations e.g. `operator` serviceaccount, 
PSPs and `kube-system` `system` serviceaccount.

Roles and bindings are defined as follows:

* Components in `kube-system` requiring priviliged PSP must use the `system`
serviceaccount (or define a custom role/serviceaccount). I kept the `system`
serviceaccount to not change everything at once. It will be easy to migrate
individual components later on.
* `system:serviceaccount:kube-system:system` gets `cluster-admin` role.
* `system:serviceaccount:kube-system:default` gets `view` role.
* All serviceaccounts can use the `restricted` PSP.
* Users with `PowerUser` group gets the `edit` role.
* Users with `ReadOnly` group gets the `view` role.
* `Administrator` group maps to `system:masters` and gets `cluster-admin` role.
* `system:serviceaccount:default:operator` gets `edit` role + priviliged PSP.
* `kubelet` user gets `system:node` role.
* `kubelet` user gets `system:node-proxier` role. This is needed because
    kube-proxy is currently using kubelet credentials in our setup.

This requires a minor change to the authentication part in the webhook:

* `Administrator` group must be converted to `system:masters`.
* business-partner support needs to be modified to convert priviliges to groups, such that you can create unique rolebindings based on group name.

And also a change in the CLM to rename user `kube-controller-manager`
to `system:kube-controller-manager`.

## TODO

* [ ] Validate that `operator` role has all needed permissions.
* [ ] Validate that `view` and `edit` roles map to what we expect for `ReadOnly` and `PowerUser` roles.
* [ ] Prevent creation of `daemonsets`.
* [ ] Optional: Add separate serviceaccounts for `kube-system` components
  * [x] heapster
  * [x] kube-dns, kube-dns-autoscaler
  * [ ] dashboard
  * [x] zmon
  * [x] kube-state-metrics
  * [ ] external-dns
  * [ ] ingress-controller
  * [ ] skipper
  * [ ] others...
* [x] Validate permissions needed for ZMON.
* [ ] Review billing role binding (has view permissions)
* [ ] Consider how RBAC can be used by users to replace `operator` going
      foward. For instance, if the deployment system is allowed to create roles
      and bindings, then you can give yourself admin rights via a deployment,
      which may or may not be an issue.
* [x] Allow kubelet to create kube-proxy mirror-pod
    ```
    pods "kube-proxy-ip-172-31-12-63.eu-central-1.compute.internal" is forbidden: no providers available to validate pod request
    ```

## Future improvements

* Move kube-proxy to a daemonset ~so it can use a custom serviceaccount.~ This is not possible as it obviously need to start before cluster service IPs become available. So it needs to bootstrap using a non-cluster IP. (Should still be a daemonset, but thats unrelated).
* Limit nodes to access only the relevant pods/secrets. I.e. per node identity (https://kubernetes.io/docs/admin/kubelet-tls-bootstrapping/).
* Deprecate and later remove operator role.

RBAC reference: https://kubernetes.io/docs/admin/authorization/rbac/