### PR TITLE
bump initial delay for apiserver, because it does not finish reliably

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -329,7 +329,7 @@ write_files:
               host: 127.0.0.1
               port: 8080
               path: /healthz
-            initialDelaySeconds: 60
+            initialDelaySeconds: 120
             timeoutSeconds: 15
           ports:
           - containerPort: 443


### PR DESCRIPTION
cherry-pick 7509736

hotfix to increase the initial delay for kube-apiserver

During cluster updates we saw that many clusters were being stuck in our update procedure. We do rolling updates first masters, after that the workers. We saw that masters were not becoming ready, so we looked at it and it turns out the apiserver exited before getting ready. We think that we have too many containers for the initialDelay of 60s, so we increased it. This fixed for us the bootstrap of masters problem.