### PR TITLE
Update kube-ingress-aws-controller to v0.6.8

### DIFF
--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.6.6
+    version: v0.6.8
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.6.6
+        version: v0.6.8
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
@@ -26,18 +26,12 @@ spec:
         operator: Exists
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.6.6
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.6.8
         args:
         - -stack-termination-protection
         env:
         - name: AWS_REGION
           value: {{ .Region }}
-        # Needed in order to find nodes that should be attached to the ALBs.
-        # We should switch to the default filter when all nodes has the
-        # k8s.io/role/node tag.
-        # https://github.com/zalando-incubator/kube-ingress-aws-controller#how-it-works
-        - name: CUSTOM_FILTERS
-          value: "tag:kubernetes.io/cluster/{{ .ID }}=owned tag:NodePool=worker-default"
         resources:
           limits:
             cpu: 200m


### PR DESCRIPTION
* Adds support for auto-discovering certificates for *all* hostnames defined in the ingress (https://github.com/zalando-incubator/kube-ingress-aws-controller/releases/tag/v0.6.8)
* Removed the `CUSTOM_FILTERS` environment variable since we can now use the default value: https://github.com/zalando-incubator/kube-ingress-aws-controller#how-it-works