### PR TITLE
autoscaling_buffer_pools: use a more specific regex

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1,5 +1,5 @@
 # Autoscaling settings
-autoscaling_buffer_pools: "worker"
+autoscaling_buffer_pools: "default-worker"
 autoscaling_buffer_cpu_scale: "1"
 autoscaling_buffer_memory_scale: "0.85"
 autoscaling_buffer_cpu_reserved: "1"


### PR DESCRIPTION
This allows us to not tinker with config items every time we create a dedicated node pool.