### PR TITLE
Add emergency-access-service

### DIFF
--- a/cluster/manifests/emergency-access-service/credentials.yaml
+++ b/cluster/manifests/emergency-access-service/credentials.yaml
@@ -1,3 +1,17 @@
+# from: ../platformcredentialsset/thirdpartyresource.yaml
+# This is a hack put in place to ensure that the ThirdPartyResource will be
+# created before the actual PlatformCredentialsSet resource.
+apiVersion: extensions/v1beta1
+kind: ThirdPartyResource
+metadata:
+  # NOTE: dashes are needed to get proper PlatformCredentialsSet name
+  name: platform-credentials-set.zalando.org
+description: "A specification to declare needed OAuth credentials (tokens, clients) for the Zalando Platform IAM system"
+versions:
+- name: v1
+
+---
+
 apiVersion: "zalando.org/v1"
 kind: PlatformCredentialsSet
 metadata:

--- a/cluster/manifests/emergency-access-service/credentials.yaml
+++ b/cluster/manifests/emergency-access-service/credentials.yaml
@@ -1,0 +1,14 @@
+apiVersion: "zalando.org/v1"
+kind: PlatformCredentialsSet
+metadata:
+   name: "emergency-access-service"
+   namespace: kube-system
+   labels:
+     application: "emergency-access-service"
+spec:
+   application: "emergency-access-service"
+   tokens:
+     audittrail:
+       privileges:
+     emergency-service:
+       privileges:

--- a/cluster/manifests/emergency-access-service/deployment.yaml
+++ b/cluster/manifests/emergency-access-service/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: emergency-access-service
-    version: master-26
+    version: master-28
 spec:
   replicas: 1
   selector:
@@ -15,12 +15,12 @@ spec:
     metadata:
       labels:
         application: emergency-access-service
-        version: master-26
+        version: master-28
     spec:
       serviceAccountName: system
       containers:
       - name: emergency-access-service
-        image: "pierone.stups.zalan.do/teapot/emergency-access-service:master-26"
+        image: "pierone.stups.zalan.do/teapot/emergency-access-service:master-28"
         args:
         - --insecure-http
         - --community={{ .Owner }}

--- a/cluster/manifests/emergency-access-service/deployment.yaml
+++ b/cluster/manifests/emergency-access-service/deployment.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: emergency-access-service
+  namespace: kube-system
+  labels:
+    application: emergency-access-service
+    version: master-26
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      application: emergency-access-service
+  template:
+    metadata:
+      labels:
+        application: emergency-access-service
+        version: master-26
+    spec:
+      serviceAccountName: system
+      containers:
+      - name: emergency-access-service
+        image: "pierone.stups.zalan.do/teapot/emergency-access-service:master-26"
+        args:
+        - --insecure-http
+        - --community={{ .Owner }}
+        - --cluster-id={{ .ID }}
+        - --teams-api-url=https://teams.auth.zalando.com
+        - --debug
+        # enable audittrail reporting
+        - --audittrail-url=https://audittrail.cloud.zalando.com
+        - --jira-url=https://techjira.zalando.net
+        env:
+        - name: CONFIGMAP_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        ports:
+        - containerPort: 8080
+        volumeMounts:
+        - name: platform-iam-credentials
+          mountPath: /meta/credentials
+          readOnly: true
+        - name: secrets
+          mountPath: /meta/secrets
+          readOnly: true
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          timeoutSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+      volumes:
+      - name: platform-iam-credentials
+        secret:
+          secretName: "emergency-access-service"
+      - name: secrets
+        secret:
+          secretName: "emergency-access-service-secrets"

--- a/cluster/manifests/emergency-access-service/ingress.yaml
+++ b/cluster/manifests/emergency-access-service/ingress.yaml
@@ -1,0 +1,15 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: emergency-access-service
+  namespace: kube-system
+  labels:
+    application: emergency-access-service
+spec:
+  rules:
+  - host: emergency-access-service.{{ .Alias }}.zalan.do
+    http:
+      paths:
+      - backend:
+          serviceName: emergency-access-service
+          servicePort: http

--- a/cluster/manifests/emergency-access-service/secret.yaml
+++ b/cluster/manifests/emergency-access-service/secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: emergency-access-service-secrets
+  namespace: kube-system
+  labels:
+    application: emergency-access-service
+type: Opaque
+data:
+  # value in the following format:
+  # {"username": "user", "password": "pass", "magic_token": "token"}
+  jira-secrets: |
+    {{ .ConfigItems.jira_secrets | base64 }}

--- a/cluster/manifests/emergency-access-service/service.yaml
+++ b/cluster/manifests/emergency-access-service/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: emergency-access-service
+  labels:
+    application: emergency-access-service
+spec:
+  selector:
+    application: emergency-access-service
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http


### PR DESCRIPTION
This deploys the emergency-access-service to every cluster.

There is currently one problem with this approach related to the PlatformCredentialsSet.
Since we just apply all manifests in random order we might apply the PlatformCredentialsSet resource before the actual definition as defined in: https://github.com/zalando-incubator/kubernetes-on-aws/blob/dev/cluster/manifests/platformcredentialsset/thirdpartyresource.yaml

I tried forcing the thirdpartyresource to be created first, but even in this case the other manifest gets applied too fast, before Kubernetes really understands the issue.

This is not a problem for existing clusters, but will be an issue for every new cluster e.g. e2e tests..

I'll think about a way to solve this.