### PR TITLE
Upgrade zmon-worker

### DIFF
--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -12,7 +12,7 @@ spec:
     metadata:
       labels:
         application: zmon-worker
-        version: "zv222"
+        version: "zv223"
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -22,7 +22,7 @@ spec:
         operator: Exists
       containers:
         - name: zmon-worker
-          image: "pierone.stups.zalan.do/stups/zmon-worker:zv222"
+          image: "pierone.stups.zalan.do/stups/zmon-worker:zv223"
           resources:
             limits:
               cpu: 500m


### PR DESCRIPTION
Upgrade zmon-worker with updated opsgenie notification that excludes alert event type in alert title.