### PR TITLE
optimize resource kubernetes-lifecycle-metrics

### DIFF
--- a/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
@@ -27,11 +27,11 @@ spec:
             - containerPort: 9090
           resources:
             limits:
-              cpu: 200m
-              memory: 500Mi
+              cpu: 5m
+              memory: 150Mi
             requests:
-              cpu: 200m
-              memory: 500Mi
+              cpu: 5m
+              memory: 150Mi
           readinessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
In our 7d graphs I did not find any use more than 100Mi and 10m in spikes -> reduce resources

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>