### PR TITLE
Add pdb-controller deployment

### DIFF
--- a/cluster/manifests/pdb-controller/deployment.yaml
+++ b/cluster/manifests/pdb-controller/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: pdb-controller
+  namespace: kube-system
+  labels:
+    application: pdb-controller
+    version: v0.0.1
+spec:
+  selector:
+    matchLabels:
+      application: pdb-controller
+  template:
+    metadata:
+      labels:
+        application: pdb-controller
+        version: v0.0.1
+    spec:
+      containers:
+      - name: pdb-controller
+        image: registry.opensource.zalan.do/teapot/pdb-controller:v0.0.1
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 10m
+            memory: 25Mi


### PR DESCRIPTION
Adds https://github.com/mikkeloscar/pdb-controller for generating default
Pod Disruption Budgets which is needed as part of the new update procedure.