### PR TITLE
LB connection metrics

### DIFF
--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -58,6 +58,7 @@ spec:
           - "-reverse-source-predicate"
           - "-lb-healthcheck-interval=3s"
           - "-metrics-flavour=codahale,prometheus"
+          - "-enable-connection-metrics"
         resources:
           limits:
             memory: 200Mi


### PR DESCRIPTION
We should enable connection metrics to see active and new connections.
These are important loadbalancer metrics to understand better the behaviour of the system and the requests.