### PR TITLE
Use kubernetes.io/role label for nodeAffinity

### DIFF
--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -30,8 +30,10 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: master
-                operator: DoesNotExist
+              - key: kubernetes.io/role
+                operator: NotIn
+                values:
+                - master
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists


### PR DESCRIPTION
Uses the more "official" kubernetes.io/role label rather than our custom
master=true label.

To align with the node affinity used in #767 