### PR TITLE
ExternalDNS v0.5.5

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: external-dns
-    version: v0.5.4
+    version: v0.5.5
 spec:
   strategy:
     type: Recreate
@@ -16,14 +16,14 @@ spec:
     metadata:
       labels:
         application: external-dns
-        version: v0.5.4
+        version: v0.5.5
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
     spec:
       priorityClassName: system-cluster-critical
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.5.4
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.5.5
         args:
         - --source=service
         - --source=ingress


### PR DESCRIPTION
See https://github.com/kubernetes-incubator/external-dns/releases/tag/v0.5.5

Interesting for us:

* Kubernetes API request timeout: https://github.com/kubernetes-incubator/external-dns/pull/681
* Route Evaluate Target Health option: https://github.com/kubernetes-incubator/external-dns/issues/627
* Fix log message: https://github.com/kubernetes-incubator/external-dns/pull/634
* (+ others issues?)