### PR TITLE
use path-prefix match instead of kubernetes regexp path match

### DIFF
--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.10.13
+    version: v0.10.20
     component: ingress
 spec:
   selector:
@@ -18,7 +18,7 @@ spec:
       name: skipper-ingress
       labels:
         application: skipper-ingress
-        version: v0.10.13
+        version: v0.10.20
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -37,7 +37,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.13
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.20
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -46,6 +46,7 @@ spec:
           - "skipper"
           - "-kubernetes"
           - "-kubernetes-in-cluster"
+          - "-kubernetes-path-mode=path-prefix"
           - "-address=:9999"
           - "-proxy-preserve-host"
           - "-serve-host-metrics"


### PR DESCRIPTION
v0.10.20 
* will fix tokeninfo filters to work for longer time
* switch to -kubernetes-path-mode=path-prefix will change the behaviour of path matches to be non kubernetes api compliant, but kubernetes user doc compliant and more obvious