### PR TITLE
scalyr: hide scalyr secrets from api users

### DIFF
--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -63,7 +63,10 @@ spec:
         - name: WATCHER_AGENTS
           value: scalyr
         - name: WATCHER_SCALYR_API_KEY
-          value: "{{ .ConfigItems.scalyr_access_key }}"
+          valueFrom:
+            secretKeyRef:
+              name: logging-agent
+              key: scalyr-access-key
         - name: WATCHER_CLUSTER_ID
           value: "{{ .ID }}"
         - name: WATCHER_SCALYR_DEST_PATH
@@ -102,7 +105,10 @@ spec:
         env:
         # Note: added for scalyr-config-base, but not needed by the scalyr-agent itself.
         - name: WATCHER_SCALYR_API_KEY
-          value: "{{ .ConfigItems.scalyr_access_key }}"
+          valueFrom:
+            secretKeyRef:
+              name: logging-agent
+              key: scalyr-access-key
         - name: WATCHER_CLUSTER_ID
           value: "{{ .ID }}"
 
@@ -150,4 +156,3 @@ spec:
       - name: scalyr-logs
         hostPath:
           path: /var/log/scalyr-agent
-

--- a/cluster/manifests/logging-agent/secret.yaml
+++ b/cluster/manifests/logging-agent/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: logging-agent
+  namespace: kube-system
+  labels:
+    application: logging-agent
+type: Opaque
+data:
+  scalyr-access-key: "{{ .ConfigItems.scalyr_access_key | base64 }}"

--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -47,7 +47,10 @@ spec:
             - name: WORKER_REDIS_SERVERS
               value: zmon-redis:6379
             - name: WORKER_PLUGIN_SCALYR_READ_KEY
-              value: "{{ .ConfigItems.scalyr_read_key }}"
+              valueFrom:
+                secretKeyRef:
+                  name: zmon-worker
+                  key: scalyr-read-key
             - name: WORKER_ACCOUNT
               value: "{{ .InfrastructureAccount }}"
             - name: WORKER_REGION

--- a/cluster/manifests/zmon-worker/secret.yaml
+++ b/cluster/manifests/zmon-worker/secret.yaml
@@ -3,7 +3,10 @@ kind: Secret
 metadata:
   name: zmon-worker
   namespace: kube-system
+  labels:
+    application: zmon-worker
 type: Opaque
 data:
   sql-user: "{{ .ConfigItems.zmon_worker_plugin_sql_user | base64 }}"
   sql-pass: "{{ .ConfigItems.zmon_worker_plugin_sql_pass | base64 }}"
+  scalyr-read-key: "{{ .ConfigItems.scalyr_read_key | base64 }}"


### PR DESCRIPTION
This uses `secretKeyRef` to populate scalyr access credentials into environment variables in order to prevent people from seeing it when using `kubectl describe pod`.