### PR TITLE
flannel: use OnDelete

### DIFF
--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -8,7 +8,7 @@ metadata:
     version: v0.10.0
 spec:
   updateStrategy:
-    type: RollingUpdate
+    type: OnDelete
   selector:
     matchLabels:
       application: flannel


### PR DESCRIPTION
A temporary workaround until we have a mitigation for https://github.com/coreos/flannel/issues/1002 in place (which can be as simple as a wrapper that just kills flannel instead of gracefully shutting it down). Every trivial change to the flannel daemonset will cause disruption in production clusters otherwise.