### PR TITLE
Dev to alpha

### DIFF
--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.3.10
+    version: v0.4.0
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.3.10
+        version: v0.4.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
@@ -26,7 +26,7 @@ spec:
         operator: Exists
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.3.10
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.4.0
         env:
         - name: AWS_REGION
           value: {{ .Region }}

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.9.115
+    version: v0.9.120
     component: ingress
 spec:
   selector:
@@ -18,7 +18,7 @@ spec:
       name: skipper-ingress
       labels:
         application: skipper-ingress
-        version: v0.9.115
+        version: v0.9.120
         component: ingress
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -38,7 +38,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.9.115
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.9.120
         ports:
         - name: ingress-port
           containerPort: 9999

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -383,6 +383,8 @@ Resources:
           Value: owned
         - Key: "ClusterID"
           Value: "{{ Arguments.ClusterID }}"
+        - Key: "kubernetes:application"
+          Value: "kube-ingress-aws-controller"
     Type: AWS::EC2::SecurityGroup
 
   MasterSecurityGroupIngressFromWorker:

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -427,7 +427,7 @@ write_files:
             - name: TOKEN_INTROSPECTION_URL
               value: http://127.0.0.1:9021/oauth2/introspect
             - name: USER_GROUPS
-              value: stups_autobahn=Administrator,stups_deployment-controller-ui=ReadOnly,credentials-provider=Administrator,credprov-kube-ops-view-read-only-token=ReadOnly,credprov-cluster-lifecycle-manager-cluster-rw-token=Administrator,credprov-cluster-lifecycle-manager-test-cluster-rw-token=Administrator,credprov-cdp-controller-cluster-token=PowerUser,credprov-api-discovery-k8s-cluster-read-only-token=ReadOnly
+              value: stups_autobahn=Administrator,stups_deployment-controller-ui=ReadOnly,credentials-provider=Administrator,credprov-kube-ops-view-read-only-token=ReadOnly,credprov-cluster-lifecycle-manager-cluster-rw-token=Administrator,credprov-cluster-lifecycle-manager-test-cluster-rw-token=Administrator,credprov-cdp-controller-cluster-token=PowerUser,credprov-api-discovery-k8s-cluster-read-only-token=ReadOnly,stups_zmon-zmon=ReadOnly
             - name: BUSINESS_PARTNER_IDS
               value: {{ APISERVER_BUSINESS_PARTNER_IDS }}
           volumeMounts:

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -526,7 +526,7 @@ write_files:
           - --cloud-config=/etc/kubernetes/cloud-config.ini
           - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true
           - --use-service-account-credentials=true
-          - --v=7
+          - --v=4
           resources:
             limits:
               cpu: 200m


### PR DESCRIPTION
Blackfriday preparation requires better monitoring

- feature: add monitoring role to allow calls from outside the cluster possible to check the apiserver
- bugfix: skipper-ingress with same hostname ignored arbitrary filters and predicates
- logs: reduce controller-manger logging to omit ratelimits in logging infrastructure
- update kube-ingress-aws-controller to reduce dependencies on our custom cluster setup