### PR TITLE
Promote alpha to beta

### DIFF
--- a/cluster/manifests/cluster-autoscaler/deployment.yaml
+++ b/cluster/manifests/cluster-autoscaler/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         operator: Exists
       containers:
       - name: cluster-autoscaler
-        image: registry.opensource.zalan.do/teapot/kube-aws-autoscaler:0.10-1
+        image: registry.opensource.zalan.do/teapot/kube-aws-autoscaler:0.11
         envFrom:
         - configMapRef:
             # load buffer settings from ConfigMap e.g. to set spare nodes to zero for test environments

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -6,6 +6,5 @@
 
 pre_apply: [] # everything defined under here will be deleted before applying the manifests
 post_apply: # everything defined under here will be deleted after applying the manifests
-- name: instana-agent
-  namespace: kube-system
-  kind: daemonset
+- name: platform-credentials-set.zalando.org
+  kind: thirdpartyresource

--- a/cluster/manifests/etcd-backup/cronjob.yaml
+++ b/cluster/manifests/etcd-backup/cronjob.yaml
@@ -32,7 +32,7 @@ spec:
             resources:
               limits:
                 cpu: 100m
-                memory: 4Gi
+                memory: 512Mi
               requests:
                 cpu: 50m
-                memory: 2Gi
+                memory: 256Mi


### PR DESCRIPTION
Notables changes:
* Remove third party resource for platform credentials set (Migrates PlatformCredentials to CRD)
* etcd-backup: reduce memory request/limits
* Update kube-aws-autoscaler to 0.11