### PR TITLE
Cherrypick autoscaling buffer changes to beta

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -5,7 +5,7 @@ autoscaling_buffer_memory_scale: "0.85"
 autoscaling_buffer_cpu_reserved: "1"
 autoscaling_buffer_memory_reserved: "1500Mi"
 {{if eq .Environment "production"}}
-autoscaling_buffer_pods: "3"
+autoscaling_buffer_pods: "1"
 {{else}}
 autoscaling_buffer_pods: "0"
 {{end}}

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -5,7 +5,10 @@
 #   kind: deployment
 
 # everything defined under here will be deleted before applying the manifests
-pre_apply: []
+pre_apply:
+- name: autoscaling-buffer
+  namespace: kube-system
+  kind: deployment
 
 # everything defined under here will be deleted after applying the manifests
 post_apply:

--- a/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment-1a.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment-1a.yaml
@@ -1,0 +1,40 @@
+{{ $zone := "eu-central-1a" }}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: autoscaling-buffer-{{$zone}}
+  namespace: kube-system
+  labels:
+    application: autoscaling-buffer
+    zone: {{$zone}}
+spec:
+  replicas: {{.ConfigItems.autoscaling_buffer_pods}}
+  selector:
+    matchLabels:
+      application: autoscaling-buffer
+      zone: {{$zone}}
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        application: autoscaling-buffer
+        zone: {{$zone}}
+    spec:
+      nodeSelector:
+        failure-domain.beta.kubernetes.io/zone: "{{$zone}}"
+      priorityClassName: autoscaling-buffer
+      terminationGracePeriodSeconds: 0
+      containers:
+      - name: pause
+        image: registry.opensource.zalan.do/teapot/pause-amd64:3.0
+        resources:
+{{ with $resources := autoscalingBufferSettings . }}
+          limits:
+            cpu: {{$resources.CPU}}
+            memory: {{$resources.Memory}}
+          requests:
+            cpu: {{$resources.CPU}}
+            memory: {{$resources.Memory}}
+{{ end }}

--- a/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment-1b.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment-1b.yaml
@@ -1,32 +1,29 @@
+{{ $zone := "eu-central-1b" }}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: autoscaling-buffer
+  name: autoscaling-buffer-{{$zone}}
   namespace: kube-system
   labels:
     application: autoscaling-buffer
+    zone: {{$zone}}
 spec:
   replicas: {{.ConfigItems.autoscaling_buffer_pods}}
   selector:
     matchLabels:
       application: autoscaling-buffer
+      zone: {{$zone}}
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
         application: autoscaling-buffer
+        zone: {{$zone}}
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: application
-                operator: In
-                values:
-                - autoscaling-buffer
-            topologyKey: failure-domain.beta.kubernetes.io/zone
+      nodeSelector:
+        failure-domain.beta.kubernetes.io/zone: "{{$zone}}"
       priorityClassName: autoscaling-buffer
       terminationGracePeriodSeconds: 0
       containers:

--- a/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment-1c.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment-1c.yaml
@@ -1,0 +1,40 @@
+{{ $zone := "eu-central-1c" }}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: autoscaling-buffer-{{$zone}}
+  namespace: kube-system
+  labels:
+    application: autoscaling-buffer
+    zone: {{$zone}}
+spec:
+  replicas: {{.ConfigItems.autoscaling_buffer_pods}}
+  selector:
+    matchLabels:
+      application: autoscaling-buffer
+      zone: {{$zone}}
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        application: autoscaling-buffer
+        zone: {{$zone}}
+    spec:
+      nodeSelector:
+        failure-domain.beta.kubernetes.io/zone: "{{$zone}}"
+      priorityClassName: autoscaling-buffer
+      terminationGracePeriodSeconds: 0
+      containers:
+      - name: pause
+        image: registry.opensource.zalan.do/teapot/pause-amd64:3.0
+        resources:
+{{ with $resources := autoscalingBufferSettings . }}
+          limits:
+            cpu: {{$resources.CPU}}
+            memory: {{$resources.Memory}}
+          requests:
+            cpu: {{$resources.CPU}}
+            memory: {{$resources.Memory}}
+{{ end }}

--- a/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment.yaml
@@ -19,16 +19,14 @@ spec:
     spec:
       affinity:
         podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                  - key: application
-                    operator: In
-                    values:
-                    - autoscaling-buffer
-                topologyKey: failure-domain.beta.kubernetes.io/zone
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: application
+                operator: In
+                values:
+                - autoscaling-buffer
+            topologyKey: failure-domain.beta.kubernetes.io/zone
       priorityClassName: autoscaling-buffer
       terminationGracePeriodSeconds: 0
       containers:

--- a/cluster/manifests/kube-cluster-autoscaler/pdb.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/pdb.yaml
@@ -1,0 +1,12 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    application: autoscaling-buffer
+  name: autoscaling-buffer
+  namespace: kube-system
+spec:
+  maxUnavailable: "100%"
+  selector:
+    matchLabels:
+      application: autoscaling-buffer


### PR DESCRIPTION
We can start rolling out the multiaz node pool to beta after this is merged.