### PR TITLE
Fix RBAC configuration for nvidia daemonsets

### DIFF
--- a/cluster/manifests/nvidia/nvidia-driver-installer.yaml
+++ b/cluster/manifests/nvidia/nvidia-driver-installer.yaml
@@ -22,7 +22,9 @@ spec:
         application: nvidia-driver-installer
         version: c117d39
     spec:
+{{ if index .ConfigItems "enable_rbac"}}
       serviceAccountName: nvidia
+{{ end }}
       tolerations:
       - key: nvidia.com/gpu
         effect: NoSchedule

--- a/cluster/manifests/nvidia/nvidia-driver-installer.yaml
+++ b/cluster/manifests/nvidia/nvidia-driver-installer.yaml
@@ -22,6 +22,7 @@ spec:
         application: nvidia-driver-installer
         version: c117d39
     spec:
+      serviceAccountName: nvidia
       tolerations:
       - key: nvidia.com/gpu
         effect: NoSchedule

--- a/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
+++ b/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
@@ -22,7 +22,9 @@ spec:
         application: nvidia-gpu-device-plugin
         version: cb2bdea5eb507a9577ce11ff058a2dfa84f54263
     spec:
+{{ if index .ConfigItems "enable_rbac"}}
       serviceAccountName: nvidia
+{{ end }}
       tolerations:
       - operator: Exists
         effect: NoExecute

--- a/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
+++ b/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
@@ -22,6 +22,7 @@ spec:
         application: nvidia-gpu-device-plugin
         version: cb2bdea5eb507a9577ce11ff058a2dfa84f54263
     spec:
+      serviceAccountName: nvidia
       tolerations:
       - operator: Exists
         effect: NoExecute

--- a/cluster/manifests/nvidia/rbac.yaml
+++ b/cluster/manifests/nvidia/rbac.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nvidia
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: nvidia-privileged-psp
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: privileged-psp
+subjects:
+- kind: ServiceAccount
+  name: nvidia
+  namespace: kube-system


### PR DESCRIPTION
Allow nvidia pods to run with privileged pod security policy.