### PR TITLE
Increase the conntrack size to reduce chances of DNS packet loss

### DIFF
--- a/cluster/manifests/kube-proxy/configmap.yaml
+++ b/cluster/manifests/kube-proxy/configmap.yaml
@@ -18,8 +18,8 @@ data:
     configSyncPeriod: 15m0s
     conntrack:
       max: 0
-      maxPerCore: 32768
-      min: 131072
+      maxPerCore: 131072
+      min: 524288
       tcpCloseWaitTimeout: 1h0m0s
       tcpEstablishedTimeout: 24h0m0s
     enableProfiling: false

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -18,6 +18,8 @@ spec:
       labels:
         application: kube-proxy
         version: v1.10.5
+      annotations:
+        config/hash: {{"configmap.yaml" | manifestHash}}
     spec:
       priorityClassName: system-node-critical
       tolerations:


### PR DESCRIPTION
ZMON makes so many connections and DNS requests that the conntrack table on a node hosting its pods gets completely overflown. If one of coredns pods is running on the same node, the whole cluster will start experiencing issues.