### PR TITLE
Make all cluster wide HPA settings configurable

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -49,3 +49,9 @@ downscaler_default_uptime: "Mon-Fri 07:30-20:30 CET"
 {{else}}
 downscaler_default_uptime: "always"
 {{end}}
+
+# HPA settings (defaults from https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/)
+horizontal_pod_autoscaler_downscale_delay: "5m0s"
+horizontal_pod_autoscaler_sync_period: "30s"
+horizontal_pod_autoscaler_tolerance: "0.1"
+horizontal_pod_autoscaler_upscale_delay: "3m0s"

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -483,10 +483,14 @@ storage:
             - --cloud-provider=aws
             - --cloud-config=/etc/kubernetes/cloud-config.ini
             - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true,ExpandPersistentVolumes=true
-            - --horizontal-pod-autoscaler-use-rest-clients=true
             - --use-service-account-credentials=true
             - --allocate-node-cidrs=true
             - --cluster-cidr=10.2.0.0/16
+            - --horizontal-pod-autoscaler-use-rest-clients=true
+            - --horizontal-pod-autoscaler-downscale-delay={{ .Cluster.ConfigItems.horizontal_pod_autoscaler_downscale_delay }}
+            - --horizontal-pod-autoscaler-sync-period={{ .Cluster.ConfigItems.horizontal_pod_autoscaler_sync_period }}
+            - --horizontal-pod-autoscaler-tolerance={{ .Cluster.ConfigItems.horizontal_pod_autoscaler_tolerance }}
+            - --horizontal-pod-autoscaler-upscale-delay={{ .Cluster.ConfigItems.horizontal_pod_autoscaler_upscale_delay }}
             resources:
               requests:
                 cpu: 100m


### PR DESCRIPTION
Make all cluster wide HPA settings configurable.

This makes it possible to tweak the settings per cluster via config items.