### PR TITLE
fix memory leak in skipper, that is triggered by using tokeninfo filters

### DIFF
--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.10.55
+    version: v0.10.59
     component: ingress
 spec:
   selector:
@@ -18,7 +18,7 @@ spec:
       name: skipper-ingress
       labels:
         application: skipper-ingress
-        version: v0.10.55
+        version: v0.10.59
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -33,7 +33,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.55
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.59
         ports:
         - name: ingress-port
           containerPort: 9999


### PR DESCRIPTION
fix memory leak in skipper, that is triggered by using tokeninfo filters