### PR TITLE
Dev to alpha

### DIFF
--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Environment "production" }}
+{{ if or (eq .Environment "production") (index .ConfigItems "audittrail_url") }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -39,7 +39,7 @@ spec:
         image: pierone.stups.zalan.do/teapot/audittrail-adapter:master-16
         args:
         - --cluster-id={{ .ID }}
-        - --audittrail-url=https://audittrail.cloud.zalando.com
+        - --audittrail-url={{if index .ConfigItems "audittrail_url"}}{{.ConfigItems.audittrail_url}}{{else}}https://audittrail.cloud.zalando.com{{end}}
         - --address=:8889
         - --metrics-address=:7980
         volumeMounts:

--- a/cluster/manifests/kube-cluster-autoscaler/autoscaler-deployment.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/autoscaler-deployment.yaml
@@ -19,6 +19,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         iam.amazonaws.com/role: "{{ .LocalID }}-app-autoscaler"
+        config/pool-sizes: "{{range .NodePools}}{{.Name}}-{{.MinSize}}-{{.MaxSize}} {{end}}"
     spec:
       serviceAccountName: system
       tolerations:

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.10.7
+    version: v0.9.202
     component: ingress
 spec:
   selector:
@@ -18,7 +18,7 @@ spec:
       name: skipper-ingress
       labels:
         application: skipper-ingress
-        version: v0.10.7
+        version: v0.9.202
         component: ingress
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -40,7 +40,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.7
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.9.202
         ports:
         - name: ingress-port
           containerPort: 9999

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -63,8 +63,8 @@ spec:
           limits:
             memory: 200Mi
           requests:
-            cpu: 30m
-            memory: 35Mi
+            cpu: 150m
+            memory: 50Mi
         readinessProbe:
           httpGet:
             path: /kube-system/healthz

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -304,7 +304,7 @@ storage:
             - --admission-control-config-file=/etc/kubernetes/config/image-policy-webhook.yaml
             - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true,ExpandPersistentVolumes=true
             - --anonymous-auth=false
-            {{ if or (eq .Cluster.Environment "production") (index .ConfigItems "audittrail_url") }}
+            {{ if or (eq .Cluster.Environment "production") (index .Cluster.ConfigItems "audittrail_url") }}
             - --audit-webhook-config-file=/etc/kubernetes/config/audit.yaml
             - --audit-webhook-mode=batch
             - --audit-policy-file=/etc/kubernetes/config/audit-policy.yaml

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -304,9 +304,11 @@ storage:
             - --admission-control-config-file=/etc/kubernetes/config/image-policy-webhook.yaml
             - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true,ExpandPersistentVolumes=true
             - --anonymous-auth=false
+            {{ if or (eq .Cluster.Environment "production") (index .ConfigItems "audittrail_url") }}
             - --audit-webhook-config-file=/etc/kubernetes/config/audit.yaml
             - --audit-webhook-mode=batch
             - --audit-policy-file=/etc/kubernetes/config/audit-policy.yaml
+            {{ end }}
             # enable aggregated apiservers
             - --client-ca-file=/etc/kubernetes/ssl/ca.pem
             - --requestheader-client-ca-file=/etc/kubernetes/ssl/ca.pem


### PR DESCRIPTION
* Only enable auditing in production clusters or if the `audittrail_url`
* adjust requests for the upper bound of cluster usage (skipper)
* Automatically restart autoscaler on node pool changes