### PR TITLE
Dev to kube 1.12

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -147,6 +147,14 @@ Resources:
           FromPort: 9153
           IpProtocol: tcp
           ToPort: 9153
+        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+          FromPort: 53
+          IpProtocol: tcp
+          ToPort: 53
+        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+          FromPort: 53
+          IpProtocol: udp
+          ToPort: 53
       Tags:
         - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
           Value: owned
@@ -320,6 +328,14 @@ Resources:
           FromPort: 30000
           IpProtocol: tcp
           ToPort: 32767
+        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+          FromPort: 53
+          IpProtocol: tcp
+          ToPort: 53
+        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+          FromPort: 53
+          IpProtocol: udp
+          ToPort: 53
       Tags:
         - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
           Value: owned

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.10.146
+    version: v0.10.150
     component: ingress
 spec:
   strategy:
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.10.146
+        version: v0.10.150
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -45,7 +45,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.146
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.150
         ports:
         - name: ingress-port
           containerPort: 9999


### PR DESCRIPTION
* **Allow pods to talk to node-local coredns pods via service ip**
   <sup>Merge pull request #1667 from zalando-incubator/open-dns-port</sup>
* **add opentracing headers to tokeninfo and tokenintrospection filters **
   <sup>Merge pull request #1665 from zalando-incubator/skipper/add-opentracing-tokeninfo</sup>
