### PR TITLE
Autoscaling buffer: use nodeSelectors instead of anti-affinity

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -5,7 +5,7 @@ autoscaling_buffer_memory_scale: "0.85"
 autoscaling_buffer_cpu_reserved: "1"
 autoscaling_buffer_memory_reserved: "1500Mi"
 {{if eq .Environment "production"}}
-autoscaling_buffer_pods: "3"
+autoscaling_buffer_pods: "1"
 {{else}}
 autoscaling_buffer_pods: "0"
 {{end}}

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -5,7 +5,10 @@
 #   kind: deployment
 
 # everything defined under here will be deleted before applying the manifests
-pre_apply: []
+pre_apply:
+- name: autoscaling-buffer
+  namespace: kube-system
+  kind: deployment
 
 # everything defined under here will be deleted after applying the manifests
 post_apply:

--- a/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment-1a.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment-1a.yaml
@@ -1,0 +1,40 @@
+{{ $zone := "eu-central-1a" }}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: autoscaling-buffer-{{$zone}}
+  namespace: kube-system
+  labels:
+    application: autoscaling-buffer
+    zone: {{$zone}}
+spec:
+  replicas: {{.ConfigItems.autoscaling_buffer_pods}}
+  selector:
+    matchLabels:
+      application: autoscaling-buffer
+      zone: {{$zone}}
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        application: autoscaling-buffer
+        zone: {{$zone}}
+    spec:
+      nodeSelector:
+        failure-domain.beta.kubernetes.io/zone: "{{$zone}}"
+      priorityClassName: autoscaling-buffer
+      terminationGracePeriodSeconds: 0
+      containers:
+      - name: pause
+        image: registry.opensource.zalan.do/teapot/pause-amd64:3.0
+        resources:
+{{ with $resources := autoscalingBufferSettings . }}
+          limits:
+            cpu: {{$resources.CPU}}
+            memory: {{$resources.Memory}}
+          requests:
+            cpu: {{$resources.CPU}}
+            memory: {{$resources.Memory}}
+{{ end }}

--- a/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment-1b.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment-1b.yaml
@@ -1,32 +1,29 @@
+{{ $zone := "eu-central-1b" }}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: autoscaling-buffer
+  name: autoscaling-buffer-{{$zone}}
   namespace: kube-system
   labels:
     application: autoscaling-buffer
+    zone: {{$zone}}
 spec:
   replicas: {{.ConfigItems.autoscaling_buffer_pods}}
   selector:
     matchLabels:
       application: autoscaling-buffer
+      zone: {{$zone}}
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
         application: autoscaling-buffer
+        zone: {{$zone}}
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: application
-                operator: In
-                values:
-                - autoscaling-buffer
-            topologyKey: failure-domain.beta.kubernetes.io/zone
+      nodeSelector:
+        failure-domain.beta.kubernetes.io/zone: "{{$zone}}"
       priorityClassName: autoscaling-buffer
       terminationGracePeriodSeconds: 0
       containers:

--- a/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment-1c.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment-1c.yaml
@@ -1,0 +1,40 @@
+{{ $zone := "eu-central-1c" }}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: autoscaling-buffer-{{$zone}}
+  namespace: kube-system
+  labels:
+    application: autoscaling-buffer
+    zone: {{$zone}}
+spec:
+  replicas: {{.ConfigItems.autoscaling_buffer_pods}}
+  selector:
+    matchLabels:
+      application: autoscaling-buffer
+      zone: {{$zone}}
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        application: autoscaling-buffer
+        zone: {{$zone}}
+    spec:
+      nodeSelector:
+        failure-domain.beta.kubernetes.io/zone: "{{$zone}}"
+      priorityClassName: autoscaling-buffer
+      terminationGracePeriodSeconds: 0
+      containers:
+      - name: pause
+        image: registry.opensource.zalan.do/teapot/pause-amd64:3.0
+        resources:
+{{ with $resources := autoscalingBufferSettings . }}
+          limits:
+            cpu: {{$resources.CPU}}
+            memory: {{$resources.Memory}}
+          requests:
+            cpu: {{$resources.CPU}}
+            memory: {{$resources.Memory}}
+{{ end }}


### PR DESCRIPTION
The current version autoscaler only pays attention to existing pods when handling anti-affinity predicates (see https://github.com/kubernetes/autoscaler/issues/257). This means that if multiple buffer pods are evicted at the same time, the autoscaler can provision two nodes in the same AZ and only rectify the situation by upscaling another AZ and downscaling the unnecessary node after one of those is ready and the buffer pod is scheduled. This issue will hopefully be fixed in the future, but for now we can avoid this by using node selectors instead of anti-affinities.

Note that this slightly changed the semantics of `autoscaling_buffer_pods` from the total count to per-az count, but we never actually overrode this setting to anything except 0.