### PR TITLE
Run flannel via etcd-proxy

### DIFF
--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -35,6 +35,17 @@ spec:
         - name: flannel-cfg
           mountPath: /etc/kube-flannel/
       containers:
+      - name: apiserver-proxy
+        image: registry.opensource.zalan.do/teapot/etcd-proxy:master-3
+        command:
+        - /bin/sh
+        args:
+        - -c
+        - "exec /etcd-proxy --listen-address 127.0.0.1:333 $KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT"
+        resources:
+          requests:
+            cpu: 25m
+            memory: 25Mi
       - name: kube-flannel
         image: registry.opensource.zalan.do/teapot/flannel:v0.10.0
         command:
@@ -44,6 +55,10 @@ spec:
         - --kube-subnet-mgr
         - --v=2
         env:
+        - name: KUBERNETES_SERVICE_HOST
+          value: "127.0.0.1"
+        - name: KUBERNETES_SERVICE_PORT
+          value: "333"
         - name: POD_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
Kubernetes client-go apparently doesn't have any timeouts whatsoever, which causes issues when we roll the master nodes because flannel might get stuck for minutes until the kernel closes the apiserver connection. Let's run it through `etcd-proxy` as a mitigation.