### PR TITLE
Updates image-policy-webhook to fix caching invalid SCM source

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -383,7 +383,7 @@ write_files:
               value: https://identity.zalando.com/.well-known/openid-configuration
             - name: ENABLE_INTROSPECTION
               value: "true"
-        - image: registry.opensource.zalan.do/teapot/image-policy-webhook:v0.3.4
+        - image: registry.opensource.zalan.do/teapot/image-policy-webhook:v0.3.5
           name: image-policy-webhook
           args:
           - --policy={{ IMAGE_POLICY }}


### PR DESCRIPTION
Fixes that image-policy-webhook can cache invalid SCM Source 