### PR TITLE
oauth filter in front of emergency-access-service 

### DIFF
--- a/cluster/manifests/emergency-access-service/ingress.yaml
+++ b/cluster/manifests/emergency-access-service/ingress.yaml
@@ -4,6 +4,9 @@ kind: Ingress
 metadata:
   name: emergency-access-service
   namespace: kube-system
+  annotations:
+    zalando.org/skipper-filter: |
+      oauthTokeninfoAnyScope("uid")
   labels:
     application: emergency-access-service
 spec:


### PR DESCRIPTION
add oauth filter in front of eas to make scanners not contributing to measured and alerted errors