### PR TITLE
Refrain from deleting DNS records temporarily

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -28,6 +28,7 @@ spec:
         - --source=service
         - --source=ingress
         - --provider=aws
+        - --policy=upsert-only
         - --registry=txt
         - --txt-owner-id={{ .Region }}:{{ .LocalID }}
         - --compatibility=mate # remove when we switched to the new annotations


### PR DESCRIPTION
We currently have issues deleting DNS records which - due to using transactions - is also blocking any pending creations and updates to DNS records. Since deleting records isn't strictly necessary we can defer that to a later point in time by leveraging the `upsert-only` policy. This unblocks our users until we have a fix for correctly deleting DNS records.

This works by pure coincidence because the subset of broken records nicely matches with one of our two policies ("ignore all deletes"). Taking problematic records out the change batch regardless of their type is a feature in itself and anticipated [in this issue](https://github.com/kubernetes-incubator/external-dns/issues/104).