### PR TITLE
chore: update zmon-agent-core to the latest version

### DIFF
--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: "kube-system"
   labels:
     application: "zmon-agent"
-    version: "0.1-a39"
+    version: "0.1-a40"
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: "zmon-agent"
-        version: "0.1-a39"
+        version: "0.1-a40"
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -47,7 +47,7 @@ spec:
 
       containers:
         - name: zmon-agent
-          image: "registry.opensource.zalan.do/zmon/zmon-agent-core:0.1-a39"
+          image: "registry.opensource.zalan.do/zmon/zmon-agent-core:0.1-a40"
           resources:
             limits:
               cpu: 100m


### PR DESCRIPTION
Update zmon-agent-core to the latest version as requested by ACID.

Note that this image is flagged with "Unfixable CVE Severity": `HIGH`.

```
Team│Artifact       │Tag                         │Created│By                                         │Fixable CVE Severity│Unfixable CVE Severity
zmon zmon-agent-core 0.1-a40                       8d ago credprov-cdp-controller-proxy_pierone-token NO_CVES_FOUND        HIGH
```

To have a reference point for the future cases I would like to get your opinion if we should allow new images with that rating in our core kube-system namespace.

/cc @hjacobs @szuecs @aermakov-zalando 