### PR TITLE
Update emergency access service

### DIFF
--- a/cluster/manifests/emergency-access-service/deployment.yaml
+++ b/cluster/manifests/emergency-access-service/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     application: emergency-access-service
-    version: master-58
+    version: master-61
 spec:
   replicas: 1
   selector:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: emergency-access-service
-        version: master-58
+        version: master-61
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
           [{"container": "emergency-access-service", "parser": "json-structured-log"}]
@@ -36,7 +36,7 @@ spec:
             cpu: 25m
             memory: 25Mi
       - name: emergency-access-service
-        image: "pierone.stups.zalan.do/teapot/emergency-access-service:master-58"
+        image: "pierone.stups.zalan.do/teapot/emergency-access-service:master-61"
         args:
         - --insecure-http
         - --community={{ .Owner }}


### PR DESCRIPTION
Resolves https://github.bus.zalan.do/teapot/issues/issues/1280
The emergency access service will now remove requests when they have been approved instead of leaving them to expire after 24 hours.