### PR TITLE
[db-alpha] Use latest logging-agent that honors scalyr_server

### DIFF
--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: logging-agent
-    version: v0.15
+    version: v0.17
     component: logging
 spec:
   selector:
@@ -18,7 +18,7 @@ spec:
       name: logging-agent
       labels:
         application: logging-agent
-        version: v0.15
+        version: v0.17
         component: logging
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -36,10 +36,10 @@ spec:
         args:
         - |
             SCALYR_CONFIG_PATH="/mnt/scalyr/agent.json"
-            IMPORT_VARS="WATCHER_SCALYR_API_KEY WATCHER_CLUSTER_ID"
+            IMPORT_VARS="WATCHER_SCALYR_API_KEY WATCHER_CLUSTER_ID WATCHER_SCALYR_SERVER"
             if [ ! -f $SCALYR_CONFIG_PATH ]; then
               echo '{
-                "import_vars": ["WATCHER_SCALYR_API_KEY", "WATCHER_CLUSTER_ID"],
+                "import_vars": ["WATCHER_SCALYR_API_KEY", "WATCHER_CLUSTER_ID", "WATCHER_SCALYR_SERVER"],
                 "server_attributes": {"serverHost": "$WATCHER_CLUSTER_ID"},
                 "implicit_agent_process_metrics_monitor": false,
                 "implicit_metric_monitor": false,
@@ -59,6 +59,17 @@ spec:
                 echo 'Updated agent.json to inital configuration';
             fi && cat $SCALYR_CONFIG_PATH;
             test -f /mnt/scalyr-checkpoint/checkpoints.json && ls -lah /mnt/scalyr-checkpoint/checkpoints.json && cat /mnt/scalyr-checkpoint/checkpoints.json || true;
+        env:
+        - name: WATCHER_SCALYR_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: logging-agent
+              key: scalyr-access-key
+        - name: WATCHER_CLUSTER_ID
+          value: "{{ .ID }}"
+        - name: WATCHER_SCALYR_SERVER
+          value: "{{ index .ConfigItems "scalyr_server" }}"
+
         volumeMounts:
         - name: scalyr-config
           mountPath: /mnt/scalyr
@@ -66,7 +77,7 @@ spec:
           mountPath: /mnt/scalyr-checkpoint
       containers:
       - name: log-watcher
-        image: registry.opensource.zalan.do/eagleeye/kubernetes-log-watcher:0.15
+        image: registry.opensource.zalan.do/eagleeye/kubernetes-log-watcher:0.17
         env:
         - name: CLUSTER_NODE_NAME
           valueFrom:
@@ -80,6 +91,8 @@ spec:
             secretKeyRef:
               name: logging-agent
               key: scalyr-access-key
+        - name: WATCHER_SCALYR_SERVER
+          value: "{{ index .ConfigItems "scalyr_server" }}"
         - name: WATCHER_CLUSTER_ID
           value: "{{ .ID }}"
         - name: WATCHER_SCALYR_DEST_PATH


### PR DESCRIPTION
db-alpha runs an older `logging-agent` config (of course) that didn't correctly respect the `scalyr_server` flag. This cherry picks the latest versions.