### PR TITLE
Downgrade Docker to 1.12

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -42,6 +42,11 @@ coreos:
             After=flanneld.service
             [Service]
             EnvironmentFile=/etc/kubernetes/cni/docker_opts_cni.env
+        - name: 50-downgrade.conf
+          content: |
+            [Unit]
+            Requires=docker-downgrade.service
+            After=docker-downgrade.service
         - name: 60-dockeropts.conf
           content: |
             [Service]
@@ -85,6 +90,15 @@ coreos:
           --jump DNAT \
           --table nat \
           --to-destination $private_ipv4:8181
+
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: docker-downgrade.service
+      content: |
+        [Service]
+        Type=oneshot
+        ExecStart=/opt/bin/downgrade-docker
 
         [Install]
         WantedBy=multi-user.target
@@ -729,6 +743,19 @@ write_files:
         }
       }
       EOF
+
+  - path: /opt/bin/downgrade-docker
+    owner: root
+    permissions: 0755
+    content: |
+      #!/bin/bash
+      set -euo pipefail
+      if [[ ! -f "/etc/coreos/docker-1.12" ]]; then
+        echo -n "yes" > /etc/coreos/docker-1.12
+        echo "Rebooting to downgrade Docker"
+        reboot
+        exit 1
+      fi
 
   - path: /home/core/.toolboxrc
     owner: core

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -42,6 +42,11 @@ coreos:
             After=flanneld.service
             [Service]
             EnvironmentFile=/etc/kubernetes/cni/docker_opts_cni.env
+        - name: 50-downgrade.conf
+          content: |
+            [Unit]
+            Requires=docker-downgrade.service
+            After=docker-downgrade.service
         - name: 60-dockeropts.conf
           content: |
             [Service]
@@ -91,6 +96,15 @@ coreos:
           --jump DNAT \
           --table nat \
           --to-destination $private_ipv4:8181
+
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: docker-downgrade.service
+      content: |
+        [Service]
+        Type=oneshot
+        ExecStart=/opt/bin/downgrade-docker
 
         [Install]
         WantedBy=multi-user.target
@@ -260,6 +274,19 @@ write_files:
         }
       }
       EOF
+
+  - path: /opt/bin/downgrade-docker
+    owner: root
+    permissions: 0755
+    content: |
+      #!/bin/bash
+      set -euo pipefail
+      if [[ ! -f "/etc/coreos/docker-1.12" ]]; then
+        echo -n "yes" > /etc/coreos/docker-1.12
+        echo "Rebooting to downgrade Docker"
+        reboot
+        exit 1
+      fi
 
   - path: /home/core/.toolboxrc
     owner: core


### PR DESCRIPTION
We've had a lot of issues with 17.09, so let's downgrade.

Since we're still using cloud-config which runs very late in the boot process, we need to reboot once after creating the config file.