### PR TITLE
remove critical-pod annotation from flannel

### DIFF
--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -17,8 +17,6 @@ spec:
       labels:
         application: flannel
         version: v0.10.0
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       priorityClassName: system-node-critical
       serviceAccountName: system


### PR DESCRIPTION
There's one annotation left... Github search... 😨 