### PR TITLE
Upgrading kube-metrics-adapter

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -24,7 +24,7 @@ spec:
 {{ end }}
       containers:
       - name: kube-metrics-adapter
-        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:master-10
+        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:master-13
         args:
         - --prometheus-server=http://prometheus.kube-system.svc.cluster.local
         - --skipper-ingress-metrics


### PR DESCRIPTION
Upgrading kube-metrics-adapter to include the changes since master-10

ref: [21](https://github.com/zalando-incubator/kube-metrics-adapter/pull/21)..[15](https://github.com/zalando-incubator/kube-metrics-adapter/pull/15)