### PR TITLE
Enable volume mount for node pools with instance_storage

### DIFF
--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -22,6 +22,24 @@ systemd:
   - name: locksmithd.service
     mask: true
 
+  # this should only be enabled for instances with instance storage. e.g.
+  # i3.large instances
+  {{if index .NodePool.ConfigItems "instance_storage"}}
+  - name: data-disk0.mount
+    enable: true
+    contents: |
+      [Unit]
+      Before=local-fs.target
+
+      [Mount]
+      What=/dev/nvme0n1
+      Where=/data/disk0
+      Type=ext4
+
+      [Install]
+      WantedBy=local-fs.target
+  {{end}}
+
   - name: set-hostname.service
     enable: true
     contents: |
@@ -124,11 +142,14 @@ systemd:
       --mount volume=var-log,target=/var/log \
       --volume var-lib-cni,kind=host,source=/var/lib/cni \
       --mount volume=var-lib-cni,target=/var/lib/cni \
+      --volume data,kind=host,source=/data \
+      --mount volume=data,target=/data \
       --volume dockercfg,kind=host,source=/root/.docker/config.json \
       --mount volume=dockercfg,target=/root/.docker/config.json \
       --set-env=HOME=/root"
       ExecStartPre=/usr/bin/mkdir -p /var/log/containers
       ExecStartPre=/bin/mkdir -p /var/lib/cni
+      ExecStartPre=/bin/mkdir -p /data
       ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
       ExecStart=/usr/lib/coreos/kubelet-wrapper \
       --cni-conf-dir=/etc/kubernetes/cni/net.d \
@@ -333,3 +354,14 @@ storage:
           --ignore-daemonsets \
           --delete-local-data \
           --force
+
+  # this should only be enabled for instances with instance storage. e.g.
+  # i3.large instances
+  {{if index .NodePool.ConfigItems "instance_storage"}}
+  filesystems:
+  - name: instance-storage
+    mount:
+      device: /dev/nvme0n1
+      format: ext4
+      wipe_filesystem: true
+  {{end}}


### PR DESCRIPTION
This allows enabling local storage config for certain node pools. This is needed by search and we need to merge the search changes back in to the main channels before it gets out of hand to maintain a separate `search-alpha` branch.

This is a very simple way of allowing this feature. It's not very flexible, but I think we can iterate on this later.

It defines `/data` as the standard place for mounting storage, by default it will just be an empty directory on the root disk.