### PR TITLE
Update Emergency Access Service to include list access requests endpoint

### DIFF
--- a/cluster/manifests/emergency-access-service/deployment.yaml
+++ b/cluster/manifests/emergency-access-service/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     application: emergency-access-service
-    version: master-50
+    version: master-54
 spec:
   replicas: 1
   selector:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: emergency-access-service
-        version: master-50
+        version: master-54
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
           [{"container": "emergency-access-service", "parser": "json-structured-log"}]
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: system
       containers:
       - name: emergency-access-service
-        image: "pierone.stups.zalan.do/teapot/emergency-access-service:master-50"
+        image: "pierone.stups.zalan.do/teapot/emergency-access-service:master-54"
         args:
         - --insecure-http
         - --community={{ .Owner }}


### PR DESCRIPTION
This adds a new endpoint `GET /access-requests` which lists all the current pending/approved access requests.