### PR TITLE
use livenessProbe to fix a metrics collector in non ready state

### DIFF
--- a/cluster/manifests/kube-dns-metrics-bash/deployment.yaml
+++ b/cluster/manifests/kube-dns-metrics-bash/deployment.yaml
@@ -34,5 +34,14 @@ spec:
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 60
+            timeoutSeconds: 3
+            failureThreshold: 5
+            successThreshold: 1
           ports:
             - containerPort: 8080


### PR DESCRIPTION
on call alert because of a hanging docker container which never became ready...

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>