### PR TITLE
enable east-west setup

### DIFF
--- a/cluster/manifests/coredns-local/configmap.yaml
+++ b/cluster/manifests/coredns-local/configmap.yaml
@@ -15,7 +15,11 @@ data:
             upstream
             fallthrough in-addr.arpa ip6.arpa
         }
-        prometheus :9153
+        template IN A skipper.cluster.local  {
+            match "^.*[.]skipper[.]cluster[.]local"
+            answer "{{"{{"}} .Name {{"}}"}} 60 IN A 10.3.99.99"
+            fallthrough
+        }        prometheus :9153
         proxy . /etc/resolv.conf
         cache 30
         reload

--- a/cluster/manifests/coredns-local/configmap.yaml
+++ b/cluster/manifests/coredns-local/configmap.yaml
@@ -15,8 +15,8 @@ data:
             upstream
             fallthrough in-addr.arpa ip6.arpa
         }
-        template IN A skipper.cluster.local  {
-            match "^.*[.]skipper[.]cluster[.]local"
+        template IN A internal.cluster.local  {
+            match "^.*[.]internal[.]cluster[.]local"
             answer "{{"{{"}} .Name {{"}}"}} 60 IN A 10.3.99.99"
             fallthrough
         }

--- a/cluster/manifests/coredns-local/configmap.yaml
+++ b/cluster/manifests/coredns-local/configmap.yaml
@@ -19,7 +19,8 @@ data:
             match "^.*[.]skipper[.]cluster[.]local"
             answer "{{"{{"}} .Name {{"}}"}} 60 IN A 10.3.99.99"
             fallthrough
-        }        prometheus :9153
+        }
+        prometheus :9153
         proxy . /etc/resolv.conf
         cache 30
         reload

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -61,6 +61,7 @@ spec:
           - "-kubernetes-path-mode=path-prefix"
           - "-address=:9999"
           - "-wait-first-route-load"
+          - "-enable-kubernetes-east-west"
           - "-proxy-preserve-host"
           - "-serve-host-metrics"
           - "-enable-ratelimits"

--- a/cluster/manifests/skipper/service-internal.yaml
+++ b/cluster/manifests/skipper/service-internal.yaml
@@ -1,0 +1,16 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: skipper-internal
+  namespace: kube-system
+  labels:
+    application: skipper-ingress
+spec:
+  type: ClusterIP
+  clusterIP: 10.3.99.99
+  ports:
+    - port: 80
+      targetPort: 9999
+      protocol: TCP
+  selector:
+    application: skipper-ingress


### PR DESCRIPTION
enable east west setup to allow service to service communication through skipper.
Enabled in skipper deployment + internal service IP and coredns daemonset.

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>