### PR TITLE
Use etcd image version provided by channel configuration

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -27,7 +27,6 @@ coreos:
         - name: 40-etcd-gateway.conf
           content: |
             [Service]
-            Environment="ETCD_IMAGE_TAG=v3.1.6"
             Environment="ETCD_OPTS=gateway start --listen-addr=127.0.0.1:2379 --endpoints={{ ETCD_ENDPOINTS }}"
 
     - name: docker.service

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -27,7 +27,6 @@ coreos:
         - name: 40-etcd-gateway.conf
           content: |
             [Service]
-            Environment="ETCD_IMAGE_TAG=v3.1.6"
             Environment="ETCD_OPTS=gateway start --listen-addr=127.0.0.1:2379 --endpoints={{ ETCD_ENDPOINTS }}"
 
     - name: docker.service


### PR DESCRIPTION
This is more to raise awareness, keep track and ask how we want to deal with that in the future.

We overwrote the `ETCD_IMAGE_TAG` at some point in the past (I think it was due to [a bug in `v3.0.x`](https://github.com/zalando-incubator/kubernetes-on-aws/commit/ddd67156d1c23575d017c4906aad4fbb76ffebd4)).

However, by now the version provided in the stable channel is newer than what we define (https://coreos.com/releases/#1465.8.0):

```
# /usr/lib/systemd/system/etcd-member.service
Environment="ETCD_IMAGE_TAG=v3.1.8"
...
# /etc/systemd/system/etcd-member.service.d/40-etcd-gateway.conf
[Service]
Environment="ETCD_IMAGE_TAG=v3.1.6"
...
```

We'll face the same issue with [`flannel`](https://github.com/zalando-incubator/kubernetes-on-aws/pull/616) in the future.

I think it's not desireable to keep track of this manually and rather let CoreDNS's channels decide. However, this can lead to surprising updates of the version which could lead to issues (even in stable channel).

What's your opinion on that?