### PR TITLE
platformcredentialsset: add status subresource

### DIFF
--- a/cluster/manifests/platformcredentialsset/customresourcedefinition.yaml
+++ b/cluster/manifests/platformcredentialsset/customresourcedefinition.yaml
@@ -14,3 +14,5 @@ spec:
     singular: platformcredentialsset
     shortNames:
     - pcs
+  subresources:
+    status: {}


### PR DESCRIPTION
This is needed so we can report the status from Credentials Provider.