### PR TITLE
Allow passing environments and strict label support for kubernetes-log-watcher

### DIFF
--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -76,7 +76,7 @@ spec:
           mountPath: /mnt/scalyr-checkpoint
       containers:
       - name: log-watcher
-        image: registry.opensource.zalan.do/eagleeye/kubernetes-log-watcher:0.19
+        image: registry.opensource.zalan.do/eagleeye/kubernetes-log-watcher:0.21
         env:
         - name: CLUSTER_NODE_NAME
           valueFrom:


### PR DESCRIPTION
Release 0.21 includes:
* Fix empty strict_labels skipping all containers (https://github.com/zalando-incubator/kubernetes-log-watcher/pull/70)
* Additionally pass 'environment' label to Scalyr (https://github.com/zalando-incubator/kubernetes-log-watcher/pull/69)
* Fixes bug that strict labels are configured but not checked against (https://github.com/zalando-incubator/kubernetes-log-watcher/pull/67)
  * Fixes bug that strict labels are configured but not checked against
  * Updated test to verify if `strict_labels` are passed from down properly
  * Fixed formatting in test
* Adds configurable JSON log parsing(https://github.com/zalando-incubator/kubernetes-log-watcher/pull/49) (https://github.com/zalando-incubator/kubernetes-log-watcher/pull/66)
  * With the new configuration parameter `WATCHER_SCALYR_PARSE_LINES_JSON` the Scalyr agent can be configured to parse log lines as JSON entries which is useful to process raw Docker logs. This behavior is disabled by default.

Signed-off-by: Felix Mueller <felix.mueller@zalando.de>