### PR TITLE
kube-dns: fix pod anti-affinity for kube-dns

### DIFF
--- a/cluster/manifests/kube-dns/depl-kube-dns.yaml
+++ b/cluster/manifests/kube-dns/depl-kube-dns.yaml
@@ -37,7 +37,7 @@ spec:
                   - key: application
                     operator: In
                     values:
-                    - kube-dns-backup
+                    - kube-dns-b
                 topologyKey: kubernetes.io/hostname
       serviceAccountName: system
       tolerations:


### PR DESCRIPTION
I forgot to change it from `-backup`.