### PR TITLE
Cadvisor daemonset

### DIFF
--- a/cluster/manifests/cadvisor/daemonset.yaml
+++ b/cluster/manifests/cadvisor/daemonset.yaml
@@ -21,6 +21,8 @@ spec:
       priorityClassName: system-node-critical
 {{ if index .ConfigItems "enable_rbac"}}
       serviceAccountName: cadvisor
+{{ else }}
+      serviceAccountName: system
 {{ end }}
       containers:
       - name: cadvisor

--- a/cluster/manifests/cadvisor/daemonset.yaml
+++ b/cluster/manifests/cadvisor/daemonset.yaml
@@ -24,7 +24,7 @@ spec:
 {{ end }}
       containers:
       - name: cadvisor
-        image: registry.opensource.zalan.do/teapot/cadvisor:v0.30.2
+        image: google/cadvisor:v0.32.0
         args:
         - --housekeeping_interval=10s
         - --max_housekeeping_interval=15s

--- a/cluster/manifests/cadvisor/daemonset.yaml
+++ b/cluster/manifests/cadvisor/daemonset.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cadvisor
+  namespace: kube-system
+  labels:
+    application: cadvisor
+    version: v0.30.2
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      application: cadvisor
+  template:
+    metadata:
+      labels:
+        application: cadvisor
+        version: v0.30.2
+    spec:
+      priorityClassName: system-node-critical
+      containers:
+      - name: cadvisor
+        image: registry.opensource.zalan.do/teapot/cadvisor:v0.30.2
+        args:
+        - --housekeeping_interval=10s
+        - --max_housekeeping_interval=15s
+        - --event_storage_event_limit=default=0
+        - --event_storage_age_limit=default=0
+        - --disable_metrics=percpu,tcp,udp
+        - --docker_only
+        - --store_container_labels=false
+        resources:
+          requests:
+            memory: 150Mi
+            cpu: 150m
+          limits:
+            memory: 150Mi
+            cpu: 150m
+        volumeMounts:
+        - name: rootfs
+          mountPath: /rootfs
+          readOnly: true
+        - name: var-run
+          mountPath: /var/run
+          readOnly: true
+        - name: sys
+          mountPath: /sys
+          readOnly: true
+        - name: docker
+          mountPath: /var/lib/docker
+          readOnly: true
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: rootfs
+        hostPath:
+          path: /
+      - name: var-run
+        hostPath:
+          path: /var/run
+      - name: sys
+        hostPath:
+          path: /sys
+      - name: docker
+        hostPath:
+          path: /var/lib/docker
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      - operator: Exists
+        effect: NoExecute

--- a/cluster/manifests/cadvisor/daemonset.yaml
+++ b/cluster/manifests/cadvisor/daemonset.yaml
@@ -35,6 +35,7 @@ spec:
         - --event_storage_age_limit=default=0
         - --disable_metrics=percpu,tcp,udp
         - --docker_only
+        - --store_container_labels=false
         - --whitelisted_container_labels=io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace,io.kubernetes.pod.uid,application
         resources:
           requests:

--- a/cluster/manifests/cadvisor/daemonset.yaml
+++ b/cluster/manifests/cadvisor/daemonset.yaml
@@ -56,6 +56,9 @@ spec:
         - name: docker
           mountPath: /var/lib/docker
           readOnly: true
+        - name: kmsg
+          mountPath: /dev/kmsg
+          readOnly: true
         ports:
         - name: http
           containerPort: 8080
@@ -75,6 +78,9 @@ spec:
       - name: docker
         hostPath:
           path: /var/lib/docker
+      - name: kmsg
+        hostPath:
+          path: /dev/kmsg
       tolerations:
       - operator: Exists
         effect: NoSchedule

--- a/cluster/manifests/cadvisor/daemonset.yaml
+++ b/cluster/manifests/cadvisor/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: cadvisor
-    version: v0.30.2
+    version: v0.32.0
 spec:
   updateStrategy:
     type: RollingUpdate
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: cadvisor
-        version: v0.30.2
+        version: v0.32.0
     spec:
       priorityClassName: system-node-critical
 {{ if index .ConfigItems "enable_rbac"}}
@@ -24,7 +24,8 @@ spec:
 {{ end }}
       containers:
       - name: cadvisor
-        image: google/cadvisor:v0.32.0
+        # https://github.com/google/cadvisor/pull/2113
+        image: mikkeloscar/cadvisor:latest
         args:
         - --housekeeping_interval=10s
         - --max_housekeeping_interval=15s
@@ -32,6 +33,7 @@ spec:
         - --event_storage_age_limit=default=0
         - --disable_metrics=percpu,tcp,udp
         - --docker_only
+        - --whitelisted_container_labels=io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace,io.kubernetes.pod.uid,application
         resources:
           requests:
             memory: 150Mi

--- a/cluster/manifests/cadvisor/daemonset.yaml
+++ b/cluster/manifests/cadvisor/daemonset.yaml
@@ -43,6 +43,8 @@ spec:
           limits:
             memory: 150Mi
             cpu: 150m
+        securityContext:
+          privileged: true # allows reading /dev/kmsg
         volumeMounts:
         - name: rootfs
           mountPath: /rootfs

--- a/cluster/manifests/cadvisor/daemonset.yaml
+++ b/cluster/manifests/cadvisor/daemonset.yaml
@@ -32,7 +32,6 @@ spec:
         - --event_storage_age_limit=default=0
         - --disable_metrics=percpu,tcp,udp
         - --docker_only
-        - --store_container_labels=false
         resources:
           requests:
             memory: 150Mi

--- a/cluster/manifests/cadvisor/daemonset.yaml
+++ b/cluster/manifests/cadvisor/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
       containers:
       - name: cadvisor
         # images including https://github.com/google/cadvisor/pull/2113
-        image: registry.opensource.zalan.do/teapot/cadvisor:v0.32.0-whitelist-master-2
+        image: registry.opensource.zalan.do/teapot/cadvisor:v0.32.0-whitelist-master-3
         args:
         - --housekeeping_interval=10s
         - --max_housekeeping_interval=15s

--- a/cluster/manifests/cadvisor/daemonset.yaml
+++ b/cluster/manifests/cadvisor/daemonset.yaml
@@ -26,8 +26,8 @@ spec:
 {{ end }}
       containers:
       - name: cadvisor
-        # https://github.com/google/cadvisor/pull/2113
-        image: mikkeloscar/cadvisor:latest
+        # images including https://github.com/google/cadvisor/pull/2113
+        image: registry.opensource.zalan.do/teapot/cadvisor:v0.32.0-whitelist-master-2
         args:
         - --housekeeping_interval=10s
         - --max_housekeeping_interval=15s

--- a/cluster/manifests/cadvisor/daemonset.yaml
+++ b/cluster/manifests/cadvisor/daemonset.yaml
@@ -19,6 +19,9 @@ spec:
         version: v0.30.2
     spec:
       priorityClassName: system-node-critical
+{{ if index .ConfigItems "enable_rbac"}}
+      serviceAccountName: cadvisor
+{{ end }}
       containers:
       - name: cadvisor
         image: registry.opensource.zalan.do/teapot/cadvisor:v0.30.2

--- a/cluster/manifests/cadvisor/rbac.yaml
+++ b/cluster/manifests/cadvisor/rbac.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cadvisor
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: cadvisor-privileged-psp
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: privileged-psp
+subjects:
+- kind: ServiceAccount
+  name: cadvisor
+  namespace: kube-system

--- a/cluster/manifests/cadvisor/service.yaml
+++ b/cluster/manifests/cadvisor/service.yaml
@@ -1,0 +1,15 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: cadvisor
+  namespace: kube-system
+  labels:
+    application: cadvisor
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+  selector:
+    application: cadvisor

--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -92,21 +92,40 @@ data:
       - action: replace
         source_labels: ['__meta_kubernetes_pod_node_name']
         target_label: node_name
-    - job_name: 'kubelet-cadvisor'
+    - job_name: 'cadvisor'
+      scheme: http
+      honor_labels: true
       kubernetes_sd_configs:
-      - role: node
+      - role: endpoints
+        namespaces:
+          names:
+            - kube-system
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_endpoints_name]
+        action: keep
+        regex: cadvisor
+      - action: replace
+        source_labels: ['__meta_kubernetes_pod_node_name']
+        target_label: node_name
       metric_relabel_configs:
+      - action: replace
+        source_labels: ['container_label_application']
+        target_label: application
+      - action: replace
+        source_labels: ['container_label_io_kubernetes_container_name']
+        target_label: container_name
+      - action: replace
+        source_labels: ['container_label_io_kubernetes_pod_name']
+        target_label: pod_name
+      - action: replace
+        source_labels: ['container_label_io_kubernetes_pod_namespace']
+        target_label: namespace
+      - action: replace
+        source_labels: ['container_label_io_kubernetes_pod_uid']
+        target_label: uid
       - source_labels: [__name__]
         action: keep
         regex: '(container_cpu_cfs_throttled_seconds_total|container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total)'
-      relabel_configs:
-      - source_labels: [__meta_kubernetes_node_address_InternalIP]
-        target_label: __address__
-        regex: (.*)
-        replacement: $1:4194
-      - action: replace
-        source_labels: [instance]
-        target_label: node_name
     - job_name: 'kubelet-metrics'
       kubernetes_sd_configs:
       - role: node


### PR DESCRIPTION
The image includes a flag white_listed_container_labels which allows specifying
a comma separated list of container labels that are allowed to be
attached to prometheus metrics. This helps limit the label space of
each data point and limits the memory used by cadvisor compared to just
add all labels from all containers which is the default.

**Why:**

Without this white listing in place we saw the memory footprint of
cadvisor explode in our production environment because users add a lot
of data in pod labels, data which is not useful for metrics but may be
useful for the individual applications.

/cc: @mikkeloscar 