### PR TITLE
Bump heapster to v1.4.0

### DIFF
--- a/cluster/manifests/heapster/deployment.yaml
+++ b/cluster/manifests/heapster/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     application: heapster
     kubernetes.io/cluster-service: "true"
-    version: v1.3.0
+    version: v1.4.0
 spec:
   replicas: 1
   selector:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: heapster
-        version: v1.3.0
+        version: v1.4.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -25,7 +25,7 @@ spec:
         operator: Exists
       serviceAccountName: system
       containers:
-        - image: gcr.io/google_containers/heapster:v1.3.0
+        - image: gcr.io/google_containers/heapster:v1.4.0
           name: heapster
           livenessProbe:
             httpGet:


### PR DESCRIPTION
Bumps to new heapster release: https://github.com/kubernetes/heapster/releases/tag/v1.4.0

I don't see any really relevant changes, it's more to stay up-to-date.