### PR TITLE
Add teapot admission controller config

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -78,6 +78,13 @@ drain_min_unhealthy_sibling_lifetime: "1h"
 drain_force_evict_interval: "5m"
 {{end}}
 
+# Teapot webhook: gradual rollout
+{{if eq .Environment "e2e"}}
+teapot_webhook_enabled: "true"
+{{else}}
+teapot_webhook_enabled: "false"
+{{end}}
+
 # etcd cluster
 {{if ne .Environment "production"}}
 etcd_instance_count: "3"

--- a/cluster/manifests/admission-control/teapot.yaml
+++ b/cluster/manifests/admission-control/teapot.yaml
@@ -1,0 +1,29 @@
+{{ if eq .ConfigItems.teapot_webhook_enabled "true" }}
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: teapot-admission-controller
+  labels:
+    application: teapot-admission-controller
+webhooks:
+  - name: pod-admitter.teapot.zalan.do
+    clientConfig:
+      url: "https://localhost:8085/pod"
+      caBundle: "{{ .ConfigItems.ca_cert_decompressed }}"
+    failurePolicy: Fail
+    rules:
+      - operations: [ "CREATE" ]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods"]
+  - name: storageclass-admitter.teapot.zalan.do
+    clientConfig:
+      url: "https://localhost:8085/storageclass"
+      caBundle: "{{ .ConfigItems.ca_cert_decompressed }}"
+    failurePolicy: Fail
+    rules:
+      - operations: [ "CREATE" ]
+        apiGroups: ["storage.k8s.io"]
+        apiVersions: ["v1"]
+        resources: ["storageclasses"]
+{{ end }}


### PR DESCRIPTION
Register the teapot admission controller for create ops on Pods and StorageClasses. We don't care about updates for now because the relevant parts are immutable and we don't care about metadata.

Only enable it by default in e2e for now.