### PR TITLE
Remove deprecated OnlyLocal annotation and use field

### DIFF
--- a/cluster/manifests/kube-node-ready/service.yaml
+++ b/cluster/manifests/kube-node-ready/service.yaml
@@ -7,10 +7,9 @@ metadata:
     application: kube-node-ready
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "kube-node-ready"
-  annotations:
-    service.beta.kubernetes.io/external-traffic: OnlyLocal
 spec:
   type: NodePort
+  externalTrafficPolicy: Local
   ports:
     - port: 80
       nodePort: 30080


### PR DESCRIPTION
This became a real field on Service.

https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#feature-availability