### PR TITLE
image-policy-webhook: update to v0.4.0

### DIFF
--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -424,7 +424,7 @@ storage:
                 value: https://identity.zalando.com/.well-known/openid-configuration
               - name: ENABLE_INTROSPECTION
                 value: "true"
-          - image: registry.opensource.zalan.do/teapot/image-policy-webhook:v0.3.10
+          - image: registry.opensource.zalan.do/teapot/image-policy-webhook:v0.4.0
             name: image-policy-webhook
             args:
             - --policy={{ .Cluster.ConfigItems.image_policy }}


### PR DESCRIPTION
* `prod` policy dropped
* webhook now returns informative errors