### PR TITLE
add opentracing headers to tokeninfo and tokenintrospection filters 

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.10.146
+    version: v0.10.150
     component: ingress
 spec:
   strategy:
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.10.146
+        version: v0.10.150
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -45,7 +45,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.146
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.150
         ports:
         - name: ingress-port
           containerPort: 9999


### PR DESCRIPTION
add opentracing headers to tokeninfo and tokenintrospection filters to make these visible

https://opensource.zalando.com/skipper/reference/filters/#oauthtokeninfoanyscope
https://opensource.zalando.com/skipper/reference/filters/#oauthtokeninfollscope
https://opensource.zalando.com/skipper/reference/filters/#oauthtokeninfoanykv
https://opensource.zalando.com/skipper/reference/filters/#oauthtokeninfoallkv
https://opensource.zalando.com/skipper/reference/filters/#oauthtokenintrospectionanyclaims
https://opensource.zalando.com/skipper/reference/filters/#oauthtokenintrospectionallclaims
https://opensource.zalando.com/skipper/reference/filters/#oauthtokenintrospectionanykv
https://opensource.zalando.com/skipper/reference/filters/#oauthtokenintrospectionallkv

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>