### PR TITLE
Revert "fix https://github.com/zalando/skipper/issues/647"

### DIFF
--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.10.7
+    version: v0.9.202
     component: ingress
 spec:
   selector:
@@ -18,7 +18,7 @@ spec:
       name: skipper-ingress
       labels:
         application: skipper-ingress
-        version: v0.10.7
+        version: v0.9.202
         component: ingress
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -40,7 +40,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.7
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.9.202
         ports:
         - name: ingress-port
           containerPort: 9999


### PR DESCRIPTION
This reverts commit 5edeaa3c22671ebefe6429c5f5b59ccf501873d2.

It looks like there's a memory leak in the new version, so let's roll back for now.