### PR TITLE
Only enable auditing in production clusters

### DIFF
--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Environment "production" }}
+{{ if or (eq .Environment "production") (index .ConfigItems "audittrail_url") }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -39,7 +39,7 @@ spec:
         image: pierone.stups.zalan.do/teapot/audittrail-adapter:master-16
         args:
         - --cluster-id={{ .ID }}
-        - --audittrail-url=https://audittrail.cloud.zalando.com
+        - --audittrail-url={{if index .ConfigItems "audittrail_url"}}{{.ConfigItems.audittrail_url}}{{else}}https://audittrail.cloud.zalando.com{{end}}
         - --address=:8889
         - --metrics-address=:7980
         volumeMounts:

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -304,9 +304,11 @@ storage:
             - --admission-control-config-file=/etc/kubernetes/config/image-policy-webhook.yaml
             - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true,ExpandPersistentVolumes=true
             - --anonymous-auth=false
+            {{ if or (eq .Cluster.Environment "production") (index .ConfigItems "audittrail_url") }}
             - --audit-webhook-config-file=/etc/kubernetes/config/audit.yaml
             - --audit-webhook-mode=batch
             - --audit-policy-file=/etc/kubernetes/config/audit-policy.yaml
+            {{ end }}
             # enable aggregated apiservers
             - --client-ca-file=/etc/kubernetes/ssl/ca.pem
             - --requestheader-client-ca-file=/etc/kubernetes/ssl/ca.pem


### PR DESCRIPTION
Only enable auditing in production clusters or if the `audittrail_url`
config item is explicitly set in a cluster. This makes it easy to
integrate with test audittrail to automatically test new versions of the
audittrail-adapter.