### PR TITLE
bump initial delay for apiserver, because it does not finish reliably

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -329,7 +329,7 @@ write_files:
               host: 127.0.0.1
               port: 8080
               path: /healthz
-            initialDelaySeconds: 60
+            initialDelaySeconds: 120
             timeoutSeconds: 15
           ports:
           - containerPort: 443


### PR DESCRIPTION
cherry-pick 7509736

hotfix to increase the initial delay for kube-apiserver