### PR TITLE
More resilient Spot support

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -229,6 +229,9 @@ Resources:
       Policies:
         - PolicyDocument:
             Statement:
+              - Action: 'autoscaling:TerminateInstanceInAutoScalingGroup'
+                Effect: Allow
+                Resource: '*'
               - Action: 'ec2:Describe*'
                 Effect: Allow
                 Resource: '*'

--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -1,3 +1,11 @@
+{{- define "version" -}}
+  {{- if index .ConfigItems "autoscaler_experimental" -}}
+    v1.3.1-teapot17
+  {{- else -}}
+    v1.3.1-teapot16
+  {{- end -}}
+{{- end -}}
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -5,7 +13,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-cluster-autoscaler
-    version: v1.3.1-teapot16
+    version: {{template "version" .}}
 spec:
   selector:
     matchLabels:
@@ -16,7 +24,7 @@ spec:
     metadata:
       labels:
         application: kube-cluster-autoscaler
-        version: v1.3.1-teapot16
+        version: {{template "version" .}}
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-autoscaler"
         config/pool-sizes: "{{range .NodePools}}{{.Name}}-{{.MinSize}}-{{.MaxSize}} {{end}}"
@@ -29,7 +37,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cluster-autoscaler
-        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler-custom:v1.3.1-teapot16
+        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler-custom:{{template "version" .}}
         command:
           - ./cluster-autoscaler
           - --v=4
@@ -42,6 +50,9 @@ spec:
           - --skip-nodes-with-local-storage=false
           - --scale-up-cloud-provider-template=true
           - --balance-similar-node-groups
+{{- if index .ConfigItems "autoscaler_experimental"}}
+          - --max-node-provision-time=10m
+{{- end}}
         resources:
           limits:
             cpu: 100m

--- a/cluster/node-pools/worker-default/stack.yaml
+++ b/cluster/node-pools/worker-default/stack.yaml
@@ -47,6 +47,9 @@ Resources:
       - Key: k8s.io/cluster-autoscaler/node-template/label/lifecycle-status
         PropagateAtLaunch: true
         Value: ready
+      - Key: k8s.io/cluster-autoscaler/node-template/label/aws.amazon.com/spot
+        PropagateAtLaunch: true
+        Value: {{if eq .NodePool.DiscountStrategy "spot_max_price"}}true{{else}}false{{end}}
 {{- if index .NodePool.ConfigItems "labels"}}
   {{- range split .NodePool.ConfigItems.labels ","}}
     {{- $label := split . "="}}

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -214,7 +214,12 @@ systemd:
       Type=simple
       Restart=on-failure
       RestartSec=5
-      ExecStart=/opt/bin/spot-termination-handler
+      ExecStart=/usr/bin/rkt run --insecure-options=image \
+        --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
+        --mount volume=dns,target=/etc/resolv.conf \
+        --net=host \
+        docker://registry.opensource.zalan.do/teapot/spot-termination-handler:master-1
+      ExecStopPost=-/opt/bin/spot-shutdown
 
       [Install]
       WantedBy=multi-user.target
@@ -381,25 +386,16 @@ storage:
 
 {{if eq .NodePool.DiscountStrategy "spot_max_price"}}
   - filesystem: root
-    path: /opt/bin/spot-termination-handler
+    path: /opt/bin/spot-shutdown
     mode: 0755
     contents:
       inline: |
         #!/bin/bash
         set -euo pipefail
 
-        AZ="$(curl -s --max-time 5 --fail http://169.254.169.254/latest/meta-data/placement/availability-zone)"
-        TYPE="$(curl -s --max-time 5 --fail http://169.254.169.254/latest/meta-data/instance-type)"
-        ID="$(curl -s --max-time 5 --fail http://169.254.169.254/latest/meta-data/instance-id)"
-
-        while true; do
-            if curl -s --max-time 5 --fail http://169.254.169.254/latest/meta-data/spot/termination-time; then
-                echo "[az=$AZ type=$TYPE id=$ID] received spot termination notice"
-                shutdown now
-                exit 0
-            fi
-            sleep 5
-        done
+        if [[ $EXIT_CODE -ne 0 ]]; then
+          shutdown now
+        fi
 {{end}}
 
   # this should only be enabled for instances with instance storage. e.g.

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -52,6 +52,9 @@ Resources:
       - Key: k8s.io/cluster-autoscaler/node-template/label/lifecycle-status
         PropagateAtLaunch: true
         Value: ready
+      - Key: k8s.io/cluster-autoscaler/node-template/label/aws.amazon.com/spot
+        PropagateAtLaunch: true
+        Value: {{if eq $data.NodePool.DiscountStrategy "spot_max_price"}}true{{else}}false{{end}}
 {{- if index $data.NodePool.ConfigItems "labels"}}
   {{- range split $data.NodePool.ConfigItems.labels ","}}
     {{- $label := split . "="}}


### PR DESCRIPTION
 * If `autoscaler_experimental` config item is set, run CA built with https://github.com/aermakov-zalando/autoscaler/commit/d426c25feb2378c94a0f68279ac38552f6def504 and slightly reduce the max. node provisioning time.
 * Add a Spot label for CA so users can opt-out of Spot for some of their stuff
 * Downscale the ASG if we receive a pending termination so CA can fallback to another pool