### PR TITLE
Open dnsmasq metrics port within private network

### DIFF
--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -257,6 +257,8 @@ Resources:
       - {CidrIp: 172.31.0.0/16, FromPort: 30080, IpProtocol: tcp, ToPort: 30080}
       # allow checking kubelet cadvisor metrics port from within the VPC
       - {CidrIp: 172.31.0.0/16, FromPort: 4194, IpProtocol: tcp, ToPort: 4194}
+      # allow checking dnsmasq metrics from within the VPC
+      - {CidrIp: 172.31.0.0/16, FromPort: 9054, IpProtocol: tcp, ToPort: 9054}
       Tags:
         - Key: "kubernetes.io/cluster/{{ Arguments.ClusterID }}"
           Value: owned
@@ -338,6 +340,8 @@ Resources:
       - {CidrIp: 172.31.0.0/16, FromPort: 10248, IpProtocol: tcp, ToPort: 10248}
       # allow checking kubelet cadvisor metrics port from within the VPC
       - {CidrIp: 172.31.0.0/16, FromPort: 4194, IpProtocol: tcp, ToPort: 4194}
+      # allow checking dnsmasq metrics from within the VPC
+      - {CidrIp: 172.31.0.0/16, FromPort: 9054, IpProtocol: tcp, ToPort: 9054}
       # allow checking kubelet metrics for disk metrics port from within the VPC
       - {CidrIp: 172.31.0.0/16, FromPort: 10255, IpProtocol: tcp, ToPort: 10255}
       # allow default service NodePort range


### PR DESCRIPTION
Opens the dnsmasq metrics port `9054` within the private network so we can collect metrics from any dnsmasq.

We were only collecting for the dnsmasq on the same node as prometheus giving unexpected data when querying.