### PR TITLE
Update audittrail-adapter to use new schema

### DIFF
--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     application: audittrail-adapter
-    version: master-14
+    version: master-15
 spec:
   selector:
     matchLabels:
@@ -17,7 +17,7 @@ spec:
     metadata:
       labels:
         application: audittrail-adapter
-        version: master-14
+        version: master-15
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -36,7 +36,7 @@ spec:
       hostNetwork: true
       containers:
       - name: audittrail-adapter
-        image: pierone.stups.zalan.do/teapot/audittrail-adapter:master-14
+        image: pierone.stups.zalan.do/teapot/audittrail-adapter:master-15
         args:
         - --cluster-id={{ .ID }}
         - --audittrail-url=https://audittrail.cloud.zalando.com


### PR DESCRIPTION
Updates the audittrail schema to 1.2 which is less strict on the type of the requestObject field. Before it was restricted to objects but that is too strict since the value can also be an array.