### PR TITLE
reduce latency of ingress 5-10 times

### DIFF
--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -60,7 +60,6 @@ spec:
           - "-metrics-flavour=codahale,prometheus"
         resources:
           limits:
-            cpu: 200m
             memory: 200Mi
           requests:
             cpu: 30m


### PR DESCRIPTION
Reduce latency of ingress 5-10 times, because of 100ms time slices set by Kubernetes for having the limits.

limits were set to `200m` before, which sets:

	cfs_quota_us /* quota = 20ms */
	cpu.cfs_period_us /* period = 100ms */

This means that we get 20ms in every 100ms slice and if a request is processed not within one time period of 100ms it will use >100ms for processing the request.