### PR TITLE
Dev to alpha

### DIFF
--- a/cluster/manifests/prometheus-node-exporter/daemonset.yaml
+++ b/cluster/manifests/prometheus-node-exporter/daemonset.yaml
@@ -4,7 +4,7 @@ metadata:
   name: prometheus-node-exporter
   labels:
     application: prometheus-node-exporter
-    version: v0.12.0
+    version: v0.16.0
     component: node-exporter
   namespace: kube-system
 spec:
@@ -18,7 +18,7 @@ spec:
       name: prometheus-node-exporter
       labels:
         application: prometheus-node-exporter
-        version: v0.12.0
+        version: v0.16.0
         component: node-exporter
     spec:
       priorityClassName: system-node-critical
@@ -28,7 +28,7 @@ spec:
       - operator: Exists
         effect: NoExecute
       containers:
-      - image: registry.opensource.zalan.do/teapot/prometheus-node-exporter:v0.14.0
+      - image: registry.opensource.zalan.do/teapot/prometheus-node-exporter:v0.16.0
         args:
           - --collector.textfile.directory=/prometheus-exporter-data
         name: prometheus-node-exporter
@@ -38,11 +38,11 @@ spec:
           hostPort: 9100
         resources:
           limits:
-            cpu: 200m
-            memory: 200Mi
+            cpu: 20m
+            memory: 50Mi
           requests:
-            cpu: 25m
-            memory: 25Mi
+            cpu: 20m
+            memory: 50Mi
         securityContext:
           privileged: true
         volumeMounts:

--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -95,6 +95,10 @@ data:
     - job_name: 'kubelet-cadvisor'
       kubernetes_sd_configs:
       - role: node
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        action: keep
+        regex: '(container_cpu_cfs_throttled_seconds_total|container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total)'
       relabel_configs:
       - source_labels: [__meta_kubernetes_node_address_InternalIP]
         target_label: __address__

--- a/cluster/manifests/prometheus/statefulset.yaml
+++ b/cluster/manifests/prometheus/statefulset.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
   labels:
     application: prometheus
-    version: v2.2.1
+    version: v2.3.2
   name: prometheus
   namespace: kube-system
 spec:
@@ -17,14 +17,14 @@ spec:
     metadata:
       labels:
         application: prometheus
-        version: v2.2.1
+        version: v2.3.2
       annotations:
         config/hash: {{"configmap.yaml" | manifestHash}}
     spec:
       priorityClassName: system-cluster-critical
       containers:
       - name: prometheus
-        image: registry.opensource.zalan.do/teapot/prometheus:v2.2.1
+        image: registry.opensource.zalan.do/teapot/prometheus:v2.3.2
         args:
         - "--config.file=/etc/prometheus/prometheus.yml"
         - "--storage.tsdb.path=/prometheus/"

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.10.43
+    version: v0.10.45
     component: ingress
 spec:
   selector:
@@ -18,7 +18,7 @@ spec:
       name: skipper-ingress
       labels:
         application: skipper-ingress
-        version: v0.10.43
+        version: v0.10.45
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -33,7 +33,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.43
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.45
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -54,6 +54,7 @@ spec:
           - "-metrics-flavour=codahale,prometheus"
           - "-enable-connection-metrics"
           - "-oauth2-tokeninfo-url={{ .ConfigItems.tokeninfo_url }}"
+          - "-histogram-metric-buckets=.01,.025,.05,.075,.1,.2,.3,.4,.5,.75,1,2,3,4,5,7,10,15,20,30,60,120,300,600"
         resources:
           limits:
             memory: 200Mi


### PR DESCRIPTION
* **Skipper: use more histogram buckets for latency metrics**
   <sup>Merge pull request #1284 from zalando-incubator/skipper-histo-buckets</sup>
* **optimize amount of metrics in prometheus**
   <sup>Merge pull request #1282 from zalando-incubator/optimize/whitelist-cadvisor-metrics</sup>
* **update prometheus and node-exporter**
   <sup>Merge pull request #1280 from zalando-incubator/update/prometheus-and-exporter</sup>
