### PR TITLE
Preparation for migration to CoreDNS DaemonSet

### DIFF
--- a/cluster/manifests/coredns/configmap.yaml
+++ b/cluster/manifests/coredns/configmap.yaml
@@ -9,7 +9,7 @@ data:
   Corefile: |
     .:53 {
         errors
-        health
+        health :9154
         kubernetes cluster.local in-addr.arpa ip6.arpa {
             pods insecure
             upstream

--- a/cluster/manifests/coredns/deployment-coredns.yaml
+++ b/cluster/manifests/coredns/deployment-coredns.yaml
@@ -22,6 +22,7 @@ spec:
     metadata:
       labels:
         application: coredns
+        instance: cluster-dns
         version: v1.2.0
         component: cluster-dns
     spec:
@@ -67,7 +68,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /health
-            port: 8080
+            port: 9154
             scheme: HTTP
           initialDelaySeconds: 60
           timeoutSeconds: 5
@@ -76,7 +77,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /health
-            port: 8080
+            port: 9154
             scheme: HTTP
           initialDelaySeconds: 10
           timeoutSeconds: 3


### PR DESCRIPTION
This prepares the current CoreDNS Deployment to be able to co-exist with both a CoreDNS DaemonSet as well as the dnsmasq DaemonSet.

Main point here is to add `instance: cluster-dns` to the `PodSpec` to differentiate with the upcoming DaemonSet pods. Furthermore, the `coredns` config is already updated to its final version (health check port change due to `hostPort`). This allows us to share the same config for both DS and Deployment and saves a migration step later.

@aermakov-zalando corresponds to
> 1) add instance=cluster-dns to pod template, merge

/cc @njuettner @aermakov-zalando @szuecs 