### PR TITLE
Update kube2iam to v0.6.4

### DIFF
--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube2iam
-    version: v0.6.2
+    version: v0.6.4
 spec:
   selector:
     matchLabels:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: kube2iam
-        version: v0.6.2
+        version: v0.6.4
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -25,7 +25,7 @@ spec:
         operator: Exists
       hostNetwork: true
       containers:
-      - image: registry.opensource.zalan.do/teapot/kube2iam:0.6.2
+      - image: registry.opensource.zalan.do/teapot/kube2iam:0.6.4
         name: kube2iam
         args:
         - --auto-discover-base-arn


### PR DESCRIPTION
Updates kube2iam to v0.6.4

https://github.com/jtblin/kube2iam/releases/tag/0.6.4

https://github.com/jtblin/kube2iam/releases/tag/0.6.3
