### PR TITLE
kube-job-cleaner: update to 0.5

### DIFF
--- a/cluster/manifests/kube-job-cleaner/cronjob.yaml
+++ b/cluster/manifests/kube-job-cleaner/cronjob.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-job-cleaner
-    version: "0.4-1"
+    version: "0.5"
 spec:
   schedule: "17 * * * *"
   concurrencyPolicy: Forbid
@@ -17,14 +17,14 @@ spec:
         metadata:
           labels:
             application: kube-job-cleaner
-            version: "0.4-1"
+            version: "0.5"
         spec:
           serviceAccountName: system
           restartPolicy: Never
           containers:
           - name: cleaner
             # delete all completed jobs after one hour
-            image: registry.opensource.zalan.do/teapot/kube-job-cleaner:0.4-1
+            image: registry.opensource.zalan.do/teapot/kube-job-cleaner:0.5
             resources:
               limits:
                 cpu: 100m


### PR DESCRIPTION
This fixes the crash on jobs with missing `startTime`.