### PR TITLE
fix skipper-ingress edge case in predicate/filter handling 

### DIFF
--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.9.115
+    version: v0.9.120
     component: ingress
 spec:
   selector:
@@ -18,7 +18,7 @@ spec:
       name: skipper-ingress
       labels:
         application: skipper-ingress
-        version: v0.9.115
+        version: v0.9.120
         component: ingress
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -38,7 +38,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.9.115
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.9.120
         ports:
         - name: ingress-port
           containerPort: 9999


### PR DESCRIPTION
fix >1 ingress with the same host header has custom predicates and filters it would only recognize them in the first route