### PR TITLE
Don't drain nodes when flannel gets restarted

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -161,7 +161,7 @@ coreos:
       runtime: true
       content: |
         [Unit]
-        Requires=docker.service
+        Description=drain this k8s node to make running pods time to gracefully shut down before stopping kubelet
         After=docker.service
 
         [Service]
@@ -169,11 +169,11 @@ coreos:
         RemainAfterExit=true
         ExecStart=/bin/true
         TimeoutStopSec=120s
-        ExecStop=/bin/sh -c '/usr/bin/rkt run \
+        ExecStop=/bin/sh -c '/usr/bin/rkt run --insecure-options=image \
         --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
         --mount=volume=kube,target=/etc/kubernetes \
         --net=host \
-        registry.opensource.zalan.do/teapot/hyperkube:v1.7.6_coreos.0 \
+        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.7.6_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           drain $(hostname) \

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -170,16 +170,16 @@ coreos:
         ExecStart=/bin/true
         TimeoutStopSec=120s
         ExecStop=/bin/sh -c '/usr/bin/rkt run --insecure-options=image \
-        --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
-        --mount=volume=kube,target=/etc/kubernetes \
-        --net=host \
-        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.7.6_coreos.0 \
+          --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
+          --mount=volume=kube,target=/etc/kubernetes \
+          --net=host \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.7.6_coreos.0 \
           --exec=/kubectl -- \
-          --kubeconfig=/etc/kubernetes/kubeconfig \
-          drain $(hostname) \
-          --ignore-daemonsets \
-          --delete-local-data \
-          --force'
+            --kubeconfig=/etc/kubernetes/kubeconfig \
+            drain $(hostname) \
+            --ignore-daemonsets \
+            --delete-local-data \
+            --force'
 
         [Install]
         WantedBy=multi-user.target

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -144,7 +144,6 @@ coreos:
       content: |
         [Unit]
         Description=drain this k8s node to make running pods time to gracefully shut down before stopping kubelet
-        Requires=docker.service
         After=docker.service
 
         [Service]
@@ -152,11 +151,11 @@ coreos:
         RemainAfterExit=true
         ExecStart=/bin/true
         TimeoutStopSec=120s
-        ExecStop=/bin/sh -c '/usr/bin/rkt run \
+        ExecStop=/bin/sh -c '/usr/bin/rkt run --insecure-options=image \
         --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
         --mount=volume=kube,target=/etc/kubernetes \
         --net=host \
-        registry.opensource.zalan.do/teapot/hyperkube:v1.7.6_coreos.0 \
+        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.7.6_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
           drain $(hostname) \

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -152,16 +152,16 @@ coreos:
         ExecStart=/bin/true
         TimeoutStopSec=120s
         ExecStop=/bin/sh -c '/usr/bin/rkt run --insecure-options=image \
-        --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
-        --mount=volume=kube,target=/etc/kubernetes \
-        --net=host \
-        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.7.6_coreos.0 \
+          --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
+          --mount=volume=kube,target=/etc/kubernetes \
+          --net=host \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.7.6_coreos.0 \
           --exec=/kubectl -- \
-          --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
-          drain $(hostname) \
-          --ignore-daemonsets \
-          --delete-local-data \
-          --force'
+            --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
+            drain $(hostname) \
+            --ignore-daemonsets \
+            --delete-local-data \
+            --force'
 
         [Install]
         WantedBy=multi-user.target


### PR DESCRIPTION
This reduces the impact of restarting flannel on a node.

When flannel gets restarted:
* docker gets restarted
* all containers get restarted
* node-drainer is restarted which drains the node permanently

### Avoid draining the node

Apart from all containers being killed, the draining is actually permanent because it marks the node as unschedulable. Furthermore there's really no draining needed when all containers just died anyways.

Because of that, we decided to mitigate the effects of restarting flannel to just avoid the draining so that the node can recover by itself and more quickly.

The dependency to docker in `kube-node-drainer` seems to be unneccessary as the unit doesn't depend on docker at all, it merely uses rkt to communicate with the Kubernetes API.

### Avoid killing containers

Furthermore, we investigated whether we can avoid restarting docker when flannel restarts in the first place but figured that it can lead to problems in case of flannel aquiring another subset for some reason (and subsequently docker not knowing about it).

Additionally, we investigated using docker's [`--live-restore`](https://docs.docker.com/engine/admin/live-restore/#enable-the-live-restore-option) which allows to restart the `dockerd` daemon (so that it can pick up the new flannel configuration) but keeps the `containerd` daemon running (hence not killing all containers). However, this leads to disfunctional pods in case of subnet change as well (the cni0 bridge isn't updated).

It should be mentioned that flannel, on restart, usually finds its IP in etcd and therefore grabs the same subnet as before so that a docker restart and bridge reconfiguration usually aren't needed. However, as we discovered, it can happen so we leave that dependency in tact. We didn't figure out in which cases it can happen, some options are:
* flannel cannot reach etcd and grabs a random subnet
* the subnet was removed from etcd itself in which case flannel cannot find it, e.g. due to:
  * a user or process removing it actively
  * the ttl of 1 day running out
  * some other inconsistency in etcd

### Conclusion

On flannel restart, this change doesn't avoid killing all containers but it avoids marking the node permanently as unschedulable.