### PR TITLE
Update ingress controller to v0.5.0

### DIFF
--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.4.2
+    version: v0.5.0
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.4.2
+        version: v0.5.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
@@ -26,7 +26,7 @@ spec:
         operator: Exists
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.4.2
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.5.0
         env:
         - name: AWS_REGION
           value: {{ .Region }}


### PR DESCRIPTION
* Fixes support for creating internal and internet-facing ingresses.
* Improves subnet selection so it can't select two subnets for a single AZ.

https://github.com/zalando-incubator/kube-ingress-aws-controller/releases/tag/v0.5.0