### PR TITLE
fix oomkiller not select skipper first

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -74,6 +74,7 @@ spec:
           - "-opentracing=lightstep component-name=skipper-ingress token=$(LIGHTSTEP_TOKEN) collector=tracing.zmon.zalan.do:8444 cmd-line=skipper-ingress max-buffered-spans=4096"
         resources:
           limits:
+            cpu: "{{ $cfg.skipper_ingress_cpu }}"
             memory: "{{ $cfg.skipper_ingress_memory }}"
           requests:
             cpu: "{{ $cfg.skipper_ingress_cpu }}"


### PR DESCRIPTION
If we do not get limits=requests we get a really bad oom score `oom_score_adj`.

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>