### PR TITLE
skipper: add an anti-affinity, switch back to cluster-critical

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -28,7 +28,17 @@ spec:
         kubernetes-log-watcher/scalyr-parser: |
           [{"container": "skipper-ingress", "parser": "skipper-access-log"}]
     spec:
-      priorityClassName: system-node-critical
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                - key: application
+                  operator: In
+                  values:
+                  - skipper-ingress
+              topologyKey: kubernetes.io/hostname
+      priorityClassName: system-cluster-critical
 {{ if index $cfg "enable_rbac"}}
       serviceAccountName: skipper-ingress
 {{ end }}


### PR DESCRIPTION
 * Add an explicit anti-affinity to avoid bugs in the scheduler
 * Go back to `system-cluster-critical`