### PR TITLE
Add support for spot worker instances

### DIFF
--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -23,6 +23,9 @@ SenzaInfo:
           Default: "m3.medium"
       - InstanceType:
           Description: "Type of instance"
+      - WorkerSpotPrice:
+          Description: "Spot price for worker nodes, not used if empty"
+          Default: ""
       - ClusterID:
           Description: "ID of the cluster"
       - HostedZone:
@@ -36,6 +39,13 @@ SenzaInfo:
       - EtcdStackName:
           Description: "AWS Stack name of the etcd cluster"
           Default: "etcd-cluster-etcd"
+
+Conditions:
+  UseWorkerSpotPrice:
+    Fn::Not:
+      - Fn::Equals:
+        - "{{Arguments.WorkerSpotPrice}}"
+        - ""
 
 Mappings:
   Images:
@@ -112,6 +122,11 @@ SenzaComponents:
          - {Ref: WorkerIAMRole}
       AssociatePublicIpAddress: true
       UserData: "{{ Arguments.UserDataWorker }}"
+      SpotPrice:
+        Fn::If:
+          - UseWorkerSpotPrice
+          - "{{Arguments.WorkerSpotPrice}}"
+          - Ref: AWS::NoValue
       AutoScaling:
          Minimum: "{{ Arguments.MinimumWorkerNodes}}"
          Maximum: "{{ Arguments.MaximumWorkerNodes}}"


### PR DESCRIPTION
This adds an optional argument to the cluster definition that allows setting a spot price for worker nodes which is then used to automatically provision spot instances instead of on-demand ones.