### PR TITLE
Tag etcd ASG with kubernetes:component=etcd-cluster

### DIFF
--- a/cluster/etcd-cluster.yaml
+++ b/cluster/etcd-cluster.yaml
@@ -28,6 +28,9 @@ SenzaComponents:
     AutoScaling:
       Minimum: "{{Arguments.InstanceCount}}"
       Maximum: "{{Arguments.InstanceCount}}"
+    Tags:
+    - Key: "kubernetes:component"
+      Value: "etcd-cluster"
 SenzaInfo:
   Parameters:
   - HostedZone:


### PR DESCRIPTION
Tags the etcd ASG with the tag `kubernetes:component=etcd-cluster`. This will enable us to easily filter etcd clusters used in our kubernetes setup in ZMON.