### PR TITLE
Rolling back Kubernetes Log Watcher

### DIFF
--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -76,7 +76,7 @@ spec:
           mountPath: /mnt/scalyr-checkpoint
       containers:
       - name: log-watcher
-        image: registry.opensource.zalan.do/eagleeye/kubernetes-log-watcher:0.21
+        image: registry.opensource.zalan.do/eagleeye/kubernetes-log-watcher:0.19
         env:
         - name: CLUSTER_NODE_NAME
           valueFrom:


### PR DESCRIPTION
Rolling back Kubernetes Log Watcher from version `0.21` to `0.19`due to performance issue (potentially memory leak).

Signed-off-by: Felix Mueller <felix.mueller@zalando.de>