### PR TITLE
Add VPA control plane

### DIFF
--- a/cluster/manifests/10-vertical-pod-autoscaler/admission-controller-deployment.yaml
+++ b/cluster/manifests/10-vertical-pod-autoscaler/admission-controller-deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vpa-admission-controller
+  namespace: kube-system
+  labels:
+    application: vpa-admission-controller
+    version: v0.1.0
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      application: vpa-admission-controller
+  template:
+    metadata:
+      labels:
+        application: vpa-admission-controller
+        version: v0.1.0
+    spec:
+      serviceAccountName: system
+      containers:
+      - name: admission-controller
+        image: registry.opensource.zalan.do/teapot/vpa-admission-controller:v0.1.0
+        volumeMounts:
+        - name: tls-certs
+          mountPath: "/etc/tls-certs"
+          readOnly: true
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 50m
+            memory: 200Mi
+        ports:
+        - containerPort: 8000
+      volumes:
+      - name: tls-certs
+        secret:
+          secretName: vpa-tls-certs

--- a/cluster/manifests/10-vertical-pod-autoscaler/admission-controller-secret.yaml
+++ b/cluster/manifests/10-vertical-pod-autoscaler/admission-controller-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vpa-tls-certs
+  namespace: kube-system
+type: Opaque
+data:
+  caKey.pem: ""
+  caCert.pem: "{{ .ConfigItems.ca_cert_decompressed }}"
+  serverCert.pem: "{{ .ConfigItems.vpa_webhook_cert }}"
+  serverKey.pem: "{{ .ConfigItems.vpa_webhook_key }}"

--- a/cluster/manifests/10-vertical-pod-autoscaler/admission-controller-service.yaml
+++ b/cluster/manifests/10-vertical-pod-autoscaler/admission-controller-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: vpa-webhook
+  namespace: kube-system
+spec:
+  ports:
+    - port: 443
+      targetPort: 8000
+  selector:
+    application: vpa-admission-controller

--- a/cluster/manifests/10-vertical-pod-autoscaler/recommender-deployment.yaml
+++ b/cluster/manifests/10-vertical-pod-autoscaler/recommender-deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vpa-recommender
+  namespace: kube-system
+  labels:
+    application: vpa-recommender
+    version: v0.1.0
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      application: vpa-recommender
+  template:
+    metadata:
+      labels:
+        application: vpa-recommender
+        version: v0.1.0
+    spec:
+      serviceAccountName: system
+      containers:
+      - name: recommender
+        image: registry.opensource.zalan.do/teapot/vpa-recommender:v0.1.0
+        resources:
+          limits:
+            cpu: 50m
+            memory: 500Mi
+          requests:
+            cpu: 50m
+            memory: 500Mi
+        ports:
+        - containerPort: 8080

--- a/cluster/manifests/10-vertical-pod-autoscaler/updater-deployment.yaml
+++ b/cluster/manifests/10-vertical-pod-autoscaler/updater-deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vpa-updater
+  namespace: kube-system
+  labels:
+    application: vpa-updater
+    version: v0.1.0
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      application: vpa-updater
+  template:
+    metadata:
+      labels:
+        application: vpa-updater
+        version: v0.1.0
+    spec:
+      serviceAccountName: system
+      containers:
+      - name: updater
+        image: registry.opensource.zalan.do/teapot/vpa-updater:v0.1.0
+        resources:
+          limits:
+            cpu: 50m
+            memory: 500Mi
+          requests:
+            cpu: 50m
+            memory: 500Mi
+        ports:
+        - containerPort: 8080

--- a/cluster/manifests/10-vertical-pod-autoscaler/vpa-crd.yaml
+++ b/cluster/manifests/10-vertical-pod-autoscaler/vpa-crd.yaml
@@ -1,0 +1,67 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: verticalpodautoscalers.poc.autoscaling.k8s.io
+spec:
+  group: poc.autoscaling.k8s.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: verticalpodautoscalers
+    singular: verticalpodautoscaler
+    kind: VerticalPodAutoscaler
+    shortNames:
+    - vpa
+  validation:
+    # openAPIV3Schema is the schema for validating custom objects.
+    openAPIV3Schema:
+      properties:
+        spec:
+          required:
+          - selector
+          properties:
+            selector:
+              type: object
+            updatePolicy:
+              properties:
+                updateMode:
+                  type: string
+                  enum:
+                  - "Off"
+                  - "Initial"
+                  - "Auto"
+            resourcePolicy:
+              properties:
+                containerPolicies:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                    - name
+                    properties:
+                      name:
+                        type: string
+                      mode:
+                        type: string
+                        enum:
+                        - "On"
+                        - "Off"
+                      minAllowed:
+                        type: object
+                      maxAllowed:
+                        type: object
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: verticalpodautoscalercheckpoints.poc.autoscaling.k8s.io
+spec:
+  group: poc.autoscaling.k8s.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: verticalpodautoscalercheckpoints
+    singular: verticalpodautoscalercheckpoint
+    kind: VerticalPodAutoscalerCheckpoint
+    shortNames:
+    - vpacheckpoint

--- a/cluster/master.clc.yaml
+++ b/cluster/master.clc.yaml
@@ -292,11 +292,11 @@ storage:
             - --allow-privileged=true
             - --service-cluster-ip-range=10.3.0.0/16
             - --secure-port=443
-            - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,PodSecurityPolicy,ImagePolicyWebhook,Priority,PersistentVolumeClaimResize
+            - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,PodSecurityPolicy,ImagePolicyWebhook,Priority,MutatingAdmissionWebhook,PersistentVolumeClaimResize
             - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
             - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
             - --service-account-key-file=/etc/kubernetes/ssl/apiserver-key.pem
-            - --runtime-config=extensions/v1beta1/networkpolicies=true,batch/v2alpha1=true,extensions/v1beta1/podsecuritypolicy=true,imagepolicy.k8s.io/v1alpha1=true,authorization.k8s.io/v1beta1=true,scheduling.k8s.io/v1alpha1=true
+            - --runtime-config=extensions/v1beta1/networkpolicies=true,batch/v2alpha1=true,extensions/v1beta1/podsecuritypolicy=true,imagepolicy.k8s.io/v1alpha1=true,authorization.k8s.io/v1beta1=true,scheduling.k8s.io/v1alpha1=true,admissionregistration.k8s.io/v1beta1=true
             - --authentication-token-webhook-config-file=/etc/kubernetes/config/authn.yaml
             - --authentication-token-webhook-cache-ttl=10s
             - --cloud-provider=aws

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -291,7 +291,7 @@ storage:
             - --allow-privileged=true
             - --service-cluster-ip-range=10.3.0.0/16
             - --secure-port=443
-            - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,PodSecurityPolicy,ImagePolicyWebhook,Priority,PersistentVolumeClaimResize
+            - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,PodSecurityPolicy,ImagePolicyWebhook,Priority,MutatingAdmissionWebhook,PersistentVolumeClaimResize
             - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
             - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
             - --service-account-key-file=/etc/kubernetes/ssl/apiserver-key.pem


### PR DESCRIPTION
Adds the control plane for the VerticalPodAutoscaler.

See https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler to understand how it works.

~I have added a VPA just for prometheus for now, since we need to understand how this actually works in practice. Maybe we even need to try a less important component first.~

~Added a VPA only to `pdb-controller`. This component is not super critical so a good test case.~

Dropped the VPA from kube-system components for now, we will test this first with a single service (green-snail-trail).

#### TODO

* [x] mirror docker images to our registry.
* [x] Add new vpa-webhook certs/keys to all clusters.