### PR TITLE
Update authnz webhook to v0.4.0

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -321,7 +321,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.3.9
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.4.0
           name: webhook
           ports:
           - containerPort: 8081


### PR DESCRIPTION
This adds support for RBAC (which we don't need yet) but also adds logging to the authn part of the webhook so it's easier to see what groups are assigned to a user.