### PR TITLE
Disable SELinux support in Docker

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -50,6 +50,7 @@ coreos:
           content: |
             [Service]
             Environment="DOCKER_OPTS=--log-opt=max-file=2 --log-opt=max-size=50m"
+            Environment=DOCKER_SELINUX=
 
     - name: flanneld.service
       drop-ins:

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -50,6 +50,7 @@ coreos:
           content: |
             [Service]
             Environment="DOCKER_OPTS=--log-opt=max-file=2 --log-opt=max-size=50m"
+            Environment=DOCKER_SELINUX=
 
     - name: flanneld.service
       drop-ins:


### PR DESCRIPTION
If SELinux support is enabled, Docker tries to recursively relabel every mounted volume. When a volume has several million files, it'll render Docker completely unresponsive for 25 minutes or more (see https://github.com/moby/moby/issues/32007 and https://github.com/moby/moby/issues/32892). The cherry on top is that CoreOS runs SELinux in permissive mode, so we also get zero security benefits.