### PR TITLE
kube-downscaler: increase memory limits

### DIFF
--- a/cluster/manifests/kube-downscaler/deployment.yaml
+++ b/cluster/manifests/kube-downscaler/deployment.yaml
@@ -30,10 +30,10 @@ spec:
           - "--default-uptime={{ .ConfigItems.downscaler_default_uptime }}"
         resources:
           limits:
-            memory: 50Mi
+            memory: 150Mi
           requests:
             cpu: 5m
-            memory: 50Mi
+            memory: 150Mi
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true


### PR DESCRIPTION
It's reading pods now, which requires a bit more memory.