### PR TITLE
Expose etcd metrics under a separate port

### DIFF
--- a/cluster/etcd-cluster.yaml
+++ b/cluster/etcd-cluster.yaml
@@ -13,6 +13,7 @@ SenzaComponents:
       ports:
         2379: 2379
         2380: 2380
+        2381: 2381
       runtime: Docker
       source: registry.opensource.zalan.do/acid/etcd-cluster:3.3.1-p20
       environment:
@@ -68,7 +69,7 @@ Resources:
         CidrIp: 172.16.0.0/12
       - IpProtocol: tcp
         FromPort: 2379
-        ToPort: 2380
+        ToPort: 2381
         CidrIp: 172.16.0.0/12
       - IpProtocol: tcp
         FromPort: 9100


### PR DESCRIPTION
etcd v3.3 introduced a new flag to allow serving `/metrics` and `/health` under a different port than `/v2/keys`. This allows us to protect etcd's data via security groups but still let `zmon-worker` to access metrics and health information.

This PR:
* Uses an etcd appliance image pending the required PR: https://github.com/zalando-stups/stups-etcd-cluster/pull/48
* Instructs taupage to map container port 2381 to the outside
* Opens port 2381 to be accessed from our worker nodes

Follow-up PR:
* [ ] restrict worker nodes from accessing port 2379 (and 2380?)

/cc @aermakov-zalando @mikkeloscar 