### PR TITLE
fix: client closed request should not count as 5xx

### DIFF
--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.10.38
+    version: v0.10.39
     component: ingress
 spec:
   selector:
@@ -18,7 +18,7 @@ spec:
       name: skipper-ingress
       labels:
         application: skipper-ingress
-        version: v0.10.38
+        version: v0.10.39
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -33,7 +33,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.38
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.39
         ports:
         - name: ingress-port
           containerPort: 9999


### PR DESCRIPTION
fix: client closed request should not count as 5xx, instead of 504 we will now count a 499, similar to nginx
log: reduce logging in case of client closed request in the proxy