### PR TITLE
Only open lightstep ports if the option is enabled

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -266,11 +266,13 @@ Resources:
           FromPort: 22
           IpProtocol: tcp
           ToPort: 22
+{{- if index .Cluster.ConfigItems "open_lightstep_collector_ports" }}
         # Allow the OpenTracing NLB to target these ports on all workers.
         - CidrIp: 0.0.0.0/0
           FromPort: 30443
           IpProtocol: tcp
           ToPort: 30444
+{{- end }}
         - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
           FromPort: 9999
           IpProtocol: tcp


### PR DESCRIPTION
Put the open NLB ports for the lightstep collector behind a config item such that we don't have to enable it in every cluster where the collector might not be running.