### PR TITLE
Add CriticalAddonsOnly toleration to static pods

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -246,6 +246,9 @@ write_files:
         annotations:
           rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
       spec:
+        tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
         hostNetwork: true
         containers:
         - name: kube-proxy
@@ -294,6 +297,9 @@ write_files:
           kubernetes-log-watcher/scalyr-parser: |
             [{"container": "webhook", "parser": "json-structured-log"}]
       spec:
+        tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
         hostNetwork: true
         containers:
         - name: kube-apiserver
@@ -466,6 +472,9 @@ write_files:
           application: kube-controller-manager
           version: v1.7.4_coreos.0
       spec:
+        tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
         containers:
         - name: kube-controller-manager
           image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.4_coreos.0
@@ -527,6 +536,9 @@ write_files:
           application: kube-scheduler
           version: v1.7.4_coreos.0
       spec:
+        tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
         hostNetwork: true
         containers:
         - name: kube-scheduler
@@ -565,6 +577,9 @@ write_files:
           kubernetes.io/cluster-service: "true"
           kubernetes.io/name: "Rescheduler"
       spec:
+        tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
         hostNetwork: true
         containers:
         - image: registry.opensource.zalan.do/teapot/rescheduler:v0.3.1

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -199,6 +199,9 @@ write_files:
           annotations:
             rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
         spec:
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
           hostNetwork: true
           containers:
           - name: kube-proxy


### PR DESCRIPTION
Adds `CriticalAddonsOnly` toleration to static pods to ensure they won't get evicted in case the node runs out of resources.

We had this on all the components in the manifests folder already, but forgot to add it to the pods defined in the userdata.