### PR TITLE
ExternalDNS: reduce batch size to 100 by default

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -28,6 +28,7 @@ spec:
         - --source=service
         - --source=ingress
         - --provider=aws
+        - --aws-batch-change-size=100
         - --registry=txt
         - --txt-owner-id={{ .Region }}:{{ .LocalID }}
         resources:


### PR DESCRIPTION
To not run into the 32k character limit we could reduce the batch size to `100` by default without much impact (most changes should be handled in a single batch even with that limit). Using this feature also helps in making sure it works correctly.