### PR TITLE
Fix kube-state-metrics OOM

### DIFF
--- a/cluster/manifests/kube-state-metrics/deployment.yaml
+++ b/cluster/manifests/kube-state-metrics/deployment.yaml
@@ -30,5 +30,5 @@ spec:
             cpu: 100m
             memory: 300Mi
           requests:
-            cpu: 50m
-            memory: 25Mi
+            cpu: 100m
+            memory: 300Mi

--- a/cluster/manifests/kube-state-metrics/deployment.yaml
+++ b/cluster/manifests/kube-state-metrics/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 100Mi
+            memory: 300Mi
           requests:
             cpu: 50m
             memory: 25Mi


### PR DESCRIPTION
This will fix the OOM issue. kube-state-metrics consumes more memory because it fetches more data 