### PR TITLE
Added iam role and deployment for kube-metrics-adapter

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1034,6 +1034,47 @@ Resources:
           PolicyName: root
       RoleName: "{{.Cluster.LocalID}}-app-zmon"
     Type: 'AWS::IAM::Role'
+
+  KubeMetricsIAMRole:
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action:
+              - 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+          - Action:
+              - 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              AWS: !Join
+                - ''
+                - - 'arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/'
+                  - !Ref WorkerIAMRole
+        Version: 2012-10-17
+      Path: /
+      Policies:
+        - PolicyDocument:
+            Statement:
+              - Action: 'sqs:GetQueueUrl'
+                Effect: Allow
+                Resource: '*'
+              - Action: 'sqs:GetQueueAttributes'
+                Effect: Allow
+                Resource: '*'
+              - Action: 'sqs:ListQueues'
+                Effect: Allow
+                Resource: '*'
+              - Action: 'sqs:ListQueueTags'
+                Effect: Allow
+                Resource: '*'
+            Version: 2012-10-17
+          PolicyName: root
+      RoleName: "{{.Cluster.LocalID}}-kube-metrics-adapter"
+    Type: 'AWS::IAM::Role'
+
 Outputs:
   MasterIAMRole:
     Export:

--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -17,7 +17,6 @@ spec:
         iam.amazonaws.com/role: {{.Cluster.LocalID}}-kube-metrics-adapter
       labels:
         application: kube-metrics-adapter
-        version: latest
     spec:
       containers:
       - args:

--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+  labels:
+    application: kube-metrics-adapter
+  name: kube-metrics-adapter
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      application: kube-metrics-adapter
+  template:
+    metadata:
+      annotations:
+        iam.amazonaws.com/role: {{.Cluster.LocalID}}-kube-metrics-adapter
+      labels:
+        application: kube-metrics-adapter
+        version: latest
+    spec:
+      containers:
+      - args:
+        - --prometheus-server=http://prometheus.kube-system.svc.cluster.local
+        - --skipper-ingress-metrics
+        - --aws-external-metrics
+        env:
+        - name: AWS_REGION
+          value: eu-central-1
+        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:master-2
+        imagePullPolicy: Always
+        name: kube-metrics-adapter
+        resources:
+          limits:
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi


### PR DESCRIPTION
The `kube-metrics-adapter` needs access to some AWS services for which we have added a an IAM role. The PR also contains a deployment manifest for running the adapter.