### PR TITLE
Don't touch non-owned ingress resources

### DIFF
--- a/cluster/manifests/ingress-template-controller/deployment.yaml
+++ b/cluster/manifests/ingress-template-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: ingress-template-controller
-    version: master-4
+    version: master-5
 spec:
   replicas: 1
   selector:
@@ -15,13 +15,13 @@ spec:
     metadata:
       labels:
         application: ingress-template-controller
-        version: master-4
+        version: master-5
     spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: system
       containers:
       - name: ingress-template-controller
-        image: pierone.stups.zalan.do/teapot/ingress-template-controller:master-4
+        image: pierone.stups.zalan.do/teapot/ingress-template-controller:master-5
         resources:
           limits:
             cpu: 10m


### PR DESCRIPTION
This updates the ingress-template-controller to a version which does not manage ingress resources it doesn't own.