### PR TITLE
kube-aws-autoscaler v0.12

### DIFF
--- a/cluster/manifests/cluster-autoscaler/config-playground.yaml
+++ b/cluster/manifests/cluster-autoscaler/config-playground.yaml
@@ -6,3 +6,5 @@ metadata:
 data:
   # do not provision any "spare" nodes for Playground
   BUFFER_SPARE_NODES: "0"
+  # allow to downscale two nodes at once
+  SCALE_DOWN_STEP_FIXED: "2"

--- a/cluster/manifests/cluster-autoscaler/config-test.yaml
+++ b/cluster/manifests/cluster-autoscaler/config-test.yaml
@@ -6,3 +6,5 @@ metadata:
 data:
   # do not provision any "spare" nodes for test/staging clusters
   BUFFER_SPARE_NODES: "0"
+  # allow to downscale two nodes at once
+  SCALE_DOWN_STEP_FIXED: "2"

--- a/cluster/manifests/cluster-autoscaler/deployment.yaml
+++ b/cluster/manifests/cluster-autoscaler/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: cluster-autoscaler
-    version: v0.11
+    version: v0.12
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: cluster-autoscaler
-        version: v0.11
+        version: v0.12
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-autoscaler"
@@ -25,7 +25,7 @@ spec:
         operator: Exists
       containers:
       - name: cluster-autoscaler
-        image: registry.opensource.zalan.do/teapot/kube-aws-autoscaler:0.11
+        image: registry.opensource.zalan.do/teapot/kube-aws-autoscaler:0.12-1
         envFrom:
         - configMapRef:
             # load buffer settings from ConfigMap e.g. to set spare nodes to zero for test environments


### PR DESCRIPTION
Use the latest version of kube-aws-autoscaler: https://github.com/hjacobs/kube-aws-autoscaler/releases/tag/0.12

Configure non-prod clusters to allow downscaling two nodes at once (potentially less availability, but not a problem for test clusters). This will speed up the daily downscale for test clusters.