### PR TITLE
Enable Kubernetes Backend for Flannel

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -4,5 +4,14 @@
 #   namespace: kube-system
 #   kind: deployment
 
-pre_apply: [] # everything defined under here will be deleted before applying the manifests
+pre_apply: # everything defined under here will be deleted before applying the manifests
+# let kubernetes handle podCIDR allocations.
+- name: pod-cidr-controller
+  namespace: kube-system
+  kind: deployment
+# in order to get rid of any apply shenanigans, like initContainers being kept
+- name: kube-flannel
+  namespace: kube-system
+  kind: daemonset
+
 post_apply: [] # everything defined under here will be deleted after applying the manifests

--- a/cluster/manifests/flannel/configmap.yaml
+++ b/cluster/manifests/flannel/configmap.yaml
@@ -1,0 +1,16 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: kube-flannel-cfg
+  namespace: kube-system
+  labels:
+    tier: node
+    app: flannel
+data:
+  net-conf.json: |
+    {
+      "Network": "10.2.0.0/16",
+      "Backend": {
+        "Type": "vxlan"
+      }
+    }

--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -20,32 +20,26 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      initContainers:
-      - name: etcdctl
-        image: quay.io/coreos/etcd:v3.2.10
-        args:
-        - etcdctl
-        - --endpoint=http://127.0.0.1:2379
-        - set
-        - /coreos.com/network/config
-        - '{"Network": "10.2.0.0/16", "Backend": {"Type": "vxlan"}}'
-        resources:
-          limits:
-            cpu: 100m
-            memory: 100Mi
-          requests:
-            cpu: 25m
-            memory: 25Mi
+      serviceAccountName: system
       containers:
       - name: kube-flannel
         image: registry.opensource.zalan.do/teapot/flannel:v0.9.1
         args:
-        - --etcd-endpoints=http://127.0.0.1:2379
+        - --kube-subnet-mgr
         - --iface=eth0
         - --ip-masq
         - --healthz-ip=127.0.0.1
         - --healthz-port=7978
         - --v=2
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         resources:
           limits:
             cpu: 100m
@@ -56,6 +50,8 @@ spec:
         securityContext:
           privileged: true
         volumeMounts:
+        - name: flannelcfg
+          mountPath: /etc/kube-flannel
         - name: runflannel
           mountPath: /run/flannel
       hostNetwork: true
@@ -69,6 +65,9 @@ spec:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
       volumes:
+      - name: flannelcfg
+        configMap:
+          name: kube-flannel-cfg
       - name: runflannel
         hostPath:
           path: /run/flannel

--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -26,7 +26,7 @@ spec:
         image: registry.opensource.zalan.do/teapot/flannel:v0.9.1
         args:
         - --kube-subnet-mgr
-        - --iface=eth0
+        - --iface=$(POD_IP)
         - --ip-masq
         - --healthz-ip=127.0.0.1
         - --healthz-port=7978
@@ -40,6 +40,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         resources:
           limits:
             cpu: 100m

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -463,6 +463,8 @@ write_files:
           - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true
           - --use-service-account-credentials=true
           - --v=4
+          - --allocate-node-cidrs=true
+          - --cluster-cidr=10.2.0.0/16
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
This modifies the flannel Daemonset to switch its backend to the `Node` resource of the Kubernetes API server and allows to prevent workers from accessing etcd at all.

The new flannels will pick up their subnet allocations from the API server and - with the help of [PodCIDR controller](https://github.bus.zalan.do/teapot/pod-cidr-controller) - will find the same allocations as are currently present in etcd. To make this work the update is required to happen without a worker node update so that previous node allocations stay valid. Because of this, we migrated it to an etcd backed daemonset first in order to make the update without a userdata change.

During update, the responsibility of allocating PodCIDRs is shifted from flannel to Kubernetes' controller manager. Once the new controller manager becomes the leader it will allocate PodCIDRs and the PodCIDR controller as well as etcd access can be removed.

For more details on the entire upgrade process read the [Migration strategy proposal](https://github.bus.zalan.do/teapot/issues/issues/683)

Part of https://github.com/zalando-incubator/kubernetes-on-aws/pull/236