### PR TITLE
Alpha to beta

### DIFF
--- a/cluster/manifests/cluster-autoscaler/deployment.yaml
+++ b/cluster/manifests/cluster-autoscaler/deployment.yaml
@@ -38,3 +38,4 @@ spec:
           requests:
             cpu: 50m
             memory: 100Mi
+      dnsPolicy: Default

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.3.9
+    version: v0.3.10
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.3.9
+        version: v0.3.10
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
@@ -26,7 +26,7 @@ spec:
         operator: Exists
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.3.9
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.3.10
         env:
         - name: AWS_REGION
           value: {{ .Region }}

--- a/cluster/manifests/kube-dns/depl-kube-dns.yaml
+++ b/cluster/manifests/kube-dns/depl-kube-dns.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-dns
-    version: v1.14.4
+    version: v1.14.5
     kubernetes.io/cluster-service: "true"
 spec:
   # replicas: not specified here:
@@ -23,7 +23,7 @@ spec:
     metadata:
       labels:
         application: kube-dns
-        version: v1.14.4
+        version: v1.14.5
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -38,7 +38,7 @@ spec:
           optional: true
       containers:
       - name: kubedns
-        image: registry.opensource.zalan.do/teapot/k8s-dns-kube-dns:1.14.4
+        image: registry.opensource.zalan.do/teapot/k8s-dns-kube-dns:1.14.5
         resources:
           limits:
             memory: 170Mi
@@ -83,7 +83,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: registry.opensource.zalan.do/teapot/k8s-dns-dnsmasq-nanny:1.14.4
+        image: registry.opensource.zalan.do/teapot/k8s-dns-dnsmasq-nanny:1.14.5
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -121,7 +121,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: registry.opensource.zalan.do/teapot/k8s-dns-sidecar:1.14.4
+        image: registry.opensource.zalan.do/teapot/k8s-dns-sidecar:1.14.5
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -186,6 +186,15 @@ coreos:
           docker://registry.opensource.zalan.do/teapot/hyperkube:v1.7.7_coreos.0 \
           --exec=/kubectl -- \
             --kubeconfig=/etc/kubernetes/kubeconfig \
+            label node $(hostname) \
+            lifecycle-status=draining \
+            --overwrite; /usr/bin/rkt run --insecure-options=image \
+          --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
+          --mount=volume=kube,target=/etc/kubernetes \
+          --net=host \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.7.7_coreos.0 \
+          --exec=/kubectl -- \
+            --kubeconfig=/etc/kubernetes/kubeconfig \
             drain $(hostname) \
             --ignore-daemonsets \
             --delete-local-data \

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -144,7 +144,7 @@ coreos:
         --rkt-path=/usr/bin/rkt \
         --register-schedulable=false \
         --allow-privileged \
-        --node-labels=master=true \
+        --node-labels=kubernetes.io/role=master,master=true \
         --node-labels={{NODE_LABELS}} \
         --pod-manifest-path=/etc/kubernetes/manifests \
         --cluster_dns=10.3.0.10 \

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -52,6 +52,10 @@ coreos:
             ExecStartPre=/usr/bin/etcdctl \
             --endpoint=http://127.0.0.1:2379 set /coreos.com/network/config \
             '{ "Network": "10.2.0.0/16", "Backend": {"Type": "vxlan"}}'
+        - name: 20-version.conf
+          content: |
+            [Service]
+            Environment="FLANNEL_IMAGE_TAG=v0.8.0"
 
     - name: kube2iam-iptables.service
       command: start

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -394,7 +394,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.3.5
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.3.6
           name: webhook
           ports:
           - containerPort: 8081

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -24,7 +24,6 @@ coreos:
         - name: 40-etcd-gateway.conf
           content: |
             [Service]
-            Environment="ETCD_IMAGE_TAG=v3.1.6"
             Environment="ETCD_OPTS=gateway start --listen-addr=127.0.0.1:2379 --endpoints={{ ETCD_ENDPOINTS }}"
 
     - name: docker.service

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -116,7 +116,7 @@ coreos:
       runtime: true
       content: |
         [Service]
-        Environment=KUBELET_IMAGE_TAG=v1.7.6_coreos.0
+        Environment=KUBELET_IMAGE_TAG=v1.7.7_coreos.0
         Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
         Environment="RKT_RUN_ARGS=--insecure-options=image \
         --uuid-file-save=/var/run/kubelet-pod.uuid \
@@ -178,7 +178,7 @@ coreos:
           --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
           --mount=volume=kube,target=/etc/kubernetes \
           --net=host \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.7.6_coreos.0 \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.7.7_coreos.0 \
           --exec=/kubectl -- \
             --kubeconfig=/etc/kubernetes/kubeconfig \
             drain $(hostname) \
@@ -258,7 +258,7 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-proxy
-          version: v1.7.6_coreos.0
+          version: v1.7.7_coreos.0
         annotations:
           scheduler.alpha.kubernetes.io/critical-pod: ''
           rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
@@ -269,7 +269,7 @@ write_files:
         hostNetwork: true
         containers:
         - name: kube-proxy
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.6_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.7_coreos.0
           command:
           - /hyperkube
           - proxy
@@ -309,7 +309,7 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-apiserver
-          version: v1.7.6_coreos.0
+          version: v1.7.7_coreos.0
         annotations:
           scheduler.alpha.kubernetes.io/critical-pod: ''
           kubernetes-log-watcher/scalyr-parser: |
@@ -321,7 +321,7 @@ write_files:
         hostNetwork: true
         containers:
         - name: kube-apiserver
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.6_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.7_coreos.0
           command:
           - /hyperkube
           - apiserver
@@ -491,7 +491,7 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-controller-manager
-          version: v1.7.6_coreos.0
+          version: v1.7.7_coreos.0
         annotations:
           scheduler.alpha.kubernetes.io/critical-pod: ''
       spec:
@@ -500,7 +500,7 @@ write_files:
           operator: Exists
         containers:
         - name: kube-controller-manager
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.6_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.7_coreos.0
           command:
           - /hyperkube
           - controller-manager
@@ -557,7 +557,7 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-scheduler
-          version: v1.7.6_coreos.0
+          version: v1.7.7_coreos.0
         annotations:
           scheduler.alpha.kubernetes.io/critical-pod: ''
       spec:
@@ -567,7 +567,7 @@ write_files:
         hostNetwork: true
         containers:
         - name: kube-scheduler
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.6_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.7_coreos.0
           command:
           - /hyperkube
           - scheduler

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -16,9 +16,6 @@ ssh_authorized_keys:
 coreos:
   update:
     reboot-strategy: "off"
-  flannel:
-    interface: $private_ipv4
-    etcd_endpoints: http://127.0.0.1:2379
   units:
     - name: etcd-member.service
       command: start
@@ -46,16 +43,25 @@ coreos:
 
     - name: flanneld.service
       drop-ins:
-        - name: 10-etcd.conf
-          content: |
-            [Service]
-            ExecStartPre=/usr/bin/etcdctl \
-            --endpoint=http://127.0.0.1:2379 set /coreos.com/network/config \
-            '{ "Network": "10.2.0.0/16", "Backend": {"Type": "vxlan"}}'
-        - name: 20-version.conf
-          content: |
-            [Service]
-            Environment="FLANNEL_IMAGE_TAG=v0.8.0"
+      - name: 10-etcd.conf
+        content: |
+          [Service]
+          ExecStartPre=/usr/bin/etcdctl \
+          --endpoint=http://127.0.0.1:2379 set /coreos.com/network/config \
+          '{ "Network": "10.2.0.0/16", "Backend": {"Type": "vxlan"}}'
+      - name: 20-version.conf
+        content: |
+          [Service]
+          Environment="FLANNELD_IFACE="$private_ipv4"
+          Environment="FLANNELD_ETCD_ENDPOINTS="http://127.0.0.1:2379"
+          Environment="FLANNEL_IMAGE_TAG=v0.9.0"
+
+    - name: flannel-docker-opts.service
+      drop-ins:
+      - name: 20-version.conf
+        content: |
+          [Service]
+          Environment="FLANNEL_IMAGE_TAG=v0.9.0"
 
     - name: kube2iam-iptables.service
       command: start

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -99,7 +99,7 @@ coreos:
       runtime: true
       content: |
         [Service]
-        Environment=KUBELET_IMAGE_TAG=v1.7.6_coreos.0
+        Environment=KUBELET_IMAGE_TAG=v1.7.7_coreos.0
         Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
         Environment="RKT_RUN_ARGS=--insecure-options=image \
         --uuid-file-save=/var/run/kubelet-pod.uuid \
@@ -163,7 +163,7 @@ coreos:
           --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
           --mount=volume=kube,target=/etc/kubernetes \
           --net=host \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.7.6_coreos.0 \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.7.7_coreos.0 \
           --exec=/kubectl -- \
             --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
             drain $(hostname) \
@@ -202,7 +202,7 @@ write_files:
           namespace: kube-system
           labels:
             application: kube-proxy
-            version: v1.7.6_coreos.0
+            version: v1.7.7_coreos.0
           annotations:
             scheduler.alpha.kubernetes.io/critical-pod: ''
             rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
@@ -213,7 +213,7 @@ write_files:
           hostNetwork: true
           containers:
           - name: kube-proxy
-            image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.6_coreos.0
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.7_coreos.0
             command:
             - /hyperkube
             - proxy

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -49,7 +49,7 @@ coreos:
       - name: 20-version.conf
         content: |
           [Service]
-          Environment="FLANNEL_IMAGE_TAG=v0.8.0"
+          Environment="FLANNEL_IMAGE_TAG=v0.9.0"
 
     - name: timesynced-enable-network-time.service
       command: start

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -171,6 +171,15 @@ coreos:
           docker://registry.opensource.zalan.do/teapot/hyperkube:v1.7.7_coreos.0 \
           --exec=/kubectl -- \
             --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
+            label node $(hostname) \
+            lifecycle-status=draining \
+            --overwrite; /usr/bin/rkt run --insecure-options=image \
+          --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
+          --mount=volume=kube,target=/etc/kubernetes \
+          --net=host \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.7.7_coreos.0 \
+          --exec=/kubectl -- \
+            --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
             drain $(hostname) \
             --ignore-daemonsets \
             --delete-local-data \

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -129,6 +129,7 @@ coreos:
         --rkt-path=/usr/bin/rkt \
         --register-node \
         --allow-privileged \
+        --node-labels=kubernetes.io/role=worker \
         --node-labels={{NODE_LABELS}} \
         --pod-manifest-path=/etc/kubernetes/manifests \
         --cluster_dns=10.3.0.10 \

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -24,7 +24,6 @@ coreos:
         - name: 40-etcd-gateway.conf
           content: |
             [Service]
-            Environment="ETCD_IMAGE_TAG=v3.1.6"
             Environment="ETCD_OPTS=gateway start --listen-addr=127.0.0.1:2379 --endpoints={{ ETCD_ENDPOINTS }}"
 
     - name: docker.service

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -50,6 +50,13 @@ coreos:
           Environment="FLANNELD_ETCD_ENDPOINTS="http://127.0.0.1:2379"
           Environment="FLANNEL_IMAGE_TAG=v0.9.0"
 
+    - name: flannel-docker-opts.service
+      drop-ins:
+      - name: 20-version.conf
+        content: |
+          [Service]
+          Environment="FLANNEL_IMAGE_TAG=v0.9.0"
+
     - name: timesynced-enable-network-time.service
       command: start
       runtime: true

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -44,6 +44,13 @@ coreos:
             [Service]
             Environment="DOCKER_OPTS=--log-opt=max-file=2 --log-opt=max-size=50m"
 
+    - name: flanneld.service
+      drop-ins:
+      - name: 20-version.conf
+        content: |
+          [Service]
+          Environment="FLANNEL_IMAGE_TAG=v0.8.0"
+
     - name: timesynced-enable-network-time.service
       command: start
       runtime: true

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -16,9 +16,6 @@ ssh_authorized_keys:
 coreos:
   update:
     reboot-strategy: "off"
-  flannel:
-    interface: $private_ipv4
-    etcd_endpoints: http://127.0.0.1:2379
   units:
     - name: etcd-member.service
       command: start
@@ -49,6 +46,8 @@ coreos:
       - name: 20-version.conf
         content: |
           [Service]
+          Environment="FLANNELD_IFACE="$private_ipv4"
+          Environment="FLANNELD_ETCD_ENDPOINTS="http://127.0.0.1:2379"
           Environment="FLANNEL_IMAGE_TAG=v0.9.0"
 
     - name: timesynced-enable-network-time.service

--- a/docs/admin-guide/public-presentations.rst
+++ b/docs/admin-guide/public-presentations.rst
@@ -4,6 +4,7 @@
 Public Presentations
 ====================
 
+* `Kubernetes on AWS at Zalando - First Kubernetes & CNCF meetup in Finland <https://www.youtube.com/watch?time_continue=4&v=H92nfJt3ymo>`_
 * `Large Scale Kubernetes on AWS at Europe's Leading Online Fashion Platform - AWS Tech Community Days Cologne <https://www.slideshare.net/HenningJacobs/large-scale-kubernetes-on-aws-at-europes-leading-online-fashion-platform-aws-tech-community-days-cologne>`_
 * `Automatic infrastructure for Kubernetes ingress in AWS - Berlin Docker Meetup <https://www.slideshare.net/SandorSzuecs/2017-0719-automatic-infrastructure-for-kubernetes-ingress-in-aws>`_
 * `Large Scale Kubernetes on AWS at Europe's Leading Online Fashion Platform - Docker Hamburg Meetup <https://drive.google.com/open?id=0B6UeTsXSqfklLXNpR0V5Tk5DbFk>`_


### PR DESCRIPTION
- Update to Kubernetes v1.7.7 (#618) 
- Update kube-dns version (fixes CVE-2017-14491): (#617) 
- Use default DNS policy in Cluster Autoscaler (#619)
- Update Ingress controller (#622)
- Update flannel to 0.9.0 (#616) 
- Add link to Cologne Tech Community Days slides (#628) 
- Use etcd form channel configuration (#623) 
- Label draining nodes (#629) 
- Well known label for node roles (#630)
- Update webhook including subresource logging and renaming `Debug` role to `Manual` (#633)
- Bumps the webhook to v0.3.6 to support CRD for operator SA (#636)
- Update emergency access: rename `debug` access to `manual` (#634)