### PR TITLE
Select GPU nodes for the driver via labels

### DIFF
--- a/cluster/manifests/nvidia/nvidia-driver-installer.yaml
+++ b/cluster/manifests/nvidia/nvidia-driver-installer.yaml
@@ -26,8 +26,13 @@ spec:
       - key: nvidia.com/gpu
         effect: NoSchedule
         operator: Exists
-      nodeSelector:
-        kubernetes.io/node-pool: worker-gpu
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: zalando.org/nvidia-gpu
+                operator: Exists
       priorityClassName: system-node-critical
       hostNetwork: true
       hostPID: true

--- a/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
+++ b/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
@@ -27,8 +27,13 @@ spec:
         effect: NoExecute
       - operator: Exists
         effect: NoSchedule
-      nodeSelector:
-        kubernetes.io/node-pool: worker-gpu
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: zalando.org/nvidia-gpu
+                operator: Exists
       priorityClassName: system-node-critical
       volumes:
       - name: device-plugin


### PR DESCRIPTION
This uses node affinity on node labels to select GPU nodes to schedule the driver installer and device plugin.