### PR TITLE
set logging level of controller manager to 7

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -526,6 +526,7 @@ write_files:
           - --cloud-config=/etc/kubernetes/cloud-config.ini
           - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true
           - --use-service-account-credentials=true
+          - --v=7
           resources:
             limits:
               cpu: 200m


### PR DESCRIPTION
this increases the logging level of the controller manager to monitor issues with volume mounts. Didn't set it to any higher number because there it starts to dump all request and with leader election it is a huge logging load. 