### PR TITLE
Prevent over committing for gerry containers

### DIFF
--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -30,11 +30,11 @@ spec:
           - --once
         resources:
           limits:
-            cpu: 100m
-            memory: 100Mi
+            cpu: 5m
+            memory: 20Mi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 5m
+            memory: 20Mi
 
         volumeMounts:
           - name: credentials
@@ -100,11 +100,11 @@ spec:
             - --mint-bucket=s3://{{ .ConfigItems.gerry_mint_bucket }}
           resources:
             limits:
-              cpu: 100m
-              memory: 100Mi
+              cpu: 5m
+              memory: 20Mi
             requests:
-              cpu: 10m
-              memory: 10Mi
+              cpu: 5m
+              memory: 20Mi
 
           volumeMounts:
             - name: credentials

--- a/cluster/manifests/zmon-aws-agent/deployment.yaml
+++ b/cluster/manifests/zmon-aws-agent/deployment.yaml
@@ -30,11 +30,11 @@ spec:
           - --once
         resources:
           limits:
-            cpu: 100m
-            memory: 100Mi
+            cpu: 5m
+            memory: 20Mi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 5m
+            memory: 20Mi
 
         volumeMounts:
           - name: credentials
@@ -73,11 +73,11 @@ spec:
             - --mint-bucket=s3://{{ .ConfigItems.gerry_mint_bucket }}
           resources:
             limits:
-              cpu: 100m
-              memory: 100Mi
+              cpu: 5m
+              memory: 20Mi
             requests:
-              cpu: 10m
-              memory: 10Mi
+              cpu: 5m
+              memory: 20Mi
 
           volumeMounts:
             - name: credentials

--- a/cluster/manifests/zmon-scheduler/deployment.yaml
+++ b/cluster/manifests/zmon-scheduler/deployment.yaml
@@ -30,11 +30,11 @@ spec:
           - --once
         resources:
           limits:
-            cpu: 100m
-            memory: 100Mi
+            cpu: 5m
+            memory: 20Mi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 5m
+            memory: 20Mi
 
         volumeMounts:
           - name: credentials
@@ -118,11 +118,11 @@ spec:
             - --mint-bucket=s3://{{ .ConfigItems.gerry_mint_bucket }}
           resources:
             limits:
-              cpu: 100m
-              memory: 100Mi
+              cpu: 5m
+              memory: 20Mi
             requests:
-              cpu: 10m
-              memory: 10Mi
+              cpu: 5m
+              memory: 20Mi
 
           volumeMounts:
             - name: credentials

--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -30,11 +30,11 @@ spec:
         - --once
         resources:
           limits:
-            cpu: 100m
-            memory: 100Mi
+            cpu: 5m
+            memory: 20Mi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 5m
+            memory: 20Mi
         volumeMounts:
           - name: credentials
             mountPath: /meta/credentials
@@ -106,11 +106,11 @@ spec:
             - --mint-bucket=s3://{{ .ConfigItems.gerry_mint_bucket }}
           resources:
             limits:
-              cpu: 100m
-              memory: 100Mi
+              cpu: 5m
+              memory: 20Mi
             requests:
-              cpu: 10m
-              memory: 10Mi
+              cpu: 5m
+              memory: 20Mi
 
           volumeMounts:
             - name: credentials


### PR DESCRIPTION
Stop over committing on memory for gerry and adjust to actual usage.

![image](https://user-images.githubusercontent.com/128566/47215013-22fc7a80-d3a0-11e8-82a6-64ad68562db2.png)
