### PR TITLE
skipper-update

### DIFF
--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.10.39
+    version: v0.10.43
     component: ingress
 spec:
   selector:
@@ -18,7 +18,7 @@ spec:
       name: skipper-ingress
       labels:
         application: skipper-ingress
-        version: v0.10.39
+        version: v0.10.43
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -33,7 +33,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.39
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.43
         ports:
         - name: ingress-port
           containerPort: 9999


### PR DESCRIPTION
- fix: kubernetes ingress custom-routes annotation for multiple hosts (#711)
- fix: kubernetes ingress backends can not have different ports from one service (#717)
- feature: predicates to match routes based on jwt content (#710)

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>