### PR TITLE
add link to slides (AWS Tech Community Days Cologne)

### DIFF
--- a/docs/admin-guide/public-presentations.rst
+++ b/docs/admin-guide/public-presentations.rst
@@ -4,7 +4,7 @@
 Public Presentations
 ====================
 
-* _`Large Scale Kubernetes on AWS at Europe's Leading Online Fashion Platform - AWS Tech Community Days Cologne <https://www.slideshare.net/HenningJacobs/large-scale-kubernetes-on-aws-at-europes-leading-online-fashion-platform-aws-tech-community-days-cologne>`_
+* `Large Scale Kubernetes on AWS at Europe's Leading Online Fashion Platform - AWS Tech Community Days Cologne <https://www.slideshare.net/HenningJacobs/large-scale-kubernetes-on-aws-at-europes-leading-online-fashion-platform-aws-tech-community-days-cologne>`_
 * `Automatic infrastructure for Kubernetes ingress in AWS - Berlin Docker Meetup <https://www.slideshare.net/SandorSzuecs/2017-0719-automatic-infrastructure-for-kubernetes-ingress-in-aws>`_
 * `Large Scale Kubernetes on AWS at Europe's Leading Online Fashion Platform - Docker Hamburg Meetup <https://drive.google.com/open?id=0B6UeTsXSqfklLXNpR0V5Tk5DbFk>`_
 * `PostgreSQL on Kubernetes - Docker Hamburg Meetup <https://drive.google.com/open?id=0B6UeTsXSqfklN2ZaM1FFMk93Qm8>`_

--- a/docs/admin-guide/public-presentations.rst
+++ b/docs/admin-guide/public-presentations.rst
@@ -4,6 +4,7 @@
 Public Presentations
 ====================
 
+* _`Large Scale Kubernetes on AWS at Europe's Leading Online Fashion Platform - AWS Tech Community Days Cologne <https://www.slideshare.net/HenningJacobs/large-scale-kubernetes-on-aws-at-europes-leading-online-fashion-platform-aws-tech-community-days-cologne>`_
 * `Automatic infrastructure for Kubernetes ingress in AWS - Berlin Docker Meetup <https://www.slideshare.net/SandorSzuecs/2017-0719-automatic-infrastructure-for-kubernetes-ingress-in-aws>`_
 * `Large Scale Kubernetes on AWS at Europe's Leading Online Fashion Platform - Docker Hamburg Meetup <https://drive.google.com/open?id=0B6UeTsXSqfklLXNpR0V5Tk5DbFk>`_
 * `PostgreSQL on Kubernetes - Docker Hamburg Meetup <https://drive.google.com/open?id=0B6UeTsXSqfklN2ZaM1FFMk93Qm8>`_


### PR DESCRIPTION
Add link to slides from AWS Tech Community Days Cologne (2017-09-28).