### PR TITLE
Use tokeninfo bridge in test clusters

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -14,7 +14,7 @@ autoscaling_buffer_pods: "0"
 {{if eq .Environment "production"}}
 tokeninfo_url: "https://info.services.auth.zalando.com/oauth2/tokeninfo"
 {{else}}
-tokeninfo_url: "https://tokeninfo.sandbox.identity.zalando.com/oauth2/tokeninfo"
+tokeninfo_url: "https://sandbox-tokeninfo-bridge.stups.zalan.do/oauth2/tokeninfo"
 {{end}}
 
 # Image Policy Webhook


### PR DESCRIPTION
Use the bridge instead of sandbox tokeninfo.