### PR TITLE
fix go template: neq -> ne

### DIFF
--- a/cluster/manifests/kube-downscaler/deployment.yaml
+++ b/cluster/manifests/kube-downscaler/deployment.yaml
@@ -1,4 +1,4 @@
-{{ if neq .Environment "production" }}
+{{ if ne .Environment "production" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
Fix Go template :cry: 

```
time='2018-08-14T08:16:23.741006906Z' log='time="2018-08-14T08:16:23Z" level=error msg="Error applying template template: /workdir/kubernetes-on-aws_fb7ce41eea62ad9ffa330162ac7ab0d980bd9424_1534234536671188093/cluster/manifests/kube-downscaler/deployment.yaml:1: function "neq" not defined" cluster=playground worker=19' 
```

https://golang.org/pkg/text/template/#hdr-Functions