### PR TITLE
Enable DynamoDB Autoscaling Service Link

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1138,7 +1138,7 @@ Resources:
           PolicyName: root
       RoleName: "{{.Cluster.LocalID}}-emergency-access-service"
     Type: 'AWS::IAM::Role'
-{{- if eq .Cluster.ConfigItems "dynamodb_service_link_enabled" "true" }}
+{{- if eq .Cluster.ConfigItems.dynamodb_service_link_enabled "true" }}
   ServiceLinkedRoleAutoScalingDynamoDB:
     Properties:
       AWSServiceName: "dynamodb.application-autoscaling.amazonaws.com"

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1138,6 +1138,13 @@ Resources:
           PolicyName: root
       RoleName: "{{.Cluster.LocalID}}-emergency-access-service"
     Type: 'AWS::IAM::Role'
+{{- if eq .Cluster.ConfigItems "dynamodb_service_link_enabled" "true" }}
+  ServiceLinkedRoleAutoScalingDynamoDB:
+    Properties:
+      AWSServiceName: "dynamodb.application-autoscaling.amazonaws.com"
+      Description: "AWS service role for application autoscaling DynamoDB"
+    Type: "AWS::IAM::ServiceLinkedRole"
+{{- end }}
 
 Outputs:
   MasterIAMRole:

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -132,4 +132,4 @@ teapot_admission_controller_ignore_namespaces: "^kube-system$"
 etcd_instance_count: "3"
 {{end}}
 
-dynamodb_service_link_enabled: "true"
+dynamodb_service_link_enabled: "false"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -131,3 +131,5 @@ teapot_admission_controller_ignore_namespaces: "^kube-system$"
 {{if ne .Environment "production"}}
 etcd_instance_count: "3"
 {{end}}
+
+dynamodb_service_link_enabled: "true"


### PR DESCRIPTION
This will add the IAM role with the policy to manage scaling on your behalf.

**Role:** 
AWSServiceRoleForApplicationAutoScaling_DynamoDBTable

**Actions:**
dynamodb:DescribeTable
dynamodb:UpdateTable
cloudwatch:DeleteAlarms
cloudwatch:DescribeAlarms
cloudwatch:PutMetricAlarm

**Service principal:**
dynamodb.application-autoscaling.amazonaws.com