### PR TITLE
Add ingress-template-controller deployment

### DIFF
--- a/cluster/manifests/ingress-template-controller/crd.yaml
+++ b/cluster/manifests/ingress-template-controller/crd.yaml
@@ -1,0 +1,14 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ingresstemplates.zalando.org
+spec:
+  group: zalando.org
+  version: v1
+  scope: Namespaced
+  names:
+    kind: IngressTemplate
+    singular: ingresstemplate
+    plural: ingresstemplates
+    shortNames:
+    - it

--- a/cluster/manifests/ingress-template-controller/deployment.yaml
+++ b/cluster/manifests/ingress-template-controller/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: ingress-template-controller
+  namespace: kube-system
+  labels:
+    application: ingress-template-controller
+    version: master-2
+spec:
+  selector:
+    matchLabels:
+      application: ingress-template-controller
+  template:
+    metadata:
+      labels:
+        application: ingress-template-controller
+        version: master-2
+    spec:
+      serviceAccountName: system
+      containers:
+      - name: ingress-template-controller
+        image: pierone.stups.zalan.do/teapot/ingress-template-controller:master-2
+        resources:
+          limits:
+            cpu: 10m
+            memory: 50Mi
+          requests:
+            cpu: 10m
+            memory: 50Mi


### PR DESCRIPTION
This adds the ingress-template-controller which will be used for traffic switching support along with the CRD describing the new `IngressTemplate` resource.