### PR TITLE
zmon: use default SA if RBAC is disabled

### DIFF
--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -23,7 +23,7 @@ spec:
 {{ if index .ConfigItems "enable_rbac"}}
       serviceAccountName: zmon
 {{ else }}
-      serviceAccountName: system
+      serviceAccountName: default
 {{ end }}
       initContainers:
       - name: gerry-init

--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -23,7 +23,7 @@ spec:
 {{ if index .ConfigItems "enable_rbac"}}
       serviceAccountName: zmon
 {{ else }}
-      serviceAccountName: system
+      serviceAccountName: default
 {{ end }}
       initContainers:
       - name: gerry-init


### PR DESCRIPTION
If RBAC is disabled, use the `default` service account since `system` doesn't exist in other namespaces. This means that ZMON will be broken while we disable RBAC, but at least it won't be broken forever.