### PR TITLE
etcd backup tool: backup v2 data as well

### DIFF
--- a/cluster/manifests/etcd-backup/cronjob.yaml
+++ b/cluster/manifests/etcd-backup/cronjob.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: etcd-backup
-    version: "master-2"
+    version: "master-3"
 spec:
   schedule: "23 * * * *"
   concurrencyPolicy: Forbid
@@ -16,14 +16,14 @@ spec:
         metadata:
           labels:
             application: etcd-backup
-            version: "master-2"
+            version: "master-3"
           annotations:
             iam.amazonaws.com/role: "{{ .LocalID }}-etcd-backup"
         spec:
           restartPolicy: Never
           containers:
           - name: etcd-backup
-            image: pierone.stups.zalan.do/teapot/etcd-backup:master-2
+            image: pierone.stups.zalan.do/teapot/etcd-backup:master-3
             env:
             - name: ETCD_S3_BACKUP_BUCKET
               value: "{{ .ConfigItems.etcd_s3_backup_bucket }}"


### PR DESCRIPTION
This will allow us to restore flannel data as well and works transparently for v2 clusters.