### PR TITLE
Update kube-ingress-aws-controller image version

### DIFF
--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.7.4
+    version: v0.8.0
 spec:
   replicas: 1
   selector:
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: system
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.7.4
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.8.0
         args:
         - -stack-termination-protection
         env:


### PR DESCRIPTION
Follow up to https://github.com/zalando-incubator/kubernetes-on-aws/pull/1393 where we forgot to update the version in all the places.