### PR TITLE
Apply security best practices (ro rootfs, runAsUser)

### DIFF
--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -52,6 +52,10 @@ spec:
           requests:
             cpu: 20m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
       volumes:
       - name: platform-iam-credentials
         secret:

--- a/cluster/manifests/dashboard/deployment.yaml
+++ b/cluster/manifests/dashboard/deployment.yaml
@@ -38,3 +38,7 @@ spec:
             port: 9090
           initialDelaySeconds: 30
           timeoutSeconds: 30
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000

--- a/cluster/manifests/emergency-access-service/deployment.yaml
+++ b/cluster/manifests/emergency-access-service/deployment.yaml
@@ -67,6 +67,10 @@ spec:
           requests:
             cpu: 50m
             memory: 100Mi
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
       volumes:
       - name: platform-iam-credentials
         secret:

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -39,3 +39,7 @@ spec:
           requests:
             cpu: 25m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -40,6 +40,7 @@ spec:
             cpu: 25m
             memory: 20Mi
         securityContext:
-          readOnlyRootFilesystem: true
+          # see https://github.com/kubernetes-incubator/external-dns/issues/595
+          readOnlyRootFilesystem: false
           runAsNonRoot: true
           runAsUser: 1000

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -65,3 +65,7 @@ spec:
             port: 9999
           initialDelaySeconds: 5
           timeoutSeconds: 5
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000


### PR DESCRIPTION
Apply security best practices such as read-only container file system and running as non-root. Some relevant links:

* https://kubernetes.io/blog/2016/08/security-best-practices-kubernetes-deployment/
* https://github.com/Shopify/kubeaudit

I only applied it for some manifests to get started.