### PR TITLE
kube-aws-autoscaler v0.10

### DIFF
--- a/cluster/manifests/cluster-autoscaler/deployment.yaml
+++ b/cluster/manifests/cluster-autoscaler/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: cluster-autoscaler
-    version: v0.9
+    version: v0.10
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: cluster-autoscaler
-        version: v0.9
+        version: v0.10
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-autoscaler"
@@ -25,7 +25,7 @@ spec:
         operator: Exists
       containers:
       - name: cluster-autoscaler
-        image: registry.opensource.zalan.do/teapot/kube-aws-autoscaler:0.9-1
+        image: registry.opensource.zalan.do/teapot/kube-aws-autoscaler:0.10-1
         envFrom:
         - configMapRef:
             # load buffer settings from ConfigMap e.g. to set spare nodes to zero for test environments


### PR DESCRIPTION
Update autoscaler to v0.10 to support >50 nodes. See https://github.com/hjacobs/kube-aws-autoscaler/releases/tag/0.10