### PR TITLE
Update Authnz webhook to v0.3.7

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -394,7 +394,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.3.6
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.3.7
           name: webhook
           ports:
           - containerPort: 8081


### PR DESCRIPTION
Enables the `default` service account in any namespace to read from the Kubernetes API.