### PR TITLE
Reduce kube-controller-manager logging

### DIFF
--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -485,7 +485,6 @@ storage:
             - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true,ExpandPersistentVolumes=true
             - --horizontal-pod-autoscaler-use-rest-clients=true
             - --use-service-account-credentials=true
-            - --v=4
             - --allocate-node-cidrs=true
             - --cluster-cidr=10.2.0.0/16
             resources:


### PR DESCRIPTION
We enabled `--v=4` logging in controller manager once and never changed it again. It's now logging roughly 1GB per hour (reported by users) and rarely provides a lot of information.

In many clusters `kube-controller-manager` is logging more than any other application.

I propose we reduce the logging to default levels to reduce logging and save cost.