### PR TITLE
Inject TOKENINFO_URL to anyone who cares based on environment

### DIFF
--- a/cluster/manifests/pod-presets/pp-tokeninfo.yaml
+++ b/cluster/manifests/pod-presets/pp-tokeninfo.yaml
@@ -11,5 +11,5 @@ spec:
 {{ if eq .Environment "production" }}
     value: https://info.services.auth.zalando.com/oauth2/tokeninfo
 {{ else }}
-    value: https://sandbox.identity.zalando.com
+    value: https://sandbox.identity.zalando.com/oauth2/tokeninfo
 {{ end }}

--- a/cluster/manifests/pod-presets/pp-tokeninfo.yaml
+++ b/cluster/manifests/pod-presets/pp-tokeninfo.yaml
@@ -1,0 +1,15 @@
+apiVersion: settings.k8s.io/v1alpha1
+kind: PodPreset
+metadata:
+  name: tokeninfo
+spec:
+  selector:
+    matchLabels:
+      zalando.org/uses-tokeninfo: "true"
+  env:
+  - name: TOKENINFO_URL
+{{ if eq .Environment "production" }}
+    value: https://info.services.auth.zalando.com/oauth2/tokeninfo
+{{ else }}
+    value: https://sandbox.identity.zalando.com
+{{ end }}

--- a/cluster/manifests/pod-presets/pp-tokeninfo.yaml
+++ b/cluster/manifests/pod-presets/pp-tokeninfo.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      zalando.org/uses-tokeninfo: "true"
+      experimental.zalando.org/uses-tokeninfo: "true"
   env:
   - name: TOKENINFO_URL
 {{ if eq .Environment "production" }}

--- a/cluster/master.clc.yaml
+++ b/cluster/master.clc.yaml
@@ -292,11 +292,11 @@ storage:
             - --allow-privileged=true
             - --service-cluster-ip-range=10.3.0.0/16
             - --secure-port=443
-            - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,PodSecurityPolicy,ImagePolicyWebhook,Priority
+            - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,PodPreset,PodSecurityPolicy,ImagePolicyWebhook,Priority
             - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
             - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
             - --service-account-key-file=/etc/kubernetes/ssl/apiserver-key.pem
-            - --runtime-config=extensions/v1beta1/networkpolicies=true,batch/v2alpha1=true,extensions/v1beta1/podsecuritypolicy=true,imagepolicy.k8s.io/v1alpha1=true,authorization.k8s.io/v1beta1=true,scheduling.k8s.io/v1alpha1=true
+            - --runtime-config=extensions/v1beta1/networkpolicies=true,batch/v2alpha1=true,extensions/v1beta1/podsecuritypolicy=true,imagepolicy.k8s.io/v1alpha1=true,authorization.k8s.io/v1beta1=true,scheduling.k8s.io/v1alpha1=true,settings.k8s.io/v1alpha1=true
             - --authentication-token-webhook-config-file=/etc/kubernetes/config/authn.yaml
             - --authentication-token-webhook-cache-ttl=10s
             - --cloud-provider=aws


### PR DESCRIPTION
This uses a `PodPreset` which injects the correct value for `TOKENINFO_URL` depending on the cluster's environment in the `default` namespace.

It results in adding the following to a Pod's `PodSpec`:

In Production clusters:
```yaml
spec:
  env:
  - name: TOKENINFO_URL
    value: https://info.services.auth.zalando.com/oauth2/tokeninfo
```

In Test clusters:
```yaml
spec:
  env:
  - name: TOKENINFO_URL
    value: https://sandbox.identity.zalando.com/oauth2/tokeninfo
```

In order to trial it for some time all Pods that want this environment variable to be injected must be labbelled with the following label:
```yaml
metadata:
  labels:
    zalando.org/uses-tokeninfo: "true"
```

Later, we could omit the label selector to apply this environment variable to all Pods. Even then it's possible to opt-out from any Presets by setting an annotation.