### PR TITLE
Add flannel annotation back to avoid extra disruptions

### DIFF
--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -17,6 +17,8 @@ spec:
       labels:
         application: flannel
         version: v0.10.0
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       priorityClassName: system-node-critical
       serviceAccountName: system


### PR DESCRIPTION
Otherwise the 1.10 merge will cause network issues again.