### PR TITLE
modify prometheus cpu and mem ressources by changing via config items

### DIFF
--- a/cluster/manifests/prometheus/statefulset.yaml
+++ b/cluster/manifests/prometheus/statefulset.yaml
@@ -34,11 +34,11 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 1000m
-            memory: 4000Mi
+            cpu: {{if index .ConfigItems "prometheus_cpu"}}{{.ConfigItems.prometheus_cpu}}{{else}}1000m{{end}}
+            memory: {{if index .ConfigItems "prometheus_mem"}}{{.ConfigItems.prometheus_mem}}{{else}}4000Mi{{end}}
           requests:
-            cpu: 1000m
-            memory: 4000Mi
+            cpu: {{if index .ConfigItems "prometheus_cpu"}}{{.ConfigItems.prometheus_cpu}}{{else}}1000m{{end}}
+            memory: {{if index .ConfigItems "prometheus_mem"}}{{.ConfigItems.prometheus_mem}}{{else}}4000Mi{{end}}
         readinessProbe:
           httpGet:
             path: /-/ready


### PR DESCRIPTION
some clusters seem to need more ressources otherwise prometheus is crashing all the time. 
by changing the ressources via config items we are more flexible to increase cpu and mem based on the cluster.