### PR TITLE
fix: remove duplicate content field

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -607,7 +607,6 @@ write_files:
       }
 
   - path: /opt/bin/gen-controller-manager-config.sh
-    content: |
     owner: root:root
     permissions: 0755
     content: |


### PR DESCRIPTION
There's a duplicate `content` field. Seems like it doesn't have any effect but let's remove it anyways.