### PR TITLE
Remove config item that defined which cluster DNS to use

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -152,5 +152,3 @@ etcd_instance_count: "3"
 {{end}}
 
 dynamodb_service_link_enabled: "false"
-
-cluster_dns: "dnsmasq"

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -165,7 +165,6 @@ systemd:
       --register-with-taints=node-role.kubernetes.io/master=:NoSchedule{{if index .NodePool.ConfigItems "taints"}},{{.NodePool.ConfigItems.taints}}{{end}} \
       --node-labels=node-role.kubernetes.io/master,kubernetes.io/role=master,master=true \
       --node-labels=kubernetes.io/node-pool={{ .NodePool.Name }}{{if index .NodePool.ConfigItems "labels"}},{{.NodePool.ConfigItems.labels}}{{end}} \
-      --node-labels=cluster-dns={{ .Cluster.ConfigItems.cluster_dns }} \
       --node-labels={{ .Values.node_labels }} \
       --pod-manifest-path=/etc/kubernetes/manifests \
       --cluster-dns=${PRIVATE_EC2_IPV4},10.3.0.11 \

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -159,7 +159,6 @@ systemd:
       --node-labels=kubernetes.io/role=worker \
       --node-labels=kubernetes.io/node-pool={{ .NodePool.Name }}{{if index .NodePool.ConfigItems "labels"}},{{.NodePool.ConfigItems.labels}}{{end}} \
       --node-labels=aws.amazon.com/spot={{if ne .Values.spot_price ""}}true{{else}}false{{end}} \
-      --node-labels=cluster-dns={{ .Cluster.ConfigItems.cluster_dns }} \
       --node-labels={{ .Values.node_labels }} \
       --cluster-dns=${PRIVATE_EC2_IPV4},10.3.0.11 \
       --cluster-domain=cluster.local \


### PR DESCRIPTION
Removes the ability to define which cluster-local DNS server is used via a ConfigItem and switches the default to CoreDNS. It rolls all nodes and activates CoreDNS-based cluster-local DNS server on a per-node basis.

This is the state of userdata before we started the rollout of the CoreDNS DaemonSet.

- [ ] do not merge before https://github.com/zalando-incubator/kubernetes-on-aws/pull/1573 is merged to beta
- [ ] do not merge before all clusters switched ClusterDNS to CoreDNS