### PR TITLE
decrease default CPU requests

### DIFF
--- a/cluster/manifests/default-limits/limits.yaml
+++ b/cluster/manifests/default-limits/limits.yaml
@@ -7,7 +7,7 @@ spec:
   limits:
     - type: "Container"
       defaultRequest:
-        cpu: "100m"
+        cpu: "50m"
         memory: 100Mi
       default:
         # default limit for CPU is 3 cores as we discovered that this is a sweet spot for JVM apps to startup quickly


### PR DESCRIPTION
Some (low-traffic) applications never set any CPU/memory requests. Reduce the default number of CPU requests to increase utilization.

This should not have any impact as it just decreases priority for apps not setting requests (and they are already low priority). This potentially decrease Kubernetes resource slack as we see mostly CPU slack (more requested than used).