### PR TITLE
Update kube-ingress-aws-controller to v0.7.2

### DIFF
--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.7.1
+    version: v0.7.2
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.7.1
+        version: v0.7.2
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
     spec:
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: system
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.7.1
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.7.2
         args:
         - -stack-termination-protection
         env:


### PR DESCRIPTION
Fixes a bug when using custom target-port value

https://github.com/zalando-incubator/kube-ingress-aws-controller/releases/tag/v0.7.2

We don't depend on this particular feature in our setup, but it makes sense to run the latest version so we can eat our own dog food.