### PR TITLE
Improve prometheus setup

### DIFF
--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -17,17 +17,47 @@ data:
       scheme: http
       kubernetes_sd_configs:
       - role: pod
+        namespaces:
+          names:
+            - kube-system
       relabel_configs:
-      - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_application, __meta_kubernetes_pod_container_port_number]
+      - source_labels: [__meta_kubernetes_pod_label_application, __meta_kubernetes_pod_container_port_number]
         action: keep
-        regex: kube-system;kube-apiserver;8082
+        regex: kube-apiserver;8082
       - action: replace
         source_labels: ['__meta_kubernetes_pod_label_application']
         target_label: application
+    - job_name: 'kube-state-metrics'
+      scheme: http
+      honor_labels: true
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+            - kube-system
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_endpoints_name]
+        action: keep
+        regex: kube-state-metrics
+      metric_relabel_configs:
+      - action: replace
+        source_labels: [pod]
+        target_label: pod_name
+      - action: replace
+        source_labels: [container]
+        target_label: container_name
+      - action: replace
+        source_labels: [node]
+        target_label: node_name
+      - action: labeldrop
+        regex: "^(pod|node|container)$"
     - job_name: 'kubernetes-service-endpoints'
       scheme: http
       kubernetes_sd_configs:
       - role: endpoints
+        namespaces:
+          names:
+            - kube-system
       relabel_configs:
       # Look for the Prometheus annotations and scrape based on those
       - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
@@ -70,6 +100,9 @@ data:
         target_label: __address__
         regex: (.*)
         replacement: $1:4194
+      - action: replace
+        source_labels: [instance]
+        target_label: node_name
     - job_name: 'kubelet-metrics'
       kubernetes_sd_configs:
       - role: node

--- a/cluster/manifests/prometheus/statefulset.yaml
+++ b/cluster/manifests/prometheus/statefulset.yaml
@@ -35,7 +35,7 @@ spec:
             cpu: 1000m
             memory: 4000Mi
           requests:
-            cpu: 500m
+            cpu: 1000m
             memory: 4000Mi
         readinessProbe:
           httpGet:

--- a/cluster/manifests/prometheus/statefulset.yaml
+++ b/cluster/manifests/prometheus/statefulset.yaml
@@ -18,6 +18,8 @@ spec:
       labels:
         application: prometheus
         version: v2.2.1
+      annotations:
+        config/hash: {{"configmap.yaml" | manifestHash}}
     spec:
       containers:
       - name: prometheus


### PR DESCRIPTION
* Scrape `kube-state-metrics` explicitly
* Change labeling rules so that pod/node/container labels are consistent
* Bump requests to match limits (let's avoid overcommitting)
* Force an update after a configmap change