### PR TITLE
Update ingress controller to v0.7.1

### DIFF
--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.6.10
+    version: v0.7.1
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.6.10
+        version: v0.7.1
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
     spec:
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: system
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.6.10
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.7.1
         args:
         - -stack-termination-protection
         env:


### PR DESCRIPTION
Updates to latest version which fixes issues when having more than 25 certificates for one cluster.

https://github.com/zalando-incubator/kube-ingress-aws-controller/releases/tag/v0.7.1

Note this also removes support for the annotation: `zalando.org/aws-load-balancer-ssl-cert-domain` which is not useful anyway anymore.

https://github.com/zalando-incubator/kube-ingress-aws-controller/releases/tag/v0.7.0