### PR TITLE
Adding manifests for kubernetes-lifecycle-metrics

### DIFF
--- a/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
@@ -32,3 +32,9 @@ spec:
             requests:
               cpu: 200m
               memory: 500Mi
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 9090
+              scheme: HTTP
+

--- a/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
@@ -5,10 +5,6 @@ metadata:
   namespace: kube-system
   labels:
     application: kubernetes-lifecycle-metrics
-  annotations:
-    prometheus.io/path: /metrics
-    prometheus.io/port: "9090"
-    prometheus.io/scrape: "true"
 spec:
   replicas: 1
   selector:

--- a/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubernetes-lifecycle-metrics
+  namespace: kube-system
+  labels:
+    application: kubernetes-lifecycle-metrics
+  annotations:
+    prometheus.io/path: /metrics
+    prometheus.io/port: "9090"
+    prometheus.io/scrape: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      application: kubernetes-lifecycle-metrics
+  template:
+    metadata:
+      labels:
+        application: kubernetes-lifecycle-metrics
+      annotations:
+        kubernetes-log-watcher/scalyr-parser: '[{"container": "kubernetes-lifecycle-metrics", "parser": "json"}]'
+    spec:
+      containers:
+        - name: kubernetes-lifecycle-metrics
+          image: "pierone.stups.zalan.do/teapot/kubernetes-lifecycle-metrics:pr-1-30"
+          ports:
+            - containerPort: 9090
+          resources:
+            limits:
+              memory: 500Mi
+            requests:
+              cpu: 200m
+              memory: 500Mi

--- a/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kubernetes-lifecycle-metrics
+    version: master-1
 spec:
   replicas: 1
   selector:
@@ -14,12 +15,14 @@ spec:
     metadata:
       labels:
         application: kubernetes-lifecycle-metrics
+        version: master-1
       annotations:
         kubernetes-log-watcher/scalyr-parser: '[{"container": "kubernetes-lifecycle-metrics", "parser": "json"}]'
     spec:
+      priorityClassName: system-cluster-critical
       containers:
         - name: kubernetes-lifecycle-metrics
-          image: "pierone.stups.zalan.do/teapot/kubernetes-lifecycle-metrics:pr-1-30"
+          image: "pierone.stups.zalan.do/teapot/kubernetes-lifecycle-metrics:master-1"
           ports:
             - containerPort: 9090
           resources:
@@ -33,4 +36,3 @@ spec:
               path: /healthz
               port: 9090
               scheme: HTTP
-

--- a/cluster/manifests/kubernetes-lifecycle-metrics/service.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    application: kubernetes-lifecycle-metrics
+  name: kubernetes-lifecycle-metrics
+  namespace: kube-system
+spec:
+  selector:
+    application: kubernetes-lifecycle-metrics
+  type: ClusterIP
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 9090

--- a/cluster/manifests/kubernetes-lifecycle-metrics/service.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/service.yaml
@@ -3,6 +3,10 @@ kind: Service
 metadata:
   labels:
     application: kubernetes-lifecycle-metrics
+  annotations:
+    prometheus.io/path: /metrics
+    prometheus.io/port: "9090"
+    prometheus.io/scrape: "true"
   name: kubernetes-lifecycle-metrics
   namespace: kube-system
 spec:


### PR DESCRIPTION
Deploying a small application called `kubernetes-lifecycle-metrics` in
clusters. It tracks, logs & exposes metrics that can be used to measure
the clusters' SLOs. Currently exposed metrics include:
 - time to schedule pods
 - time to mount the first volume in pods
 - image pull times per container
 - no. of pods waiting to be scheduled and the age of the oldest pod

Signed-off-by: Muhammad Muaaz Saleem <muhammad.muaaz.saleem@zalando.de>