### PR TITLE
Expose node labels as tags for the autoscaler

### DIFF
--- a/cluster/node-pools/worker-default/stack.yaml
+++ b/cluster/node-pools/worker-default/stack.yaml
@@ -32,6 +32,9 @@ Resources:
       - Key: k8s.io/role/node
         PropagateAtLaunch: true
         Value: worker
+      - Key: kubernetes.io/role
+        PropagateAtLaunch: true
+        Value: worker
       - Key: k8s.io/cluster-autoscaler/enabled
         PropagateAtLaunch: true
         Value: ''

--- a/cluster/node-pools/worker-default/stack.yaml
+++ b/cluster/node-pools/worker-default/stack.yaml
@@ -38,6 +38,12 @@ Resources:
       - Key: k8s.io/cluster-autoscaler/enabled
         PropagateAtLaunch: true
         Value: ''
+      - Key: k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role
+        PropagateAtLaunch: true
+        Value: worker
+      - Key: k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/node-pool
+        PropagateAtLaunch: true
+        Value: {{ .NodePool.Name }}
       - Key: k8s.io/cluster-autoscaler/node-template/label/lifecycle-status
         PropagateAtLaunch: true
         Value: ready

--- a/cluster/node-pools/worker-multiaz/stack.yaml
+++ b/cluster/node-pools/worker-multiaz/stack.yaml
@@ -37,6 +37,9 @@ Resources:
       - Key: k8s.io/role/node
         PropagateAtLaunch: true
         Value: worker
+      - Key: kubernetes.io/role
+        PropagateAtLaunch: true
+        Value: worker
       - Key: k8s.io/cluster-autoscaler/enabled
         PropagateAtLaunch: true
         Value: ''

--- a/cluster/node-pools/worker-multiaz/stack.yaml
+++ b/cluster/node-pools/worker-multiaz/stack.yaml
@@ -43,6 +43,12 @@ Resources:
       - Key: k8s.io/cluster-autoscaler/enabled
         PropagateAtLaunch: true
         Value: ''
+      - Key: k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role
+        PropagateAtLaunch: true
+        Value: worker
+      - Key: k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/node-pool
+        PropagateAtLaunch: true
+        Value: {{ .NodePool.Name }}
       - Key: k8s.io/cluster-autoscaler/node-template/label/lifecycle-status
         PropagateAtLaunch: true
         Value: ready


### PR DESCRIPTION
This exposes additonal node labels as AWS tags so that the autoscaler can create the correct node templates.

It also adds an additional role label with the - by now it seems - agreed upon name. The old one is used by our ingress controller and can be removed here once it's not used there anymore.