### PR TITLE
Enable `application-autoscaling:*` permissions for deployment role

### DIFF
--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -679,6 +679,7 @@ Resources:
             - "apigateway:*"
             - "automation:*"
             - "autoscaling:*"
+            - "application-autoscaling:*"
             - "aws-marketplace:View*"
             - "aws-portal:View*"
             - "cloudformation:*"


### PR DESCRIPTION
This enables the `application-autoscaling:*` permissions which are needed to create dynamodb tables with autoscaling enabled via CloudFormation.