### PR TITLE
Automatically restart autoscaler on node pool changes

### DIFF
--- a/cluster/manifests/kube-cluster-autoscaler/autoscaler-deployment.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/autoscaler-deployment.yaml
@@ -19,6 +19,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-autoscaler"
+        config/pool-sizes: "{{range .NodePools}}{{.Name}}-{{.MinSize}}-{{.MaxSize}} {{end}}"
     spec:
       serviceAccountName: system
       tolerations:


### PR DESCRIPTION
This is needed because the autoscaler doesn't handle ASG min/max size changes automatically.