### PR TITLE
Disable image-policy simulation mode

### DIFF
--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         effect: NoSchedule
       initContainers:
       - name: init-scalyr-config
-        image: registry.opensource.zalan.do/stups/alpine:3.5-cd10
+        image: registry.opensource.zalan.do/stups/alpine:3.7.0-1
         imagePullPolicy: IfNotPresent
         command: ["sh", "-c"]
         args:

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -385,7 +385,6 @@ write_files:
           args:
           - --policy={{ IMAGE_POLICY }}
           - --failure-policy=fail
-          - --simulate
           ports:
           - containerPort: 8083
         - name: nginx


### PR DESCRIPTION
Since simulation mode applies to all clusters it's difficult to migrate clusters to the enforced `prod` policy on a cluster by cluster basis. We switched all clusters back to `dev` policy mode and thus can safely turn of simlation mode. Once rolled out we can enable `prod` mode per cluster, e.g. for new clusters from now on.
  