### PR TITLE
Update ExternalDNS to v0.5.6

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: external-dns
-    version: v0.5.5
+    version: v0.5.6
 spec:
   strategy:
     type: Recreate
@@ -16,14 +16,14 @@ spec:
     metadata:
       labels:
         application: external-dns
-        version: v0.5.5
+        version: v0.5.6
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
     spec:
       priorityClassName: system-cluster-critical
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.5.5
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.5.6
         args:
         - --source=service
         - --source=ingress


### PR DESCRIPTION
https://github.com/kubernetes-incubator/external-dns/releases/tag/v0.5.6

Relevant for us:
* Add generic metrics for Source & Registry Errors @wleese (https://github.com/kubernetes-incubator/external-dns/pull/652)