### PR TITLE
Dev to alpha

### DIFF
--- a/cluster/etcd-cluster.yaml
+++ b/cluster/etcd-cluster.yaml
@@ -28,6 +28,9 @@ SenzaComponents:
     AutoScaling:
       Minimum: "{{Arguments.InstanceCount}}"
       Maximum: "{{Arguments.InstanceCount}}"
+    Tags:
+    - Key: "kubernetes:component"
+      Value: "etcd-cluster"
 SenzaInfo:
   Parameters:
   - HostedZone:

--- a/cluster/manifests/heapster/deployment.yaml
+++ b/cluster/manifests/heapster/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     application: heapster
     kubernetes.io/cluster-service: "true"
-    version: v1.4.0
+    version: v1.4.1
 spec:
   replicas: 1
   selector:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: heapster
-        version: v1.4.0
+        version: v1.4.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -25,7 +25,7 @@ spec:
         operator: Exists
       serviceAccountName: system
       containers:
-        - image: registry.opensource.zalan.do/teapot/heapster:v1.4.0
+        - image: registry.opensource.zalan.do/teapot/heapster:v1.4.1
           name: heapster
           livenessProbe:
             httpGet:

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.3.8
+    version: v0.3.9
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.3.8
+        version: v0.3.9
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
@@ -26,7 +26,7 @@ spec:
         operator: Exists
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.3.8
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.3.9
         env:
         - name: AWS_REGION
           value: {{ .Region }}

--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube2iam
-    version: v0.6.4
+    version: v0.7.0
 spec:
   selector:
     matchLabels:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: kube2iam
-        version: v0.6.4
+        version: v0.7.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -25,7 +25,7 @@ spec:
         operator: Exists
       hostNetwork: true
       containers:
-      - image: registry.opensource.zalan.do/teapot/kube2iam:0.6.4
+      - image: registry.opensource.zalan.do/teapot/kube2iam:0.7.0
         name: kube2iam
         args:
         - --auto-discover-base-arn

--- a/cluster/manifests/zmon-aws-agent/deployment.yaml
+++ b/cluster/manifests/zmon-aws-agent/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: "kube-system"
   labels:
     application: "zmon-aws-agent"
-    version: "v142"
+    version: "v148"
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: "zmon-aws-agent"
-        version: "v142"
+        version: "v148"
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -25,7 +25,7 @@ spec:
         operator: Exists
       containers:
         - name: zmon-aws-agent
-          image: pierone.stups.zalan.do/stups/zmon-aws-agent:zv142
+          image: pierone.stups.zalan.do/stups/zmon-aws-agent:zv148
           resources:
             limits:
               cpu: 100m
@@ -39,6 +39,8 @@ spec:
               value: https://token.services.auth.zalando.com/oauth2/access_token?realm=/services
             - name: CREDENTIALS_DIR
               value: /meta/credentials
+            - name: EXTRA_ENTITY_FIELDS
+              value: "environment={{ .Environment }}"
 
           volumeMounts:
             - name: credentials

--- a/cluster/manifests/zmon-scheduler/deployment.yaml
+++ b/cluster/manifests/zmon-scheduler/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: zmon-scheduler
-    version: "v0.1"
+    version: "v41"
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: zmon-scheduler
-        version: "v0.1"
+        version: "v41"
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -25,7 +25,7 @@ spec:
         operator: Exists
       containers:
         - name: zmon-scheduler
-          image: "registry.opensource.zalan.do/stups/zmon-scheduler:v38"
+          image: "registry.opensource.zalan.do/stups/zmon-scheduler:v41"
           resources:
             limits:
               cpu: 2

--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -12,7 +12,7 @@ spec:
     metadata:
       labels:
         application: zmon-worker
-        version: "v0.1"
+        version: "zv220"
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -22,7 +22,7 @@ spec:
         operator: Exists
       containers:
         - name: zmon-worker
-          image: "pierone.stups.zalan.do/stups/zmon-worker:zv217"
+          image: "pierone.stups.zalan.do/stups/zmon-worker:zv220"
           resources:
             limits:
               cpu: 500m

--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -12,7 +12,7 @@ spec:
     metadata:
       labels:
         application: zmon-worker
-        version: "zv220"
+        version: "zv221"
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -22,7 +22,7 @@ spec:
         operator: Exists
       containers:
         - name: zmon-worker
-          image: "pierone.stups.zalan.do/stups/zmon-worker:zv220"
+          image: "pierone.stups.zalan.do/stups/zmon-worker:zv221"
           resources:
             limits:
               cpu: 500m

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -607,7 +607,6 @@ write_files:
       }
 
   - path: /opt/bin/gen-controller-manager-config.sh
-    content: |
     owner: root:root
     permissions: 0755
     content: |

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -246,6 +246,9 @@ write_files:
         annotations:
           rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
       spec:
+        tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
         hostNetwork: true
         containers:
         - name: kube-proxy
@@ -294,6 +297,9 @@ write_files:
           kubernetes-log-watcher/scalyr-parser: |
             [{"container": "webhook", "parser": "json-structured-log"}]
       spec:
+        tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
         hostNetwork: true
         containers:
         - name: kube-apiserver
@@ -466,6 +472,9 @@ write_files:
           application: kube-controller-manager
           version: v1.7.4_coreos.0
       spec:
+        tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
         containers:
         - name: kube-controller-manager
           image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.4_coreos.0
@@ -527,6 +536,9 @@ write_files:
           application: kube-scheduler
           version: v1.7.4_coreos.0
       spec:
+        tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
         hostNetwork: true
         containers:
         - name: kube-scheduler
@@ -565,6 +577,9 @@ write_files:
           kubernetes.io/cluster-service: "true"
           kubernetes.io/name: "Rescheduler"
       spec:
+        tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
         hostNetwork: true
         containers:
         - image: registry.opensource.zalan.do/teapot/rescheduler:v0.3.1

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -355,7 +355,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.2.3
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.2.4
           name: webhook
           ports:
           - containerPort: 8081

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -329,7 +329,7 @@ write_files:
               host: 127.0.0.1
               port: 8080
               path: /healthz
-            initialDelaySeconds: 60
+            initialDelaySeconds: 120
             timeoutSeconds: 15
           ports:
           - containerPort: 443

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -199,6 +199,9 @@ write_files:
           annotations:
             rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
         spec:
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
           hostNetwork: true
           containers:
           - name: kube-proxy


### PR DESCRIPTION
* Update zmon-aws-agent to include environment entity (#555)
* Add CriticalAddonsOnly toleration to static pods (#553)
* update zmon-worker to zv220 (#552)
* Tag etcd ASG with kubernetes:component=etcd-cluster (#551)
* Add support for Emergency role in webhook (#550)
* kube-ingress-aws-controller v0.3.9 (#547)
* Update kube2iam to v0.7.0 (#541)
* Update heapster to v1.4.1 (#534)
* update zmon-scheduler to v41 (#539)