### PR TITLE
dev-to-alpha

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -70,6 +70,8 @@ zmon_worker_cpu: "750m"
 zmon_worker_count: "16"
 {{end}}
 
+zmon_redis_mem: "1Gi"
+
 prometheus_cpu: "1000m"
 prometheus_mem: "4Gi"
 prometheus_mem_max: "10Gi"

--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: system
       containers:
       - name: kube-metrics-adapter
-        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:master-8
+        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:master-10
         args:
         - --prometheus-server=http://prometheus.kube-system.svc.cluster.local
         - --skipper-ingress-metrics

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.10.112
+    version: v0.10.121-1-g5f1806d
     component: ingress
 spec:
   selector:
@@ -18,7 +18,7 @@ spec:
       name: skipper-ingress
       labels:
         application: skipper-ingress
-        version: v0.10.112
+        version: v0.10.121-1-g5f1806d
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -33,7 +33,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.112
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.121-1-g5f1806d
         ports:
         - name: ingress-port
           containerPort: 9999

--- a/cluster/manifests/zmon-redis/deployment.yaml
+++ b/cluster/manifests/zmon-redis/deployment.yaml
@@ -24,10 +24,10 @@ spec:
           resources:
             limits:
               cpu: 80m
-              memory: 1Gi
+              memory: {{.ConfigItems.zmon_redis_mem}}
             requests:
               cpu: 80m
-              memory: 1Gi
+              memory: {{.ConfigItems.zmon_redis_mem}}
           ports:
             - containerPort: 6379
           readinessProbe:

--- a/cluster/manifests/zmon-redis/deployment.yaml
+++ b/cluster/manifests/zmon-redis/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       priorityClassName: visibility-zmon
       containers:
         - name: zmon-redis
-          image: registry.opensource.zalan.do/zmon/redis:3.2.9
+          image: registry.opensource.zalan.do/zmon/redis:4.0.9-master-6
           resources:
             limits:
               cpu: 80m


### PR DESCRIPTION
* **Upgrade zmon-redis**
   <sup>Merge pull request #1536 from zalando-incubator/upgrade-zmon-redis</sup>
* **New version of kube-metrics-adapter which doesn't print false warnings.**
   <sup>Merge pull request #1533 from zalando-incubator/metrics-adapter-false-warn</sup>
* **fix one cause of 499s**
   <sup>Merge pull request #1530 from zalando-incubator/fix/skipper-context-issue</sup>
* **Allow adjusting redis memory via config items**
   <sup>Merge pull request #1529 from zalando-incubator/zmon-redis-mem</sup>