### PR TITLE
Allow zmon-agent to describe dynamodb tables

### DIFF
--- a/cluster/senza-definition.yaml
+++ b/cluster/senza-definition.yaml
@@ -531,6 +531,7 @@ Resources:
             - {Action: 'route53:List*', Effect: Allow, Resource: '*'}
             - {Action: 'tag:Get*', Effect: Allow, Resource: '*'}
             - {Action: 'dynamodb:ListTables', Effect: Allow, Resource: '*'}
+            - {Action: 'dynamodb:DescribeTable', Effect: Allow, Resource: '*'}
             - {Action: 's3:ListBucket', Effect: Allow, Resource: '*'}
             - Action: "s3:GetObject"
               Resource: "arn:aws:s3:::{{ AccountInfo.MintBucket }}/gerry/*"


### PR DESCRIPTION
Allow zmon-agent to describe dynamodb tables in order to create dynamodb entities.