### PR TITLE
Skipper: use more histogram buckets for latency metrics

### DIFF
--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.10.43
+    version: v0.10.45
     component: ingress
 spec:
   selector:
@@ -18,7 +18,7 @@ spec:
       name: skipper-ingress
       labels:
         application: skipper-ingress
-        version: v0.10.43
+        version: v0.10.45
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -33,7 +33,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.43
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.45
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -54,6 +54,7 @@ spec:
           - "-metrics-flavour=codahale,prometheus"
           - "-enable-connection-metrics"
           - "-oauth2-tokeninfo-url={{ .ConfigItems.tokeninfo_url }}"
+          - "-histogram-metric-buckets=.01,.025,.05,.075,.1,.2,.3,.4,.5,.75,1,2,3,4,5,7,10,15,20,30,60,120,300,600"
         resources:
           limits:
             memory: 200Mi


### PR DESCRIPTION
The default buckets are capped at 10 seconds, which doesn't really work for real applications. Increase the number of the buckets so we have better numbers.