### PR TITLE
autoscaling: make utilization threshold configurable

### DIFF
--- a/cluster/manifests/kube-cluster-autoscaler/autoscaler-deployment.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/autoscaler-deployment.yaml
@@ -33,6 +33,7 @@ spec:
           - ./cluster-autoscaler
           - --v=4
           - --stderrthreshold=info
+          - --scale-down-utilization-threshold={{if index .ConfigItems "autoscaling_utilization_threshold"}}{{.ConfigItems.autoscaling_utilization_threshold}}{{else}}0.75{{end}}
           - --cloud-provider=aws
           - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,zalando.de/cluster-local-id/{{ .LocalID }}
           - --expendable-pods-priority-cutoff=-1000000


### PR DESCRIPTION
 - Utilization threshold (for downscaling) is now configurable with the
`autoscaling_utilization_threshold` config item.
 - Production clusters have buffer pods, so raise the default threshold to 0.75 instead of 0.5.