### PR TITLE
Add secret with cluster-inf secrets to default ns

### DIFF
--- a/cluster/manifests/infrastructure-secrets/secret.yaml
+++ b/cluster/manifests/infrastructure-secrets/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-infrastructure-secrets
+  namespace: default
+type: Opaque
+data:
+  zmon-sql-user: "{{ .ConfigItems.zmon_worker_plugin_sql_user | base64 }}"
+  zmon-sql-pass: "{{ .ConfigItems.zmon_worker_plugin_sql_pass | base64 }}"
+  scalyr-access-key: "{{ .ConfigItems.scalyr_access_key | base64 }}"


### PR DESCRIPTION
This adds a secret `cluster-infrastructure-secrets` to the default
namespace with standard credentials like scalyr-access-key and zmon-sql
credentials such that they can be consumed by other infrastructure
services like postgres-operator.

ACID needs this for the postgres-operator such that they can automatically ship logs of the postgres clusters to scalyr (not just the stdout logs which the logging-agent ship) and they also need the zmon-sql credentials in order to create a user in the postgres clusters which zmon can use for running sql checks.