### PR TITLE
new version of emergency access service with debugger role support

### DIFF
--- a/cluster/manifests/emergency-access-service/deployment.yaml
+++ b/cluster/manifests/emergency-access-service/deployment.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: system
       containers:
       - name: emergency-access-service
-        image: "pierone.stups.zalan.do/teapot/emergency-access-service:master-30"
+        image: "pierone.stups.zalan.do/teapot/emergency-access-service:master-34"
         args:
         - --insecure-http
         - --community={{ .Owner }}


### PR DESCRIPTION
New version of emergency access service, which supports:

1. Debugger role requests/approval
2. Clean up of old format configmap records