### PR TITLE
Disable audit events from credentials-provider

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -690,6 +690,9 @@ write_files:
         # Don't audit events from system users in kube-system
         - level: None
           userGroups: ["system:serviceaccounts:kube-system"]
+        # Don't audit events from high traffic infrastructure components
+        - level: None
+          users: ["credentials-provider"]
         - level: None
           userGroups: ["system:nodes"]
           verbs: ["get"]


### PR DESCRIPTION
Disables audit events from credentials-provider as agreed with Torch. It creates most of the current events which are less important since it's an infrastructure component.