### PR TITLE
Add missing RBAC permissions for kube-metrics-adapter

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/rbac.yaml
+++ b/cluster/manifests/kube-metrics-adapter/rbac.yaml
@@ -47,6 +47,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - list
@@ -63,6 +70,14 @@ rules:
   - ingresses
   verbs:
   - get
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Adds missing RBAC permissions for the `kube-metrics-adapter`. Without this it does not work.

Was reported here: https://github.com/zalando-incubator/kube-metrics-adapter/issues/17