### PR TITLE
Add worker profile for instance storage instance types

### DIFF
--- a/cluster/node-pools/worker-instance-storage/stack.yaml
+++ b/cluster/node-pools/worker-instance-storage/stack.yaml
@@ -1,0 +1,1 @@
+../worker-default/stack.yaml

--- a/cluster/node-pools/worker-instance-storage/userdata.clc.yaml
+++ b/cluster/node-pools/worker-instance-storage/userdata.clc.yaml
@@ -1,0 +1,345 @@
+# container linux config
+passwd:
+  users:
+  - name: core
+    ssh_authorized_keys:
+    - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC8yXjMX812gbdUsosLvIA/zPrRZI+iOKo8Igq7eiwRTeJKxIkRd2vxDGDfqzCnMhUPPgLW7YM0FWt1u8ZTlXyL4fv1KZuYMRF+27GuU2b/IKu4JYlHDDHrvKCr9tyKb+YVPrAfzi2xVRTGGZG6GRmAiDw8HSUFdejuDLIropAFQu9gAow9aiuQG6kmxZK8qdwIu03eZhuUHCRySCPbusjO+I2JEyVa7lM+P1zt2znDwXsdGjTzHE7NSu5z/VHzho3STWolBm5Vk8uLNYKhjs0eiw/FXV5t+c08Y3JA1LwjAmfOBS23ERSHMG8I3EVSnB9utrdLXejwFAV/jY+Dl2QX9o8brFePBe26MbSg9udD0yfrVz4HEG6NigK6sSx97Zs0lcaSwvjJsnp/J3B1IQMlNRLJGQ7WxM9H2rtoMmD7/iPdADevehEui8C9iaADk6j8AWtN0SJbccSvidrFXW7eH/YSYW394rk8Cl1xBk2RORv3OGVy/RNVt6/Pk/BzvqKf3RvKlbvbFZsWeBSZHDAKeer7001g8HmKV7c8fnDsxIU9Ro3aeWpsX1rQ/jzH1an2deXzVDX1Xbm80VmL5M53dr4w2ZiF5uEIODEUr2nssvl6fhdnaXmbO0vsIyOVawl8mkQ7CBsW06Q+kNs7iDvwVmoG/DD0k4i86La2TBpGvQ== andre.hartmann@zalando.de'
+    - 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAt8djQXfn5U7H85oDzuZRfRONF+jVqn3Mp9t3tnBrJdKyTccfDovq1sekzEdOFdmj74yfS8bzaIO9pDUczy6j5k2MtDCoRnzAO6KZc46jMJ2GjhLArUuHLjmAw2r9LotZ30LEIEvJdmUI7mDlPMczv381PghyM8+DsYv62UrfjDiOsZ4EVkYnztQlO3ntNE16RFNj4fbfErQz67kmw0lB8C6bAf0RuRmvXzB7xRMplmknQnLusoURmySKdZM0GUe0VY6fmqOsgzHVLoEs1m82V8QK1ac/1DSHA91v50MbpCjTVLaRhjR8nmhWBedlhb6j5ClZdAQ8iwyyWC1MFQuvKw== henning@zalando.de'
+    - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDIgO42Rr98DRo4N86Uk4cqHcnbA0iPhL7/DQXRNs+o2vfnfoTVNQiyfq8XzScb+pRJpiq2wW2OthMVRUJsiO4PECw7avYAi0M8cyCsu+ZUoIeMlu+TssWA00GZgdKcQKyCoyLlGbPu2z4GpM9tX+7ASMbMuk6fpm6n9af1YbTm2eqKKXpHDJO+aex3WCj1VyQpCgCD4zquGRy8JRSiQ+QGyGZHIzWWpo3Lc1xGqSQu6L3h4RMrwtZNOjMr/xxxnApOQjBLr70Q8MlYnAhXrIyLjNOaMabMKVxDEltrvN2rCWfN/DFyRi4c5GiDKk1/lwlfO9dRieUqXm9J670PWhwx jan.mussler@zalando.de'
+    - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDOjGGBqrWGdbh0yfkBRE04IbdiAP2TJ2RXnfnp3OV8Lw+jg7cUqeZA5l2vIhFd2ctKPd5OGE3K/A6xCK3hFV9V01oYbH8S3IvrhyA+VjBG0d/ZgTm6GCrlE4XeAt9/ourBSxrrE04lfO786dhLsGEOa5WvvSG3Z/6BhyC/1e5Bd37nnWB363fjAsbg1UgSPr99QZQ5l2mSxN4i2IpJjULBWpLvrJLLJzzl67aaVhDjdtggEU+pMsOoRpDuJ46cYMMDvBI9gyyal2G1aIkqu9iejt1bly53Th2ZAiXecXxEh4K3a5H/Czf70vpCzXQiG1OuZRD1PaSpqw4+zzcizZdX matthias@zalando.de'
+    - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCs4NhH7uwlnklYYlV1GP57XX9NHYgXNv0njfEVowR1jFSKiMdEUtPKz5lOAeDtKpck9HyjxVOTSutNOIBZkkgN/FgkcpNbc59nIO4ELUzipkJivuYNO1lDAjCQi1qwYo+uksiNfcsao9mn7nd9Rh1g8TXYv95TSvml9v/Dolmanm1qj6OkbDw1xIurnNsoCjdxCWwSRGNja4r+PQc8pi+1xpdUBEvn40CeBdU7b/hZnv/BM9FIKSsVlIwMR2i/Co2rxCKo9B3q4dmdQ/2C1QczINVpPQcNUMuiljJFMXvT7dgfNsnUBe8vFuoPgqohJ/m8AiKZZOyoRNiCuELnKLRKqxosDmJz47Y0YiYgZk9jpnmt+x1fwqhY2R85F7W4RybpX3AFL1jOqOT2lE+idkhyeFq/pPoAiPvUcpQSmL9AwlrG6cPklTJZW+dUzH/W6kNlgl/T6hnMn4Mu+IljG08Iyb/HBdmOX+uRq5wdF8lI9Zjzlwg+j7HMa3p1O7MNwpSJVjVXkhUXH0WrFrK2JkwgXokIWvu0o+lajYOmXRQeGCyVybg06WFCzOXnK2toVucFMuAGoM0NkthAnodZCk+xXLNrtHOYagpdJ/x/Q88vuDsZr7IG0NvgX/OCq1a5lpnIydCe+tABNNKcRaOuOLbDYVgUaeVzIXyJjRYu5ZN/JQ== mikkel.larsen@zalando.de'
+    - 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIISHc8p8+ycB9H6SI/i3Uu/OI5G3vYNsZTn0DffPvfOA martin.linkhorst@zalando.de'
+    - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDf3X7MZjYRZD2mI7dvW+c/8dUeDrdqAKZD/C9r+aGa6hWzbGeUZ7cub8to6X9Cl5p3MsTdtFV/OIHRIvxoIGYkz3CRHEBtUdUwOjF9lpBoB/yRMJyxlogmMCm9KGSUM4K+xgIX6qBHq/UeY2Yqumec5lhuLk+7wTmXYQM3+fvvHB8MY//UEadvjuDdotNGQ4jxkJjfoTQj6dspvsZCJ4kIIef9DLSJQ4oCV7sDCVDWPllb3ni9WJYD4vTguI82DI0moQV0WIPplH6rrK+ctVmPyix/IertpqWbiLgmdz3SAyGW45uws2ozGB1S+tZJF+RcNFbbAimoz6QHT+kgL1qmpxa7yba7y3m5pUHqGdhLb+X4Xe3oMZGk7cwBOECw8JUzxzqQKxpF1PfbH8wJ8AiKF7Xr/KJNk9Axsm1zV0DDWv3Z2oK7m8pNiq3mlhv6ovIpXsTq40uaasuLSfmLjSagQDT6ufBAUbaSAJfM0VFo4diIOCDnXH0SX1T8X3EPKbyDg0l/y0pE+FxXQvBK2rzgeynoK5NrvGl1xhJGetbMsl0+WtnIr/PbIQDTo9UQAzOWnHsTs72VqNbeJN4w8ksTqNhXiQO6zlhWqoPL/BeXvRc4N0R8iq9vIstjtuAZkaFsm5TH7Uzz3WTHzKbJ0/5+sefX4cucb/QjImvcVV1UEw== nick.juettner@zalando.de'
+    - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCq3oEP8qhMvGtlR1bgVc9tFOVJ5B5RMKtm6UQ/zXQUpm8DQ04SxdM2U7TfuLien2HSfpHAlYe0eLJZUfIqCXUeZ37v0ozj2RglireEcJm0t9XJ7kTS4kqVxrL6iuN6qQVGHs0vxoo/o9+SP0YkuuJoXwJvVI4yKVbnbfA5hKaAffAYPmfgqOZ7+3AMwmaj/D3tI0xVEA48ptGkj5nnOl0pXlfLRNvbnXOCa/dTKUgkma1F0lXoTipkRspsMEiAnwfJ1dwnzgNzllt//Ao/H+yOVR8fWJ7d+nowszIk6zwUR7c6walxKKf5Oy5bQBU49MZ6xLP1oma9F2+llmV7qpqx rodrigo.reis@zalando.de'
+    - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqAikaHsZWMuJvKZphZPZG0fnKMvVCRfBAbIS6e0Y+YqM0PfsWgB5e4f5TrbisQHdKopbfZVwYIaV/NegEuinrYPKC7t2ese/HjxgjHR95zHOcDP19Cbo+xeyH8zbRd9K3iRSyCUSMNRw5NL6zN8JOSl12m8QWQA4hTjFTmt870fIT4RLxu9qGlbQipUm57E/SotsNC41MQ/PsLQzOAviKrkS1rei2vzRHzAcjz1Z7GT5oH+dFVUC66kKa0XWDvq+VtkRVoLvS2chrIPCgESeeZAyOKyiOoyJxFFFiMVK48MWDBBIYTIsHE0qs/RwBi9+8lQGiHK5Rpk2djcloO0c7 sandor.szuecs@zalando.de'
+    - 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINkh52Py+FvH9CRLDQg0gzvjEIrzwA45yMTXTsl2BVxV alexey.ermakov@zalando.de'
+systemd:
+  units:
+  # disable automatic updates
+  - name: update-engine.service
+    mask: true
+  - name: locksmithd.service
+    mask: true
+
+  # this only works for i3.large instances right now
+  - name: data0.mount
+    enable: true
+    contents: |
+      [Unit]
+      Before=local-fs.target
+
+      [Mount]
+      What=/dev/nvme0n1
+      Where=/data0
+      Type=ext4
+
+      [Install]
+      WantedBy=local-fs.target
+
+  - name: set-hostname.service
+    enable: true
+    contents: |
+      [Unit]
+      Wants=network.target
+      Before=docker.service
+
+      [Service]
+      Type=simple
+      Restart=on-failure
+      RestartSec=1
+      ExecStart=/usr/bin/bash -c "/usr/bin/hostnamectl set-hostname $(/usr/bin/curl --silent --fail http://169.254.169.254/latest/meta-data/local-hostname)"
+
+      [Install]
+      WantedBy=multi-user.target
+
+  - name: docker.service
+    dropins:
+    - name: 40-flannel.conf
+      contents: |
+        [Service]
+        EnvironmentFile=/etc/kubernetes/cni/docker_opts_cni.env
+    - name: 60-dockeropts.conf
+      contents: |
+        [Service]
+        Environment="DOCKER_OPTS=--log-opt=max-file=2 --log-opt=max-size=50m"
+        Environment=DOCKER_SELINUX=
+
+  - name: meta-data-iptables.service
+    enable: true
+    contents: |
+      [Unit]
+      After=network.target
+
+      [Service]
+      Type=simple
+      Restart=on-failure
+      RestartSec=1
+      ExecStart=/opt/bin/meta-data-iptables.sh
+
+      [Install]
+      WantedBy=multi-user.target
+
+  - name: dockercfg.service
+    enable: true
+    contents: |
+      [Unit]
+      After=network.target
+
+      [Service]
+      Type=simple
+      Restart=on-failure
+      RestartSec=5
+      ExecStartPre=/usr/bin/mkdir -p /root/.docker
+      ExecStart=/opt/bin/dockercfg.sh
+
+      [Install]
+      WantedBy=multi-user.target
+
+  - name: timesyncd-enable-network-time.service
+    enable: true
+    contents: |
+      [Service]
+      Type=oneshot
+      ExecStart=/usr/bin/timedatectl set-ntp true
+
+      [Install]
+      WantedBy=multi-user.target
+
+  - name: kubelet.service
+    enable: true
+    contents: |
+      [Unit]
+      After=docker.service dockercfg.service meta-data-iptables.service
+
+      [Service]
+      Environment=KUBELET_IMAGE_TAG=v1.9.7_coreos.0
+      Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
+      Environment="RKT_RUN_ARGS=--insecure-options=image \
+      --uuid-file-save=/var/run/kubelet-pod.uuid \
+      --volume dns,kind=host,source=/etc/resolv.conf \
+      --mount volume=dns,target=/etc/resolv.conf \
+      --volume hosts,kind=host,source=/etc/hosts \
+      --mount volume=hosts,target=/etc/hosts \
+      --volume var-log,kind=host,source=/var/log \
+      --mount volume=var-log,target=/var/log \
+      --volume var-lib-cni,kind=host,source=/var/lib/cni \
+      --mount volume=var-lib-cni,target=/var/lib/cni \
+      --volume dockercfg,kind=host,source=/root/.docker/config.json \
+      --mount volume=dockercfg,target=/root/.docker/config.json \
+      --set-env=HOME=/root"
+      ExecStartPre=/usr/bin/mkdir -p /var/log/containers
+      ExecStartPre=/bin/mkdir -p /var/lib/cni
+      ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
+      ExecStart=/usr/lib/coreos/kubelet-wrapper \
+      --cni-conf-dir=/etc/kubernetes/cni/net.d \
+      --network-plugin=cni \
+      --container-runtime=docker \
+      --rkt-path=/usr/bin/rkt \
+      --register-node \
+      --allow-privileged \
+      --node-labels=kubernetes.io/role=worker \
+      --node-labels=kubernetes.io/node-pool={{ .NodePool.Name }} \
+      --node-labels={{ .Values.node_labels }} \
+      --cluster-dns=10.3.0.10,10.3.0.11 \
+      --cluster-domain=cluster.local \
+      --kubeconfig=/etc/kubernetes/kubeconfig \
+      --require-kubeconfig \
+      --healthz-bind-address=0.0.0.0 \
+      --healthz-port=10248 \
+      --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
+      --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \
+      --cloud-provider=aws \
+      --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true \
+      --system-reserved=cpu=100m,memory=164Mi \
+      --kube-reserved=cpu=100m,memory=282Mi
+      ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
+      Restart=always
+      RestartSec=10
+
+      [Install]
+      WantedBy=multi-user.target
+
+  - name: kube-node-drainer.service
+    enable: true
+    contents: |
+      [Unit]
+      Description=drain this k8s node to make running pods time to gracefully shut down before stopping kubelet
+      After=docker.service kubelet.service
+
+      [Service]
+      Type=oneshot
+      RemainAfterExit=true
+      ExecStart=/bin/true
+      TimeoutStopSec=120s
+      ExecStop=/opt/bin/drain-node
+
+      [Install]
+      WantedBy=multi-user.target
+
+storage:
+  files:
+  - filesystem: root
+    path: /etc/kubernetes/kubeconfig
+    mode: 0644
+    contents:
+      inline: |
+        apiVersion: v1
+        kind: Config
+        clusters:
+        - name: local
+          cluster:
+            server: {{ .Cluster.APIServerURL }}
+        users:
+        - name: kubelet
+          user:
+            token: {{ .Cluster.ConfigItems.worker_shared_secret }}
+        contexts:
+        - context:
+            cluster: local
+            user: kubelet
+          name: kubelet-context
+        current-context: kubelet-context
+
+  - filesystem: root
+    path: /etc/kubernetes/cni/docker_opts_cni.env
+    mode: 0644
+    contents:
+      inline: |
+        DOCKER_OPT_BIP=""
+        DOCKER_OPT_IPMASQ=""
+
+  - filesystem: root
+    path: /etc/kubernetes/ssl/worker.pem
+    mode: 0664
+    contents:
+      remote:
+        url: "data:text/plain;base64,{{ .Cluster.ConfigItems.worker_cert_decompressed }}"
+
+  - filesystem: root
+    path: /etc/kubernetes/ssl/worker-key.pem
+    mode: 0664
+    contents:
+      remote:
+        url: "data:text/plain;base64,{{ .Cluster.ConfigItems.worker_key_decompressed }}"
+
+  - filesystem: root
+    path: /etc/kubernetes/ssl/ca.pem
+    mode: 0664
+    contents:
+      remote:
+        url: "data:text/plain;base64,{{ .Cluster.ConfigItems.ca_cert_decompressed }}"
+
+  - filesystem: root
+    path: /opt/bin/dockercfg.sh
+    mode: 0755
+    contents:
+      inline: |
+        #!/bin/bash
+        set -euo pipefail
+
+        iid="instance-identity-document:$(curl --silent --fail http://169.254.169.254/latest/dynamic/instance-identity/pkcs7)"
+        iid="$(echo -n "$iid" | base64 -w 0)"
+        cat << EOF > /root/.docker/config.json
+        {
+          "auths": {
+            "https://pierone.stups.zalan.do": {
+              "auth": "${iid}"
+            }
+          }
+        }
+        EOF
+
+  - filesystem: root
+    path: /opt/bin/meta-data-iptables.sh
+    mode: 0755
+    contents:
+      inline: |
+        #!/bin/bash
+        set -euo pipefail
+
+        PRIVATE_IPV4="$(/usr/bin/curl --silent --fail http://169.254.169.254/latest/meta-data/local-ipv4)"
+        /usr/sbin/iptables \
+          --append PREROUTING \
+          --protocol tcp \
+          --destination 169.254.169.254 \
+          --dport 80 \
+          --in-interface cni0 \
+          --match tcp \
+          --jump DNAT \
+          --table nat \
+          --to-destination ${PRIVATE_IPV4}:8181
+
+  {{if not (index .Cluster.ConfigItems "upstream_docker")}}
+  - filesystem: root
+    path: /etc/coreos/docker-1.12
+    mode: 0644
+    contents:
+      inline: yes
+  {{end}}
+
+  - filesystem: root
+    path: /home/core/.toolboxrc
+    mode: 0644
+    contents:
+      inline: |
+        TOOLBOX_DOCKER_IMAGE=registry.opensource.zalan.do/teapot/microscope
+        TOOLBOX_DOCKER_TAG=v0.0.4
+
+  - filesystem: root
+    path: /root/.toolboxrc
+    mode: 0644
+    contents:
+      inline: |
+        TOOLBOX_DOCKER_IMAGE=registry.opensource.zalan.do/teapot/microscope
+        TOOLBOX_DOCKER_TAG=v0.0.4
+
+  - filesystem: root
+    path: /etc/systemd/timesyncd.conf
+    mode: 0644
+    contents:
+      inline: |
+        [Time]
+        NTP=169.254.169.123
+
+  - filesystem: root
+    path: /opt/bin/drain-node
+    mode: 0755
+    contents:
+      inline: |
+        #!/bin/bash
+        set -euo pipefail
+
+        /usr/bin/rkt run --insecure-options=image \
+          --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
+          --mount=volume=kube,target=/etc/kubernetes \
+          --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
+          --mount volume=dns,target=/etc/resolv.conf \
+          --net=host \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.7_coreos.0 \
+          --exec=/kubectl -- \
+          --kubeconfig=/etc/kubernetes/kubeconfig \
+          label node "$(hostname)" \
+          lifecycle-status=draining \
+          --overwrite
+
+        /usr/bin/rkt run --insecure-options=image \
+          --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
+          --mount=volume=kube,target=/etc/kubernetes \
+          --net=host \
+          --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
+          --mount volume=dns,target=/etc/resolv.conf \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.9.7_coreos.0 \
+          --exec=/kubectl -- \
+          --kubeconfig=/etc/kubernetes/kubeconfig \
+          drain "$(hostname)" \
+          --ignore-daemonsets \
+          --delete-local-data \
+          --force
+
+  # this only works for i3.large instances
+  filesystems:
+  - name: instance-storage
+    mount:
+      device: /dev/nvme0n1
+      format: ext4
+      wipe_filesystem: true


### PR DESCRIPTION
This adds an extra worker profile which mounts instance storage on boot. The difference from the normal `worker-default` profile is this:

```diff
--- worker-default/userdata.clc.yaml	2018-05-24 11:42:37.920059881 +0200
+++ worker-instance-storage/userdata.clc.yaml	2018-05-24 12:30:48.957095809 +0200
@@ -21,6 +21,21 @@
   - name: locksmithd.service
     mask: true
 
+  # this only works for i3.large instances right now
+  - name: data0.mount
+    enable: true
+    contents: |
+      [Unit]
+      Before=local-fs.target
+
+      [Mount]
+      What=/dev/nvme0n1
+      Where=/data0
+      Type=ext4
+
+      [Install]
+      WantedBy=local-fs.target
+
   - name: set-hostname.service
     enable: true
     contents: |
@@ -320,3 +335,11 @@
           --ignore-daemonsets \
           --delete-local-data \
           --force
+
+  # this only works for i3.large instances
+  filesystems:
+  - name: instance-storage
+    mount:
+      device: /dev/nvme0n1
+      format: ext4
+      wipe_filesystem: true
```

This is to allow Search to use `i3.large` instances with local SSDs.

Note: This is targeting `search-alpha` to test it there first, we should later create a more generic solution which can be applied to all clusters.