### PR TITLE
Resurrect kube-job-cleaner

### DIFF
--- a/cluster/manifests/kube-job-cleaner/cronjob.yaml
+++ b/cluster/manifests/kube-job-cleaner/cronjob.yaml
@@ -1,0 +1,34 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: kube-job-cleaner
+  namespace: kube-system
+  labels:
+    application: kube-job-cleaner
+    version: "0.4-1"
+spec:
+  schedule: "17 * * * *"
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 120
+      template:
+        metadata:
+          labels:
+            application: kube-job-cleaner
+            version: "0.4-1"
+        spec:
+          serviceAccountName: system
+          restartPolicy: Never
+          containers:
+          - name: cleaner
+            # delete all completed jobs after one hour
+            image: registry.opensource.zalan.do/teapot/kube-job-cleaner:0.4-1
+            resources:
+              limits:
+                cpu: 100m
+                memory: 100Mi
+              requests:
+                cpu: 50m
+                memory: 50Mi


### PR DESCRIPTION
We don't need the job cleaner part of it, but it had a side effect of removing completed pods as well, which we still need. Let's just resurrect it for now and rename/cleanup later.