### PR TITLE
Add tolerations for daemonsets running on masters

### DIFF
--- a/cluster/manifests/kube-node-ready/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready/daemonset.yaml
@@ -24,6 +24,8 @@ spec:
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       containers:
       - name: kube-node-ready
         image: registry.opensource.zalan.do/teapot/kube-node-ready:9799c3d

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -28,6 +28,8 @@ spec:
         effect: NoExecute
       - operator: Exists
         key: CriticalAddonsOnly
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       hostNetwork: true
       containers:
       - name: kube-proxy

--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -23,6 +23,8 @@ spec:
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       hostNetwork: true
       containers:
       - image: registry.opensource.zalan.do/teapot/kube2iam:0.7.0

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -26,6 +26,8 @@ spec:
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       initContainers:
       - name: init-scalyr-config
         image: registry.opensource.zalan.do/stups/alpine:3.5-cd10

--- a/cluster/manifests/prometheus-node-exporter/daemonset.yaml
+++ b/cluster/manifests/prometheus-node-exporter/daemonset.yaml
@@ -26,6 +26,8 @@ spec:
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       containers:
       - image: registry.opensource.zalan.do/teapot/prometheus-node-exporter:v0.14.0
         name: prometheus-node-exporter


### PR DESCRIPTION
#777 has to be rolled out in two parts, since otherwise kube-node-ready and kube2iam won't be able to run on the new master nodes.