### PR TITLE
Remove limits for master components

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -337,9 +337,6 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-            limits:
-              cpu: 200m
-              memory: 1Gi
         - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.3.8
           name: webhook
           ports:
@@ -357,9 +354,6 @@ write_files:
             initialDelaySeconds: 5
             timeoutSeconds: 5
           resources:
-            limits:
-              cpu: 100m
-              memory: 100Mi
             requests:
               cpu: 50m
               memory: 50Mi
@@ -397,9 +391,6 @@ write_files:
             periodSeconds: 3
             failureThreshold: 2
           resources:
-            limits:
-              cpu: 4000m
-              memory: 512Mi
             requests:
               cpu: 100m
               memory: 20Mi
@@ -419,9 +410,6 @@ write_files:
         - name: nginx
           image: registry.opensource.zalan.do/teapot/nginx:1.12.1
           resources:
-            limits:
-              cpu: 100m
-              memory: 100Mi
             requests:
               cpu: 50m
               memory: 50Mi
@@ -476,9 +464,6 @@ write_files:
           - --use-service-account-credentials=true
           - --v=4
           resources:
-            limits:
-              cpu: 200m
-              memory: 500Mi
             requests:
               cpu: 100m
               memory: 100Mi
@@ -540,9 +525,6 @@ write_files:
           - --leader-elect=true
           - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true
           resources:
-            limits:
-              cpu: 250m
-              memory: 250Mi
             requests:
               cpu: 100m
               memory: 100Mi


### PR DESCRIPTION
The limits on Kubernetes system components, especially the API server, are very restrictive and don't really make sense. We probably don't want to limit it to 20% of a single CPU and then resize every time we change the instance type. Let's just remove the limits for now and add them back only if we run into issues.