### PR TITLE
pdb-controller: add owner reference to PDBs

### DIFF
--- a/cluster/manifests/pdb-controller/deployment.yaml
+++ b/cluster/manifests/pdb-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: pdb-controller
-    version: v0.0.5
+    version: v0.0.6
 spec:
   selector:
     matchLabels:
@@ -14,12 +14,12 @@ spec:
     metadata:
       labels:
         application: pdb-controller
-        version: v0.0.5
+        version: v0.0.6
     spec:
       serviceAccountName: system
       containers:
       - name: pdb-controller
-        image: registry.opensource.zalan.do/teapot/pdb-controller:v0.0.5
+        image: registry.opensource.zalan.do/teapot/pdb-controller:v0.0.6
         args:
         - --debug
         resources:


### PR DESCRIPTION
Adds owner references to PDBs to automatically clean them up if target
resource is removed: https://github.com/mikkeloscar/pdb-controller/pull/12