### PR TITLE
Allow deploying AWS Step Functions via CDP

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -541,6 +541,7 @@ Resources:
                   - 'ses:*'
                   - 'sns:*'
                   - 'sqs:*'
+                  - 'states:*'
                   - 'sts:*'
                   - 'support:*'
                   - 'swf:*'


### PR DESCRIPTION
This allows deploying AWS Step Functions via CDP.

https://aws.amazon.com/step-functions/

Requested feature by data engineering.