### PR TITLE
Implement HTTP timeout for logging-agent

### DIFF
--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -79,7 +79,7 @@ spec:
           mountPath: /mnt/scalyr-checkpoint
       containers:
       - name: log-watcher
-        image: registry.opensource.zalan.do/eagleeye/kubernetes-log-watcher:0.19
+        image: registry.opensource.zalan.do/logging/kubernetes-log-watcher:0.21-8-gae90f48
         env:
         - name: CLUSTER_NODE_NAME
           valueFrom:


### PR DESCRIPTION
This contains a fix that has been implemented to avoid that avoids stuck connections during rolling updates by using a HTTP timeout.

It has happened in the past that logs weren't shipped to Scalyr properly because of that.

More context can be found here:
https://github.com/zalando-incubator/kubernetes-log-watcher/pull/72

Signed-off-by: Felix Mueller <felix.mueller@zalando.de>