### PR TITLE
Fix the templating in skipper deployment

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           [{"container": "skipper-ingress", "parser": "skipper-access-log"}]
     spec:
       priorityClassName: system-node-critical
-{{ if index .ConfigItems "enable_rbac"}}
+{{ if index $cfg "enable_rbac"}}
       serviceAccountName: skipper-ingress
 {{ end }}
       tolerations:


### PR DESCRIPTION
Need to use the `$cfg` variable because of how the template scoping works.