### PR TITLE
Activate Flannel Daemonset deployment

### DIFF
--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -66,15 +66,6 @@ spec:
         effect: NoExecute
       - operator: Exists
         key: CriticalAddonsOnly
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: flannel
-                operator: NotIn
-                values:
-                - local
       volumes:
       - name: runflannel
         hostPath:

--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -66,6 +66,8 @@ spec:
         effect: NoExecute
       - operator: Exists
         key: CriticalAddonsOnly
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       volumes:
       - name: runflannel
         hostPath:

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -36,9 +36,6 @@ coreos:
       drop-ins:
         - name: 40-flannel.conf
           content: |
-            [Unit]
-            Requires=flanneld.service
-            After=flanneld.service
             [Service]
             EnvironmentFile=/etc/kubernetes/cni/docker_opts_cni.env
         - name: 50-downgrade.conf
@@ -51,28 +48,6 @@ coreos:
             [Service]
             Environment="DOCKER_OPTS=--log-opt=max-file=2 --log-opt=max-size=50m"
             Environment=DOCKER_SELINUX=
-
-    - name: flanneld.service
-      drop-ins:
-      - name: 10-etcd.conf
-        content: |
-          [Service]
-          ExecStartPre=/usr/bin/etcdctl \
-          --endpoint=http://127.0.0.1:2379 set /coreos.com/network/config \
-          '{ "Network": "10.2.0.0/16", "Backend": {"Type": "vxlan"}}'
-      - name: 20-version.conf
-        content: |
-          [Service]
-          Environment="FLANNELD_IFACE="$private_ipv4"
-          Environment="FLANNELD_ETCD_ENDPOINTS="http://127.0.0.1:2379"
-          Environment="FLANNEL_IMAGE_TAG=v0.9.1"
-
-    - name: flannel-docker-opts.service
-      drop-ins:
-      - name: 20-version.conf
-        content: |
-          [Service]
-          Environment="FLANNEL_IMAGE_TAG=v0.9.1"
 
     - name: kube2iam-iptables.service
       command: start
@@ -166,7 +141,6 @@ coreos:
         --register-schedulable=false \
         --allow-privileged \
         --node-labels=kubernetes.io/role=master,master=true \
-        --node-labels=flannel=local \
         --node-labels={{NODE_LABELS}} \
         --pod-manifest-path=/etc/kubernetes/manifests \
         --cluster-dns=10.3.0.10 \

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -36,9 +36,6 @@ coreos:
       drop-ins:
         - name: 40-flannel.conf
           content: |
-            [Unit]
-            Requires=flanneld.service
-            After=flanneld.service
             [Service]
             EnvironmentFile=/etc/kubernetes/cni/docker_opts_cni.env
         - name: 50-downgrade.conf
@@ -51,23 +48,6 @@ coreos:
             [Service]
             Environment="DOCKER_OPTS=--log-opt=max-file=2 --log-opt=max-size=50m"
             Environment=DOCKER_SELINUX=
-
-    - name: flanneld.service
-      drop-ins:
-      - name: 20-version.conf
-        content: |
-          [Service]
-          Environment="FLANNELD_IFACE="$private_ipv4"
-          Environment="FLANNELD_ETCD_ENDPOINTS="http://127.0.0.1:2379"
-          Environment="FLANNEL_IMAGE_TAG=v0.9.1"
-          Environment="FLANNEL_OPTS=--ip-masq=true -v 2"
-
-    - name: flannel-docker-opts.service
-      drop-ins:
-      - name: 20-version.conf
-        content: |
-          [Service]
-          Environment="FLANNEL_IMAGE_TAG=v0.9.1"
 
     - name: timesynced-enable-network-time.service
       command: start
@@ -152,7 +132,6 @@ coreos:
         --register-node \
         --allow-privileged \
         --node-labels=kubernetes.io/role=worker \
-        --node-labels=flannel=local \
         --node-labels={{NODE_LABELS}} \
         --cluster-dns=10.3.0.10 \
         --cluster-domain=cluster.local \


### PR DESCRIPTION
Stage two of rolling out `flannel` as a daemonset, but still with etcd backend ([Stage one](https://github.com/zalando-incubator/kubernetes-on-aws/pull/716))

This rolls all nodes. The nodes don't have flannel in the userdata anymore and they can be identified so by checking the node labels (flannel=local). Each new node will instead run an instance of flannel described by the daemonset setup in [stage one](https://github.com/zalando-incubator/kubernetes-on-aws/pull/716) due to the node-affinity now matching. The dormant flannel daemonset will slowly be rolled-in. At last, the node-affinity is removed from the daemonset.