### PR TITLE
Add config items for all ZMON components

### DIFF
--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     application: "zmon-agent"
     version: "0.1-a52-zv1"
 spec:
-  replicas: 1
+  replicas: {{if index .ConfigItems "zmon_agent_replicas"}}{{.ConfigItems.zmon_agent_replicas}}{{else}}1{{end}}
   selector:
     matchLabels:
       application: zmon-agent

--- a/cluster/manifests/zmon-aws-agent/deployment.yaml
+++ b/cluster/manifests/zmon-aws-agent/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     application: "zmon-aws-agent"
     version: "v71-zv153"
 spec:
-  replicas: {{ if ne .Alias "db" }}1{{ else }}0{{ end }}
+  replicas: {{if index .ConfigItems "zmon_aws_agent_replicas"}}{{.ConfigItems.zmon_aws_agent_replicas}}{{else}}1{{end}}
   selector:
     matchLabels:
       application: zmon-aws-agent

--- a/cluster/manifests/zmon-redis/deployment.yaml
+++ b/cluster/manifests/zmon-redis/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     application: "zmon-redis"
     version: "v0.1"
 spec:
-  replicas: 1
+  replicas: {{if index .ConfigItems "zmon_redis_replicas"}}{{.ConfigItems.zmon_redis_replicas}}{{else}}1{{end}}
   selector:
     matchLabels:
       application: "zmon-redis"

--- a/cluster/manifests/zmon-scheduler/deployment.yaml
+++ b/cluster/manifests/zmon-scheduler/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     application: zmon-scheduler
     version: "v43"
 spec:
-  replicas: 1
+  replicas: {{if index .ConfigItems "zmon_scheduler_replicas"}}{{.ConfigItems.zmon_scheduler_replicas}}{{else}}1{{end}}
   selector:
     matchLabels:
       application: zmon-scheduler


### PR DESCRIPTION
This makes it possible to not run ZMON in testing but still validate the manifests.