### PR TITLE
Reduce default CPU request to 25m

### DIFF
--- a/cluster/manifests/default-limits/limits.yaml
+++ b/cluster/manifests/default-limits/limits.yaml
@@ -7,7 +7,7 @@ spec:
   limits:
     - type: "Container"
       defaultRequest:
-        cpu: "50m"
+        cpu: "25m"
         memory: 100Mi
       default:
         # default limit for CPU is 3 cores as we discovered that this is a sweet spot for JVM apps to startup quickly


### PR DESCRIPTION
Follow up to the recent reduction of default CPU request to `50m`. This reduces it further to `25m` as requested here: https://github.com/zalando-incubator/kubernetes-on-aws/pull/1314#issuecomment-413189931