### PR TITLE
Set default memory scale to 0.9

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1,7 +1,7 @@
 # Autoscaling settings
 autoscaling_buffer_pools: "worker"
 autoscaling_buffer_cpu_scale: "1"
-autoscaling_buffer_memory_scale: "1"
+autoscaling_buffer_memory_scale: "0.9"
 autoscaling_buffer_cpu_reserved: "1"
 autoscaling_buffer_memory_reserved: "1500Mi"
 {{if eq .Environment "production"}}


### PR DESCRIPTION
We actually have less memory available, which is a problem on large instances. Use 90% or 1500Mi, which should cover both cases.