### PR TITLE
Update image policy webhook and configure failure policy

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -429,10 +429,11 @@ write_files:
               value: https://identity.zalando.com/.well-known/openid-configuration
             - name: ENABLE_INTROSPECTION
               value: "true"
-        - image: registry.opensource.zalan.do/teapot/image-policy-webhook:v0.3.1
+        - image: registry.opensource.zalan.do/teapot/image-policy-webhook:v0.3.2
           name: image-policy-webhook
           args:
           - --policy={{ IMAGE_POLICY }}
+          - --failure-policy=fail
           - --simulate
           ports:
           - containerPort: 8083


### PR DESCRIPTION
Notable features:
* Fix a bug that causes mirror pods not to be registered.
* Use a restricitive failure policy that rejects images in case of failed dependencies (like before)