### PR TITLE
completely get rid of secretary :-( bye bye

### DIFF
--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -75,7 +75,7 @@ spec:
           image: registry.opensource.zalan.do/teapot/gerry:v0.0.9
           args:
             - /meta/credentials
-            - --application-id=secretary
+            - --application-id=gerry
             - --mint-bucket=s3://{{ .ConfigItems.gerry_mint_bucket }}
 
           volumeMounts:

--- a/cluster/manifests/zmon-aws-agent/deployment.yaml
+++ b/cluster/manifests/zmon-aws-agent/deployment.yaml
@@ -49,7 +49,7 @@ spec:
           image: registry.opensource.zalan.do/teapot/gerry:v0.0.9
           args:
             - /meta/credentials
-            - --application-id=secretary
+            - --application-id=gerry
             - --mint-bucket=s3://{{ .ConfigItems.gerry_mint_bucket }}
 
           volumeMounts:

--- a/cluster/manifests/zmon-scheduler/deployment.yaml
+++ b/cluster/manifests/zmon-scheduler/deployment.yaml
@@ -95,7 +95,7 @@ spec:
           image: registry.opensource.zalan.do/teapot/gerry:v0.0.9
           args:
             - /meta/credentials
-            - --application-id=secretary
+            - --application-id=gerry
             - --mint-bucket=s3://{{ .ConfigItems.gerry_mint_bucket }}
 
           volumeMounts:

--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -73,7 +73,7 @@ spec:
           image: registry.opensource.zalan.do/teapot/gerry:v0.0.9
           args:
             - /meta/credentials
-            - --application-id=secretary
+            - --application-id=gerry
             - --mint-bucket=s3://{{ .ConfigItems.gerry_mint_bucket }}
 
           volumeMounts:

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -517,7 +517,7 @@ Resources:
             - {Action: 'tag:Get*', Effect: Allow, Resource: '*'}
             - {Action: 'dynamodb:ListTables', Effect: Allow, Resource: '*'}
             - Action: "s3:GetObject"
-              Resource: "arn:aws:s3:::{{ AccountInfo.MintBucket }}/secretary/*"
+              Resource: "arn:aws:s3:::{{ AccountInfo.MintBucket }}/gerry/*"
               Effect: Allow
             - {Action: 'sqs:GetQueueAttributes', Effect: Allow, Resource: '*'}
             - {Action: 'sqs:ListDeadLetterSourceQueues', Effect: Allow, Resource: '*'}


### PR DESCRIPTION
This removes secretary's presence from our setup. Ideally zmon should use platform credentials set or another bucket.

We removed secretary but still relied on its mint bucket which may lead to confusion.