### PR TITLE
Run the custom cluster autoscaler build

### DIFF
--- a/cluster/manifests/kube-cluster-autoscaler/deployment.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-cluster-autoscaler
-    version: v1.2.0
+    version: v1.2.2-teapot14
 spec:
   replicas: 2
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-cluster-autoscaler
-        version: v1.2.0
+        version: v1.2.2-teapot14
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-autoscaler"
         config/pool-sizes: "{{range .NodePools}}{{.Name}}-{{.MinSize}}-{{.MaxSize}} {{end}}"
@@ -28,7 +28,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cluster-autoscaler
-        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.2.0
+        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler-custom:v1.2.2-teapot14
         command:
           - ./cluster-autoscaler
           - --v=4
@@ -39,6 +39,7 @@ spec:
           - --expendable-pods-priority-cutoff=-1000000
           - --skip-nodes-with-system-pods=false
           - --skip-nodes-with-local-storage=false
+          - --scale-up-cloud-provider-template=true
         resources:
           limits:
             cpu: 100m


### PR DESCRIPTION
Change the autoscaler to our own fork and enable the new behaviour where it creates template nodes using information from the launch configuration (see https://github.com/kubernetes/autoscaler/issues/789 for details). This fixes a number of issues:
 * autoscaling works correctly when we change the instance type
 * database pods will trigger scale-up so we don't need to baby-sit the clusters during upgrades
 * autoscaler will correctly handle multi-AZ ASGs for zone-restricted pods instead of just getting stuck.

Let's test this internally for now, I'll send a PR upstream later.