### PR TITLE
Change etcd instance type to m4.large

### DIFF
--- a/cluster/etcd-cluster.yaml
+++ b/cluster/etcd-cluster.yaml
@@ -4,7 +4,7 @@ SenzaComponents:
 - AppServer:
     IamRoles:
     - Ref: EtcdRole
-    InstanceType: t2.medium
+    InstanceType: m4.large
     SecurityGroups:
     - Fn::GetAtt:
       - EtcdSecurityGroup


### PR DESCRIPTION
Changes the instance type to m4.large which is what we currently use until we get a reply from AWS regarding the t2.mediums having issues.