### PR TITLE
fix skipper-graceful-start

### DIFF
--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.10.110
+    version: v0.10.112
     component: ingress
 spec:
   selector:
@@ -18,7 +18,7 @@ spec:
       name: skipper-ingress
       labels:
         application: skipper-ingress
-        version: v0.10.110
+        version: v0.10.112
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -33,7 +33,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.110
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.112
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -50,6 +50,7 @@ spec:
           - "-kubernetes-in-cluster"
           - "-kubernetes-path-mode=path-prefix"
           - "-address=:9999"
+          - "-wait-first-route-load"
           - "-proxy-preserve-host"
           - "-serve-host-metrics"
           - "-enable-ratelimits"


### PR DESCRIPTION
fix: skipper listens on start and might not have the routes pulled from kubernetes data source

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>