### PR TITLE
Support multiple instance types for worker pools

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -10,6 +10,7 @@ autoscaling_buffer_pods: "1"
 {{else}}
 autoscaling_buffer_pods: "0"
 {{end}}
+experimental_autoscaler_mixed_instance_policy_support: "false"
 
 # skipper daemonset
 skipper_limits_mem: "250Mi"

--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-cluster-autoscaler
-    version: v1.12.1-internal-dev17
+    version: {{ if eq .ConfigItems.experimental_autoscaler_mixed_instance_policy_support "true" }}v1.12.1-internal-dev17{{ else }}v1.12.1-internal10{{ end }}
 spec:
   selector:
     matchLabels:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: kube-cluster-autoscaler
-        version: v1.12.1-internal-dev17
+        version: {{ if eq .ConfigItems.experimental_autoscaler_mixed_instance_policy_support "true" }}v1.12.1-internal-dev17{{ else }}v1.12.1-internal10{{ end }}
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-autoscaler"
         config/pool-sizes: "{{range .NodePools}}{{.Name}}-{{.MinSize}}-{{.MaxSize}} {{end}}"
@@ -29,7 +29,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cluster-autoscaler
-        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.12.1-internal-dev17
+        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:{{ if eq .ConfigItems.experimental_autoscaler_mixed_instance_policy_support "true" }}v1.12.1-internal-dev17{{ else }}v1.12.1-internal10{{ end }}
         command:
           - ./cluster-autoscaler
           - --v=4

--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-cluster-autoscaler
-    version: v1.12.1-internal10
+    version: v1.12.1-internal-dev17
 spec:
   selector:
     matchLabels:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: kube-cluster-autoscaler
-        version: v1.12.1-internal10
+        version: v1.12.1-internal-dev17
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-autoscaler"
         config/pool-sizes: "{{range .NodePools}}{{.Name}}-{{.MinSize}}-{{.MaxSize}} {{end}}"
@@ -29,7 +29,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cluster-autoscaler
-        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.12.1-internal10
+        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.12.1-internal-dev17
         command:
           - ./cluster-autoscaler
           - --v=4

--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -54,7 +54,7 @@ Resources:
         - Images
         - !Ref 'AWS::Region'
         - StableCoreOSImage
-        InstanceType: "{{ .NodePool.InstanceType }}"
+        InstanceType: "{{ index .NodePool.InstanceTypes 0 }}"
         UserData: "{{ .UserData }}"
     Type: 'AWS::EC2::LaunchTemplate'
   AutoScalingInstanceProfile:

--- a/cluster/node-pools/worker-default/stack.yaml
+++ b/cluster/node-pools/worker-default/stack.yaml
@@ -15,9 +15,24 @@ Resources:
     Properties:
       HealthCheckGracePeriod: 300
       HealthCheckType: EC2
-      LaunchTemplate:
-        LaunchTemplateId: !Ref LaunchTemplate
-        Version: !GetAtt LaunchTemplate.LatestVersionNumber
+{{ if gt (len $data.NodePool.InstanceTypes) 1 }}
+      MixedInstancesPolicy:
+        InstancesDistribution:
+          OnDemandPercentageAboveBaseCapacity: {{if eq $data.NodePool.DiscountStrategy "spot_max_price"}}0{{else}}100{{end}}
+          SpotInstancePools: {{ len $data.NodePool.InstanceTypes }}
+        LaunchTemplate:
+          LaunchTemplateSpecification:
+            LaunchTemplateId: !Ref LaunchTemplate
+            Version: !GetAtt LaunchTemplate.LatestVersionNumber
+          Overrides:
+{{ range $type := $data.NodePool.InstanceTypes }}
+            - InstanceType: "{{ $type }}"
+{{ end }}
+{{ else }}
+       LaunchTemplate:
+         LaunchTemplateId: !Ref LaunchTemplate
+         Version: !GetAtt LaunchTemplate.LatestVersionNumber
+{{ end }}
       MinSize: '{{ .NodePool.MinSize }}'
       MaxSize: '{{ .NodePool.MaxSize }}'
       Tags:
@@ -90,11 +105,11 @@ Resources:
         - Images
         - !Ref 'AWS::Region'
         - StableCoreOSImage
-        InstanceType: "{{ .NodePool.InstanceType }}"
-{{- if eq .NodePool.DiscountStrategy "spot_max_price"}}
+        InstanceType: "{{ index .NodePool.InstanceTypes 0 }}"
+{{- if and (eq .NodePool.DiscountStrategy "spot_max_price") (eq (len $data.NodePool.InstanceTypes) 1) }}
         InstanceMarketOptions:
           MarketType: spot
-{{end}}
+{{ end }}
         UserData: "{{ .UserData }}"
     Type: 'AWS::EC2::LaunchTemplate'
   AutoScalingInstanceProfile:

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -127,11 +127,25 @@ systemd:
       [Install]
       WantedBy=multi-user.target
 
+  - name: collect-instance-metadata.service
+    enable: true
+    contents: |
+      [Unit]
+      After=docker.service dockercfg.service private-ipv4.service
+
+      [Service]
+      Type=oneshot
+      ExecStart=/opt/bin/collect-instance-metadata
+      RemainAfterExit=yes
+
+      [Install]
+      WantedBy=multi-user.target
+
   - name: kubelet.service
     enable: true
     contents: |
       [Unit]
-      After=docker.service dockercfg.service meta-data-iptables.service private-ipv4.service
+      After=docker.service dockercfg.service meta-data-iptables.service private-ipv4.service collect-instance-metadata.service
 
       [Service]
       Environment=KUBELET_IMAGE_TAG=v1.12.4
@@ -151,6 +165,7 @@ systemd:
       --volume dockercfg,kind=host,source=/root/.docker/config.json \
       --mount volume=dockercfg,target=/root/.docker/config.json \
       --set-env=HOME=/root"
+      EnvironmentFile=/var/run/kubelet.vars
       ExecStartPre=/usr/bin/mkdir -p /var/log/containers
       ExecStartPre=/bin/mkdir -p /var/lib/cni
       ExecStartPre=/bin/mkdir -p /data
@@ -163,10 +178,10 @@ systemd:
       --register-node \
       --node-labels=kubernetes.io/role=worker \
       --node-labels=kubernetes.io/node-pool={{ .NodePool.Name }}{{if index .NodePool.ConfigItems "labels"}},{{.NodePool.ConfigItems.labels}}{{end}} \
-      --node-labels=aws.amazon.com/spot={{if eq .NodePool.DiscountStrategy "spot_max_price"}}true{{else}}false{{end}} \
+      --node-labels=${SPOT_LABEL} \
       --node-labels=cluster-dns={{ .Cluster.ConfigItems.cluster_dns }} \
-{{- if and (ne .NodePool.DiscountStrategy "spot_max_price") (eq .Cluster.ConfigItems.node_update_prepare_replacement_node "true") (eq .Cluster.ConfigItems.experimental_cluster_lifecycle_controller "true") }}
-      --node-labels=cluster-lifecycle-controller.zalan.do/replacement-strategy=prepare-replacement \
+{{- if and (eq .Cluster.ConfigItems.node_update_prepare_replacement_node "true") (eq .Cluster.ConfigItems.experimental_cluster_lifecycle_controller "true") }}
+      --node-labels=${REPLACEMENT_STRATEGY_LABEL} \
 {{- end }}
       --node-labels={{ .Values.node_labels }} \
       --cluster-dns=${PRIVATE_EC2_IPV4},10.3.0.11 \
@@ -208,13 +223,13 @@ systemd:
       [Install]
       WantedBy=multi-user.target
 
-{{if eq .NodePool.DiscountStrategy "spot_max_price"}}
   - name: spot-termination-handler.service
     enable: true
     contents: |
       [Unit]
       Description=poll for AWS Spot termination signal and force node shutdown
-      After=network.target
+      After=network.target collect-instance-metadata.service
+      ConditionPathExists=/var/run/spot-instance
 
       [Service]
       Type=simple
@@ -229,7 +244,6 @@ systemd:
 
       [Install]
       WantedBy=multi-user.target
-{{end}}
 
 storage:
   files:
@@ -390,7 +404,24 @@ storage:
           --delete-local-data \
           --force
 
-{{if eq .NodePool.DiscountStrategy "spot_max_price"}}
+  - filesystem: root
+    path: /opt/bin/collect-instance-metadata
+    mode: 0755
+    contents:
+      inline: |
+        #!/bin/bash
+        set -euo pipefail
+
+        IS_SPOT="$(docker run --rm -i registry.opensource.zalan.do/teapot/is-spot-instance:master-1)"
+        REPLACEMENT_STRATEGY="prepare-replacement"
+
+        if [[ "${IS_SPOT}" == "true" ]]; then
+          touch /var/run/spot-instance
+          REPLACEMENT_STRATEGY="none"
+        fi
+        echo "REPLACEMENT_STRATEGY_LABEL=cluster-lifecycle-controller.zalan.do/replacement-strategy=${REPLACEMENT_STRATEGY}" >> /var/run/kubelet.vars
+        echo "SPOT_LABEL=aws.amazon.com/spot=${IS_SPOT}" >> /var/run/kubelet.vars
+
   - filesystem: root
     path: /opt/bin/spot-shutdown
     mode: 0755
@@ -402,7 +433,6 @@ storage:
         if [[ $EXIT_CODE -ne 0 ]]; then
           shutdown now
         fi
-{{end}}
 
 {{if gt (len .Values.instance_info.InstanceStorageDevices) 0 }}
   filesystems:

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -20,9 +20,24 @@ Resources:
     Properties:
       HealthCheckGracePeriod: 300
       HealthCheckType: EC2
+{{ if gt (len $data.NodePool.InstanceTypes) 1 }}
+      MixedInstancesPolicy:
+        InstancesDistribution:
+          OnDemandPercentageAboveBaseCapacity: {{if eq $data.NodePool.DiscountStrategy "spot_max_price"}}0{{else}}100{{end}}
+          SpotInstancePools: {{ len $data.NodePool.InstanceTypes }}
+        LaunchTemplate:
+          LaunchTemplateSpecification:
+            LaunchTemplateId: !Ref LaunchTemplate
+            Version: !GetAtt LaunchTemplate.LatestVersionNumber
+          Overrides:
+{{ range $type := $data.NodePool.InstanceTypes }}
+            - InstanceType: "{{ $type }}"
+{{ end }}
+{{ else }}
       LaunchTemplate:
         LaunchTemplateId: !Ref LaunchTemplate
         Version: !GetAtt LaunchTemplate.LatestVersionNumber
+{{ end }}
       MinSize: '{{ asgSize $data.NodePool.MinSize $azCount }}'
       MaxSize: '{{ asgSize $data.NodePool.MaxSize $azCount }}'
       Tags:
@@ -105,11 +120,11 @@ Resources:
         - Images
         - !Ref 'AWS::Region'
         - StableCoreOSImage
-        InstanceType: "{{ .NodePool.InstanceType }}"
-{{- if eq .NodePool.DiscountStrategy "spot_max_price"}}
+        InstanceType: "{{ index .NodePool.InstanceTypes 0 }}"
+{{- if and (eq .NodePool.DiscountStrategy "spot_max_price") (eq (len $data.NodePool.InstanceTypes) 1) }}
         InstanceMarketOptions:
           MarketType: spot
-{{end}}
+{{ end }}
         UserData: "{{ .UserData }}"
     Type: 'AWS::EC2::LaunchTemplate'
 {{ end }}


### PR DESCRIPTION
 * Use `instance_types`, not `instance_type`.
 * Use `MixedInstancesPolicy` for worker pools if more than 1 instance type is defined.

Corresponding CLM PR: https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/115.
Depends on 1.12 because I don't want to port CA changes.