### PR TITLE
etcd-backup: reduce memory request/limits

### DIFF
--- a/cluster/manifests/etcd-backup/cronjob.yaml
+++ b/cluster/manifests/etcd-backup/cronjob.yaml
@@ -32,7 +32,7 @@ spec:
             resources:
               limits:
                 cpu: 100m
-                memory: 4Gi
+                memory: 512Mi
               requests:
                 cpu: 50m
-                memory: 2Gi
+                memory: 256Mi


### PR DESCRIPTION
It's scripting a bunch of tools that don't need 2GB to work.