### PR TITLE
Update ingress-template-controller to version with custom per service…

### DIFF
--- a/cluster/manifests/ingress-template-controller/deployment.yaml
+++ b/cluster/manifests/ingress-template-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: ingress-template-controller
-    version: master-2
+    version: master-4
 spec:
   selector:
     matchLabels:
@@ -14,12 +14,12 @@ spec:
     metadata:
       labels:
         application: ingress-template-controller
-        version: master-2
+        version: master-4
     spec:
       serviceAccountName: system
       containers:
       - name: ingress-template-controller
-        image: pierone.stups.zalan.do/teapot/ingress-template-controller:master-2
+        image: pierone.stups.zalan.do/teapot/ingress-template-controller:master-4
         resources:
           limits:
             cpu: 10m


### PR DESCRIPTION
… ingress support

This will automatically generate ingresses for each of the services selected by an ingress template such that the services are exposed on a non traffic switched endpoint for QA/manual testing before switching traffic on the main endpoint.