### PR TITLE
Critical pods don't have to run in kube-system

### DIFF
--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: logging-agent
-  namespace: kube-system
+  namespace: visibility
   labels:
     application: logging-agent
     version: v0.19
@@ -22,7 +22,7 @@ spec:
         version: v0.19
         component: logging
     spec:
-      priorityClassName: system-node-critical
+      priorityClassName: visibility-zmon
       tolerations:
       - operator: Exists
         effect: NoSchedule


### PR DESCRIPTION
In Kubernetes 1.11 pod priority and preemption feature is enabled by default.
We can run critical pods in all namespaces. 

#1217 Moving the logging-agent into visibility