### PR TITLE
Replace KubeDNS with CoreDNS

### DIFF
--- a/cluster/manifests/coredns/cm-coredns.yaml
+++ b/cluster/manifests/coredns/cm-coredns.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns
+  namespace: kube-system
+  labels:
+    application: coredns
+data:
+  Corefile: |
+    .:53 {
+        errors
+        log stdout
+        health
+        kubernetes cluster.local 10.3.0.0/24
+        proxy . /etc/resolv.conf
+        cache 30
+    }

--- a/cluster/manifests/coredns/depl-coredns-autoscaler.yaml
+++ b/cluster/manifests/coredns/depl-coredns-autoscaler.yaml
@@ -1,0 +1,41 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: coredns-autoscaler
+  namespace: kube-system
+  labels:
+    application: coredns-autoscaler
+    version: v1.1.2
+    kubernetes.io/cluster-service: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      application: coredns-autoscaler
+  template:
+    metadata:
+      labels:
+        application: coredns-autoscaler
+        version: v1.1.2
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      serviceAccountName: system
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      containers:
+      - name: autoscaler
+        image: registry.opensource.zalan.do/teapot/cluster-proportional-autoscaler:1.1.2-r2
+        resources:
+          requests:
+            cpu: "20m"
+            memory: "10Mi"
+        command:
+          - /cluster-proportional-autoscaler
+          - --namespace=kube-system
+          - --configmap=coredns-autoscaler
+          - --target=Deployment/coredns
+          - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}}
+          - --logtostderr=true
+          - --v=2

--- a/cluster/manifests/coredns/depl-coredns.yaml
+++ b/cluster/manifests/coredns/depl-coredns.yaml
@@ -1,0 +1,79 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: coredns
+  namespace: kube-system
+  labels:
+    application: coredns
+    version: "011"
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+spec:
+  # replicas: not specified here:
+  # 1. In order to make Addon Manager do not reconcile this replicas parameter.
+  # 2. Default is 1.
+  # 3. Will be tuned in real time if DNS horizontal auto-scaling is turned on.
+  strategy:
+    rollingUpdate:
+      maxSurge: 10%
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      application: coredns
+  template:
+    metadata:
+      labels:
+        application: coredns
+        version: "011"
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      serviceAccountName: system
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      containers:
+      - name: coredns
+        image: docker.io/coredns/coredns:011
+        args:
+        - -conf=/etc/coredns/Corefile
+        resources:
+          limits:
+            memory: 170Mi
+          requests:
+            cpu: 100m
+            memory: 70Mi
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/coredns
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 3
+          timeoutSeconds: 5
+      dnsPolicy: Default
+      volumes:
+      - name: config-volume
+        configMap:
+          name: coredns
+          items:
+          - key: Corefile
+            path: Corefile

--- a/cluster/manifests/coredns/svc-coredns.yaml
+++ b/cluster/manifests/coredns/svc-coredns.yaml
@@ -4,12 +4,12 @@ metadata:
   name: kube-dns
   namespace: kube-system
   labels:
-    application: kube-dns
+    application: coredns
     kubernetes.io/cluster-service: "true"
-    kubernetes.io/name: "KubeDNS"
+    kubernetes.io/name: "CoreDNS"
 spec:
   selector:
-    application: kube-dns
+    application: coredns
   clusterIP: 10.3.0.10
   ports:
   - name: dns


### PR DESCRIPTION
Initial try to replace KubeDNS with CoreDNS. Works fine in my test setup.

It's based on the migration script here: https://github.com/coredns/deployment/tree/master/kubernetes

I took the same requests/limits as well as added readiness probe and the cluster proportial autoscaling.

TODO:
- [ ] Move docker image to Pierone
- [ ] Check the impact of migrating to CoreDNS for applications
- [ ] Get rid of all the kube-dns related stuff
- [ ] Re-add any existing metrics