### PR TITLE
Bump node-exporter's memory limits

### DIFF
--- a/cluster/manifests/prometheus-node-exporter/daemonset.yaml
+++ b/cluster/manifests/prometheus-node-exporter/daemonset.yaml
@@ -39,10 +39,10 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 50Mi
+            memory: 75Mi
           requests:
             cpu: 20m
-            memory: 50Mi
+            memory: 75Mi
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
Node Exporter get's frequently OOM killed since yesterday. This bumps its memory limits a little.