### PR TITLE
Kubernetes v.1.9.7

### DIFF
--- a/cluster/manifests/heapster/deployment.yaml
+++ b/cluster/manifests/heapster/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     application: heapster
     kubernetes.io/cluster-service: "true"
-    version: v1.4.2
+    version: v1.5.2
 spec:
   replicas: 1
   selector:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: heapster
-        version: v1.4.2
+        version: v1.5.2
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -25,7 +25,7 @@ spec:
         operator: Exists
       serviceAccountName: system
       containers:
-        - image: registry.opensource.zalan.do/teapot/heapster:v1.4.2
+        - image: registry.opensource.zalan.do/teapot/heapster:v1.5.2
           name: heapster
           livenessProbe:
             httpGet:

--- a/cluster/manifests/kube-cluster-autoscaler/autoscaler-deployment.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/autoscaler-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-cluster-autoscaler
-    version: v1.1.1
+    version: v1.1.2
 spec:
   replicas: 2
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-cluster-autoscaler
-        version: v1.1.1
+        version: v1.1.2
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-autoscaler"
@@ -28,7 +28,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cluster-autoscaler
-        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.1.1
+        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.1.2
         command:
           - ./cluster-autoscaler
           - --v=4

--- a/cluster/manifests/kube-dns/depl-kube-dns-b.yaml
+++ b/cluster/manifests/kube-dns/depl-kube-dns-b.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-dns-b
-    version: v1.14.5
+    version: v1.14.10
     kubernetes.io/cluster-service: "true"
 spec:
   # replicas: not specified here:
@@ -23,7 +23,7 @@ spec:
     metadata:
       labels:
         application: kube-dns-b
-        version: v1.14.5
+        version: v1.14.10
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -50,7 +50,7 @@ spec:
           optional: true
       containers:
       - name: kubedns
-        image: registry.opensource.zalan.do/teapot/k8s-dns-kube-dns:1.14.5
+        image: registry.opensource.zalan.do/teapot/k8s-dns-kube-dns:1.14.10
         resources:
           limits:
             memory: 170Mi
@@ -95,7 +95,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: registry.opensource.zalan.do/teapot/k8s-dns-dnsmasq-nanny:1.14.5
+        image: registry.opensource.zalan.do/teapot/k8s-dns-dnsmasq-nanny:1.14.10
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -133,7 +133,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: registry.opensource.zalan.do/teapot/k8s-dns-sidecar:1.14.5
+        image: registry.opensource.zalan.do/teapot/k8s-dns-sidecar:1.14.10
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/manifests/kube-dns/depl-kube-dns-b.yaml
+++ b/cluster/manifests/kube-dns/depl-kube-dns-b.yaml
@@ -50,7 +50,7 @@ spec:
           optional: true
       containers:
       - name: kubedns
-        image: registry.opensource.zalan.do/teapot/k8s-dns-kube-dns:1.14.10
+        image: registry.opensource.zalan.do/teapot/k8s-dns-kube-dns-amd64:1.14.10
         resources:
           limits:
             memory: 170Mi
@@ -95,7 +95,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: registry.opensource.zalan.do/teapot/k8s-dns-dnsmasq-nanny:1.14.10
+        image: registry.opensource.zalan.do/teapot/k8s-dns-dnsmasq-nanny-amd64:1.14.10
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -133,7 +133,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: registry.opensource.zalan.do/teapot/k8s-dns-sidecar:1.14.10
+        image: registry.opensource.zalan.do/teapot/k8s-dns-sidecar-amd64:1.14.10
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/manifests/kube-dns/depl-kube-dns.yaml
+++ b/cluster/manifests/kube-dns/depl-kube-dns.yaml
@@ -50,7 +50,7 @@ spec:
           optional: true
       containers:
       - name: kubedns
-        image: registry.opensource.zalan.do/teapot/k8s-dns-kube-dns:1.14.10
+        image: registry.opensource.zalan.do/teapot/k8s-dns-kube-dns-amd64:1.14.10
         resources:
           limits:
             memory: 170Mi
@@ -95,7 +95,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: registry.opensource.zalan.do/teapot/k8s-dns-dnsmasq-nanny:1.14.10
+        image: registry.opensource.zalan.do/teapot/k8s-dns-dnsmasq-nanny-amd64:1.14.10
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -133,7 +133,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: registry.opensource.zalan.do/teapot/k8s-dns-sidecar:1.14.10
+        image: registry.opensource.zalan.do/teapot/k8s-dns-sidecar-amd64:1.14.10
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/manifests/kube-dns/depl-kube-dns.yaml
+++ b/cluster/manifests/kube-dns/depl-kube-dns.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-dns
-    version: v1.14.5
+    version: v1.14.10
     kubernetes.io/cluster-service: "true"
 spec:
   # replicas: not specified here:
@@ -23,7 +23,7 @@ spec:
     metadata:
       labels:
         application: kube-dns
-        version: v1.14.5
+        version: v1.14.10
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -50,7 +50,7 @@ spec:
           optional: true
       containers:
       - name: kubedns
-        image: registry.opensource.zalan.do/teapot/k8s-dns-kube-dns:1.14.5
+        image: registry.opensource.zalan.do/teapot/k8s-dns-kube-dns:1.14.10
         resources:
           limits:
             memory: 170Mi
@@ -95,7 +95,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: registry.opensource.zalan.do/teapot/k8s-dns-dnsmasq-nanny:1.14.5
+        image: registry.opensource.zalan.do/teapot/k8s-dns-dnsmasq-nanny:1.14.10
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -133,7 +133,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: registry.opensource.zalan.do/teapot/k8s-dns-sidecar:1.14.5
+        image: registry.opensource.zalan.do/teapot/k8s-dns-sidecar:1.14.10
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-proxy
-    version: v1.9.4_coreos.0
+    version: v1.9.7_coreos.0
 spec:
   selector:
     matchLabels:
@@ -17,7 +17,7 @@ spec:
       name: kube-proxy
       labels:
         application: kube-proxy
-        version: v1.9.4_coreos.0
+        version: v1.9.7_coreos.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -33,7 +33,7 @@ spec:
       hostNetwork: true
       containers:
       - name: kube-proxy
-        image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.4_coreos.0
+        image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.7_coreos.0
         command:
         - /hyperkube
         - proxy

--- a/cluster/master.clc.yaml
+++ b/cluster/master.clc.yaml
@@ -126,7 +126,7 @@ systemd:
       After=docker.service dockercfg.service meta-data-iptables.service
 
       [Service]
-      Environment=KUBELET_IMAGE_TAG=v1.9.4_coreos.0
+      Environment=KUBELET_IMAGE_TAG=v1.9.7_coreos.0
       Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
       Environment="RKT_RUN_ARGS=--insecure-options=image \
       --uuid-file-save=/var/run/kubelet-pod.uuid \
@@ -264,7 +264,7 @@ storage:
           namespace: kube-system
           labels:
             application: kube-apiserver
-            version: v1.9.4_coreos.0
+            version: v1.9.7_coreos.0
           annotations:
             scheduler.alpha.kubernetes.io/critical-pod: ''
             kubernetes-log-watcher/scalyr-parser: |
@@ -278,7 +278,7 @@ storage:
           hostNetwork: true
           containers:
           - name: kube-apiserver
-            image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.4_coreos.0
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.7_coreos.0
             command:
             - /hyperkube
             - apiserver
@@ -451,7 +451,7 @@ storage:
           namespace: kube-system
           labels:
             application: kube-controller-manager
-            version: v1.9.4_coreos.0
+            version: v1.9.7_coreos.0
           annotations:
             scheduler.alpha.kubernetes.io/critical-pod: ''
         spec:
@@ -462,7 +462,7 @@ storage:
             effect: NoSchedule
           containers:
           - name: kube-controller-manager
-            image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.4_coreos.0
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.7_coreos.0
             command:
             - /hyperkube
             - controller-manager
@@ -523,7 +523,7 @@ storage:
           namespace: kube-system
           labels:
             application: kube-scheduler
-            version: v1.9.4_coreos.0
+            version: v1.9.7_coreos.0
           annotations:
             scheduler.alpha.kubernetes.io/critical-pod: ''
         spec:
@@ -535,7 +535,7 @@ storage:
           hostNetwork: true
           containers:
           - name: kube-scheduler
-            image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.4_coreos.0
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.7_coreos.0
             command:
             - /hyperkube
             - scheduler
@@ -939,7 +939,7 @@ storage:
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
           --net=host \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.4_coreos.0 \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.7_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           label node "$(hostname)" \
@@ -952,7 +952,7 @@ storage:
           --net=host \
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.4_coreos.0 \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.7_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           drain "$(hostname)" \

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -124,7 +124,7 @@ systemd:
       After=docker.service dockercfg.service meta-data-iptables.service
 
       [Service]
-      Environment=KUBELET_IMAGE_TAG=v1.9.4_coreos.0
+      Environment=KUBELET_IMAGE_TAG=v1.9.7_coreos.0
       Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
       Environment="RKT_RUN_ARGS=--insecure-options=image \
       --uuid-file-save=/var/run/kubelet-pod.uuid \
@@ -263,7 +263,7 @@ storage:
           namespace: kube-system
           labels:
             application: kube-apiserver
-            version: v1.9.4_coreos.0
+            version: v1.9.7_coreos.0
           annotations:
             scheduler.alpha.kubernetes.io/critical-pod: ''
             kubernetes-log-watcher/scalyr-parser: |
@@ -277,7 +277,7 @@ storage:
           hostNetwork: true
           containers:
           - name: kube-apiserver
-            image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.4_coreos.0
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.7_coreos.0
             command:
             - /hyperkube
             - apiserver
@@ -450,7 +450,7 @@ storage:
           namespace: kube-system
           labels:
             application: kube-controller-manager
-            version: v1.9.4_coreos.0
+            version: v1.9.7_coreos.0
           annotations:
             scheduler.alpha.kubernetes.io/critical-pod: ''
         spec:
@@ -461,7 +461,7 @@ storage:
             effect: NoSchedule
           containers:
           - name: kube-controller-manager
-            image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.4_coreos.0
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.7_coreos.0
             command:
             - /hyperkube
             - controller-manager
@@ -522,7 +522,7 @@ storage:
           namespace: kube-system
           labels:
             application: kube-scheduler
-            version: v1.9.4_coreos.0
+            version: v1.9.7_coreos.0
           annotations:
             scheduler.alpha.kubernetes.io/critical-pod: ''
         spec:
@@ -534,7 +534,7 @@ storage:
           hostNetwork: true
           containers:
           - name: kube-scheduler
-            image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.4_coreos.0
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.9.7_coreos.0
             command:
             - /hyperkube
             - scheduler
@@ -938,7 +938,7 @@ storage:
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
           --net=host \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.4_coreos.0 \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.7_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           label node "$(hostname)" \
@@ -951,7 +951,7 @@ storage:
           --net=host \
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.4_coreos.0 \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.7_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           drain "$(hostname)" \

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -97,7 +97,7 @@ systemd:
       After=docker.service dockercfg.service meta-data-iptables.service
 
       [Service]
-      Environment=KUBELET_IMAGE_TAG=v1.9.4_coreos.0
+      Environment=KUBELET_IMAGE_TAG=v1.9.7_coreos.0
       Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
       Environment="RKT_RUN_ARGS=--insecure-options=image \
       --uuid-file-save=/var/run/kubelet-pod.uuid \
@@ -298,7 +298,7 @@ storage:
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
           --net=host \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.4_coreos.0 \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.7_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           label node "$(hostname)" \
@@ -311,7 +311,7 @@ storage:
           --net=host \
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.4_coreos.0 \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.7_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           drain "$(hostname)" \

--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -50,7 +50,7 @@ Conditions:
 Mappings:
   Images:
     eu-central-1:
-      StableCoreOSImage: "ami-862140e9"
+      StableCoreOSImage: "ami-604e118b"
 
 SenzaComponents:
   - Configuration:

--- a/cluster/worker.clc.yaml
+++ b/cluster/worker.clc.yaml
@@ -97,7 +97,7 @@ systemd:
       After=docker.service dockercfg.service meta-data-iptables.service
 
       [Service]
-      Environment=KUBELET_IMAGE_TAG=v1.9.4_coreos.0
+      Environment=KUBELET_IMAGE_TAG=v1.9.7_coreos.0
       Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
       Environment="RKT_RUN_ARGS=--insecure-options=image \
       --uuid-file-save=/var/run/kubelet-pod.uuid \
@@ -297,7 +297,7 @@ storage:
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
           --net=host \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.4_coreos.0 \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.7_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           label node "$(hostname)" \
@@ -310,7 +310,7 @@ storage:
           --net=host \
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.4_coreos.0 \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.7_coreos.0 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           drain "$(hostname)" \


### PR DESCRIPTION
* New CoreOS AMI HVM
* Bump Heapster to v1.5.2
* Bump Cluster Autoscaler to v1.1.2
* Bump Kube-DNS to v1.14.10

Signed-off-by: Nick Jüttner <nick.juettner@zalando.de>