### PR TITLE
do not bind clients to a particular apiserver instance

### DIFF
--- a/cluster/manifests/kubernetes/svc-kubernetes.yaml
+++ b/cluster/manifests/kubernetes/svc-kubernetes.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubernetes
+  namespace: default
+spec:
+  sessionAffinity: None


### PR DESCRIPTION
This overwrites the default definition of the kubernetes service to employ no session affinity, as opposed to the default on "ClientIP".

This allows clients to pick another apiserver instance in case one is down. We had trouble with this in the past when clients wouldn't pick the other apiserver in case one is down. I believe this is due its default definition of `sessionAffinity: ClientIP`.