### PR TITLE
add skipper-ingress as clusterIP svc

### DIFF
--- a/cluster/manifests/skipper/service.yaml
+++ b/cluster/manifests/skipper/service.yaml
@@ -1,0 +1,15 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: skipper-ingress
+  namespace: kube-system
+  labels:
+    application: skipper-ingress
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 9999
+      protocol: TCP
+  selector:
+    application: skipper-ingress


### PR DESCRIPTION
this PR adds a service ClusterIP to reach skipper-ingress within the cluster to get the full power of skipper-ingress route defintions from inside the cluster.

* ingress flow https://my-app.my-acc.zalan.do/ : client -> ALB -> skipper-ingress -> my-app svc -> my-app pod
* svc flow: http://my-app.default.cluster.local/: client -> my-app svc -> my-app pod
* new cluster internal: curl -H "Host: my-app.my-acc.zalan.do" http://skipper-ingress.kube-system.cluster.local/
* new skipper-svc flow:  skipper svc -> skipper-ingress -> my-app svc -> my-app pod