### PR TITLE
Update authnz webhook to v0.3.8

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -362,7 +362,7 @@ write_files:
             limits:
               cpu: 200m
               memory: 1Gi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.3.7
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.3.8
           name: webhook
           ports:
           - containerPort: 8081


### PR DESCRIPTION
Adds a realm group when authenticating users such that we can track the realm in audit events.