### PR TITLE
Remove cfn-signal.service

### DIFF
--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -110,7 +110,7 @@ SenzaComponents:
          Minimum: "{{ Arguments.MinimumWorkerNodes}}"
          Maximum: "{{ Arguments.MaximumWorkerNodes}}"
          DesiredCapacity: "{{ Arguments.WorkerNodes }}"
-         SuccessRequires: "1 within 15m"
+         SuccessRequires: "0 within 15m"
       Tags:
         - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
           Value: owned

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -167,17 +167,6 @@ coreos:
         [Install]
         WantedBy=multi-user.target
 
-    - name: cfn-signal.service
-      command: start
-      runtime: true
-      content: |
-        [Service]
-        Type=oneshot
-        ExecStart=/usr/bin/docker run registry.opensource.zalan.do/teapot/cfn-signal:1.4-4 {{LOCAL_ID}} WorkerAutoScaling 0
-
-        [Install]
-        WantedBy=multi-user.target
-
 write_files:
 
   - path: /etc/kubernetes/cni/docker_opts_cni.env


### PR DESCRIPTION
Removes the cfn-signal.service which is only usable on stack creation and is obsoleted by the kube-node-ready deamonset which triggers ASG lifecycle hooks.

Fix #538