### PR TITLE
skipper lb feature rollout

### DIFF
--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.9.152
+    version: v0.9.162
     component: ingress
 spec:
   selector:
@@ -18,7 +18,7 @@ spec:
       name: skipper-ingress
       labels:
         application: skipper-ingress
-        version: v0.9.152
+        version: v0.9.162
         component: ingress
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -40,7 +40,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.9.152
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.9.162
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -56,6 +56,7 @@ spec:
           - "-experimental-upgrade"
           - "-metrics-exp-decay-sample"
           - "-reverse-source-predicate"
+          - "-lb-healthcheck-interval=3s"
         resources:
           limits:
             cpu: 200m


### PR DESCRIPTION
this will rollout the new skipper version with enabled lb feature, that will bypass kubernetes service and request directly to endpoints