### PR TITLE
Label node role with well-known labels

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -145,7 +145,7 @@ coreos:
         --rkt-path=/usr/bin/rkt \
         --register-schedulable=false \
         --allow-privileged \
-        --node-labels=master=true \
+        --node-labels=kubernetes.io/role=master,master=true \
         --node-labels={{NODE_LABELS}} \
         --pod-manifest-path=/etc/kubernetes/manifests \
         --cluster_dns=10.3.0.10 \

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -130,6 +130,7 @@ coreos:
         --rkt-path=/usr/bin/rkt \
         --register-node \
         --allow-privileged \
+        --node-labels=kubernetes.io/role=worker \
         --node-labels={{NODE_LABELS}} \
         --pod-manifest-path=/etc/kubernetes/manifests \
         --cluster_dns=10.3.0.10 \


### PR DESCRIPTION
There's now a well-known label for the node role (actually it's two):
* `kubernetes.io/role=theRole`
* `node-role.kubernetes.io/theRole=true`

https://github.com/kubernetes/kubernetes/blob/v1.8.0/pkg/printers/internalversion/printers.go#L70

Both annotations are supported in `kubectl get nodes` beginning with 1.8 (see the ROLES column):

```console
$ kubectl get nodes
NAME                                             STATUS                     ROLES     AGE       VERSION
ip-172-31-0-28.eu-central-1.compute.internal     Ready,SchedulingDisabled   master    19h       v1.7.7+coreos.0
ip-172-31-20-163.eu-central-1.compute.internal   Ready                      worker    18h       v1.7.7+coreos.0
```

Keeping the old label for backwards-compatibility.