### PR TITLE
Increase memory reservation for autoscaling buffer pods

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -3,7 +3,7 @@ autoscaling_buffer_pools: "default-worker"
 autoscaling_buffer_cpu_scale: "1"
 autoscaling_buffer_memory_scale: "0.85"
 autoscaling_buffer_cpu_reserved: "1"
-autoscaling_buffer_memory_reserved: "1500Mi"
+autoscaling_buffer_memory_reserved: "2000Mi"
 {{if eq .Environment "production"}}
 autoscaling_buffer_pods: "1"
 {{else}}


### PR DESCRIPTION
Previous setting of 1.5Gi wasn't enough for c5 instances. Let's increase it to 2Gi for now.