### PR TITLE
Allow pods to talk to node-local coredns pods via service ip

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -147,6 +147,14 @@ Resources:
           FromPort: 9153
           IpProtocol: tcp
           ToPort: 9153
+        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+          FromPort: 53
+          IpProtocol: tcp
+          ToPort: 53
+        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+          FromPort: 53
+          IpProtocol: udp
+          ToPort: 53
       Tags:
         - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
           Value: owned
@@ -320,6 +328,14 @@ Resources:
           FromPort: 30000
           IpProtocol: tcp
           ToPort: 32767
+        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+          FromPort: 53
+          IpProtocol: tcp
+          ToPort: 53
+        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+          FromPort: 53
+          IpProtocol: udp
+          ToPort: 53
       Tags:
         - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
           Value: owned


### PR DESCRIPTION
The fallback DNS service is a service IP that targets all node-local CoreDNS pods (when `cluster_dns=coredns` config item is set for the cluster). Those pods are reachable **via their host's EC2 IP**. Unfortunately, master and worker nodes are **not** allowed to talk to port 53 on another node. This fixes it.