### PR TITLE
resolve conntrack container being killed.

### DIFF
--- a/cluster/manifests/prometheus-node-exporter/daemonset.yaml
+++ b/cluster/manifests/prometheus-node-exporter/daemonset.yaml
@@ -55,10 +55,10 @@ spec:
         resources:
           limits:
             cpu: 10m
-            memory: 40Mi
+            memory: 100Mi
           requests:
             cpu: 10m
-            memory: 40Mi
+            memory: 100Mi
         securityContext:
           privileged: true
         volumeMounts:

--- a/cluster/manifests/prometheus-node-exporter/daemonset.yaml
+++ b/cluster/manifests/prometheus-node-exporter/daemonset.yaml
@@ -49,6 +49,7 @@ spec:
         - name: prometheus-node-exporter-volume
           mountPath: /prometheus-exporter-data
           readOnly: false
+      {{- if index .ConfigItems "enable_conntrack_log" }}
       - image: registry.opensource.zalan.do/teapot/prometheus-node-exporter-txt-exporter:v0.0.4
         name: prometheus-node-exporter-conntrack-exporter
         resources:
@@ -64,6 +65,7 @@ spec:
         - name: prometheus-node-exporter-volume
           mountPath: /prometheus-exporter-data
           readOnly: false
+      {{- end }}
       hostNetwork: true
       hostPID: true
       volumes:


### PR DESCRIPTION
Conntrack uses more memory when it runs if there are more connections active on the machine. This was causing large machines to kill it due to it exceeding it's memory allowance. I have conditionally disabled it and increased the memory allocations.