### PR TITLE
Update zmon-worker deployment

### DIFF
--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -25,11 +25,11 @@ spec:
           image: "pierone.stups.zalan.do/stups/zmon-worker:zv225"
           resources:
             limits:
-              cpu: 800m
+              cpu: 500m
               memory: 2Gi
             requests:
               cpu: 500m
-              memory: 1Gi
+              memory: 2Gi
 
           ports:
             - containerPort: 8080
@@ -43,7 +43,7 @@ spec:
 
           env:
             - name: WORKER_ZMON_QUEUES
-              value: zmon:queue:default/32
+              value: zmon:queue:default/24
             - name: WORKER_REDIS_SERVERS
               value: zmon-redis:6379
             - name: WORKER_PLUGIN_SCALYR_READ_KEY

--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: zmon-worker
   namespace: kube-system
 spec:
-  replicas: 2
+  replicas: 4
   selector:
     matchLabels:
       application: zmon-worker
@@ -12,7 +12,7 @@ spec:
     metadata:
       labels:
         application: zmon-worker
-        version: "zv223"
+        version: "zv225"
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -22,13 +22,13 @@ spec:
         operator: Exists
       containers:
         - name: zmon-worker
-          image: "pierone.stups.zalan.do/stups/zmon-worker:zv223"
+          image: "pierone.stups.zalan.do/stups/zmon-worker:zv225"
           resources:
             limits:
-              cpu: 500m
+              cpu: 800m
               memory: 2Gi
             requests:
-              cpu: 200m
+              cpu: 500m
               memory: 1Gi
 
           ports:
@@ -43,7 +43,7 @@ spec:
 
           env:
             - name: WORKER_ZMON_QUEUES
-              value: zmon:queue:default/16
+              value: zmon:queue:default/32
             - name: WORKER_REDIS_SERVERS
               value: zmon-redis:6379
             - name: WORKER_PLUGIN_SCALYR_READ_KEY


### PR DESCRIPTION
Changes:

- Increase number of processes to 32
- Increase number of replicas to 4
- Increase cpu requests/limit
- Upgrade zmon-worker to zv225 with EBS wrapper and Hipchat notification link