### PR TITLE
Dev to alpha

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -394,7 +394,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.3.5
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.3.6
           name: webhook
           ports:
           - containerPort: 8081

--- a/docs/admin-guide/public-presentations.rst
+++ b/docs/admin-guide/public-presentations.rst
@@ -4,6 +4,7 @@
 Public Presentations
 ====================
 
+* `Kubernetes on AWS at Zalando - First Kubernetes & CNCF meetup in Finland <https://www.youtube.com/watch?time_continue=4&v=H92nfJt3ymo>`_
 * `Large Scale Kubernetes on AWS at Europe's Leading Online Fashion Platform - AWS Tech Community Days Cologne <https://www.slideshare.net/HenningJacobs/large-scale-kubernetes-on-aws-at-europes-leading-online-fashion-platform-aws-tech-community-days-cologne>`_
 * `Automatic infrastructure for Kubernetes ingress in AWS - Berlin Docker Meetup <https://www.slideshare.net/SandorSzuecs/2017-0719-automatic-infrastructure-for-kubernetes-ingress-in-aws>`_
 * `Large Scale Kubernetes on AWS at Europe's Leading Online Fashion Platform - Docker Hamburg Meetup <https://drive.google.com/open?id=0B6UeTsXSqfklLXNpR0V5Tk5DbFk>`_


### PR DESCRIPTION
* Bumps the webhook to v0.3.6 to support CRD for operator SA (#636)

This is needed by ACID for the postgres operator.