### PR TITLE
Alpha to beta

### DIFF
--- a/cluster/manifests/emergency-access-service/deployment.yaml
+++ b/cluster/manifests/emergency-access-service/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: emergency-access-service
-    version: master-30
+    version: master-36
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: emergency-access-service
-        version: master-30
+        version: master-36
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
           [{"container": "emergency-access-service", "parser": "json-structured-log"}]

--- a/cluster/manifests/emergency-access-service/deployment.yaml
+++ b/cluster/manifests/emergency-access-service/deployment.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: system
       containers:
       - name: emergency-access-service
-        image: "pierone.stups.zalan.do/teapot/emergency-access-service:master-35"
+        image: "pierone.stups.zalan.do/teapot/emergency-access-service:master-36"
         args:
         - --insecure-http
         - --community={{ .Owner }}

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -57,3 +57,9 @@ spec:
           requests:
             cpu: 25m
             memory: 25Mi
+        readinessProbe:
+          httpGet:
+            path: /kube-system/healthz
+            port: 9999
+          initialDelaySeconds: 5
+          timeoutSeconds: 5

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -110,7 +110,7 @@ SenzaComponents:
          Minimum: "{{ Arguments.MinimumWorkerNodes}}"
          Maximum: "{{ Arguments.MaximumWorkerNodes}}"
          DesiredCapacity: "{{ Arguments.WorkerNodes }}"
-         SuccessRequires: "1 within 15m"
+         SuccessRequires: "0 within 15m"
       Tags:
         - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
           Value: owned

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -161,7 +161,7 @@ coreos:
       runtime: true
       content: |
         [Unit]
-        Requires=docker.service
+        Description=drain this k8s node to make running pods time to gracefully shut down before stopping kubelet
         After=docker.service
 
         [Service]
@@ -169,11 +169,11 @@ coreos:
         RemainAfterExit=true
         ExecStart=/bin/true
         TimeoutStopSec=120s
-        ExecStop=/bin/sh -c '/usr/bin/rkt run \
+        ExecStop=/bin/sh -c '/usr/bin/rkt run --insecure-options=image \
         --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
         --mount=volume=kube,target=/etc/kubernetes \
         --net=host \
-        registry.opensource.zalan.do/teapot/hyperkube:v1.7.6_coreos.0 \
+        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.7.6_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           drain $(hostname) \

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -170,16 +170,16 @@ coreos:
         ExecStart=/bin/true
         TimeoutStopSec=120s
         ExecStop=/bin/sh -c '/usr/bin/rkt run --insecure-options=image \
-        --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
-        --mount=volume=kube,target=/etc/kubernetes \
-        --net=host \
-        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.7.6_coreos.0 \
+          --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
+          --mount=volume=kube,target=/etc/kubernetes \
+          --net=host \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.7.6_coreos.0 \
           --exec=/kubectl -- \
-          --kubeconfig=/etc/kubernetes/kubeconfig \
-          drain $(hostname) \
-          --ignore-daemonsets \
-          --delete-local-data \
-          --force'
+            --kubeconfig=/etc/kubernetes/kubeconfig \
+            drain $(hostname) \
+            --ignore-daemonsets \
+            --delete-local-data \
+            --force'
 
         [Install]
         WantedBy=multi-user.target

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -167,17 +167,6 @@ coreos:
         [Install]
         WantedBy=multi-user.target
 
-    - name: cfn-signal.service
-      command: start
-      runtime: true
-      content: |
-        [Service]
-        Type=oneshot
-        ExecStart=/usr/bin/docker run registry.opensource.zalan.do/teapot/cfn-signal:1.4-4 {{LOCAL_ID}} WorkerAutoScaling 0
-
-        [Install]
-        WantedBy=multi-user.target
-
 write_files:
 
   - path: /etc/kubernetes/cni/docker_opts_cni.env

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -144,7 +144,6 @@ coreos:
       content: |
         [Unit]
         Description=drain this k8s node to make running pods time to gracefully shut down before stopping kubelet
-        Requires=docker.service
         After=docker.service
 
         [Service]
@@ -152,11 +151,11 @@ coreos:
         RemainAfterExit=true
         ExecStart=/bin/true
         TimeoutStopSec=120s
-        ExecStop=/bin/sh -c '/usr/bin/rkt run \
+        ExecStop=/bin/sh -c '/usr/bin/rkt run --insecure-options=image \
         --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
         --mount=volume=kube,target=/etc/kubernetes \
         --net=host \
-        registry.opensource.zalan.do/teapot/hyperkube:v1.7.6_coreos.0 \
+        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.7.6_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
           drain $(hostname) \

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -152,16 +152,16 @@ coreos:
         ExecStart=/bin/true
         TimeoutStopSec=120s
         ExecStop=/bin/sh -c '/usr/bin/rkt run --insecure-options=image \
-        --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
-        --mount=volume=kube,target=/etc/kubernetes \
-        --net=host \
-        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.7.6_coreos.0 \
+          --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
+          --mount=volume=kube,target=/etc/kubernetes \
+          --net=host \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.7.6_coreos.0 \
           --exec=/kubectl -- \
-          --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
-          drain $(hostname) \
-          --ignore-daemonsets \
-          --delete-local-data \
-          --force'
+            --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
+            drain $(hostname) \
+            --ignore-daemonsets \
+            --delete-local-data \
+            --force'
 
         [Install]
         WantedBy=multi-user.target


### PR DESCRIPTION
* Add readiness probes to skipper DaemonSet
* Emergency Service update
* remove systemd lifecycle dependency from kube-node-ready to docker
* remove cfn-signal, because we use instead kube-node-ready