### PR TITLE
Update pdb-controller

### DIFF
--- a/cluster/manifests/pdb-controller/deployment.yaml
+++ b/cluster/manifests/pdb-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: pdb-controller
-    version: v0.0.4
+    version: v0.0.5
 spec:
   selector:
     matchLabels:
@@ -14,12 +14,12 @@ spec:
     metadata:
       labels:
         application: pdb-controller
-        version: v0.0.4
+        version: v0.0.5
     spec:
       serviceAccountName: system
       containers:
       - name: pdb-controller
-        image: registry.opensource.zalan.do/teapot/pdb-controller:v0.0.4
+        image: registry.opensource.zalan.do/teapot/pdb-controller:v0.0.5
         args:
         - --debug
         resources:


### PR DESCRIPTION
Fixes a bug where the controller could crash if a deployment didn't have any labels defined.

https://github.com/mikkeloscar/pdb-controller/pull/11