### PR TITLE
dev-to-alpha

### DIFF
--- a/cluster/manifests/10-vertical-pod-autoscaler/admission-controller-deployment.yaml
+++ b/cluster/manifests/10-vertical-pod-autoscaler/admission-controller-deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vpa-admission-controller
+  namespace: kube-system
+  labels:
+    application: vpa-admission-controller
+    version: v0.1.0
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      application: vpa-admission-controller
+  template:
+    metadata:
+      labels:
+        application: vpa-admission-controller
+        version: v0.1.0
+    spec:
+      serviceAccountName: system
+      containers:
+      - name: admission-controller
+        image: registry.opensource.zalan.do/teapot/vpa-admission-controller:v0.1.0
+        volumeMounts:
+        - name: tls-certs
+          mountPath: "/etc/tls-certs"
+          readOnly: true
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 50m
+            memory: 200Mi
+        ports:
+        - containerPort: 8000
+      volumes:
+      - name: tls-certs
+        secret:
+          secretName: vpa-tls-certs

--- a/cluster/manifests/10-vertical-pod-autoscaler/admission-controller-secret.yaml
+++ b/cluster/manifests/10-vertical-pod-autoscaler/admission-controller-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vpa-tls-certs
+  namespace: kube-system
+type: Opaque
+data:
+  caKey.pem: ""
+  caCert.pem: "{{ .ConfigItems.ca_cert_decompressed }}"
+  serverCert.pem: "{{ .ConfigItems.vpa_webhook_cert }}"
+  serverKey.pem: "{{ .ConfigItems.vpa_webhook_key }}"

--- a/cluster/manifests/10-vertical-pod-autoscaler/admission-controller-service.yaml
+++ b/cluster/manifests/10-vertical-pod-autoscaler/admission-controller-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: vpa-webhook
+  namespace: kube-system
+spec:
+  ports:
+    - port: 443
+      targetPort: 8000
+  selector:
+    application: vpa-admission-controller

--- a/cluster/manifests/10-vertical-pod-autoscaler/recommender-deployment.yaml
+++ b/cluster/manifests/10-vertical-pod-autoscaler/recommender-deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vpa-recommender
+  namespace: kube-system
+  labels:
+    application: vpa-recommender
+    version: v0.1.0
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      application: vpa-recommender
+  template:
+    metadata:
+      labels:
+        application: vpa-recommender
+        version: v0.1.0
+    spec:
+      serviceAccountName: system
+      containers:
+      - name: recommender
+        image: registry.opensource.zalan.do/teapot/vpa-recommender:v0.1.0
+        resources:
+          limits:
+            cpu: 50m
+            memory: 500Mi
+          requests:
+            cpu: 50m
+            memory: 500Mi
+        ports:
+        - containerPort: 8080

--- a/cluster/manifests/10-vertical-pod-autoscaler/updater-deployment.yaml
+++ b/cluster/manifests/10-vertical-pod-autoscaler/updater-deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vpa-updater
+  namespace: kube-system
+  labels:
+    application: vpa-updater
+    version: v0.1.0
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      application: vpa-updater
+  template:
+    metadata:
+      labels:
+        application: vpa-updater
+        version: v0.1.0
+    spec:
+      serviceAccountName: system
+      containers:
+      - name: updater
+        image: registry.opensource.zalan.do/teapot/vpa-updater:v0.1.0
+        resources:
+          limits:
+            cpu: 50m
+            memory: 500Mi
+          requests:
+            cpu: 50m
+            memory: 500Mi
+        ports:
+        - containerPort: 8080

--- a/cluster/manifests/10-vertical-pod-autoscaler/vpa-crd.yaml
+++ b/cluster/manifests/10-vertical-pod-autoscaler/vpa-crd.yaml
@@ -1,0 +1,67 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: verticalpodautoscalers.poc.autoscaling.k8s.io
+spec:
+  group: poc.autoscaling.k8s.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: verticalpodautoscalers
+    singular: verticalpodautoscaler
+    kind: VerticalPodAutoscaler
+    shortNames:
+    - vpa
+  validation:
+    # openAPIV3Schema is the schema for validating custom objects.
+    openAPIV3Schema:
+      properties:
+        spec:
+          required:
+          - selector
+          properties:
+            selector:
+              type: object
+            updatePolicy:
+              properties:
+                updateMode:
+                  type: string
+                  enum:
+                  - "Off"
+                  - "Initial"
+                  - "Auto"
+            resourcePolicy:
+              properties:
+                containerPolicies:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                    - name
+                    properties:
+                      name:
+                        type: string
+                      mode:
+                        type: string
+                        enum:
+                        - "On"
+                        - "Off"
+                      minAllowed:
+                        type: object
+                      maxAllowed:
+                        type: object
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: verticalpodautoscalercheckpoints.poc.autoscaling.k8s.io
+spec:
+  group: poc.autoscaling.k8s.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: verticalpodautoscalercheckpoints
+    singular: verticalpodautoscalercheckpoint
+    kind: VerticalPodAutoscalerCheckpoint
+    shortNames:
+    - vpacheckpoint

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: external-dns
-    version: v0.5.0
+    version: v0.5.1
 spec:
   strategy:
     type: Recreate
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: external-dns
-        version: v0.5.0
+        version: v0.5.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
@@ -26,7 +26,7 @@ spec:
          operator: Exists
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.5.0
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.5.1
         args:
         - --source=service
         - --source=ingress

--- a/cluster/manifests/pdb-controller/deployment.yaml
+++ b/cluster/manifests/pdb-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: pdb-controller
-    version: v0.0.6
+    version: v0.0.7
 spec:
   selector:
     matchLabels:
@@ -14,14 +14,15 @@ spec:
     metadata:
       labels:
         application: pdb-controller
-        version: v0.0.6
+        version: v0.0.7
     spec:
       serviceAccountName: system
       containers:
       - name: pdb-controller
-        image: registry.opensource.zalan.do/teapot/pdb-controller:v0.0.6
+        image: registry.opensource.zalan.do/teapot/pdb-controller:v0.0.7
         args:
         - --debug
+        - --non-ready-ttl={{if index .ConfigItems "pdb_non_ready_ttl"}}{{.ConfigItems.pdb_non_ready_ttl}}{{else}}1h{{end}}
         resources:
           limits:
             cpu: 200m

--- a/cluster/manifests/pdb-controller/deployment.yaml
+++ b/cluster/manifests/pdb-controller/deployment.yaml
@@ -22,7 +22,9 @@ spec:
         image: registry.opensource.zalan.do/teapot/pdb-controller:v0.0.7
         args:
         - --debug
+        {{ if or (index .ConfigItems "pdb_non_ready_ttl") (eq .Environment "test") }}
         - --non-ready-ttl={{if index .ConfigItems "pdb_non_ready_ttl"}}{{.ConfigItems.pdb_non_ready_ttl}}{{else}}1h{{end}}
+        {{end}}
         resources:
           limits:
             cpu: 200m

--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     application: "zmon-agent"
     version: "0.1-a52-zv1"
 spec:
-  replicas: 1
+  replicas: {{if index .ConfigItems "zmon_agent_replicas"}}{{.ConfigItems.zmon_agent_replicas}}{{else}}1{{end}}
   selector:
     matchLabels:
       application: zmon-agent

--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: "visibility"
   labels:
     application: "zmon-agent"
-    version: "0.1-a52-zv1"
+    version: "0.1-a53-zv1"
 spec:
   replicas: {{if index .ConfigItems "zmon_agent_replicas"}}{{.ConfigItems.zmon_agent_replicas}}{{else}}1{{end}}
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: "zmon-agent"
-        version: "0.1-a52-zv1"
+        version: "0.1-a53-zv1"
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -47,7 +47,7 @@ spec:
 
       containers:
         - name: zmon-agent
-          image: "pierone.stups.zalan.do/zmon/zmon-agent-core:0.1-a52-zv1"
+          image: "pierone.stups.zalan.do/zmon/zmon-agent-core:0.1-a53-zv1"
           resources:
             limits:
               cpu: 100m

--- a/cluster/manifests/zmon-aws-agent/deployment.yaml
+++ b/cluster/manifests/zmon-aws-agent/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     application: "zmon-aws-agent"
     version: "v71-zv153"
 spec:
-  replicas: {{ if ne .Alias "db" }}1{{ else }}0{{ end }}
+  replicas: {{if index .ConfigItems "zmon_aws_agent_replicas"}}{{.ConfigItems.zmon_aws_agent_replicas}}{{else}}1{{end}}
   selector:
     matchLabels:
       application: zmon-aws-agent

--- a/cluster/manifests/zmon-redis/deployment.yaml
+++ b/cluster/manifests/zmon-redis/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     application: "zmon-redis"
     version: "v0.1"
 spec:
-  replicas: 1
+  replicas: {{if index .ConfigItems "zmon_redis_replicas"}}{{.ConfigItems.zmon_redis_replicas}}{{else}}1{{end}}
   selector:
     matchLabels:
       application: "zmon-redis"

--- a/cluster/manifests/zmon-scheduler/deployment.yaml
+++ b/cluster/manifests/zmon-scheduler/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     application: zmon-scheduler
     version: "v43"
 spec:
-  replicas: 1
+  replicas: {{if index .ConfigItems "zmon_scheduler_replicas"}}{{.ConfigItems.zmon_scheduler_replicas}}{{else}}1{{end}}
   selector:
     matchLabels:
       application: zmon-scheduler

--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -12,7 +12,7 @@ spec:
     metadata:
       labels:
         application: zmon-worker
-        version: "v191-zv244"
+        version: "v194-zv244"
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -43,7 +43,7 @@ spec:
 
       containers:
         - name: zmon-worker
-          image: "pierone.stups.zalan.do/zmon/zmon-worker:v191-zv244"
+          image: "pierone.stups.zalan.do/zmon/zmon-worker:v194-zv244"
           resources:
             limits:
               cpu: {{if index .ConfigItems "zmon_worker_cpu"}}{{.ConfigItems.zmon_worker_cpu}}{{else}}500m{{end}}

--- a/cluster/master.clc.yaml
+++ b/cluster/master.clc.yaml
@@ -292,11 +292,11 @@ storage:
             - --allow-privileged=true
             - --service-cluster-ip-range=10.3.0.0/16
             - --secure-port=443
-            - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,PodSecurityPolicy,ImagePolicyWebhook,Priority,PersistentVolumeClaimResize
+            - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,PodSecurityPolicy,ImagePolicyWebhook,Priority,MutatingAdmissionWebhook,PersistentVolumeClaimResize
             - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
             - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
             - --service-account-key-file=/etc/kubernetes/ssl/apiserver-key.pem
-            - --runtime-config=extensions/v1beta1/networkpolicies=true,batch/v2alpha1=true,extensions/v1beta1/podsecuritypolicy=true,imagepolicy.k8s.io/v1alpha1=true,authorization.k8s.io/v1beta1=true,scheduling.k8s.io/v1alpha1=true
+            - --runtime-config=extensions/v1beta1/networkpolicies=true,batch/v2alpha1=true,extensions/v1beta1/podsecuritypolicy=true,imagepolicy.k8s.io/v1alpha1=true,authorization.k8s.io/v1beta1=true,scheduling.k8s.io/v1alpha1=true,admissionregistration.k8s.io/v1beta1=true
             - --authentication-token-webhook-config-file=/etc/kubernetes/config/authn.yaml
             - --authentication-token-webhook-cache-ttl=10s
             - --cloud-provider=aws

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -894,11 +894,13 @@ storage:
           --table nat \
           --to-destination ${PRIVATE_IPV4}:8181
 
+  {{if not (index .Cluster.ConfigItems "upstream_docker")}}
   - filesystem: root
     path: /etc/coreos/docker-1.12
     mode: 0644
     contents:
       inline: yes
+  {{end}}
 
   - filesystem: root
     path: /home/core/.toolboxrc

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -291,7 +291,7 @@ storage:
             - --allow-privileged=true
             - --service-cluster-ip-range=10.3.0.0/16
             - --secure-port=443
-            - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,PodSecurityPolicy,ImagePolicyWebhook,Priority,PersistentVolumeClaimResize
+            - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,PodSecurityPolicy,ImagePolicyWebhook,Priority,MutatingAdmissionWebhook,PersistentVolumeClaimResize
             - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
             - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
             - --service-account-key-file=/etc/kubernetes/ssl/apiserver-key.pem

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -254,11 +254,13 @@ storage:
           --table nat \
           --to-destination ${PRIVATE_IPV4}:8181
 
+  {{if not (index .Cluster.ConfigItems "upstream_docker")}}
   - filesystem: root
     path: /etc/coreos/docker-1.12
     mode: 0644
     contents:
       inline: yes
+  {{end}}
 
   - filesystem: root
     path: /home/core/.toolboxrc


### PR DESCRIPTION
Enable non-ready-ttl for pdb-controller
Make it possible to not downgrade docker
Only enable --non-ready-ttl only for test clusters
Enable non-ready-ttl for pdb-controller
This updates the pdb-controller to version v0.0.7 which enables support
for removing managed PDBs when the `--non-ready-ttl` flag is set.
See: https://github.com/mikkeloscar/pdb-controller/pull/14
The default ttl is set to one hour, but can be tweaked per cluster via a
config item: `pdb_non_ready_ttl`.
Update ZMON components
Bump ExternalDNS to v0.5.1
Update ZMON components
Add config items for all ZMON components
This makes it possible to not run ZMON in testing but still validate
the manifests.
chore: bump ExternalDNS to v0.5.1
Add VPA control plane
Adds the control plane for the VerticalPodAutoscaler.
https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler