### PR TITLE
hotfix blue green deployments creted 500s caused by a skipper route matching issue

### DIFF
--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.10.13
+    version: v0.10.26
     component: ingress
 spec:
   selector:
@@ -18,7 +18,7 @@ spec:
       name: skipper-ingress
       labels:
         application: skipper-ingress
-        version: v0.10.13
+        version: v0.10.26
         component: ingress
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -40,7 +40,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.13
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.26
         ports:
         - name: ingress-port
           containerPort: 9999


### PR DESCRIPTION
Once we have a decision of the loadbalancer group made by one decision route, we made it impossible to match the decision route again, which triggered the infinite loop. Infinite loop was triggered in ~10% of the calls, dependent on the Traffic() predicate setting.