### PR TITLE
Add readiness probe to prometheus

### DIFF
--- a/cluster/manifests/prometheus/statefulset.yaml
+++ b/cluster/manifests/prometheus/statefulset.yaml
@@ -37,6 +37,12 @@ spec:
           requests:
             cpu: 500m
             memory: 4000Mi
+        readinessProbe:
+          httpGet:
+            path: /-/ready
+            port: 9090
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
         volumeMounts:
         - name: prometheus-config-volume
           mountPath: /etc/prometheus


### PR DESCRIPTION
It can take some time for prometheus to get ready when starting up. Ensure it doesn't get traffic before it's ready.