### PR TITLE
Add node pool support

### DIFF
--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -1,0 +1,70 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Kubernetes default master node pool
+
+Mappings:
+  Images:
+    eu-central-1:
+      LatestCoreOSImage: ami-604e118b
+      StableCoreOSImage: ami-862140e9
+
+Resources:
+  AutoScalingGroup:
+    CreationPolicy:
+      ResourceSignal:
+        Count: '0'
+        Timeout: PT15M
+    Properties:
+      HealthCheckGracePeriod: 480
+      HealthCheckType: EC2
+      LaunchConfigurationName: !Ref AutoScalingConfig
+      LoadBalancerNames:
+      - !ImportValue '{{ .Cluster.ID }}:master-load-balancer'
+      MinSize: '{{ .NodePool.MinSize }}'
+      MaxSize: '{{ .NodePool.MaxSize }}'
+      VPCZoneIdentifier: !Split [",", "{{ .Cluster.ConfigItems.subnets }}"]
+    Type: 'AWS::AutoScaling::AutoScalingGroup'
+  AutoScalingConfig:
+    Properties:
+      AssociatePublicIpAddress: true
+      BlockDeviceMappings:
+      - DeviceName: /dev/xvda
+        Ebs:
+          VolumeSize: 20
+          VolumeType: standard
+      EbsOptimized: false
+      IamInstanceProfile: !Ref AutoScalingInstanceProfile
+      # ImageId: " .AMI }}" # TODO: find
+      ImageId: "ami-862140e9"
+      InstanceType: "{{ .NodePool.InstanceType }}"
+      SecurityGroups:
+      - !ImportValue '{{ .Cluster.ID }}:master-security-group'
+      UserData: "{{ .UserData }}"
+    Type: 'AWS::AutoScaling::LaunchConfiguration'
+  AutoScalingInstanceProfile:
+    Properties:
+      Path: /
+      Roles:
+      - !ImportValue '{{ .Cluster.ID }}:master-iam-role'
+    Type: 'AWS::IAM::InstanceProfile'
+  AutoScalingScaleDown:
+    Properties:
+      AdjustmentType: ChangeInCapacity
+      AutoScalingGroupName: !Ref AutoScalingGroup
+      Cooldown: '60'
+      ScalingAdjustment: '-1'
+    Type: 'AWS::AutoScaling::ScalingPolicy'
+  AutoScalingScaleUp:
+    Properties:
+      AdjustmentType: ChangeInCapacity
+      AutoScalingGroupName: !Ref AutoScalingGroup
+      Cooldown: '60'
+      ScalingAdjustment: '1'
+    Type: 'AWS::AutoScaling::ScalingPolicy'
+  AutoscalingLifecycleHook:
+    Properties:
+      AutoScalingGroupName: !Ref AutoScalingGroup
+      LifecycleHookName: "kube-node-ready-lifecycle-hook"
+      DefaultResult: CONTINUE
+      HeartbeatTimeout: '600'
+      LifecycleTransition: 'autoscaling:EC2_INSTANCE_LAUNCHING'
+    Type: 'AWS::AutoScaling::LifecycleHook'

--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -4,7 +4,7 @@ Description: Kubernetes default master node pool
 Mappings:
   Images:
     eu-central-1:
-      StableCoreOSImage: ami-862140e9
+      StableCoreOSImage: ami-604e118b
 
 Resources:
   AutoScalingGroup:

--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -4,7 +4,6 @@ Description: Kubernetes default master node pool
 Mappings:
   Images:
     eu-central-1:
-      LatestCoreOSImage: ami-604e118b
       StableCoreOSImage: ami-862140e9
 
 Resources:
@@ -21,6 +20,10 @@ Resources:
       - !ImportValue '{{ .Cluster.ID }}:master-load-balancer'
       MinSize: '{{ .NodePool.MinSize }}'
       MaxSize: '{{ .NodePool.MaxSize }}'
+      Tags:
+      - Key: Name
+        PropagateAtLaunch: true
+        Value: "{{ .NodePool.Name }} ({{ .Cluster.ID }})"
       VPCZoneIdentifier: !Split [",", "{{ .Cluster.ConfigItems.subnets }}"]
     Type: 'AWS::AutoScaling::AutoScalingGroup'
   AutoScalingConfig:
@@ -33,8 +36,10 @@ Resources:
           VolumeType: standard
       EbsOptimized: false
       IamInstanceProfile: !Ref AutoScalingInstanceProfile
-      # ImageId: " .AMI }}" # TODO: find
-      ImageId: "ami-862140e9"
+      ImageId: !FindInMap
+      - Images
+      - !Ref 'AWS::Region'
+      - StableCoreOSImage
       InstanceType: "{{ .NodePool.InstanceType }}"
       SecurityGroups:
       - !ImportValue '{{ .Cluster.ID }}:master-security-group'
@@ -46,20 +51,6 @@ Resources:
       Roles:
       - !ImportValue '{{ .Cluster.ID }}:master-iam-role'
     Type: 'AWS::IAM::InstanceProfile'
-  AutoScalingScaleDown:
-    Properties:
-      AdjustmentType: ChangeInCapacity
-      AutoScalingGroupName: !Ref AutoScalingGroup
-      Cooldown: '60'
-      ScalingAdjustment: '-1'
-    Type: 'AWS::AutoScaling::ScalingPolicy'
-  AutoScalingScaleUp:
-    Properties:
-      AdjustmentType: ChangeInCapacity
-      AutoScalingGroupName: !Ref AutoScalingGroup
-      Cooldown: '60'
-      ScalingAdjustment: '1'
-    Type: 'AWS::AutoScaling::ScalingPolicy'
   AutoscalingLifecycleHook:
     Properties:
       AutoScalingGroupName: !Ref AutoScalingGroup

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -1,0 +1,937 @@
+# container linux config
+passwd:
+  users:
+  - name: core
+    ssh_authorized_keys:
+    - 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAt8djQXfn5U7H85oDzuZRfRONF+jVqn3Mp9t3tnBrJdKyTccfDovq1sekzEdOFdmj74yfS8bzaIO9pDUczy6j5k2MtDCoRnzAO6KZc46jMJ2GjhLArUuHLjmAw2r9LotZ30LEIEvJdmUI7mDlPMczv381PghyM8+DsYv62UrfjDiOsZ4EVkYnztQlO3ntNE16RFNj4fbfErQz67kmw0lB8C6bAf0RuRmvXzB7xRMplmknQnLusoURmySKdZM0GUe0VY6fmqOsgzHVLoEs1m82V8QK1ac/1DSHA91v50MbpCjTVLaRhjR8nmhWBedlhb6j5ClZdAQ8iwyyWC1MFQuvKw== henning@zalando.de'
+    - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDOjGGBqrWGdbh0yfkBRE04IbdiAP2TJ2RXnfnp3OV8Lw+jg7cUqeZA5l2vIhFd2ctKPd5OGE3K/A6xCK3hFV9V01oYbH8S3IvrhyA+VjBG0d/ZgTm6GCrlE4XeAt9/ourBSxrrE04lfO786dhLsGEOa5WvvSG3Z/6BhyC/1e5Bd37nnWB363fjAsbg1UgSPr99QZQ5l2mSxN4i2IpJjULBWpLvrJLLJzzl67aaVhDjdtggEU+pMsOoRpDuJ46cYMMDvBI9gyyal2G1aIkqu9iejt1bly53Th2ZAiXecXxEh4K3a5H/Czf70vpCzXQiG1OuZRD1PaSpqw4+zzcizZdX matthias@zalando.de'
+    - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCs4NhH7uwlnklYYlV1GP57XX9NHYgXNv0njfEVowR1jFSKiMdEUtPKz5lOAeDtKpck9HyjxVOTSutNOIBZkkgN/FgkcpNbc59nIO4ELUzipkJivuYNO1lDAjCQi1qwYo+uksiNfcsao9mn7nd9Rh1g8TXYv95TSvml9v/Dolmanm1qj6OkbDw1xIurnNsoCjdxCWwSRGNja4r+PQc8pi+1xpdUBEvn40CeBdU7b/hZnv/BM9FIKSsVlIwMR2i/Co2rxCKo9B3q4dmdQ/2C1QczINVpPQcNUMuiljJFMXvT7dgfNsnUBe8vFuoPgqohJ/m8AiKZZOyoRNiCuELnKLRKqxosDmJz47Y0YiYgZk9jpnmt+x1fwqhY2R85F7W4RybpX3AFL1jOqOT2lE+idkhyeFq/pPoAiPvUcpQSmL9AwlrG6cPklTJZW+dUzH/W6kNlgl/T6hnMn4Mu+IljG08Iyb/HBdmOX+uRq5wdF8lI9Zjzlwg+j7HMa3p1O7MNwpSJVjVXkhUXH0WrFrK2JkwgXokIWvu0o+lajYOmXRQeGCyVybg06WFCzOXnK2toVucFMuAGoM0NkthAnodZCk+xXLNrtHOYagpdJ/x/Q88vuDsZr7IG0NvgX/OCq1a5lpnIydCe+tABNNKcRaOuOLbDYVgUaeVzIXyJjRYu5ZN/JQ== mikkel.larsen@zalando.de'
+    - 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIISHc8p8+ycB9H6SI/i3Uu/OI5G3vYNsZTn0DffPvfOA martin.linkhorst@zalando.de'
+    - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDf3X7MZjYRZD2mI7dvW+c/8dUeDrdqAKZD/C9r+aGa6hWzbGeUZ7cub8to6X9Cl5p3MsTdtFV/OIHRIvxoIGYkz3CRHEBtUdUwOjF9lpBoB/yRMJyxlogmMCm9KGSUM4K+xgIX6qBHq/UeY2Yqumec5lhuLk+7wTmXYQM3+fvvHB8MY//UEadvjuDdotNGQ4jxkJjfoTQj6dspvsZCJ4kIIef9DLSJQ4oCV7sDCVDWPllb3ni9WJYD4vTguI82DI0moQV0WIPplH6rrK+ctVmPyix/IertpqWbiLgmdz3SAyGW45uws2ozGB1S+tZJF+RcNFbbAimoz6QHT+kgL1qmpxa7yba7y3m5pUHqGdhLb+X4Xe3oMZGk7cwBOECw8JUzxzqQKxpF1PfbH8wJ8AiKF7Xr/KJNk9Axsm1zV0DDWv3Z2oK7m8pNiq3mlhv6ovIpXsTq40uaasuLSfmLjSagQDT6ufBAUbaSAJfM0VFo4diIOCDnXH0SX1T8X3EPKbyDg0l/y0pE+FxXQvBK2rzgeynoK5NrvGl1xhJGetbMsl0+WtnIr/PbIQDTo9UQAzOWnHsTs72VqNbeJN4w8ksTqNhXiQO6zlhWqoPL/BeXvRc4N0R8iq9vIstjtuAZkaFsm5TH7Uzz3WTHzKbJ0/5+sefX4cucb/QjImvcVV1UEw== nick.juettner@zalando.de'
+    - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCq3oEP8qhMvGtlR1bgVc9tFOVJ5B5RMKtm6UQ/zXQUpm8DQ04SxdM2U7TfuLien2HSfpHAlYe0eLJZUfIqCXUeZ37v0ozj2RglireEcJm0t9XJ7kTS4kqVxrL6iuN6qQVGHs0vxoo/o9+SP0YkuuJoXwJvVI4yKVbnbfA5hKaAffAYPmfgqOZ7+3AMwmaj/D3tI0xVEA48ptGkj5nnOl0pXlfLRNvbnXOCa/dTKUgkma1F0lXoTipkRspsMEiAnwfJ1dwnzgNzllt//Ao/H+yOVR8fWJ7d+nowszIk6zwUR7c6walxKKf5Oy5bQBU49MZ6xLP1oma9F2+llmV7qpqx rodrigo.reis@zalando.de'
+    - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqAikaHsZWMuJvKZphZPZG0fnKMvVCRfBAbIS6e0Y+YqM0PfsWgB5e4f5TrbisQHdKopbfZVwYIaV/NegEuinrYPKC7t2ese/HjxgjHR95zHOcDP19Cbo+xeyH8zbRd9K3iRSyCUSMNRw5NL6zN8JOSl12m8QWQA4hTjFTmt870fIT4RLxu9qGlbQipUm57E/SotsNC41MQ/PsLQzOAviKrkS1rei2vzRHzAcjz1Z7GT5oH+dFVUC66kKa0XWDvq+VtkRVoLvS2chrIPCgESeeZAyOKyiOoyJxFFFiMVK48MWDBBIYTIsHE0qs/RwBi9+8lQGiHK5Rpk2djcloO0c7 sandor.szuecs@zalando.de'
+    - 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINkh52Py+FvH9CRLDQg0gzvjEIrzwA45yMTXTsl2BVxV alexey.ermakov@zalando.de'
+systemd:
+  units:
+  # disable automatic updates
+  - name: update-engine.service
+    mask: true
+  - name: locksmithd.service
+    mask: true
+
+  - name: set-hostname.service
+    enable: true
+    contents: |
+      [Unit]
+      Wants=network.target
+      Before=docker.service
+
+      [Service]
+      Type=simple
+      Restart=on-failure
+      RestartSec=1
+      ExecStart=/usr/bin/bash -c "/usr/bin/hostnamectl set-hostname $(/usr/bin/curl --silent --fail http://169.254.169.254/latest/meta-data/local-hostname)"
+
+      [Install]
+      WantedBy=multi-user.target
+
+  - name: etcd-member.service
+    enable: true
+    contents: |
+      [Unit]
+      Wants=network.target
+
+      [Service]
+      Type=simple
+      Restart=on-failure
+      RestartSec=5s
+      StartLimitIntervalSec=0
+      ExecStartPre=/usr/bin/mkdir --parents /var/lib/coreos
+      ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/lib/coreos/etcd-member-wrapper.uuid
+      ExecStart=/usr/bin/rkt run --uuid-file-save=/var/lib/coreos/etcd-member-wrapper.uuid --port=2379-tcp:2379 --mount volume=dns,target=/etc/resolv.conf --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true --insecure-options=image docker://registry.opensource.zalan.do/teapot/etcd-proxy:master-2 -- {{ .Cluster.ConfigItems.etcd_endpoints }}
+      ExecStop=-/usr/bin/rkt stop --uuid-file=/var/lib/coreos/etcd-member-wrapper.uuid
+
+      [Install]
+      WantedBy=multi-user.target
+
+  - name: docker.service
+    dropins:
+    - name: 40-flannel.conf
+      contents: |
+        [Service]
+        EnvironmentFile=/etc/kubernetes/cni/docker_opts_cni.env
+    - name: 60-dockeropts.conf
+      contents: |
+        [Service]
+        Environment="DOCKER_OPTS=--log-opt=max-file=2 --log-opt=max-size=50m"
+        Environment=DOCKER_SELINUX=
+
+  - name: meta-data-iptables.service
+    enable: true
+    contents: |
+      [Unit]
+      After=network.target
+
+      [Service]
+      Type=simple
+      Restart=on-failure
+      RestartSec=1
+      ExecStart=/opt/bin/meta-data-iptables.sh
+
+      [Install]
+      WantedBy=multi-user.target
+
+  - name: dockercfg.service
+    enable: true
+    contents: |
+      [Unit]
+      After=network.target
+
+      [Service]
+      Type=simple
+      Restart=on-failure
+      RestartSec=5
+      ExecStartPre=/usr/bin/mkdir -p /root/.docker
+      ExecStart=/opt/bin/dockercfg.sh
+
+      [Install]
+      WantedBy=multi-user.target
+
+  - name: timesyncd-enable-network-time.service
+    enable: true
+    contents: |
+      [Service]
+      Type=oneshot
+      ExecStart=/usr/bin/timedatectl set-ntp true
+
+      [Install]
+      WantedBy=multi-user.target
+
+  - name: gen-controller-manager-config.service
+    enable: true
+    contents: |
+      [Service]
+      Type=oneshot
+      ExecStart=/opt/bin/gen-controller-manager-config.sh
+
+      [Install]
+      WantedBy=multi-user.target
+
+  - name: kubelet.service
+    enable: true
+    contents: |
+      [Unit]
+      After=docker.service dockercfg.service meta-data-iptables.service
+
+      [Service]
+      Environment=KUBELET_IMAGE_TAG=v1.9.4_coreos.0
+      Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
+      Environment="RKT_RUN_ARGS=--insecure-options=image \
+      --uuid-file-save=/var/run/kubelet-pod.uuid \
+      --volume dns,kind=host,source=/etc/resolv.conf \
+      --mount volume=dns,target=/etc/resolv.conf \
+      --volume var-log,kind=host,source=/var/log \
+      --mount volume=var-log,target=/var/log \
+      --volume var-lib-cni,kind=host,source=/var/lib/cni \
+      --mount volume=var-lib-cni,target=/var/lib/cni \
+      --volume dockercfg,kind=host,source=/root/.docker/config.json \
+      --mount volume=dockercfg,target=/root/.docker/config.json \
+      --set-env=HOME=/root"
+      ExecStartPre=/usr/bin/mkdir -p /var/log/containers
+      ExecStartPre=/bin/mkdir -p /var/lib/cni
+      ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
+      ExecStart=/usr/lib/coreos/kubelet-wrapper \
+      --cni-conf-dir=/etc/kubernetes/cni/net.d \
+      --network-plugin=cni \
+      --container-runtime=docker \
+      --rkt-path=/usr/bin/rkt \
+      --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
+      --allow-privileged \
+      --node-labels=node-role.kubernetes.io/master,kubernetes.io/role=master,master=true \
+      --node-labels=kubernetes.io/node-pool={{ .NodePool.Name }} \
+      --node-labels={{ .Values.node_labels }} \
+      --pod-manifest-path=/etc/kubernetes/manifests \
+      --cluster-dns=10.3.0.10,10.3.0.11 \
+      --cluster-domain=cluster.local \
+      --kubeconfig=/etc/kubernetes/kubeconfig \
+      --require-kubeconfig \
+      --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
+      --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \
+      --cloud-provider=aws \
+      --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true \
+      --system-reserved=cpu=100m,memory=164Mi \
+      --kube-reserved=cpu=100m,memory=282Mi
+      ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
+      Restart=always
+      RestartSec=10
+
+      [Install]
+      WantedBy=multi-user.target
+
+  - name: kube-node-drainer.service
+    enable: true
+    contents: |
+      [Unit]
+      Description=drain this k8s node to make running pods time to gracefully shut down before stopping kubelet
+      After=docker.service kubelet.service etcd-member.service
+
+      [Service]
+      Type=oneshot
+      RemainAfterExit=true
+      ExecStart=/bin/true
+      TimeoutStopSec=120s
+      ExecStop=/opt/bin/drain-node
+
+      [Install]
+      WantedBy=multi-user.target
+
+storage:
+  files:
+  - filesystem: root
+    path: /etc/kubernetes/kubeconfig
+    mode: 0644
+    contents:
+      inline: |
+        apiVersion: v1
+        kind: Config
+        clusters:
+        - name: local
+          cluster:
+            server: http://127.0.0.1:8080
+        users:
+        - name: kubelet
+        contexts:
+        - context:
+            cluster: local
+            user: kubelet
+
+  - filesystem: root
+    path: /etc/kubernetes/config/authn.yaml
+    mode: 0644
+    contents:
+      inline: |
+        clusters:
+          - name: authz-webhook
+            cluster:
+              server: http://127.0.0.1:8081/authentication
+        users:
+          - name: authz-webhook-client
+            user:
+              token: notused
+        current-context: authz-webhook
+        contexts:
+        - context:
+            cluster: authz-webhook
+            user: authz-webhook-client
+          name: authz-webhook
+
+  - filesystem: root
+    path: /etc/kubernetes/config/authz.yaml
+    mode: 0644
+    contents:
+      inline: |
+        clusters:
+          - name: authz-webhook
+            cluster:
+              server: http://127.0.0.1:8081/authorization
+        users:
+          - name: authz-webhook-client
+        current-context: authz-webhook
+        contexts:
+        - context:
+            cluster: authz-webhook
+            user: authz-webhook-client
+          name: authz-webhook
+
+  - filesystem: root
+    path: /etc/kubernetes/cni/docker_opts_cni.env
+    mode: 0644
+    contents:
+      inline: |
+        DOCKER_OPT_BIP=""
+        DOCKER_OPT_IPMASQ=""
+
+  - filesystem: root
+    path: /etc/kubernetes/manifests/kube-apiserver.yaml
+    mode: 0644
+    contents:
+      inline: |
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: kube-apiserver
+          namespace: kube-system
+          labels:
+            application: kube-apiserver
+            version: v1.9.4_coreos.0
+          annotations:
+            scheduler.alpha.kubernetes.io/critical-pod: ''
+            kubernetes-log-watcher/scalyr-parser: |
+              [{"container": "webhook", "parser": "json-structured-log"}]
+        spec:
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - key: node-role.kubernetes.io/master
+            effect: NoSchedule
+          hostNetwork: true
+          containers:
+          - name: kube-apiserver
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.4_coreos.0
+            command:
+            - /hyperkube
+            - apiserver
+            - --apiserver-count={{ .Values.apiserver_count }}
+            - --bind-address=0.0.0.0
+            - --insecure-bind-address=0.0.0.0
+            - --etcd-servers=http://127.0.0.1:2379
+            - --etcd-prefix={{ .Cluster.ConfigItems.apiserver_etcd_prefix }}
+            - --storage-backend=etcd3
+            - --storage-media-type=application/vnd.kubernetes.protobuf
+            - --allow-privileged=true
+            - --service-cluster-ip-range=10.3.0.0/16
+            - --secure-port=443
+            - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,PodSecurityPolicy,ImagePolicyWebhook,Priority
+            - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
+            - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
+            - --service-account-key-file=/etc/kubernetes/ssl/apiserver-key.pem
+            - --runtime-config=extensions/v1beta1/networkpolicies=true,batch/v2alpha1=true,extensions/v1beta1/podsecuritypolicy=true,imagepolicy.k8s.io/v1alpha1=true,authorization.k8s.io/v1beta1=true,scheduling.k8s.io/v1alpha1=true
+            - --authentication-token-webhook-config-file=/etc/kubernetes/config/authn.yaml
+            - --authentication-token-webhook-cache-ttl=10s
+            - --cloud-provider=aws
+            - --authorization-mode=Webhook
+            - --authorization-webhook-config-file=/etc/kubernetes/config/authz.yaml
+            - --admission-control-config-file=/etc/kubernetes/config/image-policy-webhook.yaml
+            - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true
+            - --anonymous-auth=false
+            - --audit-webhook-config-file=/etc/kubernetes/config/audit.yaml
+            - --audit-webhook-mode=batch
+            - --audit-policy-file=/etc/kubernetes/config/audit-policy.yaml
+            livenessProbe:
+              httpGet:
+                host: 127.0.0.1
+                port: 8080
+                path: /healthz
+              initialDelaySeconds: 120
+              timeoutSeconds: 15
+            ports:
+            - containerPort: 443
+              hostPort: 443
+              name: https
+            - containerPort: 8080
+              hostPort: 8080
+              name: local
+            volumeMounts:
+            - mountPath: /etc/kubernetes/ssl
+              name: ssl-certs-kubernetes
+              readOnly: true
+            - mountPath: /etc/ssl/certs
+              name: ssl-certs-host
+              readOnly: true
+            - mountPath: /etc/kubernetes/config
+              name: kubernetes-configs
+              readOnly: true
+            resources:
+              requests:
+                cpu: 100m
+                memory: 200Mi
+          - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.4.0
+            name: webhook
+            ports:
+            - containerPort: 8081
+            livenessProbe:
+              httpGet:
+                path: /healthcheck
+                port: 8081
+              initialDelaySeconds: 30
+              timeoutSeconds: 5
+            readinessProbe:
+              httpGet:
+                path: /healthcheck
+                port: 8081
+              initialDelaySeconds: 5
+              timeoutSeconds: 5
+            resources:
+              requests:
+                cpu: 50m
+                memory: 50Mi
+            args:
+              - --tokens-file=/etc/kubernetes/config/tokenfile.csv
+            env:
+              - name: TEAMS_API_URL
+                value: https://teams.auth.zalando.com
+              - name: CLUSTER_ID
+                value: {{ .Cluster.ConfigItems.webhook_id }}
+              - name: TOKEN_INTROSPECTION_URL
+                value: http://127.0.0.1:9021/oauth2/introspect
+              - name: USER_GROUPS
+                value: stups_autobahn=Administrator,stups_deployment-controller-ui=ReadOnly,credentials-provider=Administrator,credprov-kube-ops-view-read-only-token=ReadOnly,credprov-cluster-lifecycle-manager-cluster-rw-token=Administrator,stups_cluster-lifecycle-manager=Administrator,credprov-cluster-lifecycle-manager-test-cluster-rw-token=Administrator,credprov-cdp-controller-cluster-token=PowerUser,credprov-api-discovery-k8s-cluster-read-only-token=ReadOnly,stups_zmon-zmon=ReadOnly
+              - name: BUSINESS_PARTNER_IDS
+                value: {{ .Cluster.ConfigItems.apiserver_business_partner_ids }}
+            volumeMounts:
+            - mountPath: /etc/kubernetes/config
+              name: kubernetes-configs
+              readOnly: true
+          - image: registry.opensource.zalan.do/foundation/platform-iam-tokeninfo:2fca26c
+            name: tokeninfo
+            ports:
+              - containerPort: 9021
+            livenessProbe:
+              httpGet:
+                path: /health
+                port: 9021
+              periodSeconds: 3
+              failureThreshold: 2
+            readinessProbe:
+              httpGet:
+                path: /health
+                port: 9021
+              periodSeconds: 3
+              failureThreshold: 2
+            resources:
+              requests:
+                cpu: 100m
+                memory: 20Mi
+            env:
+              - name: OPENID_PROVIDER_CONFIGURATION_URL
+                value: https://identity.zalando.com/.well-known/openid-configuration
+              - name: ENABLE_INTROSPECTION
+                value: "true"
+          - image: registry.opensource.zalan.do/teapot/image-policy-webhook:v0.3.6
+            name: image-policy-webhook
+            args:
+            - --policy={{ .Cluster.ConfigItems.image_policy }}
+            - --failure-policy=fail
+            ports:
+            - containerPort: 8083
+          - name: nginx
+            image: registry.opensource.zalan.do/teapot/nginx:1.12.1
+            ports:
+            - containerPort: 8082
+            resources:
+              requests:
+                cpu: 50m
+                memory: 50Mi
+            volumeMounts:
+            - name: config-volume
+              mountPath: /etc/nginx
+          volumes:
+          - hostPath:
+              path: /etc/kubernetes/ssl
+            name: ssl-certs-kubernetes
+          - hostPath:
+              path: /etc/kubernetes/config
+            name: kubernetes-configs
+          - hostPath:
+              path: /usr/share/ca-certificates
+            name: ssl-certs-host
+          - hostPath:
+              path: /etc/kubernetes/nginx
+            name: config-volume
+
+  - filesystem: root
+    path: /etc/kubernetes/manifests/kube-controller-manager.yaml
+    mode: 0644
+    contents:
+      inline: |
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: kube-controller-manager
+          namespace: kube-system
+          labels:
+            application: kube-controller-manager
+            version: v1.9.4_coreos.0
+          annotations:
+            scheduler.alpha.kubernetes.io/critical-pod: ''
+        spec:
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - key: node-role.kubernetes.io/master
+            effect: NoSchedule
+          containers:
+          - name: kube-controller-manager
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.4_coreos.0
+            command:
+            - /hyperkube
+            - controller-manager
+            - --kubeconfig=/etc/kubernetes/controller-kubeconfig
+            - --leader-elect=true
+            - --service-account-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
+            - --root-ca-file=/etc/kubernetes/ssl/ca.pem
+            - --cloud-provider=aws
+            - --cloud-config=/etc/kubernetes/cloud-config.ini
+            - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true
+            - --horizontal-pod-autoscaler-use-rest-clients=false
+            - --use-service-account-credentials=true
+            - --v=4
+            - --allocate-node-cidrs=true
+            - --cluster-cidr=10.2.0.0/16
+            resources:
+              requests:
+                cpu: 100m
+                memory: 100Mi
+            livenessProbe:
+              httpGet:
+                host: 127.0.0.1
+                path: /healthz
+                port: 10252
+              initialDelaySeconds: 15
+              timeoutSeconds: 15
+            volumeMounts:
+            - mountPath: /etc/kubernetes/ssl
+              name: ssl-certs-kubernetes
+              readOnly: true
+            - mountPath: /etc/ssl/certs
+              name: ssl-certs-host
+              readOnly: true
+            - mountPath: /etc/kubernetes
+              name: kubeconfig
+              readOnly: true
+          hostNetwork: true
+          volumes:
+          - hostPath:
+              path: /etc/kubernetes/ssl
+            name: ssl-certs-kubernetes
+          - hostPath:
+              path: /etc/kubernetes
+            name: kubeconfig
+          - hostPath:
+              path: /usr/share/ca-certificates
+            name: ssl-certs-host
+
+  - filesystem: root
+    path: /etc/kubernetes/manifests/kube-scheduler.yaml
+    mode: 0644
+    contents:
+      inline: |
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: kube-scheduler
+          namespace: kube-system
+          labels:
+            application: kube-scheduler
+            version: v1.9.4_coreos.0
+          annotations:
+            scheduler.alpha.kubernetes.io/critical-pod: ''
+        spec:
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - key: node-role.kubernetes.io/master
+            effect: NoSchedule
+          hostNetwork: true
+          containers:
+          - name: kube-scheduler
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.4_coreos.0
+            command:
+            - /hyperkube
+            - scheduler
+            - --master=http://127.0.0.1:8080
+            - --leader-elect=true
+            - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true
+            resources:
+              requests:
+                cpu: 100m
+                memory: 100Mi
+            livenessProbe:
+              httpGet:
+                host: 127.0.0.1
+                path: /healthz
+                port: 10251
+              initialDelaySeconds: 15
+              timeoutSeconds: 15
+
+  - filesystem: root
+    path: /etc/kubernetes/manifests/rescheduler.yaml
+    mode: 0644
+    contents:
+      inline: |
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: rescheduler-v0.3.1
+          namespace: kube-system
+          labels:
+            application: rescheduler
+            version: v0.3.1
+            kubernetes.io/cluster-service: "true"
+            kubernetes.io/name: "Rescheduler"
+            scheduler.alpha.kubernetes.io/critical-pod: ''
+        spec:
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - key: node-role.kubernetes.io/master
+            effect: NoSchedule
+          hostNetwork: true
+          containers:
+          - image: registry.opensource.zalan.do/teapot/rescheduler:v0.3.1
+            name: rescheduler
+            resources:
+              requests:
+                cpu: 10m
+                memory: 100Mi
+            command:
+            - /rescheduler
+            args:
+            - --running-in-cluster=false
+
+  - filesystem: root
+    path: /etc/kubernetes/nginx/nginx.conf
+    mode: 0644
+    contents:
+      inline: |
+        user nginx;
+        worker_processes 1;
+        error_log /dev/stdout info;
+        events {
+          worker_connections 1024;
+        }
+        http {
+          default_type application/octet-stream;
+          server_tokens off;
+          access_log off;
+          server {
+            listen 8082;
+            server_name _;
+            location / {
+              if ($request_method != GET) {
+                return 403;
+              }
+              proxy_pass_request_body off;
+              proxy_pass http://127.0.0.1:8080;
+            }
+            location ~ /secrets(/|$) {
+              return 403 "unauthorized";
+            }
+          }
+        }
+
+  - filesystem: root
+    path: /opt/bin/gen-controller-manager-config.sh
+    mode: 0755
+    contents:
+      inline: |
+        #!/bin/bash
+        token="$(head -c 16 /dev/urandom | od -An -t x | tr -d ' ')"
+        cat << EOF > /etc/kubernetes/controller-kubeconfig
+        apiVersion: v1
+        kind: Config
+        clusters:
+        - name: local
+          cluster:
+            server: https://127.0.0.1
+            certificate-authority: /etc/kubernetes/ssl/ca.pem
+        contexts:
+        - name: local
+          context:
+            cluster: local
+            user: kube-controller-manager
+        current-context: local
+        users:
+        - name: kube-controller-manager
+          user:
+            token: ${token}
+        EOF
+
+        echo "${token},kube-controller-manager,kube-controller-manager" >> /etc/kubernetes/config/tokenfile.csv
+
+  - filesystem: root
+    path: /etc/kubernetes/config/tokenfile.csv
+    mode: 0644
+    contents:
+      inline: |
+        {{ .Cluster.ConfigItems.worker_shared_secret }},kubelet,kubelet
+
+  - filesystem: root
+    path: /etc/kubernetes/config/image-policy-webhook.yaml
+    mode: 0644
+    contents:
+      inline: |
+        imagePolicy:
+          kubeConfigFile: /etc/kubernetes/config/image-policy-webhook-kubeconfig.yaml
+          allowTTL: 2
+          denyTTL: 2
+          retryBackoff: 500
+          defaultAllow: false
+
+  - filesystem: root
+    path: /etc/kubernetes/config/image-policy-webhook-kubeconfig.yaml
+    mode: 0644
+    contents:
+      inline: |
+        clusters:
+          - name: image-policy-webhook
+            cluster:
+              server: http://127.0.0.1:8083/admit
+        users:
+          - name: image-policy-webhook
+        current-context: image-policy-webhook
+        contexts:
+        - context:
+            cluster: image-policy-webhook
+            user: image-policy-webhook
+          name: image-policy-webhook
+
+  - filesystem: root
+    path: /etc/kubernetes/config/audit.yaml
+    mode: 0644
+    contents:
+      inline: |
+        apiVersion: v1
+        kind: Config
+        clusters:
+        - name: audit
+          cluster:
+            server: http://127.0.0.1:8889/audit
+        contexts:
+        - name: audit
+          context:
+            cluster: audit
+            user: audit
+        current-context: audit
+
+  - filesystem: root
+    path: /etc/kubernetes/config/audit-policy.yaml
+    mode: 0644
+    contents:
+      inline: |
+        apiVersion: audit.k8s.io/v1beta1
+        kind: Policy
+        rules:
+          # The following requests were manually identified as high-volume and low-risk,
+          # so drop them.
+          - level: None
+            users: ["system:kube-proxy"]
+            verbs: ["watch"]
+            resources:
+              - group: "" # core
+                resources: ["endpoints", "services", "services/status"]
+          # don't audit any kubelet events
+          - level: None
+            users: ["kubelet"] # legacy kubelet identity
+          # don't audit events from the system:unsecured user. This is the user
+          # used when connecting to the apiserver over localhost, and will
+          # usuaully be done by the local kubelet.
+          - level: None
+            users: ["system:unsecured"]
+          # don't audit events from the system:apiserver user
+          - level: None
+            users: ["system:apiserver"]
+          # don't audit any kube-controller-manager events
+          - level: None
+            users: ["kube-controller-manager"]
+          # Don't audit events from system users in kube-system
+          - level: None
+            userGroups: ["system:serviceaccounts:kube-system"]
+          # Don't audit events from high traffic infrastructure components
+          - level: None
+            users: ["credentials-provider"]
+          - level: None
+            userGroups: ["system:nodes"]
+            verbs: ["get"]
+            resources:
+              - group: "" # core
+                resources: ["nodes", "nodes/status"]
+          - level: None
+            users:
+              - system:kube-controller-manager
+              - system:kube-scheduler
+              - system:serviceaccount:kube-system:endpoint-controller
+            verbs: ["get", "update"]
+            namespaces: ["kube-system"]
+            resources:
+              - group: "" # core
+                resources: ["endpoints"]
+          - level: None
+            users: ["system:apiserver"]
+            verbs: ["get"]
+            resources:
+              - group: "" # core
+                resources: ["namespaces", "namespaces/status", "namespaces/finalize"]
+          # Don't log HPA fetching metrics.
+          - level: None
+            users:
+              - system:kube-controller-manager
+            verbs: ["get", "list"]
+            resources:
+              - group: "metrics.k8s.io"
+          # Don't log these read-only URLs.
+          - level: None
+            nonResourceURLs:
+              - /healthz*
+              - /version
+              - /swagger*
+          # Don't log events requests.
+          - level: None
+            resources:
+              - group: "" # core
+                resources: ["events"]
+          # Secrets, ConfigMaps, and TokenReviews can contain sensitive & binary data,
+          # so only log at the Metadata level.
+          - level: Metadata
+            resources:
+              - group: "" # core
+                resources: ["secrets", "configmaps"]
+              - group: authentication.k8s.io
+                resources: ["tokenreviews"]
+            omitStages:
+              - "RequestReceived"
+          # Don't audit read-only events.
+          - level: None
+            verbs: ["watch", "list", "get"]
+          # Default level for all other requests.
+          - level: Request
+            omitStages:
+              - "RequestReceived"
+
+  - filesystem: root
+    path: /etc/kubernetes/ssl/ca.pem
+    mode: 0664
+    contents:
+      remote:
+        url: "data:text/plain;base64,{{ .Cluster.ConfigItems.ca_cert_decompressed }}"
+
+  - filesystem: root
+    path: /etc/kubernetes/ssl/apiserver.pem
+    mode: 0664
+    contents:
+      remote:
+        url: "data:text/plain;base64,{{ .Cluster.ConfigItems.apiserver_cert_decompressed }}"
+
+  - filesystem: root
+    path: /etc/kubernetes/ssl/apiserver-key.pem
+    mode: 0664
+    contents:
+      remote:
+        url: "data:text/plain;base64,{{ .Cluster.ConfigItems.apiserver_key_decompressed }}"
+
+  - filesystem: root
+    path: /etc/kubernetes/ssl/worker.pem
+    mode: 0664
+    contents:
+      remote:
+        url: "data:text/plain;base64,{{ .Cluster.ConfigItems.worker_cert_decompressed }}"
+
+  - filesystem: root
+    path: /etc/kubernetes/ssl/worker-key.pem
+    mode: 0664
+    contents:
+      remote:
+        url: "data:text/plain;base64,{{ .Cluster.ConfigItems.worker_key_decompressed }}"
+
+  - filesystem: root
+    path: /etc/kubernetes/cloud-config.ini
+    mode: 0644
+    contents:
+      inline: |
+        [global]
+        DisableSecurityGroupIngress = true
+
+  - filesystem: root
+    path: /opt/bin/dockercfg.sh
+    mode: 0755
+    contents:
+      inline: |
+        #!/bin/bash
+        set -euo pipefail
+
+        iid="instance-identity-document:$(curl --silent --fail http://169.254.169.254/latest/dynamic/instance-identity/pkcs7)"
+        iid="$(echo -n "$iid" | base64 -w 0)"
+        cat << EOF > /root/.docker/config.json
+        {
+          "auths": {
+            "https://pierone.stups.zalan.do": {
+              "auth": "${iid}"
+            }
+          }
+        }
+        EOF
+
+  - filesystem: root
+    path: /opt/bin/meta-data-iptables.sh
+    mode: 0755
+    contents:
+      inline: |
+        #!/bin/bash
+        set -euo pipefail
+
+        PRIVATE_IPV4="$(/usr/bin/curl --silent --fail http://169.254.169.254/latest/meta-data/local-ipv4)"
+        /usr/sbin/iptables \
+          --append PREROUTING \
+          --protocol tcp \
+          --destination 169.254.169.254 \
+          --dport 80 \
+          --in-interface cni0 \
+          --match tcp \
+          --jump DNAT \
+          --table nat \
+          --to-destination ${PRIVATE_IPV4}:8181
+
+  - filesystem: root
+    path: /etc/coreos/docker-1.12
+    mode: 0644
+    contents:
+      inline: yes
+
+  - filesystem: root
+    path: /home/core/.toolboxrc
+    mode: 0644
+    contents:
+      inline: |
+        TOOLBOX_DOCKER_IMAGE=registry.opensource.zalan.do/teapot/microscope
+        TOOLBOX_DOCKER_TAG=v0.0.4
+
+  - filesystem: root
+    path: /root/.toolboxrc
+    mode: 0644
+    contents:
+      inline: |
+        TOOLBOX_DOCKER_IMAGE=registry.opensource.zalan.do/teapot/microscope
+        TOOLBOX_DOCKER_TAG=v0.0.4
+
+  - filesystem: root
+    path: /etc/systemd/timesyncd.conf
+    mode: 0644
+    contents:
+      inline: |
+        [Time]
+        NTP=169.254.169.123
+
+  - filesystem: root
+    path: /opt/bin/drain-node
+    mode: 0755
+    contents:
+      inline: |
+        #!/bin/bash
+        set -euo pipefail
+
+        /usr/bin/rkt run --insecure-options=image \
+          --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
+          --mount=volume=kube,target=/etc/kubernetes \
+          --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
+          --mount volume=dns,target=/etc/resolv.conf \
+          --net=host \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.4_coreos.0 \
+          --exec=/kubectl -- \
+          --kubeconfig=/etc/kubernetes/kubeconfig \
+          label node "$(hostname)" \
+          lifecycle-status=draining \
+          --overwrite
+
+        /usr/bin/rkt run --insecure-options=image \
+          --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
+          --mount=volume=kube,target=/etc/kubernetes \
+          --net=host \
+          --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
+          --mount volume=dns,target=/etc/resolv.conf \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.4_coreos.0 \
+          --exec=/kubectl -- \
+          --kubeconfig=/etc/kubernetes/kubeconfig \
+          drain "$(hostname)" \
+          --ignore-daemonsets \
+          --delete-local-data \
+          --force

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -344,7 +344,7 @@ storage:
               requests:
                 cpu: 100m
                 memory: 200Mi
-          - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.4.0
+          - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.4.1
             name: webhook
             ports:
             - containerPort: 8081
@@ -472,7 +472,7 @@ storage:
             - --cloud-provider=aws
             - --cloud-config=/etc/kubernetes/cloud-config.ini
             - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true,ExpandPersistentVolumes=true
-            - --horizontal-pod-autoscaler-use-rest-clients=false
+            - --horizontal-pod-autoscaler-use-rest-clients=true
             - --use-service-account-credentials=true
             - --v=4
             - --allocate-node-cidrs=true

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -370,7 +370,7 @@ storage:
               - name: TEAMS_API_URL
                 value: https://teams.auth.zalando.com
               - name: CLUSTER_ID
-                value: {{ .Cluster.ConfigItems.webhook_id }}
+                value: {{if index .Cluster.ConfigItems "webhook_id"}}{{ .Cluster.ConfigItems.webhook_id }}{{else}}{{ .Cluster.ID }}{{end}}
               - name: TOKEN_INTROSPECTION_URL
                 value: http://127.0.0.1:9021/oauth2/introspect
               - name: USER_GROUPS

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -291,7 +291,7 @@ storage:
             - --allow-privileged=true
             - --service-cluster-ip-range=10.3.0.0/16
             - --secure-port=443
-            - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,PodSecurityPolicy,ImagePolicyWebhook,Priority
+            - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,PodSecurityPolicy,ImagePolicyWebhook,Priority,PersistentVolumeClaimResize
             - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
             - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
             - --service-account-key-file=/etc/kubernetes/ssl/apiserver-key.pem
@@ -302,7 +302,7 @@ storage:
             - --authorization-mode=Webhook
             - --authorization-webhook-config-file=/etc/kubernetes/config/authz.yaml
             - --admission-control-config-file=/etc/kubernetes/config/image-policy-webhook.yaml
-            - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true
+            - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true,ExpandPersistentVolumes=true
             - --anonymous-auth=false
             - --audit-webhook-config-file=/etc/kubernetes/config/audit.yaml
             - --audit-webhook-mode=batch
@@ -471,7 +471,7 @@ storage:
             - --root-ca-file=/etc/kubernetes/ssl/ca.pem
             - --cloud-provider=aws
             - --cloud-config=/etc/kubernetes/cloud-config.ini
-            - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true
+            - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true,ExpandPersistentVolumes=true
             - --horizontal-pod-autoscaler-use-rest-clients=false
             - --use-service-account-credentials=true
             - --v=4

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -307,6 +307,15 @@ storage:
             - --audit-webhook-config-file=/etc/kubernetes/config/audit.yaml
             - --audit-webhook-mode=batch
             - --audit-policy-file=/etc/kubernetes/config/audit-policy.yaml
+            # enable aggregated apiservers
+            - --client-ca-file=/etc/kubernetes/ssl/ca.pem
+            - --requestheader-client-ca-file=/etc/kubernetes/ssl/ca.pem
+            - --requestheader-allowed-names=aggregator
+            - --requestheader-extra-headers-prefix=X-Remote-Extra-
+            - --requestheader-group-headers=X-Remote-Group
+            - --requestheader-username-headers=X-Remote-User
+            - --proxy-client-cert-file=/etc/kubernetes/ssl/proxy-client.pem
+            - --proxy-client-key-file=/etc/kubernetes/ssl/proxy-client-key.pem
             livenessProbe:
               httpGet:
                 host: 127.0.0.1
@@ -822,6 +831,20 @@ storage:
     contents:
       remote:
         url: "data:text/plain;base64,{{ .Cluster.ConfigItems.worker_key_decompressed }}"
+
+  - filesystem: root
+    path: /etc/kubernetes/ssl/proxy-client.pem
+    mode: 0664
+    contents:
+      remote:
+        url: "data:text/plain;base64,{{ .Cluster.ConfigItems.proxy_client_cert }}"
+
+  - filesystem: root
+    path: /etc/kubernetes/ssl/proxy-client-key.pem
+    mode: 0664
+    contents:
+      remote:
+        url: "data:text/plain;base64,{{ .Cluster.ConfigItems.proxy_client_key }}"
 
   - filesystem: root
     path: /etc/kubernetes/cloud-config.ini

--- a/cluster/node-pools/worker-default/stack.yaml
+++ b/cluster/node-pools/worker-default/stack.yaml
@@ -1,0 +1,97 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Kubernetes default worker node pool
+
+Mappings:
+  Images:
+    eu-central-1:
+      LatestCoreOSImage: ami-604e118b
+      StableCoreOSImage: ami-862140e9
+
+Conditions:
+  UseSpotPrice:
+    Fn::Not:
+      - Fn::Equals:
+        - "{{ .Values.spot_price }}"
+        - ""
+
+Resources:
+  AutoScalingGroup:
+    CreationPolicy:
+      ResourceSignal:
+        Count: '0'
+        Timeout: PT15M
+    Properties:
+      HealthCheckGracePeriod: 300
+      HealthCheckType: EC2
+      LaunchConfigurationName: !Ref AutoScalingConfig
+      MinSize: '{{ .NodePool.MinSize }}'
+      MaxSize: '{{ .NodePool.MaxSize }}'
+      Tags:
+      - Key: k8s.io/role/node
+        PropagateAtLaunch: true
+        Value: worker
+      - Key: k8s.io/cluster-autoscaler/enabled
+        PropagateAtLaunch: true
+        Value: ''
+      - Key: k8s.io/cluster-autoscaler/node-template/label/lifecycle-status
+        PropagateAtLaunch: true
+        Value: ready
+      - Key: 'zalando.de/cluster-local-id/{{ .Cluster.LocalID }}'
+        PropagateAtLaunch: true
+        Value: owned
+      VPCZoneIdentifier: !Split [",", "{{ .Cluster.ConfigItems.subnets }}"]
+    Type: 'AWS::AutoScaling::AutoScalingGroup'
+  AutoScalingConfig:
+    Properties:
+      AssociatePublicIpAddress: true
+      BlockDeviceMappings:
+      - DeviceName: /dev/xvda
+        Ebs:
+          VolumeSize: 50
+          VolumeType: standard
+      EbsOptimized: false
+      IamInstanceProfile: !Ref AutoScalingInstanceProfile
+      # ImageId: !FindInMap
+      #   - Images
+      #   - !Ref 'AWS::Region'
+      #   - StableCoreOSImage
+      # ImageId: " .AMI }}" # TODO: find
+      ImageId: "ami-862140e9" # TODO: find
+      InstanceType: "{{ .NodePool.InstanceType }}"
+      SecurityGroups:
+      - !ImportValue '{{ .Cluster.ID }}:worker-security-group'
+      UserData: "{{ .UserData }}"
+      SpotPrice:
+        Fn::If:
+          - UseSpotPrice
+          - "{{ .Values.spot_price }}"
+          - Ref: AWS::NoValue
+    Type: 'AWS::AutoScaling::LaunchConfiguration'
+  AutoScalingInstanceProfile:
+    Properties:
+      Path: /
+      Roles:
+      - !ImportValue '{{ .Cluster.ID }}:worker-iam-role'
+    Type: 'AWS::IAM::InstanceProfile'
+  AutoScalingScaleDown:
+    Properties:
+      AdjustmentType: ChangeInCapacity
+      AutoScalingGroupName: !Ref AutoScalingGroup
+      Cooldown: '60'
+      ScalingAdjustment: '-1'
+    Type: 'AWS::AutoScaling::ScalingPolicy'
+  AutoScalingScaleUp:
+    Properties:
+      AdjustmentType: ChangeInCapacity
+      AutoScalingGroupName: !Ref AutoScalingGroup
+      Cooldown: '60'
+      ScalingAdjustment: '1'
+    Type: 'AWS::AutoScaling::ScalingPolicy'
+  AutoscalingLifecycleHook:
+    Properties:
+      AutoScalingGroupName: !Ref AutoScalingGroup
+      LifecycleHookName: "kube-node-ready-lifecycle-hook"
+      DefaultResult: CONTINUE
+      HeartbeatTimeout: '600'
+      LifecycleTransition: 'autoscaling:EC2_INSTANCE_LAUNCHING'
+    Type: 'AWS::AutoScaling::LifecycleHook'

--- a/cluster/node-pools/worker-default/stack.yaml
+++ b/cluster/node-pools/worker-default/stack.yaml
@@ -4,7 +4,7 @@ Description: Kubernetes default worker node pool
 Mappings:
   Images:
     eu-central-1:
-      StableCoreOSImage: ami-862140e9
+      StableCoreOSImage: ami-604e118b
 
 Conditions:
   UseSpotPrice:

--- a/cluster/node-pools/worker-default/stack.yaml
+++ b/cluster/node-pools/worker-default/stack.yaml
@@ -4,7 +4,6 @@ Description: Kubernetes default worker node pool
 Mappings:
   Images:
     eu-central-1:
-      LatestCoreOSImage: ami-604e118b
       StableCoreOSImage: ami-862140e9
 
 Conditions:
@@ -27,6 +26,9 @@ Resources:
       MinSize: '{{ .NodePool.MinSize }}'
       MaxSize: '{{ .NodePool.MaxSize }}'
       Tags:
+      - Key: Name
+        PropagateAtLaunch: true
+        Value: "{{ .NodePool.Name }} ({{ .Cluster.ID }})"
       - Key: k8s.io/role/node
         PropagateAtLaunch: true
         Value: worker
@@ -51,12 +53,10 @@ Resources:
           VolumeType: standard
       EbsOptimized: false
       IamInstanceProfile: !Ref AutoScalingInstanceProfile
-      # ImageId: !FindInMap
-      #   - Images
-      #   - !Ref 'AWS::Region'
-      #   - StableCoreOSImage
-      # ImageId: " .AMI }}" # TODO: find
-      ImageId: "ami-862140e9" # TODO: find
+      ImageId: !FindInMap
+      - Images
+      - !Ref 'AWS::Region'
+      - StableCoreOSImage
       InstanceType: "{{ .NodePool.InstanceType }}"
       SecurityGroups:
       - !ImportValue '{{ .Cluster.ID }}:worker-security-group'
@@ -73,20 +73,6 @@ Resources:
       Roles:
       - !ImportValue '{{ .Cluster.ID }}:worker-iam-role'
     Type: 'AWS::IAM::InstanceProfile'
-  AutoScalingScaleDown:
-    Properties:
-      AdjustmentType: ChangeInCapacity
-      AutoScalingGroupName: !Ref AutoScalingGroup
-      Cooldown: '60'
-      ScalingAdjustment: '-1'
-    Type: 'AWS::AutoScaling::ScalingPolicy'
-  AutoScalingScaleUp:
-    Properties:
-      AdjustmentType: ChangeInCapacity
-      AutoScalingGroupName: !Ref AutoScalingGroup
-      Cooldown: '60'
-      ScalingAdjustment: '1'
-    Type: 'AWS::AutoScaling::ScalingPolicy'
   AutoscalingLifecycleHook:
     Properties:
       AutoScalingGroupName: !Ref AutoScalingGroup

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -1,0 +1,320 @@
+# container linux config
+passwd:
+  users:
+  - name: core
+    ssh_authorized_keys:
+    - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC8yXjMX812gbdUsosLvIA/zPrRZI+iOKo8Igq7eiwRTeJKxIkRd2vxDGDfqzCnMhUPPgLW7YM0FWt1u8ZTlXyL4fv1KZuYMRF+27GuU2b/IKu4JYlHDDHrvKCr9tyKb+YVPrAfzi2xVRTGGZG6GRmAiDw8HSUFdejuDLIropAFQu9gAow9aiuQG6kmxZK8qdwIu03eZhuUHCRySCPbusjO+I2JEyVa7lM+P1zt2znDwXsdGjTzHE7NSu5z/VHzho3STWolBm5Vk8uLNYKhjs0eiw/FXV5t+c08Y3JA1LwjAmfOBS23ERSHMG8I3EVSnB9utrdLXejwFAV/jY+Dl2QX9o8brFePBe26MbSg9udD0yfrVz4HEG6NigK6sSx97Zs0lcaSwvjJsnp/J3B1IQMlNRLJGQ7WxM9H2rtoMmD7/iPdADevehEui8C9iaADk6j8AWtN0SJbccSvidrFXW7eH/YSYW394rk8Cl1xBk2RORv3OGVy/RNVt6/Pk/BzvqKf3RvKlbvbFZsWeBSZHDAKeer7001g8HmKV7c8fnDsxIU9Ro3aeWpsX1rQ/jzH1an2deXzVDX1Xbm80VmL5M53dr4w2ZiF5uEIODEUr2nssvl6fhdnaXmbO0vsIyOVawl8mkQ7CBsW06Q+kNs7iDvwVmoG/DD0k4i86La2TBpGvQ== andre.hartmann@zalando.de'
+    - 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAt8djQXfn5U7H85oDzuZRfRONF+jVqn3Mp9t3tnBrJdKyTccfDovq1sekzEdOFdmj74yfS8bzaIO9pDUczy6j5k2MtDCoRnzAO6KZc46jMJ2GjhLArUuHLjmAw2r9LotZ30LEIEvJdmUI7mDlPMczv381PghyM8+DsYv62UrfjDiOsZ4EVkYnztQlO3ntNE16RFNj4fbfErQz67kmw0lB8C6bAf0RuRmvXzB7xRMplmknQnLusoURmySKdZM0GUe0VY6fmqOsgzHVLoEs1m82V8QK1ac/1DSHA91v50MbpCjTVLaRhjR8nmhWBedlhb6j5ClZdAQ8iwyyWC1MFQuvKw== henning@zalando.de'
+    - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDIgO42Rr98DRo4N86Uk4cqHcnbA0iPhL7/DQXRNs+o2vfnfoTVNQiyfq8XzScb+pRJpiq2wW2OthMVRUJsiO4PECw7avYAi0M8cyCsu+ZUoIeMlu+TssWA00GZgdKcQKyCoyLlGbPu2z4GpM9tX+7ASMbMuk6fpm6n9af1YbTm2eqKKXpHDJO+aex3WCj1VyQpCgCD4zquGRy8JRSiQ+QGyGZHIzWWpo3Lc1xGqSQu6L3h4RMrwtZNOjMr/xxxnApOQjBLr70Q8MlYnAhXrIyLjNOaMabMKVxDEltrvN2rCWfN/DFyRi4c5GiDKk1/lwlfO9dRieUqXm9J670PWhwx jan.mussler@zalando.de'
+    - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDOjGGBqrWGdbh0yfkBRE04IbdiAP2TJ2RXnfnp3OV8Lw+jg7cUqeZA5l2vIhFd2ctKPd5OGE3K/A6xCK3hFV9V01oYbH8S3IvrhyA+VjBG0d/ZgTm6GCrlE4XeAt9/ourBSxrrE04lfO786dhLsGEOa5WvvSG3Z/6BhyC/1e5Bd37nnWB363fjAsbg1UgSPr99QZQ5l2mSxN4i2IpJjULBWpLvrJLLJzzl67aaVhDjdtggEU+pMsOoRpDuJ46cYMMDvBI9gyyal2G1aIkqu9iejt1bly53Th2ZAiXecXxEh4K3a5H/Czf70vpCzXQiG1OuZRD1PaSpqw4+zzcizZdX matthias@zalando.de'
+    - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCs4NhH7uwlnklYYlV1GP57XX9NHYgXNv0njfEVowR1jFSKiMdEUtPKz5lOAeDtKpck9HyjxVOTSutNOIBZkkgN/FgkcpNbc59nIO4ELUzipkJivuYNO1lDAjCQi1qwYo+uksiNfcsao9mn7nd9Rh1g8TXYv95TSvml9v/Dolmanm1qj6OkbDw1xIurnNsoCjdxCWwSRGNja4r+PQc8pi+1xpdUBEvn40CeBdU7b/hZnv/BM9FIKSsVlIwMR2i/Co2rxCKo9B3q4dmdQ/2C1QczINVpPQcNUMuiljJFMXvT7dgfNsnUBe8vFuoPgqohJ/m8AiKZZOyoRNiCuELnKLRKqxosDmJz47Y0YiYgZk9jpnmt+x1fwqhY2R85F7W4RybpX3AFL1jOqOT2lE+idkhyeFq/pPoAiPvUcpQSmL9AwlrG6cPklTJZW+dUzH/W6kNlgl/T6hnMn4Mu+IljG08Iyb/HBdmOX+uRq5wdF8lI9Zjzlwg+j7HMa3p1O7MNwpSJVjVXkhUXH0WrFrK2JkwgXokIWvu0o+lajYOmXRQeGCyVybg06WFCzOXnK2toVucFMuAGoM0NkthAnodZCk+xXLNrtHOYagpdJ/x/Q88vuDsZr7IG0NvgX/OCq1a5lpnIydCe+tABNNKcRaOuOLbDYVgUaeVzIXyJjRYu5ZN/JQ== mikkel.larsen@zalando.de'
+    - 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIISHc8p8+ycB9H6SI/i3Uu/OI5G3vYNsZTn0DffPvfOA martin.linkhorst@zalando.de'
+    - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDf3X7MZjYRZD2mI7dvW+c/8dUeDrdqAKZD/C9r+aGa6hWzbGeUZ7cub8to6X9Cl5p3MsTdtFV/OIHRIvxoIGYkz3CRHEBtUdUwOjF9lpBoB/yRMJyxlogmMCm9KGSUM4K+xgIX6qBHq/UeY2Yqumec5lhuLk+7wTmXYQM3+fvvHB8MY//UEadvjuDdotNGQ4jxkJjfoTQj6dspvsZCJ4kIIef9DLSJQ4oCV7sDCVDWPllb3ni9WJYD4vTguI82DI0moQV0WIPplH6rrK+ctVmPyix/IertpqWbiLgmdz3SAyGW45uws2ozGB1S+tZJF+RcNFbbAimoz6QHT+kgL1qmpxa7yba7y3m5pUHqGdhLb+X4Xe3oMZGk7cwBOECw8JUzxzqQKxpF1PfbH8wJ8AiKF7Xr/KJNk9Axsm1zV0DDWv3Z2oK7m8pNiq3mlhv6ovIpXsTq40uaasuLSfmLjSagQDT6ufBAUbaSAJfM0VFo4diIOCDnXH0SX1T8X3EPKbyDg0l/y0pE+FxXQvBK2rzgeynoK5NrvGl1xhJGetbMsl0+WtnIr/PbIQDTo9UQAzOWnHsTs72VqNbeJN4w8ksTqNhXiQO6zlhWqoPL/BeXvRc4N0R8iq9vIstjtuAZkaFsm5TH7Uzz3WTHzKbJ0/5+sefX4cucb/QjImvcVV1UEw== nick.juettner@zalando.de'
+    - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCq3oEP8qhMvGtlR1bgVc9tFOVJ5B5RMKtm6UQ/zXQUpm8DQ04SxdM2U7TfuLien2HSfpHAlYe0eLJZUfIqCXUeZ37v0ozj2RglireEcJm0t9XJ7kTS4kqVxrL6iuN6qQVGHs0vxoo/o9+SP0YkuuJoXwJvVI4yKVbnbfA5hKaAffAYPmfgqOZ7+3AMwmaj/D3tI0xVEA48ptGkj5nnOl0pXlfLRNvbnXOCa/dTKUgkma1F0lXoTipkRspsMEiAnwfJ1dwnzgNzllt//Ao/H+yOVR8fWJ7d+nowszIk6zwUR7c6walxKKf5Oy5bQBU49MZ6xLP1oma9F2+llmV7qpqx rodrigo.reis@zalando.de'
+    - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqAikaHsZWMuJvKZphZPZG0fnKMvVCRfBAbIS6e0Y+YqM0PfsWgB5e4f5TrbisQHdKopbfZVwYIaV/NegEuinrYPKC7t2ese/HjxgjHR95zHOcDP19Cbo+xeyH8zbRd9K3iRSyCUSMNRw5NL6zN8JOSl12m8QWQA4hTjFTmt870fIT4RLxu9qGlbQipUm57E/SotsNC41MQ/PsLQzOAviKrkS1rei2vzRHzAcjz1Z7GT5oH+dFVUC66kKa0XWDvq+VtkRVoLvS2chrIPCgESeeZAyOKyiOoyJxFFFiMVK48MWDBBIYTIsHE0qs/RwBi9+8lQGiHK5Rpk2djcloO0c7 sandor.szuecs@zalando.de'
+    - 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINkh52Py+FvH9CRLDQg0gzvjEIrzwA45yMTXTsl2BVxV alexey.ermakov@zalando.de'
+systemd:
+  units:
+  # disable automatic updates
+  - name: update-engine.service
+    mask: true
+  - name: locksmithd.service
+    mask: true
+
+  - name: set-hostname.service
+    enable: true
+    contents: |
+      [Unit]
+      Wants=network.target
+      Before=docker.service
+
+      [Service]
+      Type=simple
+      Restart=on-failure
+      RestartSec=1
+      ExecStart=/usr/bin/bash -c "/usr/bin/hostnamectl set-hostname $(/usr/bin/curl --silent --fail http://169.254.169.254/latest/meta-data/local-hostname)"
+
+      [Install]
+      WantedBy=multi-user.target
+
+  - name: docker.service
+    dropins:
+    - name: 40-flannel.conf
+      contents: |
+        [Service]
+        EnvironmentFile=/etc/kubernetes/cni/docker_opts_cni.env
+    - name: 60-dockeropts.conf
+      contents: |
+        [Service]
+        Environment="DOCKER_OPTS=--log-opt=max-file=2 --log-opt=max-size=50m"
+        Environment=DOCKER_SELINUX=
+
+  - name: meta-data-iptables.service
+    enable: true
+    contents: |
+      [Unit]
+      After=network.target
+
+      [Service]
+      Type=simple
+      Restart=on-failure
+      RestartSec=1
+      ExecStart=/opt/bin/meta-data-iptables.sh
+
+      [Install]
+      WantedBy=multi-user.target
+
+  - name: dockercfg.service
+    enable: true
+    contents: |
+      [Unit]
+      After=network.target
+
+      [Service]
+      Type=simple
+      Restart=on-failure
+      RestartSec=5
+      ExecStartPre=/usr/bin/mkdir -p /root/.docker
+      ExecStart=/opt/bin/dockercfg.sh
+
+      [Install]
+      WantedBy=multi-user.target
+
+  - name: timesyncd-enable-network-time.service
+    enable: true
+    contents: |
+      [Service]
+      Type=oneshot
+      ExecStart=/usr/bin/timedatectl set-ntp true
+
+      [Install]
+      WantedBy=multi-user.target
+
+  - name: kubelet.service
+    enable: true
+    contents: |
+      [Unit]
+      After=docker.service dockercfg.service meta-data-iptables.service
+
+      [Service]
+      Environment=KUBELET_IMAGE_TAG=v1.9.4_coreos.0
+      Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
+      Environment="RKT_RUN_ARGS=--insecure-options=image \
+      --uuid-file-save=/var/run/kubelet-pod.uuid \
+      --volume dns,kind=host,source=/etc/resolv.conf \
+      --mount volume=dns,target=/etc/resolv.conf \
+      --volume hosts,kind=host,source=/etc/hosts \
+      --mount volume=hosts,target=/etc/hosts \
+      --volume var-log,kind=host,source=/var/log \
+      --mount volume=var-log,target=/var/log \
+      --volume var-lib-cni,kind=host,source=/var/lib/cni \
+      --mount volume=var-lib-cni,target=/var/lib/cni \
+      --volume dockercfg,kind=host,source=/root/.docker/config.json \
+      --mount volume=dockercfg,target=/root/.docker/config.json \
+      --set-env=HOME=/root"
+      ExecStartPre=/usr/bin/mkdir -p /var/log/containers
+      ExecStartPre=/bin/mkdir -p /var/lib/cni
+      ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
+      ExecStart=/usr/lib/coreos/kubelet-wrapper \
+      --cni-conf-dir=/etc/kubernetes/cni/net.d \
+      --network-plugin=cni \
+      --container-runtime=docker \
+      --rkt-path=/usr/bin/rkt \
+      --register-node \
+      --allow-privileged \
+      --node-labels=kubernetes.io/role=worker \
+      --node-labels=kubernetes.io/node-pool={{ .NodePool.Name }} \
+      --node-labels={{ .Values.node_labels }} \
+      --cluster-dns=10.3.0.10,10.3.0.11 \
+      --cluster-domain=cluster.local \
+      --kubeconfig=/etc/kubernetes/kubeconfig \
+      --require-kubeconfig \
+      --healthz-bind-address=0.0.0.0 \
+      --healthz-port=10248 \
+      --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
+      --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \
+      --cloud-provider=aws \
+      --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true \
+      --system-reserved=cpu=100m,memory=164Mi \
+      --kube-reserved=cpu=100m,memory=282Mi
+      ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
+      Restart=always
+      RestartSec=10
+
+      [Install]
+      WantedBy=multi-user.target
+
+  - name: kube-node-drainer.service
+    enable: true
+    contents: |
+      [Unit]
+      Description=drain this k8s node to make running pods time to gracefully shut down before stopping kubelet
+      After=docker.service kubelet.service
+
+      [Service]
+      Type=oneshot
+      RemainAfterExit=true
+      ExecStart=/bin/true
+      TimeoutStopSec=120s
+      ExecStop=/opt/bin/drain-node
+
+      [Install]
+      WantedBy=multi-user.target
+
+storage:
+  files:
+  - filesystem: root
+    path: /etc/kubernetes/kubeconfig
+    mode: 0644
+    contents:
+      inline: |
+        apiVersion: v1
+        kind: Config
+        clusters:
+        - name: local
+          cluster:
+            server: {{ .Cluster.APIServerURL }}
+        users:
+        - name: kubelet
+          user:
+            token: {{ .Cluster.ConfigItems.worker_shared_secret }}
+        contexts:
+        - context:
+            cluster: local
+            user: kubelet
+          name: kubelet-context
+        current-context: kubelet-context
+
+  - filesystem: root
+    path: /etc/kubernetes/cni/docker_opts_cni.env
+    mode: 0644
+    contents:
+      inline: |
+        DOCKER_OPT_BIP=""
+        DOCKER_OPT_IPMASQ=""
+
+  - filesystem: root
+    path: /etc/kubernetes/ssl/worker.pem
+    mode: 0664
+    contents:
+      remote:
+        url: "data:text/plain;base64,{{ .Cluster.ConfigItems.worker_cert_decompressed }}"
+
+  - filesystem: root
+    path: /etc/kubernetes/ssl/worker-key.pem
+    mode: 0664
+    contents:
+      remote:
+        url: "data:text/plain;base64,{{ .Cluster.ConfigItems.worker_key_decompressed }}"
+
+  - filesystem: root
+    path: /etc/kubernetes/ssl/ca.pem
+    mode: 0664
+    contents:
+      remote:
+        url: "data:text/plain;base64,{{ .Cluster.ConfigItems.ca_cert_decompressed }}"
+
+  - filesystem: root
+    path: /opt/bin/dockercfg.sh
+    mode: 0755
+    contents:
+      inline: |
+        #!/bin/bash
+        set -euo pipefail
+
+        iid="instance-identity-document:$(curl --silent --fail http://169.254.169.254/latest/dynamic/instance-identity/pkcs7)"
+        iid="$(echo -n "$iid" | base64 -w 0)"
+        cat << EOF > /root/.docker/config.json
+        {
+          "auths": {
+            "https://pierone.stups.zalan.do": {
+              "auth": "${iid}"
+            }
+          }
+        }
+        EOF
+
+  - filesystem: root
+    path: /opt/bin/meta-data-iptables.sh
+    mode: 0755
+    contents:
+      inline: |
+        #!/bin/bash
+        set -euo pipefail
+
+        PRIVATE_IPV4="$(/usr/bin/curl --silent --fail http://169.254.169.254/latest/meta-data/local-ipv4)"
+        /usr/sbin/iptables \
+          --append PREROUTING \
+          --protocol tcp \
+          --destination 169.254.169.254 \
+          --dport 80 \
+          --in-interface cni0 \
+          --match tcp \
+          --jump DNAT \
+          --table nat \
+          --to-destination ${PRIVATE_IPV4}:8181
+
+  - filesystem: root
+    path: /etc/coreos/docker-1.12
+    mode: 0644
+    contents:
+      inline: yes
+
+  - filesystem: root
+    path: /home/core/.toolboxrc
+    mode: 0644
+    contents:
+      inline: |
+        TOOLBOX_DOCKER_IMAGE=registry.opensource.zalan.do/teapot/microscope
+        TOOLBOX_DOCKER_TAG=v0.0.4
+
+  - filesystem: root
+    path: /root/.toolboxrc
+    mode: 0644
+    contents:
+      inline: |
+        TOOLBOX_DOCKER_IMAGE=registry.opensource.zalan.do/teapot/microscope
+        TOOLBOX_DOCKER_TAG=v0.0.4
+
+  - filesystem: root
+    path: /etc/systemd/timesyncd.conf
+    mode: 0644
+    contents:
+      inline: |
+        [Time]
+        NTP=169.254.169.123
+
+  - filesystem: root
+    path: /opt/bin/drain-node
+    mode: 0755
+    contents:
+      inline: |
+        #!/bin/bash
+        set -euo pipefail
+
+        /usr/bin/rkt run --insecure-options=image \
+          --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
+          --mount=volume=kube,target=/etc/kubernetes \
+          --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
+          --mount volume=dns,target=/etc/resolv.conf \
+          --net=host \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.4_coreos.0 \
+          --exec=/kubectl -- \
+          --kubeconfig=/etc/kubernetes/kubeconfig \
+          label node "$(hostname)" \
+          lifecycle-status=draining \
+          --overwrite
+
+        /usr/bin/rkt run --insecure-options=image \
+          --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
+          --mount=volume=kube,target=/etc/kubernetes \
+          --net=host \
+          --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
+          --mount volume=dns,target=/etc/resolv.conf \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.4_coreos.0 \
+          --exec=/kubectl -- \
+          --kubeconfig=/etc/kubernetes/kubeconfig \
+          drain "$(hostname)" \
+          --ignore-daemonsets \
+          --delete-local-data \
+          --force

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -895,3 +895,34 @@ Resources:
             Resource: ["arn:aws:s3:::{{ Arguments.EtcdS3BackupBucket }}/*"]
           Version: '2012-10-17'
         PolicyName: root
+Outputs:
+  MasterSecurityGroup:
+    Value:
+      Ref: MasterSecurityGroup
+    Export:
+      Name: "{{ Arguments.ClusterID }}:master-security-group"
+  WorkerSecurityGroup:
+    Value:
+      Ref: WorkerSecurityGroup
+    Export:
+      Name: "{{ Arguments.ClusterID }}:worker-security-group"
+  MasterLoadBalancer:
+    Value:
+      Ref: MasterLoadBalancer
+    Export:
+      Name: "{{ Arguments.ClusterID }}:master-load-balancer"
+  MasterIAMRole:
+    Value:
+      Ref: MasterIAMRole
+    Export:
+      Name: "{{ Arguments.ClusterID }}:master-iam-role"
+  WorkerIAMRole:
+    Value:
+      Ref: WorkerIAMRole
+    Export:
+      Name: "{{ Arguments.ClusterID }}:worker-iam-role"
+  MasterLoadBalancerSecurityGroup:
+    Value:
+      Ref: MasterLoadBalancerSecurityGroup
+    Export:
+      Name: "{{ Arguments.ClusterID }}:master-load-balancer-security-group"


### PR DESCRIPTION
This adds node pool support as described in the (internal narrative/CLM PR, see that for context).

Basically we add the folder structure:

```
node-pools
├── master-default
│   ├── stack.yaml
│   └── userdata.clc.yaml
└── worker-default
    ├── stack.yaml
    └── userdata.clc.yaml
```

Which is then used for provisioning node pools based on the profile (`master-default` or `worker-default` in this case.)

Fix #115