### PR TITLE
Allow cluster scale-down to be switched on and off

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1,4 +1,5 @@
 # Autoscaling settings
+autoscaling_scale_down_enabled: "true"
 autoscaling_buffer_pools: "default-worker"
 autoscaling_buffer_cpu_scale: "1"
 autoscaling_buffer_memory_scale: "0.85"

--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -43,6 +43,7 @@ spec:
           - --scale-up-cloud-provider-template=true
           - --balance-similar-node-groups
           - --max-node-provision-time=10m
+          - --scale-down-enabled={{ .ConfigItems.autoscaling_scale_down_enabled }}
         resources:
           limits:
             cpu: 100m


### PR DESCRIPTION
Add a config item to turn cluster downscaling on and off. Defaults to the current behaviour: scale down enabled.