### PR TITLE
Restore full sync behaviour for ExternalDNS

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -28,11 +28,8 @@ spec:
         - --source=service
         - --source=ingress
         - --provider=aws
-        - --policy=upsert-only
         - --registry=txt
         - --txt-owner-id={{ .Region }}:{{ .LocalID }}
-        - --compatibility=mate # remove when we switched to the new annotations
-        - --log-level=debug # remove when we are sure external-dns can be trusted
         resources:
           limits:
             cpu: 200m

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: external-dns
-    version: v0.5.7
+    version: v0.5.8
 spec:
   strategy:
     type: Recreate
@@ -16,14 +16,14 @@ spec:
     metadata:
       labels:
         application: external-dns
-        version: v0.5.7
+        version: v0.5.8
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
     spec:
       priorityClassName: system-cluster-critical
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.5.7
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.5.8
         args:
         - --source=service
         - --source=ingress


### PR DESCRIPTION
We fixed brokens records manually in all clusters. Restore full-sync for ExternalDNS.

The full list of changes https://github.com/kubernetes-incubator/external-dns/pull/733/files#diff-4ac32a78649ca5bdd8e0ba38b7006a1e

Also in this change:
* remove `mate` compatibility as no user cluster has any resources with the old annotation anymore
* remove the long-overdue debug logging

There's one last service in `stups`/`stups-test` that uses the old annotation 😢 

PR for it here: https://github.bus.zalan.do/automata/cdp-controller/pull/740