### PR TITLE
Use required affinity for autoscaling pods

### DIFF
--- a/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment.yaml
@@ -19,16 +19,14 @@ spec:
     spec:
       affinity:
         podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                  - key: application
-                    operator: In
-                    values:
-                    - autoscaling-buffer
-                topologyKey: failure-domain.beta.kubernetes.io/zone
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: application
+                operator: In
+                values:
+                - autoscaling-buffer
+            topologyKey: failure-domain.beta.kubernetes.io/zone
       priorityClassName: autoscaling-buffer
       terminationGracePeriodSeconds: 0
       containers:


### PR DESCRIPTION
This makes the scaling a bit more fair, since the autoscaler doesn't really handle preferred affinities. It won't allow us to use more than 3 pods, however, but if we ever want this we can just split into 3 different deployments, one for each AZ.