### PR TITLE
Flannel, let's at least log something

### DIFF
--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -43,6 +43,7 @@ spec:
         args:
         - --ip-masq
         - --kube-subnet-mgr
+        - --v=2
         env:
         - name: POD_NAME
           valueFrom:


### PR DESCRIPTION
Without this it doesn't log anything after the initial boot which is really annoying:

Have a look at the timestamp:

```console
I0323 09:59:39.662667       1 iptables.go:125] Adding iptables rule: ! -s 10.2.0.0/16 -d 10.2.0.0/24 -j RETURN
I0323 09:59:39.665110       1 iptables.go:125] Adding iptables rule: ! -s 10.2.0.0/16 -d 10.2.0.0/16 -j MASQUERADE
E0323 10:25:17.163968       1 iptables.go:97] Failed to ensure iptables rules: Error checking rule existence: failed to check rule existence: running [/sbin/iptables -t nat -C POSTROUTING -s 10.2.0.0/16 ! -d 224.0.0.0/4 -j MASQUERADE --wait]: exit status 4: iptables: Resource temporarily unavailable.
E0326 18:30:46.065969       1 iptables.go:97] Failed to ensure iptables rules: Error checking rule existence: failed to check rule existence: running [/sbin/iptables -t nat -C POSTROUTING -s 10.2.0.0/16 ! -d 224.0.0.0/4 -j MASQUERADE --wait]: exit status 4: iptables: Resource temporarily unavailable.
E0328 12:04:37.661204       1 streamwatcher.go:109] Unable to decode an event from the watch stream: http2: server sent GOAWAY and closed the connection; LastStreamID=1975, ErrCode=NO_ERROR, debug=""
```

Whereare with verbose logging it logs when nodes join and leave the pod network and which rules are added and removed for them.

```console
I0403 13:21:05.116364       1 vxlan_network.go:179] removing subnet: 10.2.14.0/24 PublicIP: 172.31.19.151 VtepMAC: 92:a4:7a:9b:ca:c9
I0403 13:32:20.488843       1 vxlan_network.go:179] removing subnet: 10.2.3.0/24 PublicIP: 172.31.14.13 VtepMAC: 56:c7:77:46:bb:24
I0403 13:34:28.646471       1 vxlan_network.go:138] adding subnet: 10.2.17.0/24 PublicIP: 172.31.20.137 VtepMAC: 46:76:cd:f4:f9:7b
I0403 13:36:46.098112       1 vxlan_network.go:179] removing subnet: 10.2.12.0/24 PublicIP: 172.31.16.186 VtepMAC: b6:84:88:46:03:d7
I0403 13:42:31.350808       1 vxlan_network.go:179] removing subnet: 10.2.0.0/24 PublicIP: 172.31.7.254 VtepMAC: aa:0f:78:6a:7f:64
I0403 13:43:16.630512       1 vxlan_network.go:179] removing subnet: 10.2.13.0/24 PublicIP: 172.31.5.72 VtepMAC: 5a:10:73:ce:c9:04
I0403 13:49:39.216175       1 vxlan_network.go:138] adding subnet: 10.2.18.0/24 PublicIP: 172.31.3.182 VtepMAC: 0a:8b:e8:6a:e2:35
```