### PR TITLE
Worker nodes: don't enable useless feature gate

### DIFF
--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -175,7 +175,7 @@ systemd:
       --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
       --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \
       --cloud-provider=aws \
-      --feature-gates=TaintBasedEvictions=true,TaintNodesByCondition=true,ScheduleDaemonSetPods=true \
+      --feature-gates=TaintBasedEvictions=true,TaintNodesByCondition=true \
       --pod-infra-container-image=registry.opensource.zalan.do/teapot/pause-amd64:3.1 \
 {{- if not (index .Cluster.ConfigItems "enable_cfs_quota") }}
       --cpu-cfs-quota=false \


### PR DESCRIPTION
We don't actually need this on the workers, so let's avoid an extra node rotation.