### PR TITLE
Scrape metrics from kube-apiserver pods

### DIFF
--- a/cluster/manifests/audittrail-adapter/service.yaml
+++ b/cluster/manifests/audittrail-adapter/service.yaml
@@ -1,0 +1,21 @@
+{{ if eq .Environment "production" }}
+kind: Service
+apiVersion: v1
+metadata:
+  name: audittrail-adapter
+  namespace: kube-system
+  labels:
+    application: audittrail-adapter
+  annotations:
+    prometheus.io/path: /metrics
+    prometheus.io/port: "7980"
+    prometheus.io/scrape: "true"
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 8889
+    protocol: TCP
+  selector:
+    application: audittrail-adapter
+{{ end }}

--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -12,6 +12,18 @@ data:
       external_labels:
         monitor: 'skipper-ingress'
     scrape_configs:
+    # scrape from kube-apiserver pods
+    - job_name: 'kubernetes-apiservers'
+      scheme: http
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_application, __meta_kubernetes_pod_container_port_number]
+        action: keep
+        regex: kube-system;kube-apiserver;8082
+      - action: replace
+        source_labels: ['__meta_kubernetes_pod_label_application']
+        target_label: application
     - job_name: 'kubernetes-service-endpoints'
       scheme: http
       kubernetes_sd_configs:

--- a/cluster/master.clc.yaml
+++ b/cluster/master.clc.yaml
@@ -407,6 +407,8 @@ storage:
             - containerPort: 8083
           - name: nginx
             image: registry.opensource.zalan.do/teapot/nginx:1.12.1
+            ports:
+            - containerPort: 8082
             resources:
               requests:
                 cpu: 50m

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -342,6 +342,8 @@ Resources:
       - {CidrIp: 172.31.0.0/16, FromPort: 9100, IpProtocol: tcp, ToPort: 9100}
       - {CidrIp: 172.31.0.0/16, FromPort: 9911, IpProtocol: tcp, ToPort: 9911}
       - {CidrIp: 172.31.0.0/16, FromPort: 30080, IpProtocol: tcp, ToPort: 30080}
+      # allow checking kubelet cadvisor metrics port from within the VPC
+      - {CidrIp: 172.31.0.0/16, FromPort: 4194, IpProtocol: tcp, ToPort: 4194}
       Tags:
         - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
           Value: owned


### PR DESCRIPTION
This enables scraping metrics of kube-apiserver pods (a lot of metrics) as well as the audittrail-adapter pods (very few metrics).

The purpose of this is to be able to answer important questions like rps, latency, error rate etc. for apiservers and additionally monitor the audit events in a better way.

Additionally I added a commit to enable scraping cadavisor metrics on master nodes because I saw this was failing in prometheus because the port was not open in the SG.