### PR TITLE
disallow privilege escalation for restricted policy

### DIFF
--- a/cluster/manifests/psp/pod_security_policy.yaml
+++ b/cluster/manifests/psp/pod_security_policy.yaml
@@ -27,10 +27,7 @@ kind: PodSecurityPolicy
 metadata:
   name: restricted
 spec:
-  # Enabled for now due to issues with Docker 1.12, see
-  # https://github.com/zalando-incubator/kubernetes-on-aws/pull/771
-  # for details
-  allowPrivilegeEscalation: true
+  allowPrivilegeEscalation: false
   fsGroup:
     rule: RunAsAny
   runAsUser:


### PR DESCRIPTION
Now that we run docker 1.18 we can disallow privilege escalation for restricted policy as originally intended.

reverts: https://github.com/zalando-incubator/kubernetes-on-aws/pull/771

Note: untested, let's see what e2e says
