### PR TITLE
fix kernel race condition in DNAT rules for DNS

### DIFF
--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -84,6 +84,25 @@ spec:
           mountPath: /etc/kube-flannel/
         - name: run
           mountPath: /run
+      - args:
+        - -c
+        - /tc-flannel.sh
+        command:
+        - /bin/bash
+        image: registry.opensource.zalan.do/teapot/flannel-tc:v0.0.2
+        name: flannel-tc
+        resources:
+          requests:
+            cpu: 25m
+            memory: 25Mi
+        securityContext:
+          privileged: true
+        stdin: true
+        volumeMounts:
+        - mountPath: /run
+          name: run
+        - mountPath: /lib/tc
+          name: lib-tc
       hostNetwork: true
       tolerations:
       - operator: Exists
@@ -100,3 +119,7 @@ spec:
       - name: run
         hostPath:
           path: /run
+      - hostPath:
+          path: /lib/tc
+          type: ""
+        name: lib-tc


### PR DESCRIPTION
This adds a sidecar into flannel pod spec, that adds a 1-4ms delay for udp port 53 packets going through DNAT, such that the kernel race condition happens less likely.

Background see https://blog.quentin-machu.fr/2018/06/24/5-15s-dns-lookups-on-kubernetes/
https://github.com/kubernetes/kubernetes/issues/62628
https://github.com/coreos/flannel/pull/1001#issuecomment-403802099