### PR TITLE
New version of kube-metrics-adapter which doesn't print false warnings.

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: system
       containers:
       - name: kube-metrics-adapter
-        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:master-8
+        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:master-10
         args:
         - --prometheus-server=http://prometheus.kube-system.svc.cluster.local
         - --skipper-ingress-metrics


### PR DESCRIPTION
The `kube-metrics-adapter` was trying to process metrics of `Resource` type which is provided by the `metrics-server`. This was fixed in this [PR](https://github.com/zalando-incubator/kube-metrics-adapter/pull/15)
Signed-off-by: Arjun Naik <arjun.rn@gmail.com>