### PR TITLE
actively remove secretary from all clusters

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -2,3 +2,6 @@ pre_apply: # everything defined under here will be deleted before applying the m
 - name: app-ingress-controller
   namespace: kube-system
   kind: deployment
+- name: secretary
+  namespace: kube-system
+  kind: deployment


### PR DESCRIPTION
We retired `secretary` but forgot to remove already running ones (since apply doesn't remove). This fixes it.