### PR TITLE
Disable the daemonset when it's not needed anymore

### DIFF
--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -33,6 +33,9 @@ spec:
         operator: Exists
       nodeSelector:
         kubernetes.io/role: worker
+{{ if eq .ConfigItems.zone_suffixes "a,b,c" }}
+        dummy.zalando.org/no-nodes: "true"
+{{ end }}
       hostNetwork: true
       containers:
       - name: skipper-ingress


### PR DESCRIPTION
If a cluster has more nodes than deployment pods, we will still continue running daemonset pods. Disable them automagically once we've rolled out the deployment to all 3 AZs.