### PR TITLE
Protected etcd: part 2 [do not squash!]

### DIFF
--- a/cluster/etcd-cluster.yaml
+++ b/cluster/etcd-cluster.yaml
@@ -68,7 +68,7 @@ Resources:
         ToPort: 22
         CidrIp: 172.16.0.0/12
       - IpProtocol: tcp
-        FromPort: 2379
+        FromPort: 2381
         ToPort: 2381
         CidrIp: 172.16.0.0/12
       - IpProtocol: tcp


### PR DESCRIPTION
Part 2 of #897. This removes the default ingress rule that allows anyone to talk to etcd nodes.

**THIS HAS TO BE ROLLED OUT SEPARATELY!**