### PR TITLE
Update hyperkube to 1.10.5

### DIFF
--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-proxy
-    version: v1.10.2_coreos.0
+    version: v1.10.5
 spec:
   selector:
     matchLabels:
@@ -17,7 +17,7 @@ spec:
       name: kube-proxy
       labels:
         application: kube-proxy
-        version: v1.10.2_coreos.0
+        version: v1.10.5
     spec:
       priorityClassName: system-node-critical
       tolerations:
@@ -28,7 +28,7 @@ spec:
       hostNetwork: true
       containers:
       - name: kube-proxy
-        image: registry.opensource.zalan.do/teapot/hyperkube:v1.10.2_coreos.0
+        image: gcr.io/google-containers/hyperkube-amd64:v1.10.5
         command:
         - /hyperkube
         - proxy

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       hostNetwork: true
       containers:
       - name: kube-proxy
-        image: gcr.io/google-containers/hyperkube-amd64:v1.10.5
+        image: registry.opensource.zalan.do/teapot/hyperkube:v1.10.5
         command:
         - /hyperkube
         - proxy

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -140,7 +140,7 @@ systemd:
 
       [Service]
       Environment=KUBELET_IMAGE_TAG=v1.10.5
-      Environment=KUBELET_IMAGE_URL=docker://gcr.io/google-containers/hyperkube-amd64
+      Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
       Environment="RKT_RUN_ARGS=--insecure-options=image \
       --uuid-file-save=/var/run/kubelet-pod.uuid \
       --volume dns,kind=host,source=/etc/resolv.conf \
@@ -288,7 +288,7 @@ storage:
           hostNetwork: true
           containers:
           - name: kube-apiserver
-            image: gcr.io/google-containers/hyperkube-amd64:v1.10.5
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.10.5
             command:
             - /hyperkube
             - apiserver
@@ -471,7 +471,7 @@ storage:
             effect: NoSchedule
           containers:
           - name: kube-controller-manager
-            image: gcr.io/google-containers/hyperkube-amd64:v1.10.5
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.10.5
             command:
             - /hyperkube
             - controller-manager
@@ -541,7 +541,7 @@ storage:
           hostNetwork: true
           containers:
           - name: kube-scheduler
-            image: gcr.io/google-containers/hyperkube-amd64:v1.10.5
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.10.5
             command:
             - /hyperkube
             - scheduler
@@ -911,7 +911,7 @@ storage:
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
           --net=host \
-          docker://gcr.io/google-containers/hyperkube-amd64:v1.10.5 \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.10.5 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           label node "$(hostname)" \
@@ -924,7 +924,7 @@ storage:
           --net=host \
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
-          docker://gcr.io/google-containers/hyperkube-amd64:v1.10.5 \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.10.5 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           drain "$(hostname)" \

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -139,8 +139,8 @@ systemd:
       After=docker.service dockercfg.service meta-data-iptables.service private-ipv4.service
 
       [Service]
-      Environment=KUBELET_IMAGE_TAG=v1.10.2_coreos.0
-      Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
+      Environment=KUBELET_IMAGE_TAG=v1.10.5
+      Environment=KUBELET_IMAGE_URL=docker://gcr.io/google-containers/hyperkube-amd64
       Environment="RKT_RUN_ARGS=--insecure-options=image \
       --uuid-file-save=/var/run/kubelet-pod.uuid \
       --volume dns,kind=host,source=/etc/resolv.conf \
@@ -276,7 +276,7 @@ storage:
           namespace: kube-system
           labels:
             application: kube-apiserver
-            version: v1.10.2_coreos.0
+            version: v1.10.5
           annotations:
             kubernetes-log-watcher/scalyr-parser: |
               [{"container": "webhook", "parser": "json-structured-log"}]
@@ -288,7 +288,7 @@ storage:
           hostNetwork: true
           containers:
           - name: kube-apiserver
-            image: registry.opensource.zalan.do/teapot/hyperkube:v1.10.2_coreos.0
+            image: gcr.io/google-containers/hyperkube-amd64:v1.10.5
             command:
             - /hyperkube
             - apiserver
@@ -463,7 +463,7 @@ storage:
           namespace: kube-system
           labels:
             application: kube-controller-manager
-            version: v1.10.2_coreos.0
+            version: v1.10.5
         spec:
           priorityClassName: system-node-critical
           tolerations:
@@ -471,7 +471,7 @@ storage:
             effect: NoSchedule
           containers:
           - name: kube-controller-manager
-            image: registry.opensource.zalan.do/teapot/hyperkube:v1.10.2_coreos.0
+            image: gcr.io/google-containers/hyperkube-amd64:v1.10.5
             command:
             - /hyperkube
             - controller-manager
@@ -532,7 +532,7 @@ storage:
           namespace: kube-system
           labels:
             application: kube-scheduler
-            version: v1.10.2_coreos.0
+            version: v1.10.5
         spec:
           priorityClassName: system-node-critical
           tolerations:
@@ -541,7 +541,7 @@ storage:
           hostNetwork: true
           containers:
           - name: kube-scheduler
-            image: registry.opensource.zalan.do/teapot/hyperkube:v1.10.2_coreos.0
+            image: gcr.io/google-containers/hyperkube-amd64:v1.10.5
             command:
             - /hyperkube
             - scheduler
@@ -911,7 +911,7 @@ storage:
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
           --net=host \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.10.2_coreos.0 \
+          docker://gcr.io/google-containers/hyperkube-amd64:v1.10.5 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           label node "$(hostname)" \
@@ -924,7 +924,7 @@ storage:
           --net=host \
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.10.2_coreos.0 \
+          docker://gcr.io/google-containers/hyperkube-amd64:v1.10.5 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           drain "$(hostname)" \

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -131,7 +131,7 @@ systemd:
 
       [Service]
       Environment=KUBELET_IMAGE_TAG=v1.10.5
-      Environment=KUBELET_IMAGE_URL=docker://gcr.io/google-containers/hyperkube-amd64
+      Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
       Environment="RKT_RUN_ARGS=--insecure-options=image \
       --uuid-file-save=/var/run/kubelet-pod.uuid \
       --volume dns,kind=host,source=/etc/resolv.conf \
@@ -334,7 +334,7 @@ storage:
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
           --net=host \
-          docker://gcr.io/google-containers/hyperkube-amd64:v1.10.5 \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.10.5 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           label node "$(hostname)" \
@@ -347,7 +347,7 @@ storage:
           --net=host \
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
-          docker://gcr.io/google-containers/hyperkube-amd64:v1.10.5 \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.10.5 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           drain "$(hostname)" \

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -130,8 +130,8 @@ systemd:
       After=docker.service dockercfg.service meta-data-iptables.service private-ipv4.service
 
       [Service]
-      Environment=KUBELET_IMAGE_TAG=v1.10.2_coreos.0
-      Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
+      Environment=KUBELET_IMAGE_TAG=v1.10.5
+      Environment=KUBELET_IMAGE_URL=docker://gcr.io/google-containers/hyperkube-amd64
       Environment="RKT_RUN_ARGS=--insecure-options=image \
       --uuid-file-save=/var/run/kubelet-pod.uuid \
       --volume dns,kind=host,source=/etc/resolv.conf \
@@ -334,7 +334,7 @@ storage:
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
           --net=host \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.10.2_coreos.0 \
+          docker://gcr.io/google-containers/hyperkube-amd64:v1.10.5 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           label node "$(hostname)" \
@@ -347,7 +347,7 @@ storage:
           --net=host \
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.10.2_coreos.0 \
+          docker://gcr.io/google-containers/hyperkube-amd64:v1.10.5 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           drain "$(hostname)" \


### PR DESCRIPTION
* and switch to gcr based hyperkube image which is updated more frequently

This update is important as Kubernetes 1.10.5 fixes the backoffLimit issue for CronJobs: https://github.com/kubernetes/kubernetes/pull/63650 (fix regression in `v1.JobSpec.backoffLimit` that caused failed Jobs to be restarted indefinitely.)

