### PR TITLE
new version of kube-state-metrics v1.3.0

### DIFF
--- a/cluster/manifests/kube-state-metrics/deployment.yaml
+++ b/cluster/manifests/kube-state-metrics/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-state-metrics
-    version: v1.1.0
+    version: v1.3.0
 spec:
   replicas: 1
   selector:
@@ -15,10 +15,10 @@ spec:
     metadata:
       labels:
         application: kube-state-metrics
-        version: v1.1.0
+        version: v1.3.0
     spec:
       containers:
-      - image: registry.opensource.zalan.do/teapot/kube-state-metrics:v1.1.0
+      - image: registry.opensource.zalan.do/teapot/kube-state-metrics:v1.3.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080


### PR DESCRIPTION
Skipping Version 1.2
New in Version v.1.3.0:

[FEATURE] Allow to specify multiple namespace.
[FEATURE] Add kube_pod_completion_time, kube_pod_spec_volumes_persistentvolumeclaims_info, and kube_pod_spec_volumes_persistentvolumeclaims_readonly metrics to the Pod collector.
[FEATURE] Add kube_node_spec_taint metric.
[FEATURE] Add kube_namespace_annotations metric.
[FEATURE] Add kube_deployment_spec_strategy_rollingupdate_max_surge metric.
[FEATURE] Add kube_persistentvolume_labels metric.
[FEATURE] Add kube_persistentvolumeclaim_lables metric.
[FEATURE] Add kube_daemonset_labels metric.
[FEATURE] Add Secret metrics.
[FEATURE] Add ConfigMap metrics.
[ENHANCEMENT] Add additional reasons to kube_pod_container_status_waiting_reason metric.
[BUGFIX] Fix namespacing of HPA.
[BUGFIX] Fix namespacing of PersistentVolumes.
[BUGFIX] Fix CronJob tab parsing.

New in Version v.1.2.0:

[CHANGE] The CronJob collector now expects the version to be v1beta1.
[FEATURE] Add Endpoints metrics collector.
[FEATURE] Add PersistentVolume metrics collector.
[FEATURE] Add HorizontalPodAutoscaler metrics collector.
[FEATURE] Add kube_pod_container_status_terminated_reason metric.
[FEATURE] Add kube_job_labels metric.
[FEATURE] Add kube_cronjob_labels metric.
[FEATURE] Add kube_service_spec_type metric.
[FEATURE] Add kube_statefulset_status_replicas_current metric.
[FEATURE] Add kube_statefulset_status_replicas_ready metric.
[FEATURE] Add kube_statefulset_status_replicas_updated metric.
[ENHANCEMENT] Allow specifying the host/IP kube-state-metrics binds to.
[ENHANCEMENT] Add volumename label to kube_persistentvolumeclaim_info metric.
[ENHANCEMENT] Add cluster_ip label to kube_service_info metric.
[ENHANCEMENT] Print version on startup and useful debug information at runtime.
[ENHANCEMENT] Add metrics for kube-state-metrics itself. For separation purposes this listens on a separate host/IP and port, both configurable respectively.