### PR TITLE
Update kube-ingress-aws-controller to v0.6.10

### DIFF
--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.6.8
+    version: v0.6.10
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.6.8
+        version: v0.6.10
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
@@ -26,7 +26,7 @@ spec:
         operator: Exists
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.6.8
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.6.10
         args:
         - -stack-termination-protection
         env:


### PR DESCRIPTION
This fixes the issue where CF stack updates remove some certificates from the LB.