### PR TITLE
skipper update custom-routes change and OAuth tokeninfo request timeouts

### DIFF
--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.10.45
+    version: v0.10.55
     component: ingress
 spec:
   selector:
@@ -18,7 +18,7 @@ spec:
       name: skipper-ingress
       labels:
         application: skipper-ingress
-        version: v0.10.45
+        version: v0.10.55
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -33,7 +33,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.45
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.55
         ports:
         - name: ingress-port
           containerPort: 9999


### PR DESCRIPTION
This will use a released version:
  - Add -histogram-metric-buckets option (#722 @aermakov-zalando )
    If set, use a custom set of buckets for Prometheus histogram metrics
    instead of the default one.
  - Add flag for Oauth request timeout (#707 @addityasingh )
  - Add filter setQuery(string) #723 (#724) to set only the key without =
  - feature: Adds Gauges to metrics (#726 @topicus)
  - fix kube dataclient: (#720)
        custom-routes annotation should specify the path with pathmode if set in the ingress spec
        pathmode lookup is global for an ingress and should follow the other annotation handling, too. It will default to the global pathmode if it is not able to parse the mode. Find more information about pathmodes in our documentation https://opensource.zalando.com/skipper/kubernetes/ingress-usage/\#ingress-path-handling
        adds path to route id and add test cases for custom skipper routes via ingress annotations
        makes sure to test #720 (comment) object works as expected

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>