### PR TITLE
Dev to alpha

### DIFF
--- a/cluster/manifests/emergency-access-service/deployment.yaml
+++ b/cluster/manifests/emergency-access-service/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     application: emergency-access-service
-    version: master-49
+    version: master-50
 spec:
   replicas: 1
   selector:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: emergency-access-service
-        version: master-49
+        version: master-50
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
           [{"container": "emergency-access-service", "parser": "json-structured-log"}]
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: system
       containers:
       - name: emergency-access-service
-        image: "pierone.stups.zalan.do/teapot/emergency-access-service:master-49"
+        image: "pierone.stups.zalan.do/teapot/emergency-access-service:master-50"
         args:
         - --insecure-http
         - --community={{ .Owner }}

--- a/cluster/manifests/emergency-access-service/deployment.yaml
+++ b/cluster/manifests/emergency-access-service/deployment.yaml
@@ -1,5 +1,5 @@
 {{ if eq .Environment "production" }}
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: emergency-access-service

--- a/cluster/manifests/ingress-template-controller/deployment.yaml
+++ b/cluster/manifests/ingress-template-controller/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ingress-template-controller

--- a/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: autoscaling-buffer

--- a/cluster/manifests/pdb-controller/deployment.yaml
+++ b/cluster/manifests/pdb-controller/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pdb-controller

--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -50,3 +50,12 @@ data:
       - action: replace
         source_labels: ['__meta_kubernetes_pod_node_name']
         target_label: node_name
+    - job_name: 'kubelet-cadvisor'
+      kubernetes_sd_configs:
+      - role: node
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_node_address_InternalIP]
+        target_label: __address__
+        regex: (.*)
+        replacement: $1:4194
+

--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: "kube-system"
   labels:
     application: "zmon-agent"
-    version: "0.1-a45-zv1"
+    version: "0.1-a46-zv1"
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: "zmon-agent"
-        version: "0.1-a45-zv1"
+        version: "0.1-a46-zv1"
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -47,7 +47,7 @@ spec:
 
       containers:
         - name: zmon-agent
-          image: "pierone.stups.zalan.do/zmon/zmon-agent-core:0.1-a45-zv1"
+          image: "pierone.stups.zalan.do/zmon/zmon-agent-core:0.1-a46-zv1"
           resources:
             limits:
               cpu: 100m

--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -12,7 +12,7 @@ spec:
     metadata:
       labels:
         application: zmon-worker
-        version: "v190-zv244"
+        version: "v191-zv244"
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -43,7 +43,7 @@ spec:
 
       containers:
         - name: zmon-worker
-          image: "pierone.stups.zalan.do/zmon/zmon-worker:v190-zv244"
+          image: "pierone.stups.zalan.do/zmon/zmon-worker:v191-zv244"
           resources:
             limits:
               cpu: 500m

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -412,6 +412,8 @@ Resources:
       - {CidrIp: 172.31.0.0/16, FromPort: 9100, IpProtocol: tcp, ToPort: 9100}
       # allow checking kubelet healthz port from within the VPC
       - {CidrIp: 172.31.0.0/16, FromPort: 10248, IpProtocol: tcp, ToPort: 10248}
+      # allow checking kubelet cadvisor metrics port from within the VPC
+      - {CidrIp: 172.31.0.0/16, FromPort: 4194, IpProtocol: tcp, ToPort: 4194}
       # allow default service NodePort range
       - {CidrIp: 172.31.0.0/16, FromPort: 30000, IpProtocol: tcp, ToPort: 32767}
       Tags:
@@ -473,17 +475,6 @@ Resources:
       GroupId: {Ref: WorkerSecurityGroup}
       IpProtocol: tcp
       SourceSecurityGroupId: {Ref: MasterSecurityGroup}
-      ToPort: 4194
-      Tags:
-        - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
-          Value: owned
-    Type: AWS::EC2::SecurityGroupIngress
-  WorkerSecurityGroupIngressFromWorkerTocAdvisor:
-    Properties:
-      FromPort: 4194
-      GroupId: {Ref: WorkerSecurityGroup}
-      IpProtocol: tcp
-      SourceSecurityGroupId: {Ref: WorkerSecurityGroup}
       ToPort: 4194
       Tags:
         - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -478,6 +478,17 @@ Resources:
         - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
           Value: owned
     Type: AWS::EC2::SecurityGroupIngress
+  WorkerSecurityGroupIngressFromWorkerTocAdvisor:
+    Properties:
+      FromPort: 4194
+      GroupId: {Ref: WorkerSecurityGroup}
+      IpProtocol: tcp
+      SourceSecurityGroupId: {Ref: WorkerSecurityGroup}
+      ToPort: 4194
+      Tags:
+        - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
+          Value: owned
+    Type: AWS::EC2::SecurityGroupIngress
   MasterSecurityGroupIngressFromFlannelToMaster:
     Properties:
       FromPort: 8472


### PR DESCRIPTION
* emergency-access-service (global roles)
* kubelet cadvisor metrics (port 4194 and prometheus scraping config)
* zmon update
* update manifests not migrated to apps/v1