### PR TITLE
Fix CoreDNS PDB

### DIFF
--- a/cluster/manifests/coredns/poddisruptionbudget.yaml
+++ b/cluster/manifests/coredns/poddisruptionbudget.yaml
@@ -2,11 +2,12 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    component: cluster-dns
-  name: cluster-dns
+    application: coredns
+  name: coredns
   namespace: kube-system
 spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-      component: cluster-dns
+      application: coredns
+      instance: cluster-dns

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -1,5 +1,8 @@
 # everything defined under here will be deleted before applying the manifests
-pre_apply: []
+pre_apply:
+  - name: cluster-dns
+    namespace: kube-system
+    kind: PodDisruptionBudget
 
 # everything defined under here will be deleted after applying the manifests
 post_apply: []


### PR DESCRIPTION
Modify the PDB for CoreDNS to only match deployment pods. Deleted/renamed because PDBs are immutable for some reason.