### PR TITLE
enable apiMonitoring

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -27,6 +27,12 @@ skipper_ingress_memory: "500Mi"
 # AZ
 zone_suffixes: "a,b,c"
 
+{{if eq .Environment "production"}}
+enable_apimonitoring: "false"
+{{else}}
+enable_apimonitoring: "true"
+{{end}}
+
 # lightstep
 {{if eq .Environment "production"}}
 lightstep_token: "aws:kms:AQICAHgrx06TPoR1aNmcPHJjFu5mmoICT5KJkx2fsTJpmXmbNAH+8Ml18b8ZkUO/0KAwtIZTAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMSf79AuT/RI5rvWWjAgEQgDuN7obV7JD4iBMnOJ4Th93DfM5j572dXjf+gWmHx4JKMTTJPX2w6hgfQXX3LjI49l0p479a6IXIlZJOSg=="

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -28,7 +28,6 @@ skipper_ingress_memory: "500Mi"
 zone_suffixes: "a,b,c"
 
 {{if eq .Environment "production"}}
-enable_apimonitoring: "false"
 {{else}}
 enable_apimonitoring: "true"
 {{end}}

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -66,7 +66,7 @@ spec:
           - "-lb-healthcheck-interval=3s"
           - "-metrics-flavour=codahale,prometheus"
           - "-enable-connection-metrics"
-{{ if index $cfg "enable_apimonitoring"}}
+{{ if index .ConfigItems.enable_apimonitoring }}
           - "-enable-api-usage-monitoring"
           - "-api-usage-monitoring-realm-keys=https://identity.zalando.com/realm"
           - "-api-usage-monitoring-client-keys=https://identity.zalando.com/managed-id,sub"

--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -66,6 +66,12 @@ spec:
           - "-lb-healthcheck-interval=3s"
           - "-metrics-flavour=codahale,prometheus"
           - "-enable-connection-metrics"
+{{ if index $cfg "enable_apimonitoring"}}
+          - "-enable-api-usage-monitoring"
+          - "-api-usage-monitoring-realm-keys=https://identity.zalando.com/realm"
+          - "-api-usage-monitoring-client-keys=https://identity.zalando.com/managed-id,sub"
+          - "-api-usage-monitoring-default-client-tracking-pattern=services[.].*"
+{{ end }}
           - "-max-audit-body=0"
           - "-oauth2-tokeninfo-url={{ .ConfigItems.tokeninfo_url }}"
           - "-histogram-metric-buckets=.01,.025,.05,.075,.1,.2,.3,.4,.5,.75,1,2,3,4,5,7,10,15,20,30,60,120,300,600"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -68,6 +68,12 @@ spec:
           - "-lb-healthcheck-interval=3s"
           - "-metrics-flavour=codahale,prometheus"
           - "-enable-connection-metrics"
+{{ if index $cfg "enable_apimonitoring"}}
+          - "-enable-api-usage-monitoring"
+          - "-api-usage-monitoring-realm-keys=https://identity.zalando.com/realm"
+          - "-api-usage-monitoring-client-keys=https://identity.zalando.com/managed-id,sub"
+          - "-api-usage-monitoring-default-client-tracking-pattern=services[.].*"
+{{ end }}
           - "-max-audit-body=0"
           - "-oauth2-tokeninfo-url={{ $cfg.tokeninfo_url }}"
           - "-histogram-metric-buckets=.01,.025,.05,.075,.1,.2,.3,.4,.5,.75,1,2,3,4,5,7,10,15,20,30,60,120,300,600"


### PR DESCRIPTION
fix  #1516
enable apiMonitoring via feature toggle enable_apimonitoring, default is not to enable it for production, but enable it for test.

Usage of apiMonitoring filter can lead to memory consumption in skipper. We should close contact to customers, that want to use this feature and monitor the memory consumption more closely.   

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>