### PR TITLE
Use dnsPolicy: Default for cluster autoscaler

### DIFF
--- a/cluster/manifests/kube-cluster-autoscaler/deployment.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/deployment.yaml
@@ -22,6 +22,7 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: system
+      dnsPolicy: Default
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule


### PR DESCRIPTION
Using kube-dns means that we can't scale-up from 0, since the autoscaler won't be able to resolve any addresses. Since it doesn't really use any addresses we can safely run it with `dnsPolicy: Default`.