### PR TITLE
Update prometheus to 2.6.0

### DIFF
--- a/cluster/manifests/prometheus/statefulset.yaml
+++ b/cluster/manifests/prometheus/statefulset.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
   labels:
     application: prometheus
-    version: v2.3.2
+    version: v2.6.0
   name: prometheus
   namespace: kube-system
 spec:
@@ -17,14 +17,14 @@ spec:
     metadata:
       labels:
         application: prometheus
-        version: v2.3.2
+        version: v2.6.0
       annotations:
         config/hash: {{"configmap.yaml" | manifestHash}}
     spec:
       priorityClassName: system-cluster-critical
       containers:
       - name: prometheus
-        image: registry.opensource.zalan.do/teapot/prometheus:v2.3.2
+        image: registry.opensource.zalan.do/teapot/prometheus:v2.6.0
         args:
         - "--config.file=/etc/prometheus/prometheus.yml"
         - "--storage.tsdb.path=/prometheus/"


### PR DESCRIPTION
Updates to prometheus 2.6.0 https://github.com/prometheus/prometheus/releases/tag/v2.6.0

One of the things it brings is better error messages when parsing broken metric endpoints which can be helpful when debugging why a metrics endpoint doesn't work.