### PR TITLE
Disable CFS quota by default

### DIFF
--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -174,7 +174,7 @@ systemd:
       --cloud-provider=aws \
       --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true \
       --pod-infra-container-image=registry.opensource.zalan.do/teapot/pause-amd64:3.1 \
-{{- if index .Cluster.ConfigItems "disable_cfs_quota" }}
+{{- if not (index .Cluster.ConfigItems "enable_cfs_quota") }}
       --cpu-cfs-quota=false \
 {{- end }}
       --system-reserved=cpu=100m,memory=164Mi \

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -173,7 +173,7 @@ systemd:
       --cloud-provider=aws \
       --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodPriority=true \
       --pod-infra-container-image=registry.opensource.zalan.do/teapot/pause-amd64:3.1 \
-{{- if index .Cluster.ConfigItems "disable_cfs_quota" }}
+{{- if not (index .Cluster.ConfigItems "enable_cfs_quota") }}
       --cpu-cfs-quota=false \
 {{- end }}
       --system-reserved=cpu=100m,memory=164Mi \


### PR DESCRIPTION
Let's add a config item to enable it back just in case. We can drop it a month or two later, once we're comfortable enough.