### PR TITLE
Add missing resource requests

### DIFF
--- a/cluster/manifests/emergency-access-service/deployment.yaml
+++ b/cluster/manifests/emergency-access-service/deployment.yaml
@@ -63,7 +63,7 @@ spec:
           timeoutSeconds: 1
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 100Mi
       volumes:
       - name: platform-iam-credentials

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -35,3 +35,10 @@ spec:
         - --txt-owner-id={{ .Region }}:{{ .LocalID }}
         - --compatibility=mate # remove when we switched to the new annotations
         - --log-level=debug # remove when we are sure external-dns can be trusted
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 25m
+            memory: 20Mi

--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -79,6 +79,13 @@ spec:
             - /meta/credentials
             - --application-id=gerry
             - --mint-bucket=s3://{{ .ConfigItems.gerry_mint_bucket }}
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+            requests:
+              cpu: 10m
+              memory: 10Mi
 
           volumeMounts:
             - name: credentials

--- a/cluster/manifests/zmon-aws-agent/deployment.yaml
+++ b/cluster/manifests/zmon-aws-agent/deployment.yaml
@@ -53,6 +53,13 @@ spec:
             - /meta/credentials
             - --application-id=gerry
             - --mint-bucket=s3://{{ .ConfigItems.gerry_mint_bucket }}
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+            requests:
+              cpu: 10m
+              memory: 10Mi
 
           volumeMounts:
             - name: credentials

--- a/cluster/manifests/zmon-scheduler/deployment.yaml
+++ b/cluster/manifests/zmon-scheduler/deployment.yaml
@@ -98,6 +98,13 @@ spec:
             - /meta/credentials
             - --application-id=gerry
             - --mint-bucket=s3://{{ .ConfigItems.gerry_mint_bucket }}
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+            requests:
+              cpu: 10m
+              memory: 10Mi
 
           volumeMounts:
             - name: credentials

--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -82,6 +82,13 @@ spec:
             - /meta/credentials
             - --application-id=gerry
             - --mint-bucket=s3://{{ .ConfigItems.gerry_mint_bucket }}
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+            requests:
+              cpu: 10m
+              memory: 10Mi
 
           volumeMounts:
             - name: credentials


### PR DESCRIPTION
This PR simply tweaks resource requests:

* add missing resource requests, esp. for the `gerry` container and `external-dns`
* reduce the CPU requests for Emergency Access Service (it does not do anything most of the time)

I think the requests are reasonable, see the current resource usage:

```
$ zkubectl top pod -n kube-system --containers | grep 'gerry\|external-dns'
zmon-scheduler-1791387885-hhjkn                                         gerry                      0m           6Mi             
zmon-worker-2083801963-wnsm0                                            gerry                      0m           5Mi             
zmon-agent-3058079644-h7gqt                                             gerry                      0m           6Mi             
zmon-worker-2083801963-vr3x4                                            gerry                      0m           7Mi             
zmon-worker-2083801963-jlm7t                                            gerry                      0m           7Mi             
external-dns-35691714-2405z                                             external-dns               0m           12Mi            
```

I found these missing resource requests when running `zkubectl get pods -o custom-columns=NAME:.metadata.name,RES:.spec.containers[0].resources -n kube-system` to check the current requests.