### PR TITLE
enable production/test mode on emergency-access-service

### DIFF
--- a/cluster/manifests/emergency-access-service/deployment.yaml
+++ b/cluster/manifests/emergency-access-service/deployment.yaml
@@ -36,6 +36,7 @@ spec:
         # enable audittrail reporting
         - --audittrail-url=https://audittrail.cloud.zalando.com
         - --jira-url=https://techjira.zalando.net
+        - --environment={{ .Environment }}
         env:
         - name: CONFIGMAP_NAMESPACE
           valueFrom:


### PR DESCRIPTION
This is needed to prevent emergency-access-service deployed to test clusters from creating invalid requests to teams api with a staging token. 

The PR to add this functionality to emergency-access-service was merged couple weeks ago 