### PR TITLE
bump version 

### DIFF
--- a/cluster/manifests/kube-state-metrics/deployment.yaml
+++ b/cluster/manifests/kube-state-metrics/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-state-metrics
-    version: v1.0.0
+    version: v1.1.0
 spec:
   replicas: 1
   selector:
@@ -15,10 +15,10 @@ spec:
     metadata:
       labels:
         application: kube-state-metrics
-        version: v1.0.0
+        version: v1.1.0
     spec:
       containers:
-      - image: registry.opensource.zalan.do/teapot/kube-state-metrics:v1.0.0
+      - image: registry.opensource.zalan.do/teapot/kube-state-metrics:v1.1.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/cluster/manifests/kube-state-metrics/deployment.yaml
+++ b/cluster/manifests/kube-state-metrics/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-state-metrics
-    version: v0.3.3
+    version: v1.0.0
 spec:
   replicas: 1
   selector:
@@ -15,10 +15,10 @@ spec:
     metadata:
       labels:
         application: kube-state-metrics
-        version: v0.3.3
+        version: v1.0.0
     spec:
       containers:
-      - image: registry.opensource.zalan.do/teapot/kube-state-metrics:v0.5.0
+      - image: registry.opensource.zalan.do/teapot/kube-state-metrics:v1.0.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080


### PR DESCRIPTION
https://github.com/kubernetes/kube-state-metrics/releases

    [FEATURE] Add kube_pod_container_status_waiting_reason metric.
    [FEATURE] Add kube_node_status_capacity_nvidia_gpu_cards and kube_node_status_allocatable_nvidia_gpu_cards metrics.
    [FEATURE] Add kube_persistentvolumeclaim_info, kube_persistentvolumeclaim_status_phase and kube_persistentvolumeclaim_resource_requests_storage_bytes metrics.
    [FEATURE] Add kube_cronjob_created metric.
    [FEATURE] Add kube_namespace_status_phase, kube_namespace_labels and kube_namespace_created metrics.
    [FEATURE] Add *_created metrics for all available collectors and resources.
    [FEATURE] Add ability to specify glog flags.
    [FEATURE] Add ability to limit kube-state-metrics objects to single namespace.
    [ENHANCEMENT] Bump client-go to 5.0 release branch.
    [ENHANCEMENT] Add pprof endpoints for profiling.
    [ENHANCEMENT] Log resources and API versions used when collecting metrics from objects.
    [ENHANCEMENT] Log number of resources used to generate metrics off of.
    [ENHANCEMENT] Improve a usage message for collectors flag.
    [BUGFIX] Fix Job start time nil panic.

    [BUGFIX] Fix nil pointer panic when pods have an owner without controllers.

    [CHANGE] Remove kube_node_status_ready, kube_node_status_out_of_disk, kube_node_status_memory_pressure, kube_node_status_disk_pressure, and kube_node_status_network_unavailable metrics in favor of one generic kube_node_status_condition metric.
    [CHANGE] Flatten created by label on kube_pod_info metric.
    [FEATURE] Add kube_pod_start_time metric.
    [FEATURE] Add PersistentVolumeClaim metrics.
    [FEATURE] Add StatefulSet metrics.
    [FEATURE] Add Job and CronJob metrics.
    [FEATURE] Add label metrics for deployments.
    [FEATURE] Add kube_node_status_disk_pressure metric.
    [FEATURE] Add kube_pod_owner metrics.
    [ENHANCEMENT] Add provider_id label to kube_node_info metric.
    [BUGFIX] Fix various nil pointer panics.