### PR TITLE
Enable metrics-server (heapster replacement)

### DIFF
--- a/cluster/manifests/metrics-server/apiservice.yaml
+++ b/cluster/manifests/metrics-server/apiservice.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+  name: v1beta1.metrics.k8s.io
+spec:
+  service:
+    name: metrics-server
+    namespace: kube-system
+  group: metrics.k8s.io
+  version: v1beta1
+  insecureSkipTLSVerify: true
+  groupPriorityMinimum: 100
+  versionPriority: 100

--- a/cluster/manifests/metrics-server/deployment.yaml
+++ b/cluster/manifests/metrics-server/deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-server
+  namespace: kube-system
+  labels:
+    application: metrics-server
+    version: v0.2.1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      application: metrics-server
+  template:
+    metadata:
+      name: metrics-server
+      labels:
+        application: metrics-server
+        version: v0.2.1
+    spec:
+      serviceAccountName: system
+      containers:
+      - name: metrics-server
+        image: registry.opensource.zalan.do/teapot/metrics-server:v0.2.1
+        command:
+        - /metrics-server
+        - --source=kubernetes.summary_api:''
+        resources:
+          limits:
+            cpu: 100m
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi

--- a/cluster/manifests/metrics-server/service.yaml
+++ b/cluster/manifests/metrics-server/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: metrics-server
+  namespace: kube-system
+  labels:
+    application: metrics-server
+    kubernetes.io/name: "Metrics-server"
+spec:
+  selector:
+    application: metrics-server
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 443

--- a/cluster/master.clc.yaml
+++ b/cluster/master.clc.yaml
@@ -308,6 +308,15 @@ storage:
             - --audit-webhook-config-file=/etc/kubernetes/config/audit.yaml
             - --audit-webhook-mode=batch
             - --audit-policy-file=/etc/kubernetes/config/audit-policy.yaml
+            # enable aggregated apiservers
+            - --client-ca-file=/etc/kubernetes/ssl/ca.pem
+            - --requestheader-client-ca-file=/etc/kubernetes/ssl/ca.pem
+            - --requestheader-allowed-names=aggregator
+            - --requestheader-extra-headers-prefix=X-Remote-Extra-
+            - --requestheader-group-headers=X-Remote-Group
+            - --requestheader-username-headers=X-Remote-User
+            - --proxy-client-cert-file=/etc/kubernetes/ssl/proxy-client.pem
+            - --proxy-client-key-file=/etc/kubernetes/ssl/proxy-client-key.pem
             livenessProbe:
               httpGet:
                 host: 127.0.0.1
@@ -464,7 +473,7 @@ storage:
             - --cloud-provider=aws
             - --cloud-config=/etc/kubernetes/cloud-config.ini
             - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true
-            - --horizontal-pod-autoscaler-use-rest-clients=false
+            - --horizontal-pod-autoscaler-use-rest-clients=true
             - --use-service-account-credentials=true
             - --v=4
             - --allocate-node-cidrs=true
@@ -823,6 +832,20 @@ storage:
     contents:
       remote:
         url: "data:text/plain;base64,{{WORKER_KEY_DECOMPRESSED}}"
+
+  - filesystem: root
+    path: /etc/kubernetes/ssl/proxy-client.pem
+    mode: 0664
+    contents:
+      remote:
+        url: "data:text/plain;base64,{{PROXY_CLIENT_CERT}}"
+
+  - filesystem: root
+    path: /etc/kubernetes/ssl/proxy-client-key.pem
+    mode: 0664
+    contents:
+      remote:
+        url: "data:text/plain;base64,{{PROXY_CLIENT_KEY}}"
 
   - filesystem: root
     path: /etc/kubernetes/cloud-config.ini


### PR DESCRIPTION
Introduce [metrics-server](https://github.com/kubernetes-incubator/metrics-server) as a replacement for heapster and to further enable custom and external metrics for HPA later on.

I didn't find any of our checks that really depend on heapster, but I'll let it stay there in case someone still depends on it. We can clean that up separately.

I tested manually that HPA works with this configuration (we previously broke it #938)

### TODO

* [x] Mirror image to our registry.
* [x] Add proxy-client certs/keys to e2e tests.
* [x] Add proxy-client certs/keys to account creator.
* [x] Add proxy-client certs/keys to all existing cluster in cluster-registry.