### PR TITLE
pdb-controller needs more privileges

### DIFF
--- a/cluster/manifests/pdb-controller/deployment.yaml
+++ b/cluster/manifests/pdb-controller/deployment.yaml
@@ -16,6 +16,7 @@ spec:
         application: pdb-controller
         version: v0.0.1
     spec:
+      serviceAccountName: system
       containers:
       - name: pdb-controller
         image: registry.opensource.zalan.do/teapot/pdb-controller:v0.0.1


### PR DESCRIPTION
The controller needs to run with the system service account in order to create PDBs.