### PR TITLE
custom opentracing instana POC skipper

### DIFF
--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.9.83
+    version: v0.10.0-alpha
     component: ingress
 spec:
   selector:
@@ -18,7 +18,7 @@ spec:
       name: skipper-ingress
       labels:
         application: skipper-ingress
-        version: v0.9.83
+        version: v0.10.0-alpha
         component: ingress
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -38,18 +38,18 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.9.83
+        image: pierone.stups.zalan.do/eagleeye/skipper:9fb8c11dc9ac1a1ba26772328a6ac06bcb2ef775
         ports:
         - name: ingress-port
           containerPort: 9999
           hostPort: 9999
         args:
-          - "skipper"
           - "-kubernetes"
           - "-kubernetes-in-cluster"
           - "-address=:9999"
           - "-proxy-preserve-host"
           - "-serve-host-metrics"
+          - "-opentracing=tracing_instana"
         resources:
           limits:
             cpu: 200m


### PR DESCRIPTION
Replace normal ingress skipper with the new skipper plugin opentracing flavour instana.
This test will probably show logs that show failing connections to instana-agent from skipper-ingress