### PR TITLE
Update zmon-worker

### DIFF
--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -12,7 +12,7 @@ spec:
     metadata:
       labels:
         application: zmon-worker
-        version: "zv227"
+        version: "zv228"
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -22,7 +22,7 @@ spec:
         operator: Exists
       containers:
         - name: zmon-worker
-          image: "pierone.stups.zalan.do/stups/zmon-worker:zv227"
+          image: "pierone.stups.zalan.do/stups/zmon-worker:zv228"
           resources:
             limits:
               cpu: 500m


### PR DESCRIPTION
Changes:

**zmon-worker**

- Send extra kubernetes related fields in check results: ``application``, ``version``, ``cluster_alias``, ``alias``.
- Fields come from entities discovered by ZMON kubernetes [agent](https://github.com/zalando-zmon/zmon-agent-core).