### PR TITLE
limits: remove the maximum

### DIFF
--- a/cluster/manifests/default-limits/limits.yaml
+++ b/cluster/manifests/default-limits/limits.yaml
@@ -13,6 +13,3 @@ spec:
         # default limit for CPU is 3 cores as we discovered that this is a sweet spot for JVM apps to startup quickly
         cpu: "3000m"
         memory: 1Gi
-      max:
-        cpu: "16"
-        memory: 64Gi


### PR DESCRIPTION
This didn't really do anything and prevented scheduling in at least one cluster.