### PR TITLE
Make it possible to not downgrade docker

### DIFF
--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -894,11 +894,13 @@ storage:
           --table nat \
           --to-destination ${PRIVATE_IPV4}:8181
 
+  {{if not (index .Cluster.ConfigItems "upstream_docker")}}
   - filesystem: root
     path: /etc/coreos/docker-1.12
     mode: 0644
     contents:
       inline: yes
+  {{end}}
 
   - filesystem: root
     path: /home/core/.toolboxrc

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -254,11 +254,13 @@ storage:
           --table nat \
           --to-destination ${PRIVATE_IPV4}:8181
 
+  {{if not (index .Cluster.ConfigItems "upstream_docker")}}
   - filesystem: root
     path: /etc/coreos/docker-1.12
     mode: 0644
     contents:
       inline: yes
+  {{end}}
 
   - filesystem: root
     path: /home/core/.toolboxrc


### PR DESCRIPTION
This makes it possible to not downgrade docker to v1.12 by setting the config item: `upstream_docker=yes` in the cluster registry.

This way we can easily try out the default docker version from CoreOS in selected clusters.

Note: Only works for the new node pools.

Reference for the docker downgrade file: https://coreos.com/blog/toward-docker-17-in-container-linux