### PR TITLE
add kubelet metrics to get disk metrics

### DIFF
--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -58,4 +58,12 @@ data:
         target_label: __address__
         regex: (.*)
         replacement: $1:4194
+    - job_name: 'kubelet-metrics'
+      kubernetes_sd_configs:
+      - role: node
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_node_address_InternalIP]
+        target_label: __address__
+        regex: (.*)
+        replacement: $1:10255
 

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -414,6 +414,8 @@ Resources:
       - {CidrIp: 172.31.0.0/16, FromPort: 10248, IpProtocol: tcp, ToPort: 10248}
       # allow checking kubelet cadvisor metrics port from within the VPC
       - {CidrIp: 172.31.0.0/16, FromPort: 4194, IpProtocol: tcp, ToPort: 4194}
+      # allow checking kubelet metrics for disk metrics port from within the VPC
+      - {CidrIp: 172.31.0.0/16, FromPort: 10255, IpProtocol: tcp, ToPort: 10255}
       # allow default service NodePort range
       - {CidrIp: 172.31.0.0/16, FromPort: 30000, IpProtocol: tcp, ToPort: 32767}
       Tags:


### PR DESCRIPTION
This will grant access from all nodes in VPC access to port 10255, which is the default readonly port from kubelet.
The change is driven by getting ebs volume metrics attached as pv from a statefulset.