### PR TITLE
Add readinessprobe to skipper deamonset

### DIFF
--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -57,3 +57,9 @@ spec:
           requests:
             cpu: 25m
             memory: 25Mi
+        readinessProbe:
+          httpGet:
+            path: /kube-system/healthz
+            port: 9999
+          initialDelaySeconds: 5
+          timeoutSeconds: 5


### PR DESCRIPTION
Adds readinessprobe to the skipper deamonset to detect unhealthy skippers during a rolling update and automatically stop the update.