### PR TITLE
enable oauthTokeninfo filters

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -10,6 +10,13 @@ autoscaling_buffer_pods: "1"
 autoscaling_buffer_pods: "0"
 {{end}}
 
+# tokeninfo
+{{if eq .Environment "production"}}
+tokeninfo_url: "https://info.services.auth.zalando.com/oauth2/tokeninfo"
+{{else}}
+tokeninfo_url: "https://sandbox.identity.zalando.com/oauth2/tokeninfo"
+{{end}}
+
 # Monitoring settings
 {{if eq .Environment "e2e"}}
 logging_agent_enabled: "false"

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.10.26
+    version: v0.10.38
     component: ingress
 spec:
   selector:
@@ -18,7 +18,7 @@ spec:
       name: skipper-ingress
       labels:
         application: skipper-ingress
-        version: v0.10.26
+        version: v0.10.38
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -33,7 +33,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.26
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.38
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -53,6 +53,7 @@ spec:
           - "-lb-healthcheck-interval=3s"
           - "-metrics-flavour=codahale,prometheus"
           - "-enable-connection-metrics"
+          - "-oauth2-tokeninfo-url={{ .ConfigItems.tokeninfo_url }}"
         resources:
           limits:
             memory: 200Mi


### PR DESCRIPTION
enable oauth filter in skipper and set dependent on the environment prod and sandbox endpoints

increase version
- fix invalid connection header issue reported via slack channel (https://github.com/zalando/skipper/issues/699)
- use 308 in Kubernetes HTTPS redirect instead of 301 (https://github.com/zalando/skipper/issues/695)
- do not add annotation filters to LB decision routes (https://github.com/zalando/skipper/issues/694)
- Added ID of the matching route to open tracing span (https://github.com/zalando/skipper/issues/692)
- sort routing table output on support endpoint (https://github.com/zalando/skipper/issues/681)
- add option to strip query strings from request URIs in the access logs (https://github.com/zalando/skipper/issues/392)

