### PR TITLE
Make Scalyr Region configurable 

### DIFF
--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -33,22 +33,28 @@ spec:
         command: ["sh", "-c"]
         args:
         - |
-            if [ ! -f /mnt/scalyr/agent.json ]; then
+            SCALYR_CONFIG_PATH="/mnt/scalyr/agent.json"
+            IMPORT_VARS="WATCHER_SCALYR_API_KEY WATCHER_CLUSTER_ID"
+            if [ ! -f $SCALYR_CONFIG_PATH ]; then
               echo '{
-                "import_vars": ["WATCHER_SCALYR_API_KEY", "WATCHER_SCALYR_REGION", "WATCHER_CLUSTER_ID"],
+                "import_vars": ["WATCHER_SCALYR_API_KEY", "WATCHER_CLUSTER_ID"],
                 "server_attributes": {"serverHost": "$WATCHER_CLUSTER_ID"},
                 "implicit_agent_process_metrics_monitor": false,
                 "implicit_metric_monitor": false,
                 "api_key": "$WATCHER_SCALYR_API_KEY",
                 "monitors": [],
                 "logs": []
-                ' > /mnt/scalyr/agent.json;
+                ' > $SCALYR_CONFIG_PATH;
                 if [ -n "$WATCHER_SCALYR_REGION" ]; then
-                  echo ',"scalyr_server": "$WATCHER_SCALYR_REGION"' >> /mnt/scalyr/agent.json
+                  IMPORT_VARS="$IMPORT_VARS WATCHER_SCALYR_REGION"
+                  echo ',"scalyr_server": "$WATCHER_SCALYR_REGION"' >> $SCALYR_CONFIG_PATH
                 fi
-                echo "}" >> /mnt/scalyr/agent.json
+                echo ', "import_vars":[' >> $SCALYR_CONFIG_PATH
+                for i in $IMPORT_VARS; do echo "\"$i\","; done | sed 's/",$/"/' >> $SCALYR_CONFIG_PATH
+                echo ' ]' >> $SCALYR_CONFIG_PATH
+                echo "}" >> $SCALYR_CONFIG_PATH
                 echo 'Updated agent.json to inital configuration';
-            fi && cat /mnt/scalyr/agent.json;
+            fi && cat $SCALYR_CONFIG_PATH;
             test -f /mnt/scalyr-checkpoint/checkpoints.json && ls -lah /mnt/scalyr-checkpoint/checkpoints.json && cat /mnt/scalyr-checkpoint/checkpoints.json || true;
         volumeMounts:
         - name: scalyr-config

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -45,12 +45,13 @@ spec:
                 "monitors": [],
                 "logs": []
                 ' > $SCALYR_CONFIG_PATH;
-                if [ -n "$WATCHER_SCALYR_REGION" ]; then
-                  IMPORT_VARS="$IMPORT_VARS WATCHER_SCALYR_REGION"
-                  echo ',"scalyr_server": "$WATCHER_SCALYR_REGION"' >> $SCALYR_CONFIG_PATH
+                if [ -n "$WATCHER_SCALYR_SERVER" ]; then
+                  IMPORT_VARS="$IMPORT_VARS WATCHER_SCALYR_SERVER"
+                  echo ',"scalyr_server": "$WATCHER_SCALYR_SERVER"' >> $SCALYR_CONFIG_PATH
                 fi
                 echo ', "import_vars":[' >> $SCALYR_CONFIG_PATH
-                for i in $IMPORT_VARS; do echo "\"$i\","; done | sed 's/",$/"/' >> $SCALYR_CONFIG_PATH
+                ALL_IMPORT_VARS=`for i in $IMPORT_VARS; do echo "\"$i\","; done`
+                echo $ALL_IMPORT_VARS | sed 's/",$/"/' >> $SCALYR_CONFIG_PATH
                 echo ' ]' >> $SCALYR_CONFIG_PATH
                 echo "}" >> $SCALYR_CONFIG_PATH
                 echo 'Updated agent.json to inital configuration';
@@ -119,8 +120,8 @@ spec:
             secretKeyRef:
               name: logging-agent
               key: scalyr-access-key
-        - name: WATCHER_SCALYR_REGION
-          value: "{{ .ConfigItems.scalyr_region }}"
+        - name: WATCHER_SCALYR_SERVER
+          value: "{{ .ConfigItems.scalyr_server }}"
         - name: WATCHER_CLUSTER_ID
           value: "{{ .ID }}"
 

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -35,11 +35,12 @@ spec:
         - |
             if [ ! -f /mnt/scalyr/agent.json ]; then
               echo '{
-                "import_vars": ["WATCHER_SCALYR_API_KEY", "WATCHER_CLUSTER_ID"],
+                "import_vars": ["WATCHER_SCALYR_API_KEY", "WATCHER_SCALYR_REGION", "WATCHER_CLUSTER_ID"],
                 "server_attributes": {"serverHost": "$WATCHER_CLUSTER_ID"},
                 "implicit_agent_process_metrics_monitor": false,
                 "implicit_metric_monitor": false,
                 "api_key": "$WATCHER_SCALYR_API_KEY",
+                "scalyr_server": "$WATCHER_SCALYR_REGION",
                 "monitors": [],
                 "logs": []
                 }' > /mnt/scalyr/agent.json;
@@ -109,6 +110,8 @@ spec:
             secretKeyRef:
               name: logging-agent
               key: scalyr-access-key
+        - name: WATCHER_SCALYR_REGION
+          value: "{{ .ConfigItems.scalyr_region }}"
         - name: WATCHER_CLUSTER_ID
           value: "{{ .ID }}"
 

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -40,10 +40,13 @@ spec:
                 "implicit_agent_process_metrics_monitor": false,
                 "implicit_metric_monitor": false,
                 "api_key": "$WATCHER_SCALYR_API_KEY",
-                "scalyr_server": "$WATCHER_SCALYR_REGION",
                 "monitors": [],
                 "logs": []
-                }' > /mnt/scalyr/agent.json;
+                ' > /mnt/scalyr/agent.json;
+                if [ -n "$WATCHER_SCALYR_REGION" ]; then
+                  echo ',"scalyr_server": "$WATCHER_SCALYR_REGION"' >> /mnt/scalyr/agent.json
+                fi
+                echo "}" >> /mnt/scalyr/agent.json
                 echo 'Updated agent.json to inital configuration';
             fi && cat /mnt/scalyr/agent.json;
             test -f /mnt/scalyr-checkpoint/checkpoints.json && ls -lah /mnt/scalyr-checkpoint/checkpoints.json && cat /mnt/scalyr-checkpoint/checkpoints.json || true;


### PR DESCRIPTION
This makes the Scalyr Region configurable and introduces the
environment variable ``WATCHER_SCALYR_REGION``.

This is required in order to log to ``https://upload.eu.scalyr.com``.

This fixes #654. Please do not merge yet, but let's discuss before.