### PR TITLE
Use static names for lifecycle hooks

### DIFF
--- a/cluster/manifests/kube-node-ready/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready/daemonset.yaml
@@ -28,10 +28,9 @@ spec:
         effect: NoSchedule
       containers:
       - name: kube-node-ready
-        image: registry.opensource.zalan.do/teapot/kube-node-ready:9799c3d
+        image: registry.opensource.zalan.do/teapot/kube-node-ready:v0.0.1
         args:
-        - --master-lifecycle-hook={{ .Outputs.MasterAutoscalingLifecycleHook }}
-        - --worker-lifecycle-hook={{ .Outputs.WorkerAutoscalingLifecycleHook }}
+        - --lifecycle-hook=kube-node-ready-lifecycle-hook
         resources:
           limits:
             cpu: 50m

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -789,6 +789,7 @@ Resources:
       HeartbeatTimeout: "600"
       AutoScalingGroupName:
         Ref: MasterAutoScaling
+      LifecycleHookName: "kube-node-ready-lifecycle-hook"
       LifecycleTransition: "autoscaling:EC2_INSTANCE_LAUNCHING"
   WorkerAutoscalingLifecycleHook:
     Type: "AWS::AutoScaling::LifecycleHook"
@@ -796,8 +797,8 @@ Resources:
       DefaultResult: "CONTINUE"
       HeartbeatTimeout: "600"
       AutoScalingGroupName:
-        Ref:
-          WorkerAutoScaling
+        Ref: WorkerAutoScaling
+      LifecycleHookName: "kube-node-ready-lifecycle-hook"
       LifecycleTransition: "autoscaling:EC2_INSTANCE_LAUNCHING"
   KubeReadyIAMRole:
     Type: AWS::IAM::Role
@@ -875,10 +876,3 @@ Resources:
             Resource: ["arn:aws:s3:::{{ Arguments.EtcdS3BackupBucket }}/*"]
           Version: '2012-10-17'
         PolicyName: root
-Outputs:
-  MasterAutoscalingLifecycleHook:
-    Value:
-      Ref: MasterAutoscalingLifecycleHook
-  WorkerAutoscalingLifecycleHook:
-    Value:
-      Ref: WorkerAutoscalingLifecycleHook


### PR DESCRIPTION
This uses static names for lifecycle hooks which is now supported in
cloudformation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-lifecyclehook.html#cfn-as-lifecyclehook-lifecyclehookname

This means that we don't have to pass the dynamic lifecycle hooks around
which was just a stupid workaround because of this missing feature in
cloudformation in the past.