### PR TITLE
Update image-policy-webhook to v0.3.4

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -383,7 +383,7 @@ write_files:
               value: https://identity.zalando.com/.well-known/openid-configuration
             - name: ENABLE_INTROSPECTION
               value: "true"
-        - image: registry.opensource.zalan.do/teapot/image-policy-webhook:v0.3.3
+        - image: registry.opensource.zalan.do/teapot/image-policy-webhook:v0.3.4
           name: image-policy-webhook
           args:
           - --policy={{ IMAGE_POLICY }}

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -383,7 +383,7 @@ write_files:
               value: https://identity.zalando.com/.well-known/openid-configuration
             - name: ENABLE_INTROSPECTION
               value: "true"
-        - image: registry.opensource.zalan.do/teapot/image-policy-webhook:v0.3.2
+        - image: registry.opensource.zalan.do/teapot/image-policy-webhook:v0.3.3
           name: image-policy-webhook
           args:
           - --policy={{ IMAGE_POLICY }}


### PR DESCRIPTION
Updates image-policy-webhook to a version with scm-source cache and retries for getting scm-source from PierOne.