### PR TITLE
ZMON RBAC rules for pcs and acid dbs

### DIFF
--- a/cluster/manifests/zmon-agent/rbac.yaml
+++ b/cluster/manifests/zmon-agent/rbac.yaml
@@ -110,7 +110,7 @@ rules:
 - apiGroup:
   - zalando.org
   resources:
-  - platformcredentialsets
+  - platformcredentialssets
   verbs:
   - get
   - list

--- a/cluster/manifests/zmon-agent/rbac.yaml
+++ b/cluster/manifests/zmon-agent/rbac.yaml
@@ -107,6 +107,22 @@ rules:
   - get
   - list
   - watch
+- apiGroup:
+  - zalando.org
+  resources:
+  - platformcredentialsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroup:
+  - acid.zalan.do
+  resources:
+  - postgresqls
+  verbs:
+  - get
+  - list
+  - watch
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
Added Rules for ZMON serviceaccount to allow querying platform credential sets and acid dbs

Signed-off-by: Arjun Naik <arjun.rn@gmail.com>