### PR TITLE
Default storage class: explicitly specify zones

### DIFF
--- a/cluster/manifests/storageclass/_standard.yaml
+++ b/cluster/manifests/storageclass/_standard.yaml
@@ -1,0 +1,11 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: standard
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "false"
+  labels:
+    kubernetes.io/cluster-service: "true"
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: gp2

--- a/cluster/manifests/storageclass/default.yaml
+++ b/cluster/manifests/storageclass/default.yaml
@@ -1,7 +1,7 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: standard
+  name: default
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
   labels:
@@ -9,3 +9,4 @@ metadata:
 provisioner: kubernetes.io/aws-ebs
 parameters:
   type: gp2
+  zones: eu-central-1a, eu-central-1b, eu-central-1c


### PR DESCRIPTION
We've switched to ASGs with min. size 0 recently, which means that some of the statefulsets, especially those created early on use just 1 AZ instead of all 3 (because the default is to use only the zones where there's at least one node).