### PR TITLE
Make master node instance type configurable

### DIFF
--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -18,6 +18,9 @@ SenzaInfo:
           Description: "Minimum number of nodes in the worker ASG"
       - MaximumWorkerNodes:
           Description: "Maximum number of nodes in the worker ASG"
+      - MasterInstanceType:
+          Description: "Type of instance for master nodes"
+          Default: "m3.medium"
       - InstanceType:
           Description: "Type of instance"
       - ClusterID:
@@ -60,7 +63,7 @@ SenzaComponents:
           Value: "{{ Arguments.ClusterID }}"
   - MasterAutoScaling:
       Type: Senza::AutoScalingGroup
-      InstanceType: m3.medium
+      InstanceType: "{{ Arguments.MasterInstanceType }}"
       Image: LatestCoreOSImage
       BlockDeviceMappings:
         - DeviceName: /dev/xvda


### PR DESCRIPTION
Until now we hardcoded master nodes to use `m3.medium`, which is a problem now that we have the new 3rd which doesn't support `m3.medium`.

It was never the idea to hardcode it, since we have it defined in the cluster registry as well, so let's just make it configurable.