### PR TITLE
chore: use latest version of ingress controller

### DIFF
--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.4.0
+    version: v0.4.1
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.4.0
+        version: v0.4.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
@@ -26,7 +26,7 @@ spec:
         operator: Exists
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.4.0
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.4.1
         env:
         - name: AWS_REGION
           value: {{ .Region }}


### PR DESCRIPTION
* ~~Support for multiple subnets~~ support the old KubernetesCluster tag used by kops 

/cc @szuecs 