### PR TITLE
dnsmasq-node to 1.9 (production 1/2)

### DIFF
--- a/cluster/manifests/kube-dns/node-local-daemonset.yaml
+++ b/cluster/manifests/kube-dns/node-local-daemonset.yaml
@@ -15,6 +15,8 @@ spec:
     metadata:
       labels:
         application: dnsmasq-node
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       priorityClassName: system-node-critical
       serviceAccountName: system


### PR DESCRIPTION
This needs to be merged before #1181 so that flannel doesn't evict dnsmasq.