### PR TITLE
Add service accounts for logging-agent and prometheus-node-exporter

### DIFF
--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -23,6 +23,9 @@ spec:
         component: logging
     spec:
       priorityClassName: system-node-critical
+{{ if index .ConfigItems "enable_rbac"}}
+      serviceAccountName: logging-agent
+{{ end }}
       tolerations:
       - operator: Exists
         effect: NoSchedule

--- a/cluster/manifests/logging-agent/rbac.yaml
+++ b/cluster/manifests/logging-agent/rbac.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: logging-agent
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: logging-agent
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: logging-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: logging-agent
+subjects:
+- kind: ServiceAccount
+  name: logging-agent
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: logging-agent-privileged-psp
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: privileged-psp
+subjects:
+- kind: ServiceAccount
+  name: logging-agent
+  namespace: kube-system

--- a/cluster/manifests/prometheus-node-exporter/daemonset.yaml
+++ b/cluster/manifests/prometheus-node-exporter/daemonset.yaml
@@ -22,6 +22,9 @@ spec:
         component: node-exporter
     spec:
       priorityClassName: system-node-critical
+{{ if index .ConfigItems "enable_rbac"}}
+      serviceAccountName: prometheus-node-exporter
+{{ end }}
       tolerations:
       - operator: Exists
         effect: NoSchedule

--- a/cluster/manifests/prometheus-node-exporter/rbac.yaml
+++ b/cluster/manifests/prometheus-node-exporter/rbac.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-node-exporter
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: prometheus-node-exporter-privileged-psp
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: privileged-psp
+subjects:
+- kind: ServiceAccount
+  name: prometheus-node-exporter
+  namespace: kube-system


### PR DESCRIPTION
Adds service accounts for `logging-agent` and `prometheus-node-exporter`. Both service accounts can use the `privileged` psp which is needed for using `hostPort`.