### PR TITLE
Run cAdvisor as a daemonset

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -136,10 +136,6 @@ Resources:
           IpProtocol: tcp
           ToPort: 30080
         - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 4194
-          IpProtocol: tcp
-          ToPort: 4194
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
           FromPort: 9054
           IpProtocol: tcp
           ToPort: 9054

--- a/cluster/manifests/cadvisor/daemonset.yaml
+++ b/cluster/manifests/cadvisor/daemonset.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cadvisor
+  namespace: kube-system
+  labels:
+    application: cadvisor
+    version: v0.30.2
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      application: cadvisor
+  template:
+    metadata:
+      labels:
+        application: cadvisor
+        version: v0.30.2
+    spec:
+      priorityClassName: system-node-critical
+      containers:
+      - name: cadvisor
+        image: registry.opensource.zalan.do/teapot/cadvisor:v0.30.2
+        args:
+        - --housekeeping_interval=10s
+        - --max_housekeeping_interval=15s
+        - --event_storage_event_limit=default=0
+        - --event_storage_age_limit=default=0
+        - --disable_metrics=percpu,tcp,udp
+        - --docker_only
+        resources:
+          requests:
+            memory: 150Mi
+            cpu: 150m
+        volumeMounts:
+        - name: rootfs
+          mountPath: /rootfs
+          readOnly: true
+        - name: var-run
+          mountPath: /var/run
+          readOnly: true
+        - name: sys
+          mountPath: /sys
+          readOnly: true
+        - name: docker
+          mountPath: /var/lib/docker
+          readOnly: true
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: rootfs
+        hostPath:
+          path: /
+      - name: var-run
+        hostPath:
+          path: /var/run
+      - name: sys
+        hostPath:
+          path: /sys
+      - name: docker
+        hostPath:
+          path: /var/lib/docker
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      - operator: Exists
+        effect: NoExecute

--- a/cluster/manifests/cadvisor/service.yaml
+++ b/cluster/manifests/cadvisor/service.yaml
@@ -1,0 +1,15 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: cadvisor
+  namespace: kube-system
+  labels:
+    application: cadvisor
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    application: cadvisor

--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -92,21 +92,40 @@ data:
       - action: replace
         source_labels: ['__meta_kubernetes_pod_node_name']
         target_label: node_name
-    - job_name: 'kubelet-cadvisor'
+    - job_name: 'cadvisor'
+      scheme: http
+      honor_labels: true
       kubernetes_sd_configs:
-      - role: node
+      - role: endpoints
+        namespaces:
+          names:
+            - kube-system
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_endpoints_name]
+        action: keep
+        regex: cadvisor
+      - action: replace
+        source_labels: ['__meta_kubernetes_pod_node_name']
+        target_label: node_name
       metric_relabel_configs:
+      - action: replace
+        source_labels: ['container_label_application']
+        target_label: application
+      - action: replace
+        source_labels: ['container_label_io_kubernetes_container_name']
+        target_label: container_name
+      - action: replace
+        source_labels: ['container_label_io_kubernetes_pod_name']
+        target_label: pod_name
+      - action: replace
+        source_labels: ['container_label_io_kubernetes_pod_namespace']
+        target_label: namespace
+      - action: replace
+        source_labels: ['container_label_io_kubernetes_pod_uid']
+        target_label: uid
       - source_labels: [__name__]
         action: keep
         regex: '(container_cpu_cfs_throttled_seconds_total|container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total)'
-      relabel_configs:
-      - source_labels: [__meta_kubernetes_node_address_InternalIP]
-        target_label: __address__
-        regex: (.*)
-        replacement: $1:4194
-      - action: replace
-        source_labels: [instance]
-        target_label: node_name
     - job_name: 'kubelet-metrics'
       kubernetes_sd_configs:
       - role: node


### PR DESCRIPTION
In 1.11, kubelet no longer exposes cAdvisor metrics by default. Since it's going to be removed in 1.12, let's just run cAdvisor as a daemonset.