### PR TITLE
Several upgrades that piled up in our internal repo

### DIFF
--- a/cluster/manifests/kube-job-cleaner/cronjob.yaml
+++ b/cluster/manifests/kube-job-cleaner/cronjob.yaml
@@ -17,7 +17,7 @@ spec:
             version: "0.3"
         spec:
           serviceAccountName: system
-          restartPolicy: OnFailure
+          restartPolicy: Never
           containers:
           - name: cleaner
             # delete all completed jobs after one hour

--- a/cluster/manifests/quota/resource_quota.yaml
+++ b/cluster/manifests/quota/resource_quota.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: compute-resources
+spec:
+  hard:
+    pods: "1500"

--- a/cluster/manifests/quota/resource_quota_kubesystem.yaml
+++ b/cluster/manifests/quota/resource_quota_kubesystem.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  namespace: kube-system
+  name: compute-resources
+spec:
+  hard:
+    pods: "1500"

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.9.49-1-gd2a3df5
+    version: v0.9.83
     component: ingress
 spec:
   selector:
@@ -18,7 +18,7 @@ spec:
       name: skipper-ingress
       labels:
         application: skipper-ingress
-        version: v0.9.49-1-gd2a3df5
+        version: v0.9.83
         component: ingress
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -38,7 +38,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.9.49-1-gd2a3df5
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.9.83
         ports:
         - name: ingress-port
           containerPort: 9999

--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: "kube-system"
   labels:
     application: "zmon-agent"
-    version: "v0.1-a25"
+    version: "v0.1-a27"
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: "zmon-agent"
-        version: "v0.1-a25"
+        version: "v0.1-a27"
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -25,7 +25,7 @@ spec:
         operator: Exists
       containers:
         - name: zmon-agent
-          image: "registry.opensource.zalan.do/zmon/zmon-agent-core:0.1-a25"
+          image: "registry.opensource.zalan.do/zmon/zmon-agent-core:0.1-a27"
           resources:
             limits:
               cpu: 100m
@@ -49,6 +49,8 @@ spec:
               value: "{{ .ID }}"
             - name: ZMON_AGENT_KUBERNETES_CLUSTER_ALIAS
               value: "{{ .Alias }}"
+            - name: ZMON_AGENT_KUBERNETES_CLUSTER_ENVIRONMENT
+              value: "{{ .Environment }}"
 
             - name: ZMON_AGENT_POSTGRES_USER
               valueFrom:

--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -48,6 +48,10 @@ spec:
               value: zmon-redis:6379
             - name: WORKER_PLUGIN_SCALYR_READ_KEY
               value: "{{ .ConfigItems.scalyr_read_key }}"
+            - name: WORKER_ACCOUNT
+              value: "{{ .InfrastructureAccount }}"
+            - name: WORKER_REGION
+              value: "{{ .Region }}"
             - name: WORKER_PLUGIN_SQL_USER
               valueFrom:
                 secretKeyRef:

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -49,7 +49,7 @@ coreos:
           content: |
             [Service]
             ExecStartPre=/usr/bin/etcdctl \
-            --endpoint=http://localhost:2379 set /coreos.com/network/config \
+            --endpoint=http://127.0.0.1:2379 set /coreos.com/network/config \
             '{ "Network": "10.2.0.0/16", "Backend": {"Type": "vxlan"}}'
 
     - name: kube2iam-iptables.service
@@ -80,6 +80,17 @@ coreos:
         Type=oneshot
         ExecStartPre=/usr/bin/mkdir -p /root/.docker
         ExecStart=/opt/bin/dockercfg.sh
+
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: gen-controller-manager-config.service
+      command: start
+      runtime: true
+      content: |
+        [Service]
+        Type=oneshot
+        ExecStart=/opt/bin/gen-controller-manager-config.sh
 
         [Install]
         WantedBy=multi-user.target
@@ -171,7 +182,7 @@ write_files:
       clusters:
       - name: local
         cluster:
-          server: http://localhost:8080
+          server: http://127.0.0.1:8080
       users:
       - name: kubelet
       contexts:
@@ -186,7 +197,7 @@ write_files:
       clusters:
         - name: authz-webhook
           cluster:
-            server: http://localhost:8081/authentication
+            server: http://127.0.0.1:8081/authentication
       users:
         - name: authz-webhook-client
           user:
@@ -205,7 +216,7 @@ write_files:
       clusters:
         - name: authz-webhook
           cluster:
-            server: http://localhost:8081/authorization
+            server: http://127.0.0.1:8081/authorization
       users:
         - name: authz-webhook-client
       current-context: authz-webhook
@@ -585,7 +596,7 @@ write_files:
               return 403;
             }
             proxy_pass_request_body off;
-            proxy_pass http://localhost:8080;
+            proxy_pass http://127.0.0.1:8080;
           }
           location ~ /secrets(/|$) {
             return 403 "unauthorized";
@@ -593,30 +604,38 @@ write_files:
         }
       }
 
-  - path: /etc/kubernetes/controller-kubeconfig
+  - path: /opt/bin/gen-controller-manager-config.sh
     content: |
+    owner: root:root
+    permissions: 0755
+    content: |
+      #!/bin/bash
+      token="$(head -c 16 /dev/urandom | od -An -t x | tr -d ' ')"
+      cat << EOF > /etc/kubernetes/controller-kubeconfig
       apiVersion: v1
       kind: Config
       clusters:
-      - name: https://10.3.0.1
+      - name: local
         cluster:
-          server: https://10.3.0.1
+          server: https://127.0.0.1
           certificate-authority: /etc/kubernetes/ssl/ca.pem
       contexts:
-      - name: https://10.3.0.1
+      - name: local
         context:
-          cluster: https://10.3.0.1
+          cluster: local
           user: kube-controller-manager
-      current-context: https://10.3.0.1
+      current-context: local
       users:
       - name: kube-controller-manager
         user:
-          token: {{CONTROLLER_MANAGER_SECRET}}
+          token: ${token}
+      EOF
+
+      echo "${token},kube-controller-manager,kube-controller-manager" >> /etc/kubernetes/config/tokenfile.csv
 
   - path: /etc/kubernetes/config/tokenfile.csv
     content: |
       {{WORKER_SHARED_SECRET}},kubelet,kubelet
-      {{CONTROLLER_MANAGER_SECRET}},kube-controller-manager,kube-controller-manager
 
   - path: /etc/kubernetes/config/image-policy-webhook.yaml
     permissions: 0644
@@ -636,7 +655,7 @@ write_files:
       clusters:
         - name: image-policy-webhook
           cluster:
-            server: http://localhost:8083/admit
+            server: http://127.0.0.1:8083/admit
       users:
         - name: image-policy-webhook
       current-context: image-policy-webhook
@@ -689,3 +708,15 @@ write_files:
         }
       }
       EOF
+
+  - path: /home/core/.toolboxrc
+    owner: core
+    content: |
+      TOOLBOX_DOCKER_IMAGE=registry.opensource.zalan.do/teapot/microscope
+      TOOLBOX_DOCKER_TAG=v0.0.4
+
+  - path: /root/.toolboxrc
+    owner: root
+    content: |
+      TOOLBOX_DOCKER_IMAGE=registry.opensource.zalan.do/teapot/microscope
+      TOOLBOX_DOCKER_TAG=v0.0.4

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -289,3 +289,15 @@ write_files:
         }
       }
       EOF
+
+  - path: /home/core/.toolboxrc
+    owner: core
+    content: |
+      TOOLBOX_DOCKER_IMAGE=registry.opensource.zalan.do/teapot/microscope
+      TOOLBOX_DOCKER_TAG=v0.0.4
+
+  - path: /root/.toolboxrc
+    owner: root
+    content: |
+      TOOLBOX_DOCKER_IMAGE=registry.opensource.zalan.do/teapot/microscope
+      TOOLBOX_DOCKER_TAG=v0.0.4


### PR DESCRIPTION
Things that piled up in our internal repo over the last weeks
* stop restarting cronjobs
* add pod count quota to default and kube-system namespace
* update skipper ingress daemon set
* add region information to zmon
* cleanup localhost/127.0.0.1
* controller-manager: connect to local apiserver and use randomly generated secret
* add back the custom toolbox image