### PR TITLE
Enable CoreDNS's autopath feature

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -154,3 +154,5 @@ etcd_instance_count: "3"
 {{end}}
 
 dynamodb_service_link_enabled: "false"
+
+coredns_autopath: "false"

--- a/cluster/manifests/coredns/configmap.yaml
+++ b/cluster/manifests/coredns/configmap.yaml
@@ -11,7 +11,7 @@ data:
         errors
         health
         kubernetes cluster.local in-addr.arpa ip6.arpa {
-        resyncperiod 1m
+            resyncperiod 1m
 {{ if eq .ConfigItems.coredns_autopath "true" }}
             pods verified
 {{ else }}

--- a/cluster/manifests/coredns/configmap.yaml
+++ b/cluster/manifests/coredns/configmap.yaml
@@ -11,10 +11,11 @@ data:
         errors
         health
         kubernetes cluster.local in-addr.arpa ip6.arpa {
-            pods insecure
+            pods verified
             upstream
             fallthrough in-addr.arpa ip6.arpa
         }
+        autopath @kubernetes
         prometheus :9153
         proxy . /etc/resolv.conf
         cache 30

--- a/cluster/manifests/coredns/configmap.yaml
+++ b/cluster/manifests/coredns/configmap.yaml
@@ -11,11 +11,17 @@ data:
         errors
         health
         kubernetes cluster.local in-addr.arpa ip6.arpa {
+{{ if eq .ConfigItems.coredns_autopath "true" }}
             pods verified
+{{ else }}
+            pods insecure
+{{ end }}
             upstream
             fallthrough in-addr.arpa ip6.arpa
         }
+{{ if eq .ConfigItems.coredns_autopath "true" }}
         autopath @kubernetes
+{{ end }}
         prometheus :9153
         proxy . /etc/resolv.conf
         cache 30

--- a/cluster/manifests/coredns/configmap.yaml
+++ b/cluster/manifests/coredns/configmap.yaml
@@ -11,6 +11,7 @@ data:
         errors
         health
         kubernetes cluster.local in-addr.arpa ip6.arpa {
+        resyncperiod 1m
 {{ if eq .ConfigItems.coredns_autopath "true" }}
             pods verified
 {{ else }}

--- a/cluster/manifests/coredns/configmap.yaml
+++ b/cluster/manifests/coredns/configmap.yaml
@@ -11,7 +11,9 @@ data:
         errors
         health
         kubernetes cluster.local in-addr.arpa ip6.arpa {
-            resyncperiod 1m
+{{if index .ConfigItems "coredns_resyncperiod"}}
+            resyncperiod {{.ConfigItems.coredns_resyncperiod}}
+{{end}}
 {{ if eq .ConfigItems.coredns_autopath "true" }}
             pods verified
 {{ else }}


### PR DESCRIPTION
Enable CoreDNS's [autopath](https://coredns.io/plugins/autopath/) feature for Kubernetes.

So far I didn't find any good indication whether one should also change the `resolv.conf`.

With this setup a lookup to an external name like `google.com` would go first to `google.com.kube-system.svc.cluster.local` which `autopath`-enabled CoreDNS is able to answer with a CNAME to `google.com` instead of an NXDOMAIN, thus not needing the client to do any further requests for the other search domains.

Using `pods verified` is required when using `autopath`.

Interesting read about Kubernetes' DNS issues: https://blog.quentin-machu.fr/2018/06/24/5-15s-dns-lookups-on-kubernetes/