### PR TITLE
update ingress controller

### DIFF
--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.7.3
+    version: v0.7.4
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.7.3
+        version: v0.7.4
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
     spec:
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: system
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.7.3
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.7.4
         args:
         - -stack-termination-protection
         env:


### PR DESCRIPTION
* add dualstack (IPv6) support (#209)
* added a flag to blacklist certificate ARNs, that will not be considered
* Allow control of the SSL policy applied to https listeners via flag (#20 @jhohertz)
* Detach non-existing target groups from ASGs (#198)
* Reduce cert lookups within a single update (#193)
* Cleanup controller initialization and termination (#194)

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>