### PR TITLE
Disable creating parameters on the etcd stack

### DIFF
--- a/cluster/etcd-cluster.yaml
+++ b/cluster/etcd-cluster.yaml
@@ -1,6 +1,7 @@
 SenzaComponents:
 - Configuration:
     Type: Senza::StupsAutoConfiguration
+    DefineParameters: false # skip CF template parameter definition
 - AppServer:
     IamRoles:
     - Ref: EtcdRole


### PR DESCRIPTION
This just disables the creation of cloudformation stack parameters for the etcd stack. This change is needed to make the CLM update the etcd stack as part of cluster provisioning. Before we had to update the etcd stacks manually outside of CLM.

The parameters are not needed since the values passed to senza will be injected into the right place in the template anyway.

There's an internal PR for CLM that depends on this change.