### PR TITLE
Don't configure kubelet to read from /etc/kubernetes/manifests on wor…

### DIFF
--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -152,7 +152,6 @@ coreos:
         --node-labels=kubernetes.io/role=worker \
         --node-labels=flannel=local \
         --node-labels={{NODE_LABELS}} \
-        --pod-manifest-path=/etc/kubernetes/manifests \
         --cluster-dns=10.3.0.10 \
         --cluster-domain=cluster.local \
         --kubeconfig=/etc/kubernetes/kubeconfig \


### PR DESCRIPTION
…ker nodes

Since we no longer have any manifests on the node of worker nodes the
kubelet doesn't need to read from it.

From the kubelet logs:
```
Unable to read manifest path "/etc/kubernetes/manifests": path does not exist, ignoring
```