### PR TITLE
Support m5d instances

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -154,3 +154,5 @@ etcd_instance_count: "3"
 dynamodb_service_link_enabled: "false"
 
 cluster_dns: "dnsmasq"
+
+coreos_image: "ami-03ee0a0310474a00e"

--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -4,7 +4,7 @@ Description: Kubernetes default master node pool
 Mappings:
   Images:
     eu-central-1:
-      StableCoreOSImage: ami-03ee0a0310474a00e
+      StableCoreOSImage: '{{ .Cluster.ConfigItems.coreos_image }}'
 
 Resources:
   AutoScalingGroup:

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -28,7 +28,7 @@ systemd:
   - name: sshd.socket
     mask: true
 
-{{if .Values.instance_info.NVMEInstanceStorage }}
+{{if gt (len .Values.instance_info.InstanceStorageDevices) 0 }}
   - name: {{if index .NodePool.ConfigItems "instance_storage_mount_path"}}{{.NodePool.ConfigItems.instance_storage_mount_path | mountUnitName}}{{else}}var-lib-docker{{end}}.mount
     enable: true
     contents: |
@@ -36,7 +36,7 @@ systemd:
       Before=local-fs.target
 
       [Mount]
-      What=/dev/nvme0n1
+      What={{(index .Values.instance_info.InstanceStorageDevices 0).Path}}
       Where={{if index .NodePool.ConfigItems "instance_storage_mount_path"}}{{.NodePool.ConfigItems.instance_storage_mount_path}}{{else}}/var/lib/docker{{end}}
       Type=ext4
 
@@ -402,11 +402,11 @@ storage:
         fi
 {{end}}
 
-{{if .Values.instance_info.NVMEInstanceStorage }}
+{{if gt (len .Values.instance_info.InstanceStorageDevices) 0 }}
   filesystems:
   - name: instance-storage
     mount:
-      device: /dev/nvme0n1
+      device: {{(index .Values.instance_info.InstanceStorageDevices 0).Path}}
       format: ext4
       wipe_filesystem: true
 {{end}}

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -4,7 +4,7 @@ Description: Kubernetes default worker node pool
 Mappings:
   Images:
     eu-central-1:
-      StableCoreOSImage: ami-03ee0a0310474a00e
+      StableCoreOSImage: '{{ .Cluster.ConfigItems.coreos_image }}'
 
 Conditions:
   UseSpotPrice:


### PR DESCRIPTION
Use `instance_info.InstanceStorageDevices` instead of a hard-coded path. Depends on https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/108.