### PR TITLE
Worker ASG: add a lifecycle-status node template tag

### DIFF
--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -128,6 +128,8 @@ SenzaComponents:
           Value: ""
         - Key: "zalando.de/cluster-local-id/{{SenzaInfo.StackName}}-{{SenzaInfo.StackVersion}}"
           Value: owned
+        - Key: "k8s.io/cluster-autoscaler/node-template/label/lifecycle-status"
+          Value: ready
 Resources:
   MasterIAMRole:
     Properties:


### PR DESCRIPTION
This will make it possible to use a node selector targeting lifecycle-status: ready nodes without breaking the autoscaling.