### PR TITLE
Promote dev to db-alpha

### DIFF
--- a/cluster/etcd-cluster.yaml
+++ b/cluster/etcd-cluster.yaml
@@ -87,7 +87,7 @@ Resources:
             Prefix: ""
             Status: Enabled
       VersioningConfiguration:
-        Status: Enabled
+        Status: Suspended
   EtcdRole:
     Type: AWS::IAM::Role
     Properties:

--- a/cluster/etcd-cluster.yaml
+++ b/cluster/etcd-cluster.yaml
@@ -78,6 +78,14 @@ Resources:
     DeletionPolicy: Retain
     Properties:
       BucketName: "{{Arguments.EtcdS3Backup}}"
+      LifecycleConfiguration:
+        Rules:
+          - AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 1
+            ExpirationInDays: 7
+            NoncurrentVersionExpirationInDays: 1
+            Prefix: ""
+            Status: Enabled
       VersioningConfiguration:
         Status: Enabled
   EtcdRole:

--- a/cluster/manifests/cluster-autoscaler/deployment.yaml
+++ b/cluster/manifests/cluster-autoscaler/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         operator: Exists
       containers:
       - name: cluster-autoscaler
-        image: registry.opensource.zalan.do/teapot/kube-aws-autoscaler:0.10-1
+        image: registry.opensource.zalan.do/teapot/kube-aws-autoscaler:0.11
         envFrom:
         - configMapRef:
             # load buffer settings from ConfigMap e.g. to set spare nodes to zero for test environments

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -6,6 +6,5 @@
 
 pre_apply: [] # everything defined under here will be deleted before applying the manifests
 post_apply: # everything defined under here will be deleted after applying the manifests
-- name: instana-agent
-  namespace: kube-system
-  kind: daemonset
+- name: platform-credentials-set.zalando.org
+  kind: thirdpartyresource

--- a/cluster/manifests/etcd-backup/cronjob.yaml
+++ b/cluster/manifests/etcd-backup/cronjob.yaml
@@ -32,7 +32,7 @@ spec:
             resources:
               limits:
                 cpu: 100m
-                memory: 4Gi
+                memory: 512Mi
               requests:
                 cpu: 50m
-                memory: 2Gi
+                memory: 256Mi

--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -1,0 +1,81 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: kube-flannel
+  namespace: kube-system
+  labels:
+    application: flannel
+    version: v0.9.1
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      application: flannel
+  template:
+    metadata:
+      labels:
+        application: flannel
+        version: v0.9.1
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      initContainers:
+      - name: etcdctl
+        image: quay.io/coreos/etcd:v3.2.10
+        args:
+        - etcdctl
+        - --endpoint=http://127.0.0.1:2379
+        - set
+        - /coreos.com/network/config
+        - '{"Network": "10.2.0.0/16", "Backend": {"Type": "vxlan"}}'
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+          requests:
+            cpu: 25m
+            memory: 25Mi
+      containers:
+      - name: kube-flannel
+        image: quay.io/coreos/flannel:v0.9.1
+        args:
+        - --etcd-endpoints=http://127.0.0.1:2379
+        - --iface=eth0
+        - --ip-masq
+        - --healthz-ip=127.0.0.1
+        - --healthz-port=7978
+        - --v=2
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+          requests:
+            cpu: 25m
+            memory: 25Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: runflannel
+          mountPath: /run/flannel
+      hostNetwork: true
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      - operator: Exists
+        effect: NoExecute
+      - operator: Exists
+        key: CriticalAddonsOnly
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: flannel
+                operator: NotIn
+                values:
+                - local
+      volumes:
+      - name: runflannel
+        hostPath:
+          path: /run/flannel

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.4.0
+    version: v0.4.1
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.4.0
+        version: v0.4.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
@@ -26,7 +26,7 @@ spec:
         operator: Exists
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.4.0
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.4.1
         env:
         - name: AWS_REGION
           value: {{ .Region }}

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.4.1
+    version: v0.4.2
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.4.1
+        version: v0.4.2
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
@@ -26,7 +26,7 @@ spec:
         operator: Exists
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.4.1
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.4.2
         env:
         - name: AWS_REGION
           value: {{ .Region }}

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -6,8 +6,6 @@ metadata:
   labels:
     application: kube-proxy
     version: v1.7.9_coreos.0
-  annotations:
-    rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
 spec:
   selector:
     matchLabels:

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     application: kube-proxy
     version: v1.7.9_coreos.0
+  annotations:
+    rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
 spec:
   selector:
     matchLabels:
@@ -20,7 +22,6 @@ spec:
         version: v1.7.9_coreos.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
     spec:
       affinity:
         nodeAffinity:
@@ -32,8 +33,12 @@ spec:
                 values:
                 - local
       tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
+      - operator: Exists
+        effect: NoSchedule
+      - operator: Exists
+        effect: NoExecute
+      - operator: Exists
+        key: CriticalAddonsOnly
       hostNetwork: true
       containers:
       - name: kube-proxy
@@ -63,9 +68,6 @@ spec:
         - name: etc-kube-ssl
           mountPath: /etc/kubernetes/ssl
           readOnly: true
-        - name: dbus
-          mountPath: /var/run/dbus
-          readOnly: false
       volumes:
       - name: ssl-certs
         hostPath:
@@ -76,6 +78,3 @@ spec:
       - name: etc-kube-ssl
         hostPath:
           path: /etc/kubernetes/ssl
-      - name: dbus
-        hostPath:
-          path: /var/run/dbus

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -1,0 +1,72 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: kube-proxy
+  namespace: kube-system
+  labels:
+    application: kube-proxy
+    version: v1.7.9_coreos.0
+spec:
+  selector:
+    matchLabels:
+      application: kube-proxy
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      name: kube-proxy
+      labels:
+        application: kube-proxy
+        version: v1.7.9_coreos.0
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
+    spec:
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      hostNetwork: true
+      containers:
+      - name: kube-proxy
+        image: registry.opensource.zalan.do/teapot/hyperkube:v1.7.9_coreos.0
+        command:
+        - /hyperkube
+        - proxy
+        - --kubeconfig=/etc/kubernetes/kubeconfig
+        - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true
+        - --v=2
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 50m
+            memory: 75Mi
+          limits:
+            cpu: 200m
+            memory: 200Mi
+        volumeMounts:
+        - name: ssl-certs
+          mountPath: /etc/ssl/certs
+          readOnly: true
+        - name: kubeconfig
+          mountPath: /etc/kubernetes/kubeconfig
+          readOnly: true
+        - name: etc-kube-ssl
+          mountPath: /etc/kubernetes/ssl
+          readOnly: true
+        - name: dbus
+          mountPath: /var/run/dbus
+          readOnly: false
+      volumes:
+      - name: ssl-certs
+        hostPath:
+          path: /usr/share/ca-certificates
+      - name: kubeconfig
+        hostPath:
+          path: /etc/kubernetes/kubeconfig
+      - name: etc-kube-ssl
+        hostPath:
+          path: /etc/kubernetes/ssl
+      - name: dbus
+        hostPath:
+          path: /var/run/dbus

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -22,6 +22,15 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kube-proxy
+                operator: NotIn
+                values:
+                - local
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -20,10 +20,6 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-static-egress-controller"
     spec:
-      serviceAccountName: system
-      tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
       containers:
       - name: controller
         image: registry.opensource.zalan.do/teapot/kube-static-egress-controller:v0.0.3
@@ -41,7 +37,7 @@ spec:
           value: eu-central-1
         resources:
           limits:
-            cpu: 200m
+            cpu: 100m
             memory: 200Mi
           requests:
             cpu: 5m

--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: kube-static-egress-controller

--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kube-static-egress-controller
+  namespace: kube-system
+  labels:
+    application: kube-static-egress-controller
+    version: v0.0.3
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      application: kube-static-egress-controller
+  template:
+    metadata:
+      labels:
+        application: kube-static-egress-controller
+        version: v0.0.3
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        iam.amazonaws.com/role: "{{ .LocalID }}-static-egress-controller"
+    spec:
+      serviceAccountName: system
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      containers:
+      - name: controller
+        image: registry.opensource.zalan.do/teapot/kube-static-egress-controller:v0.0.3
+        args:
+        - "--log-level=debug"
+        - "--provider=aws"
+        - "--aws-nat-cidr-block=172.31.64.0/28"
+        - "--aws-nat-cidr-block=172.31.64.16/28"
+        - "--aws-nat-cidr-block=172.31.64.32/28"
+        - "--aws-az=eu-central-1a"
+        - "--aws-az=eu-central-1b"
+        - "--aws-az=eu-central-1c"
+        env:
+        - name: AWS_REGION
+          value: eu-central-1
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 5m
+            memory: 25Mi

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: logging-agent
-    version: v0.16
+    version: v0.17
     component: logging
 spec:
   selector:
@@ -18,7 +18,7 @@ spec:
       name: logging-agent
       labels:
         application: logging-agent
-        version: v0.16
+        version: v0.17
         component: logging
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -64,7 +64,7 @@ spec:
           mountPath: /mnt/scalyr-checkpoint
       containers:
       - name: log-watcher
-        image: registry.opensource.zalan.do/eagleeye/kubernetes-log-watcher:0.16
+        image: registry.opensource.zalan.do/eagleeye/kubernetes-log-watcher:0.17
         env:
         - name: CLUSTER_NODE_NAME
           valueFrom:

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -57,6 +57,17 @@ spec:
                 echo 'Updated agent.json to inital configuration';
             fi && cat $SCALYR_CONFIG_PATH;
             test -f /mnt/scalyr-checkpoint/checkpoints.json && ls -lah /mnt/scalyr-checkpoint/checkpoints.json && cat /mnt/scalyr-checkpoint/checkpoints.json || true;
+        env:
+        - name: WATCHER_SCALYR_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: logging-agent
+              key: scalyr-access-key
+        - name: WATCHER_CLUSTER_ID
+          value: "{{ .ID }}"
+        - name: WATCHER_SCALYR_SERVER
+          value: "{{ index .ConfigItems "scalyr_server" }}"
+
         volumeMounts:
         - name: scalyr-config
           mountPath: /mnt/scalyr

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: logging-agent
-    version: v0.15
+    version: v0.16
     component: logging
 spec:
   selector:
@@ -18,7 +18,7 @@ spec:
       name: logging-agent
       labels:
         application: logging-agent
-        version: v0.15
+        version: v0.16
         component: logging
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -64,7 +64,7 @@ spec:
           mountPath: /mnt/scalyr-checkpoint
       containers:
       - name: log-watcher
-        image: registry.opensource.zalan.do/eagleeye/kubernetes-log-watcher:0.15
+        image: registry.opensource.zalan.do/eagleeye/kubernetes-log-watcher:0.16
         env:
         - name: CLUSTER_NODE_NAME
           valueFrom:

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -75,7 +75,7 @@ spec:
           mountPath: /mnt/scalyr-checkpoint
       containers:
       - name: log-watcher
-        image: registry.opensource.zalan.do/eagleeye/kubernetes-log-watcher:0.15
+        image: registry.opensource.zalan.do/eagleeye/kubernetes-log-watcher:0.17
         env:
         - name: CLUSTER_NODE_NAME
           valueFrom:

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -34,10 +34,10 @@ spec:
         args:
         - |
             SCALYR_CONFIG_PATH="/mnt/scalyr/agent.json"
-            IMPORT_VARS="WATCHER_SCALYR_API_KEY WATCHER_CLUSTER_ID"
+            IMPORT_VARS="WATCHER_SCALYR_API_KEY WATCHER_CLUSTER_ID WATCHER_SCALYR_SERVER"
             if [ ! -f $SCALYR_CONFIG_PATH ]; then
               echo '{
-                "import_vars": ["WATCHER_SCALYR_API_KEY", "WATCHER_CLUSTER_ID"],
+                "import_vars": ["WATCHER_SCALYR_API_KEY", "WATCHER_CLUSTER_ID", "WATCHER_SCALYR_SERVER"],
                 "server_attributes": {"serverHost": "$WATCHER_CLUSTER_ID"},
                 "implicit_agent_process_metrics_monitor": false,
                 "implicit_metric_monitor": false,
@@ -89,6 +89,8 @@ spec:
             secretKeyRef:
               name: logging-agent
               key: scalyr-access-key
+        - name: WATCHER_SCALYR_SERVER
+          value: "{{ index .ConfigItems "scalyr_server" }}"
         - name: WATCHER_CLUSTER_ID
           value: "{{ .ID }}"
         - name: WATCHER_SCALYR_DEST_PATH

--- a/cluster/manifests/pod-cidr-controller/deployment.yaml
+++ b/cluster/manifests/pod-cidr-controller/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: pod-cidr-controller
@@ -19,7 +19,14 @@ spec:
         version: v0.1.0
     spec:
       hostNetwork: true
+      serviceAccountName: system
       containers:
       - name: pod-cidr-controller
         image: pierone.stups.zalan.do/teapot/pod-cidr-controller:v0.1.0
-      serviceAccountName: system
+        resources:
+          requests:
+            memory: 32Mi
+            cpu: 10m
+          limits:
+            memory: 128Mi
+            cpu: 100m

--- a/cluster/manifests/pod-cidr-controller/deployment.yaml
+++ b/cluster/manifests/pod-cidr-controller/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: pod-cidr-controller
+  namespace: kube-system
+  labels:
+    application: pod-cidr-controller
+    version: v0.1.0
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      application: pod-cidr-controller
+  template:
+    metadata:
+      labels:
+        application: pod-cidr-controller
+        version: v0.1.0
+    spec:
+      hostNetwork: true
+      containers:
+      - name: pod-cidr-controller
+        image: pierone.stups.zalan.do/teapot/pod-cidr-controller:v0.1.0
+      serviceAccountName: system

--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: "kube-system"
   labels:
     application: "zmon-agent"
-    version: "v0.1-a36"
+    version: "v0.1-a37"
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: "zmon-agent"
-        version: "v0.1-a36"
+        version: "v0.1-a37"
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -25,7 +25,7 @@ spec:
         operator: Exists
       containers:
         - name: zmon-agent
-          image: "registry.opensource.zalan.do/zmon/zmon-agent-core:0.1-a36"
+          image: "registry.opensource.zalan.do/zmon/zmon-agent-core:0.1-a37"
           resources:
             limits:
               cpu: 100m

--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: "kube-system"
   labels:
     application: "zmon-agent"
-    version: "v0.1-a37"
+    version: "0.1-a38-2-g0a44e32"
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: "zmon-agent"
-        version: "v0.1-a37"
+        version: "0.1-a38-2-g0a44e32"
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -25,7 +25,7 @@ spec:
         operator: Exists
       containers:
         - name: zmon-agent
-          image: "registry.opensource.zalan.do/zmon/zmon-agent-core:0.1-a37"
+          image: "registry.opensource.zalan.do/zmon/zmon-agent-core:0.1-a38-2-g0a44e32"
           resources:
             limits:
               cpu: 100m
@@ -67,7 +67,8 @@ spec:
               value: https://token.services.auth.zalando.com/oauth2/access_token?realm=/services
             - name: CREDENTIALS_DIR
               value: /meta/credentials
-
+            - name: ZMON_HOSTED_ZONE_FORMAT_STRING
+              value: "{}.{}.zalan.do"
           volumeMounts:
             - name: credentials
               mountPath: /meta/credentials

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -261,6 +261,53 @@ Resources:
           Version: '2012-10-17'
         PolicyName: root
     Type: AWS::IAM::Role
+  StaticEgressControllerIAMRole:
+    Properties:
+      RoleName: "{{SenzaInfo.StackName}}-{{SenzaInfo.StackVersion}}-static-egress-controller"
+      AssumeRolePolicyDocument:
+        Statement:
+        - Action: ['sts:AssumeRole']
+          Effect: Allow
+          Principal:
+            Service: [ec2.amazonaws.com]
+        - Action: ['sts:AssumeRole']
+          Effect: Allow
+          Principal:
+            AWS:
+              Fn::Join:
+                - ""
+                -
+                  - arn:aws:iam::{{ AccountInfo.AccountID }}:role/
+                  -
+                    Ref: WorkerIAMRole
+        Version: '2012-10-17'
+      Path: /
+      Policies:
+      - PolicyDocument:
+          Statement:
+          - {Action: 'cloudformation:*', Effect: Allow, Resource: '*'}
+          - {Action: 'ec2:AllocateAddress', Effect: Allow, Resource: '*'}
+          - {Action: 'ec2:AssociateRouteTable', Effect: Allow, Resource: '*'}
+          - {Action: 'ec2:DisassociateRouteTable', Effect: Allow, Resource: '*'}
+          - {Action: 'ec2:CreateRouteTable', Effect: Allow, Resource: '*'}
+          - {Action: 'ec2:CreateRoute', Effect: Allow, Resource: '*'}
+          - {Action: 'ec2:CreateNatGateway', Effect: Allow, Resource: '*'}
+          - {Action: 'ec2:CreateSubnet', Effect: Allow, Resource: '*'}
+          - {Action: 'ec2:CreateTags', Effect: Allow, Resource: '*'}
+          - {Action: 'ec2:ReleaseAddress', Effect: Allow, Resource: '*'}
+          - {Action: 'ec2:DeleteRouteTable', Effect: Allow, Resource: '*'}
+          - {Action: 'ec2:DeleteRoute', Effect: Allow, Resource: '*'}
+          - {Action: 'ec2:DeleteNatGateway', Effect: Allow, Resource: '*'}
+          - {Action: 'ec2:DeleteSubnet', Effect: Allow, Resource: '*'}
+          - {Action: 'ec2:DescribeAddresses', Effect: Allow, Resource: '*'}
+          - {Action: 'ec2:DescribeInternetGateways', Effect: Allow, Resource: '*'}
+          - {Action: 'ec2:DescribeRouteTables', Effect: Allow, Resource: '*'}
+          - {Action: 'ec2:DescribeNatGateways', Effect: Allow, Resource: '*'}
+          - {Action: 'ec2:DescribeSubnets', Effect: Allow, Resource: '*'}
+          - {Action: 'ec2:DescribeVpcs', Effect: Allow, Resource: '*'}
+          Version: '2012-10-17'
+        PolicyName: root
+    Type: AWS::IAM::Role
 
   MasterSecurityGroup:
     Properties:

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -61,8 +61,6 @@ SenzaComponents:
       Tags:
         - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
           Value: owned
-        - Key: "ClusterID"
-          Value: "{{ Arguments.ClusterID }}"
   - MasterAutoScaling:
       Type: Senza::AutoScalingGroup
       InstanceType: "{{ Arguments.MasterInstanceType }}"
@@ -89,8 +87,6 @@ SenzaComponents:
       Tags:
         - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
           Value: owned
-        - Key: "ClusterID"
-          Value: "{{ Arguments.ClusterID }}"
         - Key: "NodePool"
           Value: "{{ Arguments.MasterNodePoolName }}"
   - WorkerAutoScaling:
@@ -116,8 +112,6 @@ SenzaComponents:
       Tags:
         - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
           Value: owned
-        - Key: "ClusterID"
-          Value: "{{ Arguments.ClusterID }}"
         - Key: "NodePool"
           Value: "{{ Arguments.WorkerNodePoolName }}"
 Resources:
@@ -282,8 +276,6 @@ Resources:
       Tags:
         - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
           Value: owned
-        - Key: "ClusterID"
-          Value: "{{ Arguments.ClusterID }}"
       VpcId: "{{ AccountInfo.VpcID }}"
     Type: AWS::EC2::SecurityGroup
   MasterLoadBalancerSecurityGroup:
@@ -295,8 +287,6 @@ Resources:
       Tags:
         - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
           Value: owned
-        - Key: "ClusterID"
-          Value: "{{ Arguments.ClusterID }}"
       VpcId: "{{ AccountInfo.VpcID }}"
     Type: AWS::EC2::SecurityGroup
   MasterSecurityGroupIngressFromLoadBalancerHealthCheck:
@@ -309,8 +299,6 @@ Resources:
       Tags:
         - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
           Value: owned
-        - Key: "ClusterID"
-          Value: "{{ Arguments.ClusterID }}"
     Type: AWS::EC2::SecurityGroupIngress
   MasterSecurityGroupIngressFromLoadBalancer:
     Properties:
@@ -322,8 +310,6 @@ Resources:
       Tags:
         - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
           Value: owned
-        - Key: "ClusterID"
-          Value: "{{ Arguments.ClusterID }}"
     Type: AWS::EC2::SecurityGroupIngress
   MasterSecurityGroupIngressFromMaster:
     Properties:
@@ -335,8 +321,6 @@ Resources:
       Tags:
         - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
           Value: owned
-        - Key: "ClusterID"
-          Value: "{{ Arguments.ClusterID }}"
     Type: AWS::EC2::SecurityGroupIngress
   MasterKubeletToMasterKubeletSecurityGroup:
     Properties:
@@ -348,8 +332,6 @@ Resources:
       Tags:
         - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
           Value: owned
-        - Key: "ClusterID"
-          Value: "{{ Arguments.ClusterID }}"
     Type: AWS::EC2::SecurityGroupIngress
   WorkerSecurityGroup:
     Properties:
@@ -366,8 +348,6 @@ Resources:
       Tags:
         - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
           Value: owned
-        - Key: "ClusterID"
-          Value: "{{ Arguments.ClusterID }}"
       VpcId: "{{ AccountInfo.VpcID }}"
     Type: AWS::EC2::SecurityGroup
 
@@ -381,8 +361,6 @@ Resources:
       Tags:
         - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
           Value: owned
-        - Key: "ClusterID"
-          Value: "{{ Arguments.ClusterID }}"
         - Key: "kubernetes:application"
           Value: "kube-ingress-aws-controller"
     Type: AWS::EC2::SecurityGroup
@@ -397,8 +375,6 @@ Resources:
       Tags:
         - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
           Value: owned
-        - Key: "ClusterID"
-          Value: "{{ Arguments.ClusterID }}"
     Type: AWS::EC2::SecurityGroupIngress
   WorkerSecurityGroupIngressFromMasterToFlannel:
     Properties:
@@ -410,8 +386,6 @@ Resources:
       Tags:
         - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
           Value: owned
-        - Key: "ClusterID"
-          Value: "{{ Arguments.ClusterID }}"
     Type: AWS::EC2::SecurityGroupIngress
   WorkerSecurityGroupIngressFromMasterToKubelet:
     Properties:
@@ -423,8 +397,6 @@ Resources:
       Tags:
         - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
           Value: owned
-        - Key: "ClusterID"
-          Value: "{{ Arguments.ClusterID }}"
     Type: AWS::EC2::SecurityGroupIngress
   WorkerSecurityGroupIngressFromMasterTocAdvisor:
     Properties:
@@ -436,8 +408,6 @@ Resources:
       Tags:
         - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
           Value: owned
-        - Key: "ClusterID"
-          Value: "{{ Arguments.ClusterID }}"
     Type: AWS::EC2::SecurityGroupIngress
   MasterSecurityGroupIngressFromFlannelToMaster:
     Properties:
@@ -449,8 +419,6 @@ Resources:
       Tags:
         - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
           Value: owned
-        - Key: "ClusterID"
-          Value: "{{ Arguments.ClusterID }}"
     Type: AWS::EC2::SecurityGroupIngress
   MasterSecurityGroupIngressFromWorkerToMasterKubeletReadOnly:
     Properties:
@@ -462,8 +430,6 @@ Resources:
       Tags:
         - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
           Value: owned
-        - Key: "ClusterID"
-          Value: "{{ Arguments.ClusterID }}"
     Type: AWS::EC2::SecurityGroupIngress
   WorkerSecurityGroupIngressFromWorkerToFlannel:
     Properties:
@@ -475,8 +441,6 @@ Resources:
       Tags:
         - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
           Value: owned
-        - Key: "ClusterID"
-          Value: "{{ Arguments.ClusterID }}"
     Type: AWS::EC2::SecurityGroupIngress
   WorkerSecurityGroupIngressFromWorkerToWorkerKubeletReadOnly:
     Properties:
@@ -488,8 +452,6 @@ Resources:
       Tags:
         - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
           Value: owned
-        - Key: "ClusterID"
-          Value: "{{ Arguments.ClusterID }}"
     Type: AWS::EC2::SecurityGroupIngress
   WorkerSecurityGroupIngressFromWorkerToWorkerSkipperMetrics:
     Properties:
@@ -501,8 +463,6 @@ Resources:
       Tags:
         - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
           Value: owned
-        - Key: "ClusterID"
-          Value: "{{ Arguments.ClusterID }}"
     Type: AWS::EC2::SecurityGroupIngress
 
   ZmonIAMRole:

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -53,14 +53,14 @@ coreos:
           [Service]
           Environment="FLANNELD_IFACE="$private_ipv4"
           Environment="FLANNELD_ETCD_ENDPOINTS="http://127.0.0.1:2379"
-          Environment="FLANNEL_IMAGE_TAG=v0.9.0"
+          Environment="FLANNEL_IMAGE_TAG=v0.9.1"
 
     - name: flannel-docker-opts.service
       drop-ins:
       - name: 20-version.conf
         content: |
           [Service]
-          Environment="FLANNEL_IMAGE_TAG=v0.9.0"
+          Environment="FLANNEL_IMAGE_TAG=v0.9.1"
 
     - name: kube2iam-iptables.service
       command: start
@@ -145,6 +145,7 @@ coreos:
         --register-schedulable=false \
         --allow-privileged \
         --node-labels=kubernetes.io/role=master,master=true \
+        --node-labels=flannel=local \
         --node-labels={{NODE_LABELS}} \
         --pod-manifest-path=/etc/kubernetes/manifests \
         --cluster_dns=10.3.0.10 \

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -145,6 +145,7 @@ coreos:
         --register-schedulable=false \
         --allow-privileged \
         --node-labels=kubernetes.io/role=master,master=true \
+        --node-labels=kube-proxy=local \
         --node-labels={{NODE_LABELS}} \
         --pod-manifest-path=/etc/kubernetes/manifests \
         --cluster_dns=10.3.0.10 \

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -17,6 +17,25 @@ coreos:
   update:
     reboot-strategy: "off"
   units:
+{{#ETCD_PROXY_ENABLED}}
+    - name: etcd-member.service
+      command: start
+      enabled: true
+      content: |
+        [Unit]
+        Wants=network.target
+        [Service]
+        Type=simple
+        Restart=on-failure
+        RestartSec=10s
+        ExecStartPre=/usr/bin/mkdir --parents /var/lib/coreos
+        ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/lib/coreos/etcd-member-wrapper.uuid
+        ExecStart=/usr/bin/rkt run --uuid-file-save=/var/lib/coreos/etcd-member-wrapper.uuid --port=2379-tcp:2379 --mount volume=dns,target=/etc/resolv.conf --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true --insecure-options=image docker://registry.opensource.zalan.do/teapot/etcd-proxy:master-1 -- {{ETCD_ENDPOINTS}}
+        ExecStop=-/usr/bin/rkt stop --uuid-file=/var/lib/coreos/etcd-member-wrapper.uuid
+        [Install]
+        WantedBy=multi-user.target
+{{/ETCD_PROXY_ENABLED}}
+{{^ETCD_PROXY_ENABLED}}
     - name: etcd-member.service
       command: start
       enable: true
@@ -25,6 +44,7 @@ coreos:
           content: |
             [Service]
             Environment="ETCD_OPTS=gateway start --listen-addr=127.0.0.1:2379 --endpoints={{ ETCD_ENDPOINTS }}"
+{{/ETCD_PROXY_ENABLED}}
 
     - name: docker.service
       drop-ins:

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -268,10 +268,10 @@ write_files:
       apiVersion: v1
       kind: Pod
       metadata:
-        name: kube-proxy
+        name: kube-proxy-userdata
         namespace: kube-system
         labels:
-          application: kube-proxy
+          application: kube-proxy-userdata
           version: v1.7.9_coreos.0
         annotations:
           scheduler.alpha.kubernetes.io/critical-pod: ''

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -17,6 +17,25 @@ coreos:
   update:
     reboot-strategy: "off"
   units:
+{{#ETCD_PROXY_ENABLED}}
+    - name: etcd-member.service
+      command: start
+      enabled: true
+      content: |
+        [Unit]
+        Wants=network.target
+        [Service]
+        Type=simple
+        Restart=on-failure
+        RestartSec=10s
+        ExecStartPre=/usr/bin/mkdir --parents /var/lib/coreos
+        ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/lib/coreos/etcd-member-wrapper.uuid
+        ExecStart=/usr/bin/rkt run --uuid-file-save=/var/lib/coreos/etcd-member-wrapper.uuid --port=2379-tcp:2379 --mount volume=dns,target=/etc/resolv.conf --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true --insecure-options=image docker://registry.opensource.zalan.do/teapot/etcd-proxy:master-1 -- {{ETCD_ENDPOINTS}}
+        ExecStop=-/usr/bin/rkt stop --uuid-file=/var/lib/coreos/etcd-member-wrapper.uuid
+        [Install]
+        WantedBy=multi-user.target
+{{/ETCD_PROXY_ENABLED}}
+{{^ETCD_PROXY_ENABLED}}
     - name: etcd-member.service
       command: start
       enable: true
@@ -25,6 +44,7 @@ coreos:
           content: |
             [Service]
             Environment="ETCD_OPTS=gateway start --listen-addr=127.0.0.1:2379 --endpoints={{ ETCD_ENDPOINTS }}"
+{{/ETCD_PROXY_ENABLED}}
 
     - name: docker.service
       drop-ins:

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -47,7 +47,7 @@ coreos:
           [Service]
           Environment="FLANNELD_IFACE="$private_ipv4"
           Environment="FLANNELD_ETCD_ENDPOINTS="http://127.0.0.1:2379"
-          Environment="FLANNEL_IMAGE_TAG=v0.9.0"
+          Environment="FLANNEL_IMAGE_TAG=v0.9.1"
           Environment="FLANNEL_OPTS=--ip-masq=true -v 2"
 
     - name: flannel-docker-opts.service
@@ -55,7 +55,7 @@ coreos:
       - name: 20-version.conf
         content: |
           [Service]
-          Environment="FLANNEL_IMAGE_TAG=v0.9.0"
+          Environment="FLANNEL_IMAGE_TAG=v0.9.1"
 
     - name: timesynced-enable-network-time.service
       command: start
@@ -131,6 +131,7 @@ coreos:
         --register-node \
         --allow-privileged \
         --node-labels=kubernetes.io/role=worker \
+        --node-labels=flannel=local \
         --node-labels={{NODE_LABELS}} \
         --pod-manifest-path=/etc/kubernetes/manifests \
         --cluster_dns=10.3.0.10 \

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -134,7 +134,7 @@ coreos:
         --pod-manifest-path=/etc/kubernetes/manifests \
         --cluster_dns=10.3.0.10 \
         --cluster_domain=cluster.local \
-        --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
+        --kubeconfig=/etc/kubernetes/kubeconfig \
         --require-kubeconfig \
         --healthz-bind-address=0.0.0.0 \
         --healthz-port=10248 \
@@ -180,7 +180,7 @@ coreos:
           --net=host \
           docker://registry.opensource.zalan.do/teapot/hyperkube:v1.7.9_coreos.0 \
           --exec=/kubectl -- \
-            --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
+            --kubeconfig=/etc/kubernetes/kubeconfig \
             drain $(hostname) \
             --ignore-daemonsets \
             --delete-local-data \
@@ -213,10 +213,10 @@ write_files:
         apiVersion: v1
         kind: Pod
         metadata:
-          name: kube-proxy
+          name: kube-proxy-userdata
           namespace: kube-system
           labels:
-            application: kube-proxy
+            application: kube-proxy-userdata
             version: v1.7.9_coreos.0
           annotations:
             scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -232,7 +232,7 @@ write_files:
             command:
             - /hyperkube
             - proxy
-            - --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml
+            - --kubeconfig=/etc/kubernetes/kubeconfig
             - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true
             - --v=2
             securityContext:
@@ -247,7 +247,7 @@ write_files:
             volumeMounts:
               - mountPath: /etc/ssl/certs
                 name: "ssl-certs"
-              - mountPath: /etc/kubernetes/worker-kubeconfig.yaml
+              - mountPath: /etc/kubernetes/kubeconfig
                 name: "kubeconfig"
                 readOnly: true
               - mountPath: /etc/kubernetes/ssl
@@ -262,7 +262,7 @@ write_files:
                 path: "/usr/share/ca-certificates"
             - name: "kubeconfig"
               hostPath:
-                path: "/etc/kubernetes/worker-kubeconfig.yaml"
+                path: "/etc/kubernetes/kubeconfig"
             - name: "etc-kube-ssl"
               hostPath:
                 path: "/etc/kubernetes/ssl"
@@ -270,7 +270,7 @@ write_files:
                 path: /var/run/dbus
               name: dbus
 
-  - path: /etc/kubernetes/worker-kubeconfig.yaml
+  - path: /etc/kubernetes/kubeconfig
     content: |
         apiVersion: v1
         kind: Config

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -130,6 +130,7 @@ coreos:
         --register-node \
         --allow-privileged \
         --node-labels=kubernetes.io/role=worker \
+        --node-labels=kube-proxy=local \
         --node-labels={{NODE_LABELS}} \
         --pod-manifest-path=/etc/kubernetes/manifests \
         --cluster_dns=10.3.0.10 \


### PR DESCRIPTION
Notables changes:
* bump logwatcher to v0.17 for EU migration
* Add support for our own etcd proxy (disabled by default)
* fix multi subnet support to enable statig egress via NAT GWs in another subnet
* prepare inactive flannel daemonset rollout
* Remove third party resource for platform credentials set
* Remove ClusterID tag
* prepare inactive kube-proxy daemonset
* add pod-cidr-controller for flannel daemonset migration

Do not merge: egress controller is currently incompatible with mixed kubernetes/senza accounts.