### PR TITLE
Deactivate egress controller

### DIFF
--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     application: kube-static-egress-controller
     version: v0.0.3
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       application: kube-static-egress-controller


### PR DESCRIPTION
Egress controller leads to undesired side-effects whes used. By scaling it to zero we ensure that it won't do anything.