### PR TITLE
Introduce kube-aws-iam-controller

### DIFF
--- a/cluster/manifests/etcd-backup/cronjob.yaml
+++ b/cluster/manifests/etcd-backup/cronjob.yaml
@@ -17,8 +17,6 @@ spec:
           labels:
             application: etcd-backup
             version: "master-5"
-          annotations:
-            iam.amazonaws.com/role: "{{ .LocalID }}-etcd-backup"
         spec:
           restartPolicy: Never
           containers:
@@ -29,6 +27,13 @@ spec:
               value: "{{ .ConfigItems.etcd_s3_backup_bucket }}"
             - name: ETCD_ENDPOINTS
               value: "{{ .ConfigItems.etcd_endpoints }}"
+            # must be set for the AWS SDK/AWS CLI to find the credentials file.
+            - name: AWS_SHARED_CREDENTIALS_FILE
+              value: /meta/aws-iam/credentials
+            volumeMounts:
+            - name: aws-iam-credentials
+              mountPath: /meta/aws-iam
+              readOnly: true
             resources:
               limits:
                 cpu: 100m
@@ -36,6 +41,11 @@ spec:
               requests:
                 cpu: 50m
                 memory: 256Mi
+          volumes:
+          - name: aws-iam-credentials
+            secret:
+              # secret should be named: aws-iam-<name-of-your-aws-iam-role>
+              secretName: aws-iam-{{ .LocalID }}-etcd-backup
           tolerations:
           - key: node-role.kubernetes.io/master
             effect: NoSchedule

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -19,7 +19,6 @@ spec:
         version: v0.5.0-alpha.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
     spec:
       tolerations:
        - key: CriticalAddonsOnly
@@ -35,6 +34,14 @@ spec:
         - --txt-owner-id={{ .Region }}:{{ .LocalID }}
         - --compatibility=mate # remove when we switched to the new annotations
         - --log-level=debug # remove when we are sure external-dns can be trusted
+        env:
+        # must be set for the AWS SDK/AWS CLI to find the credentials file.
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: /meta/aws-iam/credentials
+        volumeMounts:
+        - name: aws-iam-credentials
+          mountPath: /meta/aws-iam
+          readOnly: true
         resources:
           limits:
             cpu: 200m
@@ -42,3 +49,8 @@ spec:
           requests:
             cpu: 25m
             memory: 20Mi
+      volumes:
+      - name: aws-iam-credentials
+        secret:
+          # secret should be named: aws-iam-<name-of-your-aws-iam-role>
+          secretName: aws-iam-{{ .LocalID }}-app-external-dns

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -18,7 +18,6 @@ spec:
         version: v0.6.6
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
     spec:
       serviceAccountName: system
       tolerations:
@@ -30,6 +29,9 @@ spec:
         args:
         - -stack-termination-protection
         env:
+        # must be set for the AWS SDK/AWS CLI to find the credentials file.
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: /meta/aws-iam/credentials
         - name: AWS_REGION
           value: {{ .Region }}
         # Needed in order to find nodes that should be attached to the ALBs.
@@ -38,6 +40,10 @@ spec:
         # https://github.com/zalando-incubator/kube-ingress-aws-controller#how-it-works
         - name: CUSTOM_FILTERS
           value: "tag:kubernetes.io/cluster/{{ .ID }}=owned tag:NodePool=worker-default"
+        volumeMounts:
+        - name: aws-iam-credentials
+          mountPath: /meta/aws-iam
+          readOnly: true
         resources:
           limits:
             cpu: 200m
@@ -45,3 +51,8 @@ spec:
           requests:
             cpu: 50m
             memory: 25Mi
+      volumes:
+      - name: aws-iam-credentials
+        secret:
+          # secret should be named: aws-iam-<name-of-your-aws-iam-role>
+          secretName: aws-iam-{{ .LocalID }}-app-ingr-ctrl

--- a/cluster/manifests/kube-aws-iam-controller/deployment.yaml
+++ b/cluster/manifests/kube-aws-iam-controller/deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-aws-iam-controller
+  namespace: kube-system
+  labels:
+    application: kube-aws-iam-controller
+    version: v0.0.1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      application: kube-aws-iam-controller
+  template:
+    metadata:
+      labels:
+        application: kube-aws-iam-controller
+        version: v0.0.1
+    spec:
+      serviceAccount: system
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      # running with hostNetwork to bypass metadata service block from pod
+      # network.
+      hostNetwork: true
+      containers:
+      - name: kube-aws-iam-controller
+        image: registry.opensource.zalan.do/teapot/kube-aws-iam-controller:v0.0.1
+        resources:
+          limits:
+            cpu: 200m
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 512Mi

--- a/cluster/manifests/kube-cluster-autoscaler/autoscaler-deployment.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/autoscaler-deployment.yaml
@@ -18,7 +18,6 @@ spec:
         version: v1.1.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        iam.amazonaws.com/role: "{{ .LocalID }}-app-autoscaler"
     spec:
       serviceAccountName: system
       tolerations:
@@ -39,6 +38,10 @@ spec:
           - --expendable-pods-priority-cutoff=-1000000
           - --skip-nodes-with-system-pods=false
           - --skip-nodes-with-local-storage=false
+        volumeMounts:
+        - name: aws-iam-credentials
+          mountPath: /meta/aws-iam
+          readOnly: true
         resources:
           limits:
             cpu: 100m
@@ -47,7 +50,15 @@ spec:
             cpu: 100m
             memory: 300Mi
         env:
-          - name: AWS_REGION
-            value: {{ .Region }}
+        # must be set for the AWS SDK/AWS CLI to find the credentials file.
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: /meta/aws-iam/credentials
+        - name: AWS_REGION
+          value: {{ .Region }}
+      volumes:
+      - name: aws-iam-credentials
+        secret:
+          # secret should be named: aws-iam-<name-of-your-aws-iam-role>
+          secretName: aws-iam-{{ .LocalID }}-app-autoscaler
       nodeSelector:
         node-role.kubernetes.io/master: ""

--- a/cluster/manifests/kube-node-ready/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready/daemonset.yaml
@@ -19,7 +19,6 @@ spec:
         version: v0.0.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        iam.amazonaws.com/role: "{{ .LocalID }}-kube-node-ready"
     spec:
       tolerations:
       - key: CriticalAddonsOnly
@@ -32,6 +31,14 @@ spec:
         args:
         - --master-lifecycle-hook={{ .Outputs.MasterAutoscalingLifecycleHook }}
         - --worker-lifecycle-hook={{ .Outputs.WorkerAutoscalingLifecycleHook }}
+        env:
+        # must be set for the AWS SDK/AWS CLI to find the credentials file.
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: /meta/aws-iam/credentials
+        volumeMounts:
+        - name: aws-iam-credentials
+          mountPath: /meta/aws-iam
+          readOnly: true
         resources:
           limits:
             cpu: 50m
@@ -39,3 +46,8 @@ spec:
           requests:
             cpu: 20m
             memory: 20Mi
+      volumes:
+      - name: aws-iam-credentials
+        secret:
+          # secret should be named: aws-iam-<name-of-your-aws-iam-role>
+          secretName: aws-iam-{{ .LocalID }}-kube-node-ready

--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -18,7 +18,6 @@ spec:
         version: v0.1.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        iam.amazonaws.com/role: "{{ .LocalID }}-static-egress-controller"
     spec:
       containers:
       - name: controller
@@ -34,8 +33,15 @@ spec:
         - "--aws-az=eu-central-1c"
         - "--stack-termination-protection"
         env:
+        # must be set for the AWS SDK/AWS CLI to find the credentials file.
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: /meta/aws-iam/credentials
         - name: AWS_REGION
           value: eu-central-1
+        volumeMounts:
+        - name: aws-iam-credentials
+          mountPath: /meta/aws-iam
+          readOnly: true
         resources:
           limits:
             cpu: 100m
@@ -43,3 +49,8 @@ spec:
           requests:
             cpu: 5m
             memory: 25Mi
+      volumes:
+      - name: aws-iam-credentials
+        secret:
+          # secret should be named: aws-iam-<name-of-your-aws-iam-role>
+          secretName: aws-iam-{{ .LocalID }}-static-egress-controller

--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -17,21 +17,23 @@ spec:
         application: "zmon-agent"
         version: "0.1-a47-zv1"
       annotations:
-        iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
-
       initContainers:
       - name: gerry-init
         image: registry.opensource.zalan.do/teapot/gerry:v0.0.14
         args:
-          - /meta/credentials
-          - --application-id=gerry
-          - --mint-bucket=s3://{{ .ConfigItems.gerry_mint_bucket }}
-          - --once
+        - /meta/credentials
+        - --application-id=gerry
+        - --mint-bucket=s3://{{ .ConfigItems.gerry_mint_bucket }}
+        - --once
+        env:
+        # must be set for the AWS SDK/AWS CLI to find the credentials file.
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: /meta/aws-iam/credentials
         resources:
           limits:
             cpu: 100m
@@ -39,83 +41,93 @@ spec:
           requests:
             cpu: 10m
             memory: 10Mi
-
         volumeMounts:
-          - name: credentials
-            mountPath: /meta/credentials
-            readOnly: false
-
-      containers:
-        - name: zmon-agent
-          image: "pierone.stups.zalan.do/zmon/zmon-agent-core:0.1-a47-zv1"
-          resources:
-            limits:
-              cpu: 100m
-              memory: 200Mi
-            requests:
-              cpu: 50m
-              memory: 80Mi
-
-          env:
-            - name: ZMON_AGENT_INFRASTRUCTURE_ACCOUNT
-              value: "{{ .InfrastructureAccount }}"
-            - name: ZMON_AGENT_REGION
-              value: "{{ .Region }}"
-            - name: ZMON_AGENT_INTERVAL
-              value: "60"
-
-            - name: ZMON_AGENT_ENTITY_SERVICE_URL
-              value: https://data-service.zmon.zalan.do
-
-            - name: ZMON_AGENT_KUBERNETES_CLUSTER_ID
-              value: "{{ .ID }}"
-            - name: ZMON_AGENT_KUBERNETES_CLUSTER_ALIAS
-              value: "{{ .Alias }}"
-            - name: ZMON_AGENT_KUBERNETES_CLUSTER_ENVIRONMENT
-              value: "{{ .Environment }}"
-
-            - name: ZMON_AGENT_POSTGRES_USER
-              valueFrom:
-                secretKeyRef:
-                  name: zmon-worker
-                  key: sql-user
-            - name: ZMON_AGENT_POSTGRES_PASS
-              valueFrom:
-                secretKeyRef:
-                  name: zmon-worker
-                  key: sql-pass
-
-            - name: OAUTH2_ACCESS_TOKEN_URL
-              value: https://token.services.auth.zalando.com/oauth2/access_token?realm=/services
-            - name: CREDENTIALS_DIR
-              value: /meta/credentials
-            - name: ZMON_HOSTED_ZONE_FORMAT_STRING
-              value: "{}.{}.zalan.do"
-          volumeMounts:
-            - name: credentials
-              mountPath: /meta/credentials
-              readOnly: true
-
-        - name: gerry
-          image: registry.opensource.zalan.do/teapot/gerry:v0.0.14
-          args:
-            - /meta/credentials
-            - --application-id=gerry
-            - --mint-bucket=s3://{{ .ConfigItems.gerry_mint_bucket }}
-          resources:
-            limits:
-              cpu: 100m
-              memory: 100Mi
-            requests:
-              cpu: 10m
-              memory: 10Mi
-
-          volumeMounts:
-            - name: credentials
-              mountPath: /meta/credentials
-              readOnly: false
-
-      volumes:
         - name: credentials
-          emptyDir:
-            medium: Memory
+          mountPath: /meta/credentials
+          readOnly: false
+        - name: aws-iam-credentials
+          mountPath: /meta/aws-iam
+          readOnly: true
+      containers:
+      - name: zmon-agent
+        image: "pierone.stups.zalan.do/zmon/zmon-agent-core:0.1-a47-zv1"
+        resources:
+          limits:
+            cpu: 100m
+            memory: 200Mi
+          requests:
+            cpu: 50m
+            memory: 80Mi
+        env:
+        # must be set for the AWS SDK/AWS CLI to find the credentials file.
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: /meta/aws-iam/credentials
+        - name: ZMON_AGENT_INFRASTRUCTURE_ACCOUNT
+          value: "{{ .InfrastructureAccount }}"
+        - name: ZMON_AGENT_REGION
+          value: "{{ .Region }}"
+        - name: ZMON_AGENT_INTERVAL
+          value: "60"
+        - name: ZMON_AGENT_ENTITY_SERVICE_URL
+          value: https://data-service.zmon.zalan.do
+        - name: ZMON_AGENT_KUBERNETES_CLUSTER_ID
+          value: "{{ .ID }}"
+        - name: ZMON_AGENT_KUBERNETES_CLUSTER_ALIAS
+          value: "{{ .Alias }}"
+        - name: ZMON_AGENT_KUBERNETES_CLUSTER_ENVIRONMENT
+          value: "{{ .Environment }}"
+        - name: ZMON_AGENT_POSTGRES_USER
+          valueFrom:
+            secretKeyRef:
+              name: zmon-worker
+              key: sql-user
+        - name: ZMON_AGENT_POSTGRES_PASS
+          valueFrom:
+            secretKeyRef:
+              name: zmon-worker
+              key: sql-pass
+        - name: OAUTH2_ACCESS_TOKEN_URL
+          value: https://token.services.auth.zalando.com/oauth2/access_token?realm=/services
+        - name: CREDENTIALS_DIR
+          value: /meta/credentials
+        - name: ZMON_HOSTED_ZONE_FORMAT_STRING
+          value: "{}.{}.zalan.do"
+        volumeMounts:
+        - name: credentials
+          mountPath: /meta/credentials
+          readOnly: true
+        - name: aws-iam-credentials
+          mountPath: /meta/aws-iam
+          readOnly: true
+      - name: gerry
+        image: registry.opensource.zalan.do/teapot/gerry:v0.0.14
+        args:
+        - /meta/credentials
+        - --application-id=gerry
+        - --mint-bucket=s3://{{ .ConfigItems.gerry_mint_bucket }}
+        env:
+        # must be set for the AWS SDK/AWS CLI to find the credentials file.
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: /meta/aws-iam/credentials
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        volumeMounts:
+        - name: credentials
+          mountPath: /meta/credentials
+          readOnly: false
+        - name: aws-iam-credentials
+          mountPath: /meta/aws-iam
+          readOnly: true
+      volumes:
+      - name: credentials
+        emptyDir:
+          medium: Memory
+      - name: aws-iam-credentials
+        secret:
+          # secret should be named: aws-iam-<name-of-your-aws-iam-role>
+          secretName: aws-iam-{{ .LocalID }}-app-zmon

--- a/cluster/manifests/zmon-aws-agent/deployment.yaml
+++ b/cluster/manifests/zmon-aws-agent/deployment.yaml
@@ -17,21 +17,23 @@ spec:
         application: "zmon-aws-agent"
         version: "v71-zv153"
       annotations:
-        iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
-
       initContainers:
       - name: gerry-init
         image: registry.opensource.zalan.do/teapot/gerry:v0.0.14
         args:
-          - /meta/credentials
-          - --application-id=gerry
-          - --mint-bucket=s3://{{ .ConfigItems.gerry_mint_bucket }}
-          - --once
+        - /meta/credentials
+        - --application-id=gerry
+        - --mint-bucket=s3://{{ .ConfigItems.gerry_mint_bucket }}
+        - --once
+        env:
+        # must be set for the AWS SDK/AWS CLI to find the credentials file.
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: /meta/aws-iam/credentials
         resources:
           limits:
             cpu: 100m
@@ -39,56 +41,69 @@ spec:
           requests:
             cpu: 10m
             memory: 10Mi
-
         volumeMounts:
-          - name: credentials
-            mountPath: /meta/credentials
-            readOnly: false
-
-      containers:
-        - name: zmon-aws-agent
-          image: pierone.stups.zalan.do/zmon/zmon-aws-agent:v71-zv153
-          resources:
-            limits:
-              cpu: 100m
-              memory: 200Mi
-            requests:
-              cpu: 50m
-              memory: 80Mi
-
-          env:
-            - name: OAUTH2_ACCESS_TOKEN_URL
-              value: https://token.services.auth.zalando.com/oauth2/access_token?realm=/services
-            - name: CREDENTIALS_DIR
-              value: /meta/credentials
-            - name: EXTRA_ENTITY_FIELDS
-              value: "environment={{ .Environment }}"
-
-          volumeMounts:
-            - name: credentials
-              mountPath: /meta/credentials
-              readOnly: true
-
-        - name: gerry
-          image: registry.opensource.zalan.do/teapot/gerry:v0.0.14
-          args:
-            - /meta/credentials
-            - --application-id=gerry
-            - --mint-bucket=s3://{{ .ConfigItems.gerry_mint_bucket }}
-          resources:
-            limits:
-              cpu: 100m
-              memory: 100Mi
-            requests:
-              cpu: 10m
-              memory: 10Mi
-
-          volumeMounts:
-            - name: credentials
-              mountPath: /meta/credentials
-              readOnly: false
-
-      volumes:
         - name: credentials
-          emptyDir:
-            medium: Memory
+          mountPath: /meta/credentials
+          readOnly: false
+        - name: aws-iam-credentials
+          mountPath: /meta/aws-iam
+          readOnly: true
+      containers:
+      - name: zmon-aws-agent
+        image: pierone.stups.zalan.do/zmon/zmon-aws-agent:v71-zv153
+        resources:
+          limits:
+            cpu: 100m
+            memory: 200Mi
+          requests:
+            cpu: 50m
+            memory: 80Mi
+        env:
+        # must be set for the AWS SDK/AWS CLI to find the credentials file.
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: /meta/aws-iam/credentials
+        - name: OAUTH2_ACCESS_TOKEN_URL
+          value: https://token.services.auth.zalando.com/oauth2/access_token?realm=/services
+        - name: CREDENTIALS_DIR
+          value: /meta/credentials
+        - name: EXTRA_ENTITY_FIELDS
+          value: "environment={{ .Environment }}"
+        volumeMounts:
+        - name: credentials
+          mountPath: /meta/credentials
+          readOnly: true
+        - name: aws-iam-credentials
+          mountPath: /meta/aws-iam
+          readOnly: true
+      - name: gerry
+        image: registry.opensource.zalan.do/teapot/gerry:v0.0.14
+        args:
+        - /meta/credentials
+        - --application-id=gerry
+        - --mint-bucket=s3://{{ .ConfigItems.gerry_mint_bucket }}
+        env:
+        # must be set for the AWS SDK/AWS CLI to find the credentials file.
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: /meta/aws-iam/credentials
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        volumeMounts:
+        - name: credentials
+          mountPath: /meta/credentials
+          readOnly: false
+        - name: aws-iam-credentials
+          mountPath: /meta/aws-iam
+          readOnly: true
+      volumes:
+      - name: credentials
+        emptyDir:
+          medium: Memory
+      - name: aws-iam-credentials
+        secret:
+          # secret should be named: aws-iam-<name-of-your-aws-iam-role>
+          secretName: aws-iam-{{ .LocalID }}-app-zmon

--- a/cluster/manifests/zmon-scheduler/deployment.yaml
+++ b/cluster/manifests/zmon-scheduler/deployment.yaml
@@ -17,21 +17,23 @@ spec:
         application: zmon-scheduler
         version: "v43"
       annotations:
-        iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
-
       initContainers:
       - name: gerry-init
         image: registry.opensource.zalan.do/teapot/gerry:v0.0.14
         args:
-          - /meta/credentials
-          - --application-id=gerry
-          - --mint-bucket=s3://{{ .ConfigItems.gerry_mint_bucket }}
-          - --once
+        - /meta/credentials
+        - --application-id=gerry
+        - --mint-bucket=s3://{{ .ConfigItems.gerry_mint_bucket }}
+        - --once
+        env:
+        # must be set for the AWS SDK/AWS CLI to find the credentials file.
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: /meta/aws-iam/credentials
         resources:
           limits:
             cpu: 100m
@@ -39,101 +41,107 @@ spec:
           requests:
             cpu: 10m
             memory: 10Mi
-
         volumeMounts:
-          - name: credentials
-            mountPath: /meta/credentials
-            readOnly: false
-
-      containers:
-        - name: zmon-scheduler
-          image: "registry.opensource.zalan.do/stups/zmon-scheduler:v43"
-          resources:
-            limits:
-              cpu: 2
-              memory: 1.5Gi
-            requests:
-              cpu: 100m
-              memory: 512Mi
-
-          ports:
-            - containerPort: 7979
-            - containerPort: 8085
-
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: 7979
-            initialDelaySeconds: 30
-            periodSeconds: 60
-
-          env:
-            - name: LOCAL_ENTITY_ID
-              value: kube-cluster[{{ .ID }}]
-
-            - name: MEM_TOTAL_KB
-              valueFrom:
-                resourceFieldRef:
-                  resource: limits.memory
-                  divisor: 1Ki
-
-            - name: SCHEDULER_OAUTH2_ACCESS_TOKEN_URL
-              value: https://token.services.auth.zalando.com/oauth2/access_token?realm=/services
-            - name: CREDENTIALS_DIR
-              value: /meta/credentials
-            - name: ZMON_BASE_URL
-              value: https://data-service.zmon.zalan.do
-
-            - name: MANAGEMENT_PORT
-              value: "7979"
-
-            - name: SCHEDULER_REDIS_HOST
-              value: zmon-redis
-            - name: SCHEDULER_REDIS_PORT
-              value: "6379"
-
-            - name: SCHEDULER_ENTITY_BASE_FILTER_STR
-              value: '[{"infrastructure_account":"{{ .InfrastructureAccount }}","region":"{{ .Region }}"{{ if eq .Alias "db" }}, "kube_cluster":"{{ .ID }}"{{ end }}}]'
-            - name: SCHEDULER_INSTANT_EVAL_HTTP_URL
-              value: https://data-service.zmon.zalan.do/api/v1/instant-evaluations/kube-cluster[{{ .InfrastructureAccount }}:{{ .Region }}]/
-            - name: SCHEDULER_TRIAL_RUN_HTTP_URL
-              value: https://data-service.zmon.zalan.do/api/v1/trial-runs/kube-cluster[{{ .InfrastructureAccount }}:{{ .Region }}]/
-            - name: SCHEDULER_DOWNTIME_HTTP_URL
-              value: https://data-service.zmon.zalan.do/api/v1/downtimes/kube-cluster[{{ .InfrastructureAccount }}:{{ .Region }}]/
-            - name: SCHEDULER_CHECK_DETAIL_METRICS
-              value: "true"
-            - name: SCHEDULER_ENTITY_SERVICE_URL
-              value: https://data-service.zmon.zalan.do/
-            - name: SCHEDULER_CONTROLLER_URL
-              value: https://data-service.zmon.zalan.do/
-            - name: SCHEDULER_ENABLE_GLOBAL_ENTITY
-              value: "false"
-
-          volumeMounts:
-            - name: credentials
-              mountPath: /meta/credentials
-              readOnly: true
-
-        - name: gerry
-          image: registry.opensource.zalan.do/teapot/gerry:v0.0.14
-          args:
-            - /meta/credentials
-            - --application-id=gerry
-            - --mint-bucket=s3://{{ .ConfigItems.gerry_mint_bucket }}
-          resources:
-            limits:
-              cpu: 100m
-              memory: 100Mi
-            requests:
-              cpu: 10m
-              memory: 10Mi
-
-          volumeMounts:
-            - name: credentials
-              mountPath: /meta/credentials
-              readOnly: false
-
-      volumes:
         - name: credentials
-          emptyDir:
-            medium: Memory
+          mountPath: /meta/credentials
+          readOnly: false
+        - name: aws-iam-credentials
+          mountPath: /meta/aws-iam
+          readOnly: true
+      containers:
+      - name: zmon-scheduler
+        image: "registry.opensource.zalan.do/stups/zmon-scheduler:v43"
+        resources:
+          limits:
+            cpu: 2
+            memory: 1.5Gi
+          requests:
+            cpu: 100m
+            memory: 512Mi
+        ports:
+        - containerPort: 7979
+        - containerPort: 8085
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 7979
+          initialDelaySeconds: 30
+          periodSeconds: 60
+        env:
+        # must be set for the AWS SDK/AWS CLI to find the credentials file.
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: /meta/aws-iam/credentials
+        - name: LOCAL_ENTITY_ID
+          value: kube-cluster[{{ .ID }}]
+        - name: MEM_TOTAL_KB
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+              divisor: 1Ki
+        - name: SCHEDULER_OAUTH2_ACCESS_TOKEN_URL
+          value: https://token.services.auth.zalando.com/oauth2/access_token?realm=/services
+        - name: CREDENTIALS_DIR
+          value: /meta/credentials
+        - name: ZMON_BASE_URL
+          value: https://data-service.zmon.zalan.do
+        - name: MANAGEMENT_PORT
+          value: "7979"
+        - name: SCHEDULER_REDIS_HOST
+          value: zmon-redis
+        - name: SCHEDULER_REDIS_PORT
+          value: "6379"
+        - name: SCHEDULER_ENTITY_BASE_FILTER_STR
+          value: '[{"infrastructure_account":"{{ .InfrastructureAccount }}","region":"{{ .Region }}"{{ if eq .Alias "db" }}, "kube_cluster":"{{ .ID }}"{{ end }}}]'
+        - name: SCHEDULER_INSTANT_EVAL_HTTP_URL
+          value: https://data-service.zmon.zalan.do/api/v1/instant-evaluations/kube-cluster[{{ .InfrastructureAccount }}:{{ .Region }}]/
+        - name: SCHEDULER_TRIAL_RUN_HTTP_URL
+          value: https://data-service.zmon.zalan.do/api/v1/trial-runs/kube-cluster[{{ .InfrastructureAccount }}:{{ .Region }}]/
+        - name: SCHEDULER_DOWNTIME_HTTP_URL
+          value: https://data-service.zmon.zalan.do/api/v1/downtimes/kube-cluster[{{ .InfrastructureAccount }}:{{ .Region }}]/
+        - name: SCHEDULER_CHECK_DETAIL_METRICS
+          value: "true"
+        - name: SCHEDULER_ENTITY_SERVICE_URL
+          value: https://data-service.zmon.zalan.do/
+        - name: SCHEDULER_CONTROLLER_URL
+          value: https://data-service.zmon.zalan.do/
+        - name: SCHEDULER_ENABLE_GLOBAL_ENTITY
+          value: "false"
+        volumeMounts:
+        - name: credentials
+          mountPath: /meta/credentials
+          readOnly: true
+        - name: aws-iam-credentials
+          mountPath: /meta/aws-iam
+          readOnly: true
+      - name: gerry
+        image: registry.opensource.zalan.do/teapot/gerry:v0.0.14
+        args:
+        - /meta/credentials
+        - --application-id=gerry
+        - --mint-bucket=s3://{{ .ConfigItems.gerry_mint_bucket }}
+        env:
+        # must be set for the AWS SDK/AWS CLI to find the credentials file.
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: /meta/aws-iam/credentials
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        volumeMounts:
+        - name: credentials
+          mountPath: /meta/credentials
+          readOnly: false
+        - name: aws-iam-credentials
+          mountPath: /meta/aws-iam
+          readOnly: true
+      volumes:
+      - name: credentials
+        emptyDir:
+          medium: Memory
+      - name: aws-iam-credentials
+        secret:
+          # secret should be named: aws-iam-<name-of-your-aws-iam-role>
+          secretName: aws-iam-{{ .LocalID }}-app-zmon

--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -14,7 +14,6 @@ spec:
         application: zmon-worker
         version: "v191-zv244"
       annotations:
-        iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       tolerations:
@@ -29,6 +28,10 @@ spec:
         - --application-id=gerry
         - --mint-bucket=s3://{{ .ConfigItems.gerry_mint_bucket }}
         - --once
+        env:
+        # must be set for the AWS SDK/AWS CLI to find the credentials file.
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: /meta/aws-iam/credentials
         resources:
           limits:
             cpu: 100m
@@ -37,86 +40,97 @@ spec:
             cpu: 10m
             memory: 10Mi
         volumeMounts:
-          - name: credentials
-            mountPath: /meta/credentials
-            readOnly: false
-
-      containers:
-        - name: zmon-worker
-          image: "pierone.stups.zalan.do/zmon/zmon-worker:v191-zv244"
-          resources:
-            limits:
-              cpu: 500m
-              memory: 2Gi
-            requests:
-              cpu: 500m
-              memory: 2Gi
-
-          ports:
-            - containerPort: 8080
-
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: 8080
-            initialDelaySeconds: 30
-            periodSeconds: 60
-
-          env:
-            - name: WORKER_ZMON_QUEUES
-              value: zmon:queue:default/24
-            - name: WORKER_REDIS_SERVERS
-              value: zmon-redis:6379
-            - name: WORKER_PLUGIN_SCALYR_READ_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: zmon-worker
-                  key: scalyr-read-key
-            - name: WORKER_ACCOUNT
-              value: "{{ .InfrastructureAccount }}"
-            - name: WORKER_REGION
-              value: "{{ .Region }}"
-            - name: WORKER_PLUGIN_SQL_USER
-              valueFrom:
-                secretKeyRef:
-                  name: zmon-worker
-                  key: sql-user
-            - name: WORKER_PLUGIN_SQL_PASS
-              valueFrom:
-                secretKeyRef:
-                  name: zmon-worker
-                  key: sql-pass
-
-            - name: OAUTH2_ACCESS_TOKEN_URL
-              value: https://token.services.auth.zalando.com/oauth2/access_token?realm=/services
-            - name: CREDENTIALS_DIR
-              value: /meta/credentials
-
-          volumeMounts:
-            - name: credentials
-              mountPath: /meta/credentials
-              readOnly: true
-
-        - name: gerry
-          image: registry.opensource.zalan.do/teapot/gerry:v0.0.14
-          args:
-            - /meta/credentials
-            - --application-id=gerry
-            - --mint-bucket=s3://{{ .ConfigItems.gerry_mint_bucket }}
-          resources:
-            limits:
-              cpu: 100m
-              memory: 100Mi
-            requests:
-              cpu: 10m
-              memory: 10Mi
-
-          volumeMounts:
-            - name: credentials
-              mountPath: /meta/credentials
-              readOnly: false
-
-      volumes:
         - name: credentials
-          emptyDir:
-            medium: Memory
+          mountPath: /meta/credentials
+          readOnly: false
+        - name: aws-iam-credentials
+          mountPath: /meta/aws-iam
+          readOnly: true
+      containers:
+      - name: zmon-worker
+        image: "pierone.stups.zalan.do/zmon/zmon-worker:v191-zv244"
+        resources:
+          limits:
+            cpu: 500m
+            memory: 2Gi
+          requests:
+            cpu: 500m
+            memory: 2Gi
+        ports:
+        - containerPort: 8080
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 60
+        env:
+        # must be set for the AWS SDK/AWS CLI to find the credentials file.
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: /meta/aws-iam/credentials
+        - name: WORKER_ZMON_QUEUES
+          value: zmon:queue:default/24
+        - name: WORKER_REDIS_SERVERS
+          value: zmon-redis:6379
+        - name: WORKER_PLUGIN_SCALYR_READ_KEY
+          valueFrom:
+            secretKeyRef:
+              name: zmon-worker
+              key: scalyr-read-key
+        - name: WORKER_ACCOUNT
+          value: "{{ .InfrastructureAccount }}"
+        - name: WORKER_REGION
+          value: "{{ .Region }}"
+        - name: WORKER_PLUGIN_SQL_USER
+          valueFrom:
+            secretKeyRef:
+              name: zmon-worker
+              key: sql-user
+        - name: WORKER_PLUGIN_SQL_PASS
+          valueFrom:
+            secretKeyRef:
+              name: zmon-worker
+              key: sql-pass
+        - name: OAUTH2_ACCESS_TOKEN_URL
+          value: https://token.services.auth.zalando.com/oauth2/access_token?realm=/services
+        - name: CREDENTIALS_DIR
+          value: /meta/credentials
+        volumeMounts:
+        - name: credentials
+          mountPath: /meta/credentials
+          readOnly: true
+        - name: aws-iam-credentials
+          mountPath: /meta/aws-iam
+          readOnly: true
+      - name: gerry
+        image: registry.opensource.zalan.do/teapot/gerry:v0.0.14
+        args:
+        - /meta/credentials
+        - --application-id=gerry
+        - --mint-bucket=s3://{{ .ConfigItems.gerry_mint_bucket }}
+        env:
+        # must be set for the AWS SDK/AWS CLI to find the credentials file.
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: /meta/aws-iam/credentials
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        volumeMounts:
+        - name: credentials
+          mountPath: /meta/credentials
+          readOnly: false
+        - name: aws-iam-credentials
+          mountPath: /meta/aws-iam
+          readOnly: true
+      volumes:
+      - name: credentials
+        emptyDir:
+          medium: Memory
+      - name: aws-iam-credentials
+        secret:
+          # secret should be named: aws-iam-<name-of-your-aws-iam-role>
+          secretName: aws-iam-{{ .LocalID }}-app-zmon

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -183,7 +183,7 @@ Resources:
                 -
                   - arn:aws:iam::{{ AccountInfo.AccountID }}:role/
                   -
-                    Ref: MasterIAMRole
+                    Ref: WorkerIAMRole
         Version: '2012-10-17'
       Path: /
       Policies:
@@ -849,7 +849,7 @@ Resources:
                 -
                   - arn:aws:iam::{{ AccountInfo.AccountID }}:role/
                   -
-                    Ref: MasterIAMRole
+                    Ref: WorkerIAMRole
         Version: '2012-10-17'
       Path: /
       Policies:


### PR DESCRIPTION
This is to introduce and use the [kube-aws-iam-controller](https://github.com/mikkeloscar/kube-aws-iam-controller) for all our components. It's intended as a replacement for kube2iam (the problem that it solves is described in the [README](https://github.com/mikkeloscar/kube-aws-iam-controller#ec2-metadata-service-solution-kube2iam)) but for now it can run side-by-side with kube2iam to not break apps depending on the kube2iam annotation.

I'm opening the PR now, mostly to run e2e tests. I'll follow up and update this with more motivations for introducing this component.