### PR TITLE
Add the PodCIDR controller

### DIFF
--- a/cluster/manifests/pod-cidr-controller/deployment.yaml
+++ b/cluster/manifests/pod-cidr-controller/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: pod-cidr-controller
@@ -19,7 +19,14 @@ spec:
         version: v0.1.0
     spec:
       hostNetwork: true
+      serviceAccountName: system
       containers:
       - name: pod-cidr-controller
         image: pierone.stups.zalan.do/teapot/pod-cidr-controller:v0.1.0
-      serviceAccountName: system
+        resources:
+          requests:
+            memory: 32Mi
+            cpu: 10m
+          limits:
+            memory: 128Mi
+            cpu: 100m

--- a/cluster/manifests/pod-cidr-controller/deployment.yaml
+++ b/cluster/manifests/pod-cidr-controller/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: pod-cidr-controller
+  namespace: kube-system
+  labels:
+    application: pod-cidr-controller
+    version: v0.1.0
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      application: pod-cidr-controller
+  template:
+    metadata:
+      labels:
+        application: pod-cidr-controller
+        version: v0.1.0
+    spec:
+      hostNetwork: true
+      containers:
+      - name: pod-cidr-controller
+        image: pierone.stups.zalan.do/teapot/pod-cidr-controller:v0.1.0
+      serviceAccountName: system


### PR DESCRIPTION
Populate Node's `PodCIDR` field with data from etcd (in order to switch from etcd-flannel to kube-flannel).

## Why

When migrating from an `etcd`-backed `flannel` to a Kubernetes API-backed `flannel` daemon it's necessary to keep both backends synchronized so that old nodes and already updated nodes don't enter a split brain situation resulting in a malfunctioning Pod network.

---

Check out the [README.md](https://github.bus.zalan.do/teapot/pod-cidr-controller/blob/fc87d046db367c8668a85f4383f6852eed44fcaa/README.md) if you want to know more.