### PR TITLE
HPA: use the old API for getting metrics

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -444,6 +444,7 @@ write_files:
           - --cloud-provider=aws
           - --cloud-config=/etc/kubernetes/cloud-config.ini
           - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true
+          - --horizontal-pod-autoscaler-use-rest-clients=false
           - --use-service-account-credentials=true
           - --v=4
           - --allocate-node-cidrs=true


### PR DESCRIPTION
We broke the horizontal pod autoscaler when updating to 1.9. It now uses the new metrics server APIs by default, which we don't deploy. See [a similar issue](https://github.com/kubernetes/kubernetes/issues/57673) for details.