### PR TITLE
Update webhook to v0.3.5

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -394,7 +394,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.3.4
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.3.5
           name: webhook
           ports:
           - containerPort: 8081


### PR DESCRIPTION
Updates the webhook to v0.3.5 which includes logging of subresources and renaming the `Debug` role to `Manual`.