### PR TITLE
Revert "deploy local multi-tenant tokeninfo with introspection"

### DIFF
--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -185,7 +185,9 @@ Resources:
       - PolicyDocument:
           Statement:
           - {Action: 'ec2:Describe*', Effect: Allow, Resource: '*'}
-          - {Action: 'autoscaling:*', Effect: Allow, Resource: '*'}
+          - {Action: 'autoscaling:Describe*', Effect: Allow, Resource: '*'}
+          - {Action: 'autoscaling:SetDesiredCapacity', Effect: Allow, Resource: '*'}
+          - {Action: 'autoscaling:TerminateInstanceInAutoScalingGroup', Effect: Allow, Resource: '*'}
           Version: '2012-10-17'
         PolicyName: root
     Type: AWS::IAM::Role

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -323,7 +323,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.2.0
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.1.14
           name: webhook
           ports:
           - containerPort: 8081
@@ -353,44 +353,14 @@ write_files:
               value: https://users.auth.zalando.com
             - name: CLUSTER_ID
               value: {{WEBHOOK_ID}}
-            - name: TOKEN_INTROSPECTION_URL
-              value: http://127.0.0.1:9021/oauth2/introspect
+            - name: TOKENINFO_URL
+              value: https://info.services.auth.zalando.com/oauth2/tokeninfo
             - name: USER_GROUPS
               value: stups_autobahn=Administrator,stups_deployment-controller-ui=ReadOnly,credentials-provider=Administrator,credprov-kube-ops-view-read-only-token=ReadOnly,credprov-cluster-lifecycle-manager-cluster-rw-token=Administrator,credprov-cluster-lifecycle-manager-test-cluster-rw-token=Administrator,credprov-cdp-controller-cluster-token=PowerUser
-            - name: BUSINESS_PARTNER_IDS
-              value: {{ APISERVER_BUSINESS_PARTNER_IDS }}
           volumeMounts:
           - mountPath: /etc/kubernetes/config
             name: kubernetes-configs
             readOnly: true
-        - image: registry.opensource.zalan.do/foundation/platform-iam-tokeninfo:4feeb5a
-          name: tokeninfo
-          ports:
-            - containerPort: 9021
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: 9021
-            periodSeconds: 3
-            failureThreshold: 2
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: 9021
-            periodSeconds: 3
-            failureThreshold: 2
-          resources:
-            limits:
-              cpu: 4000m
-              memory: 512Mi
-            requests:
-              cpu: 100m
-              memory: 20Mi
-          env:
-            - name: OPENID_PROVIDER_CONFIGURATION_URL
-              value: https://identity.zalando.com/.well-known/openid-configuration
-            - name: ENABLE_INTROSPECTION
-              value: "true"
         - name: nginx
           image: registry.opensource.zalan.do/teapot/nginx:1.11.5
           resources:


### PR DESCRIPTION
Reverts zalando-incubator/kubernetes-on-aws#456

unfortunately it doesn't work for all types of tokens yet.