### PR TITLE
Alpha to beta

### DIFF
--- a/cluster/manifests/prometheus/statefulset.yaml
+++ b/cluster/manifests/prometheus/statefulset.yaml
@@ -25,17 +25,18 @@ spec:
         args:
         - "--config.file=/etc/prometheus/prometheus.yml"
         - "--storage.tsdb.path=/prometheus/"
+        - "--storage.tsdb.retention=1d"
         ports:
         - name: ingress-port
           containerPort: 9090
           protocol: TCP
         resources:
           limits:
-            cpu: 200m
+            cpu: 300m
             memory: 2000Mi
           requests:
-            cpu: 25m
-            memory: 200Mi
+            cpu: 250m
+            memory: 500Mi
         volumeMounts:
         - name: prometheus-config-volume
           mountPath: /etc/prometheus

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.9.171
+    version: v0.9.177
     component: ingress
 spec:
   selector:
@@ -18,7 +18,7 @@ spec:
       name: skipper-ingress
       labels:
         application: skipper-ingress
-        version: v0.9.171
+        version: v0.9.177
         component: ingress
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -40,7 +40,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.9.171
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.9.177
         ports:
         - name: ingress-port
           containerPort: 9999

--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: "kube-system"
   labels:
     application: "zmon-agent"
-    version: "0.1-a46-zv1"
+    version: "0.1-a47-zv1"
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: "zmon-agent"
-        version: "0.1-a46-zv1"
+        version: "0.1-a47-zv1"
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -47,7 +47,7 @@ spec:
 
       containers:
         - name: zmon-agent
-          image: "pierone.stups.zalan.do/zmon/zmon-agent-core:0.1-a46-zv1"
+          image: "pierone.stups.zalan.do/zmon/zmon-agent-core:0.1-a47-zv1"
           resources:
             limits:
               cpu: 100m

--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -321,7 +321,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.3.8
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.3.9
           name: webhook
           ports:
           - containerPort: 8081


### PR DESCRIPTION
- skipper endpoint handling fixes, that improve reliability for single endpoints, and legacy predicate usage
- webhook update to log resource names
- prometheus: adjust resource settings and drop retention policy to 1d to make it more stable
- zmon-agen: update