### PR TITLE
Tell kubernetes how many master nodes it can expect

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -287,6 +287,7 @@ write_files:
           command:
           - /hyperkube
           - apiserver
+          - --apiserver-count={{ APISERVER_COUNT }}
           - --bind-address=0.0.0.0
           - --insecure-bind-address=0.0.0.0
           - --etcd-servers=http://127.0.0.1:2379
@@ -619,7 +620,7 @@ write_files:
     content: |
       {{WORKER_SHARED_SECRET}},kubelet,kubelet
       {{CONTROLLER_MANAGER_SECRET}},kube-controller-manager,kube-controller-manager
-  
+
   - path: /etc/kubernetes/config/image-policy-webhook.yaml
     permissions: 0644
     owner: root:root


### PR DESCRIPTION
was wondering for a while about the usage of this and now found https://github.com/mantl/mantl/issues/1811.

If you look at our teapot cluster, which has two nodes:
```console
kubectl --namespace=default describe svc kubernetes | grep Endpoints
Endpoints:		172.31.20.166:443
```
However, the internal Kubernetes service only exports one of the nodes.