### PR TITLE
Bumping image-policy-webhook version

### DIFF
--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -419,7 +419,7 @@ storage:
                 value: https://identity.zalando.com/.well-known/openid-configuration
               - name: ENABLE_INTROSPECTION
                 value: "true"
-          - image: registry.opensource.zalan.do/teapot/image-policy-webhook:v0.3.6
+          - image: registry.opensource.zalan.do/teapot/image-policy-webhook:v0.3.7
             name: image-policy-webhook
             args:
             - --policy={{ .Cluster.ConfigItems.image_policy }}


### PR DESCRIPTION
A new image-policy-webhook version was tagged. So bumping the version here to be able to test

* Includes initial support for PierOne's `X-Trusted` header

