### PR TITLE
Alpha to beta

### DIFF
--- a/cluster/etcd-cluster.yaml
+++ b/cluster/etcd-cluster.yaml
@@ -70,6 +70,13 @@ Resources:
         Fn::GetAtt:
           - EtcdSecurityGroup
           - GroupId
+  EtcdBackupBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    Properties:
+      BucketName: "{{Arguments.EtcdS3Backup}}"
+      VersioningConfiguration:
+        Status: Enabled
   EtcdRole:
     Type: AWS::IAM::Role
     Properties:

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.3.6
+    version: v0.3.8
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.3.6
+        version: v0.3.8
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
@@ -26,7 +26,7 @@ spec:
         operator: Exists
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.3.7
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.3.8
         env:
         - name: AWS_REGION
           value: {{ .Region }}


### PR DESCRIPTION
* This will use the new ingress controller version that will fix the issue for all ingress CF stacks, that have  targetGroups in eu-central-1-c, but are not in use, because the ALB has no Network interface in that AZ.
* EtcdBackupBucket added to support etcd cluster backups