### PR TITLE
Make Scalyr Region configurable

### DIFF
--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -35,11 +35,12 @@ spec:
         - |
             if [ ! -f /mnt/scalyr/agent.json ]; then
               echo '{
-                "import_vars": ["WATCHER_SCALYR_API_KEY", "WATCHER_CLUSTER_ID"],
+                "import_vars": ["WATCHER_SCALYR_API_KEY", "WATCHER_SCALYR_REGION", "WATCHER_CLUSTER_ID"],
                 "server_attributes": {"serverHost": "$WATCHER_CLUSTER_ID"},
                 "implicit_agent_process_metrics_monitor": false,
                 "implicit_metric_monitor": false,
                 "api_key": "$WATCHER_SCALYR_API_KEY",
+                "scalyr_server": "$WATCHER_SCALYR_REGION",
                 "monitors": [],
                 "logs": []
                 }' > /mnt/scalyr/agent.json;
@@ -109,6 +110,8 @@ spec:
             secretKeyRef:
               name: logging-agent
               key: scalyr-access-key
+        - name: WATCHER_SCALYR_REGION
+          value: "{{ .ConfigItems.scalyr_region }}"
         - name: WATCHER_CLUSTER_ID
           value: "{{ .ID }}"
 

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -40,10 +40,13 @@ spec:
                 "implicit_agent_process_metrics_monitor": false,
                 "implicit_metric_monitor": false,
                 "api_key": "$WATCHER_SCALYR_API_KEY",
-                "scalyr_server": "$WATCHER_SCALYR_REGION",
                 "monitors": [],
                 "logs": []
-                }' > /mnt/scalyr/agent.json;
+                ' > /mnt/scalyr/agent.json;
+                if [ -n "$WATCHER_SCALYR_REGION" ]; then
+                  echo ',"scalyr_server": "$WATCHER_SCALYR_REGION"' >> /mnt/scalyr/agent.json
+                fi
+                echo "}" >> /mnt/scalyr/agent.json
                 echo 'Updated agent.json to inital configuration';
             fi && cat /mnt/scalyr/agent.json;
             test -f /mnt/scalyr-checkpoint/checkpoints.json && ls -lah /mnt/scalyr-checkpoint/checkpoints.json && cat /mnt/scalyr-checkpoint/checkpoints.json || true;


### PR DESCRIPTION
This makes the Scalyr Region configurable and introduces the
environment variable ``WATCHER_SCALYR_REGION``.

This is required in order to log to ``https://upload.eu.scalyr.com``.

This fixes #654. Please do not merge yet, but let's discuss before.