### PR TITLE
Decrease timeout for lifecycle hook

### DIFF
--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -587,7 +587,7 @@ Resources:
     Type: "AWS::AutoScaling::LifecycleHook"
     Properties:
       DefaultResult: "CONTINUE"
-      HeartbeatTimeout: "900"
+      HeartbeatTimeout: "600"
       AutoScalingGroupName:
         Ref: MasterAutoScaling
       LifecycleTransition: "autoscaling:EC2_INSTANCE_LAUNCHING"
@@ -595,7 +595,7 @@ Resources:
     Type: "AWS::AutoScaling::LifecycleHook"
     Properties:
       DefaultResult: "CONTINUE"
-      HeartbeatTimeout: "900"
+      HeartbeatTimeout: "600"
       AutoScalingGroupName:
         Ref:
           WorkerAutoScaling


### PR DESCRIPTION
Decrease lifecycle hook timeout to 10 min. to ensure the CLM doesn't timeout before new instances are considered ready by AWS.