### PR TITLE
Emergency Access Service: Expose expiry time in GET /access-requests

### DIFF
--- a/cluster/manifests/emergency-access-service/deployment.yaml
+++ b/cluster/manifests/emergency-access-service/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     application: emergency-access-service
-    version: master-54
+    version: master-55
 spec:
   replicas: 1
   selector:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: emergency-access-service
-        version: master-54
+        version: master-55
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
           [{"container": "emergency-access-service", "parser": "json-structured-log"}]
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: system
       containers:
       - name: emergency-access-service
-        image: "pierone.stups.zalan.do/teapot/emergency-access-service:master-54"
+        image: "pierone.stups.zalan.do/teapot/emergency-access-service:master-55"
         args:
         - --insecure-http
         - --community={{ .Owner }}


### PR DESCRIPTION
For "beta" channel: expose expiry time in `GET /access-requests` of the emergency-access-service (#1095)