### PR TITLE
Update webhook to allow aws-cloud-provider serviceaccount to patch nodes

### DIFF
--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -357,7 +357,7 @@ storage:
               requests:
                 cpu: 100m
                 memory: 200Mi
-          - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.4.1
+          - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.4.2
             name: webhook
             ports:
             - containerPort: 8081


### PR DESCRIPTION
Allow aws-cloud-provider service account to patch nodes which is needed for setting a taint on nodes where volume attachment fails.

https://github.com/kubernetes/kubernetes/commit/514f219c229647ad2a3d6223fbcb596ea032363c