### PR TITLE
Fix to update egress clouformation stacks

### DIFF
--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-static-egress-controller
-    version: v0.1.1
+    version: v0.1.2
 spec:
   replicas: 1
   selector:
@@ -15,14 +15,14 @@ spec:
     metadata:
       labels:
         application: kube-static-egress-controller
-        version: v0.1.1
+        version: v0.1.2
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-static-egress-controller"
     spec:
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-static-egress-controller:v0.1.1
+        image: registry.opensource.zalan.do/teapot/kube-static-egress-controller:v0.1.2
         args:
         - "--log-level=debug"
         - "--provider=aws"


### PR DESCRIPTION
Bump the version to v0.1.2

This fixes https://github.com/szuecs/kube-static-egress-controller/issues/13

The code checks termination protection before it would update the cloudformation stack. It will return an error before that because the stack name is invalid. Currently no changes will happen after changing the config maps.

`time="2018-04-05T14:20:25Z" level=info msg="InvalidParameter | 1 validation error(s) found. | InvalidParameter: 1 validation error(s) found.\ncaused by: ParamMinLenError: minimum field size of 1, UpdateTerminationProtectionInput.StackName."`