### PR TITLE
Allow pods to direct traffic to itself via a service

### DIFF
--- a/cluster/manifests/flannel/configmap.yaml
+++ b/cluster/manifests/flannel/configmap.yaml
@@ -11,7 +11,8 @@ data:
         "name": "podnet",
         "type": "flannel",
         "delegate": {
-            "isDefaultGateway": true
+            "isDefaultGateway": true,
+            "hairpinMode": true
         }
     }
   net-conf.json: |


### PR DESCRIPTION
Currently pods can't direct traffic to itself using services

I just looked how kubelet is configured and it seems like from the logs it sets the hairpin mode to *hairpin-veth*:

```bash
...
Hairpin mode set to "hairpin-veth"
...
```

From checking the bridge it seems like flannel isn't set correctly to enable hairpin mode.

Checking on a node if hairpin is enabled:

```bash
for intf in /sys/devices/virtual/net/cni0/brif/*; do cat $intf/hairpin_mode; done
0
0
0
...
```

PR in Flannel https://github.com/coreos/flannel/pull/849