### PR TITLE
set authentication ttl to 10 sec

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -337,6 +337,7 @@ write_files:
           - --service-account-key-file=/etc/kubernetes/ssl/apiserver-key.pem
           - --runtime-config=extensions/v1beta1/networkpolicies=true,batch/v2alpha1=true,extensions/v1beta1/podsecuritypolicy=true,imagepolicy.k8s.io/v1alpha1=true,authorization.k8s.io/v1beta1=true
           - --authentication-token-webhook-config-file=/etc/kubernetes/config/authn.yaml
+          - --authentication-token-webhook-cache-ttl=10s
           - --cloud-provider=aws
           - --authorization-mode=Webhook
           - --authorization-webhook-config-file=/etc/kubernetes/config/authz.yaml


### PR DESCRIPTION
This sets authentication webhook cache TTL to 10 seconds. Authentication caching happens based on tokens, as used [here in kubernetes code](https://github.com/kubernetes/apiserver/blob/19667a1afc13cc13930c40a20f2c12bbdcaaa246/plugin/pkg/authenticator/token/webhook/webhook.go#L75)

This should make emergency access service more user-friendly by not forcing the user to wait for 2minutes (current default ttl) before new role is visible by API server 


