### PR TITLE
Increase CPU limit for kube-state-metrics

### DIFF
--- a/cluster/manifests/kube-state-metrics/deployment.yaml
+++ b/cluster/manifests/kube-state-metrics/deployment.yaml
@@ -27,8 +27,8 @@ spec:
         - --port=8080
         resources:
           limits:
-            cpu: 100m
+            cpu: 300m
             memory: 300Mi
           requests:
-            cpu: 100m
+            cpu: 300m
             memory: 300Mi


### PR DESCRIPTION
`100m` is not enough for clusters with a large number of pods so we get no metrics.