### PR TITLE
Update kube-aws-autoscaler to 0.11

### DIFF
--- a/cluster/manifests/cluster-autoscaler/deployment.yaml
+++ b/cluster/manifests/cluster-autoscaler/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         operator: Exists
       containers:
       - name: cluster-autoscaler
-        image: registry.opensource.zalan.do/teapot/kube-aws-autoscaler:0.10-1
+        image: registry.opensource.zalan.do/teapot/kube-aws-autoscaler:0.11
         envFrom:
         - configMapRef:
             # load buffer settings from ConfigMap e.g. to set spare nodes to zero for test environments


### PR DESCRIPTION
This should fix the issue with failed job pods still being considered by the autoscaler.