### PR TITLE
Alpha to beta (Kubernetes v1.9)

### DIFF
--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -1,5 +1,5 @@
 {{ if eq .Environment "production" }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: audittrail-adapter

--- a/cluster/manifests/dashboard/deployment.yaml
+++ b/cluster/manifests/dashboard/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kubernetes-dashboard

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: external-dns

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: external-dns
-    version: v0.5.0-alpha.0
+    version: v0.5.0-alpha.1
 spec:
   strategy:
     type: Recreate
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: external-dns
-        version: v0.5.0-alpha.0
+        version: v0.5.0-alpha.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
@@ -26,7 +26,7 @@ spec:
          operator: Exists
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.5.0-alpha.0
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.5.0-alpha.1
         args:
         - --source=service
         - --source=ingress

--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kube-flannel

--- a/cluster/manifests/heapster/deployment.yaml
+++ b/cluster/manifests/heapster/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: heapster

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kube-ingress-aws-controller

--- a/cluster/manifests/kube-cluster-autoscaler/autoscaler-deployment.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/autoscaler-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kube-cluster-autoscaler

--- a/cluster/manifests/kube-cluster-autoscaler/autoscaler-deployment.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/autoscaler-deployment.yaml
@@ -48,6 +48,5 @@ spec:
         env:
           - name: AWS_REGION
             value: {{ .Region }}
-        imagePullPolicy: "Always"
       nodeSelector:
         node-role.kubernetes.io/master: ""

--- a/cluster/manifests/kube-cluster-autoscaler/autoscaler-deployment.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/autoscaler-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-cluster-autoscaler
-    version: v1.0.3
+    version: v1.1.1
 spec:
   replicas: 2
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-cluster-autoscaler
-        version: v1.0.3
+        version: v1.1.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-autoscaler"
@@ -28,7 +28,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cluster-autoscaler
-        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.0.3
+        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.1.1
         command:
           - ./cluster-autoscaler
           - --v=4
@@ -36,6 +36,7 @@ spec:
           - --scale-down-utilization-threshold={{if index .ConfigItems "autoscaling_utilization_threshold"}}{{.ConfigItems.autoscaling_utilization_threshold}}{{else}}0.75{{end}}
           - --cloud-provider=aws
           - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,zalando.de/cluster-local-id/{{ .LocalID }}
+          - --expendable-pods-priority-cutoff=-1000000
           - --skip-nodes-with-system-pods=false
           - --skip-nodes-with-local-storage=false
         resources:

--- a/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment.yaml
@@ -41,4 +41,3 @@ spec:
           requests:
             cpu: {{if index .ConfigItems "autoscaling_buffer_cpu"}}{{.ConfigItems.autoscaling_buffer_cpu}}{{else}}1{{end}}
             memory: {{if index .ConfigItems "autoscaling_buffer_memory"}}{{.ConfigItems.autoscaling_buffer_memory}}{{else}}4000Mi{{end}}
-        imagePullPolicy: "Always"

--- a/cluster/manifests/kube-dns-metrics-bash/deployment.yaml
+++ b/cluster/manifests/kube-dns-metrics-bash/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kube-dns-metrics-bash

--- a/cluster/manifests/kube-dns-metrics/deployment.yaml
+++ b/cluster/manifests/kube-dns-metrics/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kube-dns-metrics

--- a/cluster/manifests/kube-dns/depl-kube-dns-autoscaler.yaml
+++ b/cluster/manifests/kube-dns/depl-kube-dns-autoscaler.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kube-dns-autoscaler

--- a/cluster/manifests/kube-dns/depl-kube-dns-b-autoscaler.yaml
+++ b/cluster/manifests/kube-dns/depl-kube-dns-b-autoscaler.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kube-dns-b-autoscaler

--- a/cluster/manifests/kube-dns/depl-kube-dns-b.yaml
+++ b/cluster/manifests/kube-dns/depl-kube-dns-b.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kube-dns-b

--- a/cluster/manifests/kube-dns/depl-kube-dns.yaml
+++ b/cluster/manifests/kube-dns/depl-kube-dns.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kube-dns

--- a/cluster/manifests/kube-node-ready/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kube-node-ready

--- a/cluster/manifests/kube-proxy/configmap.yaml
+++ b/cluster/manifests/kube-proxy/configmap.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-proxy-config
+  namespace: kube-system
+data:
+  # generated from ./kube-proxy --proxy-mode=iptables --kubeconfig=/etc/kubernetes/kubeconfig --write-config-to kube-proxy.yaml
+  kube-proxy.yaml: |
+    apiVersion: kubeproxy.config.k8s.io/v1alpha1
+    bindAddress: 0.0.0.0
+    clientConnection:
+      acceptContentTypes: ""
+      burst: 10
+      contentType: application/vnd.kubernetes.protobuf
+      kubeconfig: /etc/kubernetes/kubeconfig
+      qps: 5
+    clusterCIDR: ""
+    configSyncPeriod: 15m0s
+    conntrack:
+      max: 0
+      maxPerCore: 32768
+      min: 131072
+      tcpCloseWaitTimeout: 1h0m0s
+      tcpEstablishedTimeout: 24h0m0s
+    enableProfiling: false
+    featureGates: "ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true"
+    healthzBindAddress: 0.0.0.0:10256
+    hostnameOverride: ""
+    iptables:
+      masqueradeAll: false
+      masqueradeBit: 14
+      minSyncPeriod: 0s
+      syncPeriod: 30s
+    ipvs:
+      minSyncPeriod: 0s
+      scheduler: ""
+      syncPeriod: 30s
+    kind: KubeProxyConfiguration
+    metricsBindAddress: 127.0.0.1:10249
+    mode: iptables
+    oomScoreAdj: -999
+    portRange: ""
+    resourceContainer: /kube-proxy
+    udpTimeoutMilliseconds: 250ms

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -37,8 +37,7 @@ spec:
         command:
         - /hyperkube
         - proxy
-        - --kubeconfig=/etc/kubernetes/kubeconfig
-        - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true
+        - --config=/config/kube-proxy.yaml
         - --v=2
         securityContext:
           privileged: true
@@ -59,6 +58,9 @@ spec:
         - name: etc-kube-ssl
           mountPath: /etc/kubernetes/ssl
           readOnly: true
+        - name: kube-proxy-config
+          mountPath: /config
+          readOnly: true
       volumes:
       - name: ssl-certs
         hostPath:
@@ -69,3 +71,6 @@ spec:
       - name: etc-kube-ssl
         hostPath:
           path: /etc/kubernetes/ssl
+      - name: kube-proxy-config
+        configMap:
+          name: kube-proxy-config

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -1,11 +1,11 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kube-proxy
   namespace: kube-system
   labels:
     application: kube-proxy
-    version: v1.8.5_coreos.0
+    version: v1.9.0_coreos.0
 spec:
   selector:
     matchLabels:
@@ -17,7 +17,7 @@ spec:
       name: kube-proxy
       labels:
         application: kube-proxy
-        version: v1.8.5_coreos.0
+        version: v1.9.0_coreos.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -33,7 +33,7 @@ spec:
       hostNetwork: true
       containers:
       - name: kube-proxy
-        image: registry.opensource.zalan.do/teapot/hyperkube:v1.8.5_coreos.0
+        image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.0_coreos.0
         command:
         - /hyperkube
         - proxy

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-proxy
-    version: v1.9.1_coreos.0
+    version: v1.9.2_coreos.0
 spec:
   selector:
     matchLabels:
@@ -17,7 +17,7 @@ spec:
       name: kube-proxy
       labels:
         application: kube-proxy
-        version: v1.9.1_coreos.0
+        version: v1.9.2_coreos.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -33,7 +33,7 @@ spec:
       hostNetwork: true
       containers:
       - name: kube-proxy
-        image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.1_coreos.0
+        image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.2_coreos.0
         command:
         - /hyperkube
         - proxy

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-proxy
-    version: v1.9.2_coreos.0
+    version: v1.9.3_coreos.0
 spec:
   selector:
     matchLabels:
@@ -17,7 +17,7 @@ spec:
       name: kube-proxy
       labels:
         application: kube-proxy
-        version: v1.9.2_coreos.0
+        version: v1.9.3_coreos.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -33,7 +33,7 @@ spec:
       hostNetwork: true
       containers:
       - name: kube-proxy
-        image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.2_coreos.0
+        image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.3_coreos.0
         command:
         - /hyperkube
         - proxy

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-proxy
-    version: v1.9.0_coreos.0
+    version: v1.9.1_coreos.0
 spec:
   selector:
     matchLabels:
@@ -17,7 +17,7 @@ spec:
       name: kube-proxy
       labels:
         application: kube-proxy
-        version: v1.9.0_coreos.0
+        version: v1.9.1_coreos.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -33,7 +33,7 @@ spec:
       hostNetwork: true
       containers:
       - name: kube-proxy
-        image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.0_coreos.0
+        image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.1_coreos.0
         command:
         - /hyperkube
         - proxy

--- a/cluster/manifests/kube-state-metrics/deployment.yaml
+++ b/cluster/manifests/kube-state-metrics/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kube-state-metrics

--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -1,11 +1,11 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kube-static-egress-controller
   namespace: kube-system
   labels:
     application: kube-static-egress-controller
-    version: v0.0.6
+    version: v0.1.1
 spec:
   replicas: 1
   selector:
@@ -15,14 +15,14 @@ spec:
     metadata:
       labels:
         application: kube-static-egress-controller
-        version: v0.0.6
+        version: v0.1.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-static-egress-controller"
     spec:
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-static-egress-controller:v0.0.6
+        image: registry.opensource.zalan.do/teapot/kube-static-egress-controller:v0.1.1
         args:
         - "--log-level=debug"
         - "--provider=aws"
@@ -32,6 +32,7 @@ spec:
         - "--aws-az=eu-central-1a"
         - "--aws-az=eu-central-1b"
         - "--aws-az=eu-central-1c"
+        - "--stack-termination-protection"
         env:
         - name: AWS_REGION
           value: eu-central-1

--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kube2iam

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -31,7 +31,6 @@ spec:
       initContainers:
       - name: init-scalyr-config
         image: registry.opensource.zalan.do/stups/alpine:3.7.0-1
-        imagePullPolicy: IfNotPresent
         command: ["sh", "-c"]
         args:
         - |

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: logging-agent

--- a/cluster/manifests/prometheus-node-exporter/daemonset.yaml
+++ b/cluster/manifests/prometheus-node-exporter/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: prometheus-node-exporter

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: skipper-ingress

--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "zmon-agent"

--- a/cluster/manifests/zmon-aws-agent/deployment.yaml
+++ b/cluster/manifests/zmon-aws-agent/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "zmon-aws-agent"

--- a/cluster/manifests/zmon-redis/deployment.yaml
+++ b/cluster/manifests/zmon-redis/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "zmon-redis"

--- a/cluster/manifests/zmon-scheduler/deployment.yaml
+++ b/cluster/manifests/zmon-scheduler/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: zmon-scheduler

--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: zmon-worker

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -256,6 +256,7 @@ Resources:
           - {Action: 'autoscaling:DetachLoadBalancers', Effect: Allow, Resource: '*'}
           - {Action: 'autoscaling:DetachLoadBalancerTargetGroups', Effect: Allow, Resource: '*'}
           - {Action: 'autoscaling:AttachLoadBalancerTargetGroups', Effect: Allow, Resource: '*'}
+          - {Action: 'autoscaling:DescribeLoadBalancerTargetGroups', Effect: Allow, Resource: '*'}
           - {Action: 'cloudformation:*', Effect: Allow, Resource: '*'}
           - {Action: 'elasticloadbalancing:*', Effect: Allow, Resource: '*'}
           - {Action: 'elasticloadbalancingv2:*', Effect: Allow, Resource: '*'}

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -383,7 +383,7 @@ write_files:
               value: https://identity.zalando.com/.well-known/openid-configuration
             - name: ENABLE_INTROSPECTION
               value: "true"
-        - image: registry.opensource.zalan.do/teapot/image-policy-webhook:v0.3.5
+        - image: registry.opensource.zalan.do/teapot/image-policy-webhook:v0.3.6
           name: image-policy-webhook
           args:
           - --policy={{ IMAGE_POLICY }}

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -117,7 +117,7 @@ coreos:
       runtime: true
       content: |
         [Service]
-        Environment=KUBELET_IMAGE_TAG=v1.9.2_coreos.0
+        Environment=KUBELET_IMAGE_TAG=v1.9.3_coreos.0
         Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
         Environment="RKT_RUN_ARGS=--insecure-options=image \
         --uuid-file-save=/var/run/kubelet-pod.uuid \
@@ -248,7 +248,7 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-apiserver
-          version: v1.9.2_coreos.0
+          version: v1.9.3_coreos.0
         annotations:
           scheduler.alpha.kubernetes.io/critical-pod: ''
           kubernetes-log-watcher/scalyr-parser: |
@@ -262,7 +262,7 @@ write_files:
         hostNetwork: true
         containers:
         - name: kube-apiserver
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.2_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.3_coreos.0
           command:
           - /hyperkube
           - apiserver
@@ -422,7 +422,7 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-controller-manager
-          version: v1.9.2_coreos.0
+          version: v1.9.3_coreos.0
         annotations:
           scheduler.alpha.kubernetes.io/critical-pod: ''
       spec:
@@ -433,7 +433,7 @@ write_files:
           effect: NoSchedule
         containers:
         - name: kube-controller-manager
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.2_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.3_coreos.0
           command:
           - /hyperkube
           - controller-manager
@@ -490,7 +490,7 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-scheduler
-          version: v1.9.2_coreos.0
+          version: v1.9.3_coreos.0
         annotations:
           scheduler.alpha.kubernetes.io/critical-pod: ''
       spec:
@@ -502,7 +502,7 @@ write_files:
         hostNetwork: true
         containers:
         - name: kube-scheduler
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.2_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.3_coreos.0
           command:
           - /hyperkube
           - scheduler
@@ -847,7 +847,7 @@ write_files:
         --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
         --mount volume=dns,target=/etc/resolv.conf \
         --net=host \
-        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.2_coreos.0 \
+        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.3_coreos.0 \
         --exec=/kubectl -- \
         --kubeconfig=/etc/kubernetes/kubeconfig \
         label node "$(hostname)" \
@@ -860,7 +860,7 @@ write_files:
         --net=host \
         --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
         --mount volume=dns,target=/etc/resolv.conf \
-        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.2_coreos.0 \
+        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.3_coreos.0 \
         --exec=/kubectl -- \
         --kubeconfig=/etc/kubernetes/kubeconfig \
         drain "$(hostname)" \

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -117,7 +117,7 @@ coreos:
       runtime: true
       content: |
         [Service]
-        Environment=KUBELET_IMAGE_TAG=v1.9.1_coreos.0
+        Environment=KUBELET_IMAGE_TAG=v1.9.2_coreos.0
         Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
         Environment="RKT_RUN_ARGS=--insecure-options=image \
         --uuid-file-save=/var/run/kubelet-pod.uuid \
@@ -248,7 +248,7 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-apiserver
-          version: v1.9.1_coreos.0
+          version: v1.9.2_coreos.0
         annotations:
           scheduler.alpha.kubernetes.io/critical-pod: ''
           kubernetes-log-watcher/scalyr-parser: |
@@ -262,7 +262,7 @@ write_files:
         hostNetwork: true
         containers:
         - name: kube-apiserver
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.1_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.2_coreos.0
           command:
           - /hyperkube
           - apiserver
@@ -422,7 +422,7 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-controller-manager
-          version: v1.9.1_coreos.0
+          version: v1.9.2_coreos.0
         annotations:
           scheduler.alpha.kubernetes.io/critical-pod: ''
       spec:
@@ -433,7 +433,7 @@ write_files:
           effect: NoSchedule
         containers:
         - name: kube-controller-manager
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.1_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.2_coreos.0
           command:
           - /hyperkube
           - controller-manager
@@ -490,7 +490,7 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-scheduler
-          version: v1.9.1_coreos.0
+          version: v1.9.2_coreos.0
         annotations:
           scheduler.alpha.kubernetes.io/critical-pod: ''
       spec:
@@ -502,7 +502,7 @@ write_files:
         hostNetwork: true
         containers:
         - name: kube-scheduler
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.1_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.2_coreos.0
           command:
           - /hyperkube
           - scheduler
@@ -847,7 +847,7 @@ write_files:
         --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
         --mount volume=dns,target=/etc/resolv.conf \
         --net=host \
-        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.1_coreos.0 \
+        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.2_coreos.0 \
         --exec=/kubectl -- \
         --kubeconfig=/etc/kubernetes/kubeconfig \
         label node "$(hostname)" \
@@ -860,7 +860,7 @@ write_files:
         --net=host \
         --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
         --mount volume=dns,target=/etc/resolv.conf \
-        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.1_coreos.0 \
+        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.2_coreos.0 \
         --exec=/kubectl -- \
         --kubeconfig=/etc/kubernetes/kubeconfig \
         drain "$(hostname)" \

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -117,7 +117,7 @@ coreos:
       runtime: true
       content: |
         [Service]
-        Environment=KUBELET_IMAGE_TAG=v1.8.5_coreos.0
+        Environment=KUBELET_IMAGE_TAG=v1.9.0_coreos.0
         Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
         Environment="RKT_RUN_ARGS=--insecure-options=image \
         --uuid-file-save=/var/run/kubelet-pod.uuid \
@@ -248,7 +248,7 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-apiserver
-          version: v1.8.5_coreos.0
+          version: v1.9.0_coreos.0
         annotations:
           scheduler.alpha.kubernetes.io/critical-pod: ''
           kubernetes-log-watcher/scalyr-parser: |
@@ -262,7 +262,7 @@ write_files:
         hostNetwork: true
         containers:
         - name: kube-apiserver
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.8.5_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.0_coreos.0
           command:
           - /hyperkube
           - apiserver
@@ -422,7 +422,7 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-controller-manager
-          version: v1.8.5_coreos.0
+          version: v1.9.0_coreos.0
         annotations:
           scheduler.alpha.kubernetes.io/critical-pod: ''
       spec:
@@ -433,7 +433,7 @@ write_files:
           effect: NoSchedule
         containers:
         - name: kube-controller-manager
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.8.5_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.0_coreos.0
           command:
           - /hyperkube
           - controller-manager
@@ -490,7 +490,7 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-scheduler
-          version: v1.8.5_coreos.0
+          version: v1.9.0_coreos.0
         annotations:
           scheduler.alpha.kubernetes.io/critical-pod: ''
       spec:
@@ -502,7 +502,7 @@ write_files:
         hostNetwork: true
         containers:
         - name: kube-scheduler
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.8.5_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.0_coreos.0
           command:
           - /hyperkube
           - scheduler
@@ -847,7 +847,7 @@ write_files:
         --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
         --mount volume=dns,target=/etc/resolv.conf \
         --net=host \
-        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.8.5_coreos.0 \
+        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.0_coreos.0 \
         --exec=/kubectl -- \
         --kubeconfig=/etc/kubernetes/kubeconfig \
         label node "$(hostname)" \
@@ -860,7 +860,7 @@ write_files:
         --net=host \
         --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
         --mount volume=dns,target=/etc/resolv.conf \
-        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.8.5_coreos.0 \
+        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.0_coreos.0 \
         --exec=/kubectl -- \
         --kubeconfig=/etc/kubernetes/kubeconfig \
         drain "$(hostname)" \

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -117,7 +117,7 @@ coreos:
       runtime: true
       content: |
         [Service]
-        Environment=KUBELET_IMAGE_TAG=v1.9.0_coreos.0
+        Environment=KUBELET_IMAGE_TAG=v1.9.1_coreos.0
         Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
         Environment="RKT_RUN_ARGS=--insecure-options=image \
         --uuid-file-save=/var/run/kubelet-pod.uuid \
@@ -248,7 +248,7 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-apiserver
-          version: v1.9.0_coreos.0
+          version: v1.9.1_coreos.0
         annotations:
           scheduler.alpha.kubernetes.io/critical-pod: ''
           kubernetes-log-watcher/scalyr-parser: |
@@ -262,7 +262,7 @@ write_files:
         hostNetwork: true
         containers:
         - name: kube-apiserver
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.0_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.1_coreos.0
           command:
           - /hyperkube
           - apiserver
@@ -422,7 +422,7 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-controller-manager
-          version: v1.9.0_coreos.0
+          version: v1.9.1_coreos.0
         annotations:
           scheduler.alpha.kubernetes.io/critical-pod: ''
       spec:
@@ -433,7 +433,7 @@ write_files:
           effect: NoSchedule
         containers:
         - name: kube-controller-manager
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.0_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.1_coreos.0
           command:
           - /hyperkube
           - controller-manager
@@ -490,7 +490,7 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-scheduler
-          version: v1.9.0_coreos.0
+          version: v1.9.1_coreos.0
         annotations:
           scheduler.alpha.kubernetes.io/critical-pod: ''
       spec:
@@ -502,7 +502,7 @@ write_files:
         hostNetwork: true
         containers:
         - name: kube-scheduler
-          image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.0_coreos.0
+          image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.1_coreos.0
           command:
           - /hyperkube
           - scheduler
@@ -847,7 +847,7 @@ write_files:
         --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
         --mount volume=dns,target=/etc/resolv.conf \
         --net=host \
-        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.0_coreos.0 \
+        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.1_coreos.0 \
         --exec=/kubectl -- \
         --kubeconfig=/etc/kubernetes/kubeconfig \
         label node "$(hostname)" \
@@ -860,7 +860,7 @@ write_files:
         --net=host \
         --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
         --mount volume=dns,target=/etc/resolv.conf \
-        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.0_coreos.0 \
+        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.1_coreos.0 \
         --exec=/kubectl -- \
         --kubeconfig=/etc/kubernetes/kubeconfig \
         drain "$(hostname)" \

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -108,7 +108,7 @@ coreos:
       runtime: true
       content: |
         [Service]
-        Environment=KUBELET_IMAGE_TAG=v1.9.2_coreos.0
+        Environment=KUBELET_IMAGE_TAG=v1.9.3_coreos.0
         Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
         Environment="RKT_RUN_ARGS=--insecure-options=image \
         --uuid-file-save=/var/run/kubelet-pod.uuid \
@@ -281,7 +281,7 @@ write_files:
         --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
         --mount volume=dns,target=/etc/resolv.conf \
         --net=host \
-        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.2_coreos.0 \
+        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.3_coreos.0 \
         --exec=/kubectl -- \
         --kubeconfig=/etc/kubernetes/kubeconfig \
         label node "$(hostname)" \
@@ -294,7 +294,7 @@ write_files:
         --net=host \
         --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
         --mount volume=dns,target=/etc/resolv.conf \
-        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.2_coreos.0 \
+        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.3_coreos.0 \
         --exec=/kubectl -- \
         --kubeconfig=/etc/kubernetes/kubeconfig \
         drain "$(hostname)" \

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -108,7 +108,7 @@ coreos:
       runtime: true
       content: |
         [Service]
-        Environment=KUBELET_IMAGE_TAG=v1.9.1_coreos.0
+        Environment=KUBELET_IMAGE_TAG=v1.9.2_coreos.0
         Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
         Environment="RKT_RUN_ARGS=--insecure-options=image \
         --uuid-file-save=/var/run/kubelet-pod.uuid \
@@ -281,7 +281,7 @@ write_files:
         --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
         --mount volume=dns,target=/etc/resolv.conf \
         --net=host \
-        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.1_coreos.0 \
+        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.2_coreos.0 \
         --exec=/kubectl -- \
         --kubeconfig=/etc/kubernetes/kubeconfig \
         label node "$(hostname)" \
@@ -294,7 +294,7 @@ write_files:
         --net=host \
         --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
         --mount volume=dns,target=/etc/resolv.conf \
-        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.1_coreos.0 \
+        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.2_coreos.0 \
         --exec=/kubectl -- \
         --kubeconfig=/etc/kubernetes/kubeconfig \
         drain "$(hostname)" \

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -108,7 +108,7 @@ coreos:
       runtime: true
       content: |
         [Service]
-        Environment=KUBELET_IMAGE_TAG=v1.8.5_coreos.0
+        Environment=KUBELET_IMAGE_TAG=v1.9.0_coreos.0
         Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
         Environment="RKT_RUN_ARGS=--insecure-options=image \
         --uuid-file-save=/var/run/kubelet-pod.uuid \
@@ -281,7 +281,7 @@ write_files:
         --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
         --mount volume=dns,target=/etc/resolv.conf \
         --net=host \
-        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.8.5_coreos.0 \
+        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.0_coreos.0 \
         --exec=/kubectl -- \
         --kubeconfig=/etc/kubernetes/kubeconfig \
         label node "$(hostname)" \
@@ -294,7 +294,7 @@ write_files:
         --net=host \
         --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
         --mount volume=dns,target=/etc/resolv.conf \
-        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.8.5_coreos.0 \
+        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.0_coreos.0 \
         --exec=/kubectl -- \
         --kubeconfig=/etc/kubernetes/kubeconfig \
         drain "$(hostname)" \

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -108,7 +108,7 @@ coreos:
       runtime: true
       content: |
         [Service]
-        Environment=KUBELET_IMAGE_TAG=v1.9.0_coreos.0
+        Environment=KUBELET_IMAGE_TAG=v1.9.1_coreos.0
         Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
         Environment="RKT_RUN_ARGS=--insecure-options=image \
         --uuid-file-save=/var/run/kubelet-pod.uuid \
@@ -281,7 +281,7 @@ write_files:
         --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
         --mount volume=dns,target=/etc/resolv.conf \
         --net=host \
-        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.0_coreos.0 \
+        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.1_coreos.0 \
         --exec=/kubectl -- \
         --kubeconfig=/etc/kubernetes/kubeconfig \
         label node "$(hostname)" \
@@ -294,7 +294,7 @@ write_files:
         --net=host \
         --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
         --mount volume=dns,target=/etc/resolv.conf \
-        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.0_coreos.0 \
+        docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.1_coreos.0 \
         --exec=/kubectl -- \
         --kubeconfig=/etc/kubernetes/kubeconfig \
         drain "$(hostname)" \

--- a/kubernetes_e2e_version
+++ b/kubernetes_e2e_version
@@ -1,1 +1,1 @@
-v1.8.4-disable-psp
+v1.9.0-disable-psp-rbac


### PR DESCRIPTION
* Update to Kubernetes v1.9.3
* Add autoscaling:DescribeLoadBalancerTargetGroups permissions
* chore: update ExternalDNS to include multi-target changes
* Update egress-controller to a version with stack-termination-protection
* Remove imagePullPolicy overrides
* chore: update imagePolicyWebhook to v0.3.6
* cluster-autoscaler: update to v1.1.1
* Configure kube-proxy via config file (configmap)