### PR TITLE
Better pool name for the multi-ASG pool

### DIFF
--- a/cluster/node-pools/worker-splitaz
+++ b/cluster/node-pools/worker-splitaz
@@ -1,0 +1,1 @@
+worker-multiaz


### PR DESCRIPTION
`multiaz` is exactly the opposite of what it actually does. I've added the new name as a symlink, so we can start using it and then clean up after we fix all existing clusters to not use the old name.