### PR TITLE
Switch privileged components to system service account

### DIFF
--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -19,6 +19,7 @@ spec:
         application: audittrail-adapter
         version: master-18
     spec:
+      serviceAccountName: system
       priorityClassName: system-node-critical
       affinity:
         nodeAffinity:

--- a/cluster/manifests/coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/coredns-local/daemonset-coredns.yaml
@@ -74,6 +74,8 @@ spec:
       priorityClassName: system-node-critical
 {{ if index .ConfigItems "enable_rbac"}}
       serviceAccountName: coredns
+{{ else }}
+      serviceAccountName: system
 {{ end }}
       hostNetwork: true
       dnsPolicy: Default

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -24,6 +24,8 @@ spec:
       priorityClassName: system-node-critical
 {{ if index .ConfigItems "enable_rbac"}}
       serviceAccountName: kube-proxy
+{{ else }}
+      serviceAccountName: system
 {{ end }}
       tolerations:
       - operator: Exists

--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -21,6 +21,8 @@ spec:
       priorityClassName: system-node-critical
 {{ if index .ConfigItems "enable_rbac"}}
       serviceAccountName: kube2iam
+{{ else }}
+      serviceAccountName: system
 {{ end }}
       tolerations:
       - operator: Exists

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -25,6 +25,8 @@ spec:
       priorityClassName: system-node-critical
 {{ if index .ConfigItems "enable_rbac"}}
       serviceAccountName: logging-agent
+{{ else }}
+      serviceAccountName: system
 {{ end }}
       tolerations:
       - operator: Exists

--- a/cluster/manifests/nvidia/nvidia-driver-installer.yaml
+++ b/cluster/manifests/nvidia/nvidia-driver-installer.yaml
@@ -24,6 +24,8 @@ spec:
     spec:
 {{ if index .ConfigItems "enable_rbac"}}
       serviceAccountName: nvidia
+{{ else }}
+      serviceAccountName: system
 {{ end }}
       tolerations:
       - key: nvidia.com/gpu

--- a/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
+++ b/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
@@ -24,6 +24,8 @@ spec:
     spec:
 {{ if index .ConfigItems "enable_rbac"}}
       serviceAccountName: nvidia
+{{ else }}
+      serviceAccountName: system
 {{ end }}
       tolerations:
       - operator: Exists

--- a/cluster/manifests/prometheus-node-exporter/daemonset.yaml
+++ b/cluster/manifests/prometheus-node-exporter/daemonset.yaml
@@ -24,6 +24,8 @@ spec:
       priorityClassName: system-node-critical
 {{ if index .ConfigItems "enable_rbac"}}
       serviceAccountName: prometheus-node-exporter
+{{ else }}
+      serviceAccountName: system
 {{ end }}
       tolerations:
       - operator: Exists

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -37,6 +37,8 @@ spec:
       priorityClassName: system-cluster-critical
 {{ if index .ConfigItems "enable_rbac"}}
       serviceAccountName: skipper-ingress
+{{ else }}
+      serviceAccountName: system
 {{ end }}
       nodeSelector:
         kubernetes.io/role: worker


### PR DESCRIPTION
We have several priviledged components that use the `default` service account. It was a mistake to give that account so many permissions. It got fixed when switching to RBAC but that breaks our deployments. This switches them to `system` so they work with and without RBAC.