### PR TITLE
Dev to kube 1.11

### DIFF
--- a/cluster/manifests/platformcredentialsset/customresourcedefinition.yaml
+++ b/cluster/manifests/platformcredentialsset/customresourcedefinition.yaml
@@ -14,3 +14,5 @@ spec:
     singular: platformcredentialsset
     shortNames:
     - pcs
+  subresources:
+    status: {}

--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: "visibility"
   labels:
     application: "zmon-agent"
-    version: "0.1-a54-zv1"
+    version: "0.1-a56-zv2"
 spec:
   replicas: {{.ConfigItems.zmon_agent_replicas}}
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: "zmon-agent"
-        version: "0.1-a54-zv1"
+        version: "0.1-a56-zv2"
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
     spec:
@@ -43,7 +43,7 @@ spec:
 
       containers:
         - name: zmon-agent
-          image: "pierone.stups.zalan.do/zmon/zmon-agent-core:0.1-a54-zv1"
+          image: "pierone.stups.zalan.do/zmon/zmon-agent-core:0.1-a56-zv2"
           resources:
             limits:
               cpu: 100m

--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -4,7 +4,7 @@ Description: Kubernetes default master node pool
 Mappings:
   Images:
     eu-central-1:
-      StableCoreOSImage: ami-d0dcef3b
+      StableCoreOSImage: ami-03ee0a0310474a00e
 
 Resources:
   AutoScalingGroup:

--- a/cluster/node-pools/worker-default/stack.yaml
+++ b/cluster/node-pools/worker-default/stack.yaml
@@ -4,7 +4,7 @@ Description: Kubernetes default worker node pool
 Mappings:
   Images:
     eu-central-1:
-      StableCoreOSImage: ami-d0dcef3b
+      StableCoreOSImage: ami-03ee0a0310474a00e
 
 Conditions:
   UseSpotPrice:

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -4,7 +4,7 @@ Description: Kubernetes default worker node pool
 Mappings:
   Images:
     eu-central-1:
-      StableCoreOSImage: ami-d0dcef3b
+      StableCoreOSImage: ami-03ee0a0310474a00e
 
 Conditions:
   UseSpotPrice:


### PR DESCRIPTION
* **platformcredentialsset: add status subresource**
   <sup>Merge pull request #1370 from zalando-incubator/pcs-add-status</sup>
* **Bump the agent version to 0.1-a56-zv2**
   <sup>Merge pull request #1368 from avaczi/update-zmon-agent-core-to-56-zv2-2</sup>
* **Update CoreOS**
   <sup>Merge pull request #1366 from zalando-incubator/update-ami</sup>
