### PR TITLE
Upgrade ingress controller to v0.6.0

### DIFF
--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.5.0
+    version: v0.6.0
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.5.0
+        version: v0.6.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
@@ -26,10 +26,16 @@ spec:
         operator: Exists
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.5.0
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.6.0
         env:
         - name: AWS_REGION
           value: {{ .Region }}
+        # Needed in order to find nodes that should be attached to the ALBs.
+        # We should switch to the default filter when all nodes has the
+        # k8s.io/role/node tag.
+        # https://github.com/zalando-incubator/kube-ingress-aws-controller#how-it-works
+        - name: CUSTOM_FILTERS
+          value: "tag:kubernetes.io/cluster/{{ .ID }}=owned tag:NodePool=worker-default"
         resources:
           limits:
             cpu: 200m

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -114,6 +114,8 @@ SenzaComponents:
           Value: owned
         - Key: "NodePool"
           Value: "{{ Arguments.WorkerNodePoolName }}"
+        - Key: "k8s.io/role/node"
+          Value: "worker"
 Resources:
   MasterIAMRole:
     Properties:


### PR DESCRIPTION
Upgrades to v0.6.0 of the kube-ingress-aws-controller: https://github.com/zalando-incubator/kube-ingress-aws-controller/releases/tag/v0.6.0

This adds support for multiple certs per ALB reducing the number of ALBs that we provision. It also adds support for attaching multiple autoscaling groups and single ec2 instances to the ALB target groups. This will enable us to support Spot fleet in the future.