### PR TITLE
Enable CustomResourceSubresources=true featuregate

### DIFF
--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -313,7 +313,7 @@ storage:
             - --authorization-mode=Webhook
             - --authorization-webhook-config-file=/etc/kubernetes/config/authz.yaml
             - --admission-control-config-file=/etc/kubernetes/config/image-policy-webhook.yaml
-            - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true,ExpandPersistentVolumes=true
+            - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true,ExpandPersistentVolumes=true,CustomResourceSubresources=true
             - --anonymous-auth=false
             {{ if or (eq .Cluster.Environment "production") (index .Cluster.ConfigItems "audittrail_url") }}
             - --audit-webhook-config-file=/etc/kubernetes/config/audit.yaml


### PR DESCRIPTION
Enables the CustomResourceSubresources=true featuregate to enable custom
resource endpoints `/status` & `/scale`

https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/#subresources

This is an alpha feature but enabling it to test the new feature *should* be fine :)