### PR TITLE
Enable VPA by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -118,7 +118,7 @@ horizontal_pod_autoscaler_tolerance: "0.1"
 horizontal_pod_autoscaler_upscale_delay: "3m0s"
 
 # VPA
-vpa_enabled: "false"
+vpa_enabled: "true"
 
 # Cluster update settings
 {{if eq .Environment "production"}}


### PR DESCRIPTION
With VPAs rolled out to all clusters they should be enabled by default when new clusters are created.

Signed-off-by: Arjun Naik <arjun.rn@gmail.com>