### PR TITLE
External DNS v0.4.8

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: external-dns
-    version: v0.4.6
+    version: v0.4.8
 spec:
   strategy:
     type: Recreate
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: external-dns
-        version: v0.4.6
+        version: v0.4.8
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
@@ -26,7 +26,7 @@ spec:
          operator: Exists
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.6
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.8
         args:
         - --source=service
         - --source=ingress


### PR DESCRIPTION
External DNS v0.4.8 was just released: https://github.com/kubernetes-incubator/external-dns/releases/tag/v0.4.8 :tada: 

Notable changes for us:

* add support for Headless hostPort services
* AWS: Added change batch limiting to a maximum of 4000 Route53 updates in one API call. 