### PR TITLE
Add support for Emergency role in webhook

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -355,7 +355,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.2.3
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.2.4
           name: webhook
           ports:
           - containerPort: 8081


### PR DESCRIPTION
Adds support for the `Emergency` role temporarily granted by the emergency-access-service. This role has the same permissions as `PowerUser`.