### PR TITLE
Update authnz webhook to the latest version

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -361,7 +361,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.2.4
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.3.1
           name: webhook
           ports:
           - containerPort: 8081


### PR DESCRIPTION
Notables changes:
* Give collaborators access to all clusters
* Allow `operator` service account access to node objects

/cc @szuecs @ikitiki 