### PR TITLE
Allow changing resources for metrics-service

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -48,6 +48,9 @@ zmon_scheduler_replicas: "1"
 zmon_worker_replicas: "4"
 {{end}}
 
+metrics_service_cpu: "100m"
+metrics_service_mem: "200Mi"
+
 # Kubernetes Downscaler (for non-production clusters)
 {{if eq .Environment "test"}}
 downscaler_default_uptime: "Mon-Fri 07:30-20:30 CET"

--- a/cluster/manifests/metrics-server/deployment.yaml
+++ b/cluster/manifests/metrics-server/deployment.yaml
@@ -28,8 +28,8 @@ spec:
         - --source=kubernetes.summary_api:''
         resources:
           limits:
-            cpu: 100m
-            memory: 200Mi
+            cpu: "{{.ConfigItems.metrics_service_cpu}}"
+            memory: "{{.ConfigItems.metrics_service_mem}}"
           requests:
-            cpu: 100m
-            memory: 200Mi
+            cpu: "{{.ConfigItems.metrics_service_cpu}}"
+            memory: "{{.ConfigItems.metrics_service_mem}}"


### PR DESCRIPTION
The metrics-service needs to scale in proportion to the cluster size especially for memory. Since we don't have VPA yet, make it possible to manually bump the resources if needed.