### PR TITLE
Adding ports needed for cross master communication

### DIFF
--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -275,6 +275,7 @@ Resources:
       - {CidrIp: 172.31.0.0/16, FromPort: 8082, IpProtocol: tcp, ToPort: 8082}
       - {CidrIp: 172.31.0.0/16, FromPort: 9100, IpProtocol: tcp, ToPort: 9100}
       - {CidrIp: 172.31.0.0/16, FromPort: 9911, IpProtocol: tcp, ToPort: 9911}
+      - {CidrIp: 172.31.0.0/16, FromPort: 30080, IpProtocol: tcp, ToPort: 30080}
       Tags:
         - Key: "KubernetesCluster"
           Value: kubernetes
@@ -315,6 +316,32 @@ Resources:
       IpProtocol: tcp
       SourceSecurityGroupId: {Ref: MasterLoadBalancerSecurityGroup}
       ToPort: 443
+      Tags:
+        - Key: "KubernetesCluster"
+          Value: kubernetes
+        - Key: "ClusterID"
+          Value: "{{ Arguments.ClusterID }}"
+    Type: AWS::EC2::SecurityGroupIngress
+  MasterSecurityGroupIngressFromMaster:
+    Properties:
+      FromPort: 443
+      GroupId: {Ref: MasterSecurityGroup}
+      IpProtocol: tcp
+      SourceSecurityGroupId: {Ref: MasterSecurityGroup}
+      ToPort: 443
+      Tags:
+        - Key: "KubernetesCluster"
+          Value: kubernetes
+        - Key: "ClusterID"
+          Value: "{{ Arguments.ClusterID }}"
+    Type: AWS::EC2::SecurityGroupIngress
+  MasterKubeletToMasterKubeletSecurityGroup:
+    Properties:
+      FromPort: 10250
+      GroupId: {Ref: MasterSecurityGroup}
+      IpProtocol: tcp
+      SourceSecurityGroupId: {Ref: MasterSecurityGroup}
+      ToPort: 10250
       Tags:
         - Key: "KubernetesCluster"
           Value: kubernetes


### PR DESCRIPTION
This fixes: 

- the issue with a communication from master to master dealing with some master failures spotted with kube-node-ready
- master to master communication is now fixed to allow streaming logs 
- kube-node-ready port (30080) is not accessible from zmon so that we can use it for monitoring

