### PR TITLE
Configure kube-proxy via config file (configmap)

### DIFF
--- a/cluster/manifests/kube-proxy/configmap.yaml
+++ b/cluster/manifests/kube-proxy/configmap.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-proxy-config
+  namespace: kube-system
+data:
+  # generated from ./kube-proxy --proxy-mode=iptables --kubeconfig=/etc/kubernetes/kubeconfig --write-config-to kube-proxy.yaml
+  kube-proxy.yaml: |
+    apiVersion: kubeproxy.config.k8s.io/v1alpha1
+    bindAddress: 0.0.0.0
+    clientConnection:
+      acceptContentTypes: ""
+      burst: 10
+      contentType: application/vnd.kubernetes.protobuf
+      kubeconfig: /etc/kubernetes/kubeconfig
+      qps: 5
+    clusterCIDR: ""
+    configSyncPeriod: 15m0s
+    conntrack:
+      max: 0
+      maxPerCore: 32768
+      min: 131072
+      tcpCloseWaitTimeout: 1h0m0s
+      tcpEstablishedTimeout: 24h0m0s
+    enableProfiling: false
+    featureGates: "ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true"
+    healthzBindAddress: 0.0.0.0:10256
+    hostnameOverride: ""
+    iptables:
+      masqueradeAll: false
+      masqueradeBit: 14
+      minSyncPeriod: 0s
+      syncPeriod: 30s
+    ipvs:
+      minSyncPeriod: 0s
+      scheduler: ""
+      syncPeriod: 30s
+    kind: KubeProxyConfiguration
+    metricsBindAddress: 127.0.0.1:10249
+    mode: iptables
+    oomScoreAdj: -999
+    portRange: ""
+    resourceContainer: /kube-proxy
+    udpTimeoutMilliseconds: 250ms

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -37,8 +37,7 @@ spec:
         command:
         - /hyperkube
         - proxy
-        - --kubeconfig=/etc/kubernetes/kubeconfig
-        - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true
+        - --config=/config/kube-proxy.yaml
         - --v=2
         securityContext:
           privileged: true
@@ -59,6 +58,9 @@ spec:
         - name: etc-kube-ssl
           mountPath: /etc/kubernetes/ssl
           readOnly: true
+        - name: kube-proxy-config
+          mountPath: /config
+          readOnly: true
       volumes:
       - name: ssl-certs
         hostPath:
@@ -69,3 +71,6 @@ spec:
       - name: etc-kube-ssl
         hostPath:
           path: /etc/kubernetes/ssl
+      - name: kube-proxy-config
+        configMap:
+          name: kube-proxy-config


### PR DESCRIPTION
Configures kube-proxy via a config file (provided as configmap) instead of using flags which are deprecated.

```
W1215 09:33:56.758561       1 server.go:190] WARNING: all flags other than --config, --write-config-to, and --cleanup-iptables are deprecated. Please begin using a config file ASAP.
```