### PR TITLE
Add kube-proxy daemonset

### DIFF
--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -6,8 +6,6 @@ metadata:
   labels:
     application: kube-proxy
     version: v1.7.9_coreos.0
-  annotations:
-    rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
 spec:
   selector:
     matchLabels:

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     application: kube-proxy
     version: v1.7.9_coreos.0
+  annotations:
+    rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
 spec:
   selector:
     matchLabels:
@@ -20,7 +22,6 @@ spec:
         version: v1.7.9_coreos.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
     spec:
       affinity:
         nodeAffinity:
@@ -32,8 +33,12 @@ spec:
                 values:
                 - local
       tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
+      - operator: Exists
+        effect: NoSchedule
+      - operator: Exists
+        effect: NoExecute
+      - operator: Exists
+        key: CriticalAddonsOnly
       hostNetwork: true
       containers:
       - name: kube-proxy
@@ -63,9 +68,6 @@ spec:
         - name: etc-kube-ssl
           mountPath: /etc/kubernetes/ssl
           readOnly: true
-        - name: dbus
-          mountPath: /var/run/dbus
-          readOnly: false
       volumes:
       - name: ssl-certs
         hostPath:
@@ -76,6 +78,3 @@ spec:
       - name: etc-kube-ssl
         hostPath:
           path: /etc/kubernetes/ssl
-      - name: dbus
-        hostPath:
-          path: /var/run/dbus

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -1,0 +1,72 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: kube-proxy
+  namespace: kube-system
+  labels:
+    application: kube-proxy
+    version: v1.7.9_coreos.0
+spec:
+  selector:
+    matchLabels:
+      application: kube-proxy
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      name: kube-proxy
+      labels:
+        application: kube-proxy
+        version: v1.7.9_coreos.0
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
+    spec:
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      hostNetwork: true
+      containers:
+      - name: kube-proxy
+        image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.9_coreos.0
+        command:
+        - /hyperkube
+        - proxy
+        - --kubeconfig=/etc/kubernetes/kubeconfig
+        - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true
+        - --v=2
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 50m
+            memory: 75Mi
+          limits:
+            cpu: 200m
+            memory: 200Mi
+        volumeMounts:
+        - name: ssl-certs
+          mountPath: /etc/ssl/certs
+          readOnly: true
+        - name: kubeconfig
+          mountPath: /etc/kubernetes/kubeconfig
+          readOnly: true
+        - name: etc-kube-ssl
+          mountPath: /etc/kubernetes/ssl
+          readOnly: true
+        - name: dbus
+          mountPath: /var/run/dbus
+          readOnly: false
+      volumes:
+      - name: ssl-certs
+        hostPath:
+          path: /usr/share/ca-certificates
+      - name: kubeconfig
+        hostPath:
+          path: /etc/kubernetes/kubeconfig
+      - name: etc-kube-ssl
+        hostPath:
+          path: /etc/kubernetes/ssl
+      - name: dbus
+        hostPath:
+          path: /var/run/dbus

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -22,6 +22,15 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kube-proxy
+                operator: NotIn
+                values:
+                - local
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -145,6 +145,7 @@ coreos:
         --register-schedulable=false \
         --allow-privileged \
         --node-labels=kubernetes.io/role=master,master=true \
+        --node-labels=kube-proxy=local \
         --node-labels={{NODE_LABELS}} \
         --pod-manifest-path=/etc/kubernetes/manifests \
         --cluster_dns=10.3.0.10 \

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -268,10 +268,10 @@ write_files:
       apiVersion: v1
       kind: Pod
       metadata:
-        name: kube-proxy
+        name: kube-proxy-userdata
         namespace: kube-system
         labels:
-          application: kube-proxy
+          application: kube-proxy-userdata
           version: v1.7.9_coreos.0
         annotations:
           scheduler.alpha.kubernetes.io/critical-pod: ''

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -134,7 +134,7 @@ coreos:
         --pod-manifest-path=/etc/kubernetes/manifests \
         --cluster_dns=10.3.0.10 \
         --cluster_domain=cluster.local \
-        --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
+        --kubeconfig=/etc/kubernetes/kubeconfig \
         --require-kubeconfig \
         --healthz-bind-address=0.0.0.0 \
         --healthz-port=10248 \
@@ -180,7 +180,7 @@ coreos:
           --net=host \
           docker://registry.opensource.zalan.do/teapot/hyperkube:v1.7.9_coreos.0 \
           --exec=/kubectl -- \
-            --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
+            --kubeconfig=/etc/kubernetes/kubeconfig \
             drain $(hostname) \
             --ignore-daemonsets \
             --delete-local-data \
@@ -213,10 +213,10 @@ write_files:
         apiVersion: v1
         kind: Pod
         metadata:
-          name: kube-proxy
+          name: kube-proxy-userdata
           namespace: kube-system
           labels:
-            application: kube-proxy
+            application: kube-proxy-userdata
             version: v1.7.9_coreos.0
           annotations:
             scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -232,7 +232,7 @@ write_files:
             command:
             - /hyperkube
             - proxy
-            - --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml
+            - --kubeconfig=/etc/kubernetes/kubeconfig
             - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true
             - --v=2
             securityContext:
@@ -247,7 +247,7 @@ write_files:
             volumeMounts:
               - mountPath: /etc/ssl/certs
                 name: "ssl-certs"
-              - mountPath: /etc/kubernetes/worker-kubeconfig.yaml
+              - mountPath: /etc/kubernetes/kubeconfig
                 name: "kubeconfig"
                 readOnly: true
               - mountPath: /etc/kubernetes/ssl
@@ -262,7 +262,7 @@ write_files:
                 path: "/usr/share/ca-certificates"
             - name: "kubeconfig"
               hostPath:
-                path: "/etc/kubernetes/worker-kubeconfig.yaml"
+                path: "/etc/kubernetes/kubeconfig"
             - name: "etc-kube-ssl"
               hostPath:
                 path: "/etc/kubernetes/ssl"
@@ -270,7 +270,7 @@ write_files:
                 path: /var/run/dbus
               name: dbus
 
-  - path: /etc/kubernetes/worker-kubeconfig.yaml
+  - path: /etc/kubernetes/kubeconfig
     content: |
         apiVersion: v1
         kind: Config

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -130,6 +130,7 @@ coreos:
         --register-node \
         --allow-privileged \
         --node-labels=kubernetes.io/role=worker \
+        --node-labels=kube-proxy=local \
         --node-labels={{NODE_LABELS}} \
         --pod-manifest-path=/etc/kubernetes/manifests \
         --cluster_dns=10.3.0.10 \


### PR DESCRIPTION
This is an effort to move the static kube-proxy pod out of the userdata and make it into a daemonset. The reason for this is to have more stuff managed by Kubernetes and have less node specific configuration in the config.

I kept the mirror pod in the userdata for now in order to have a smooth upgrade path. It was renamed to `kube-proxy-userdata` in order to ensure that the daemonset doesn't try to manage the mirror pods.

Still need to verify a few things before this is ready:

* [x] ~~Running both mirror and daemonset pods should not have any impact (e2e should be enough to verify this)~~ we ensure that only one of them is running
* [x] Try running without the mirror pods (tested with e2e tests on [this branch](https://github.com/zalando-incubator/kubernetes-on-aws/tree/kube-proxy-rm-mirror))