### PR TITLE
Promote alpha to beta

### DIFF
--- a/cluster/manifests/emergency-access-service/credentials.yaml
+++ b/cluster/manifests/emergency-access-service/credentials.yaml
@@ -1,14 +1,20 @@
-# from: ../platformcredentialsset/thirdpartyresource.yaml
+# from: ../platformcredentialsset/customresourcedefinition.yaml
 # This is a hack put in place to ensure that the ThirdPartyResource will be
 # created before the actual PlatformCredentialsSet resource.
-apiVersion: extensions/v1beta1
-kind: ThirdPartyResource
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
 metadata:
-  # NOTE: dashes are needed to get proper PlatformCredentialsSet name
-  name: platform-credentials-set.zalando.org
-description: "A specification to declare needed OAuth credentials (tokens, clients) for the Zalando Platform IAM system"
-versions:
-- name: v1
+  name: platformcredentialssets.zalando.org
+spec:
+  scope: Namespaced
+  group: zalando.org
+  version: v1
+  names:
+    kind: PlatformCredentialsSet
+    plural: platformcredentialssets
+    singular: platformcredentialsset
+    shortNames:
+    - pcs
 
 ---
 

--- a/cluster/manifests/emergency-access-service/deployment.yaml
+++ b/cluster/manifests/emergency-access-service/deployment.yaml
@@ -63,7 +63,7 @@ spec:
           timeoutSeconds: 1
         resources:
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 100Mi
       volumes:
       - name: platform-iam-credentials

--- a/cluster/manifests/etcd-backup/cronjob.yaml
+++ b/cluster/manifests/etcd-backup/cronjob.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: etcd-backup
-    version: "master-3"
+    version: "master-5"
 spec:
   schedule: "23 * * * *"
   concurrencyPolicy: Forbid
@@ -16,14 +16,14 @@ spec:
         metadata:
           labels:
             application: etcd-backup
-            version: "master-3"
+            version: "master-5"
           annotations:
             iam.amazonaws.com/role: "{{ .LocalID }}-etcd-backup"
         spec:
           restartPolicy: Never
           containers:
           - name: etcd-backup
-            image: pierone.stups.zalan.do/teapot/etcd-backup:master-3
+            image: pierone.stups.zalan.do/teapot/etcd-backup:master-5
             env:
             - name: ETCD_S3_BACKUP_BUCKET
               value: "{{ .ConfigItems.etcd_s3_backup_bucket }}"

--- a/cluster/manifests/etcd-backup/cronjob.yaml
+++ b/cluster/manifests/etcd-backup/cronjob.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: etcd-backup
-    version: "master-2"
+    version: "master-3"
 spec:
   schedule: "23 * * * *"
   concurrencyPolicy: Forbid
@@ -16,14 +16,14 @@ spec:
         metadata:
           labels:
             application: etcd-backup
-            version: "master-2"
+            version: "master-3"
           annotations:
             iam.amazonaws.com/role: "{{ .LocalID }}-etcd-backup"
         spec:
           restartPolicy: Never
           containers:
           - name: etcd-backup
-            image: pierone.stups.zalan.do/teapot/etcd-backup:master-2
+            image: pierone.stups.zalan.do/teapot/etcd-backup:master-3
             env:
             - name: ETCD_S3_BACKUP_BUCKET
               value: "{{ .ConfigItems.etcd_s3_backup_bucket }}"

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: external-dns
-    version: v0.4.6
+    version: v0.4.8
 spec:
   strategy:
     type: Recreate
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: external-dns
-        version: v0.4.6
+        version: v0.4.8
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
@@ -26,7 +26,7 @@ spec:
          operator: Exists
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.6
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.8
         args:
         - --source=service
         - --source=ingress

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -35,3 +35,10 @@ spec:
         - --txt-owner-id={{ .Region }}:{{ .LocalID }}
         - --compatibility=mate # remove when we switched to the new annotations
         - --log-level=debug # remove when we are sure external-dns can be trusted
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 25m
+            memory: 20Mi

--- a/cluster/manifests/platformcredentialsset/customresourcedefinition.yaml
+++ b/cluster/manifests/platformcredentialsset/customresourcedefinition.yaml
@@ -1,0 +1,16 @@
+# A specification to declare needed OAuth credentials (tokens, clients) for the
+# Zalando Platform IAM system
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: platformcredentialssets.zalando.org
+spec:
+  scope: Namespaced
+  group: zalando.org
+  version: v1
+  names:
+    kind: PlatformCredentialsSet
+    plural: platformcredentialssets
+    singular: platformcredentialsset
+    shortNames:
+    - pcs

--- a/cluster/manifests/platformcredentialsset/thirdpartyresource.yaml
+++ b/cluster/manifests/platformcredentialsset/thirdpartyresource.yaml
@@ -1,8 +1,0 @@
-apiVersion: extensions/v1beta1
-kind: ThirdPartyResource
-metadata:
-  # NOTE: dashes are needed to get proper PlatformCredentialsSet name
-  name: platform-credentials-set.zalando.org
-description: "A specification to declare needed OAuth credentials (tokens, clients) for the Zalando Platform IAM system"
-versions:
-- name: v1

--- a/cluster/manifests/skipper/service.yaml
+++ b/cluster/manifests/skipper/service.yaml
@@ -1,0 +1,15 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: skipper-ingress
+  namespace: kube-system
+  labels:
+    application: skipper-ingress
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 9999
+      protocol: TCP
+  selector:
+    application: skipper-ingress

--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -79,6 +79,13 @@ spec:
             - /meta/credentials
             - --application-id=gerry
             - --mint-bucket=s3://{{ .ConfigItems.gerry_mint_bucket }}
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+            requests:
+              cpu: 10m
+              memory: 10Mi
 
           volumeMounts:
             - name: credentials

--- a/cluster/manifests/zmon-aws-agent/deployment.yaml
+++ b/cluster/manifests/zmon-aws-agent/deployment.yaml
@@ -53,6 +53,13 @@ spec:
             - /meta/credentials
             - --application-id=gerry
             - --mint-bucket=s3://{{ .ConfigItems.gerry_mint_bucket }}
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+            requests:
+              cpu: 10m
+              memory: 10Mi
 
           volumeMounts:
             - name: credentials

--- a/cluster/manifests/zmon-scheduler/deployment.yaml
+++ b/cluster/manifests/zmon-scheduler/deployment.yaml
@@ -98,6 +98,13 @@ spec:
             - /meta/credentials
             - --application-id=gerry
             - --mint-bucket=s3://{{ .ConfigItems.gerry_mint_bucket }}
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+            requests:
+              cpu: 10m
+              memory: 10Mi
 
           volumeMounts:
             - name: credentials

--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -82,6 +82,13 @@ spec:
             - /meta/credentials
             - --application-id=gerry
             - --mint-bucket=s3://{{ .ConfigItems.gerry_mint_bucket }}
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+            requests:
+              cpu: 10m
+              memory: 10Mi
 
           volumeMounts:
             - name: credentials

--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -12,7 +12,7 @@ spec:
     metadata:
       labels:
         application: zmon-worker
-        version: "zv227"
+        version: "zv228"
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -22,7 +22,7 @@ spec:
         operator: Exists
       containers:
         - name: zmon-worker
-          image: "pierone.stups.zalan.do/stups/zmon-worker:zv227"
+          image: "pierone.stups.zalan.do/stups/zmon-worker:zv228"
           resources:
             limits:
               cpu: 500m

--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -12,7 +12,7 @@ spec:
     metadata:
       labels:
         application: zmon-worker
-        version: "zv225"
+        version: "zv227"
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -22,7 +22,7 @@ spec:
         operator: Exists
       containers:
         - name: zmon-worker
-          image: "pierone.stups.zalan.do/stups/zmon-worker:zv225"
+          image: "pierone.stups.zalan.do/stups/zmon-worker:zv227"
           resources:
             limits:
               cpu: 500m

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -394,7 +394,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.3.6
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.3.7
           name: webhook
           ports:
           - containerPort: 8081


### PR DESCRIPTION
Notable changes:
* Convert PlatformCredentialsSets from TPR -> CRD
* Upgrade zmon-worker
* etcd backup tool: backup v2 data as well
* External DNS v0.4.8
* Update Authnz webhook to v0.3.7
* add missing resource requests
* this PR adds a service ClusterIP to reach skipper-ingress within the cluster to get the full power of skipper-ingress route defintions from inside the cluster.