### PR TITLE
Upgrade logging-agent

### DIFF
--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: logging-agent
-    version: v0.17
+    version: v0.18
     component: logging
 spec:
   selector:
@@ -18,7 +18,7 @@ spec:
       name: logging-agent
       labels:
         application: logging-agent
-        version: v0.17
+        version: v0.18
         component: logging
     spec:
       priorityClassName: system-node-critical
@@ -73,7 +73,7 @@ spec:
           mountPath: /mnt/scalyr-checkpoint
       containers:
       - name: log-watcher
-        image: registry.opensource.zalan.do/eagleeye/kubernetes-log-watcher:0.17
+        image: registry.opensource.zalan.do/eagleeye/kubernetes-log-watcher:0.18
         env:
         - name: CLUSTER_NODE_NAME
           valueFrom:


### PR DESCRIPTION
Changes:

- Fix logs with missing pod metadata labels and annotations
- log-watcher will now make an API call for every pod instead of using cached pod per namespace. This is to overcome some race condition were container config files are available before their corresponding pods. Log-watcher will ignore containers with no pods until the next watcher iteration.
- This issue is mainly visible in cronjob/job pods.