### PR TITLE
Dev to alpha

### DIFF
--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -60,7 +60,6 @@ spec:
           - "-metrics-flavour=codahale,prometheus"
         resources:
           limits:
-            cpu: 200m
             memory: 200Mi
           requests:
             cpu: 30m


### PR DESCRIPTION
* reduce latency of ingress 5-10 times, because of 100ms time slices set by kubernetes for having the limits