### PR TITLE
Revert "Update zmon-agent"

### DIFF
--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: "kube-system"
   labels:
     application: "zmon-agent"
-    version: "0.1-a48-zv1"
+    version: "0.1-a47-zv1"
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: "zmon-agent"
-        version: "0.1-a48-zv1"
+        version: "0.1-a47-zv1"
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -47,7 +47,7 @@ spec:
 
       containers:
         - name: zmon-agent
-          image: "pierone.stups.zalan.do/zmon/zmon-agent-core:0.1-a48-zv1"
+          image: "pierone.stups.zalan.do/zmon/zmon-agent-core:0.1-a47-zv1"
           resources:
             limits:
               cpu: 100m


### PR DESCRIPTION
This reverts #941.
The new version doesn't work correctly in clusters where the postgresql resource doesn't exist.