### PR TITLE
autoscaler: enable --balance-similar-node-groups

### DIFF
--- a/cluster/manifests/kube-cluster-autoscaler/deployment.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/deployment.yaml
@@ -40,6 +40,7 @@ spec:
           - --skip-nodes-with-system-pods=false
           - --skip-nodes-with-local-storage=false
           - --scale-up-cloud-provider-template=true
+          - --balance-similar-node-groups
         resources:
           limits:
             cpu: 100m


### PR DESCRIPTION
We have 3 ASGs with different AZs but the same instance type and labels. The autoscaler should try to balance their sizes unless it's not possible for some reason, but this doesn't happen by default and we need to explicitly enable it by running the autoscaler with `--balance-similar-node-groups`.