### PR TITLE
Ignore logging-agent in e2e clusters

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -9,3 +9,20 @@ autoscaling_buffer_pods: "3"
 {{else}}
 autoscaling_buffer_pods: "0"
 {{end}}
+
+# Monitoring settings
+{{if eq .Environment "e2e"}}
+logging_agent_enabled: "false"
+zmon_agent_replicas: "0"
+zmon_aws_agent_replicas: "0"
+zmon_redis_replicas: "0"
+zmon_scheduler_replicas: "0"
+zmon_worker_replicas: "0"
+{{else}}
+logging_agent_enabled: "true"
+zmon_agent_replicas: "1"
+zmon_aws_agent_replicas: "1"
+zmon_redis_replicas: "1"
+zmon_scheduler_replicas: "1"
+zmon_worker_replicas: "4"
+{{end}}

--- a/cluster/manifests/kube-node-ready-controller/deployment.yaml
+++ b/cluster/manifests/kube-node-ready-controller/deployment.yaml
@@ -36,7 +36,9 @@ spec:
         # format <namespace>:<labelKey>=<labelValue>,+
         - "--pod-selector=kube-system:application=kube2iam"
         - "--pod-selector=kube-system:application=kube-proxy"
+{{ if eq .ConfigItems.logging_agent_enabled "true" }}
         - "--pod-selector=kube-system:application=logging-agent"
+{{ end }}
         - "--pod-selector=kube-system:application=prometheus-node-exporter"
         - "--pod-selector=kube-system:application=flannel"
         - "--pod-selector=kube-system:application=kube-node-ready"

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -1,3 +1,4 @@
+{{ if eq .ConfigItems.logging_agent_enabled "true" }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -182,3 +183,4 @@ spec:
       - name: scalyr-logs
         hostPath:
           path: /var/log/scalyr-agent
+{{ end }}

--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     application: "zmon-agent"
     version: "0.1-a53-zv1"
 spec:
-  replicas: {{if index .ConfigItems "zmon_agent_replicas"}}{{.ConfigItems.zmon_agent_replicas}}{{else}}1{{end}}
+  replicas: {{.ConfigItems.zmon_agent_replicas}}
   selector:
     matchLabels:
       application: zmon-agent

--- a/cluster/manifests/zmon-aws-agent/deployment.yaml
+++ b/cluster/manifests/zmon-aws-agent/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     application: "zmon-aws-agent"
     version: "v71-zv153"
 spec:
-  replicas: {{if index .ConfigItems "zmon_aws_agent_replicas"}}{{.ConfigItems.zmon_aws_agent_replicas}}{{else}}1{{end}}
+  replicas: {{.ConfigItems.zmon_aws_agent_replicas}}
   selector:
     matchLabels:
       application: zmon-aws-agent

--- a/cluster/manifests/zmon-redis/deployment.yaml
+++ b/cluster/manifests/zmon-redis/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     application: "zmon-redis"
     version: "v0.1"
 spec:
-  replicas: {{if index .ConfigItems "zmon_redis_replicas"}}{{.ConfigItems.zmon_redis_replicas}}{{else}}1{{end}}
+  replicas: {{.ConfigItems.zmon_redis_replicas}}
   selector:
     matchLabels:
       application: "zmon-redis"

--- a/cluster/manifests/zmon-scheduler/deployment.yaml
+++ b/cluster/manifests/zmon-scheduler/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     application: zmon-scheduler
     version: "v43"
 spec:
-  replicas: {{if index .ConfigItems "zmon_scheduler_replicas"}}{{.ConfigItems.zmon_scheduler_replicas}}{{else}}1{{end}}
+  replicas: {{.ConfigItems.zmon_scheduler_replicas}}
   selector:
     matchLabels:
       application: zmon-scheduler


### PR DESCRIPTION
This fixes the e2e clusters, which currently wait forever for `logging-agent` to start.