### PR TITLE
Update auth webhook to v0.4.4

### DIFF
--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -361,7 +361,7 @@ storage:
               requests:
                 cpu: 100m
                 memory: 200Mi
-          - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.4.3
+          - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.4.4
             name: webhook
             ports:
             - containerPort: 8081


### PR DESCRIPTION
Notable changes:
* Allow operator to read resources in other namespaces https://github.bus.zalan.do/teapot/k8s-authnz-webhook/pull/100

related: https://github.bus.zalan.do/teapot/issues/issues/1382