### PR TITLE
enable upgrade headers

### DIFF
--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -49,6 +49,7 @@ spec:
           - "-address=:9999"
           - "-proxy-preserve-host"
           - "-serve-host-metrics"
+          - "-experimental-upgrade"
           - "-opentracing=tracing_instana"
         resources:
           limits:


### PR DESCRIPTION
enable upgrade headers in skipper-ingress to support protocols like websockets