### PR TITLE
Updating Scalyr Agent

### DIFF
--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -100,7 +100,7 @@ spec:
 
       - name: scalyr-agent
 
-        image: registry.opensource.zalan.do/eagleeye/scalyr-agent:0.4
+        image: registry.opensource.zalan.do/eagleeye/scalyr-agent:0.5
 
         env:
         # Note: added for scalyr-config-base, but not needed by the scalyr-agent itself.


### PR DESCRIPTION
Since we need the new default ``max_line_size``, I'm updating the
scalyr-agent Docker image to the latest agent version.

https://github.com/scalyr/scalyr-agent-2/blob/master/CHANGELOG.md#2030-ewok---oct-25-2017