### PR TITLE
chore: update ExternalDNS to v0.5.0-alpha.2

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: external-dns
-    version: v0.5.0-alpha.1
+    version: v0.5.0-alpha.2
 spec:
   strategy:
     type: Recreate
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: external-dns
-        version: v0.5.0-alpha.1
+        version: v0.5.0-alpha.2
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
@@ -26,7 +26,7 @@ spec:
          operator: Exists
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.5.0-alpha.1
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.5.0-alpha.2
         args:
         - --source=service
         - --source=ingress


### PR DESCRIPTION
notable changes (none of this is used by us):
* add pdns provider
* add openstack designate provider
* add flag: combine-fqdn-annotation