### PR TITLE
Tag resources with cluster ID

### DIFF
--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -57,8 +57,8 @@ SenzaComponents:
       VersionDomain: "{{SenzaInfo.StackName}}-{{SenzaInfo.StackVersion}}.{{Arguments.HostedZone}}"
       MainDomain: "{{SenzaInfo.StackName}}.{{Arguments.HostedZone}}"
       Tags:
-        - Key: "KubernetesCluster"
-          Value: kubernetes
+        - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
+          Value: owned
         - Key: "ClusterID"
           Value: "{{ Arguments.ClusterID }}"
   - MasterAutoScaling:
@@ -85,8 +85,8 @@ SenzaComponents:
          DesiredCapacity: "{{ Arguments.MasterNodes }}"
          SuccessRequires: "0 within 15m"
       Tags:
-        - Key: "KubernetesCluster"
-          Value: kubernetes
+        - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
+          Value: owned
         - Key: "ClusterID"
           Value: "{{ Arguments.ClusterID }}"
         - Key: "NodePool"
@@ -112,8 +112,8 @@ SenzaComponents:
          DesiredCapacity: "{{ Arguments.WorkerNodes }}"
          SuccessRequires: "1 within 15m"
       Tags:
-        - Key: "KubernetesCluster"
-          Value: kubernetes
+        - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
+          Value: owned
         - Key: "ClusterID"
           Value: "{{ Arguments.ClusterID }}"
         - Key: "NodePool"
@@ -278,8 +278,8 @@ Resources:
       - {CidrIp: 172.31.0.0/16, FromPort: 9911, IpProtocol: tcp, ToPort: 9911}
       - {CidrIp: 172.31.0.0/16, FromPort: 30080, IpProtocol: tcp, ToPort: 30080}
       Tags:
-        - Key: "KubernetesCluster"
-          Value: kubernetes
+        - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
+          Value: owned
         - Key: "ClusterID"
           Value: "{{ Arguments.ClusterID }}"
       VpcId: "{{ AccountInfo.VpcID }}"
@@ -291,8 +291,8 @@ Resources:
       - {CidrIp: 0.0.0.0/0, FromPort: -1, IpProtocol: icmp, ToPort: -1}
       - {CidrIp: 0.0.0.0/0, FromPort: 443, IpProtocol: tcp, ToPort: 443}
       Tags:
-        - Key: "KubernetesCluster"
-          Value: kubernetes
+        - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
+          Value: owned
         - Key: "ClusterID"
           Value: "{{ Arguments.ClusterID }}"
       VpcId: "{{ AccountInfo.VpcID }}"
@@ -305,8 +305,8 @@ Resources:
       SourceSecurityGroupId: {Ref: MasterLoadBalancerSecurityGroup}
       ToPort: 8080
       Tags:
-        - Key: "KubernetesCluster"
-          Value: kubernetes
+        - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
+          Value: owned
         - Key: "ClusterID"
           Value: "{{ Arguments.ClusterID }}"
     Type: AWS::EC2::SecurityGroupIngress
@@ -318,8 +318,8 @@ Resources:
       SourceSecurityGroupId: {Ref: MasterLoadBalancerSecurityGroup}
       ToPort: 443
       Tags:
-        - Key: "KubernetesCluster"
-          Value: kubernetes
+        - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
+          Value: owned
         - Key: "ClusterID"
           Value: "{{ Arguments.ClusterID }}"
     Type: AWS::EC2::SecurityGroupIngress
@@ -331,8 +331,8 @@ Resources:
       SourceSecurityGroupId: {Ref: MasterSecurityGroup}
       ToPort: 443
       Tags:
-        - Key: "KubernetesCluster"
-          Value: kubernetes
+        - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
+          Value: owned
         - Key: "ClusterID"
           Value: "{{ Arguments.ClusterID }}"
     Type: AWS::EC2::SecurityGroupIngress
@@ -344,8 +344,8 @@ Resources:
       SourceSecurityGroupId: {Ref: MasterSecurityGroup}
       ToPort: 10250
       Tags:
-        - Key: "KubernetesCluster"
-          Value: kubernetes
+        - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
+          Value: owned
         - Key: "ClusterID"
           Value: "{{ Arguments.ClusterID }}"
     Type: AWS::EC2::SecurityGroupIngress
@@ -362,8 +362,8 @@ Resources:
       # allow default service NodePort range
       - {CidrIp: 172.31.0.0/16, FromPort: 30000, IpProtocol: tcp, ToPort: 32767}
       Tags:
-        - Key: "KubernetesCluster"
-          Value: kubernetes
+        - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
+          Value: owned
         - Key: "ClusterID"
           Value: "{{ Arguments.ClusterID }}"
       VpcId: "{{ AccountInfo.VpcID }}"
@@ -377,6 +377,8 @@ Resources:
       - {CidrIp: 0.0.0.0/0, FromPort: 443, IpProtocol: tcp, ToPort: 443}
       VpcId: "{{ AccountInfo.VpcID }}"
       Tags:
+        - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
+          Value: owned
         - Key: "ClusterID"
           Value: "{{ Arguments.ClusterID }}"
     Type: AWS::EC2::SecurityGroup
@@ -389,8 +391,8 @@ Resources:
       SourceSecurityGroupId: {Ref: WorkerSecurityGroup}
       ToPort: 443
       Tags:
-        - Key: "KubernetesCluster"
-          Value: kubernetes
+        - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
+          Value: owned
         - Key: "ClusterID"
           Value: "{{ Arguments.ClusterID }}"
     Type: AWS::EC2::SecurityGroupIngress
@@ -402,8 +404,8 @@ Resources:
       SourceSecurityGroupId: {Ref: MasterSecurityGroup}
       ToPort: 8472
       Tags:
-        - Key: "KubernetesCluster"
-          Value: kubernetes
+        - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
+          Value: owned
         - Key: "ClusterID"
           Value: "{{ Arguments.ClusterID }}"
     Type: AWS::EC2::SecurityGroupIngress
@@ -415,8 +417,8 @@ Resources:
       SourceSecurityGroupId: {Ref: MasterSecurityGroup}
       ToPort: 10250
       Tags:
-        - Key: "KubernetesCluster"
-          Value: kubernetes
+        - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
+          Value: owned
         - Key: "ClusterID"
           Value: "{{ Arguments.ClusterID }}"
     Type: AWS::EC2::SecurityGroupIngress
@@ -428,8 +430,8 @@ Resources:
       SourceSecurityGroupId: {Ref: MasterSecurityGroup}
       ToPort: 4194
       Tags:
-        - Key: "KubernetesCluster"
-          Value: kubernetes
+        - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
+          Value: owned
         - Key: "ClusterID"
           Value: "{{ Arguments.ClusterID }}"
     Type: AWS::EC2::SecurityGroupIngress
@@ -441,8 +443,8 @@ Resources:
       SourceSecurityGroupId: {Ref: WorkerSecurityGroup}
       ToPort: 8472
       Tags:
-        - Key: "KubernetesCluster"
-          Value: kubernetes
+        - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
+          Value: owned
         - Key: "ClusterID"
           Value: "{{ Arguments.ClusterID }}"
     Type: AWS::EC2::SecurityGroupIngress
@@ -454,8 +456,8 @@ Resources:
       SourceSecurityGroupId: {Ref: WorkerSecurityGroup}
       ToPort: 10255
       Tags:
-        - Key: "KubernetesCluster"
-          Value: kubernetes
+        - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
+          Value: owned
         - Key: "ClusterID"
           Value: "{{ Arguments.ClusterID }}"
     Type: AWS::EC2::SecurityGroupIngress
@@ -467,8 +469,8 @@ Resources:
       SourceSecurityGroupId: {Ref: WorkerSecurityGroup}
       ToPort: 8472
       Tags:
-        - Key: "KubernetesCluster"
-          Value: kubernetes
+        - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
+          Value: owned
         - Key: "ClusterID"
           Value: "{{ Arguments.ClusterID }}"
     Type: AWS::EC2::SecurityGroupIngress
@@ -480,8 +482,8 @@ Resources:
       SourceSecurityGroupId: {Ref: WorkerSecurityGroup}
       ToPort: 10255
       Tags:
-        - Key: "KubernetesCluster"
-          Value: kubernetes
+        - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
+          Value: owned
         - Key: "ClusterID"
           Value: "{{ Arguments.ClusterID }}"
     Type: AWS::EC2::SecurityGroupIngress
@@ -493,8 +495,8 @@ Resources:
       SourceSecurityGroupId: {Ref: WorkerSecurityGroup}
       ToPort: 9911
       Tags:
-        - Key: "KubernetesCluster"
-          Value: kubernetes
+        - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
+          Value: owned
         - Key: "ClusterID"
           Value: "{{ Arguments.ClusterID }}"
     Type: AWS::EC2::SecurityGroupIngress


### PR DESCRIPTION
Tags resources with the `kubernetes.io/cluster/<cluster-id>` tag introduced in https://github.com/kubernetes/kubernetes/pull/41695 and removes the deprecated `KubernetesCluster: kubernetes` tag.

This is part of the fix for https://github.com/zalando-incubator/kube-ingress-aws-controller/issues/77 and will also allow us to fix the problem of ELBs created for a service of type LoadBalancer not attaching to worker nodes in all subnets. The subnet issue also requires a change in the CLM to attach this tag to existing subnets. There is a PR for this in the CLM repo.

The tag `ClusterID` is still required by the ingress-controller, but can be removed once https://github.com/zalando-incubator/kube-ingress-aws-controller/issues/77 is fixed.

Additionally we will eventually be able to solve #138 by having consisting tagging on all resources.