### PR TITLE
Flannel to 1.9 (production 2/2)

### DIFF
--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -20,22 +20,37 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: system-node-critical
       serviceAccountName: system
-      initContainers:
-      - name: install-cni
+      containers:
+      - name: delayed-install-cni
         image: registry.opensource.zalan.do/teapot/flannel:v0.10.0
         command:
-        - cp
+        - /bin/sh
         args:
-        - -f
-        - /etc/kube-flannel/cni-conf.json
-        - /etc/cni/net.d/10-flannel.conf
+        - -c
+        - "sleep 120 && cp -f /etc/kube-flannel/cni-conf.json /etc/cni/net.d/10-flannel.conf && cat"
+        stdin: true
         volumeMounts:
         - name: cni
           mountPath: /etc/cni/net.d
         - name: flannel-cfg
           mountPath: /etc/kube-flannel/
-      containers:
+        resources:
+          requests:
+            cpu: 25m
+            memory: 25Mi
+      - name: apiserver-proxy
+        image: registry.opensource.zalan.do/teapot/etcd-proxy:master-3
+        command:
+        - /bin/sh
+        args:
+        - -c
+        - "exec /etcd-proxy --listen-address 127.0.0.1:333 $KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT"
+        resources:
+          requests:
+            cpu: 25m
+            memory: 25Mi
       - name: kube-flannel
         image: registry.opensource.zalan.do/teapot/flannel:v0.10.0
         command:
@@ -45,6 +60,10 @@ spec:
         - --kube-subnet-mgr
         - --v=2
         env:
+        - name: KUBERNETES_SERVICE_HOST
+          value: "127.0.0.1"
+        - name: KUBERNETES_SERVICE_PORT
+          value: "333"
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -73,10 +92,6 @@ spec:
         effect: NoSchedule
       - operator: Exists
         effect: NoExecute
-      - operator: Exists
-        key: CriticalAddonsOnly
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
       volumes:
       - name: flannel-cfg
         configMap:


### PR DESCRIPTION
Port flannel changes from alpha.

**WARNING** do not merge until #1183 is merged and the clusters are fully updated.