### PR TITLE
Allow to share PID namespace between containers in a pod

### DIFF
--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -171,7 +171,7 @@ systemd:
       --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
       --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \
       --cloud-provider=aws \
-      --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true \
+      --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodShareProcessNamespace=true \
       --pod-infra-container-image=registry.opensource.zalan.do/teapot/pause-amd64:3.1 \
 {{- if not (index .Cluster.ConfigItems "enable_cfs_quota") }}
       --cpu-cfs-quota=false \
@@ -317,7 +317,7 @@ storage:
             - --authorization-mode=Webhook
             - --authorization-webhook-config-file=/etc/kubernetes/config/authz.yaml
             - --admission-control-config-file=/etc/kubernetes/config/image-policy-webhook.yaml
-            - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true
+            - --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodShareProcessNamespace=true
             - --anonymous-auth=false
             {{ if or (eq .Cluster.Environment "production") (index .Cluster.ConfigItems "audittrail_url") }}
             - --audit-webhook-config-file=/etc/kubernetes/config/audit.yaml

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -168,7 +168,7 @@ systemd:
       --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
       --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \
       --cloud-provider=aws \
-      --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true \
+      --feature-gates=ExperimentalCriticalPodAnnotation=true,TaintBasedEvictions=true,PodShareProcessNamespace=true \
       --pod-infra-container-image=registry.opensource.zalan.do/teapot/pause-amd64:3.1 \
 {{- if not (index .Cluster.ConfigItems "enable_cfs_quota") }}
       --cpu-cfs-quota=false \


### PR DESCRIPTION
Enables users to specify `shareProcessNamespace: true` in their `PodSpec` to share the PIDs between containers of the same Pod.

> Sharing the PID namespace inside a pod has a few effects. Most prominently, processes inside containers are visible to all other containers in the pod, and signals can be sent to processes across container boundaries. **This makes sidecar containers more powerful (for example, sending a SIGHUP signal to reload configuration for an application running in a separate container is now possible)**.

https://blog.jetstack.io/blog/hidden-gems-1.10/#shared-pid-namespaces

Here's how it looks from inside a container of a 2-container Pod:

```console
root@logging-agent-vsths:/# ps aux
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root         1  0.0  0.0   1024     4 ?        Ss   10:17   0:00 /pause
root        14  3.0  0.2  85180 35200 ?        Ss   10:17   0:02 /usr/bin/python /usr/local/bin/kube-log-watcher
root        22  3.6  0.1 263604 31784 ?        Ssl  10:17   0:02 python /usr/sbin/scalyr-agent-2 --no-fork --no-change-user start
root        32  0.0  0.0  21508  4008 pts/0    Ss   10:18   0:00 bash
root        44  0.0  0.0  21244  3660 pts/0    Ss+  10:18   0:00 bash
root        54  0.0  0.0  41936  3468 pts/0    R+   10:18   0:00 ps aux
```

Here are the effects:
* `/pause` will always be PID 1 (you don't see this normally)
* The main process of both containers get arbitrary PIDs other than 1 (they would get PID 1 each when PID sharing is disabled)
* I see all processes of all containers (2x `bash` due to 2 `exec`s in the containers)

Note:
* This will be enabled by default in Kubernetes 1.12 and the feature flag can be removed then.
* Mostly here for reference now as the issue that triggered it might be solved otherwise.