### PR TITLE
Drop emergency access service from test clusters

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -17,7 +17,4 @@ pre_apply: # everything defined under here will be deleted before applying the m
 - name: emergency-access-service-secrets
   namespace: kube-system
   kind: secret
-- name: emergency-access-service
-  namespace: kube-system
-  kind: platformcredentialsset
 post_apply: [] # everything defined under here will be deleted after applying the manifests

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -4,5 +4,20 @@
 #   namespace: kube-system
 #   kind: deployment
 
-pre_apply: [] # everything defined under here will be deleted before applying the manifests
+pre_apply: # everything defined under here will be deleted before applying the manifests
+- name: emergency-access-service
+  namespace: kube-system
+  kind: deployment
+- name: emergency-access-service
+  namespace: kube-system
+  kind: service
+- name: emergency-access-service
+  namespace: kube-system
+  kind: ingress
+- name: emergency-access-service-secrets
+  namespace: kube-system
+  kind: secret
+- name: emergency-access-service
+  namespace: kube-system
+  kind: platformcredentialsset
 post_apply: [] # everything defined under here will be deleted after applying the manifests

--- a/cluster/manifests/emergency-access-service/credentials.yaml
+++ b/cluster/manifests/emergency-access-service/credentials.yaml
@@ -1,3 +1,4 @@
+{{ if eq .Environment "production" }}
 # from: ../platformcredentialsset/customresourcedefinition.yaml
 # This is a hack put in place to ensure that the CustomResourceDefinition will
 # be created before the actual PlatformCredentialsSet resource.
@@ -32,3 +33,4 @@ spec:
        privileges:
      emergency-service:
        privileges:
+{{ end }}

--- a/cluster/manifests/emergency-access-service/deployment.yaml
+++ b/cluster/manifests/emergency-access-service/deployment.yaml
@@ -1,3 +1,4 @@
+{{ if eq .Environment "production" }}
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
@@ -72,3 +73,4 @@ spec:
       - name: secrets
         secret:
           secretName: "emergency-access-service-secrets"
+{{ end }}

--- a/cluster/manifests/emergency-access-service/deployment.yaml
+++ b/cluster/manifests/emergency-access-service/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     application: emergency-access-service
-    version: master-48
+    version: master-49
 spec:
   replicas: 1
   selector:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: emergency-access-service
-        version: master-48
+        version: master-49
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
           [{"container": "emergency-access-service", "parser": "json-structured-log"}]
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: system
       containers:
       - name: emergency-access-service
-        image: "pierone.stups.zalan.do/teapot/emergency-access-service:master-48"
+        image: "pierone.stups.zalan.do/teapot/emergency-access-service:master-49"
         args:
         - --insecure-http
         - --community={{ .Owner }}

--- a/cluster/manifests/emergency-access-service/ingress.yaml
+++ b/cluster/manifests/emergency-access-service/ingress.yaml
@@ -1,3 +1,4 @@
+{{ if eq .Environment "production" }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -13,3 +14,4 @@ spec:
       - backend:
           serviceName: emergency-access-service
           servicePort: http
+{{ end }}

--- a/cluster/manifests/emergency-access-service/secret.yaml
+++ b/cluster/manifests/emergency-access-service/secret.yaml
@@ -1,3 +1,4 @@
+{{ if eq .Environment "production" }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,3 +11,4 @@ data:
   # value in the following format:
   # {"username": "user", "password": "pass", "magic_token": "token"}
   jira-secrets: "{{ .ConfigItems.jira_secrets | base64 }}"
+{{ end }}

--- a/cluster/manifests/emergency-access-service/service.yaml
+++ b/cluster/manifests/emergency-access-service/service.yaml
@@ -1,3 +1,4 @@
+{{ if eq .Environment "production" }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -14,3 +15,4 @@ spec:
       targetPort: 8080
       protocol: TCP
       name: http
+{{ end }}


### PR DESCRIPTION
Drops the emergency access service from all test clusters where it can't be used anyway. This will save us an ALB in each test cluster where no other ingress resources are defined.

Also bumps the emergency-access-service to version: master-49 which includes support for the special Zalando Payments community format.