### PR TITLE
Update kube-node-ready-controller. Add timeouts and retries

### DIFF
--- a/cluster/manifests/kube-node-ready-controller/deployment.yaml
+++ b/cluster/manifests/kube-node-ready-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-node-ready-controller
-    version: v0.0.3
+    version: v0.0.4
 spec:
   replicas: 1
   strategy:
@@ -17,7 +17,7 @@ spec:
     metadata:
       labels:
         application: kube-node-ready-controller
-        version: v0.0.3
+        version: v0.0.4
     spec:
       serviceAccountName: system
       tolerations:
@@ -28,7 +28,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: kube-node-ready-controller
-        image: registry.opensource.zalan.do/teapot/kube-node-ready-controller:v0.0.3
+        image: registry.opensource.zalan.do/teapot/kube-node-ready-controller:v0.0.4
         args:
         - --not-ready-taint-name=zalando.org/node-not-ready
         # only handle worker nodes


### PR DESCRIPTION
Updates kube-node-ready-controller to include timeouts in client-go calls and also do retries when updating node taints.

https://github.com/mikkeloscar/kube-node-ready-controller/pull/6
https://github.com/mikkeloscar/kube-node-ready-controller/pull/7