### PR TITLE
prometheus-node-exporter: increase memory for the conntrack exporter

### DIFF
--- a/cluster/manifests/prometheus-node-exporter/daemonset.yaml
+++ b/cluster/manifests/prometheus-node-exporter/daemonset.yaml
@@ -54,10 +54,10 @@ spec:
         resources:
           limits:
             cpu: 10m
-            memory: 20Mi
+            memory: 40Mi
           requests:
             cpu: 10m
-            memory: 20Mi
+            memory: 40Mi
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
It's crashing at 20Mi, let's bump it to 40.