### PR TITLE
fix the uneven startup of roundrobin

### DIFF
--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.9.200
+    version: v0.9.202
     component: ingress
 spec:
   selector:
@@ -18,7 +18,7 @@ spec:
       name: skipper-ingress
       labels:
         application: skipper-ingress
-        version: v0.9.200
+        version: v0.9.202
         component: ingress
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -40,7 +40,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.9.200
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.9.202
         ports:
         - name: ingress-port
           containerPort: 9999


### PR DESCRIPTION
As requested by a user, which did benchmarks and saw some weird numbers in the beginning of POD starts