### PR TITLE
Dev to alpha

### DIFF
--- a/cluster/etcd-cluster.yaml
+++ b/cluster/etcd-cluster.yaml
@@ -68,7 +68,7 @@ Resources:
         ToPort: 22
         CidrIp: 172.16.0.0/12
       - IpProtocol: tcp
-        FromPort: 2379
+        FromPort: 2381
         ToPort: 2381
         CidrIp: 172.16.0.0/12
       - IpProtocol: tcp

--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: "kube-system"
   labels:
     application: "zmon-agent"
-    version: "0.1-a48-zv1"
+    version: "0.1-a47-zv1"
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: "zmon-agent"
-        version: "0.1-a48-zv1"
+        version: "0.1-a47-zv1"
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -47,7 +47,7 @@ spec:
 
       containers:
         - name: zmon-agent
-          image: "pierone.stups.zalan.do/zmon/zmon-agent-core:0.1-a48-zv1"
+          image: "pierone.stups.zalan.do/zmon/zmon-agent-core:0.1-a47-zv1"
           resources:
             limits:
               cpu: 100m


### PR DESCRIPTION
* Downgrade ZMON because of a bug in the new version
* Remove the default etcd cluster access from worker nodes (this will not be applied by CLM, so it's safe to merge, and it's easier than cherry-picking)