### PR TITLE
Create emergency-access-service in kube-system namespace

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -5,4 +5,7 @@
 #   kind: deployment
 
 pre_apply: [] # everything defined under here will be deleted before applying the manifests
-post_apply: [] # everything defined under here will be deleted after applying the manifests
+post_apply: # everything defined under here will be deleted after applying the manifests
+- name: emergency-access-service
+  namespace: default
+  kind: service

--- a/cluster/manifests/emergency-access-service/service.yaml
+++ b/cluster/manifests/emergency-access-service/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: emergency-access-service
+  namespace: kube-system
   labels:
     application: emergency-access-service
 spec:


### PR DESCRIPTION
The `emergency-access-service` Service resource was deployed to default namespace instead of kube-system...

This fixes it and makes the service available via ingress.