### PR TITLE
Add support for node pool taints via config items

### DIFF
--- a/cluster/manifests/kube-node-ready/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       priorityClassName: system-node-critical
       tolerations:
-      - key: node-role.kubernetes.io/master
+      - operator: Exists
         effect: NoSchedule
       containers:
       - name: kube-node-ready

--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       priorityClassName: system-node-critical
       tolerations:
-      - key: node-role.kubernetes.io/master
+      - operator: Exists
         effect: NoSchedule
       hostNetwork: true
       containers:

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       priorityClassName: system-node-critical
       tolerations:
-      - key: node-role.kubernetes.io/master
+      - operator: Exists
         effect: NoSchedule
       initContainers:
       - name: init-scalyr-config

--- a/cluster/manifests/prometheus-node-exporter/daemonset.yaml
+++ b/cluster/manifests/prometheus-node-exporter/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       priorityClassName: system-node-critical
       tolerations:
-      - key: node-role.kubernetes.io/master
+      - operator: Exists
         effect: NoSchedule
       containers:
       - image: registry.opensource.zalan.do/teapot/prometheus-node-exporter:v0.14.0

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -25,6 +25,7 @@ spec:
           [{"container": "skipper-ingress", "parser": "skipper-access-log"}]
     spec:
       priorityClassName: system-node-critical
+      tolerations:
       - key: dedicated
         effect: NoSchedule
       affinity:

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -26,17 +26,10 @@ spec:
     spec:
       priorityClassName: system-node-critical
       tolerations:
-      - key: dedicated
+      - operator: Exists
         effect: NoSchedule
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/role
-                operator: NotIn
-                values:
-                - master
+      nodeSelector:
+        kubernetes.io/role=worker
       hostNetwork: true
       containers:
       - name: skipper-ingress

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
       - operator: Exists
         effect: NoSchedule
       nodeSelector:
-        kubernetes.io/role=worker
+        kubernetes.io/role: worker
       hostNetwork: true
       containers:
       - name: skipper-ingress

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -26,8 +26,8 @@ spec:
     spec:
       priorityClassName: system-node-critical
       tolerations:
-      - operator: Exists
-        effect: NoSchedule
+      - key: dedicated
+        operator: Exists
       nodeSelector:
         kubernetes.io/role: worker
       hostNetwork: true

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -25,6 +25,8 @@ spec:
           [{"container": "skipper-ingress", "parser": "skipper-access-log"}]
     spec:
       priorityClassName: system-node-critical
+      - key: dedicated
+        effect: NoSchedule
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -160,6 +160,7 @@ systemd:
       --network-plugin=cni \
       --container-runtime=docker \
       --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
+      --register-with-taints={{if index .NodePool.ConfigItems "taints"}}{{.NodePool.ConfigItems.taints}}{{end}} \
       --allow-privileged \
       --node-labels=node-role.kubernetes.io/master,kubernetes.io/role=master,master=true \
       --node-labels=kubernetes.io/node-pool={{ .NodePool.Name }} \

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -159,8 +159,7 @@ systemd:
       --cni-conf-dir=/etc/kubernetes/cni/net.d \
       --network-plugin=cni \
       --container-runtime=docker \
-      --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
-      --register-with-taints={{if index .NodePool.ConfigItems "taints"}}{{.NodePool.ConfigItems.taints}}{{end}} \
+      --register-with-taints=node-role.kubernetes.io/master=:NoSchedule{{if index .NodePool.ConfigItems "taints"}},{{.NodePool.ConfigItems.taints}}{{end}} \
       --allow-privileged \
       --node-labels=node-role.kubernetes.io/master,kubernetes.io/role=master,master=true \
       --node-labels=kubernetes.io/node-pool={{ .NodePool.Name }} \

--- a/cluster/node-pools/worker-default/stack.yaml
+++ b/cluster/node-pools/worker-default/stack.yaml
@@ -38,6 +38,14 @@ Resources:
       - Key: k8s.io/cluster-autoscaler/node-template/label/lifecycle-status
         PropagateAtLaunch: true
         Value: ready
+{{- if index .NodePool.ConfigItems "taints"}}
+  {{- range split .NodePool.ConfigItems.taints ","}}
+    {{- $taint := split . "="}}
+      - Key: k8s.io/cluster-autoscaler/node-template/taint/{{index $taint 0}}
+        PropagateAtLaunch: true
+        Value: {{index $taint 1}}
+  {{- end}}
+{{end}}
       - Key: 'zalando.de/cluster-local-id/{{ .Cluster.LocalID }}'
         PropagateAtLaunch: true
         Value: owned

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -134,6 +134,7 @@ systemd:
       --cni-conf-dir=/etc/kubernetes/cni/net.d \
       --network-plugin=cni \
       --container-runtime=docker \
+      --register-with-taints={{if index .NodePool.ConfigItems "taints"}}{{.NodePool.ConfigItems.taints}}{{end}} \
       --register-node \
       --allow-privileged \
       --node-labels=kubernetes.io/role=worker \

--- a/cluster/node-pools/worker-multiaz/stack.yaml
+++ b/cluster/node-pools/worker-multiaz/stack.yaml
@@ -43,6 +43,14 @@ Resources:
       - Key: k8s.io/cluster-autoscaler/node-template/label/lifecycle-status
         PropagateAtLaunch: true
         Value: ready
+{{- if index .NodePool.ConfigItems "taints"}}
+  {{- range split .NodePool.ConfigItems.taints ","}}
+    {{- $taint := split . "="}}
+      - Key: k8s.io/cluster-autoscaler/node-template/taint/{{index $taint 0}}
+        PropagateAtLaunch: true
+        Value: {{index $taint 1}}
+  {{- end}}
+{{end}}
       - Key: 'zalando.de/cluster-local-id/{{ $data.Cluster.LocalID }}'
         PropagateAtLaunch: true
         Value: owned


### PR DESCRIPTION
* add taints from a specific config item to master and worker node pools
* tolerate the `dedicated` taint for core components (where not already present)

todo:
- [x] node-labels (we use the node-pool label for node selection)
- [x] taints exposed as launch config tags