### PR TITLE
add node label aws.amazon.com/spot=true

### DIFF
--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -160,6 +160,7 @@ systemd:
       --allow-privileged \
       --node-labels=kubernetes.io/role=worker \
       --node-labels=kubernetes.io/node-pool={{ .NodePool.Name }}{{if index .NodePool.ConfigItems "labels"}},{{.NodePool.ConfigItems.labels}}{{end}} \
+      --node-labels=spot={{if .Values.spot_price ne ""}}true{{else}}false{{end}} \
       --node-labels={{ .Values.node_labels }} \
       --cluster-dns=${PRIVATE_EC2_IPV4},10.3.0.11 \
       --cluster-domain=cluster.local \

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -160,7 +160,7 @@ systemd:
       --allow-privileged \
       --node-labels=kubernetes.io/role=worker \
       --node-labels=kubernetes.io/node-pool={{ .NodePool.Name }}{{if index .NodePool.ConfigItems "labels"}},{{.NodePool.ConfigItems.labels}}{{end}} \
-      --node-labels=spot={{if .Values.spot_price ne ""}}true{{else}}false{{end}} \
+      --node-labels=spot={{if ne .Values.spot_price ""}}true{{else}}false{{end}} \
       --node-labels={{ .Values.node_labels }} \
       --cluster-dns=${PRIVATE_EC2_IPV4},10.3.0.11 \
       --cluster-domain=cluster.local \

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -160,7 +160,7 @@ systemd:
       --allow-privileged \
       --node-labels=kubernetes.io/role=worker \
       --node-labels=kubernetes.io/node-pool={{ .NodePool.Name }}{{if index .NodePool.ConfigItems "labels"}},{{.NodePool.ConfigItems.labels}}{{end}} \
-      --node-labels=node-role.kubernetes.io/spot-worker={{if ne .Values.spot_price ""}}true{{else}}false{{end}} \
+      --node-labels=aws.amazon.com/spot={{if ne .Values.spot_price ""}}true{{else}}false{{end}} \
       --node-labels={{ .Values.node_labels }} \
       --cluster-dns=${PRIVATE_EC2_IPV4},10.3.0.11 \
       --cluster-domain=cluster.local \

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -160,7 +160,7 @@ systemd:
       --allow-privileged \
       --node-labels=kubernetes.io/role=worker \
       --node-labels=kubernetes.io/node-pool={{ .NodePool.Name }}{{if index .NodePool.ConfigItems "labels"}},{{.NodePool.ConfigItems.labels}}{{end}} \
-      --node-labels=spot={{if ne .Values.spot_price ""}}true{{else}}false{{end}} \
+      --node-labels=node-role.kubernetes.io/spot-worker={{if ne .Values.spot_price ""}}true{{else}}false{{end}} \
       --node-labels={{ .Values.node_labels }} \
       --cluster-dns=${PRIVATE_EC2_IPV4},10.3.0.11 \
       --cluster-domain=cluster.local \


### PR DESCRIPTION
Mark EC2 Spot instances with `aws.amazon.com/spot=true`. I initially planned to use the same label as kops, they use "spot", see https://github.com/kubernetes/kops/blob/70118bda4d05a331dce2b6c4f5c82a4cf4b1a001/docs/instance_groups.md

Marking nodes with a "aws.amazon.com/spot" label allows to have adequate scheduling decisions and helps to build proper reporting, e.g. like https://github.com/hjacobs/kube-resource-report/issues/18

The `spot_price` value is set in https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/4efbc647b6364095d349230b10bc5f8a5d9300f4/provisioner/node_pools.go#L168