### PR TITLE
Use latest compliant pause image everywhere

### DIFF
--- a/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment-1a.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment-1a.yaml
@@ -28,7 +28,7 @@ spec:
       terminationGracePeriodSeconds: 0
       containers:
       - name: pause
-        image: registry.opensource.zalan.do/teapot/pause-amd64:3.0
+        image: registry.opensource.zalan.do/teapot/pause-amd64:3.1
         resources:
 {{ with $resources := autoscalingBufferSettings . }}
           limits:

--- a/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment-1b.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment-1b.yaml
@@ -28,7 +28,7 @@ spec:
       terminationGracePeriodSeconds: 0
       containers:
       - name: pause
-        image: registry.opensource.zalan.do/teapot/pause-amd64:3.0
+        image: registry.opensource.zalan.do/teapot/pause-amd64:3.1
         resources:
 {{ with $resources := autoscalingBufferSettings . }}
           limits:

--- a/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment-1c.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment-1c.yaml
@@ -28,7 +28,7 @@ spec:
       terminationGracePeriodSeconds: 0
       containers:
       - name: pause
-        image: registry.opensource.zalan.do/teapot/pause-amd64:3.0
+        image: registry.opensource.zalan.do/teapot/pause-amd64:3.1
         resources:
 {{ with $resources := autoscalingBufferSettings . }}
           limits:

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -172,6 +172,7 @@ systemd:
       --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \
       --cloud-provider=aws \
       --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true \
+      --pod-infra-container-image=registry.opensource.zalan.do/teapot/pause-amd64:3.1 \
       --system-reserved=cpu=100m,memory=164Mi \
       --kube-reserved=cpu=100m,memory=282Mi
       ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -170,6 +170,7 @@ systemd:
       --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \
       --cloud-provider=aws \
       --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true \
+      --pod-infra-container-image=registry.opensource.zalan.do/teapot/pause-amd64:3.1 \
       --system-reserved=cpu=100m,memory=164Mi \
       --kube-reserved=cpu=100m,memory=282Mi
       ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid


### PR DESCRIPTION
* Unifies and updates the `pause` container's version to `3.1` so we don't pull redundant versions.
* Instructs the `kubelet` to use this version for the magical hidden network pods as well.