### PR TITLE
Cherry pick autoscaling changes to beta

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1,7 +1,7 @@
 # Autoscaling settings
 autoscaling_buffer_pools: "worker"
 autoscaling_buffer_cpu_scale: "1"
-autoscaling_buffer_memory_scale: "1"
+autoscaling_buffer_memory_scale: "0.9"
 autoscaling_buffer_cpu_reserved: "1"
 autoscaling_buffer_memory_reserved: "1500Mi"
 {{if eq .Environment "production"}}

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1,7 +1,7 @@
 # Autoscaling settings
 autoscaling_buffer_pools: "worker"
 autoscaling_buffer_cpu_scale: "1"
-autoscaling_buffer_memory_scale: "0.9"
+autoscaling_buffer_memory_scale: "0.85"
 autoscaling_buffer_cpu_reserved: "1"
 autoscaling_buffer_memory_reserved: "1500Mi"
 {{if eq .Environment "production"}}


### PR DESCRIPTION
Cherry-picking #1116, #1117 to beta so we can properly deal with m5 instances.