### PR TITLE
Prevent scheduling on master nodes with taints

### DIFF
--- a/cluster/manifests/kube-node-ready/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready/daemonset.yaml
@@ -24,6 +24,8 @@ spec:
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       containers:
       - name: kube-node-ready
         image: registry.opensource.zalan.do/teapot/kube-node-ready:9799c3d

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -28,6 +28,8 @@ spec:
         effect: NoExecute
       - operator: Exists
         key: CriticalAddonsOnly
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       hostNetwork: true
       containers:
       - name: kube-proxy

--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -23,6 +23,8 @@ spec:
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       hostNetwork: true
       containers:
       - image: registry.opensource.zalan.do/teapot/kube2iam:0.7.0

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -26,6 +26,8 @@ spec:
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       initContainers:
       - name: init-scalyr-config
         image: registry.opensource.zalan.do/stups/alpine:3.5-cd10

--- a/cluster/manifests/prometheus-node-exporter/daemonset.yaml
+++ b/cluster/manifests/prometheus-node-exporter/daemonset.yaml
@@ -26,6 +26,8 @@ spec:
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       containers:
       - image: registry.opensource.zalan.do/teapot/prometheus-node-exporter:v0.14.0
         name: prometheus-node-exporter

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -163,9 +163,9 @@ coreos:
         --network-plugin=cni \
         --container-runtime=docker \
         --rkt-path=/usr/bin/rkt \
-        --register-schedulable=false \
+        --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
         --allow-privileged \
-        --node-labels=kubernetes.io/role=master,master=true \
+        --node-labels=node-role.kubernetes.io/master,kubernetes.io/role=master,master=true \
         --node-labels=flannel=local \
         --node-labels={{NODE_LABELS}} \
         --pod-manifest-path=/etc/kubernetes/manifests \
@@ -302,6 +302,8 @@ write_files:
         tolerations:
         - key: CriticalAddonsOnly
           operator: Exists
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
         hostNetwork: true
         containers:
         - name: kube-apiserver
@@ -482,6 +484,8 @@ write_files:
         tolerations:
         - key: CriticalAddonsOnly
           operator: Exists
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
         containers:
         - name: kube-controller-manager
           image: registry.opensource.zalan.do/teapot/hyperkube:v1.8.5_coreos.0
@@ -549,6 +553,8 @@ write_files:
         tolerations:
         - key: CriticalAddonsOnly
           operator: Exists
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
         hostNetwork: true
         containers:
         - name: kube-scheduler
@@ -591,6 +597,8 @@ write_files:
         tolerations:
         - key: CriticalAddonsOnly
           operator: Exists
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
         hostNetwork: true
         containers:
         - image: registry.opensource.zalan.do/teapot/rescheduler:v0.3.1


### PR DESCRIPTION
Use a taint to prevent unwanted stuff from running on the master nodes. It's still possible to work around this with tolerations, but at least you'll have to be explicit now. See https://github.com/kubernetes/kubernetes/pull/41835 and related issues for the discussion of the taint & label names.