### PR TITLE
Skipper daemonset: change matchLabels

### DIFF
--- a/cluster/manifests/skipper/daemonset.yaml
+++ b/cluster/manifests/skipper/daemonset.yaml
@@ -11,6 +11,7 @@ spec:
   selector:
     matchLabels:
       application: skipper-ingress
+      legacy: daemonset
   updateStrategy:
     type: RollingUpdate
   template:
@@ -20,6 +21,7 @@ spec:
         application: skipper-ingress
         version: v0.10.121-1-g5f1806d
         component: ingress
+        legacy: daemonset
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
           [{"container": "skipper-ingress", "parser": "skipper-access-log"}]


### PR DESCRIPTION
Otherwise Kubernetes will remove the deployment pods as well.