### PR TITLE
fix: use correct labels for autoscaler version

### DIFF
--- a/cluster/manifests/cluster-autoscaler/deployment.yaml
+++ b/cluster/manifests/cluster-autoscaler/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: cluster-autoscaler
-    version: v0.10
+    version: v0.11
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: cluster-autoscaler
-        version: v0.10
+        version: v0.11
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-autoscaler"


### PR DESCRIPTION
use correct labels for autoscaler version