### PR TITLE
dev-to-alpha

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -9,3 +9,20 @@ autoscaling_buffer_pods: "3"
 {{else}}
 autoscaling_buffer_pods: "0"
 {{end}}
+
+# Monitoring settings
+{{if eq .Environment "e2e"}}
+logging_agent_enabled: "false"
+zmon_agent_replicas: "0"
+zmon_aws_agent_replicas: "0"
+zmon_redis_replicas: "0"
+zmon_scheduler_replicas: "0"
+zmon_worker_replicas: "0"
+{{else}}
+logging_agent_enabled: "true"
+zmon_agent_replicas: "1"
+zmon_aws_agent_replicas: "1"
+zmon_redis_replicas: "1"
+zmon_scheduler_replicas: "1"
+zmon_worker_replicas: "4"
+{{end}}

--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -28,8 +28,10 @@ spec:
               - key: node-role.kubernetes.io/master
                 operator: Exists
       tolerations:
-      - key: node-role.kubernetes.io/master
+      - operator: Exists
         effect: NoSchedule
+      - operator: Exists
+        effect: NoExecute
       hostNetwork: true
       containers:
       - name: audittrail-adapter

--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -35,6 +35,17 @@ spec:
         - name: flannel-cfg
           mountPath: /etc/kube-flannel/
       containers:
+      - name: apiserver-proxy
+        image: registry.opensource.zalan.do/teapot/etcd-proxy:master-3
+        command:
+        - /bin/sh
+        args:
+        - -c
+        - "exec /etcd-proxy --listen-address 127.0.0.1:333 $KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT"
+        resources:
+          requests:
+            cpu: 25m
+            memory: 25Mi
       - name: kube-flannel
         image: registry.opensource.zalan.do/teapot/flannel:v0.10.0
         command:
@@ -44,6 +55,10 @@ spec:
         - --kube-subnet-mgr
         - --v=2
         env:
+        - name: KUBERNETES_SERVICE_HOST
+          value: "127.0.0.1"
+        - name: KUBERNETES_SERVICE_PORT
+          value: "333"
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -72,8 +72,6 @@ spec:
         effect: NoSchedule
       - operator: Exists
         effect: NoExecute
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
       volumes:
       - name: flannel-cfg
         configMap:

--- a/cluster/manifests/ingress-template-controller/deployment.yaml
+++ b/cluster/manifests/ingress-template-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: ingress-template-controller
-    version: master-4
+    version: master-5
 spec:
   replicas: 1
   selector:
@@ -15,13 +15,13 @@ spec:
     metadata:
       labels:
         application: ingress-template-controller
-        version: master-4
+        version: master-5
     spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: system
       containers:
       - name: ingress-template-controller
-        image: pierone.stups.zalan.do/teapot/ingress-template-controller:master-4
+        image: pierone.stups.zalan.do/teapot/ingress-template-controller:master-5
         resources:
           limits:
             cpu: 10m

--- a/cluster/manifests/kube-cluster-autoscaler/pdb.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/pdb.yaml
@@ -1,0 +1,12 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    application: autoscaling-buffer
+  name: autoscaling-buffer
+  namespace: kube-system
+spec:
+  maxUnavailable: "100%"
+  selector:
+    matchLabels:
+      application: autoscaling-buffer

--- a/cluster/manifests/kube-dns/node-local-daemonset.yaml
+++ b/cluster/manifests/kube-dns/node-local-daemonset.yaml
@@ -19,8 +19,6 @@ spec:
       priorityClassName: system-node-critical
       serviceAccountName: system
       tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
       - operator: Exists
         effect: NoSchedule
       - operator: Exists

--- a/cluster/manifests/kube-node-ready-controller/deployment.yaml
+++ b/cluster/manifests/kube-node-ready-controller/deployment.yaml
@@ -19,6 +19,7 @@ spec:
         application: kube-node-ready-controller
         version: v0.0.3
     spec:
+      serviceAccountName: system
       tolerations:
       - key: zalando.org/node-not-ready
         operator: Exists

--- a/cluster/manifests/kube-node-ready-controller/deployment.yaml
+++ b/cluster/manifests/kube-node-ready-controller/deployment.yaml
@@ -36,7 +36,9 @@ spec:
         # format <namespace>:<labelKey>=<labelValue>,+
         - "--pod-selector=kube-system:application=kube2iam"
         - "--pod-selector=kube-system:application=kube-proxy"
+{{ if eq .ConfigItems.logging_agent_enabled "true" }}
         - "--pod-selector=kube-system:application=logging-agent"
+{{ end }}
         - "--pod-selector=kube-system:application=prometheus-node-exporter"
         - "--pod-selector=kube-system:application=flannel"
         - "--pod-selector=kube-system:application=kube-node-ready"

--- a/cluster/manifests/kube-node-ready-controller/deployment.yaml
+++ b/cluster/manifests/kube-node-ready-controller/deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-node-ready-controller
+  namespace: kube-system
+  labels:
+    application: kube-node-ready-controller
+    version: v0.0.3
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      application: kube-node-ready-controller
+  template:
+    metadata:
+      labels:
+        application: kube-node-ready-controller
+        version: v0.0.3
+    spec:
+      tolerations:
+      - key: zalando.org/node-not-ready
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      containers:
+      - name: kube-node-ready-controller
+        image: registry.opensource.zalan.do/teapot/kube-node-ready-controller:v0.0.3
+        args:
+        - --not-ready-taint-name=zalando.org/node-not-ready
+        # only handle worker nodes
+        - --node-selector=kubernetes.io/role=worker
+        # format <namespace>:<labelKey>=<labelValue>,+
+        - "--pod-selector=kube-system:application=kube2iam"
+        - "--pod-selector=kube-system:application=kube-proxy"
+        - "--pod-selector=kube-system:application=logging-agent"
+        - "--pod-selector=kube-system:application=prometheus-node-exporter"
+        - "--pod-selector=kube-system:application=flannel"
+        - "--pod-selector=kube-system:application=kube-node-ready"
+        - "--pod-selector=kube-system:application=dnsmasq-node"
+        resources:
+          limits:
+            cpu: 20m
+            memory: 50Mi
+          requests:
+            cpu: 20m
+            memory: 50Mi
+      nodeSelector:
+        node-role.kubernetes.io/master: ""

--- a/cluster/manifests/kube-node-ready/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       priorityClassName: system-node-critical
       tolerations:
-      - key: node-role.kubernetes.io/master
+      - operator: Exists
         effect: NoSchedule
       containers:
       - name: kube-node-ready

--- a/cluster/manifests/kube-node-ready/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready/daemonset.yaml
@@ -1,3 +1,5 @@
+{{ $version := "v0.0.2" }}
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -5,7 +7,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-node-ready
-    version: v0.0.1
+    version: {{$version}}
 spec:
   selector:
     matchLabels:
@@ -16,7 +18,7 @@ spec:
     metadata:
       labels:
         application: kube-node-ready
-        version: v0.0.1
+        version: {{$version}}
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-kube-node-ready"
     spec:
@@ -28,9 +30,10 @@ spec:
         effect: NoExecute
       containers:
       - name: kube-node-ready
-        image: registry.opensource.zalan.do/teapot/kube-node-ready:v0.0.1
+        image: registry.opensource.zalan.do/teapot/kube-node-ready:{{$version}}
         args:
         - --lifecycle-hook=kube-node-ready-lifecycle-hook
+        - --startup-delay=3m
         resources:
           limits:
             cpu: 50m
@@ -38,3 +41,9 @@ spec:
           requests:
             cpu: 20m
             memory: 20Mi
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 10
+          timeoutSeconds: 300

--- a/cluster/manifests/kube-node-ready/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready/daemonset.yaml
@@ -24,6 +24,8 @@ spec:
       tolerations:
       - operator: Exists
         effect: NoSchedule
+      - operator: Exists
+        effect: NoExecute
       containers:
       - name: kube-node-ready
         image: registry.opensource.zalan.do/teapot/kube-node-ready:v0.0.1

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -25,8 +25,6 @@ spec:
         effect: NoSchedule
       - operator: Exists
         effect: NoExecute
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
       hostNetwork: true
       containers:
       - name: kube-proxy

--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -22,6 +22,8 @@ spec:
       tolerations:
       - operator: Exists
         effect: NoSchedule
+      - operator: Exists
+        effect: NoExecute
       hostNetwork: true
       containers:
       # kube2iam 0.9.0 with these patchs https://github.com/jtblin/kube2iam/pull/108, https://github.com/jtblin/kube2iam/pull/130

--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       priorityClassName: system-node-critical
       tolerations:
-      - key: node-role.kubernetes.io/master
+      - operator: Exists
         effect: NoSchedule
       hostNetwork: true
       containers:

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -25,6 +25,8 @@ spec:
       tolerations:
       - operator: Exists
         effect: NoSchedule
+      - operator: Exists
+        effect: NoExecute
       initContainers:
       - name: init-scalyr-config
         image: registry.opensource.zalan.do/stups/alpine:3.7.0-1

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -1,3 +1,4 @@
+{{ if eq .ConfigItems.logging_agent_enabled "true" }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -182,3 +183,4 @@ spec:
       - name: scalyr-logs
         hostPath:
           path: /var/log/scalyr-agent
+{{ end }}

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       priorityClassName: system-node-critical
       tolerations:
-      - key: node-role.kubernetes.io/master
+      - operator: Exists
         effect: NoSchedule
       initContainers:
       - name: init-scalyr-config

--- a/cluster/manifests/prometheus-node-exporter/daemonset.yaml
+++ b/cluster/manifests/prometheus-node-exporter/daemonset.yaml
@@ -25,6 +25,8 @@ spec:
       tolerations:
       - operator: Exists
         effect: NoSchedule
+      - operator: Exists
+        effect: NoExecute
       containers:
       - image: registry.opensource.zalan.do/teapot/prometheus-node-exporter:v0.14.0
         name: prometheus-node-exporter

--- a/cluster/manifests/prometheus-node-exporter/daemonset.yaml
+++ b/cluster/manifests/prometheus-node-exporter/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       priorityClassName: system-node-critical
       tolerations:
-      - key: node-role.kubernetes.io/master
+      - operator: Exists
         effect: NoSchedule
       containers:
       - image: registry.opensource.zalan.do/teapot/prometheus-node-exporter:v0.14.0

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -25,6 +25,7 @@ spec:
           [{"container": "skipper-ingress", "parser": "skipper-access-log"}]
     spec:
       priorityClassName: system-node-critical
+      tolerations:
       - key: dedicated
         effect: NoSchedule
       affinity:

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -26,17 +26,10 @@ spec:
     spec:
       priorityClassName: system-node-critical
       tolerations:
-      - key: dedicated
+      - operator: Exists
         effect: NoSchedule
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/role
-                operator: NotIn
-                values:
-                - master
+      nodeSelector:
+        kubernetes.io/role=worker
       hostNetwork: true
       containers:
       - name: skipper-ingress

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
       - operator: Exists
         effect: NoSchedule
       nodeSelector:
-        kubernetes.io/role=worker
+        kubernetes.io/role: worker
       hostNetwork: true
       containers:
       - name: skipper-ingress

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -26,8 +26,8 @@ spec:
     spec:
       priorityClassName: system-node-critical
       tolerations:
-      - operator: Exists
-        effect: NoSchedule
+      - key: dedicated
+        operator: Exists
       nodeSelector:
         kubernetes.io/role: worker
       hostNetwork: true

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -25,6 +25,8 @@ spec:
           [{"container": "skipper-ingress", "parser": "skipper-access-log"}]
     spec:
       priorityClassName: system-node-critical
+      - key: dedicated
+        effect: NoSchedule
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     application: "zmon-agent"
     version: "0.1-a53-zv1"
 spec:
-  replicas: {{if index .ConfigItems "zmon_agent_replicas"}}{{.ConfigItems.zmon_agent_replicas}}{{else}}1{{end}}
+  replicas: {{.ConfigItems.zmon_agent_replicas}}
   selector:
     matchLabels:
       application: zmon-agent

--- a/cluster/manifests/zmon-aws-agent/deployment.yaml
+++ b/cluster/manifests/zmon-aws-agent/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     application: "zmon-aws-agent"
     version: "v71-zv153"
 spec:
-  replicas: {{if index .ConfigItems "zmon_aws_agent_replicas"}}{{.ConfigItems.zmon_aws_agent_replicas}}{{else}}1{{end}}
+  replicas: {{.ConfigItems.zmon_aws_agent_replicas}}
   selector:
     matchLabels:
       application: zmon-aws-agent

--- a/cluster/manifests/zmon-redis/deployment.yaml
+++ b/cluster/manifests/zmon-redis/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     application: "zmon-redis"
     version: "v0.1"
 spec:
-  replicas: {{if index .ConfigItems "zmon_redis_replicas"}}{{.ConfigItems.zmon_redis_replicas}}{{else}}1{{end}}
+  replicas: {{.ConfigItems.zmon_redis_replicas}}
   selector:
     matchLabels:
       application: "zmon-redis"

--- a/cluster/manifests/zmon-scheduler/deployment.yaml
+++ b/cluster/manifests/zmon-scheduler/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     application: zmon-scheduler
     version: "v43"
 spec:
-  replicas: {{if index .ConfigItems "zmon_scheduler_replicas"}}{{.ConfigItems.zmon_scheduler_replicas}}{{else}}1{{end}}
+  replicas: {{.ConfigItems.zmon_scheduler_replicas}}
   selector:
     matchLabels:
       application: zmon-scheduler

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -160,6 +160,7 @@ systemd:
       --network-plugin=cni \
       --container-runtime=docker \
       --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
+      --register-with-taints={{if index .NodePool.ConfigItems "taints"}}{{.NodePool.ConfigItems.taints}}{{end}} \
       --allow-privileged \
       --node-labels=node-role.kubernetes.io/master,kubernetes.io/role=master,master=true \
       --node-labels=kubernetes.io/node-pool={{ .NodePool.Name }} \

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -159,8 +159,7 @@ systemd:
       --cni-conf-dir=/etc/kubernetes/cni/net.d \
       --network-plugin=cni \
       --container-runtime=docker \
-      --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
-      --register-with-taints={{if index .NodePool.ConfigItems "taints"}}{{.NodePool.ConfigItems.taints}}{{end}} \
+      --register-with-taints=node-role.kubernetes.io/master=:NoSchedule{{if index .NodePool.ConfigItems "taints"}},{{.NodePool.ConfigItems.taints}}{{end}} \
       --allow-privileged \
       --node-labels=node-role.kubernetes.io/master,kubernetes.io/role=master,master=true \
       --node-labels=kubernetes.io/node-pool={{ .NodePool.Name }} \

--- a/cluster/node-pools/worker-default/stack.yaml
+++ b/cluster/node-pools/worker-default/stack.yaml
@@ -32,6 +32,9 @@ Resources:
       - Key: k8s.io/role/node
         PropagateAtLaunch: true
         Value: worker
+      - Key: kubernetes.io/role
+        PropagateAtLaunch: true
+        Value: worker
       - Key: k8s.io/cluster-autoscaler/enabled
         PropagateAtLaunch: true
         Value: ''

--- a/cluster/node-pools/worker-default/stack.yaml
+++ b/cluster/node-pools/worker-default/stack.yaml
@@ -38,6 +38,12 @@ Resources:
       - Key: k8s.io/cluster-autoscaler/enabled
         PropagateAtLaunch: true
         Value: ''
+      - Key: k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role
+        PropagateAtLaunch: true
+        Value: worker
+      - Key: k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/node-pool
+        PropagateAtLaunch: true
+        Value: {{ .NodePool.Name }}
       - Key: k8s.io/cluster-autoscaler/node-template/label/lifecycle-status
         PropagateAtLaunch: true
         Value: ready

--- a/cluster/node-pools/worker-default/stack.yaml
+++ b/cluster/node-pools/worker-default/stack.yaml
@@ -38,6 +38,14 @@ Resources:
       - Key: k8s.io/cluster-autoscaler/node-template/label/lifecycle-status
         PropagateAtLaunch: true
         Value: ready
+{{- if index .NodePool.ConfigItems "taints"}}
+  {{- range split .NodePool.ConfigItems.taints ","}}
+    {{- $taint := split . "="}}
+      - Key: k8s.io/cluster-autoscaler/node-template/taint/{{index $taint 0}}
+        PropagateAtLaunch: true
+        Value: {{index $taint 1}}
+  {{- end}}
+{{end}}
       - Key: 'zalando.de/cluster-local-id/{{ .Cluster.LocalID }}'
         PropagateAtLaunch: true
         Value: owned

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -134,6 +134,7 @@ systemd:
       --cni-conf-dir=/etc/kubernetes/cni/net.d \
       --network-plugin=cni \
       --container-runtime=docker \
+      --register-with-taints={{if index .NodePool.ConfigItems "taints"}}{{.NodePool.ConfigItems.taints}}{{end}} \
       --register-node \
       --allow-privileged \
       --node-labels=kubernetes.io/role=worker \

--- a/cluster/node-pools/worker-multiaz/stack.yaml
+++ b/cluster/node-pools/worker-multiaz/stack.yaml
@@ -37,6 +37,9 @@ Resources:
       - Key: k8s.io/role/node
         PropagateAtLaunch: true
         Value: worker
+      - Key: kubernetes.io/role
+        PropagateAtLaunch: true
+        Value: worker
       - Key: k8s.io/cluster-autoscaler/enabled
         PropagateAtLaunch: true
         Value: ''

--- a/cluster/node-pools/worker-multiaz/stack.yaml
+++ b/cluster/node-pools/worker-multiaz/stack.yaml
@@ -43,6 +43,12 @@ Resources:
       - Key: k8s.io/cluster-autoscaler/enabled
         PropagateAtLaunch: true
         Value: ''
+      - Key: k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role
+        PropagateAtLaunch: true
+        Value: worker
+      - Key: k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/node-pool
+        PropagateAtLaunch: true
+        Value: {{ .NodePool.Name }}
       - Key: k8s.io/cluster-autoscaler/node-template/label/lifecycle-status
         PropagateAtLaunch: true
         Value: ready

--- a/cluster/node-pools/worker-multiaz/stack.yaml
+++ b/cluster/node-pools/worker-multiaz/stack.yaml
@@ -43,6 +43,14 @@ Resources:
       - Key: k8s.io/cluster-autoscaler/node-template/label/lifecycle-status
         PropagateAtLaunch: true
         Value: ready
+{{- if index .NodePool.ConfigItems "taints"}}
+  {{- range split .NodePool.ConfigItems.taints ","}}
+    {{- $taint := split . "="}}
+      - Key: k8s.io/cluster-autoscaler/node-template/taint/{{index $taint 0}}
+        PropagateAtLaunch: true
+        Value: {{index $taint 1}}
+  {{- end}}
+{{end}}
       - Key: 'zalando.de/cluster-local-id/{{ $data.Cluster.LocalID }}'
         PropagateAtLaunch: true
         Value: owned

--- a/cluster/node-pools/worker-multiaz/stack.yaml
+++ b/cluster/node-pools/worker-multiaz/stack.yaml
@@ -48,12 +48,12 @@ Resources:
         Value: worker
       - Key: k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/node-pool
         PropagateAtLaunch: true
-        Value: {{ .NodePool.Name }}
+        Value: {{ $data.NodePool.Name }}
       - Key: k8s.io/cluster-autoscaler/node-template/label/lifecycle-status
         PropagateAtLaunch: true
         Value: ready
-{{- if index .NodePool.ConfigItems "taints"}}
-  {{- range split .NodePool.ConfigItems.taints ","}}
+{{- if index $data.NodePool.ConfigItems "taints"}}
+  {{- range split $data.NodePool.ConfigItems.taints ","}}
     {{- $taint := split . "="}}
       - Key: k8s.io/cluster-autoscaler/node-template/taint/{{index $taint 0}}
         PropagateAtLaunch: true


### PR DESCRIPTION
* **kube-node-ready: add a startup delay**
   <sup>Merge pull request #1158 from zalando-incubator/node-ready-startup-delay</sup>
* **Ignore logging-agent in e2e clusters**
   <sup>Merge pull request #1159 from zalando-incubator/fix-tests</sup>
* **Use system serviceAccount to update nodes**
   <sup>Merge pull request #1157 from zalando-incubator/kube-node-ready-controller-sa</sup>
* **Deploy kube-node-ready-controller**
   <sup>Merge pull request #1151 from zalando-incubator/kube-node-ready-controller</sup>
* **Allow evicting any number of buffer pods**
   <sup>Merge pull request #1155 from zalando-incubator/autoscaling-buffer-pdb</sup>
* **Run flannel via etcd-proxy**
   <sup>Merge pull request #1153 from zalando-incubator/flannel-proxy</sup>
* **Use correct NodePool struct for multi-az worker profile**
   <sup>Merge pull request #1152 from zalando-incubator/node-pool-config-items</sup>
* **Add support for node pool taints via config items**
   <sup>Merge pull request #1145 from zalando-incubator/node-pool-config-items</sup>
* **Expose node labels as tags for the autoscaler**
   <sup>Merge pull request #1150 from zalando-incubator/expose-node-labels</sup>
* **Don't touch non-owned ingress resources**
   <sup>Merge pull request #1147 from zalando-incubator/ingress-template-controller-update</sup>