### PR TITLE
Kube 1.11 patch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,10 +10,10 @@ This repo contains configuration templates to provision Kubernetes_ clusters on 
 However, **we are open to ideas from the community at large about potentially turning this idea into a project that provides universal/general value to others**.
 Please contact us via our Issues Tracker with your thoughts and suggestions.
 
-Configuration in this repository initially was based on kube-aws_, but now depends on three components which are not yet open sourced:
+Configuration in this repository initially was based on kube-aws_, but now depends on three components which aren't all yet open sourced:
 
 * Cluster Registry to keep desired cluster states (e.g. used config channel and version)
-* Cluster Lifecycle Manager to provision the cluster's Cloud Formation stack and apply Kubernetes manifests for system components
+* `Cluster Lifecycle Manager`_ to provision the cluster's Cloud Formation stack and apply Kubernetes manifests for system components
 * Authnz Webhook to validate OAuth tokens and authorize access
 
 We plan to release all required components to the community in Q2/2018.
@@ -71,6 +71,7 @@ Directory Structure
 .. _kube-aws: https://github.com/coreos/coreos-kubernetes/tree/master/multi-node/aws
 .. _Senza Cloud Formation tool: https://github.com/zalando-stups/senza
 .. _OAuth Token Info: http://planb.readthedocs.io/en/latest/intro.html#token-info
+.. _Cluster Lifecycle Manager: https://github.com/zalando-incubator/cluster-lifecycle-manager
 .. _External DNS: https://github.com/kubernetes-incubator/external-dns
 .. _kube2iam: https://github.com/jtblin/kube2iam
 .. _kube-aws-autoscaler: https://github.com/hjacobs/kube-aws-autoscaler

--- a/cluster/etcd-cluster.yaml
+++ b/cluster/etcd-cluster.yaml
@@ -16,7 +16,7 @@ SenzaComponents:
         2380: 2380
         2381: 2381
       runtime: Docker
-      source: registry.opensource.zalan.do/acid/etcd-cluster:3.3.1-p20
+      source: registry.opensource.zalan.do/acid/etcd-cluster:3.3.9-p21
       environment:
         HOSTED_ZONE: '{{Arguments.HostedZone}}'
       mounts:

--- a/cluster/manifests/coredns/deployment-coredns.yaml
+++ b/cluster/manifests/coredns/deployment-coredns.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: coredns
-    version: v1.1.3
+    version: v1.2.0
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
     component: cluster-dns
@@ -22,7 +22,7 @@ spec:
     metadata:
       labels:
         application: coredns
-        version: v1.1.3
+        version: v1.2.0
         component: cluster-dns
     spec:
       affinity:
@@ -48,7 +48,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: coredns
-        image: registry.opensource.zalan.do/teapot/coredns:1.1.3
+        image: registry.opensource.zalan.do/teapot/coredns:1.2.0
         resources:
           requests:
             cpu: 250m

--- a/cluster/manifests/emergency-access-service/deployment.yaml
+++ b/cluster/manifests/emergency-access-service/deployment.yaml
@@ -24,6 +24,17 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: system
       containers:
+      - name: apiserver-proxy
+        image: registry.opensource.zalan.do/teapot/etcd-proxy:master-3
+        command:
+        - /bin/sh
+        args:
+        - -c
+        - "exec /etcd-proxy --listen-address 127.0.0.1:333 $KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT"
+        resources:
+          requests:
+            cpu: 25m
+            memory: 25Mi
       - name: emergency-access-service
         image: "pierone.stups.zalan.do/teapot/emergency-access-service:master-58"
         args:
@@ -40,6 +51,10 @@ spec:
         - --jira-url=https://techjira.zalando.net
         - --environment={{ .Environment }}
         env:
+        - name: KUBERNETES_SERVICE_HOST
+          value: "127.0.0.1"
+        - name: KUBERNETES_SERVICE_PORT
+          value: "333"
         - name: CONFIGMAP_NAMESPACE
           valueFrom:
             fieldRef:

--- a/cluster/manifests/heapster/deployment.yaml
+++ b/cluster/manifests/heapster/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     application: heapster
     kubernetes.io/cluster-service: "true"
-    version: v1.5.2
+    version: v1.5.4
 spec:
   replicas: 1
   selector:
@@ -16,12 +16,12 @@ spec:
     metadata:
       labels:
         application: heapster
-        version: v1.5.2
+        version: v1.5.4
     spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: system
       containers:
-        - image: registry.opensource.zalan.do/teapot/heapster:v1.5.2
+        - image: registry.opensource.zalan.do/teapot/heapster:v1.5.4
           name: heapster
           livenessProbe:
             httpGet:

--- a/cluster/manifests/kube-cluster-autoscaler/deployment.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/deployment.yaml
@@ -51,5 +51,7 @@ spec:
         env:
           - name: AWS_REGION
             value: {{ .Region }}
+          - name: KUBE_MAX_PD_VOLS
+            value: "26"
       nodeSelector:
         node-role.kubernetes.io/master: ""

--- a/cluster/manifests/kube-proxy/configmap.yaml
+++ b/cluster/manifests/kube-proxy/configmap.yaml
@@ -38,7 +38,7 @@ data:
       syncPeriod: 30s
     kind: KubeProxyConfiguration
     metricsBindAddress: 127.0.0.1:10249
-    mode: ipvs
+    mode: iptables
     oomScoreAdj: -999
     portRange: ""
     resourceContainer: /kube-proxy

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-proxy
-    version: v1.11.1
+    version: v1.11.2
 spec:
   selector:
     matchLabels:
@@ -17,7 +17,7 @@ spec:
       name: kube-proxy
       labels:
         application: kube-proxy
-        version: v1.11.1
+        version: v1.11.2
       annotations:
         config/hash: {{"configmap.yaml" | manifestHash}}
     spec:
@@ -30,7 +30,7 @@ spec:
       hostNetwork: true
       containers:
       - name: kube-proxy
-        image: registry.opensource.zalan.do/teapot/hyperkube:v1.11.1
+        image: registry.opensource.zalan.do/teapot/hyperkube:v1.11.2
         command:
         - /hyperkube
         - proxy

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -548,6 +548,9 @@ storage:
             - --master=http://127.0.0.1:8080
             - --leader-elect=true
             - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true
+            env:
+            - name: KUBE_MAX_PD_VOLS
+              value: "26"
             resources:
               requests:
                 cpu: 100m

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -139,7 +139,7 @@ systemd:
       After=docker.service dockercfg.service meta-data-iptables.service private-ipv4.service
 
       [Service]
-      Environment=KUBELET_IMAGE_TAG=v1.11.1
+      Environment=KUBELET_IMAGE_TAG=v1.11.2
       Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
       Environment="RKT_RUN_ARGS=--insecure-options=image \
       --uuid-file-save=/var/run/kubelet-pod.uuid \
@@ -277,7 +277,7 @@ storage:
           namespace: kube-system
           labels:
             application: kube-apiserver
-            version: v1.11.1
+            version: v1.11.2
           annotations:
             kubernetes-log-watcher/scalyr-parser: |
               [{"container": "webhook", "parser": "json-structured-log"}]
@@ -289,7 +289,7 @@ storage:
           hostNetwork: true
           containers:
           - name: kube-apiserver
-            image: registry.opensource.zalan.do/teapot/hyperkube:v1.11.1
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.11.2
             command:
             - /hyperkube
             - apiserver
@@ -464,7 +464,7 @@ storage:
           namespace: kube-system
           labels:
             application: kube-controller-manager
-            version: v1.11.1
+            version: v1.11.2
         spec:
           priorityClassName: system-node-critical
           tolerations:
@@ -472,7 +472,7 @@ storage:
             effect: NoSchedule
           containers:
           - name: kube-controller-manager
-            image: registry.opensource.zalan.do/teapot/hyperkube:v1.11.1
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.11.2
             command:
             - /hyperkube
             - controller-manager
@@ -532,7 +532,7 @@ storage:
           namespace: kube-system
           labels:
             application: kube-scheduler
-            version: v1.11.1
+            version: v1.11.2
         spec:
           priorityClassName: system-node-critical
           tolerations:
@@ -541,7 +541,7 @@ storage:
           hostNetwork: true
           containers:
           - name: kube-scheduler
-            image: registry.opensource.zalan.do/teapot/hyperkube:v1.11.1
+            image: registry.opensource.zalan.do/teapot/hyperkube:v1.11.2
             command:
             - /hyperkube
             - scheduler
@@ -906,7 +906,7 @@ storage:
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
           --net=host \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.11.1 \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.11.2 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           label node "$(hostname)" \
@@ -919,7 +919,7 @@ storage:
           --net=host \
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.11.1 \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.11.2 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           drain "$(hostname)" \

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -198,6 +198,24 @@ systemd:
       [Install]
       WantedBy=multi-user.target
 
+{{if eq .NodePool.DiscountStrategy "spot_max_price"}}
+  - name: spot-termination-handler.service
+    enable: true
+    contents: |
+      [Unit]
+      Description=poll for AWS Spot termination signal and force node shutdown
+      After=network.target
+
+      [Service]
+      Type=simple
+      Restart=on-failure
+      RestartSec=5
+      ExecStart=/opt/bin/spot-termination-handler
+
+      [Install]
+      WantedBy=multi-user.target
+{{end}}
+
 storage:
   files:
   - filesystem: root
@@ -356,6 +374,29 @@ storage:
           --ignore-daemonsets \
           --delete-local-data \
           --force
+
+{{if eq .NodePool.DiscountStrategy "spot_max_price"}}
+  - filesystem: root
+    path: /opt/bin/spot-termination-handler
+    mode: 0755
+    contents:
+      inline: |
+        #!/bin/bash
+        set -euo pipefail
+
+        AZ="$(curl -s --max-time 5 --fail http://169.254.169.254/latest/meta-data/placement/availability-zone)"
+        TYPE="$(curl -s --max-time 5 --fail http://169.254.169.254/latest/meta-data/instance-type)"
+        ID="$(curl -s --max-time 5 --fail http://169.254.169.254/latest/meta-data/instance-id)"
+
+        while true; do
+            if curl -s --max-time 5 --fail http://169.254.169.254/latest/meta-data/spot/termination-time; then
+                echo "[az=$AZ type=$TYPE id=$ID] received spot termination notice"
+                shutdown now
+                exit 0
+            fi
+            sleep 5
+        done
+{{end}}
 
   # this should only be enabled for instances with instance storage. e.g.
   # i3.large instances

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -130,7 +130,7 @@ systemd:
       After=docker.service dockercfg.service meta-data-iptables.service private-ipv4.service
 
       [Service]
-      Environment=KUBELET_IMAGE_TAG=v1.11.1
+      Environment=KUBELET_IMAGE_TAG=v1.11.2
       Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
       Environment="RKT_RUN_ARGS=--insecure-options=image \
       --uuid-file-save=/var/run/kubelet-pod.uuid \
@@ -346,7 +346,7 @@ storage:
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
           --net=host \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.11.1 \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.11.2 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           label node "$(hostname)" \
@@ -359,7 +359,7 @@ storage:
           --net=host \
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.11.1 \
+          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.11.2 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           drain "$(hostname)" \


### PR DESCRIPTION
Takes the latest changes from dev and bump Kubernetes version to 1.11.2.
Also changes the mode of kube-proxy back to iptables, because of the issue https://github.com/kubernetes/kubernetes/issues/57841 which will be fixed in the future