### PR TITLE
Don't use custom rootfs mount

### DIFF
--- a/cluster/manifests/nvidia/nvidia-driver-installer.yaml
+++ b/cluster/manifests/nvidia/nvidia-driver-installer.yaml
@@ -55,7 +55,7 @@ spec:
         - name: NVIDIA_INSTALL_DIR_CONTAINER
           value: /usr/local/nvidia
         - name: ROOT_MOUNT_DIR
-          value: /rootfs
+          value: /root
         - name: NVIDIA_DRIVER_VERSION
           value: "396.26"
         volumeMounts:
@@ -64,7 +64,7 @@ spec:
         - name: dev
           mountPath: /dev
         - name: root-mount
-          mountPath: /rootfs
+          mountPath: /root
       containers:
       - image: registry.opensource.zalan.do/teapot/pause-amd64:3.1
         name: pause


### PR DESCRIPTION
Using a custom path for rootfs mount (different from the upstream config) isn't fully supported by the script. Falling back to the original path to make it work for now.