### PR TITLE
Bump --node-monitor-grace-period as well

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -526,6 +526,7 @@ write_files:
           - --cloud-config=/etc/kubernetes/cloud-config.ini
           - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true
           - --use-service-account-credentials=true
+          - --node-monitor-grace-period=1h
           - --pod-eviction-timeout=1h
           - --v=4
           resources:


### PR DESCRIPTION
`pod-eviction-timeout` is ignored when using taint-based evictions apparently.