### PR TITLE
update skipper to v0.10.92

### DIFF
--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.10.80
+    version: v0.10.92
     component: ingress
 spec:
   selector:
@@ -18,7 +18,7 @@ spec:
       name: skipper-ingress
       labels:
         application: skipper-ingress
-        version: v0.10.80
+        version: v0.10.92
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -33,7 +33,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper-lightstep:v0.10.80
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.92
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -45,6 +45,7 @@ spec:
               name: skipper-ingress
               key: lightstep-token
         args:
+          - "skipper"
           - "-kubernetes"
           - "-kubernetes-in-cluster"
           - "-kubernetes-path-mode=path-prefix"
@@ -60,7 +61,7 @@ spec:
           - "-enable-connection-metrics"
           - "-oauth2-tokeninfo-url={{ .ConfigItems.tokeninfo_url }}"
           - "-histogram-metric-buckets=.01,.025,.05,.075,.1,.2,.3,.4,.5,.75,1,2,3,4,5,7,10,15,20,30,60,120,300,600"
-          - "-opentracing=tracing_lightstep component-name=skipper-ingress token=$(LIGHTSTEP_TOKEN) collector=tracing.zmon.zalan.do:8444 cmd-line=skipper-ingress max-buffered-spans=4096"
+          - "-opentracing=lightstep component-name=skipper-ingress token=$(LIGHTSTEP_TOKEN) collector=tracing.zmon.zalan.do:8444 cmd-line=skipper-ingress max-buffered-spans=4096"
         resources:
           limits:
             memory: 200Mi


### PR DESCRIPTION
-  build the tracing implementations into skipper, use -opentracing="<type> <configkey>=configvalue..." with type is one of "jaegr", "lightstep", "instana"
-  deprecation - Deprecate accessLogDisabled in favor of disableAccessLog and enableAccessLog filters
-  feature - Filter for fowarding tokeninfo and token introspection results.
-  feature - Retry After Header
-  fix - Go modules for all tasks

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>