### PR TITLE
Update the VPA to version 0.3.0

### DIFF
--- a/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
@@ -20,7 +20,7 @@ metadata:
   namespace: kube-system
   labels:
     application: vpa-admission-controller
-    version: patched-master-7
+    version: patched-0.3.0-master-9
     component: vpa
 spec:
   replicas: 1
@@ -31,13 +31,13 @@ spec:
     metadata:
       labels:
         application: vpa-admission-controller
-        version: patched-master-7
+        version: patched-0.3.0-master-9
         component: vpa
     spec:
       serviceAccountName: system
       containers:
       - name: admission-controller
-        image: registry.opensource.zalan.do/teapot/vpa-admission-controller:patched-master-7
+        image: registry.opensource.zalan.do/teapot/vpa-admission-controller:patched-0.3.0-master-9
         volumeMounts:
           - name: tls-certs
             mountPath: "/etc/tls-certs"

--- a/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     application: vpa-recommender
-    version: patched-master-7
+    version: patched-0.3.0-master-9
     component: vpa
 spec:
   replicas: 1
@@ -17,13 +17,13 @@ spec:
     metadata:
       labels:
         application: vpa-recommender
-        version: patched-master-7
+        version: patched-0.3.0-master-9
         component: vpa
     spec:
       serviceAccountName: system
       containers:
       - name: recommender
-        image: registry.opensource.zalan.do/teapot/vpa-recommender:patched-master-7
+        image: registry.opensource.zalan.do/teapot/vpa-recommender:patched-0.3.0-master-9
         resources:
           limits:
             memory: 500Mi

--- a/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     application: vpa-updater
-    version: patched-master-7
+    version: patched-0.3.0-master-9
     component: vpa
 spec:
   replicas: 1
@@ -17,13 +17,13 @@ spec:
     metadata:
       labels:
         application: vpa-updater
-        version: patched-master-7
+        version: patched-0.3.0-master-9
         component: vpa
     spec:
       serviceAccountName: system
       containers:
       - name: updater
-        image: registry.opensource.zalan.do/teapot/vpa-updater:patched-master-7
+        image: registry.opensource.zalan.do/teapot/vpa-updater:patched-0.3.0-master-9
         args:
           - ./updater
           - --v=4


### PR DESCRIPTION
A [new version](https://github.com/kubernetes/autoscaler/releases/tag/vertical-pod-autoscaler-0.3.0) was released recently and this PR updates the images to the new version.
