### PR TITLE
Label draining nodes

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -187,6 +187,15 @@ coreos:
           docker://registry.opensource.zalan.do/teapot/hyperkube:v1.7.7_coreos.0 \
           --exec=/kubectl -- \
             --kubeconfig=/etc/kubernetes/kubeconfig \
+            label node $(hostname) \
+            lifecycle-status=draining \
+            --overwrite; /usr/bin/rkt run --insecure-options=image \
+          --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
+          --mount=volume=kube,target=/etc/kubernetes \
+          --net=host \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.7.7_coreos.0 \
+          --exec=/kubectl -- \
+            --kubeconfig=/etc/kubernetes/kubeconfig \
             drain $(hostname) \
             --ignore-daemonsets \
             --delete-local-data \

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -172,6 +172,15 @@ coreos:
           docker://registry.opensource.zalan.do/teapot/hyperkube:v1.7.7_coreos.0 \
           --exec=/kubectl -- \
             --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
+            label node $(hostname) \
+            lifecycle-status=draining \
+            --overwrite; /usr/bin/rkt run --insecure-options=image \
+          --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
+          --mount=volume=kube,target=/etc/kubernetes \
+          --net=host \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.7.7_coreos.0 \
+          --exec=/kubectl -- \
+            --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
             drain $(hostname) \
             --ignore-daemonsets \
             --delete-local-data \


### PR DESCRIPTION
This labels nodes as "draining" before they will get drained by the node drainer.

This allows to nicely follow the termination procedure via `kubectl get nodes`:

```console
$ kubectl get nodes -L lifecycle-status
NAME                                             STATUS                     AGE       VERSION           LIFECYCLE-STATUS       
ip-172-31-1-212.eu-central-1.compute.internal    Ready                      27m       v1.7.6+coreos.0   decommission-pending   
ip-172-31-19-142.eu-central-1.compute.internal   Ready,SchedulingDisabled   19m       v1.7.6+coreos.0   draining               
ip-172-31-14-47.eu-central-1.compute.internal    Ready                      16m       v1.7.6+coreos.0   decommission-pending   
```