### PR TITLE
Promote dev to alpha

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: external-dns
-    version: v0.4.0
+    version: v0.4.3
 spec:
   strategy:
     type: Recreate
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: external-dns
-        version: v0.4.0
+        version: v0.4.3
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
@@ -26,7 +26,7 @@ spec:
          operator: Exists
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.0
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.3
         args:
         - --source=service
         - --source=ingress

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: external-dns
-    version: v0.4.3
+    version: v0.4.4
 spec:
   strategy:
     type: Recreate
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: external-dns
-        version: v0.4.3
+        version: v0.4.4
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
@@ -26,7 +26,7 @@ spec:
          operator: Exists
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.3
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.4
         args:
         - --source=service
         - --source=ingress

--- a/cluster/manifests/heapster/deployment.yaml
+++ b/cluster/manifests/heapster/deployment.yaml
@@ -44,7 +44,7 @@ spec:
           command:
             - /heapster
             - --source=kubernetes.summary_api:''
-        - image: registry.opensource.zalan.do/teapot/addon-resizer:1.6
+        - image: registry.opensource.zalan.do/teapot/addon-resizer:2.0
           name: heapster-nanny
           resources:
             limits:
@@ -68,8 +68,7 @@ spec:
             - --extra-cpu=4m
             - --memory=200Mi
             - --extra-memory=4Mi
-            - --threshold=5
+            - --recommendation-offset=5
             - --deployment=heapster
             - --container=heapster
             - --poll-period=300000
-            - --estimator=exponential

--- a/cluster/manifests/kube-dns/depl-kube-dns.yaml
+++ b/cluster/manifests/kube-dns/depl-kube-dns.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-dns
-    version: v1.14.2
+    version: v1.14.4
     kubernetes.io/cluster-service: "true"
 spec:
   # replicas: not specified here:
@@ -23,7 +23,7 @@ spec:
     metadata:
       labels:
         application: kube-dns
-        version: v1.14.2
+        version: v1.14.4
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -38,7 +38,7 @@ spec:
           optional: true
       containers:
       - name: kubedns
-        image: registry.opensource.zalan.do/teapot/k8s-dns-kube-dns:1.14.2
+        image: registry.opensource.zalan.do/teapot/k8s-dns-kube-dns:1.14.4
         resources:
           limits:
             memory: 170Mi
@@ -83,7 +83,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: registry.opensource.zalan.do/teapot/k8s-dns-dnsmasq-nanny:1.14.2
+        image: registry.opensource.zalan.do/teapot/k8s-dns-dnsmasq-nanny:1.14.4
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -121,7 +121,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: registry.opensource.zalan.do/teapot/k8s-dns-sidecar:1.14.2
+        image: registry.opensource.zalan.do/teapot/k8s-dns-sidecar:1.14.4
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -63,7 +63,10 @@ spec:
         - name: WATCHER_AGENTS
           value: scalyr
         - name: WATCHER_SCALYR_API_KEY
-          value: "{{ .ConfigItems.scalyr_access_key }}"
+          valueFrom:
+            secretKeyRef:
+              name: logging-agent
+              key: scalyr-access-key
         - name: WATCHER_CLUSTER_ID
           value: "{{ .ID }}"
         - name: WATCHER_SCALYR_DEST_PATH
@@ -102,7 +105,10 @@ spec:
         env:
         # Note: added for scalyr-config-base, but not needed by the scalyr-agent itself.
         - name: WATCHER_SCALYR_API_KEY
-          value: "{{ .ConfigItems.scalyr_access_key }}"
+          valueFrom:
+            secretKeyRef:
+              name: logging-agent
+              key: scalyr-access-key
         - name: WATCHER_CLUSTER_ID
           value: "{{ .ID }}"
 
@@ -150,4 +156,3 @@ spec:
       - name: scalyr-logs
         hostPath:
           path: /var/log/scalyr-agent
-

--- a/cluster/manifests/logging-agent/secret.yaml
+++ b/cluster/manifests/logging-agent/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: logging-agent
+  namespace: kube-system
+  labels:
+    application: logging-agent
+type: Opaque
+data:
+  scalyr-access-key: "{{ .ConfigItems.scalyr_access_key | base64 }}"

--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: "kube-system"
   labels:
     application: "zmon-agent"
-    version: "v0.1-a27"
+    version: "v0.1-a28"
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: "zmon-agent"
-        version: "v0.1-a27"
+        version: "v0.1-a28"
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -25,7 +25,7 @@ spec:
         operator: Exists
       containers:
         - name: zmon-agent
-          image: "registry.opensource.zalan.do/zmon/zmon-agent-core:0.1-a27"
+          image: "registry.opensource.zalan.do/zmon/zmon-agent-core:0.1-a28"
           resources:
             limits:
               cpu: 100m

--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         operator: Exists
       containers:
         - name: zmon-worker
-          image: "pierone.stups.zalan.do/stups/zmon-worker:zv207"
+          image: "pierone.stups.zalan.do/stups/zmon-worker:zv217"
           resources:
             limits:
               cpu: 500m

--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -47,7 +47,10 @@ spec:
             - name: WORKER_REDIS_SERVERS
               value: zmon-redis:6379
             - name: WORKER_PLUGIN_SCALYR_READ_KEY
-              value: "{{ .ConfigItems.scalyr_read_key }}"
+              valueFrom:
+                secretKeyRef:
+                  name: zmon-worker
+                  key: scalyr-read-key
             - name: WORKER_ACCOUNT
               value: "{{ .InfrastructureAccount }}"
             - name: WORKER_REGION

--- a/cluster/manifests/zmon-worker/secret.yaml
+++ b/cluster/manifests/zmon-worker/secret.yaml
@@ -3,7 +3,10 @@ kind: Secret
 metadata:
   name: zmon-worker
   namespace: kube-system
+  labels:
+    application: zmon-worker
 type: Opaque
 data:
   sql-user: "{{ .ConfigItems.zmon_worker_plugin_sql_user | base64 }}"
   sql-pass: "{{ .ConfigItems.zmon_worker_plugin_sql_pass | base64 }}"
+  scalyr-read-key: "{{ .ConfigItems.scalyr_read_key | base64 }}"

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -100,7 +100,7 @@ coreos:
       runtime: true
       content: |
         [Service]
-        Environment=KUBELET_IMAGE_TAG=v1.7.2_coreos.0
+        Environment=KUBELET_IMAGE_TAG=v1.7.3_coreos.0
         Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
         Environment="RKT_RUN_ARGS=--insecure-options=image \
         --uuid-file-save=/var/run/kubelet-pod.uuid \
@@ -162,7 +162,7 @@ coreos:
         --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
         --mount=volume=kube,target=/etc/kubernetes \
         --net=host \
-        registry.opensource.zalan.do/teapot/hyperkube:v1.7.2_coreos.0 \
+        registry.opensource.zalan.do/teapot/hyperkube:v1.7.3_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           drain $(hostname) \
@@ -242,14 +242,14 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-proxy
-          version: v1.7.2_coreos.0
+          version: v1.7.3_coreos.0
         annotations:
           rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
       spec:
         hostNetwork: true
         containers:
         - name: kube-proxy
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.2_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.3_coreos.0
           command:
           - /hyperkube
           - proxy
@@ -289,7 +289,7 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-apiserver
-          version: v1.7.2_coreos.0
+          version: v1.7.3_coreos.0
         annotations:
           kubernetes-log-watcher/scalyr-parser: |
             [{"container": "webhook", "parser": "json-structured-log"}]
@@ -297,7 +297,7 @@ write_files:
         hostNetwork: true
         containers:
         - name: kube-apiserver
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.2_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.3_coreos.0
           command:
           - /hyperkube
           - apiserver
@@ -464,11 +464,11 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-controller-manager
-          version: v1.7.2_coreos.0
+          version: v1.7.3_coreos.0
       spec:
         containers:
         - name: kube-controller-manager
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.2_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.3_coreos.0
           command:
           - /hyperkube
           - controller-manager
@@ -525,12 +525,12 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-scheduler
-          version: v1.7.2_coreos.0
+          version: v1.7.3_coreos.0
       spec:
         hostNetwork: true
         containers:
         - name: kube-scheduler
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.2_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.3_coreos.0
           command:
           - /hyperkube
           - scheduler

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -100,7 +100,7 @@ coreos:
       runtime: true
       content: |
         [Service]
-        Environment=KUBELET_IMAGE_TAG=v1.6.7_coreos.0
+        Environment=KUBELET_IMAGE_TAG=v1.7.2_coreos.0
         Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
         Environment="RKT_RUN_ARGS=--insecure-options=image \
         --uuid-file-save=/var/run/kubelet-pod.uuid \
@@ -160,7 +160,7 @@ coreos:
         --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
         --mount=volume=kube,target=/etc/kubernetes \
         --net=host \
-        registry.opensource.zalan.do/teapot/hyperkube:v1.6.7_coreos.0 \
+        registry.opensource.zalan.do/teapot/hyperkube:v1.7.2_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           drain $(hostname) \
@@ -240,14 +240,14 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-proxy
-          version: v1.6.7_coreos.0
+          version: v1.7.2_coreos.0
         annotations:
           rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
       spec:
         hostNetwork: true
         containers:
         - name: kube-proxy
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.6.7_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.2_coreos.0
           command:
           - /hyperkube
           - proxy
@@ -287,7 +287,7 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-apiserver
-          version: v1.6.7_coreos.0
+          version: v1.7.2_coreos.0
         annotations:
           kubernetes-log-watcher/scalyr-parser: |
             [{"container": "webhook", "parser": "json-structured-log"}]
@@ -295,7 +295,7 @@ write_files:
         hostNetwork: true
         containers:
         - name: kube-apiserver
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.6.7_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.2_coreos.0
           command:
           - /hyperkube
           - apiserver
@@ -327,7 +327,7 @@ write_files:
               host: 127.0.0.1
               port: 8080
               path: /healthz
-            initialDelaySeconds: 15
+            initialDelaySeconds: 60
             timeoutSeconds: 15
           ports:
           - containerPort: 443
@@ -462,11 +462,11 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-controller-manager
-          version: v1.6.7_coreos.0
+          version: v1.7.2_coreos.0
       spec:
         containers:
         - name: kube-controller-manager
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.6.7_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.2_coreos.0
           command:
           - /hyperkube
           - controller-manager
@@ -523,12 +523,12 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-scheduler
-          version: v1.6.7_coreos.0
+          version: v1.7.2_coreos.0
       spec:
         hostNetwork: true
         containers:
         - name: kube-scheduler
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.6.7_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.2_coreos.0
           command:
           - /hyperkube
           - scheduler

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -388,7 +388,7 @@ write_files:
             - name: TOKEN_INTROSPECTION_URL
               value: http://127.0.0.1:9021/oauth2/introspect
             - name: USER_GROUPS
-              value: stups_autobahn=Administrator,stups_deployment-controller-ui=ReadOnly,credentials-provider=Administrator,credprov-kube-ops-view-read-only-token=ReadOnly,credprov-cluster-lifecycle-manager-cluster-rw-token=Administrator,credprov-cluster-lifecycle-manager-test-cluster-rw-token=Administrator,credprov-cdp-controller-cluster-token=PowerUser
+              value: stups_autobahn=Administrator,stups_deployment-controller-ui=ReadOnly,credentials-provider=Administrator,credprov-kube-ops-view-read-only-token=ReadOnly,credprov-cluster-lifecycle-manager-cluster-rw-token=Administrator,credprov-cluster-lifecycle-manager-test-cluster-rw-token=Administrator,credprov-cdp-controller-cluster-token=PowerUser,credprov-api-discovery-k8s-cluster-read-only-token=ReadOnly
             - name: BUSINESS_PARTNER_IDS
               value: {{ APISERVER_BUSINESS_PARTNER_IDS }}
           volumeMounts:

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -130,6 +130,8 @@ coreos:
         --cluster_domain=cluster.local \
         --kubeconfig=/etc/kubernetes/kubeconfig \
         --require-kubeconfig \
+        --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
+        --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \
         --cloud-provider=aws \
         --low-diskspace-threshold-mb=1000 \
         --feature-gates=AllAlpha=true \
@@ -676,6 +678,14 @@ write_files:
   - path: /etc/kubernetes/ssl/apiserver-key.pem
     encoding: gzip+base64
     content: {{APISERVER_KEY}}
+
+  - path: /etc/kubernetes/ssl/worker.pem
+    encoding: gzip+base64
+    content: {{WORKER_CERT}}
+
+  - path: /etc/kubernetes/ssl/worker-key.pem
+    encoding: gzip+base64
+    content: {{WORKER_KEY}}
 
   - path: /etc/kubernetes/cni/net.d/10-flannel.conf
     content: |

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -353,7 +353,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.2.2
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.2.3
           name: webhook
           ports:
           - containerPort: 8081

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -100,7 +100,7 @@ coreos:
       runtime: true
       content: |
         [Service]
-        Environment=KUBELET_IMAGE_TAG=v1.7.3_coreos.0
+        Environment=KUBELET_IMAGE_TAG=v1.7.4_coreos.0
         Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
         Environment="RKT_RUN_ARGS=--insecure-options=image \
         --uuid-file-save=/var/run/kubelet-pod.uuid \
@@ -162,7 +162,7 @@ coreos:
         --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
         --mount=volume=kube,target=/etc/kubernetes \
         --net=host \
-        registry.opensource.zalan.do/teapot/hyperkube:v1.7.3_coreos.0 \
+        registry.opensource.zalan.do/teapot/hyperkube:v1.7.4_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           drain $(hostname) \
@@ -242,14 +242,14 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-proxy
-          version: v1.7.3_coreos.0
+          version: v1.7.4_coreos.0
         annotations:
           rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
       spec:
         hostNetwork: true
         containers:
         - name: kube-proxy
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.3_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.4_coreos.0
           command:
           - /hyperkube
           - proxy
@@ -289,7 +289,7 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-apiserver
-          version: v1.7.3_coreos.0
+          version: v1.7.4_coreos.0
         annotations:
           kubernetes-log-watcher/scalyr-parser: |
             [{"container": "webhook", "parser": "json-structured-log"}]
@@ -297,7 +297,7 @@ write_files:
         hostNetwork: true
         containers:
         - name: kube-apiserver
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.3_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.4_coreos.0
           command:
           - /hyperkube
           - apiserver
@@ -464,11 +464,11 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-controller-manager
-          version: v1.7.3_coreos.0
+          version: v1.7.4_coreos.0
       spec:
         containers:
         - name: kube-controller-manager
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.3_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.4_coreos.0
           command:
           - /hyperkube
           - controller-manager
@@ -525,12 +525,12 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-scheduler
-          version: v1.7.3_coreos.0
+          version: v1.7.4_coreos.0
       spec:
         hostNetwork: true
         containers:
         - name: kube-scheduler
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.3_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.4_coreos.0
           command:
           - /hyperkube
           - scheduler

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -80,7 +80,7 @@ coreos:
       runtime: true
       content: |
         [Service]
-        Environment=KUBELET_IMAGE_TAG=v1.7.3_coreos.0
+        Environment=KUBELET_IMAGE_TAG=v1.7.4_coreos.0
         Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
         Environment="RKT_RUN_ARGS=--insecure-options=image \
         --uuid-file-save=/var/run/kubelet-pod.uuid \
@@ -145,7 +145,7 @@ coreos:
         --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
         --mount=volume=kube,target=/etc/kubernetes \
         --net=host \
-        registry.opensource.zalan.do/teapot/hyperkube:v1.7.3_coreos.0 \
+        registry.opensource.zalan.do/teapot/hyperkube:v1.7.4_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
           drain $(hostname) \
@@ -195,14 +195,14 @@ write_files:
           namespace: kube-system
           labels:
             application: kube-proxy
-            version: v1.7.3_coreos.0
+            version: v1.7.4_coreos.0
           annotations:
             rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
         spec:
           hostNetwork: true
           containers:
           - name: kube-proxy
-            image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.3_coreos.0
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.4_coreos.0
             command:
             - /hyperkube
             - proxy

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -80,7 +80,7 @@ coreos:
       runtime: true
       content: |
         [Service]
-        Environment=KUBELET_IMAGE_TAG=v1.7.2_coreos.0
+        Environment=KUBELET_IMAGE_TAG=v1.7.3_coreos.0
         Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
         Environment="RKT_RUN_ARGS=--insecure-options=image \
         --uuid-file-save=/var/run/kubelet-pod.uuid \
@@ -145,7 +145,7 @@ coreos:
         --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
         --mount=volume=kube,target=/etc/kubernetes \
         --net=host \
-        registry.opensource.zalan.do/teapot/hyperkube:v1.7.2_coreos.0 \
+        registry.opensource.zalan.do/teapot/hyperkube:v1.7.3_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
           drain $(hostname) \
@@ -195,14 +195,14 @@ write_files:
           namespace: kube-system
           labels:
             application: kube-proxy
-            version: v1.7.2_coreos.0
+            version: v1.7.3_coreos.0
           annotations:
             rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
         spec:
           hostNetwork: true
           containers:
           - name: kube-proxy
-            image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.2_coreos.0
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.3_coreos.0
             command:
             - /hyperkube
             - proxy

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -80,7 +80,7 @@ coreos:
       runtime: true
       content: |
         [Service]
-        Environment=KUBELET_IMAGE_TAG=v1.6.7_coreos.0
+        Environment=KUBELET_IMAGE_TAG=v1.7.2_coreos.0
         Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
         Environment="RKT_RUN_ARGS=--insecure-options=image \
         --uuid-file-save=/var/run/kubelet-pod.uuid \
@@ -145,7 +145,7 @@ coreos:
         --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
         --mount=volume=kube,target=/etc/kubernetes \
         --net=host \
-        registry.opensource.zalan.do/teapot/hyperkube:v1.6.7_coreos.0 \
+        registry.opensource.zalan.do/teapot/hyperkube:v1.7.2_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
           drain $(hostname) \
@@ -195,14 +195,14 @@ write_files:
           namespace: kube-system
           labels:
             application: kube-proxy
-            version: v1.6.7_coreos.0
+            version: v1.7.2_coreos.0
           annotations:
             rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
         spec:
           hostNetwork: true
           containers:
           - name: kube-proxy
-            image: registry.opensource.zalan.do/teapot/hyperkube:v1.6.7_coreos.0
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.2_coreos.0
             command:
             - /hyperkube
             - proxy


### PR DESCRIPTION
Notable changes:
* Update to Kubernetes v1.7.4 (4 hours ago)
* hide scalyr secrets from api users (4 hours ago)
* Grant ReadOnly access for apidescovery app (4 days ago)
* update ExternalDNS to v0.4.4 (2 hours ago)
* bump version of zmon to integrate opsgenie (3 hours ago)
* Use TLS for kubelet on masters (2 days ago)
* Update webhook to allow users of system:masters group (2 days ago)
