### PR TITLE
Update image policy hook with simulate and metrics

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -429,10 +429,11 @@ write_files:
               value: https://identity.zalando.com/.well-known/openid-configuration
             - name: ENABLE_INTROSPECTION
               value: "true"
-        - image: registry.opensource.zalan.do/teapot/image-policy-webhook:v0.2.2
+        - image: registry.opensource.zalan.do/teapot/image-policy-webhook:v0.3.0
           name: image-policy-webhook
           args:
           - --policy={{ IMAGE_POLICY }}
+          - --simulate
           ports:
           - containerPort: 8083
         - name: nginx


### PR DESCRIPTION
Updates imagePolicyWebhook with the `--simulate` feature and a `/metrics` endpoint.

