### PR TITLE
Update kube-metrics-adapter with fix to ZMON collector

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -24,7 +24,7 @@ spec:
 {{ end }}
       containers:
       - name: kube-metrics-adapter
-        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:master-13
+        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:master-15
         args:
         - --prometheus-server=http://prometheus.kube-system.svc.cluster.local
         - --skipper-ingress-metrics


### PR DESCRIPTION
* [Fix json serialization naming for zmon queries (#25)](https://github.com/zalando-incubator/kube-metrics-adapter/pull/25)
* [Update aws-sdk-go version to be compatible with kube-aws-iam-controller (#22)](https://github.com/zalando-incubator/kube-metrics-adapter/pull/22)