### PR TITLE
Delete logging agent before apply to update correctly

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -5,3 +5,6 @@ pre_apply: # everything defined under here will be deleted before applying the m
 - name: secretary
   namespace: kube-system
   kind: deployment
+- name: logging-agent
+  namespace: kube-system
+  kind: daemonset


### PR DESCRIPTION
`init-containers` defined as field don't get updated with `kubectl apply` currently.

We currently run an old version of the logging agent's init container's definition that contains a non-compliant image on most of our clusters. Removing the DS before applying ensures we get the latest version which uses a compliant image. This should not disrupt the functionality much but should be removed afterwards.

TODO:
- [x] Create a reverting PR once this has been rolled out to beta sucessfully. (https://github.com/zalando-incubator/kubernetes-on-aws/pull/577)