### PR TITLE
Disable AllAlpha=true flag to not run with experimental alpha features

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -134,6 +134,7 @@ coreos:
         --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \
         --cloud-provider=aws \
         --low-diskspace-threshold-mb=1000 \
+        --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true \
         --system-reserved=cpu=100m,memory=164Mi \
         --kube-reserved=cpu=100m,memory=282Mi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
@@ -256,6 +257,7 @@ write_files:
           - /hyperkube
           - proxy
           - --master=http://127.0.0.1:8080
+          - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true
           - --v=2
           securityContext:
             privileged: true
@@ -326,6 +328,7 @@ write_files:
           - --authorization-mode=Webhook
           - --authorization-webhook-config-file=/etc/kubernetes/config/authz.yaml
           - --admission-control-config-file=/etc/kubernetes/config/image-policy-webhook.yaml
+          - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true
           - --anonymous-auth=false
           livenessProbe:
             httpGet:
@@ -484,6 +487,7 @@ write_files:
           - --root-ca-file=/etc/kubernetes/ssl/ca.pem
           - --cloud-provider=aws
           - --cloud-config=/etc/kubernetes/cloud-config.ini
+          - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true
           - --use-service-account-credentials=true
           resources:
             limits:
@@ -544,6 +548,7 @@ write_files:
           - scheduler
           - --master=http://127.0.0.1:8080
           - --leader-elect=true
+          - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true
           resources:
             limits:
               cpu: 250m

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -134,7 +134,6 @@ coreos:
         --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \
         --cloud-provider=aws \
         --low-diskspace-threshold-mb=1000 \
-        --feature-gates=AllAlpha=true \
         --system-reserved=cpu=100m,memory=164Mi \
         --kube-reserved=cpu=100m,memory=282Mi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
@@ -257,7 +256,6 @@ write_files:
           - /hyperkube
           - proxy
           - --master=http://127.0.0.1:8080
-          - --feature-gates=AllAlpha=true
           - --v=2
           securityContext:
             privileged: true
@@ -328,7 +326,6 @@ write_files:
           - --authorization-mode=Webhook
           - --authorization-webhook-config-file=/etc/kubernetes/config/authz.yaml
           - --admission-control-config-file=/etc/kubernetes/config/image-policy-webhook.yaml
-          - --feature-gates=AllAlpha=true
           - --anonymous-auth=false
           livenessProbe:
             httpGet:
@@ -486,7 +483,6 @@ write_files:
           - --service-account-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
           - --root-ca-file=/etc/kubernetes/ssl/ca.pem
           - --cloud-provider=aws
-          - --feature-gates=AllAlpha=true
           - --cloud-config=/etc/kubernetes/cloud-config.ini
           - --use-service-account-credentials=true
           resources:
@@ -548,7 +544,6 @@ write_files:
           - scheduler
           - --master=http://127.0.0.1:8080
           - --leader-elect=true
-          - --feature-gates=AllAlpha=true
           resources:
             limits:
               cpu: 250m

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -117,7 +117,6 @@ coreos:
         --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \
         --cloud-provider=aws \
         --low-diskspace-threshold-mb=1000 \
-        --feature-gates=AllAlpha=true \
         --system-reserved=cpu=100m,memory=164Mi \
         --kube-reserved=cpu=100m,memory=282Mi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
@@ -210,7 +209,6 @@ write_files:
             - /hyperkube
             - proxy
             - --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml
-            - --feature-gates=AllAlpha=true
             - --v=2
             securityContext:
               privileged: true

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -117,6 +117,7 @@ coreos:
         --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \
         --cloud-provider=aws \
         --low-diskspace-threshold-mb=1000 \
+        --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true \
         --system-reserved=cpu=100m,memory=164Mi \
         --kube-reserved=cpu=100m,memory=282Mi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
@@ -209,6 +210,7 @@ write_files:
             - /hyperkube
             - proxy
             - --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml
+            - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true
             - --v=2
             securityContext:
               privileged: true


### PR DESCRIPTION
This disables the `--AllAlpha=true` flag on all components so we don't run with experimental alpha features. One example is the certificatesigningrequest feature which we intended not to have enabled at this time.

https://kubernetes.slack.com/archives/C09NXKJKA/p1504200253000371