### PR TITLE
Use the latest Docker version by default

### DIFF
--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -876,7 +876,7 @@ storage:
           --table nat \
           --to-destination ${PRIVATE_EC2_IPV4}:8181
 
-  {{if not (index .Cluster.ConfigItems "upstream_docker")}}
+  {{if index .Cluster.ConfigItems "docker-1.12"}}
   - filesystem: root
     path: /etc/coreos/docker-1.12
     mode: 0644

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -311,7 +311,7 @@ storage:
           --table nat \
           --to-destination ${PRIVATE_EC2_IPV4}:8181
 
-  {{if not (index .Cluster.ConfigItems "upstream_docker")}}
+  {{if index .Cluster.ConfigItems "docker-1.12"}}
   - filesystem: root
     path: /etc/coreos/docker-1.12
     mode: 0644


### PR DESCRIPTION
Doing this alongside 1.11 rollout will avoid rolling the nodes multiple times.