### PR TITLE
Support for adding node pool labels via config items

### DIFF
--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -162,7 +162,7 @@ systemd:
       --register-with-taints=node-role.kubernetes.io/master=:NoSchedule{{if index .NodePool.ConfigItems "taints"}},{{.NodePool.ConfigItems.taints}}{{end}} \
       --allow-privileged \
       --node-labels=node-role.kubernetes.io/master,kubernetes.io/role=master,master=true \
-      --node-labels=kubernetes.io/node-pool={{ .NodePool.Name }} \
+      --node-labels=kubernetes.io/node-pool={{ .NodePool.Name }}{{if index .NodePool.ConfigItems "labels"}},{{.NodePool.ConfigItems.labels}}{{end}} \
       --node-labels={{ .Values.node_labels }} \
       --pod-manifest-path=/etc/kubernetes/manifests \
       --cluster-dns=${PRIVATE_EC2_IPV4},10.3.0.11 \

--- a/cluster/node-pools/worker-default/stack.yaml
+++ b/cluster/node-pools/worker-default/stack.yaml
@@ -47,6 +47,14 @@ Resources:
       - Key: k8s.io/cluster-autoscaler/node-template/label/lifecycle-status
         PropagateAtLaunch: true
         Value: ready
+{{- if index .NodePool.ConfigItems "labels"}}
+  {{- range split .NodePool.ConfigItems.labels ","}}
+    {{- $label := split . "="}}
+      - Key: k8s.io/cluster-autoscaler/node-template/label/{{index $label 0}}
+        PropagateAtLaunch: true
+        Value: {{index $label 1}}
+  {{- end}}
+{{end}}
 {{- if index .NodePool.ConfigItems "taints"}}
   {{- range split .NodePool.ConfigItems.taints ","}}
     {{- $taint := split . "="}}

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -159,7 +159,7 @@ systemd:
       --register-node \
       --allow-privileged \
       --node-labels=kubernetes.io/role=worker \
-      --node-labels=kubernetes.io/node-pool={{ .NodePool.Name }} \
+      --node-labels=kubernetes.io/node-pool={{ .NodePool.Name }}{{if index .NodePool.ConfigItems "labels"}},{{.NodePool.ConfigItems.labels}}{{end}} \
       --node-labels={{ .Values.node_labels }} \
       --cluster-dns=${PRIVATE_EC2_IPV4},10.3.0.11 \
       --cluster-domain=cluster.local \

--- a/cluster/node-pools/worker-multiaz/stack.yaml
+++ b/cluster/node-pools/worker-multiaz/stack.yaml
@@ -52,6 +52,14 @@ Resources:
       - Key: k8s.io/cluster-autoscaler/node-template/label/lifecycle-status
         PropagateAtLaunch: true
         Value: ready
+{{- if index $data.NodePool.ConfigItems "labels"}}
+  {{- range split $data.NodePool.ConfigItems.labels ","}}
+    {{- $label := split . "="}}
+      - Key: k8s.io/cluster-autoscaler/node-template/label/{{index $label 0}}
+        PropagateAtLaunch: true
+        Value: {{index $label 1}}
+  {{- end}}
+{{end}}
 {{- if index $data.NodePool.ConfigItems "taints"}}
   {{- range split $data.NodePool.ConfigItems.taints ","}}
     {{- $taint := split . "="}}


### PR DESCRIPTION
This allows configuring node labels per node pool, e.g.
```yaml
  - discount_strategy: none
    instance_type: p2.xlarge
    min_size: 1
    max_size: 1
    name: worker-gpu
    profile: worker-default
    config_items:
      labels: cloud.google.com/gke-accelerator=nvidia-tesla-k80,foo=bar
      taints: nvidia.com/gpu=present:NoSchedule,foo2=bar2
```

Like above, this can be used to mark nodes of a node pool with their special hardware such as GPUs so that users can schedule pods on a subset of all GPU nodes without using node pool names, e.g.

via `nodeSelector` for targetting a specific type of device as explained [here](https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/):
```yaml
  nodeSelector:
    cloud.google.com/gke-accelerator: nvidia-tesla-p100 # or nvidia-tesla-k80 etc.
```

or for targetting all types of devices like for [installing the drivers](https://github.com/GoogleCloudPlatform/container-engine-accelerators/blob/k8s-1.10/nvidia-driver-installer/cos/daemonset-preloaded.yaml#L42-L48) themselves for arbitrary node pool names:
```yaml
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
            - matchExpressions:
              - key: cloud.google.com/gke-accelerator
                operator: Exists
```