### PR TITLE
Revert allowPrivilegeEscalation changes

### DIFF
--- a/cluster/manifests/psp/pod_security_policy.yaml
+++ b/cluster/manifests/psp/pod_security_policy.yaml
@@ -27,6 +27,10 @@ kind: PodSecurityPolicy
 metadata:
   name: restricted
 spec:
+  # Enabled for now due to issues with Docker 1.12, see
+  # https://github.com/zalando-incubator/kubernetes-on-aws/pull/771
+  # for details
+  allowPrivilegeEscalation: true
   fsGroup:
     rule: RunAsAny
   runAsUser:
@@ -42,4 +46,3 @@ spec:
   - persistentVolumeClaim
   - downwardAPI
   - configMap
-  allowPrivilegeEscalation: false


### PR DESCRIPTION
This will make sure that we have this change to beta before rolling the latest version of our config in beta that will downgrade docker and cause problems. 