### PR TITLE
Update kube-ingress-aws-controller to v0.6.1

### DIFF
--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.6.0
+    version: v0.6.1
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.6.0
+        version: v0.6.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
@@ -26,7 +26,7 @@ spec:
         operator: Exists
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.6.0
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.6.1
         env:
         - name: AWS_REGION
           value: {{ .Region }}

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -250,6 +250,7 @@ Resources:
           - {Action: 'autoscaling:DetachLoadBalancers', Effect: Allow, Resource: '*'}
           - {Action: 'autoscaling:DetachLoadBalancerTargetGroups', Effect: Allow, Resource: '*'}
           - {Action: 'autoscaling:AttachLoadBalancerTargetGroups', Effect: Allow, Resource: '*'}
+          - {Action: 'autoscaling:DescribeLoadBalancerTargetGroups', Effect: Allow, Resource: '*'}
           - {Action: 'cloudformation:*', Effect: Allow, Resource: '*'}
           - {Action: 'elasticloadbalancing:*', Effect: Allow, Resource: '*'}
           - {Action: 'elasticloadbalancingv2:*', Effect: Allow, Resource: '*'}


### PR DESCRIPTION
Fixes a problem of removing obsolete Target groups from the ASGs.

https://github.com/zalando-incubator/kube-ingress-aws-controller/pull/127