### PR TITLE
Convert PlatformCredentialsSets from TPR -> CRD

### DIFF
--- a/cluster/manifests/emergency-access-service/credentials.yaml
+++ b/cluster/manifests/emergency-access-service/credentials.yaml
@@ -1,14 +1,20 @@
-# from: ../platformcredentialsset/thirdpartyresource.yaml
+# from: ../platformcredentialsset/customresourcedefinition.yaml
 # This is a hack put in place to ensure that the ThirdPartyResource will be
 # created before the actual PlatformCredentialsSet resource.
-apiVersion: extensions/v1beta1
-kind: ThirdPartyResource
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
 metadata:
-  # NOTE: dashes are needed to get proper PlatformCredentialsSet name
-  name: platform-credentials-set.zalando.org
-description: "A specification to declare needed OAuth credentials (tokens, clients) for the Zalando Platform IAM system"
-versions:
-- name: v1
+  name: platformcredentialssets.zalando.org
+spec:
+  scope: Namespaced
+  group: zalando.org
+  version: v1
+  names:
+    kind: PlatformCredentialsSet
+    plural: platformcredentialssets
+    singular: platformcredentialsset
+    shortNames:
+    - pcs
 
 ---
 

--- a/cluster/manifests/platformcredentialsset/customresourcedefinition.yaml
+++ b/cluster/manifests/platformcredentialsset/customresourcedefinition.yaml
@@ -1,0 +1,16 @@
+# A specification to declare needed OAuth credentials (tokens, clients) for the
+# Zalando Platform IAM system
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: platformcredentialssets.zalando.org
+spec:
+  scope: Namespaced
+  group: zalando.org
+  version: v1
+  names:
+    kind: PlatformCredentialsSet
+    plural: platformcredentialssets
+    singular: platformcredentialsset
+    shortNames:
+    - pcs

--- a/cluster/manifests/platformcredentialsset/thirdpartyresource.yaml
+++ b/cluster/manifests/platformcredentialsset/thirdpartyresource.yaml
@@ -1,8 +1,0 @@
-apiVersion: extensions/v1beta1
-kind: ThirdPartyResource
-metadata:
-  # NOTE: dashes are needed to get proper PlatformCredentialsSet name
-  name: platform-credentials-set.zalando.org
-description: "A specification to declare needed OAuth credentials (tokens, clients) for the Zalando Platform IAM system"
-versions:
-- name: v1


### PR DESCRIPTION
This replaces the Third Party Resource defintion for the `PlatformCredentialsSets` to a Custom Resource Definition.

It's a prerequisite before merging that all clusters in the target branch has been converted manually following the guide here: https://kubernetes.io/docs/tasks/access-kubernetes-api/migrate-third-party-resource/

## Clusters

* [x] teapot
* [ ] stups-test
* [ ] playground