### PR TITLE
Run flannel with etcd backend as daemonset

### DIFF
--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -1,0 +1,81 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: kube-flannel
+  namespace: kube-system
+  labels:
+    application: flannel
+    version: v0.9.1
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      application: flannel
+  template:
+    metadata:
+      labels:
+        application: flannel
+        version: v0.9.1
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      initContainers:
+      - name: etcdctl
+        image: quay.io/coreos/etcd:v3.2.10
+        args:
+        - etcdctl
+        - --endpoint=http://127.0.0.1:2379
+        - set
+        - /coreos.com/network/config
+        - '{"Network": "10.2.0.0/16", "Backend": {"Type": "vxlan"}}'
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+          requests:
+            cpu: 25m
+            memory: 25Mi
+      containers:
+      - name: kube-flannel
+        image: quay.io/coreos/flannel:v0.9.1
+        args:
+        - --etcd-endpoints=http://127.0.0.1:2379
+        - --iface=eth0
+        - --ip-masq
+        - --healthz-ip=127.0.0.1
+        - --healthz-port=7978
+        - --v=2
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+          requests:
+            cpu: 25m
+            memory: 25Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: runflannel
+          mountPath: /run/flannel
+      hostNetwork: true
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      - operator: Exists
+        effect: NoExecute
+      - operator: Exists
+        key: CriticalAddonsOnly
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: flannel
+                operator: NotIn
+                values:
+                - local
+      volumes:
+      - name: runflannel
+        hostPath:
+          path: /run/flannel

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -53,14 +53,14 @@ coreos:
           [Service]
           Environment="FLANNELD_IFACE="$private_ipv4"
           Environment="FLANNELD_ETCD_ENDPOINTS="http://127.0.0.1:2379"
-          Environment="FLANNEL_IMAGE_TAG=v0.9.0"
+          Environment="FLANNEL_IMAGE_TAG=v0.9.1"
 
     - name: flannel-docker-opts.service
       drop-ins:
       - name: 20-version.conf
         content: |
           [Service]
-          Environment="FLANNEL_IMAGE_TAG=v0.9.0"
+          Environment="FLANNEL_IMAGE_TAG=v0.9.1"
 
     - name: kube2iam-iptables.service
       command: start
@@ -145,6 +145,7 @@ coreos:
         --register-schedulable=false \
         --allow-privileged \
         --node-labels=kubernetes.io/role=master,master=true \
+        --node-labels=flannel=local \
         --node-labels={{NODE_LABELS}} \
         --pod-manifest-path=/etc/kubernetes/manifests \
         --cluster_dns=10.3.0.10 \

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -47,7 +47,7 @@ coreos:
           [Service]
           Environment="FLANNELD_IFACE="$private_ipv4"
           Environment="FLANNELD_ETCD_ENDPOINTS="http://127.0.0.1:2379"
-          Environment="FLANNEL_IMAGE_TAG=v0.9.0"
+          Environment="FLANNEL_IMAGE_TAG=v0.9.1"
           Environment="FLANNEL_OPTS=--ip-masq=true -v 2"
 
     - name: flannel-docker-opts.service
@@ -55,7 +55,7 @@ coreos:
       - name: 20-version.conf
         content: |
           [Service]
-          Environment="FLANNEL_IMAGE_TAG=v0.9.0"
+          Environment="FLANNEL_IMAGE_TAG=v0.9.1"
 
     - name: timesynced-enable-network-time.service
       command: start
@@ -131,6 +131,7 @@ coreos:
         --register-node \
         --allow-privileged \
         --node-labels=kubernetes.io/role=worker \
+        --node-labels=flannel=local \
         --node-labels={{NODE_LABELS}} \
         --pod-manifest-path=/etc/kubernetes/manifests \
         --cluster_dns=10.3.0.10 \


### PR DESCRIPTION
This changes `flannel` to run as a Daemonset but still keeping the etcd backend in order to prepare for the migration, see [Migration strategy](https://github.bus.zalan.do/teapot/issues/issues/683#issue-251780).

This is the first stage of a two-stage rollout which deploys but doesn't activate the flannel daemonset, yet.

- [x] This is PR is intended to see if e2e passes. The actual rollout will require to split this PR in two stages.