### PR TITLE
Bump kube-dns version to fix CVE-2017-14491

### DIFF
--- a/cluster/manifests/kube-dns/depl-kube-dns.yaml
+++ b/cluster/manifests/kube-dns/depl-kube-dns.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-dns
-    version: v1.14.4
+    version: v1.14.5
     kubernetes.io/cluster-service: "true"
 spec:
   # replicas: not specified here:
@@ -23,7 +23,7 @@ spec:
     metadata:
       labels:
         application: kube-dns
-        version: v1.14.4
+        version: v1.14.5
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -38,7 +38,7 @@ spec:
           optional: true
       containers:
       - name: kubedns
-        image: registry.opensource.zalan.do/teapot/k8s-dns-kube-dns:1.14.4
+        image: registry.opensource.zalan.do/teapot/k8s-dns-kube-dns:1.14.5
         resources:
           limits:
             memory: 170Mi
@@ -83,7 +83,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: registry.opensource.zalan.do/teapot/k8s-dns-dnsmasq-nanny:1.14.4
+        image: registry.opensource.zalan.do/teapot/k8s-dns-dnsmasq-nanny:1.14.5
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -121,7 +121,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: registry.opensource.zalan.do/teapot/k8s-dns-sidecar:1.14.4
+        image: registry.opensource.zalan.do/teapot/k8s-dns-sidecar:1.14.5
         livenessProbe:
           httpGet:
             path: /metrics


### PR DESCRIPTION
This fixes CVE-2017-14491 as described in https://groups.google.com/forum/#!topic/kubernetes-dev/QWIzhD3JhhE 