### PR TITLE
ZMON: use a user-defined priority class

### DIFF
--- a/cluster/manifests/01-visibility/priority.yaml
+++ b/cluster/manifests/01-visibility/priority.yaml
@@ -1,0 +1,7 @@
+apiVersion: scheduling.k8s.io/v1alpha1
+kind: PriorityClass
+metadata:
+  name: visibility-zmon
+value: 1000000000
+globalDefault: false
+description: "This priority class is used by ZMON components."

--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
     spec:
-      priorityClassName: system-cluster-critical
+      priorityClassName: visibility-zmon
       initContainers:
       - name: gerry-init
         image: registry.opensource.zalan.do/teapot/gerry:v0.0.14

--- a/cluster/manifests/zmon-aws-agent/deployment.yaml
+++ b/cluster/manifests/zmon-aws-agent/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
     spec:
-      priorityClassName: system-cluster-critical
+      priorityClassName: visibility-zmon
       initContainers:
       - name: gerry-init
         image: registry.opensource.zalan.do/teapot/gerry:v0.0.14

--- a/cluster/manifests/zmon-redis/deployment.yaml
+++ b/cluster/manifests/zmon-redis/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         application: "zmon-redis"
         version: "v0.1"
     spec:
-      priorityClassName: system-cluster-critical
+      priorityClassName: visibility-zmon
       containers:
         - name: zmon-redis
           image: registry.opensource.zalan.do/zmon/redis:3.2.9

--- a/cluster/manifests/zmon-scheduler/deployment.yaml
+++ b/cluster/manifests/zmon-scheduler/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
     spec:
-      priorityClassName: system-cluster-critical
+      priorityClassName: visibility-zmon
       initContainers:
       - name: gerry-init
         image: registry.opensource.zalan.do/teapot/gerry:v0.0.14

--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
     spec:
-      priorityClassName: system-cluster-critical
+      priorityClassName: visibility-zmon
       initContainers:
       - name: gerry-init
         image: registry.opensource.zalan.do/teapot/gerry:v0.0.14


### PR DESCRIPTION
In 1.11, system priority classes [are restricted](https://github.com/kubernetes/kubernetes/pull/65593) to `kube-system` only. Fix by creating a separate priority class for ZMON components.