### PR TITLE
Bumps the webhook to v0.3.6 to support CRD for operator SA

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -394,7 +394,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.3.5
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.3.6
           name: webhook
           ports:
           - containerPort: 8081


### PR DESCRIPTION
This bumps the webhook to v0.3.6 that supports CRDs for the operator SA.