### PR TITLE
Instruct prometheus to scrape kube-state-metrics

### DIFF
--- a/cluster/manifests/kube-state-metrics/service.yaml
+++ b/cluster/manifests/kube-state-metrics/service.yaml
@@ -3,6 +3,10 @@ kind: Service
 metadata:
   name: kube-state-metrics
   namespace: kube-system
+  annotations:
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8080"
+    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:


### PR DESCRIPTION
Since we're using Prometheus now 🎉 let's also scrape `kube-state-metrics` to get [some more great metrics](https://github.com/kubernetes/kube-state-metrics/tree/master/Documentation#documentation).

/cc @szuecs 