### PR TITLE
Update zmon-scheduler ports

### DIFF
--- a/cluster/manifests/zmon-scheduler/deployment.yaml
+++ b/cluster/manifests/zmon-scheduler/deployment.yaml
@@ -36,6 +36,7 @@ spec:
 
           ports:
             - containerPort: 7979
+            - containerPort: 8085
 
           readinessProbe:
             httpGet:


### PR DESCRIPTION
Add port 8085 to expose scheduler API