### PR TITLE
Add back rescheduler

### DIFF
--- a/cluster/manifests/rescheduler/deployment.yaml
+++ b/cluster/manifests/rescheduler/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rescheduler
+  namespace: kube-system
+  labels:
+    application: rescheduler
+    version: v0.4.0
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      application: rescheduler
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        application: rescheduler
+        version: v0.4.0
+    spec:
+      priorityClassName: system-cluster-critical
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      serviceAccountName: system
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      containers:
+      - name: rescheduler
+        image: registry.opensource.zalan.do/teapot/rescheduler:v0.4.0
+        resources:
+          requests:
+            cpu: 25m
+            memory: 100Mi
+          limits:
+            cpu: 25m
+            memory: 100Mi


### PR DESCRIPTION
We actually _need_ the rescheduler, because the DS controller doesn't handle preemption. :(