### PR TITLE
use default dns policy for cluster autoscaler

### DIFF
--- a/cluster/manifests/cluster-autoscaler/deployment.yaml
+++ b/cluster/manifests/cluster-autoscaler/deployment.yaml
@@ -38,3 +38,4 @@ spec:
           requests:
             cpu: 50m
             memory: 100Mi
+      dnsPolicy: Default


### PR DESCRIPTION
This is required in scenarios when kube-dns fails to be scheduled on a node, when there is no space available, in which case cluster-autoscaler fails to communicate with AWS ASG API, which causes a deadlock - kube-dns cannot be scheduled on a node, because not enough nodes. Cluster-autoscaler fails to add nodes, because kube-dns is not accessible 