### PR TITLE
Master nodes: enable T2 unlimited

### DIFF
--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -15,7 +15,9 @@ Resources:
     Properties:
       HealthCheckGracePeriod: 480
       HealthCheckType: EC2
-      LaunchConfigurationName: !Ref AutoScalingConfig
+      LaunchTemplate:
+        LaunchTemplateId: !Ref LaunchTemplate
+        Version: !GetAtt LaunchTemplate.LatestVersionNumber
       LoadBalancerNames:
       - !ImportValue '{{ .Cluster.ID }}:master-load-balancer'
       MinSize: '{{ .NodePool.MinSize }}'
@@ -26,25 +28,31 @@ Resources:
         Value: "{{ .NodePool.Name }} ({{ .Cluster.ID }})"
       VPCZoneIdentifier: !Split [",", "{{ .Cluster.ConfigItems.subnets }}"]
     Type: 'AWS::AutoScaling::AutoScalingGroup'
-  AutoScalingConfig:
+  LaunchTemplate:
     Properties:
-      AssociatePublicIpAddress: true
-      BlockDeviceMappings:
-      - DeviceName: /dev/xvda
-        Ebs:
-          VolumeSize: 20
-          VolumeType: standard
-      EbsOptimized: false
-      IamInstanceProfile: !Ref AutoScalingInstanceProfile
-      ImageId: !FindInMap
-      - Images
-      - !Ref 'AWS::Region'
-      - StableCoreOSImage
-      InstanceType: "{{ .NodePool.InstanceType }}"
-      SecurityGroups:
-      - !ImportValue '{{ .Cluster.ID }}:master-security-group'
-      UserData: "{{ .UserData }}"
-    Type: 'AWS::AutoScaling::LaunchConfiguration'
+      LaunchTemplateName: '{{.Cluster.LocalID}}-master'
+      LaunchTemplateData:
+        NetworkInterfaces:
+        - DeviceIndex: 0
+          AssociatePublicIpAddress: true
+          Groups:
+          - !ImportValue '{{ .Cluster.ID }}:master-security-group'
+        BlockDeviceMappings:
+        - DeviceName: /dev/xvda
+          Ebs:
+            VolumeSize: 20
+            VolumeType: standard
+        EbsOptimized: false
+        IamInstanceProfile:
+          Name: !Ref AutoScalingInstanceProfile
+        InstanceInitiatedShutdownBehavior: terminate
+        ImageId: !FindInMap
+        - Images
+        - !Ref 'AWS::Region'
+        - StableCoreOSImage
+        InstanceType: "{{ .NodePool.InstanceType }}"
+        UserData: "{{ .UserData }}"
+    Type: 'AWS::EC2::LaunchTemplate'
   AutoScalingInstanceProfile:
     Properties:
       Path: /

--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -32,6 +32,10 @@ Resources:
     Properties:
       LaunchTemplateName: '{{.Cluster.LocalID}}-master'
       LaunchTemplateData:
+{{ if .Values.supports_t2_unlimited }}
+        CreditSpecification:
+          CpuCredits: unlimited
+{{ end }}
         NetworkInterfaces:
         - DeviceIndex: 0
           AssociatePublicIpAddress: true


### PR DESCRIPTION
* Switch master node pool to use LaunchTemplate instead of LaunchConfiguration
* Automatically enable T2 unlimited for master nodes

**Note**: depends on https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/66!