### PR TITLE
Use latest etcd appliance version

### DIFF
--- a/cluster/etcd-cluster.yaml
+++ b/cluster/etcd-cluster.yaml
@@ -14,7 +14,7 @@ SenzaComponents:
         2379: 2379
         2380: 2380
       runtime: Docker
-      source: registry.opensource.zalan.do/acid/etcd-cluster:3.0.17-p15
+      source: registry.opensource.zalan.do/acid/etcd-cluster:3.0.17-p17
       environment:
         HOSTED_ZONE: '{{Arguments.HostedZone}}'
       mounts:

--- a/cluster/etcd-cluster.yaml
+++ b/cluster/etcd-cluster.yaml
@@ -4,7 +4,7 @@ SenzaComponents:
 - AppServer:
     IamRoles:
     - Ref: EtcdRole
-    InstanceType: m3.medium
+    InstanceType: t2.medium
     SecurityGroups:
     - Fn::GetAtt:
       - EtcdSecurityGroup


### PR DESCRIPTION
This is needed only for compliance reason as the source repo was changed with the recent url and the scm source of the image has to be updated. From what @CyberDem0n says, there should be no differences, it's clearly still worth testing. 