### PR TITLE
Use Amazon time sync service

### DIFF
--- a/cluster/userdata-master.yaml
+++ b/cluster/userdata-master.yaml
@@ -90,7 +90,7 @@ coreos:
         [Install]
         WantedBy=multi-user.target
 
-    - name: timesynced-enable-network-time.service
+    - name: timesyncd-enable-network-time.service
       command: start
       runtime: true
       content: |
@@ -819,11 +819,11 @@ write_files:
       TOOLBOX_DOCKER_IMAGE=registry.opensource.zalan.do/teapot/microscope
       TOOLBOX_DOCKER_TAG=v0.0.4
 
-  - path: /etc/systemd/timesynced.conf
+  - path: /etc/systemd/timesyncd.conf
     owner: root
     content: |
       [Time]
-      NTP=0.amazon.pool.ntp.org 1.amazon.pool.ntp.org 2.amazon.pool.ntp.org 3.amazon.pool.ntp.org
+      NTP=169.254.169.123
 
   - path: /opt/bin/drain-node
     owner: root:root

--- a/cluster/userdata-worker.yaml
+++ b/cluster/userdata-worker.yaml
@@ -31,7 +31,7 @@ coreos:
             Environment="DOCKER_OPTS=--log-opt=max-file=2 --log-opt=max-size=50m"
             Environment=DOCKER_SELINUX=
 
-    - name: timesynced-enable-network-time.service
+    - name: timesyncd-enable-network-time.service
       command: start
       runtime: true
       content: |
@@ -232,11 +232,11 @@ write_files:
       TOOLBOX_DOCKER_IMAGE=registry.opensource.zalan.do/teapot/microscope
       TOOLBOX_DOCKER_TAG=v0.0.4
 
-  - path: /etc/systemd/timesynced.conf
+  - path: /etc/systemd/timesyncd.conf
     owner: root
     content: |
       [Time]
-      NTP=0.amazon.pool.ntp.org 1.amazon.pool.ntp.org 2.amazon.pool.ntp.org 3.amazon.pool.ntp.org
+      NTP=169.254.169.123
 
   - path: /opt/bin/drain-node
     owner: root:root


### PR DESCRIPTION
* Use the correct filename for `timesyncd` (our previous changes weren't really picked up)
* Use [Time Sync Service](https://aws.amazon.com/blogs/aws/keeping-time-with-amazon-time-sync-service/) instead of public IPs