### PR TITLE
Enable TTLAfterFinished (apiserver, controller-manager)

### DIFF
--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -329,7 +329,7 @@ storage:
             {{ end }}
             - --authorization-webhook-config-file=/etc/kubernetes/config/authz.yaml
             - --admission-control-config-file=/etc/kubernetes/config/image-policy-webhook.yaml
-            - --feature-gates=TaintBasedEvictions=true,TaintNodesByCondition=false,ScheduleDaemonSetPods=false
+            - --feature-gates=TaintBasedEvictions=true,TaintNodesByCondition=false,ScheduleDaemonSetPods=false,TTLAfterFinished=true
             - --anonymous-auth=false
             {{ if or (eq .Cluster.Environment "production") (index .Cluster.ConfigItems "audittrail_url") }}
             - --audit-webhook-config-file=/etc/kubernetes/config/audit.yaml
@@ -530,7 +530,7 @@ storage:
             - --root-ca-file=/etc/kubernetes/ssl/ca.pem
             - --cloud-provider=aws
             - --cloud-config=/etc/kubernetes/cloud-config.ini
-            - --feature-gates=TaintBasedEvictions=true,TaintNodesByCondition=false,ScheduleDaemonSetPods=false
+            - --feature-gates=TaintBasedEvictions=true,TaintNodesByCondition=false,ScheduleDaemonSetPods=false,TTLAfterFinished=true
             - --horizontal-pod-autoscaler-use-rest-clients=true
             - --use-service-account-credentials=true
             - --allocate-node-cidrs=true


### PR DESCRIPTION
This allows us to get rid of [kube-job-cleaner](https://github.com/hjacobs/kube-job-cleaner).