### PR TITLE
Use compliant images to pass through imagePolicyWebhook

### DIFF
--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
         operator: Exists
       initContainers:
       - name: init-scalyr-config
-        image: registry.opensource.zalan.do/stups/alpine:latest
+        image: registry.opensource.zalan.do/stups/alpine:3.5-cd10
         imagePullPolicy: IfNotPresent
         command: ["sh", "-c"]
         args:

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -401,7 +401,7 @@ write_files:
           - mountPath: /etc/kubernetes/config
             name: kubernetes-configs
             readOnly: true
-        - image: registry.opensource.zalan.do/foundation/platform-iam-tokeninfo:4feeb5a
+        - image: registry.opensource.zalan.do/foundation/platform-iam-tokeninfo:2fca26c
           name: tokeninfo
           ports:
             - containerPort: 9021


### PR DESCRIPTION
This uses
* a tagged image for alpine
* a valid scm-source for platform-iam-tokeninfo

to pass through the imagePolicyWebhook.

see https://github.bus.zalan.do/teapot/issues/issues/533#issuecomment-422869