### PR TITLE
First draft of NVIDIA GPU support

### DIFF
--- a/cluster/manifests/nvidia/nvidia-driver-installer.yaml
+++ b/cluster/manifests/nvidia/nvidia-driver-installer.yaml
@@ -1,3 +1,7 @@
+# based on:
+#
+#   https://github.com/shelmangroup/coreos-gpu-installer/blob/master/daemonset.yaml
+#
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -5,9 +9,10 @@ metadata:
   namespace: kube-system
   labels:
     application: nvidia-driver-installer
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ''
+    version: c117d39
 spec:
+  updateStrategy:
+    type: RollingUpdate
   selector:
     matchLabels:
       application: nvidia-driver-installer
@@ -15,13 +20,12 @@ spec:
     metadata:
       labels:
         application: nvidia-driver-installer
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
+        version: c117d39
     spec:
       tolerations:
-      - effect: NoSchedule
-        key: dedicated
-        value: gpu
+      - key: nvidia.com/gpu
+        effect: NoSchedule
+        operator: Exists
       nodeSelector:
         kubernetes.io/node-pool: worker-gpu
       priorityClassName: system-node-critical
@@ -38,29 +42,29 @@ spec:
         hostPath:
           path: /
       initContainers:
-      - image: "shelmangroup/coreos-nvidia-driver-installer:latest"
-        name: nvidia-driver-installer
+      - name: nvidia-driver-installer
+        image: registry.opensource.zalan.do/teapot/coreos-nvidia-driver-installer:c117d39
         resources:
           requests:
             cpu: 0.15
         securityContext:
           privileged: true
         env:
-          - name: NVIDIA_INSTALL_DIR_HOST
-            value: /opt/nvidia
-          - name: NVIDIA_INSTALL_DIR_CONTAINER
-            value: /usr/local/nvidia
-          - name: ROOT_MOUNT_DIR
-            value: /root
-          - name: NVIDIA_DRIVER_VERSION
-            value: "396.26"
+        - name: NVIDIA_INSTALL_DIR_HOST
+          value: /opt/nvidia
+        - name: NVIDIA_INSTALL_DIR_CONTAINER
+          value: /usr/local/nvidia
+        - name: ROOT_MOUNT_DIR
+          value: /rootfs
+        - name: NVIDIA_DRIVER_VERSION
+          value: "396.26"
         volumeMounts:
         - name: nvidia-install-dir-host
           mountPath: /usr/local/nvidia
         - name: dev
           mountPath: /dev
         - name: root-mount
-          mountPath: /root
+          mountPath: /rootfs
       containers:
-      - image: "gcr.io/google-containers/pause:2.0"
+      - image: registry.opensource.zalan.do/teapot/pause-amd64:3.1
         name: pause

--- a/cluster/manifests/nvidia/nvidia-driver-installer.yaml
+++ b/cluster/manifests/nvidia/nvidia-driver-installer.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-driver-installer
+  namespace: kube-system
+  labels:
+    application: nvidia-driver-installer
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ''
+spec:
+  selector:
+    matchLabels:
+      application: nvidia-driver-installer
+  template:
+    metadata:
+      labels:
+        application: nvidia-driver-installer
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      tolerations:
+      - effect: NoSchedule
+        key: dedicated
+        value: gpu
+      nodeSelector:
+        kubernetes.io/node-pool: worker-gpu
+      priorityClassName: system-node-critical
+      hostNetwork: true
+      hostPID: true
+      volumes:
+      - name: dev
+        hostPath:
+          path: /dev
+      - name: nvidia-install-dir-host
+        hostPath:
+          path: /opt/nvidia
+      - name: root-mount
+        hostPath:
+          path: /
+      initContainers:
+      - image: "shelmangroup/coreos-nvidia-driver-installer:latest"
+        name: nvidia-driver-installer
+        resources:
+          requests:
+            cpu: 0.15
+        securityContext:
+          privileged: true
+        env:
+          - name: NVIDIA_INSTALL_DIR_HOST
+            value: /opt/nvidia
+          - name: NVIDIA_INSTALL_DIR_CONTAINER
+            value: /usr/local/nvidia
+          - name: ROOT_MOUNT_DIR
+            value: /root
+          - name: NVIDIA_DRIVER_VERSION
+            value: "396.26"
+        volumeMounts:
+        - name: nvidia-install-dir-host
+          mountPath: /usr/local/nvidia
+        - name: dev
+          mountPath: /dev
+        - name: root-mount
+          mountPath: /root
+      containers:
+      - image: "gcr.io/google-containers/pause:2.0"
+        name: pause

--- a/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
+++ b/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-gpu-device-plugin
+  namespace: kube-system
+  labels:
+    application: nvidia-gpu-device-plugin
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  selector:
+    matchLabels:
+      application: nvidia-gpu-device-plugin
+  template:
+    metadata:
+      labels:
+        application: nvidia-gpu-device-plugin
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      tolerations:
+      - effect: NoSchedule
+        key: dedicated
+        value: gpu
+      nodeSelector:
+        kubernetes.io/node-pool: worker-gpu
+      priorityClassName: system-node-critical
+      hostNetwork: true
+      hostPID: true
+      volumes:
+      - name: device-plugin
+        hostPath:
+          path: /var/lib/kubelet/device-plugins
+      - name: dev
+        hostPath:
+          path: /dev
+      containers:
+      - image: "k8s.gcr.io/nvidia-gpu-device-plugin@sha256:0842734032018be107fa2490c98156992911e3e1f2a21e059ff0105b07dd8e9e"
+        command: ["/usr/bin/nvidia-gpu-device-plugin", "-logtostderr", "-host-path=/opt/nvidia"]
+        name: nvidia-gpu-device-plugin
+        resources:
+          requests:
+            cpu: 50m
+            memory: 10Mi
+          limits:
+            cpu: 50m
+            memory: 10Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: device-plugin
+          mountPath: /device-plugin
+        - name: dev
+          mountPath: /dev

--- a/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
+++ b/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
@@ -1,3 +1,7 @@
+# based on:
+#
+#   https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/device-plugins/nvidia-gpu/daemonset.yaml
+#
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -5,8 +9,10 @@ metadata:
   namespace: kube-system
   labels:
     application: nvidia-gpu-device-plugin
-    addonmanager.kubernetes.io/mode: Reconcile
+    version: cb2bdea5eb507a9577ce11ff058a2dfa84f54263
 spec:
+  updateStrategy:
+    type: RollingUpdate
   selector:
     matchLabels:
       application: nvidia-gpu-device-plugin
@@ -14,18 +20,16 @@ spec:
     metadata:
       labels:
         application: nvidia-gpu-device-plugin
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
+        version: cb2bdea5eb507a9577ce11ff058a2dfa84f54263
     spec:
       tolerations:
-      - effect: NoSchedule
-        key: dedicated
-        value: gpu
+      - operator: Exists
+        effect: NoExecute
+      - operator: Exists
+        effect: NoSchedule
       nodeSelector:
         kubernetes.io/node-pool: worker-gpu
       priorityClassName: system-node-critical
-      hostNetwork: true
-      hostPID: true
       volumes:
       - name: device-plugin
         hostPath:
@@ -34,9 +38,12 @@ spec:
         hostPath:
           path: /dev
       containers:
-      - image: "k8s.gcr.io/nvidia-gpu-device-plugin@sha256:0842734032018be107fa2490c98156992911e3e1f2a21e059ff0105b07dd8e9e"
-        command: ["/usr/bin/nvidia-gpu-device-plugin", "-logtostderr", "-host-path=/opt/nvidia"]
-        name: nvidia-gpu-device-plugin
+      - name: nvidia-gpu-device-plugin
+        image: registry.opensource.zalan.do/teapot/nvidia-gpu-device-plugin:cb2bdea5eb507a9577ce11ff058a2dfa84f54263
+        command:
+        - /usr/bin/nvidia-gpu-device-plugin
+        - -host-path=/opt/nvidia
+        - -logtostderr
         resources:
           requests:
             cpu: 50m

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -302,7 +302,7 @@ storage:
             - --allow-privileged=true
             - --service-cluster-ip-range=10.3.0.0/16
             - --secure-port=443
-            - --enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota,PodSecurityPolicy,ImagePolicyWebhook,Priority,PersistentVolumeClaimResize
+            - --enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota,PodSecurityPolicy,ImagePolicyWebhook,Priority,PersistentVolumeClaimResize,ExtendedResourceToleration
             - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
             - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
             - --service-account-key-file=/etc/kubernetes/ssl/apiserver-key.pem


### PR DESCRIPTION
- Use deamonset to install gpu drivers
- Use k8s-device-plugin to expose GPUs to GPU enabled containers

### Test with a GPU deployment
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: gpu-tester
  labels:
    application: gpu-tester
spec:
  replicas: 1
  selector:
    matchLabels:
      application: gpu-tester
  template:
    metadata:
      labels:
        application: gpu-tester
    spec:
      containers:
      - name: gpu-tester
        image: gcr.io/google_containers/cuda-vector-add:v0.1
        resources:
          limits:
            nvidia.com/gpu: 1 # requesting 1 GPUs
```

`zkubectl logs -f <POD Name>`
```
[Vector addition of 50000 elements]
Copy input data from the host memory to the CUDA device
CUDA kernel launch with 196 blocks of 256 threads
Copy output data from the CUDA device to the host memory
Test PASSED
Done
```

TODO:
- [ ] documentation
- [x] mirror images to pierone
- [x] extensible resources admission controller