### PR TITLE
Run kube-downscaler in production

### DIFF
--- a/cluster/manifests/kube-downscaler/deployment.yaml
+++ b/cluster/manifests/kube-downscaler/deployment.yaml
@@ -1,4 +1,3 @@
-{{ if ne .Environment "production" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -39,4 +38,3 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 1000
-{{ end }}


### PR DESCRIPTION
Run `kube-downscaler` in production, too (default uptime is "always"). This allows using annotations  (e.g. `downscaler/downtime`) to scale down deployments in off-hours (e.g. low-traffic employee services).

Fixes #1327.