### PR TITLE
update skipper to add timeouts to calls to apiserver

### DIFF
--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.9.202
+    version: v0.10.13
     component: ingress
 spec:
   selector:
@@ -18,7 +18,7 @@ spec:
       name: skipper-ingress
       labels:
         application: skipper-ingress
-        version: v0.9.202
+        version: v0.10.13
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -37,7 +37,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.9.202
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.13
         ports:
         - name: ingress-port
           containerPort: 9999


### PR DESCRIPTION
update skipper to fix the problem of hanging skipper in apiserver call could take long and result in inconsistent routing tables, which could lead to 504 GW timeouts from ALB or skipper depending on the timeout settings used

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>