### PR TITLE
Update zmon-aws-agent to include environment entity

### DIFF
--- a/cluster/manifests/zmon-aws-agent/deployment.yaml
+++ b/cluster/manifests/zmon-aws-agent/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: "kube-system"
   labels:
     application: "zmon-aws-agent"
-    version: "v142"
+    version: "v148"
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: "zmon-aws-agent"
-        version: "v142"
+        version: "v148"
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -25,7 +25,7 @@ spec:
         operator: Exists
       containers:
         - name: zmon-aws-agent
-          image: pierone.stups.zalan.do/stups/zmon-aws-agent:zv142
+          image: pierone.stups.zalan.do/stups/zmon-aws-agent:zv148
           resources:
             limits:
               cpu: 100m
@@ -39,6 +39,8 @@ spec:
               value: https://token.services.auth.zalando.com/oauth2/access_token?realm=/services
             - name: CREDENTIALS_DIR
               value: /meta/credentials
+            - name: EXTRA_ENTITY_FIELDS
+              value: "environment={{ .Environment }}"
 
           volumeMounts:
             - name: credentials


### PR DESCRIPTION
Updates zmon-aws-agent to include this feature: https://github.com/zalando-zmon/zmon-aws-agent/pull/115 allowing us to add environment to all entities, making it possible to filter on product/test environment in zmon alerts.