### PR TITLE
Open a subset of ports on all workers for NLB support

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -266,6 +266,11 @@ Resources:
           FromPort: 22
           IpProtocol: tcp
           ToPort: 22
+        # Allow NLBs to target these ports on all workers.
+        - CidrIp: 0.0.0.0/0
+          FromPort: 30443
+          IpProtocol: tcp
+          ToPort: 30444
         - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
           FromPort: 9999
           IpProtocol: tcp

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -266,7 +266,7 @@ Resources:
           FromPort: 22
           IpProtocol: tcp
           ToPort: 22
-        # Allow NLBs to target these ports on all workers.
+        # Allow the OpenTracing NLB to target these ports on all workers.
         - CidrIp: 0.0.0.0/0
           FromPort: 30443
           IpProtocol: tcp


### PR DESCRIPTION
In order to allow an NLB necessary for OpenTracing to work we need to open some ports on all workers (30443-30444).

see: https://github.bus.zalan.do/eagleeye/lightstep-collector-deploy/pull/21/files#diff-34b78ece998339dae031d09457f9bd2c