### PR TITLE
Reduce the memory scaling coefficient to 0.85

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1,7 +1,7 @@
 # Autoscaling settings
 autoscaling_buffer_pools: "worker"
 autoscaling_buffer_cpu_scale: "1"
-autoscaling_buffer_memory_scale: "0.9"
+autoscaling_buffer_memory_scale: "0.85"
 autoscaling_buffer_cpu_reserved: "1"
 autoscaling_buffer_memory_reserved: "1500Mi"
 {{if eq .Environment "production"}}


### PR DESCRIPTION
m5 instances have even less memory available, so 0.9 wouldn't work for m5.xlarge. Let's just reduce to 0.85 and see if we can get this information from somewhere.