### PR TITLE
EAS: revert readOnlyRootFilesystem change

### DIFF
--- a/cluster/manifests/emergency-access-service/deployment.yaml
+++ b/cluster/manifests/emergency-access-service/deployment.yaml
@@ -68,7 +68,6 @@ spec:
             cpu: 50m
             memory: 100Mi
         securityContext:
-          readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 1000
       volumes:


### PR DESCRIPTION
EAS creates a log file somewhere and crashes on startup if the FS is read-only.