### PR TITLE
Fetch gerry credentials once before starting zmon-worker

### DIFF
--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -23,6 +23,28 @@ spec:
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
+
+      initContainers:
+      - name: gerry-init
+        image: registry.opensource.zalan.do/teapot/gerry:v0.0.14
+        args:
+          - /meta/credentials
+          - --application-id=gerry
+          - --mint-bucket=s3://{{ .ConfigItems.gerry_mint_bucket }}
+          - --once
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+          requests:
+            cpu: 10m
+            memory: 10Mi
+
+        volumeMounts:
+          - name: credentials
+            mountPath: /meta/credentials
+            readOnly: false
+
       containers:
         - name: zmon-agent
           image: "registry.opensource.zalan.do/zmon/zmon-agent-core:0.1-a39"

--- a/cluster/manifests/zmon-aws-agent/deployment.yaml
+++ b/cluster/manifests/zmon-aws-agent/deployment.yaml
@@ -23,6 +23,28 @@ spec:
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
+
+      initContainers:
+      - name: gerry-init
+        image: registry.opensource.zalan.do/teapot/gerry:v0.0.14
+        args:
+          - /meta/credentials
+          - --application-id=gerry
+          - --mint-bucket=s3://{{ .ConfigItems.gerry_mint_bucket }}
+          - --once
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+          requests:
+            cpu: 10m
+            memory: 10Mi
+
+        volumeMounts:
+          - name: credentials
+            mountPath: /meta/credentials
+            readOnly: false
+
       containers:
         - name: zmon-aws-agent
           image: pierone.stups.zalan.do/stups/zmon-aws-agent:zv149

--- a/cluster/manifests/zmon-scheduler/deployment.yaml
+++ b/cluster/manifests/zmon-scheduler/deployment.yaml
@@ -23,6 +23,28 @@ spec:
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
+
+      initContainers:
+      - name: gerry-init
+        image: registry.opensource.zalan.do/teapot/gerry:v0.0.14
+        args:
+          - /meta/credentials
+          - --application-id=gerry
+          - --mint-bucket=s3://{{ .ConfigItems.gerry_mint_bucket }}
+          - --once
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+          requests:
+            cpu: 10m
+            memory: 10Mi
+
+        volumeMounts:
+          - name: credentials
+            mountPath: /meta/credentials
+            readOnly: false
+
       containers:
         - name: zmon-scheduler
           image: "registry.opensource.zalan.do/stups/zmon-scheduler:v43"

--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -20,6 +20,27 @@ spec:
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
+
+      initContainers:
+      - name: gerry-init
+        image: registry.opensource.zalan.do/teapot/gerry:v0.0.14
+        args:
+        - /meta/credentials
+        - --application-id=gerry
+        - --mint-bucket=s3://{{ .ConfigItems.gerry_mint_bucket }}
+        - --once
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        volumeMounts:
+          - name: credentials
+            mountPath: /meta/credentials
+            readOnly: false
+
       containers:
         - name: zmon-worker
           image: "pierone.stups.zalan.do/stups/zmon-worker:zv228"


### PR DESCRIPTION
This is a quick fix for https://github.com/zalando-zmon/zmon-worker/issues/270 which haunted pitchfork and possibly others.

Using an `initContainer` here is similar to how taupage makes sure credentials are loaded before anything else: https://github.com/zalando-stups/taupage/blob/Taupage-AMI-20180102-114355/runtime/opt/taupage/init.d/02-start-berry.sh#L7