### PR TITLE
Add CoreOS's update operator

### DIFF
--- a/cluster/manifests/container-linux-update-operator/depl-update-operator.yaml
+++ b/cluster/manifests/container-linux-update-operator/depl-update-operator.yaml
@@ -1,0 +1,42 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: container-linux-update-operator
+  namespace: kube-system
+  labels:
+    application: container-linux-update-operator
+    version: v0.4.1
+    kubernetes.io/cluster-service: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      application: container-linux-update-operator
+  template:
+    metadata:
+      labels:
+        application: container-linux-update-operator
+        version: v0.4.1
+    spec:
+      containers:
+      - name: update-operator
+        image: quay.io/coreos/container-linux-update-operator:v0.4.1
+        command:
+        - /bin/update-operator
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 50m
+            memory: 25Mi
+      serviceAccountName: system
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule

--- a/cluster/manifests/container-linux-update-operator/ds-update-agent.yaml
+++ b/cluster/manifests/container-linux-update-operator/ds-update-agent.yaml
@@ -1,0 +1,72 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: container-linux-update-agent
+  namespace: kube-system
+  labels:
+    application: container-linux-update-agent
+    version: v0.4.1
+    kubernetes.io/cluster-service: "true"
+spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      application: container-linux-update-agent
+  template:
+    metadata:
+      labels:
+        application: container-linux-update-agent
+        version: v0.4.1
+    spec:
+      containers:
+      - name: update-agent
+        image: quay.io/coreos/container-linux-update-operator:v0.4.1
+        command:
+        - /bin/update-agent
+        volumeMounts:
+          - mountPath: /var/run/dbus
+            name: var-run-dbus
+          - mountPath: /etc/coreos
+            name: etc-coreos
+          - mountPath: /usr/share/coreos
+            name: usr-share-coreos
+          - mountPath: /etc/os-release
+            name: etc-os-release
+        env:
+        # read by update-agent as the node name to manage reboots for
+        - name: UPDATE_AGENT_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 50m
+            memory: 25Mi
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      volumes:
+      - name: var-run-dbus
+        hostPath:
+          path: /var/run/dbus
+      - name: etc-coreos
+        hostPath:
+          path: /etc/coreos
+      - name: usr-share-coreos
+        hostPath:
+          path: /usr/share/coreos
+      - name: etc-os-release
+        hostPath:
+          path: /etc/os-release
+      serviceAccountName: system

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -11,8 +11,6 @@ ssh_authorized_keys:
   - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqAikaHsZWMuJvKZphZPZG0fnKMvVCRfBAbIS6e0Y+YqM0PfsWgB5e4f5TrbisQHdKopbfZVwYIaV/NegEuinrYPKC7t2ese/HjxgjHR95zHOcDP19Cbo+xeyH8zbRd9K3iRSyCUSMNRw5NL6zN8JOSl12m8QWQA4hTjFTmt870fIT4RLxu9qGlbQipUm57E/SotsNC41MQ/PsLQzOAviKrkS1rei2vzRHzAcjz1Z7GT5oH+dFVUC66kKa0XWDvq+VtkRVoLvS2chrIPCgESeeZAyOKyiOoyJxFFFiMVK48MWDBBIYTIsHE0qs/RwBi9+8lQGiHK5Rpk2djcloO0c7 sandor.szuecs@zalando.de'
   - 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINkh52Py+FvH9CRLDQg0gzvjEIrzwA45yMTXTsl2BVxV alexey.ermakov@zalando.de'
 coreos:
-  update:
-    reboot-strategy: "off"
   units:
     - name: etcd-member.service
       command: start
@@ -178,6 +176,9 @@ coreos:
 
         [Install]
         WantedBy=multi-user.target
+
+    - name: locksmithd.service
+      mask: true
 
 write_files:
 

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -11,8 +11,6 @@ ssh_authorized_keys:
   - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqAikaHsZWMuJvKZphZPZG0fnKMvVCRfBAbIS6e0Y+YqM0PfsWgB5e4f5TrbisQHdKopbfZVwYIaV/NegEuinrYPKC7t2ese/HjxgjHR95zHOcDP19Cbo+xeyH8zbRd9K3iRSyCUSMNRw5NL6zN8JOSl12m8QWQA4hTjFTmt870fIT4RLxu9qGlbQipUm57E/SotsNC41MQ/PsLQzOAviKrkS1rei2vzRHzAcjz1Z7GT5oH+dFVUC66kKa0XWDvq+VtkRVoLvS2chrIPCgESeeZAyOKyiOoyJxFFFiMVK48MWDBBIYTIsHE0qs/RwBi9+8lQGiHK5Rpk2djcloO0c7 sandor.szuecs@zalando.de'
   - 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINkh52Py+FvH9CRLDQg0gzvjEIrzwA45yMTXTsl2BVxV alexey.ermakov@zalando.de'
 coreos:
-  update:
-    reboot-strategy: "off"
   units:
     - name: etcd-member.service
       command: start
@@ -169,6 +167,9 @@ coreos:
 
         [Install]
         WantedBy=multi-user.target
+
+    - name: locksmithd.service
+      mask: true
 
 write_files:
 


### PR DESCRIPTION
This adds CoreOS's update operator which is the original auto-restart service adapted to take advantage of Kubernetes. It coordinates updates across the cluster via node labels. It also uses taints/tolerations to prevent daemonsets from being scheduled on master nodes by default.

### Update Operator

Currently, we update the CoreOS AMI whenever we update the userdata which happens somewhat around once a week. However, the goal should be to make the CoreOS layer as thin as possible and run the same images across all clusters. This can be achieved by moving more parts into the environment (e.g. pulling arguments from etcd) and into Kubernetes itself (e.g. via self-hosted components).

In this scenario, the in-place updates will become more relevant as nodes get replaced less often by userdata changes. Another advantage of in-place updates is that they are faster in general as docker images don't need to be re-pulled.

When a new CoreOS image is realesed for the current channel, the agent marks each outdated node with "reboot-needed". The operator watches theses labels and allows one node at a time to reboot via setting another label on the node. A human can prevent nodes from being restarted with yet another label (see https://github.com/coreos/container-linux-update-operator/blob/master/pkg/constants/constants.go for a full list of available labels). The update operator drains and cordons the node before restarting it.

### Taints for master nodes

The PR also adds node taints for the master's which I think is much better to work with. If you want to run a pod on a master node you have to explicitely opt-in instead of opt-out. This makes much more sense as can be seen in the changes to the `skipper` daemonset.

### Caveats

`SchedulingDisabled` is removed from the master nodes and replaced by the taint. With the changes in this PR this works as expected and similar as before.

However, when `cordon`ing a node it gets correctly set to `SchedulingDisabled` but if for some reason the `update-agent` on this node restarts it makes it scheduleable again like after a successful reboot.