### PR TITLE
Re-add granular access rights to CF stack

### DIFF
--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -185,7 +185,11 @@ Resources:
       - PolicyDocument:
           Statement:
           - {Action: 'ec2:Describe*', Effect: Allow, Resource: '*'}
-          - {Action: 'autoscaling:*', Effect: Allow, Resource: '*'}
+          - {Action: 'autoscaling:DescribeAutoScalingGroups', Effect: Allow, Resource: '*'}
+          - {Action: 'autoscaling:DescribeAutoScalingInstances', Effect: Allow, Resource: '*'}
+          - {Action: 'autoscaling:DescribeScalingActivities', Effect: Allow, Resource: '*'}
+          - {Action: 'autoscaling:SetDesiredCapacity', Effect: Allow, Resource: '*'}
+          - {Action: 'autoscaling:TerminateInstanceInAutoScalingGroup', Effect: Allow, Resource: '*'}
           Version: '2012-10-17'
         PolicyName: root
     Type: AWS::IAM::Role
@@ -241,19 +245,23 @@ Resources:
       Policies:
       - PolicyDocument:
           Statement:
-          - {Action: 'acm:*', Effect: Allow, Resource: '*'}
-          #- {Action: 'acm:DescribeCertificate', Effect: Allow, Resource: '*'}
-          # - {Action: 'autoscaling:DescribeAutoScalingGroups', Effect: Allow, Resource: '*'}
-          - {Action: 'autoscaling:*', Effect: Allow, Resource: '*'}
-          # - {Action: 'autoscaling:DetachLoadBalancers', Effect: Allow, Resource: '*'}
-          # - {Action: 'autoscaling:DetachLoadBalancerTargetGroups', Effect: Allow, Resource: '*'}
-          # - {Action: 'autoscaling:AttachLoadBalancerTargetGroups', Effect: Allow, Resource: '*'}
+          - {Action: 'acm:ListCertificates', Effect: Allow, Resource: '*'}
+          - {Action: 'acm:DescribeCertificate', Effect: Allow, Resource: '*'}
+          - {Action: 'autoscaling:DescribeAutoScalingGroups', Effect: Allow, Resource: '*'}
+          - {Action: 'autoscaling:AttachLoadBalancers', Effect: Allow, Resource: '*'}
+          - {Action: 'autoscaling:DetachLoadBalancers', Effect: Allow, Resource: '*'}
+          - {Action: 'autoscaling:DetachLoadBalancerTargetGroups', Effect: Allow, Resource: '*'}
+          - {Action: 'autoscaling:AttachLoadBalancerTargetGroups', Effect: Allow, Resource: '*'}
           - {Action: 'cloudformation:*', Effect: Allow, Resource: '*'}
           - {Action: 'elasticloadbalancing:*', Effect: Allow, Resource: '*'}
           - {Action: 'elasticloadbalancingv2:*', Effect: Allow, Resource: '*'}
-          - {Action: 'ec2:Describe*', Effect: Allow, Resource: '*'}
-          - {Action: 'iam:*', Effect: Allow, Resource: '*'}
-          # - {Action: 'iam:ListServerCertificates', Effect: Allow, Resource: '*'}
+          - {Action: 'ec2:DescribeInstances', Effect: Allow, Resource: '*'}
+          - {Action: 'ec2:DescribeSubnets', Effect: Allow, Resource: '*'}
+          - {Action: 'ec2:DescribeSecurityGroups', Effect: Allow, Resource: '*'}
+          - {Action: 'ec2:DescribeRouteTables', Effect: Allow, Resource: '*'}
+          - {Action: 'ec2:DescribeVpcs', Effect: Allow, Resource: '*'}
+          - {Action: 'iam:GetServerCertificate', Effect: Allow, Resource: '*'}
+          - {Action: 'iam:ListServerCertificates', Effect: Allow, Resource: '*'}
           Version: '2012-10-17'
         PolicyName: root
     Type: AWS::IAM::Role
@@ -550,6 +558,7 @@ Resources:
   DeploymentSecretKey:
     Type: AWS::KMS::Key
     Properties:
+      Description: "Key used by deployment pipeline for secret encryption/decryption"
       Enabled: true
       EnableKeyRotation: false
       KeyUsage: "ENCRYPT_DECRYPT"
@@ -557,13 +566,29 @@ Resources:
         Version: "2012-10-17"
         Id: "{{SenzaInfo.StackName}}-{{SenzaInfo.StackVersion}}-deployment-key"
         Statement:
-        - Effect: "Allow"
+        - Sid: "Allow access for Key Administrators"
+          Effect: "Allow"
           Resource: "*"
           Principal:
             AWS: "arn:aws:iam::{{ AccountInfo.AccountID }}:root"
           Action:
-          - "kms:*"
-        - Effect: "Allow"
+          - "kms:ReEncrypt*"
+          - "kms:Create*"
+          - "kms:Describe*"
+          - "kms:Enable*"
+          - "kms:Encrypt"
+          - "kms:Decrypt"
+          - "kms:List*"
+          - "kms:Put*"
+          - "kms:Update*"
+          - "kms:Revoke*"
+          - "kms:Disable*"
+          - "kms:Get*"
+          - "kms:Delete*"
+          - "kms:ScheduleKeyDeletion"
+          - "kms:CancelKeyDeletion"
+        - Sid: "Allow access for deployment system to decrypt the keys"
+          Effect: "Allow"
           Resource: "*"
           Principal:
             AWS:


### PR DESCRIPTION
Re-add the access rights removed in #470 and #479.

Needs changes to CLM before it can be tested/merged.