### PR TITLE
Add missing priority classes on system components

### DIFF
--- a/cluster/manifests/dashboard/deployment.yaml
+++ b/cluster/manifests/dashboard/deployment.yaml
@@ -19,6 +19,7 @@ spec:
         version: v1.6.1
         kubernetes.io/cluster-service: "true"
     spec:
+      priorityClassName: system-cluster-critical
       containers:
       - name: kubernetes-dashboard
         image: registry.opensource.zalan.do/teapot/kubernetes-dashboard:v1.6.1

--- a/cluster/manifests/emergency-access-service/deployment.yaml
+++ b/cluster/manifests/emergency-access-service/deployment.yaml
@@ -21,6 +21,7 @@ spec:
         kubernetes-log-watcher/scalyr-parser: |
           [{"container": "emergency-access-service", "parser": "json-structured-log"}]
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: system
       containers:
       - name: emergency-access-service

--- a/cluster/manifests/etcd-backup/cronjob.yaml
+++ b/cluster/manifests/etcd-backup/cronjob.yaml
@@ -20,6 +20,7 @@ spec:
           annotations:
             iam.amazonaws.com/role: "{{ .LocalID }}-etcd-backup"
         spec:
+          priorityClassName: system-cluster-critical
           restartPolicy: Never
           containers:
           - name: etcd-backup

--- a/cluster/manifests/kube-dns-metrics-bash/deployment.yaml
+++ b/cluster/manifests/kube-dns-metrics-bash/deployment.yaml
@@ -17,6 +17,7 @@ spec:
         application: kube-dns-metrics-bash
         version: v0.0.4
     spec:
+      priorityClassName: system-cluster-critical
       containers:
         - image: pierone.stups.zalan.do/teapot/kube-dns-metrics-bash:v0.0.5
           name: kube-dns-metrics-bash

--- a/cluster/manifests/kube-dns-metrics/deployment.yaml
+++ b/cluster/manifests/kube-dns-metrics/deployment.yaml
@@ -17,6 +17,7 @@ spec:
         application: kube-dns-metrics
         version: v1.0.2
     spec:
+      priorityClassName: system-cluster-critical
       containers:
         - image: pierone.stups.zalan.do/teapot/kube-dns-metrics:v1.0.2
           name: kube-dns-metrics

--- a/cluster/manifests/kube-state-metrics/deployment.yaml
+++ b/cluster/manifests/kube-state-metrics/deployment.yaml
@@ -17,6 +17,7 @@ spec:
         application: kube-state-metrics
         version: v1.3.0
     spec:
+      priorityClassName: system-cluster-critical
       containers:
       - image: registry.opensource.zalan.do/teapot/kube-state-metrics:v1.3.0
         name: kube-state-metrics


### PR DESCRIPTION
We should avoid preemption of kube-system components, and now that some of them have priority all of them should have it.