### PR TITLE
Add etcd-backup cronjob

### DIFF
--- a/cluster/manifests/etcd-backup/cronjob.yaml
+++ b/cluster/manifests/etcd-backup/cronjob.yaml
@@ -1,0 +1,38 @@
+apiVersion: batch/v2alpha1
+kind: CronJob
+metadata:
+  name: etcd-backup
+  namespace: kube-system
+  labels:
+    application: etcd-backup
+    version: "master-2"
+spec:
+  schedule: "23 * * * *"
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            application: etcd-backup
+            version: "master-2"
+          annotations:
+            iam.amazonaws.com/role: "{{ .LocalID }}-etcd-backup"
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: etcd-backup
+            image: pierone.stups.zalan.do/teapot/etcd-backup:master-2
+            env:
+            - name: ETCD_S3_BACKUP_BUCKET
+              value: "{{ .ConfigItems.etcd_s3_backup_bucket }}"
+            - name: ETCD_ENDPOINTS
+              value: "{{ .ConfigItems.etcd_endpoints }}"
+            resources:
+              limits:
+                cpu: 100m
+                memory: 4Gi
+              requests:
+                cpu: 50m
+                memory: 2Gi

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -31,6 +31,8 @@ SenzaInfo:
           Description: "Name of the master node pool (ASG)"
       - WorkerNodePoolName:
           Description: "Name of the worker node pool (ASG)"
+      - EtcdS3BackupBucket:
+          Description: "Name of the S3 bucket used for etcd backups"
 
 SenzaComponents:
   - Configuration:
@@ -788,6 +790,42 @@ Resources:
             - {Action: 'autoscaling:Describe*', Effect: Allow, Resource: '*'}
             - {Action: 'autoscaling:CompleteLifecycleAction', Effect: Allow, Resource: '*'}
             - {Action: 'sts:AssumeRole', Effect: Allow, Resource: '*'}
+          Version: '2012-10-17'
+        PolicyName: root
+  ETCDS3BackupIAMRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: "{{SenzaInfo.StackName}}-{{SenzaInfo.StackVersion}}-etcd-backup"
+      AssumeRolePolicyDocument:
+        Statement:
+        - Action: ['sts:AssumeRole']
+          Effect: Allow
+          Principal:
+            Service: [ec2.amazonaws.com]
+        - Action: ['sts:AssumeRole']
+          Effect: Allow
+          Principal:
+            AWS:
+              Fn::Join:
+                - ""
+                -
+                  - arn:aws:iam::{{ AccountInfo.AccountID }}:role/
+                  -
+                    Ref: WorkerIAMRole
+        Version: '2012-10-17'
+      Path: /
+      Policies:
+      - PolicyDocument:
+          Statement:
+          - Effect: Allow
+            Action: ["s3:ListBucket"]
+            Resource: ["arn:aws:s3:::{{ Arguments.EtcdS3BackupBucket }}"]
+          - Effect: Allow
+            Action:
+            - "s3:PutObject"
+            - "s3:GetObject"
+            - "s3:DeleteObject"
+            Resource: ["arn:aws:s3:::{{ Arguments.EtcdS3BackupBucket }}/*"]
           Version: '2012-10-17'
         PolicyName: root
 Outputs:

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -548,6 +548,7 @@ Resources:
             - {Action: 'route53:List*', Effect: Allow, Resource: '*'}
             - {Action: 'tag:Get*', Effect: Allow, Resource: '*'}
             - {Action: 'dynamodb:ListTables', Effect: Allow, Resource: '*'}
+            - {Action: 's3:ListBucket', Effect: Allow, Resource: '*'}
             - Action: "s3:GetObject"
               Resource: "arn:aws:s3:::{{ AccountInfo.MintBucket }}/gerry/*"
               Effect: Allow


### PR DESCRIPTION
This adds a Cronjob for making snapshots of etcd3 and pushing it to an S3 bucket once an hour.

Also allows ZMON `s3:ListBucket` access so we can make a zmon check that verifies that the backups are created every hour.