### PR TITLE
Add prometheus service for external-dns

### DIFF
--- a/cluster/manifests/external-dns/external-dns-svc.yaml
+++ b/cluster/manifests/external-dns/external-dns-svc.yaml
@@ -1,0 +1,22 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: external-dns
+  namespace: kube-system
+  labels:
+    application: external-dns
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "ExternalDNS"
+  annotations:
+    prometheus.io/path: /metrics
+    prometheus.io/port: "7979"
+    prometheus.io/scrape: "true"
+spec:
+  selector:
+    application: external-dns
+  type: ClusterIP
+  ports:
+  - name: monitor
+    port: 7979
+    targetPort: 7979
+    protocol: TCP


### PR DESCRIPTION
Allow prometheus scraping so that we can alert on external-dns failing to create dns records