### PR TITLE
external-dns v0.5.3

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: external-dns
-    version: v0.5.2
+    version: v0.5.3
 spec:
   strategy:
     type: Recreate
@@ -16,14 +16,14 @@ spec:
     metadata:
       labels:
         application: external-dns
-        version: v0.5.2
+        version: v0.5.3
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
     spec:
       priorityClassName: system-cluster-critical
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.5.2
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.5.3
         args:
         - --source=service
         - --source=ingress


### PR DESCRIPTION
Includes:

* Print a message if no hosted zones match (aws provider) (#592) @svend
* Add support for NodePort services (#559) @grimmy
* Update azure.md to fix protocol value (#593) @JasonvanBrackel
* Add cache to limit calls to providers (#589) @jessfraz
* Add Azure MSI support (#578) @r7vme
* CoreDNS/SkyDNS provider (#253) @istalker2

Signed-off-by: Nick Jüttner <nick@zalando.de>