### PR TITLE
Bump version for cluster autoscaler healthcheck

### DIFF
--- a/cluster/manifests/cluster-autoscaler/deployment.yaml
+++ b/cluster/manifests/cluster-autoscaler/deployment.yaml
@@ -25,7 +25,9 @@ spec:
         operator: Exists
       containers:
       - name: cluster-autoscaler
-        image: registry.opensource.zalan.do/teapot/kube-aws-autoscaler:0.9-1
+        image: registry.opensource.zalan.do/teapot/kube-aws-autoscaler:0.11
+        args:
+        - --enable-healthcheck-endpoint
         envFrom:
         - configMapRef:
             # load buffer settings from ConfigMap e.g. to set spare nodes to zero for test environments

--- a/cluster/manifests/cluster-autoscaler/service.yaml
+++ b/cluster/manifests/cluster-autoscaler/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    application: cluster-autoscaler
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 5000
+    name: main-port
+  selector:
+    application: cluster-autoscaler


### PR DESCRIPTION
 **DO NOT MERGE, STILL WIP** 

The goal of this PR is to update the cluster-autoscaler to add an healthcheck. We want to use this to identify when scaling attempts fail and take action on that. This is a very simple approach that could probably be improved to export proper metrics that are more actionable than just an health endpoint. 

Related PR: https://github.com/hjacobs/kube-aws-autoscaler/pull/35 