### PR TITLE
Fix heapster deployment

### DIFF
--- a/cluster/manifests/heapster/deployment.yaml
+++ b/cluster/manifests/heapster/deployment.yaml
@@ -32,6 +32,7 @@ spec:
             timeoutSeconds: 5
           resources:
             limits:
+              cpu: 100m # don't remove unless nanny is disabled
               memory: 200Mi
             requests:
               cpu: 100m


### PR DESCRIPTION
Removing `cpu.limit` from the deployment causes future updates to fail if the `nanny` container reduces the `limit` below the `request` in the manifest. Keep it for until we get rid of `nanny`.