### PR TITLE
kube-ingress-aws-controller v0.3.9

### DIFF
--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.3.8
+    version: v0.3.9
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.3.8
+        version: v0.3.9
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
@@ -26,7 +26,7 @@ spec:
         operator: Exists
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.3.8
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.3.9
         env:
         - name: AWS_REGION
           value: {{ .Region }}


### PR DESCRIPTION
Support overwriting the SSL cert by domain (instead of ARN) via the `zalando.org/aws-load-balancer-ssl-cert-domain` annotation, see https://github.com/zalando-incubator/kube-ingress-aws-controller/releases/tag/v0.3.9