### PR TITLE
Dev to alpha

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: external-dns
-    version: v0.4.4
+    version: v0.4.5
 spec:
   strategy:
     type: Recreate
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: external-dns
-        version: v0.4.4
+        version: v0.4.5
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
@@ -26,7 +26,7 @@ spec:
          operator: Exists
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.4
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.5
         args:
         - --source=service
         - --source=ingress
@@ -34,4 +34,4 @@ spec:
         - --registry=txt
         - --txt-owner-id={{ .Region }}:{{ .LocalID }}
         - --compatibility=mate # remove when we switched to the new annotations
-        - --debug # remove when we are sure external-dns can be trusted
+        - --log-level=debug # remove when we are sure external-dns can be trusted

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: external-dns
-    version: v0.4.5
+    version: v0.4.6
 spec:
   strategy:
     type: Recreate
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: external-dns
-        version: v0.4.5
+        version: v0.4.6
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
@@ -26,7 +26,7 @@ spec:
          operator: Exists
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.5
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.6
         args:
         - --source=service
         - --source=ingress

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -49,6 +49,7 @@ spec:
           - "-address=:9999"
           - "-proxy-preserve-host"
           - "-serve-host-metrics"
+          - "-experimental-upgrade"
           - "-opentracing=tracing_instana"
         resources:
           limits:

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.10.0-alpha
+    version: v0.10.1-alpha
     component: ingress
 spec:
   selector:
@@ -18,7 +18,7 @@ spec:
       name: skipper-ingress
       labels:
         application: skipper-ingress
-        version: v0.10.0-alpha
+        version: v0.10.1-alpha
         component: ingress
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -38,7 +38,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: pierone.stups.zalan.do/teapot/skipper-tracing:v0.0.2
+        image: pierone.stups.zalan.do/teapot/skipper-tracing:v0.0.3
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -49,6 +49,7 @@ spec:
           - "-address=:9999"
           - "-proxy-preserve-host"
           - "-serve-host-metrics"
+          - "-metrics-exp-decay-sample"
           - "-opentracing=tracing_instana"
         resources:
           limits:


### PR DESCRIPTION
* externa-dns update from v0.4.4 to v0.4.6 which enables setting TTL for reference see: https://github.com/kubernetes-incubator/external-dns/releases/tag/v0.4.5 and https://github.com/kubernetes-incubator/external-dns/releases/tag/v0.4.6
* skipper-ingress with upgrade header support, which supports protocols like websockets or SPDY
* skipper-ingress update uses -metrics-exp-decay-sample flag which will fix calculation of SLOs for not high frequently used services