### PR TITLE
Remove obsolete stack parameters (Legacy pools step 4/4)

### DIFF
--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -15,40 +15,6 @@ SenzaInfo:
       - EtcdStackName:
           Description: "AWS Stack name of the etcd cluster"
           Default: "etcd-cluster-etcd"
-      # Deprecated parameters default to null values
-      - UserDataMaster:
-          Description: "User data of master"
-          Default: ""
-      - UserDataWorker:
-          Description: "User data of worker"
-          Default: ""
-      - MasterNodePoolName:
-          Description: "Name of the master node pool (ASG)"
-          Default: ""
-      - WorkerNodePoolName:
-          Description: "Name of the worker node pool (ASG)"
-          Default: ""
-      - MasterNodes:
-          Description: "Number of master nodes"
-          Default: 0
-      - WorkerNodes:
-          Description: "Number of worker nodes"
-          Default: 0
-      - MinimumWorkerNodes:
-          Description: "Minimum number of nodes in the worker ASG"
-          Default: 0
-      - MaximumWorkerNodes:
-          Description: "Maximum number of nodes in the worker ASG"
-          Default: 0
-      - MasterInstanceType:
-          Description: "Type of instance for master nodes"
-          Default: "m3.medium"
-      - InstanceType:
-          Description: "Type of instance"
-          Default: "m3.medium"
-      - WorkerSpotPrice:
-          Description: "Spot price for worker nodes, not used if empty"
-          Default: ""
 
 SenzaComponents:
   - Configuration:


### PR DESCRIPTION
Step 4/4 to remove legacy node pools:
* make CLM tolerate missing legacy node pool stack and userdata files (https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/49)
* update stack to remove legacy resources and set "empty" default values for to-be-removed stack parameters (https://github.com/zalando-incubator/kubernetes-on-aws/pull/1091)
* stop specifying stack parameters in CLM. Default stack values from step 2 will take over. (https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/46)
* finally remove unused stack parameters from stack config (https://github.com/zalando-incubator/kubernetes-on-aws/pull/1121) <==

Purpose of this PR:
* final version drops all obsolete stack parameters without replacement.