### PR TITLE
etcd-proxy: bump version, remove restart limit

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -23,10 +23,11 @@ coreos:
         [Service]
         Type=simple
         Restart=on-failure
-        RestartSec=10s
+        RestartSec=5s
+        StartLimitIntervalSec=0
         ExecStartPre=/usr/bin/mkdir --parents /var/lib/coreos
         ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/lib/coreos/etcd-member-wrapper.uuid
-        ExecStart=/usr/bin/rkt run --uuid-file-save=/var/lib/coreos/etcd-member-wrapper.uuid --port=2379-tcp:2379 --mount volume=dns,target=/etc/resolv.conf --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true --insecure-options=image docker://registry.opensource.zalan.do/teapot/etcd-proxy:master-1 -- {{ETCD_ENDPOINTS}}
+        ExecStart=/usr/bin/rkt run --uuid-file-save=/var/lib/coreos/etcd-member-wrapper.uuid --port=2379-tcp:2379 --mount volume=dns,target=/etc/resolv.conf --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true --insecure-options=image docker://registry.opensource.zalan.do/teapot/etcd-proxy:master-2 -- {{ETCD_ENDPOINTS}}
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/lib/coreos/etcd-member-wrapper.uuid
         [Install]
         WantedBy=multi-user.target

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -23,10 +23,11 @@ coreos:
         [Service]
         Type=simple
         Restart=on-failure
-        RestartSec=10s
+        RestartSec=5s
+        StartLimitIntervalSec=0
         ExecStartPre=/usr/bin/mkdir --parents /var/lib/coreos
         ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/lib/coreos/etcd-member-wrapper.uuid
-        ExecStart=/usr/bin/rkt run --uuid-file-save=/var/lib/coreos/etcd-member-wrapper.uuid --port=2379-tcp:2379 --mount volume=dns,target=/etc/resolv.conf --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true --insecure-options=image docker://registry.opensource.zalan.do/teapot/etcd-proxy:master-1 -- {{ETCD_ENDPOINTS}}
+        ExecStart=/usr/bin/rkt run --uuid-file-save=/var/lib/coreos/etcd-member-wrapper.uuid --port=2379-tcp:2379 --mount volume=dns,target=/etc/resolv.conf --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true --insecure-options=image docker://registry.opensource.zalan.do/teapot/etcd-proxy:master-2 -- {{ETCD_ENDPOINTS}}
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/lib/coreos/etcd-member-wrapper.uuid
         [Install]
         WantedBy=multi-user.target


### PR DESCRIPTION
This should avoid the transient DNS errors we get sometimes.