### PR TITLE
Use apps/v1 for kube-metrics-adapter deployment

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:


### PR DESCRIPTION
Use apps/v1 for kube-metrics-adapter deployment