### PR TITLE
Don't use spot_price

### DIFF
--- a/cluster/node-pools/worker-default/stack.yaml
+++ b/cluster/node-pools/worker-default/stack.yaml
@@ -93,10 +93,6 @@ Resources:
         InstanceType: "{{ .NodePool.InstanceType }}"
 {{- if eq .NodePool.DiscountStrategy "spot_max_price"}}
         InstanceMarketOptions:
-          SpotOptions:
-            SpotInstanceType: one-time
-            InstanceInterruptionBehavior: terminate
-            MaxPrice: "{{ .Values.spot_price }}"
           MarketType: spot
 {{end}}
         UserData: "{{ .UserData }}"

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -164,7 +164,7 @@ systemd:
       --register-node \
       --node-labels=kubernetes.io/role=worker \
       --node-labels=kubernetes.io/node-pool={{ .NodePool.Name }}{{if index .NodePool.ConfigItems "labels"}},{{.NodePool.ConfigItems.labels}}{{end}} \
-      --node-labels=aws.amazon.com/spot={{if ne .Values.spot_price ""}}true{{else}}false{{end}} \
+      --node-labels=aws.amazon.com/spot={{if eq .NodePool.DiscountStrategy "spot_max_price"}}true{{else}}false{{end}} \
       --node-labels=cluster-dns={{ .Cluster.ConfigItems.cluster_dns }} \
       --node-labels={{ .Values.node_labels }} \
       --cluster-dns=${PRIVATE_EC2_IPV4},10.3.0.11 \

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -108,9 +108,6 @@ Resources:
         InstanceType: "{{ .NodePool.InstanceType }}"
 {{- if eq .NodePool.DiscountStrategy "spot_max_price"}}
         InstanceMarketOptions:
-          SpotOptions:
-            SpotInstanceType: one-time
-            MaxPrice: "{{ .Values.spot_price }}"
           MarketType: spot
 {{end}}
         UserData: "{{ .UserData }}"


### PR DESCRIPTION
LaunchTemplates allow running spot instances without specifying the price limit. Remove from the templates, drop from CLM later.