### PR TITLE
fix skipper endpoint issue

### DIFF
--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.9.162
+    version: v0.9.165
     component: ingress
 spec:
   selector:
@@ -18,7 +18,7 @@ spec:
       name: skipper-ingress
       labels:
         application: skipper-ingress
-        version: v0.9.162
+        version: v0.9.165
         component: ingress
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -40,7 +40,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.9.162
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.9.165
         ports:
         - name: ingress-port
           containerPort: 9999


### PR DESCRIPTION
Skipper did not consider kubernetes services with more than one port.
see https://github.com/zalando/skipper/issues/563