### PR TITLE
Update the VPA CRD version.

### DIFF
--- a/cluster/manifests/vertical-pod-autoscaler/01-crd.yaml
+++ b/cluster/manifests/vertical-pod-autoscaler/01-crd.yaml
@@ -2,12 +2,12 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: verticalpodautoscalers.poc.autoscaling.k8s.io
+  name: verticalpodautoscalers.autoscaling.k8s.io
   labels:
     component: vpa
 spec:
-  group: poc.autoscaling.k8s.io
-  version: v1alpha1
+  group: autoscaling.k8s.io
+  version: v1beta1
   scope: Namespaced
   names:
     plural: verticalpodautoscalers
@@ -37,12 +37,12 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: verticalpodautoscalercheckpoints.poc.autoscaling.k8s.io
+  name: verticalpodautoscalercheckpoints.autoscaling.k8s.io
   labels:
     component: vpa
 spec:
-  group: poc.autoscaling.k8s.io
-  version: v1alpha1
+  group: autoscaling.k8s.io
+  version: v1beta1
   scope: Namespaced
   names:
     plural: verticalpodautoscalercheckpoints

--- a/cluster/manifests/vertical-pod-autoscaler/metrics-server-vpa.yaml
+++ b/cluster/manifests/vertical-pod-autoscaler/metrics-server-vpa.yaml
@@ -1,5 +1,5 @@
 {{ if eq .ConfigItems.vpa_enabled "true" }}
-apiVersion: poc.autoscaling.k8s.io/v1alpha1
+apiVersion: autoscaling.k8s.io/v1beta1
 kind: VerticalPodAutoscaler
 metadata:
   name: metrics-server-vpa

--- a/cluster/manifests/vertical-pod-autoscaler/prometheus-vpa.yaml
+++ b/cluster/manifests/vertical-pod-autoscaler/prometheus-vpa.yaml
@@ -1,5 +1,5 @@
 {{ if eq .ConfigItems.vpa_enabled "true" }}
-apiVersion: poc.autoscaling.k8s.io/v1alpha1
+apiVersion: autoscaling.k8s.io/v1beta1
 kind: VerticalPodAutoscaler
 metadata:
   name: prometheus-vpa


### PR DESCRIPTION
It appears that we tested the VPA stuff with an pre-release version and now VPAs are no longer `poc` :champagne: . So we have to update the CRD manifests as well. 


Signed-off-by: Arjun Naik <arjun.naik@zalando.de>