### PR TITLE
chore: update ExternalDNS to v0.5.0-alpha.3

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: external-dns
-    version: v0.5.0-alpha.2
+    version: v0.5.0-alpha.3
 spec:
   strategy:
     type: Recreate
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: external-dns
-        version: v0.5.0-alpha.2
+        version: v0.5.0-alpha.3
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
@@ -26,7 +26,7 @@ spec:
          operator: Exists
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.5.0-alpha.2
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.5.0-alpha.3
         args:
         - --source=service
         - --source=ingress


### PR DESCRIPTION
notable changes:
* **inititial support for multiple targets per record on AWS**
* allow to assume role
* NLB support

https://github.com/kubernetes-incubator/external-dns/releases/tag/v0.5.0-alpha.3
