### PR TITLE
Flannel v0.9.0

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -52,6 +52,10 @@ coreos:
             ExecStartPre=/usr/bin/etcdctl \
             --endpoint=http://127.0.0.1:2379 set /coreos.com/network/config \
             '{ "Network": "10.2.0.0/16", "Backend": {"Type": "vxlan"}}'
+        - name: 20-version.conf
+          content: |
+            [Service]
+            Environment="FLANNEL_IMAGE_TAG=v0.8.0"
 
     - name: kube2iam-iptables.service
       command: start

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -16,9 +16,6 @@ ssh_authorized_keys:
 coreos:
   update:
     reboot-strategy: "off"
-  flannel:
-    interface: $private_ipv4
-    etcd_endpoints: http://127.0.0.1:2379
   units:
     - name: etcd-member.service
       command: start
@@ -46,16 +43,25 @@ coreos:
 
     - name: flanneld.service
       drop-ins:
-        - name: 10-etcd.conf
-          content: |
-            [Service]
-            ExecStartPre=/usr/bin/etcdctl \
-            --endpoint=http://127.0.0.1:2379 set /coreos.com/network/config \
-            '{ "Network": "10.2.0.0/16", "Backend": {"Type": "vxlan"}}'
-        - name: 20-version.conf
-          content: |
-            [Service]
-            Environment="FLANNEL_IMAGE_TAG=v0.8.0"
+      - name: 10-etcd.conf
+        content: |
+          [Service]
+          ExecStartPre=/usr/bin/etcdctl \
+          --endpoint=http://127.0.0.1:2379 set /coreos.com/network/config \
+          '{ "Network": "10.2.0.0/16", "Backend": {"Type": "vxlan"}}'
+      - name: 20-version.conf
+        content: |
+          [Service]
+          Environment="FLANNELD_IFACE="$private_ipv4"
+          Environment="FLANNELD_ETCD_ENDPOINTS="http://127.0.0.1:2379"
+          Environment="FLANNEL_IMAGE_TAG=v0.9.0"
+
+    - name: flannel-docker-opts.service
+      drop-ins:
+      - name: 20-version.conf
+        content: |
+          [Service]
+          Environment="FLANNEL_IMAGE_TAG=v0.9.0"
 
     - name: kube2iam-iptables.service
       command: start

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -49,7 +49,7 @@ coreos:
       - name: 20-version.conf
         content: |
           [Service]
-          Environment="FLANNEL_IMAGE_TAG=v0.8.0"
+          Environment="FLANNEL_IMAGE_TAG=v0.9.0"
 
     - name: timesynced-enable-network-time.service
       command: start

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -50,6 +50,13 @@ coreos:
           Environment="FLANNELD_ETCD_ENDPOINTS="http://127.0.0.1:2379"
           Environment="FLANNEL_IMAGE_TAG=v0.9.0"
 
+    - name: flannel-docker-opts.service
+      drop-ins:
+      - name: 20-version.conf
+        content: |
+          [Service]
+          Environment="FLANNEL_IMAGE_TAG=v0.9.0"
+
     - name: timesynced-enable-network-time.service
       command: start
       runtime: true

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -44,6 +44,13 @@ coreos:
             [Service]
             Environment="DOCKER_OPTS=--log-opt=max-file=2 --log-opt=max-size=50m"
 
+    - name: flanneld.service
+      drop-ins:
+      - name: 20-version.conf
+        content: |
+          [Service]
+          Environment="FLANNEL_IMAGE_TAG=v0.8.0"
+
     - name: timesynced-enable-network-time.service
       command: start
       runtime: true

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -16,9 +16,6 @@ ssh_authorized_keys:
 coreos:
   update:
     reboot-strategy: "off"
-  flannel:
-    interface: $private_ipv4
-    etcd_endpoints: http://127.0.0.1:2379
   units:
     - name: etcd-member.service
       command: start
@@ -49,6 +46,8 @@ coreos:
       - name: 20-version.conf
         content: |
           [Service]
+          Environment="FLANNELD_IFACE="$private_ipv4"
+          Environment="FLANNELD_ETCD_ENDPOINTS="http://127.0.0.1:2379"
           Environment="FLANNEL_IMAGE_TAG=v0.9.0"
 
     - name: timesynced-enable-network-time.service


### PR DESCRIPTION

Initial experimental branch to update the flannel version with several bugfixes. Default CoreOS stable uses v0.7.1. 

Still need to figure out why flannel is started first with the wrong version: 

```
UUID		APP		IMAGE NAME							STATE	CREATED		STARTED		NETWORKS
12ef5fd2	etcd		quay.io/coreos/etcd:v3.1.6					running	12 minutes ago12 minutes ago
7a92bbbf	hyperkube	registry.opensource.zalan.do/teapot/hyperkube:v1.7.6_coreos.0	running	9 minutes ago9 minutes ago
bc1d0a7f	flannel		quay.io/coreos/flannel:v0.9.0					running	29 seconds ago29 seconds ago
ea727f7e	flannel		quay.io/coreos/flannel:v0.7.1					exited	29 seconds ago29 seconds ago
```
