### PR TITLE
Downgrade zmon-scheduler

### DIFF
--- a/cluster/manifests/zmon-scheduler/deployment.yaml
+++ b/cluster/manifests/zmon-scheduler/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: zmon-scheduler
-    version: "v45-zv147"
+    version: "v43"
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: zmon-scheduler
-        version: "v45-zv147"
+        version: "v43"
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -47,7 +47,7 @@ spec:
 
       containers:
         - name: zmon-scheduler
-          image: "pierone.stups.zalan.do/zmon/zmon-scheduler:v45-zv147"
+          image: "registry.opensource.zalan.do/stups/zmon-scheduler:v43"
           resources:
             limits:
               cpu: 2


### PR DESCRIPTION
The new version introduced in #884 is using much more memory. Roll back to a working version.