### PR TITLE
Enable zmon metrics HPA in production clusters

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/credentials.yaml
+++ b/cluster/manifests/kube-metrics-adapter/credentials.yaml
@@ -1,0 +1,14 @@
+{{ if eq .Environment "production" }}
+apiVersion: zalando.org/v1
+kind: PlatformCredentialsSet
+metadata:
+  name: "kube-metrics-adapter"
+  namespace: kube-system
+  labels:
+    application: "kube-metrics-adapter"
+spec:
+  application: "kube-metrics-adapter"
+  tokens:
+    zmon:
+      privileges: []
+{{ end }}

--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -1,7 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
   labels:
     application: kube-metrics-adapter
   name: kube-metrics-adapter
@@ -20,20 +19,30 @@ spec:
     spec:
       serviceAccountName: system
       containers:
-      - args:
+      - name: kube-metrics-adapter
+        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:master-8
+        args:
         - --prometheus-server=http://prometheus.kube-system.svc.cluster.local
         - --skipper-ingress-metrics
         - --aws-external-metrics
-        - --aws-region
-        - eu-central-1
-        - --aws-region
-        - eu-west-1
-        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:master-3
-        imagePullPolicy: Always
-        name: kube-metrics-adapter
+        - --aws-region=eu-central-1
+        - --aws-region=eu-west-1
+        {{ if eq .Environment "production" }}
+        - --zmon-kariosdb-endpoint=https://data-service.zmon.zalan.do/kairosdb-proxy
+        volumeMounts:
+        - name: credentials
+          mountPath: /meta/credentials
+          readOnly: true
+        {{ end }}
         resources:
           limits:
             memory: 100Mi
           requests:
             cpu: 100m
             memory: 100Mi
+      {{ if eq .Environment "production" }}
+      volumes:
+      - name: credentials
+        secret:
+          secretName: "kube-metrics-adapter"
+      {{ end }}


### PR DESCRIPTION
This updates the kube-metrics-adapter and includes ZMON support as implemented in (https://github.com/zalando-incubator/kube-metrics-adapter/pull/2)

For now ZMON is only enabled in production clusters as it requires production credentials to talk to ZMON kariosdb. We need something like gerry, but I would like to avoid implementing token management in the kube-metrics-adapter.