### PR TITLE
Handle special zmon config for db cluster

### DIFF
--- a/cluster/manifests/zmon-aws-agent/deployment.yaml
+++ b/cluster/manifests/zmon-aws-agent/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     application: "zmon-aws-agent"
     version: "v149"
 spec:
-  replicas: 1
+  replicas: {{ if ne .Alias "db" }}1{{ else }}0{{ end }}
   selector:
     matchLabels:
       application: zmon-aws-agent

--- a/cluster/manifests/zmon-scheduler/deployment.yaml
+++ b/cluster/manifests/zmon-scheduler/deployment.yaml
@@ -93,7 +93,7 @@ spec:
               value: "6379"
 
             - name: SCHEDULER_ENTITY_BASE_FILTER_STR
-              value: '[{"infrastructure_account":"{{ .InfrastructureAccount }}","region":"{{ .Region }}"}]'
+              value: '[{"infrastructure_account":"{{ .InfrastructureAccount }}","region":"{{ .Region }}"{{ if eq .Alias "db" }}, "kube_cluster":"{{ .ID }}"{{ end }}}]'
             - name: SCHEDULER_INSTANT_EVAL_HTTP_URL
               value: https://data-service.zmon.zalan.do/api/v1/instant-evaluations/kube-cluster[{{ .InfrastructureAccount }}:{{ .Region }}]/
             - name: SCHEDULER_TRIAL_RUN_HTTP_URL


### PR DESCRIPTION
Add special config for zmon components when applied to the DB cluster.

This will allow us to get rid of the db-alpha branch and should be a temporary fix until ACID switches to the in-kubernetes zmon appliance.