### PR TITLE
Change admission controller and enable it fully

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -79,10 +79,14 @@ drain_force_evict_interval: "5m"
 {{end}}
 
 # Teapot webhook: gradual rollout
+teapot_admission_controller_default_cpu_request: "25m"
+teapot_admission_controller_default_memory_request: "100Mi"
+teapot_admission_controller_process_resources: "true"
+
 {{if eq .Environment "e2e"}}
-teapot_webhook_enabled: "true"
+teapot_admission_controller_enabled: "true"
 {{else}}
-teapot_webhook_enabled: "false"
+teapot_admission_controller_enabled: "false"
 {{end}}
 
 # etcd cluster

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -85,8 +85,10 @@ teapot_admission_controller_process_resources: "true"
 
 {{if eq .Environment "e2e"}}
 teapot_admission_controller_enabled: "true"
+teapot_admission_controller_ignore_namespaces: "^kube-system|(e2e-tests-(downward-api|kubectl|projected)-.*)$"
 {{else}}
 teapot_admission_controller_enabled: "false"
+teapot_admission_controller_ignore_namespaces: "^kube-system$"
 {{end}}
 
 # etcd cluster

--- a/cluster/manifests/admission-control/teapot.yaml
+++ b/cluster/manifests/admission-control/teapot.yaml
@@ -1,4 +1,4 @@
-{{ if eq .ConfigItems.teapot_webhook_enabled "true" }}
+{{ if eq .ConfigItems.teapot_admission_controller_enabled "true" }}
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:

--- a/cluster/manifests/default-limits/limits.yaml
+++ b/cluster/manifests/default-limits/limits.yaml
@@ -1,3 +1,4 @@
+{{ if ne .ConfigItems.teapot_admission_controller_enabled "true" }}
 apiVersion: "v1"
 kind: "LimitRange"
 metadata:
@@ -11,3 +12,4 @@ spec:
         memory: 100Mi
       default:
         memory: 1Gi
+{{ end }}

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -361,7 +361,7 @@ storage:
               requests:
                 cpu: 100m
                 memory: 200Mi
-          - image: registry.opensource.zalan.do/teapot/admission-controller:master-6
+          - image: registry.opensource.zalan.do/teapot/admission-controller:master-7
             name: admission-controller
             readinessProbe:
               httpGet:
@@ -380,6 +380,7 @@ storage:
               - --tls-key-file=/etc/kubernetes/ssl/admission-controller-key.pem
               - --pod-default-cpu-request={{ .Cluster.ConfigItems.teapot_admission_controller_default_cpu_request }}
               - --pod-default-memory-request={{ .Cluster.ConfigItems.teapot_admission_controller_default_memory_request }}
+              - --pod-ignore-namespaces={{ .Cluster.ConfigItems.teapot_admission_controller_ignore_namespaces }}
 {{- if eq .Cluster.ConfigItems.teapot_admission_controller_process_resources "true" }}
               - --pod-process-resources
 {{- end }}

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -361,7 +361,7 @@ storage:
               requests:
                 cpu: 100m
                 memory: 200Mi
-          - image: registry.opensource.zalan.do/teapot/admission-controller:master-4
+          - image: registry.opensource.zalan.do/teapot/admission-controller:master-6
             name: admission-controller
             readinessProbe:
               httpGet:

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -378,6 +378,11 @@ storage:
               - --address=:8085
               - --tls-cert-file=/etc/kubernetes/ssl/admission-controller.pem
               - --tls-key-file=/etc/kubernetes/ssl/admission-controller-key.pem
+              - --pod-default-cpu-request={{ .Cluster.ConfigItems.teapot_admission_controller_default_cpu_request }}
+              - --pod-default-memory-request={{ .Cluster.ConfigItems.teapot_admission_controller_default_memory_request }}
+{{- if eq .Cluster.ConfigItems.teapot_admission_controller_process_resources "true" }}
+              - --pod-process-resources
+{{- end }}
             ports:
               - containerPort: 8085
             volumeMounts:


### PR DESCRIPTION
If teapot_admission_controller_enabled is set to 'true', fully enable the admission controller:

 * don't create limits/default
 * enable pod and storageclass admitter
 * enable `--pod-process-resources`