### PR TITLE
Fix azID in templates

### DIFF
--- a/cluster/node-pools/worker-multiaz/stack.yaml
+++ b/cluster/node-pools/worker-multiaz/stack.yaml
@@ -18,8 +18,8 @@ Resources:
 {{ with $azCount := azCount $data.Values.subnets }}
 {{ range $az, $subnets := $data.Values.subnets }}
 {{ if ne $az "*" }}
-{{ with $azId := azId $az }}
-  AutoScalingGroup{{$azId}}:
+{{ with $azID := azID $az }}
+  AutoScalingGroup{{$azID}}:
     CreationPolicy:
       ResourceSignal:
         Count: '0'
@@ -48,9 +48,9 @@ Resources:
         Value: owned
       VPCZoneIdentifier: !Split [",", "{{$subnets}}"]
     Type: 'AWS::AutoScaling::AutoScalingGroup'
-  AutoscalingLifecycleHook{{$azId}}:
+  AutoscalingLifecycleHook{{$azID}}:
     Properties:
-      AutoScalingGroupName: !Ref AutoScalingGroup{{$azId}}
+      AutoScalingGroupName: !Ref AutoScalingGroup{{$azID}}
       LifecycleHookName: "kube-node-ready-lifecycle-hook"
       DefaultResult: CONTINUE
       HeartbeatTimeout: '600'


### PR DESCRIPTION
`azId` was renamed to `azID`, but I forgot to update the template.