### PR TITLE
Remove default CPU limits

### DIFF
--- a/cluster/manifests/default-limits/limits.yaml
+++ b/cluster/manifests/default-limits/limits.yaml
@@ -10,6 +10,4 @@ spec:
         cpu: "25m"
         memory: 100Mi
       default:
-        # default limit for CPU is 3 cores as we discovered that this is a sweet spot for JVM apps to startup quickly
-        cpu: "3000m"
         memory: 1Gi


### PR DESCRIPTION
They don't do anything anyway, so let's just drop them.