### PR TITLE
Dev to kube 1.11

### DIFF
--- a/cluster/manifests/prometheus-node-exporter/daemonset.yaml
+++ b/cluster/manifests/prometheus-node-exporter/daemonset.yaml
@@ -54,10 +54,10 @@ spec:
         resources:
           limits:
             cpu: 10m
-            memory: 20Mi
+            memory: 40Mi
           requests:
             cpu: 10m
-            memory: 20Mi
+            memory: 40Mi
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
* **prometheus-node-exporter: increase memory for the conntrack exporter**
   <sup>Merge pull request #1360 from zalando-incubator/node-exporter-mem</sup>
