### PR TITLE
Fast lane fix for ExternalDNS bug

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: external-dns
-    version: v0.5.6
+    version: v0.5.7
 spec:
   strategy:
     type: Recreate
@@ -16,14 +16,14 @@ spec:
     metadata:
       labels:
         application: external-dns
-        version: v0.5.6
+        version: v0.5.7
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
     spec:
       priorityClassName: system-cluster-critical
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.5.6
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.5.7
         args:
         - --source=service
         - --source=ingress

--- a/cluster/manifests/external-dns/external-dns-svc.yaml
+++ b/cluster/manifests/external-dns/external-dns-svc.yaml
@@ -1,0 +1,22 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: external-dns
+  namespace: kube-system
+  labels:
+    application: external-dns
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "ExternalDNS"
+  annotations:
+    prometheus.io/path: /metrics
+    prometheus.io/port: "7979"
+    prometheus.io/scrape: "true"
+spec:
+  selector:
+    application: external-dns
+  type: ClusterIP
+  ports:
+  - name: monitor
+    port: 7979
+    targetPort: 7979
+    protocol: TCP


### PR DESCRIPTION
Avoids spreading the bug and enables alerting that allows us to detect broken clusters.

Cherry pick to beta of:
* b55e97a (Dion Bramley) - Add prometheus service for external-dns (2 hours ago)
* fa723e9 (Martin Linkhorst) - (origin/linki-patch-1, linki-patch-1) chore: update ExternalDNS to v0.5.7 (4 days ago)

(no userdata changes)