### PR TITLE
Add etcd backup bucket to the etcd stack

### DIFF
--- a/cluster/etcd-cluster.yaml
+++ b/cluster/etcd-cluster.yaml
@@ -70,6 +70,13 @@ Resources:
         Fn::GetAtt:
           - EtcdSecurityGroup
           - GroupId
+  EtcdBackupBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    Properties:
+      BucketName: "{{Arguments.EtcdS3Backup}}"
+      VersioningConfiguration:
+        Status: Enabled
   EtcdRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
This makes the etcd backup bucket part of the etcd stack such that it's owned by the stack instead of being owned by CLM.

It uses `DeletionPolicy: Retain` to make sure the bucket sticks around even if the etcd stack is accidentally deleted.

