### PR TITLE
Run external-dns with limited privileges

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -40,7 +40,8 @@ spec:
             cpu: 25m
             memory: 20Mi
         securityContext:
-          # see https://github.com/kubernetes-incubator/external-dns/issues/595
-          readOnlyRootFilesystem: false
+          readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 1000
+          capabilities:
+            drop: ["ALL"]


### PR DESCRIPTION
https://github.com/kubernetes-incubator/external-dns/pull/714 replaces glog with a package that doesn't write to the filesystem.

It allows us to run `external-dns` with all the settings recommended by [https://kubesec.io/](https://kubesec.io/).

Note: this is a test and if desired can be added to the remaining components where applicable.

fixes https://github.com/kubernetes-incubator/external-dns/issues/595

requires: >v0.5.6


