### PR TITLE
Update to Kubernetes v1.10.2

### DIFF
--- a/cluster/manifests/10-vertical-pod-autoscaler/admission-controller-deployment.yaml
+++ b/cluster/manifests/10-vertical-pod-autoscaler/admission-controller-deployment.yaml
@@ -17,6 +17,7 @@ spec:
         application: vpa-admission-controller
         version: v0.1.0
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: system
       containers:
       - name: admission-controller

--- a/cluster/manifests/10-vertical-pod-autoscaler/recommender-deployment.yaml
+++ b/cluster/manifests/10-vertical-pod-autoscaler/recommender-deployment.yaml
@@ -17,6 +17,7 @@ spec:
         application: vpa-recommender
         version: v0.1.0
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: system
       containers:
       - name: recommender

--- a/cluster/manifests/10-vertical-pod-autoscaler/updater-deployment.yaml
+++ b/cluster/manifests/10-vertical-pod-autoscaler/updater-deployment.yaml
@@ -17,6 +17,7 @@ spec:
         application: vpa-updater
         version: v0.1.0
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: system
       containers:
       - name: updater

--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -21,6 +21,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: critical
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -29,8 +30,6 @@ spec:
               - key: node-role.kubernetes.io/master
                 operator: Exists
       tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
       hostNetwork: true

--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -18,10 +18,8 @@ spec:
       labels:
         application: audittrail-adapter
         version: master-16
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      priorityClassName: critical
+      priorityClassName: system-node-critical
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/cluster/manifests/dashboard/deployment.yaml
+++ b/cluster/manifests/dashboard/deployment.yaml
@@ -18,12 +18,7 @@ spec:
         application: kubernetes-dashboard
         version: v1.6.1
         kubernetes.io/cluster-service: "true"
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
       containers:
       - name: kubernetes-dashboard
         image: registry.opensource.zalan.do/teapot/kubernetes-dashboard:v1.6.1

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -21,9 +21,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
     spec:
-      tolerations:
-       - key: CriticalAddonsOnly
-         operator: Exists
+      priorityClassName: critical
       containers:
       - name: external-dns
         image: registry.opensource.zalan.do/teapot/external-dns:v0.5.1

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -18,10 +18,9 @@ spec:
         application: external-dns
         version: v0.5.1
       annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
     spec:
-      priorityClassName: critical
+      priorityClassName: system-cluster-critical
       containers:
       - name: external-dns
         image: registry.opensource.zalan.do/teapot/external-dns:v0.5.1

--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -20,6 +20,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: critical
       serviceAccountName: system
       initContainers:
       - name: install-cni
@@ -73,8 +74,6 @@ spec:
         effect: NoSchedule
       - operator: Exists
         effect: NoExecute
-      - operator: Exists
-        key: CriticalAddonsOnly
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
       volumes:

--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -17,10 +17,8 @@ spec:
       labels:
         application: flannel
         version: v0.10.0
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      priorityClassName: critical
+      priorityClassName: system-node-critical
       serviceAccountName: system
       initContainers:
       - name: install-cni

--- a/cluster/manifests/heapster/deployment.yaml
+++ b/cluster/manifests/heapster/deployment.yaml
@@ -20,9 +20,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
+      priorityClassName: critical
       serviceAccountName: system
       containers:
         - image: registry.opensource.zalan.do/teapot/heapster:v1.5.2

--- a/cluster/manifests/heapster/deployment.yaml
+++ b/cluster/manifests/heapster/deployment.yaml
@@ -17,10 +17,8 @@ spec:
       labels:
         application: heapster
         version: v1.5.2
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      priorityClassName: critical
+      priorityClassName: system-cluster-critical
       serviceAccountName: system
       containers:
         - image: registry.opensource.zalan.do/teapot/heapster:v1.5.2

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -17,10 +17,9 @@ spec:
         application: kube-ingress-aws-controller
         version: v0.6.10
       annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
     spec:
-      priorityClassName: critical
+      priorityClassName: system-cluster-critical
       serviceAccountName: system
       containers:
       - name: controller

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -20,10 +20,8 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
     spec:
+      priorityClassName: critical
       serviceAccountName: system
-      tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
       containers:
       - name: controller
         image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.6.10

--- a/cluster/manifests/ingress-template-controller/deployment.yaml
+++ b/cluster/manifests/ingress-template-controller/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     application: ingress-template-controller
     version: master-4
 spec:
+  replicas: 1
   selector:
     matchLabels:
       application: ingress-template-controller
@@ -16,6 +17,7 @@ spec:
         application: ingress-template-controller
         version: master-4
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: system
       containers:
       - name: ingress-template-controller

--- a/cluster/manifests/kube-cluster-autoscaler/autoscaler-deployment.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/autoscaler-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-cluster-autoscaler
-    version: v1.1.2
+    version: v1.2.0
 spec:
   replicas: 2
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-cluster-autoscaler
-        version: v1.1.2
+        version: v1.2.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-autoscaler"
@@ -29,7 +29,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cluster-autoscaler
-        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.1.2
+        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.2.0
         command:
           - ./cluster-autoscaler
           - --v=4

--- a/cluster/manifests/kube-cluster-autoscaler/deployment.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/deployment.yaml
@@ -17,11 +17,10 @@ spec:
         application: kube-cluster-autoscaler
         version: v1.2.0
       annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-autoscaler"
         config/pool-sizes: "{{range .NodePools}}{{.Name}}-{{.MinSize}}-{{.MaxSize}} {{end}}"
     spec:
-      priorityClassName: critical
+      priorityClassName: system-cluster-critical
       serviceAccountName: system
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/cluster/manifests/kube-cluster-autoscaler/deployment.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/deployment.yaml
@@ -21,10 +21,9 @@ spec:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-autoscaler"
         config/pool-sizes: "{{range .NodePools}}{{.Name}}-{{.MinSize}}-{{.MaxSize}} {{end}}"
     spec:
+      priorityClassName: critical
       serviceAccountName: system
       tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
       containers:

--- a/cluster/manifests/kube-dns/depl-kube-dns-autoscaler.yaml
+++ b/cluster/manifests/kube-dns/depl-kube-dns-autoscaler.yaml
@@ -17,10 +17,8 @@ spec:
       labels:
         application: kube-dns-autoscaler
         version: v1.1.2
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      priorityClassName: critical
+      priorityClassName: system-cluster-critical
       serviceAccountName: system
       containers:
       - name: autoscaler

--- a/cluster/manifests/kube-dns/depl-kube-dns-autoscaler.yaml
+++ b/cluster/manifests/kube-dns/depl-kube-dns-autoscaler.yaml
@@ -20,10 +20,8 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: critical
       serviceAccountName: system
-      tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
       containers:
       - name: autoscaler
         image: registry.opensource.zalan.do/teapot/cluster-proportional-autoscaler:1.1.2-r2

--- a/cluster/manifests/kube-dns/depl-kube-dns-b-autoscaler.yaml
+++ b/cluster/manifests/kube-dns/depl-kube-dns-b-autoscaler.yaml
@@ -17,10 +17,8 @@ spec:
       labels:
         application: kube-dns-b-autoscaler
         version: v1.1.2
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      priorityClassName: critical
+      priorityClassName: system-cluster-critical
       serviceAccountName: system
       containers:
       - name: autoscaler

--- a/cluster/manifests/kube-dns/depl-kube-dns-b-autoscaler.yaml
+++ b/cluster/manifests/kube-dns/depl-kube-dns-b-autoscaler.yaml
@@ -20,10 +20,8 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: critical
       serviceAccountName: system
-      tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
       containers:
       - name: autoscaler
         image: registry.opensource.zalan.do/teapot/cluster-proportional-autoscaler:1.1.2-r2

--- a/cluster/manifests/kube-dns/depl-kube-dns-b.yaml
+++ b/cluster/manifests/kube-dns/depl-kube-dns-b.yaml
@@ -27,6 +27,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: critical
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -40,9 +41,6 @@ spec:
                     - kube-dns
                 topologyKey: kubernetes.io/hostname
       serviceAccountName: system
-      tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
       volumes:
       - name: kube-dns-config
         configMap:

--- a/cluster/manifests/kube-dns/depl-kube-dns-b.yaml
+++ b/cluster/manifests/kube-dns/depl-kube-dns-b.yaml
@@ -24,10 +24,8 @@ spec:
       labels:
         application: kube-dns-b
         version: v1.14.10
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      priorityClassName: critical
+      priorityClassName: system-cluster-critical
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/cluster/manifests/kube-dns/depl-kube-dns.yaml
+++ b/cluster/manifests/kube-dns/depl-kube-dns.yaml
@@ -27,6 +27,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: critical
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -40,9 +41,6 @@ spec:
                     - kube-dns-b
                 topologyKey: kubernetes.io/hostname
       serviceAccountName: system
-      tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
       volumes:
       - name: kube-dns-config
         configMap:

--- a/cluster/manifests/kube-dns/depl-kube-dns.yaml
+++ b/cluster/manifests/kube-dns/depl-kube-dns.yaml
@@ -24,10 +24,8 @@ spec:
       labels:
         application: kube-dns
         version: v1.14.10
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      priorityClassName: critical
+      priorityClassName: system-cluster-critical
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/cluster/manifests/kube-node-ready/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready/daemonset.yaml
@@ -21,9 +21,8 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-kube-node-ready"
     spec:
+      priorityClassName: critical
       tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
       containers:

--- a/cluster/manifests/kube-node-ready/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready/daemonset.yaml
@@ -18,10 +18,9 @@ spec:
         application: kube-node-ready
         version: v0.0.1
       annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-kube-node-ready"
     spec:
-      priorityClassName: critical
+      priorityClassName: system-node-critical
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule

--- a/cluster/manifests/kube-proxy/configmap.yaml
+++ b/cluster/manifests/kube-proxy/configmap.yaml
@@ -23,7 +23,10 @@ data:
       tcpCloseWaitTimeout: 1h0m0s
       tcpEstablishedTimeout: 24h0m0s
     enableProfiling: false
-    featureGates: "ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true"
+    featureGates:
+      ExperimentalCriticalPodAnnotation: true
+      TaintBasedEvictions: true
+      PodPriority: true
     healthzBindAddress: 0.0.0.0:10256
     hostnameOverride: ""
     iptables:

--- a/cluster/manifests/kube-proxy/configmap.yaml
+++ b/cluster/manifests/kube-proxy/configmap.yaml
@@ -24,7 +24,6 @@ data:
       tcpEstablishedTimeout: 24h0m0s
     enableProfiling: false
     featureGates:
-      ExperimentalCriticalPodAnnotation: true
       TaintBasedEvictions: true
       PodPriority: true
     healthzBindAddress: 0.0.0.0:10256

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -21,13 +21,12 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: critical
       tolerations:
       - operator: Exists
         effect: NoSchedule
       - operator: Exists
         effect: NoExecute
-      - operator: Exists
-        key: CriticalAddonsOnly
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
       hostNetwork: true

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-proxy
-    version: v1.10.0_coreos.0
+    version: v1.10.1_coreos.0
 spec:
   selector:
     matchLabels:
@@ -17,7 +17,7 @@ spec:
       name: kube-proxy
       labels:
         application: kube-proxy
-        version: v1.10.0_coreos.0
+        version: v1.10.1_coreos.0
     spec:
       priorityClassName: system-node-critical
       tolerations:
@@ -30,7 +30,7 @@ spec:
       hostNetwork: true
       containers:
       - name: kube-proxy
-        image: registry.opensource.zalan.do/teapot/hyperkube:v1.10.0_coreos.0
+        image: registry.opensource.zalan.do/teapot/hyperkube:v1.10.1_coreos.0
         command:
         - /hyperkube
         - proxy

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -18,10 +18,8 @@ spec:
       labels:
         application: kube-proxy
         version: v1.10.0_coreos.0
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      priorityClassName: critical
+      priorityClassName: system-node-critical
       tolerations:
       - operator: Exists
         effect: NoSchedule

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-proxy
-    version: v1.10.1_coreos.0
+    version: v1.10.2_coreos.0
 spec:
   selector:
     matchLabels:
@@ -17,7 +17,7 @@ spec:
       name: kube-proxy
       labels:
         application: kube-proxy
-        version: v1.10.1_coreos.0
+        version: v1.10.2_coreos.0
     spec:
       priorityClassName: system-node-critical
       tolerations:
@@ -30,7 +30,7 @@ spec:
       hostNetwork: true
       containers:
       - name: kube-proxy
-        image: registry.opensource.zalan.do/teapot/hyperkube:v1.10.1_coreos.0
+        image: registry.opensource.zalan.do/teapot/hyperkube:v1.10.2_coreos.0
         command:
         - /hyperkube
         - proxy

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-proxy
-    version: v1.9.7_coreos.0
+    version: v1.10.0_coreos.0
 spec:
   selector:
     matchLabels:
@@ -17,7 +17,7 @@ spec:
       name: kube-proxy
       labels:
         application: kube-proxy
-        version: v1.9.7_coreos.0
+        version: v1.10.0_coreos.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -33,7 +33,7 @@ spec:
       hostNetwork: true
       containers:
       - name: kube-proxy
-        image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.7_coreos.0
+        image: registry.opensource.zalan.do/teapot/hyperkube:v1.10.0_coreos.0
         command:
         - /hyperkube
         - proxy

--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -17,10 +17,9 @@ spec:
         application: kube-static-egress-controller
         version: v0.1.3
       annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-static-egress-controller"
     spec:
-      priorityClassName: critical
+      priorityClassName: system-cluster-critical
       containers:
       - name: controller
         image: registry.opensource.zalan.do/teapot/kube-static-egress-controller:v0.1.3

--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-static-egress-controller"
     spec:
+      priorityClassName: critical
       containers:
       - name: controller
         image: registry.opensource.zalan.do/teapot/kube-static-egress-controller:v0.1.3

--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -20,9 +20,8 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: critical
       tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
       hostNetwork: true

--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -17,10 +17,8 @@ spec:
       labels:
         application: kube2iam
         version: master-6
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      priorityClassName: critical
+      priorityClassName: system-node-critical
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -20,10 +20,8 @@ spec:
         application: logging-agent
         version: v0.17
         component: logging
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      priorityClassName: critical
+      priorityClassName: system-node-critical
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -23,9 +23,8 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: critical
       tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
       initContainers:

--- a/cluster/manifests/metrics-server/deployment.yaml
+++ b/cluster/manifests/metrics-server/deployment.yaml
@@ -18,6 +18,7 @@ spec:
         application: metrics-server
         version: v0.2.1
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: system
       containers:
       - name: metrics-server

--- a/cluster/manifests/pdb-controller/deployment.yaml
+++ b/cluster/manifests/pdb-controller/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     application: pdb-controller
     version: v0.0.8
 spec:
+  replicas: 1
   selector:
     matchLabels:
       application: pdb-controller
@@ -16,6 +17,7 @@ spec:
         application: pdb-controller
         version: v0.0.8
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: system
       containers:
       - name: pdb-controller

--- a/cluster/manifests/priorityclass/critical.yaml
+++ b/cluster/manifests/priorityclass/critical.yaml
@@ -1,0 +1,9 @@
+apiVersion: scheduling.k8s.io/v1alpha1
+kind: PriorityClass
+metadata:
+  name: critical
+value: 1000000
+globalDefault: false
+description: |
+  This priority class is used for critical pods running in kube-system
+  namespace.

--- a/cluster/manifests/priorityclass/critical.yaml
+++ b/cluster/manifests/priorityclass/critical.yaml
@@ -1,9 +1,0 @@
-apiVersion: scheduling.k8s.io/v1alpha1
-kind: PriorityClass
-metadata:
-  name: critical
-value: 1000000
-globalDefault: false
-description: |
-  This priority class is used for critical pods running in kube-system
-  namespace.

--- a/cluster/manifests/prometheus-node-exporter/daemonset.yaml
+++ b/cluster/manifests/prometheus-node-exporter/daemonset.yaml
@@ -20,10 +20,8 @@ spec:
         application: prometheus-node-exporter
         version: v0.12.0
         component: node-exporter
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      priorityClassName: critical
+      priorityClassName: system-node-critical
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule

--- a/cluster/manifests/prometheus-node-exporter/daemonset.yaml
+++ b/cluster/manifests/prometheus-node-exporter/daemonset.yaml
@@ -23,9 +23,8 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: critical
       tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
       containers:

--- a/cluster/manifests/prometheus/statefulset.yaml
+++ b/cluster/manifests/prometheus/statefulset.yaml
@@ -21,6 +21,7 @@ spec:
       annotations:
         config/hash: {{"configmap.yaml" | manifestHash}}
     spec:
+      priorityClassName: system-cluster-critical
       containers:
       - name: prometheus
         image: registry.opensource.zalan.do/teapot/prometheus:v2.2.1

--- a/cluster/manifests/psp/pod_security_policy.yaml
+++ b/cluster/manifests/psp/pod_security_policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: privileged
@@ -22,7 +22,7 @@ spec:
   volumes:
   - '*'
 ---
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: restricted

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -25,6 +25,7 @@ spec:
         kubernetes-log-watcher/scalyr-parser: |
           [{"container": "skipper-ingress", "parser": "skipper-access-log"}]
     spec:
+      priorityClassName: critical
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -34,9 +35,6 @@ spec:
                 operator: NotIn
                 values:
                 - master
-      tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
       hostNetwork: true
       containers:
       - name: skipper-ingress

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -21,11 +21,10 @@ spec:
         version: v0.9.202
         component: ingress
       annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
         kubernetes-log-watcher/scalyr-parser: |
           [{"container": "skipper-ingress", "parser": "skipper-access-log"}]
     spec:
-      priorityClassName: critical
+      priorityClassName: system-node-critical
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -20,10 +20,7 @@ spec:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
-
+      priorityClassName: critical
       initContainers:
       - name: gerry-init
         image: registry.opensource.zalan.do/teapot/gerry:v0.0.14

--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -18,9 +18,8 @@ spec:
         version: "0.1-a53-zv1"
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      priorityClassName: critical
+      priorityClassName: system-cluster-critical
       initContainers:
       - name: gerry-init
         image: registry.opensource.zalan.do/teapot/gerry:v0.0.14

--- a/cluster/manifests/zmon-aws-agent/deployment.yaml
+++ b/cluster/manifests/zmon-aws-agent/deployment.yaml
@@ -20,10 +20,7 @@ spec:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
-
+      priorityClassName: critical
       initContainers:
       - name: gerry-init
         image: registry.opensource.zalan.do/teapot/gerry:v0.0.14

--- a/cluster/manifests/zmon-aws-agent/deployment.yaml
+++ b/cluster/manifests/zmon-aws-agent/deployment.yaml
@@ -18,9 +18,8 @@ spec:
         version: "v71-zv153"
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      priorityClassName: critical
+      priorityClassName: system-cluster-critical
       initContainers:
       - name: gerry-init
         image: registry.opensource.zalan.do/teapot/gerry:v0.0.14

--- a/cluster/manifests/zmon-redis/deployment.yaml
+++ b/cluster/manifests/zmon-redis/deployment.yaml
@@ -19,9 +19,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
+      priorityClassName: critical
       containers:
         - name: zmon-redis
           image: registry.opensource.zalan.do/zmon/redis:3.2.9

--- a/cluster/manifests/zmon-redis/deployment.yaml
+++ b/cluster/manifests/zmon-redis/deployment.yaml
@@ -16,10 +16,8 @@ spec:
       labels:
         application: "zmon-redis"
         version: "v0.1"
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      priorityClassName: critical
+      priorityClassName: system-cluster-critical
       containers:
         - name: zmon-redis
           image: registry.opensource.zalan.do/zmon/redis:3.2.9

--- a/cluster/manifests/zmon-scheduler/deployment.yaml
+++ b/cluster/manifests/zmon-scheduler/deployment.yaml
@@ -20,10 +20,7 @@ spec:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
-
+      priorityClassName: critical
       initContainers:
       - name: gerry-init
         image: registry.opensource.zalan.do/teapot/gerry:v0.0.14

--- a/cluster/manifests/zmon-scheduler/deployment.yaml
+++ b/cluster/manifests/zmon-scheduler/deployment.yaml
@@ -18,9 +18,8 @@ spec:
         version: "v43"
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      priorityClassName: critical
+      priorityClassName: system-cluster-critical
       initContainers:
       - name: gerry-init
         image: registry.opensource.zalan.do/teapot/gerry:v0.0.14

--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -20,10 +20,7 @@ spec:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
-
+      priorityClassName: critical
       initContainers:
       - name: gerry-init
         image: registry.opensource.zalan.do/teapot/gerry:v0.0.14

--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -3,6 +3,9 @@ kind: Deployment
 metadata:
   name: zmon-worker
   namespace: visibility
+  labels:
+    application: zmon-worker
+    version: "v191-zv244"
 spec:
   replicas: {{if index .ConfigItems "zmon_worker_replicas"}}{{.ConfigItems.zmon_worker_replicas}}{{else}}4{{end}}
   selector:

--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -18,9 +18,8 @@ spec:
         version: "v194-zv244"
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      priorityClassName: critical
+      priorityClassName: system-cluster-critical
       initContainers:
       - name: gerry-init
         image: registry.opensource.zalan.do/teapot/gerry:v0.0.14

--- a/cluster/master.clc.yaml
+++ b/cluster/master.clc.yaml
@@ -126,7 +126,7 @@ systemd:
       After=docker.service dockercfg.service meta-data-iptables.service
 
       [Service]
-      Environment=KUBELET_IMAGE_TAG=v1.10.0_coreos.0
+      Environment=KUBELET_IMAGE_TAG=v1.10.1_coreos.0
       Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
       Environment="RKT_RUN_ARGS=--insecure-options=image \
       --uuid-file-save=/var/run/kubelet-pod.uuid \
@@ -262,7 +262,7 @@ storage:
           namespace: kube-system
           labels:
             application: kube-apiserver
-            version: v1.10.0_coreos.0
+            version: v1.10.1_coreos.0
           annotations:
             kubernetes-log-watcher/scalyr-parser: |
               [{"container": "webhook", "parser": "json-structured-log"}]
@@ -274,7 +274,7 @@ storage:
           hostNetwork: true
           containers:
           - name: kube-apiserver
-            image: registry.opensource.zalan.do/teapot/hyperkube:v1.10.0_coreos.0
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.10.1_coreos.0
             command:
             - /hyperkube
             - apiserver
@@ -447,7 +447,7 @@ storage:
           namespace: kube-system
           labels:
             application: kube-controller-manager
-            version: v1.10.0_coreos.0
+            version: v1.10.1_coreos.0
         spec:
           priorityClassName: system-node-critical
           tolerations:
@@ -455,7 +455,7 @@ storage:
             effect: NoSchedule
           containers:
           - name: kube-controller-manager
-            image: registry.opensource.zalan.do/teapot/hyperkube:v1.10.0_coreos.0
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.10.1_coreos.0
             command:
             - /hyperkube
             - controller-manager
@@ -516,7 +516,7 @@ storage:
           namespace: kube-system
           labels:
             application: kube-scheduler
-            version: v1.10.0_coreos.0
+            version: v1.10.1_coreos.0
         spec:
           priorityClassName: system-node-critical
           tolerations:
@@ -525,7 +525,7 @@ storage:
           hostNetwork: true
           containers:
           - name: kube-scheduler
-            image: registry.opensource.zalan.do/teapot/hyperkube:v1.10.0_coreos.0
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.10.1_coreos.0
             command:
             - /hyperkube
             - scheduler
@@ -894,7 +894,7 @@ storage:
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
           --net=host \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.10.0_coreos.0 \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.10.1_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           label node "$(hostname)" \
@@ -907,7 +907,7 @@ storage:
           --net=host \
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.10.0_coreos.0 \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.10.1_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           drain "$(hostname)" \

--- a/cluster/master.clc.yaml
+++ b/cluster/master.clc.yaml
@@ -126,7 +126,7 @@ systemd:
       After=docker.service dockercfg.service meta-data-iptables.service
 
       [Service]
-      Environment=KUBELET_IMAGE_TAG=v1.10.1_coreos.0
+      Environment=KUBELET_IMAGE_TAG=v1.10.2_coreos.0
       Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
       Environment="RKT_RUN_ARGS=--insecure-options=image \
       --uuid-file-save=/var/run/kubelet-pod.uuid \
@@ -262,7 +262,7 @@ storage:
           namespace: kube-system
           labels:
             application: kube-apiserver
-            version: v1.10.1_coreos.0
+            version: v1.10.2_coreos.0
           annotations:
             kubernetes-log-watcher/scalyr-parser: |
               [{"container": "webhook", "parser": "json-structured-log"}]
@@ -274,7 +274,7 @@ storage:
           hostNetwork: true
           containers:
           - name: kube-apiserver
-            image: registry.opensource.zalan.do/teapot/hyperkube:v1.10.1_coreos.0
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.10.2_coreos.0
             command:
             - /hyperkube
             - apiserver
@@ -447,7 +447,7 @@ storage:
           namespace: kube-system
           labels:
             application: kube-controller-manager
-            version: v1.10.1_coreos.0
+            version: v1.10.2_coreos.0
         spec:
           priorityClassName: system-node-critical
           tolerations:
@@ -455,7 +455,7 @@ storage:
             effect: NoSchedule
           containers:
           - name: kube-controller-manager
-            image: registry.opensource.zalan.do/teapot/hyperkube:v1.10.1_coreos.0
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.10.2_coreos.0
             command:
             - /hyperkube
             - controller-manager
@@ -516,7 +516,7 @@ storage:
           namespace: kube-system
           labels:
             application: kube-scheduler
-            version: v1.10.1_coreos.0
+            version: v1.10.2_coreos.0
         spec:
           priorityClassName: system-node-critical
           tolerations:
@@ -525,7 +525,7 @@ storage:
           hostNetwork: true
           containers:
           - name: kube-scheduler
-            image: registry.opensource.zalan.do/teapot/hyperkube:v1.10.1_coreos.0
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.10.2_coreos.0
             command:
             - /hyperkube
             - scheduler
@@ -894,7 +894,7 @@ storage:
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
           --net=host \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.10.1_coreos.0 \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.10.2_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           label node "$(hostname)" \
@@ -907,7 +907,7 @@ storage:
           --net=host \
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.10.1_coreos.0 \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.10.2_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           drain "$(hostname)" \

--- a/cluster/master.clc.yaml
+++ b/cluster/master.clc.yaml
@@ -288,7 +288,7 @@ storage:
             - --allow-privileged=true
             - --service-cluster-ip-range=10.3.0.0/16
             - --secure-port=443
-            - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,PodSecurityPolicy,ImagePolicyWebhook,Priority,MutatingAdmissionWebhook,PersistentVolumeClaimResize
+            - --enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota,PodSecurityPolicy,ImagePolicyWebhook,Priority,PersistentVolumeClaimResize
             - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
             - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
             - --service-account-key-file=/etc/kubernetes/ssl/apiserver-key.pem

--- a/cluster/master.clc.yaml
+++ b/cluster/master.clc.yaml
@@ -157,7 +157,7 @@ systemd:
       --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
       --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \
       --cloud-provider=aws \
-      --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true \
+      --feature-gates=TaintBasedEvictions=true,PodPriority=true \
       --system-reserved=cpu=100m,memory=164Mi \
       --kube-reserved=cpu=100m,memory=282Mi
       ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
@@ -299,7 +299,7 @@ storage:
             - --authorization-mode=Webhook
             - --authorization-webhook-config-file=/etc/kubernetes/config/authz.yaml
             - --admission-control-config-file=/etc/kubernetes/config/image-policy-webhook.yaml
-            - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true,ExpandPersistentVolumes=true
+            - --feature-gates=TaintBasedEvictions=true,PodPriority=true,ExpandPersistentVolumes=true
             - --anonymous-auth=false
             - --audit-webhook-config-file=/etc/kubernetes/config/audit.yaml
             - --audit-webhook-mode=batch
@@ -465,7 +465,7 @@ storage:
             - --root-ca-file=/etc/kubernetes/ssl/ca.pem
             - --cloud-provider=aws
             - --cloud-config=/etc/kubernetes/cloud-config.ini
-            - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true,ExpandPersistentVolumes=true
+            - --feature-gates=TaintBasedEvictions=true,PodPriority=true,ExpandPersistentVolumes=true
             - --horizontal-pod-autoscaler-use-rest-clients=true
             - --use-service-account-credentials=true
             - --v=4
@@ -531,7 +531,7 @@ storage:
             - scheduler
             - --master=http://127.0.0.1:8080
             - --leader-elect=true
-            - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true
+            - --feature-gates=TaintBasedEvictions=true,PodPriority=true
             resources:
               requests:
                 cpu: 100m

--- a/cluster/master.clc.yaml
+++ b/cluster/master.clc.yaml
@@ -292,7 +292,7 @@ storage:
             - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
             - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
             - --service-account-key-file=/etc/kubernetes/ssl/apiserver-key.pem
-            - --runtime-config=extensions/v1beta1/networkpolicies=true,batch/v2alpha1=true,extensions/v1beta1/podsecuritypolicy=true,imagepolicy.k8s.io/v1alpha1=true,authorization.k8s.io/v1beta1=true,scheduling.k8s.io/v1alpha1=true,admissionregistration.k8s.io/v1beta1=true
+            - --runtime-config=extensions/v1beta1/networkpolicies=true,batch/v2alpha1=true,policy/v1beta1/podsecuritypolicy=true,imagepolicy.k8s.io/v1alpha1=true,authorization.k8s.io/v1beta1=true,scheduling.k8s.io/v1alpha1=true,admissionregistration.k8s.io/v1beta1=true
             - --authentication-token-webhook-config-file=/etc/kubernetes/config/authn.yaml
             - --authentication-token-webhook-cache-ttl=10s
             - --cloud-provider=aws

--- a/cluster/master.clc.yaml
+++ b/cluster/master.clc.yaml
@@ -126,7 +126,7 @@ systemd:
       After=docker.service dockercfg.service meta-data-iptables.service
 
       [Service]
-      Environment=KUBELET_IMAGE_TAG=v1.9.7_coreos.0
+      Environment=KUBELET_IMAGE_TAG=v1.10.0_coreos.0
       Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
       Environment="RKT_RUN_ARGS=--insecure-options=image \
       --uuid-file-save=/var/run/kubelet-pod.uuid \
@@ -146,7 +146,6 @@ systemd:
       --cni-conf-dir=/etc/kubernetes/cni/net.d \
       --network-plugin=cni \
       --container-runtime=docker \
-      --rkt-path=/usr/bin/rkt \
       --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
       --allow-privileged \
       --node-labels=node-role.kubernetes.io/master,kubernetes.io/role=master,master=true \
@@ -155,7 +154,6 @@ systemd:
       --cluster-dns=10.3.0.10,10.3.0.11 \
       --cluster-domain=cluster.local \
       --kubeconfig=/etc/kubernetes/kubeconfig \
-      --require-kubeconfig \
       --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
       --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \
       --cloud-provider=aws \
@@ -264,21 +262,19 @@ storage:
           namespace: kube-system
           labels:
             application: kube-apiserver
-            version: v1.9.7_coreos.0
+            version: v1.10.0_coreos.0
           annotations:
-            scheduler.alpha.kubernetes.io/critical-pod: ''
             kubernetes-log-watcher/scalyr-parser: |
               [{"container": "webhook", "parser": "json-structured-log"}]
         spec:
+          priorityClassName: system-node-critical
           tolerations:
-          - key: CriticalAddonsOnly
-            operator: Exists
           - key: node-role.kubernetes.io/master
             effect: NoSchedule
           hostNetwork: true
           containers:
           - name: kube-apiserver
-            image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.7_coreos.0
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.10.0_coreos.0
             command:
             - /hyperkube
             - apiserver
@@ -451,18 +447,15 @@ storage:
           namespace: kube-system
           labels:
             application: kube-controller-manager
-            version: v1.9.7_coreos.0
-          annotations:
-            scheduler.alpha.kubernetes.io/critical-pod: ''
+            version: v1.10.0_coreos.0
         spec:
+          priorityClassName: system-node-critical
           tolerations:
-          - key: CriticalAddonsOnly
-            operator: Exists
           - key: node-role.kubernetes.io/master
             effect: NoSchedule
           containers:
           - name: kube-controller-manager
-            image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.7_coreos.0
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.10.0_coreos.0
             command:
             - /hyperkube
             - controller-manager
@@ -523,19 +516,16 @@ storage:
           namespace: kube-system
           labels:
             application: kube-scheduler
-            version: v1.9.7_coreos.0
-          annotations:
-            scheduler.alpha.kubernetes.io/critical-pod: ''
+            version: v1.10.0_coreos.0
         spec:
+          priorityClassName: system-node-critical
           tolerations:
-          - key: CriticalAddonsOnly
-            operator: Exists
           - key: node-role.kubernetes.io/master
             effect: NoSchedule
           hostNetwork: true
           containers:
           - name: kube-scheduler
-            image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.7_coreos.0
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.10.0_coreos.0
             command:
             - /hyperkube
             - scheduler
@@ -553,41 +543,6 @@ storage:
                 port: 10251
               initialDelaySeconds: 15
               timeoutSeconds: 15
-
-  - filesystem: root
-    path: /etc/kubernetes/manifests/rescheduler.yaml
-    mode: 0644
-    contents:
-      inline: |
-        apiVersion: v1
-        kind: Pod
-        metadata:
-          name: rescheduler-v0.3.1
-          namespace: kube-system
-          labels:
-            application: rescheduler
-            version: v0.3.1
-            kubernetes.io/cluster-service: "true"
-            kubernetes.io/name: "Rescheduler"
-            scheduler.alpha.kubernetes.io/critical-pod: ''
-        spec:
-          tolerations:
-          - key: CriticalAddonsOnly
-            operator: Exists
-          - key: node-role.kubernetes.io/master
-            effect: NoSchedule
-          hostNetwork: true
-          containers:
-          - image: registry.opensource.zalan.do/teapot/rescheduler:v0.3.1
-            name: rescheduler
-            resources:
-              requests:
-                cpu: 10m
-                memory: 100Mi
-            command:
-            - /rescheduler
-            args:
-            - --running-in-cluster=false
 
   - filesystem: root
     path: /etc/kubernetes/nginx/nginx.conf
@@ -939,7 +894,7 @@ storage:
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
           --net=host \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.7_coreos.0 \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.10.0_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           label node "$(hostname)" \
@@ -952,7 +907,7 @@ storage:
           --net=host \
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.7_coreos.0 \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.10.0_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           drain "$(hostname)" \

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -124,7 +124,7 @@ systemd:
       After=docker.service dockercfg.service meta-data-iptables.service
 
       [Service]
-      Environment=KUBELET_IMAGE_TAG=v1.9.7_coreos.0
+      Environment=KUBELET_IMAGE_TAG=v1.10.2_coreos.0
       Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
       Environment="RKT_RUN_ARGS=--insecure-options=image \
       --uuid-file-save=/var/run/kubelet-pod.uuid \
@@ -144,7 +144,6 @@ systemd:
       --cni-conf-dir=/etc/kubernetes/cni/net.d \
       --network-plugin=cni \
       --container-runtime=docker \
-      --rkt-path=/usr/bin/rkt \
       --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
       --allow-privileged \
       --node-labels=node-role.kubernetes.io/master,kubernetes.io/role=master,master=true \
@@ -154,11 +153,10 @@ systemd:
       --cluster-dns=10.3.0.10,10.3.0.11 \
       --cluster-domain=cluster.local \
       --kubeconfig=/etc/kubernetes/kubeconfig \
-      --require-kubeconfig \
       --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
       --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \
       --cloud-provider=aws \
-      --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true \
+      --feature-gates=TaintBasedEvictions=true,PodPriority=true \
       --system-reserved=cpu=100m,memory=164Mi \
       --kube-reserved=cpu=100m,memory=282Mi
       ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
@@ -263,21 +261,19 @@ storage:
           namespace: kube-system
           labels:
             application: kube-apiserver
-            version: v1.9.7_coreos.0
+            version: v1.10.2_coreos.0
           annotations:
-            scheduler.alpha.kubernetes.io/critical-pod: ''
             kubernetes-log-watcher/scalyr-parser: |
               [{"container": "webhook", "parser": "json-structured-log"}]
         spec:
+          priorityClassName: system-node-critical
           tolerations:
-          - key: CriticalAddonsOnly
-            operator: Exists
           - key: node-role.kubernetes.io/master
             effect: NoSchedule
           hostNetwork: true
           containers:
           - name: kube-apiserver
-            image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.7_coreos.0
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.10.2_coreos.0
             command:
             - /hyperkube
             - apiserver
@@ -291,18 +287,18 @@ storage:
             - --allow-privileged=true
             - --service-cluster-ip-range=10.3.0.0/16
             - --secure-port=443
-            - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,PodSecurityPolicy,ImagePolicyWebhook,Priority,MutatingAdmissionWebhook,PersistentVolumeClaimResize
+            - --enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota,PodSecurityPolicy,ImagePolicyWebhook,Priority,PersistentVolumeClaimResize
             - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
             - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
             - --service-account-key-file=/etc/kubernetes/ssl/apiserver-key.pem
-            - --runtime-config=extensions/v1beta1/networkpolicies=true,batch/v2alpha1=true,extensions/v1beta1/podsecuritypolicy=true,imagepolicy.k8s.io/v1alpha1=true,authorization.k8s.io/v1beta1=true,scheduling.k8s.io/v1alpha1=true
+            - --runtime-config=extensions/v1beta1/networkpolicies=true,batch/v2alpha1=true,policy/v1beta1/podsecuritypolicy=true,imagepolicy.k8s.io/v1alpha1=true,authorization.k8s.io/v1beta1=true,scheduling.k8s.io/v1alpha1=true,admissionregistration.k8s.io/v1beta1=true
             - --authentication-token-webhook-config-file=/etc/kubernetes/config/authn.yaml
             - --authentication-token-webhook-cache-ttl=10s
             - --cloud-provider=aws
             - --authorization-mode=Webhook
             - --authorization-webhook-config-file=/etc/kubernetes/config/authz.yaml
             - --admission-control-config-file=/etc/kubernetes/config/image-policy-webhook.yaml
-            - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true,ExpandPersistentVolumes=true
+            - --feature-gates=TaintBasedEvictions=true,PodPriority=true,ExpandPersistentVolumes=true
             - --anonymous-auth=false
             {{ if or (eq .Cluster.Environment "production") (index .Cluster.ConfigItems "audittrail_url") }}
             - --audit-webhook-config-file=/etc/kubernetes/config/audit.yaml
@@ -452,18 +448,15 @@ storage:
           namespace: kube-system
           labels:
             application: kube-controller-manager
-            version: v1.9.7_coreos.0
-          annotations:
-            scheduler.alpha.kubernetes.io/critical-pod: ''
+            version: v1.10.2_coreos.0
         spec:
+          priorityClassName: system-node-critical
           tolerations:
-          - key: CriticalAddonsOnly
-            operator: Exists
           - key: node-role.kubernetes.io/master
             effect: NoSchedule
           containers:
           - name: kube-controller-manager
-            image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.7_coreos.0
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.10.2_coreos.0
             command:
             - /hyperkube
             - controller-manager
@@ -473,7 +466,7 @@ storage:
             - --root-ca-file=/etc/kubernetes/ssl/ca.pem
             - --cloud-provider=aws
             - --cloud-config=/etc/kubernetes/cloud-config.ini
-            - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true,ExpandPersistentVolumes=true
+            - --feature-gates=TaintBasedEvictions=true,PodPriority=true,ExpandPersistentVolumes=true
             - --horizontal-pod-autoscaler-use-rest-clients=true
             - --use-service-account-credentials=true
             - --v=4
@@ -524,25 +517,22 @@ storage:
           namespace: kube-system
           labels:
             application: kube-scheduler
-            version: v1.9.7_coreos.0
-          annotations:
-            scheduler.alpha.kubernetes.io/critical-pod: ''
+            version: v1.10.2_coreos.0
         spec:
+          priorityClassName: system-node-critical
           tolerations:
-          - key: CriticalAddonsOnly
-            operator: Exists
           - key: node-role.kubernetes.io/master
             effect: NoSchedule
           hostNetwork: true
           containers:
           - name: kube-scheduler
-            image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.7_coreos.0
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.10.2_coreos.0
             command:
             - /hyperkube
             - scheduler
             - --master=http://127.0.0.1:8080
             - --leader-elect=true
-            - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true
+            - --feature-gates=TaintBasedEvictions=true,PodPriority=true
             resources:
               requests:
                 cpu: 100m
@@ -554,41 +544,6 @@ storage:
                 port: 10251
               initialDelaySeconds: 15
               timeoutSeconds: 15
-
-  - filesystem: root
-    path: /etc/kubernetes/manifests/rescheduler.yaml
-    mode: 0644
-    contents:
-      inline: |
-        apiVersion: v1
-        kind: Pod
-        metadata:
-          name: rescheduler-v0.3.1
-          namespace: kube-system
-          labels:
-            application: rescheduler
-            version: v0.3.1
-            kubernetes.io/cluster-service: "true"
-            kubernetes.io/name: "Rescheduler"
-            scheduler.alpha.kubernetes.io/critical-pod: ''
-        spec:
-          tolerations:
-          - key: CriticalAddonsOnly
-            operator: Exists
-          - key: node-role.kubernetes.io/master
-            effect: NoSchedule
-          hostNetwork: true
-          containers:
-          - image: registry.opensource.zalan.do/teapot/rescheduler:v0.3.1
-            name: rescheduler
-            resources:
-              requests:
-                cpu: 10m
-                memory: 100Mi
-            command:
-            - /rescheduler
-            args:
-            - --running-in-cluster=false
 
   - filesystem: root
     path: /etc/kubernetes/nginx/nginx.conf
@@ -942,7 +897,7 @@ storage:
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
           --net=host \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.7_coreos.0 \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.10.2_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           label node "$(hostname)" \
@@ -955,7 +910,7 @@ storage:
           --net=host \
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.7_coreos.0 \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.10.2_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           drain "$(hostname)" \

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -97,7 +97,7 @@ systemd:
       After=docker.service dockercfg.service meta-data-iptables.service
 
       [Service]
-      Environment=KUBELET_IMAGE_TAG=v1.9.7_coreos.0
+      Environment=KUBELET_IMAGE_TAG=v1.10.2_coreos.0
       Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
       Environment="RKT_RUN_ARGS=--insecure-options=image \
       --uuid-file-save=/var/run/kubelet-pod.uuid \
@@ -119,7 +119,6 @@ systemd:
       --cni-conf-dir=/etc/kubernetes/cni/net.d \
       --network-plugin=cni \
       --container-runtime=docker \
-      --rkt-path=/usr/bin/rkt \
       --register-node \
       --allow-privileged \
       --node-labels=kubernetes.io/role=worker \
@@ -128,13 +127,12 @@ systemd:
       --cluster-dns=10.3.0.10,10.3.0.11 \
       --cluster-domain=cluster.local \
       --kubeconfig=/etc/kubernetes/kubeconfig \
-      --require-kubeconfig \
       --healthz-bind-address=0.0.0.0 \
       --healthz-port=10248 \
       --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
       --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \
       --cloud-provider=aws \
-      --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true \
+      --feature-gates=TaintBasedEvictions=true,PodPriority=true \
       --system-reserved=cpu=100m,memory=164Mi \
       --kube-reserved=cpu=100m,memory=282Mi
       ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
@@ -300,7 +298,7 @@ storage:
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
           --net=host \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.7_coreos.0 \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.10.2_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           label node "$(hostname)" \
@@ -313,7 +311,7 @@ storage:
           --net=host \
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.7_coreos.0 \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.10.2_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           drain "$(hostname)" \

--- a/cluster/worker.clc.yaml
+++ b/cluster/worker.clc.yaml
@@ -97,7 +97,7 @@ systemd:
       After=docker.service dockercfg.service meta-data-iptables.service
 
       [Service]
-      Environment=KUBELET_IMAGE_TAG=v1.10.0_coreos.0
+      Environment=KUBELET_IMAGE_TAG=v1.10.1_coreos.0
       Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
       Environment="RKT_RUN_ARGS=--insecure-options=image \
       --uuid-file-save=/var/run/kubelet-pod.uuid \
@@ -295,7 +295,7 @@ storage:
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
           --net=host \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.10.0_coreos.0 \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.10.1_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           label node "$(hostname)" \
@@ -308,7 +308,7 @@ storage:
           --net=host \
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.10.0_coreos.0 \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.10.1_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           drain "$(hostname)" \

--- a/cluster/worker.clc.yaml
+++ b/cluster/worker.clc.yaml
@@ -131,7 +131,7 @@ systemd:
       --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
       --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \
       --cloud-provider=aws \
-      --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true \
+      --feature-gates=TaintBasedEvictions=true,PodPriority=true \
       --system-reserved=cpu=100m,memory=164Mi \
       --kube-reserved=cpu=100m,memory=282Mi
       ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid

--- a/cluster/worker.clc.yaml
+++ b/cluster/worker.clc.yaml
@@ -97,7 +97,7 @@ systemd:
       After=docker.service dockercfg.service meta-data-iptables.service
 
       [Service]
-      Environment=KUBELET_IMAGE_TAG=v1.9.7_coreos.0
+      Environment=KUBELET_IMAGE_TAG=v1.10.0_coreos.0
       Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
       Environment="RKT_RUN_ARGS=--insecure-options=image \
       --uuid-file-save=/var/run/kubelet-pod.uuid \
@@ -119,7 +119,6 @@ systemd:
       --cni-conf-dir=/etc/kubernetes/cni/net.d \
       --network-plugin=cni \
       --container-runtime=docker \
-      --rkt-path=/usr/bin/rkt \
       --register-node \
       --allow-privileged \
       --node-labels=kubernetes.io/role=worker \
@@ -127,7 +126,6 @@ systemd:
       --cluster-dns=10.3.0.10,10.3.0.11 \
       --cluster-domain=cluster.local \
       --kubeconfig=/etc/kubernetes/kubeconfig \
-      --require-kubeconfig \
       --healthz-bind-address=0.0.0.0 \
       --healthz-port=10248 \
       --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
@@ -297,7 +295,7 @@ storage:
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
           --net=host \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.7_coreos.0 \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.10.0_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           label node "$(hostname)" \
@@ -310,7 +308,7 @@ storage:
           --net=host \
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.7_coreos.0 \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.10.0_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           drain "$(hostname)" \

--- a/cluster/worker.clc.yaml
+++ b/cluster/worker.clc.yaml
@@ -97,7 +97,7 @@ systemd:
       After=docker.service dockercfg.service meta-data-iptables.service
 
       [Service]
-      Environment=KUBELET_IMAGE_TAG=v1.10.1_coreos.0
+      Environment=KUBELET_IMAGE_TAG=v1.10.2_coreos.0
       Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
       Environment="RKT_RUN_ARGS=--insecure-options=image \
       --uuid-file-save=/var/run/kubelet-pod.uuid \
@@ -295,7 +295,7 @@ storage:
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
           --net=host \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.10.1_coreos.0 \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.10.2_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           label node "$(hostname)" \
@@ -308,7 +308,7 @@ storage:
           --net=host \
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.10.1_coreos.0 \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.10.2_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           drain "$(hostname)" \

--- a/kubernetes_e2e_version
+++ b/kubernetes_e2e_version
@@ -1,1 +1,1 @@
-v1.9.4-disable-psp-rbac
+v1.10.0


### PR DESCRIPTION
**WORK IN PROGRESS**

https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.10.md#v1100

### Notable changes
* Removes rescheduler and uses Priority classes instead. (https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/#rescheduler-guaranteed-scheduling-of-critical-add-ons)
  * Adds the system defined PriorityClasses to kube-system pods:
    * `system-node-critical` for daemonset pods and static pods on masters (this is the highest possible priority in Kubernetes).
    * `system-cluster-critical` for deployment pods (second highest).
    * Removes the `scheduler.alpha.kubernetes.io/critical-pod` annotation as setting the priorityClass to a system-critical one has the same effect: https://github.com/kubernetes/kubernetes/blob/v1.10.0/pkg/kubelet/types/pod_update.go#L143-L175
  * Makes `kube-dashboard` non-critical.
  * Makes `prometheus` cluster-critical.
* Uses the recommmended Admission Controllers as defined here: https://kubernetes.io/docs/admin/admission-controllers/#is-there-a-recommended-set-of-admission-controllers-to-use

Fixes #975 