### PR TITLE
Enable non-ready-ttl for pdb-controller

### DIFF
--- a/cluster/manifests/pdb-controller/deployment.yaml
+++ b/cluster/manifests/pdb-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: pdb-controller
-    version: v0.0.6
+    version: v0.0.7
 spec:
   selector:
     matchLabels:
@@ -14,14 +14,15 @@ spec:
     metadata:
       labels:
         application: pdb-controller
-        version: v0.0.6
+        version: v0.0.7
     spec:
       serviceAccountName: system
       containers:
       - name: pdb-controller
-        image: registry.opensource.zalan.do/teapot/pdb-controller:v0.0.6
+        image: registry.opensource.zalan.do/teapot/pdb-controller:v0.0.7
         args:
         - --debug
+        - --non-ready-ttl={{if index .ConfigItems "pdb_non_ready_ttl"}}{{.ConfigItems.pdb_non_ready_ttl}}{{else}}1h{{end}}
         resources:
           limits:
             cpu: 200m

--- a/cluster/manifests/pdb-controller/deployment.yaml
+++ b/cluster/manifests/pdb-controller/deployment.yaml
@@ -22,7 +22,9 @@ spec:
         image: registry.opensource.zalan.do/teapot/pdb-controller:v0.0.7
         args:
         - --debug
+        {{ if or (index .ConfigItems "pdb_non_ready_ttl") (eq .Environment "test") }}
         - --non-ready-ttl={{if index .ConfigItems "pdb_non_ready_ttl"}}{{.ConfigItems.pdb_non_ready_ttl}}{{else}}1h{{end}}
+        {{end}}
         resources:
           limits:
             cpu: 200m


### PR DESCRIPTION
This updates the pdb-controller to version v0.0.7 which enables support
for removing managed PDBs when the `--non-ready-ttl` flag is set.

See: https://github.com/mikkeloscar/pdb-controller/pull/14

The default ttl is set to one hour, but can be tweaked per cluster via a
config item: `pdb_non_ready_ttl`.

Signed-off-by: Mikkel Oscar Lyderik Larsen <mikkel.larsen@zalando.de>