### PR TITLE
Allow evicting any number of buffer pods

### DIFF
--- a/cluster/manifests/kube-cluster-autoscaler/pdb.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/pdb.yaml
@@ -1,0 +1,12 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    application: autoscaling-buffer
+  name: autoscaling-buffer
+  namespace: kube-system
+spec:
+  maxUnavailable: "100%"
+  selector:
+    matchLabels:
+      application: autoscaling-buffer


### PR DESCRIPTION
We didn't notice that pdb-controller created a PDB for the buffer pods, preventing users' stuff from getting scheduled ASAP. :(