### PR TITLE
Upgrade to kube-ingress-aws-controller v0.6.6

### DIFF
--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.6.3
+    version: v0.6.4
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.6.3
+        version: v0.6.4
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
@@ -26,7 +26,9 @@ spec:
         operator: Exists
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.6.3
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.6.4
+        args:
+        - -stack-termination-protection
         env:
         - name: AWS_REGION
           value: {{ .Region }}

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.6.1
+    version: v0.6.3
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.6.1
+        version: v0.6.3
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
@@ -26,7 +26,7 @@ spec:
         operator: Exists
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.6.1
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.6.3
         env:
         - name: AWS_REGION
           value: {{ .Region }}

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.6.4
+    version: v0.6.6
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.6.4
+        version: v0.6.6
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
@@ -26,7 +26,7 @@ spec:
         operator: Exists
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.6.4
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.6.6
         args:
         - -stack-termination-protection
         env:


### PR DESCRIPTION
Adds possibility to get unique ALB for an ingress resource: https://github.com/zalando-incubator/kube-ingress-aws-controller/pull/133

* https://github.com/zalando-incubator/kube-ingress-aws-controller/releases/tag/v0.6.6
* https://github.com/zalando-incubator/kube-ingress-aws-controller/releases/tag/v0.6.5
* https://github.com/zalando-incubator/kube-ingress-aws-controller/releases/tag/v0.6.4
* https://github.com/zalando-incubator/kube-ingress-aws-controller/releases/tag/v0.6.3
* https://github.com/zalando-incubator/kube-ingress-aws-controller/releases/tag/v0.6.2