### PR TITLE
etcd-backup: fix role so that masters can assume it

### DIFF
--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -845,7 +845,7 @@ Resources:
                 -
                   - arn:aws:iam::{{ AccountInfo.AccountID }}:role/
                   -
-                    Ref: WorkerIAMRole
+                    Ref: MasterIAMRole
         Version: '2012-10-17'
       Path: /
       Policies:


### PR DESCRIPTION
Makes it possible for the backup to actually run.