### PR TITLE
coredns - limit the number of roundtrips

### DIFF
--- a/cluster/manifests/coredns/configmap.yaml
+++ b/cluster/manifests/coredns/configmap.yaml
@@ -15,6 +15,7 @@ data:
             upstream
             fallthrough in-addr.arpa ip6.arpa
         }
+        autopath @kubernetes
         prometheus :9153
         proxy . /etc/resolv.conf
         cache 30

--- a/cluster/manifests/coredns/configmap.yaml
+++ b/cluster/manifests/coredns/configmap.yaml
@@ -18,6 +18,6 @@ data:
         autopath @kubernetes
         prometheus :9153
         proxy . /etc/resolv.conf
-        cache 30
+        cache 60
         reload
     }

--- a/cluster/manifests/kube-dns/node-local-daemonset.yaml
+++ b/cluster/manifests/kube-dns/node-local-daemonset.yaml
@@ -50,6 +50,7 @@ spec:
         - --
         - -k
         - --cache-size=10000
+        - --dns-forward-max=1000
         - --no-negcache
         - --server=/cluster.local/10.3.0.11#53
         - --server=/in-addr.arpa/10.3.0.11#53


### PR DESCRIPTION
Automatically detect queries being made with a known Kubernetes suffix

See https://github.com/coredns/coredns/issues/1752

There is also a comment which mentions enable sequential lookups for A and AAAA, using `single-request` or `single-request-reopen` in /etc.resolv.conf

...
>
              single-request (since glibc 2.10)
                     Sets RES_SNGLKUP in _res.options.  By default, glibc
                     performs IPv4 and IPv6 lookups in parallel since
                     version 2.9.  Some appliance DNS servers cannot handle
                     these queries properly and make the requests time out.
                     This option disables the behavior and makes glibc
                     perform the IPv6 and IPv4 requests sequentially (at the
                     cost of some slowdown of the resolving process).

              single-request-reopen (since glibc 2.9)
                     Sets RES_SNGLKUPREOP in _res.options.  The resolver
                     uses the same socket for the A and AAAA requests.  Some
                     hardware mistakenly sends back only one reply.  When
                     that happens the client system will sit and wait for
                     the second reply.  Turning this option on changes this
                     behavior so that if two requests from the same port are
                     not handled correctly it will close the socket and open
                     a new one before sending the second request.