### PR TITLE
Deploy kube-node-ready-controller

### DIFF
--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -28,8 +28,10 @@ spec:
               - key: node-role.kubernetes.io/master
                 operator: Exists
       tolerations:
-      - key: node-role.kubernetes.io/master
+      - operator: Exists
         effect: NoSchedule
+      - operator: Exists
+        effect: NoExecute
       hostNetwork: true
       containers:
       - name: audittrail-adapter

--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -72,8 +72,6 @@ spec:
         effect: NoSchedule
       - operator: Exists
         effect: NoExecute
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
       volumes:
       - name: flannel-cfg
         configMap:

--- a/cluster/manifests/kube-dns/node-local-daemonset.yaml
+++ b/cluster/manifests/kube-dns/node-local-daemonset.yaml
@@ -19,8 +19,6 @@ spec:
       priorityClassName: system-node-critical
       serviceAccountName: system
       tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
       - operator: Exists
         effect: NoSchedule
       - operator: Exists

--- a/cluster/manifests/kube-node-ready-controller/deployment.yaml
+++ b/cluster/manifests/kube-node-ready-controller/deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-node-ready-controller
+  namespace: kube-system
+  labels:
+    application: kube-node-ready-controller
+    version: v0.0.3
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      application: kube-node-ready-controller
+  template:
+    metadata:
+      labels:
+        application: kube-node-ready-controller
+        version: v0.0.3
+    spec:
+      tolerations:
+      - key: zalando.org/node-not-ready
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      containers:
+      - name: kube-node-ready-controller
+        image: registry.opensource.zalan.do/teapot/kube-node-ready-controller:v0.0.3
+        args:
+        - --not-ready-taint-name=zalando.org/node-not-ready
+        # only handle worker nodes
+        - --node-selector=kubernetes.io/role=worker
+        # format <namespace>:<labelKey>=<labelValue>,+
+        - "--pod-selector=kube-system:application=kube2iam"
+        - "--pod-selector=kube-system:application=kube-proxy"
+        - "--pod-selector=kube-system:application=logging-agent"
+        - "--pod-selector=kube-system:application=prometheus-node-exporter"
+        - "--pod-selector=kube-system:application=flannel"
+        - "--pod-selector=kube-system:application=kube-node-ready"
+        - "--pod-selector=kube-system:application=dnsmasq-node"
+        resources:
+          limits:
+            cpu: 20m
+            memory: 50Mi
+          requests:
+            cpu: 20m
+            memory: 50Mi
+      nodeSelector:
+        node-role.kubernetes.io/master: ""

--- a/cluster/manifests/kube-node-ready/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready/daemonset.yaml
@@ -24,6 +24,8 @@ spec:
       tolerations:
       - operator: Exists
         effect: NoSchedule
+      - operator: Exists
+        effect: NoExecute
       containers:
       - name: kube-node-ready
         image: registry.opensource.zalan.do/teapot/kube-node-ready:v0.0.1

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -25,8 +25,6 @@ spec:
         effect: NoSchedule
       - operator: Exists
         effect: NoExecute
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
       hostNetwork: true
       containers:
       - name: kube-proxy

--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -22,6 +22,8 @@ spec:
       tolerations:
       - operator: Exists
         effect: NoSchedule
+      - operator: Exists
+        effect: NoExecute
       hostNetwork: true
       containers:
       # kube2iam 0.9.0 with these patchs https://github.com/jtblin/kube2iam/pull/108, https://github.com/jtblin/kube2iam/pull/130

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -25,6 +25,8 @@ spec:
       tolerations:
       - operator: Exists
         effect: NoSchedule
+      - operator: Exists
+        effect: NoExecute
       initContainers:
       - name: init-scalyr-config
         image: registry.opensource.zalan.do/stups/alpine:3.7.0-1

--- a/cluster/manifests/prometheus-node-exporter/daemonset.yaml
+++ b/cluster/manifests/prometheus-node-exporter/daemonset.yaml
@@ -25,6 +25,8 @@ spec:
       tolerations:
       - operator: Exists
         effect: NoSchedule
+      - operator: Exists
+        effect: NoExecute
       containers:
       - image: registry.opensource.zalan.do/teapot/prometheus-node-exporter:v0.14.0
         name: prometheus-node-exporter


### PR DESCRIPTION
This deploys the [kube-node-ready-controller](https://github.com/mikkeloscar/kube-node-ready-controller) which will look for non-ready nodes in the cluster (specified by a taint on the node) and remove the taint if all specified daemonset pods are ready on the node. This is to ensure user pods doesn't start up until all system pods has started.

This will slow down node startup time, but it is the intention to prevent issues with flannel not propagating updates fast enough.

This is step 1/2. Next step is to roll out nodes where kubelet is configured with a `--register-with-taints` flag.


### TODO

* [x] push image to registry.opensource.zalan.do