### PR TITLE
Allow deployment role to manage other roles

### DIFF
--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -567,7 +567,7 @@ Resources:
             - "iam:Delete*"
             - "iam:Attach*"
             - "iam:Detach*"
-            Resource: "*"
+            Resource: "arn:aws:iam::*:role/Shibboleth*"
           - Effect: "Deny"
             Action:
             - "ec2:DeleteRoute"


### PR DESCRIPTION
This matches the resource with what we have for the `PowerUser` role. Without this the deployment role is not allowed to manage other roles.