### PR TITLE
Enable AWS Glue for the deployment role (to enable deployment via CDP)

### DIFF
--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -721,6 +721,7 @@ Resources:
             - "es:*"
             - "events:*"
             - "glacier:*"
+            - "glue:*"
             - "health:*"
             - "iam:*"
             - "kinesis:*"


### PR DESCRIPTION
This was enabled some time ago for PowerUsers in our AWS accounts, but it should also be enabled in the deployment role so people can deploy [Glue](https://aws.amazon.com/glue/) via cloudformation in CDP.