### PR TITLE
Protected etcd: part 1

### DIFF
--- a/cluster/etcd-cluster.yaml
+++ b/cluster/etcd-cluster.yaml
@@ -31,6 +31,7 @@ SenzaComponents:
     Tags:
     - Key: "kubernetes:component"
       Value: "etcd-cluster"
+
 SenzaInfo:
   Parameters:
   - HostedZone:
@@ -41,6 +42,17 @@ SenzaInfo:
   - EtcdS3Backup:
       Description: AWS S3 Bucket to backup ETCD to
   StackName: etcd-cluster
+
+Outputs:
+  EtcdSecurityGroupId:
+    Description: "Security Group ID of the etcd cluster"
+    Value:
+      Fn::GetAtt:
+        - EtcdSecurityGroup
+        - GroupId
+    Export:
+      Name: "{{SenzaInfo.StackName}}-{{SenzaInfo.StackVersion}}:security-group-id"
+
 Resources:
   EtcdSecurityGroup:
     Type: AWS::EC2::SecurityGroup

--- a/cluster/etcd-cluster.yaml
+++ b/cluster/etcd-cluster.yaml
@@ -14,7 +14,7 @@ SenzaComponents:
         2379: 2379
         2380: 2380
       runtime: Docker
-      source: registry.opensource.zalan.do/acid/etcd-cluster:3.3.1-p19
+      source: registry.opensource.zalan.do/acid/etcd-cluster:3.3.1-p20
       environment:
         HOSTED_ZONE: '{{Arguments.HostedZone}}'
       mounts:

--- a/cluster/etcd-cluster.yaml
+++ b/cluster/etcd-cluster.yaml
@@ -4,7 +4,7 @@ SenzaComponents:
 - AppServer:
     IamRoles:
     - Ref: EtcdRole
-    InstanceType: t2.medium
+    InstanceType: '{{Arguments.InstanceType}}'
     SecurityGroups:
     - Fn::GetAtt:
       - EtcdSecurityGroup
@@ -39,6 +39,9 @@ SenzaInfo:
   - InstanceCount:
       Description: Instance number in ASG
       Default: 5
+  - InstanceType:
+      Description: Instance Type
+      Default: "t2.medium"
   - EtcdS3Backup:
       Description: AWS S3 Bucket to backup ETCD to
   StackName: etcd-cluster

--- a/cluster/manifests/etcd-backup/cronjob.yaml
+++ b/cluster/manifests/etcd-backup/cronjob.yaml
@@ -36,3 +36,8 @@ spec:
               requests:
                 cpu: 50m
                 memory: 256Mi
+          tolerations:
+          - key: node-role.kubernetes.io/master
+            effect: NoSchedule
+          nodeSelector:
+            node-role.kubernetes.io/master: ""

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -33,6 +33,9 @@ SenzaInfo:
           Description: "Name of the worker node pool (ASG)"
       - EtcdS3BackupBucket:
           Description: "Name of the S3 bucket used for etcd backups"
+      - EtcdStackName:
+          Description: "AWS Stack name of the etcd cluster"
+          Default: "etcd-cluster-etcd"
 
 SenzaComponents:
   - Configuration:
@@ -346,6 +349,15 @@ Resources:
           Value: owned
       VpcId: "{{ AccountInfo.VpcID }}"
     Type: AWS::EC2::SecurityGroup
+  EtcdSecurityGroupIngressFromMaster:
+    Properties:
+      FromPort: 2379
+      ToPort: 2379
+      IpProtocol: tcp
+      GroupId:
+        Fn::ImportValue: "{{Arguments.EtcdStackName}}:security-group-id"
+      SourceSecurityGroupId: {Ref: MasterSecurityGroup}
+    Type: AWS::EC2::SecurityGroupIngress
   MasterSecurityGroupIngressFromLoadBalancerHealthCheck:
     Properties:
       FromPort: 8080


### PR DESCRIPTION
This change exports the security group ID from the etcd stack and adds an explicit ingress definition as part of the Kubernetes stack to allow master->etcd communication. `etcd-backup` is also configured to run on master nodes.

This has to be applied separately from the follow-up change, and the etcd stacks have to be updated manually.