### PR TITLE
Taint worker nodes not-ready on startup

### DIFF
--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -134,7 +134,7 @@ systemd:
       --cni-conf-dir=/etc/kubernetes/cni/net.d \
       --network-plugin=cni \
       --container-runtime=docker \
-      --register-with-taints={{if index .NodePool.ConfigItems "taints"}}{{.NodePool.ConfigItems.taints}}{{end}} \
+      --register-with-taints=zalando.org/node-not-ready=:NoSchedule{{if index .NodePool.ConfigItems "taints"}},{{.NodePool.ConfigItems.taints}}{{end}} \
       --register-node \
       --allow-privileged \
       --node-labels=kubernetes.io/role=worker \


### PR DESCRIPTION
This is the follow up to #1151 for tainting worker nodes as not ready on startup. They will then be marked ready when the `kube-node-ready-controller` removes the taint after all expected daemonset pods has started.