### PR TITLE
Cluster Lifecycle Controller integration

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -442,6 +442,54 @@ Resources:
           PolicyName: root
       RoleName: "{{.Cluster.LocalID}}-app-autoscaler"
     Type: 'AWS::IAM::Role'
+  ClusterLifecycleControllerIAMRole:
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action:
+              - 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+          - Action:
+              - 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              AWS: !Join
+                - ''
+                - - 'arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/'
+                  - !Ref MasterIAMRole
+        Version: 2012-10-17
+      Path: /
+      Policies:
+        - PolicyDocument:
+            Statement:
+              - Action: 'ec2:DescribeInstanceStatus'
+                Effect: Allow
+                Resource: '*'
+              - Action: 'autoscaling:DescribeAutoScalingGroups'
+                Effect: Allow
+                Resource: '*'
+              - Action: 'autoscaling:DescribeAutoScalingInstances'
+                Effect: Allow
+                Resource: '*'
+              - Action: 'autoscaling:DescribeLoadBalancers'
+                Effect: Allow
+                Resource: '*'
+              - Action: 'autoscaling:SetDesiredCapacity'
+                Effect: Allow
+                Resource: '*'
+              - Action: 'elasticloadbalancing:DescribeInstanceHealth'
+                Effect: Allow
+                Resource: '*'
+              - Action: 'autoscaling:TerminateInstanceInAutoScalingGroup'
+                Effect: Allow
+                Resource: '*'
+            Version: 2012-10-17
+          PolicyName: root
+      RoleName: "{{.Cluster.LocalID}}-app-cluster-lifecycle-controller"
+    Type: 'AWS::IAM::Role'
   DeploymentIAMRole:
     Properties:
       AssumeRolePolicyDocument:

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -130,6 +130,9 @@ drain_min_unhealthy_sibling_lifetime: "1h"
 drain_force_evict_interval: "5m"
 {{end}}
 
+# Temporary feature toggles for the cluster lifecycle controller
+experimental_cluster_lifecycle_controller: "false"
+
 # Teapot webhook: gradual rollout
 teapot_admission_controller_default_cpu_request: "25m"
 teapot_admission_controller_default_memory_request: "100Mi"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -129,7 +129,7 @@ drain_min_pod_lifetime: "8h"
 drain_min_healthy_sibling_lifetime: "1h"
 drain_min_unhealthy_sibling_lifetime: "1h"
 drain_force_evict_interval: "5m"
-node_update_prepare_replacement_node: "false"
+node_update_prepare_replacement_node: "false" # don't wait for a replacement instance for on-demand pools in test clusters
 {{end}}
 
 # Temporary feature toggles for the cluster lifecycle controller

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -122,12 +122,14 @@ drain_min_pod_lifetime: "72h"
 drain_min_healthy_sibling_lifetime: "1h"
 drain_min_unhealthy_sibling_lifetime: "6h"
 drain_force_evict_interval: "5m"
+node_update_prepare_replacement_node: "true"
 {{else}}
 drain_grace_period: "2h"
 drain_min_pod_lifetime: "8h"
 drain_min_healthy_sibling_lifetime: "1h"
 drain_min_unhealthy_sibling_lifetime: "1h"
 drain_force_evict_interval: "5m"
+node_update_prepare_replacement_node: "false"
 {{end}}
 
 # Temporary feature toggles for the cluster lifecycle controller

--- a/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-lifecycle-controller
+  namespace: kube-system
+  labels:
+    application: cluster-lifecycle-controller
+    version: master-1
+spec:
+  replicas: {{if eq .ConfigItems.experimental_cluster_lifecycle_controller "true"}}1{{else}}0{{end}}
+  selector:
+    matchLabels:
+      application: cluster-lifecycle-controller
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        application: cluster-lifecycle-controller
+        version: master-1
+      annotations:
+        iam.amazonaws.com/role: "{{ .LocalID }}-app-cluster-lifecycle-controller"
+    spec:
+      priorityClassName: system-cluster-critical
+      serviceAccountName: system
+      dnsPolicy: Default
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      containers:
+      - name: cluster-autoscaler
+        image: registry.opensource.zalan.do/teapot/cluster-lifecycle-controller:master-1
+        args:
+            - --drain-grace-period={{.ConfigItems.drain_grace_period}}
+            - --drain-min-pod-lifetime={{.ConfigItems.drain_min_pod_lifetime}}
+            - --drain-min-healthy-sibling-lifetime={{.ConfigItems.drain_min_healthy_sibling_lifetime}}
+            - --drain-min-unhealthy-sibling-lifetime={{.ConfigItems.drain_min_unhealthy_sibling_lifetime}}
+            - --drain-force-evict-interval={{.ConfigItems.drain_force_evict_interval}}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 250Mi
+          requests:
+            cpu: 100m
+            memory: 250Mi
+        env:
+          - name: AWS_REGION
+            value: {{ .Region }}
+      nodeSelector:
+        node-role.kubernetes.io/master: ""

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -170,6 +170,9 @@ systemd:
       --cadvisor-port=4194 \
       --register-with-taints=node-role.kubernetes.io/master=:NoSchedule{{if index .NodePool.ConfigItems "taints"}},{{.NodePool.ConfigItems.taints}}{{end}} \
       --node-labels=node-role.kubernetes.io/master,kubernetes.io/role=master,master=true \
+{{- if eq .Cluster.ConfigItems.experimental_cluster_lifecycle_controller "true" }}
+      --node-labels=cluster-lifecycle-controller.zalan.do/replacement-strategy=ensure-minimum-healthy-nodes \
+{{- end }}
       --node-labels=kubernetes.io/node-pool={{ .NodePool.Name }}{{if index .NodePool.ConfigItems "labels"}},{{.NodePool.ConfigItems.labels}}{{end}} \
       --node-labels=cluster-dns={{ .Cluster.ConfigItems.cluster_dns }} \
       --node-labels={{ .Values.node_labels }} \

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -166,6 +166,9 @@ systemd:
       --node-labels=kubernetes.io/node-pool={{ .NodePool.Name }}{{if index .NodePool.ConfigItems "labels"}},{{.NodePool.ConfigItems.labels}}{{end}} \
       --node-labels=aws.amazon.com/spot={{if eq .NodePool.DiscountStrategy "spot_max_price"}}true{{else}}false{{end}} \
       --node-labels=cluster-dns={{ .Cluster.ConfigItems.cluster_dns }} \
+{{- if and (ne .NodePool.DiscountStrategy "spot_max_price") (eq .Cluster.ConfigItems.experimental_cluster_lifecycle_controller "true") }}
+      --node-labels=cluster-lifecycle-controller.zalan.do/replacement-strategy=prepare-replacement \
+{{- end }}
       --node-labels={{ .Values.node_labels }} \
       --cluster-dns=${PRIVATE_EC2_IPV4},10.3.0.11 \
       --cluster-domain=cluster.local \

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -166,7 +166,7 @@ systemd:
       --node-labels=kubernetes.io/node-pool={{ .NodePool.Name }}{{if index .NodePool.ConfigItems "labels"}},{{.NodePool.ConfigItems.labels}}{{end}} \
       --node-labels=aws.amazon.com/spot={{if eq .NodePool.DiscountStrategy "spot_max_price"}}true{{else}}false{{end}} \
       --node-labels=cluster-dns={{ .Cluster.ConfigItems.cluster_dns }} \
-{{- if and (ne .NodePool.DiscountStrategy "spot_max_price") (eq .Cluster.ConfigItems.experimental_cluster_lifecycle_controller "true") }}
+{{- if and (ne .NodePool.DiscountStrategy "spot_max_price") (eq .Cluster.ConfigItems.node_update_prepare_replacement_node "true") (eq .Cluster.ConfigItems.experimental_cluster_lifecycle_controller "true") }}
       --node-labels=cluster-lifecycle-controller.zalan.do/replacement-strategy=prepare-replacement \
 {{- end }}
       --node-labels={{ .Values.node_labels }} \


### PR DESCRIPTION
 * Create IAM role for the Cluster Lifecycle Controller
 * Configure the replacement strategy by setting the labels
 * If `experimental_cluster_lifecycle_controller` is set to `true`, run the controller