### PR TITLE
daemonset manifests for Instana agent in kubernetes clusters

### DIFF
--- a/cluster/manifests/instana-poc/daemonset-instana.yaml
+++ b/cluster/manifests/instana-poc/daemonset-instana.yaml
@@ -41,7 +41,10 @@ spec:
           - name: INSTANA_HOST
             value: "saas-eu-west-1.instana.io"
           - name: INSTANA_KEY
-            value: "QxEv-oNJSbOfODIR5MqiIw"
+            valueFrom:
+              secretKeyRef:
+                name: instana-agent
+                key: instana-key
           - name: INSTANA_TAGS
             value: "zmon-staging,kubernetes"
           - name: INSTANA_ZONE

--- a/cluster/manifests/instana-poc/daemonset-instana.yaml
+++ b/cluster/manifests/instana-poc/daemonset-instana.yaml
@@ -9,8 +9,8 @@ metadata:
   namespace: kube-system
 spec:
   selector:
-   matchLabels:
-     application: instana-agent
+    matchLabels:
+      application: instana-agent
   updateStrategy:
     type: RollingUpdate
   template:

--- a/cluster/manifests/instana-poc/daemonset-instana.yaml
+++ b/cluster/manifests/instana-poc/daemonset-instana.yaml
@@ -1,0 +1,90 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  labels:
+    name: monitor
+    application: instana-agent
+    version: v1
+  name: instana-agent
+  namespace: kube-system
+spec:
+  template:
+    metadata:
+      name: instana-agent
+      labels:
+        application: instana-agent
+    spec:
+      hostNetwork: true
+      hostIPC: true
+      hostPID: true
+      containers:
+      - name: instana-agent
+        image: pierone.stups.zalan.do/eagleeye/instana-agent:master-8 
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: docker
+          mountPath: /var/run/docker.sock
+        - name: dev
+          mountPath: /dev
+        - name: sys
+          mountPath: /sys
+        - name: varlog
+          mountPath: /var/log
+        ports:
+        env:
+          - name: INSTANA_PORT
+            value: "443"
+          - name: INSTANA_HOST
+            value: "saas-eu-west-1.instana.io"
+          - name: INSTANA_KEY
+            value: "QxEv-oNJSbOfODIR5MqiIw"
+          - name: INSTANA_TAGS
+            value: "zmon-staging,kubernetes"
+          - name: INSTANA_ZONE
+            value: "AWS-Europe"
+          - name: INSTANA_AGENT_KUBERNETES_CLUSTER_ID
+            value: "{{ .ID }}"
+          - name: INSTANA_AGENT_KUBERNETES_CLUSTER_ALIAS
+            value: "{{ .Alias }}"
+          - name: INSTANA_AGENT_KUBERNETES_CLUSTER_ENVIRONMENT
+            value: "{{ .Environment }}"
+        livenessProbe:
+          exec:
+            command:
+              - echo
+              - noop
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 5
+        readinessProbe:
+          exec:
+            command:
+              - echo
+              - noop
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 5
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "0.2"
+          limits:
+            memory: "512Mi"
+            cpu: "0.5"
+      volumes:
+      - name: docker
+        hostPath:
+          path: /var/run/docker.sock
+      - name: dev
+        hostPath:
+          path: /dev
+      - name: sys
+        hostPath:
+          path: /sys
+      - name: varlog
+        hostPath:
+          path: /var/log

--- a/cluster/manifests/instana-poc/daemonset-instana.yaml
+++ b/cluster/manifests/instana-poc/daemonset-instana.yaml
@@ -8,6 +8,9 @@ metadata:
   name: instana-agent
   namespace: kube-system
 spec:
+  selector:
+   matchLabels:
+     application: instana-agent
   updateStrategy:
     type: RollingUpdate
   template:

--- a/cluster/manifests/instana-poc/daemonset-instana.yaml
+++ b/cluster/manifests/instana-poc/daemonset-instana.yaml
@@ -46,7 +46,7 @@ spec:
                 name: instana-agent
                 key: instana-key
           - name: INSTANA_TAGS
-            value: "zmon-staging,kubernetes"
+            value: "zmon=zmon-staging,platform=kubernetes,environment={{ .Environment }}"
           - name: INSTANA_ZONE
             value: "{{ .Alias }}"
           - name: INSTANA_AGENT_KUBERNETES_CLUSTER_ID

--- a/cluster/manifests/instana-poc/daemonset-instana.yaml
+++ b/cluster/manifests/instana-poc/daemonset-instana.yaml
@@ -43,13 +43,13 @@ spec:
           - name: INSTANA_TAGS
             value: "zmon-staging,kubernetes"
           - name: INSTANA_ZONE
-            value: "stups-test"
+            value: "{{ .Alias }}"
           - name: INSTANA_AGENT_KUBERNETES_CLUSTER_ID
-            value: "aws:085668006708:eu-central-1:kube-1"
+            value: "{{ .ID }}"
           - name: INSTANA_AGENT_KUBERNETES_CLUSTER_ALIAS
-            value: "stups-test"
+            value: "{{ .Alias }}"
           - name: INSTANA_AGENT_KUBERNETES_CLUSTER_ENVIRONMENT
-            value: "test"
+            value: "{{ .Environment }}"
         livenessProbe:
           exec:
             command:

--- a/cluster/manifests/instana-poc/daemonset-instana.yaml
+++ b/cluster/manifests/instana-poc/daemonset-instana.yaml
@@ -19,7 +19,7 @@ spec:
       hostPID: true
       containers:
       - name: instana-agent
-        image: pierone.stups.zalan.do/eagleeye/instana-agent:master-8 
+        image: pierone.stups.zalan.do/eagleeye/instana-agent:master-9
         imagePullPolicy: Always
         securityContext:
           privileged: true
@@ -43,13 +43,13 @@ spec:
           - name: INSTANA_TAGS
             value: "zmon-staging,kubernetes"
           - name: INSTANA_ZONE
-            value: "{{ .Alias }}" 
+            value: "stups-test"
           - name: INSTANA_AGENT_KUBERNETES_CLUSTER_ID
-            value: "{{ .ID }}"
+            value: "aws:085668006708:eu-central-1:kube-1"
           - name: INSTANA_AGENT_KUBERNETES_CLUSTER_ALIAS
-            value: "{{ .Alias }}"
+            value: "stups-test"
           - name: INSTANA_AGENT_KUBERNETES_CLUSTER_ENVIRONMENT
-            value: "{{ .Environment }}"
+            value: "test"
         livenessProbe:
           exec:
             command:

--- a/cluster/manifests/instana-poc/daemonset-instana.yaml
+++ b/cluster/manifests/instana-poc/daemonset-instana.yaml
@@ -43,7 +43,7 @@ spec:
           - name: INSTANA_TAGS
             value: "zmon-staging,kubernetes"
           - name: INSTANA_ZONE
-            value: "AWS-Europe"
+            value: "{{ .Alias }}" 
           - name: INSTANA_AGENT_KUBERNETES_CLUSTER_ID
             value: "{{ .ID }}"
           - name: INSTANA_AGENT_KUBERNETES_CLUSTER_ALIAS

--- a/cluster/manifests/instana-poc/daemonset-instana.yaml
+++ b/cluster/manifests/instana-poc/daemonset-instana.yaml
@@ -18,6 +18,7 @@ spec:
       name: instana-agent
       labels:
         application: instana-agent
+        version: v1
     spec:
       hostNetwork: true
       hostIPC: true

--- a/cluster/manifests/instana-poc/daemonset-instana.yaml
+++ b/cluster/manifests/instana-poc/daemonset-instana.yaml
@@ -8,6 +8,8 @@ metadata:
   name: instana-agent
   namespace: kube-system
 spec:
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       name: instana-agent

--- a/cluster/manifests/instana-poc/daemonset-instana.yaml
+++ b/cluster/manifests/instana-poc/daemonset-instana.yaml
@@ -46,7 +46,7 @@ spec:
                 name: instana-agent
                 key: instana-key
           - name: INSTANA_TAGS
-            value: "zmon=zmon-staging,platform=kubernetes,environment={{ .Environment }}"
+            value: "zmon=staging,platform=kubernetes,environment={{ .Environment }}"
           - name: INSTANA_ZONE
             value: "{{ .Alias }}"
           - name: INSTANA_AGENT_KUBERNETES_CLUSTER_ID

--- a/cluster/manifests/instana-poc/secret.yaml
+++ b/cluster/manifests/instana-poc/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: instana-agent
+  namespace: kube-system
+  labels:
+    application: instana-agent
+type: Opaque
+data:
+  instana-key: "{{ .ConfigItems.instana_key | base64 }}"

--- a/cluster/manifests/psp/pod_security_policy.yaml
+++ b/cluster/manifests/psp/pod_security_policy.yaml
@@ -8,6 +8,7 @@ spec:
   privileged: true
   hostPID: true
   hostNetwork: true
+  hostIPC: true
   hostPorts:
   - max: 10000
     min: 50


### PR DESCRIPTION
This pull request is regarding integration of instana agent in Kubernetes clusters. This request is part of Instana POC. Hence to start with could be deployed to stups-test cluster. 

1. We need to enable hostIPC as true in cluster/manifests/psp/pod_security_policy.yaml. hostNetwork and hostPID are already set as true. These are required for the proper working of instana agent in the containerized environment.

2. The daemonset depends on the following parameters for configuration of tags that show up in Instana UI. It assumes that these are set while creation/provision of the cluster. 
          - name: INSTANA_AGENT_KUBERNETES_CLUSTER_ID
            value: "{{ .ID }}"
          - name: INSTANA_AGENT_KUBERNETES_CLUSTER_ALIAS
            value: "{{ .Alias }}"
          - name: INSTANA_AGENT_KUBERNETES_CLUSTER_ENVIRONMENT
            value: "{{ .Environment }}"
3. Repo for instana agent dockerized image. https://github.bus.zalan.do/eagleeye/instana-agent. The image is build and pushed through CDP. 

The daemonset has been tested on eagleeye test cluster - https://kube-aws-test-eagleeye.teapot.zalan.do. 

Instana UI can be access at https://zalando-zalando.instana.io/#/physical?timeline.to=&timeline.ws=600000