### PR TITLE
kube-job-cleaner: update to master-12

### DIFF
--- a/cluster/manifests/kube-job-cleaner/cronjob.yaml
+++ b/cluster/manifests/kube-job-cleaner/cronjob.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-job-cleaner
-    version: "master-11"
+    version: "master-12"
 spec:
   schedule: "*/5 * * * *"
   concurrencyPolicy: Forbid
@@ -17,14 +17,14 @@ spec:
         metadata:
           labels:
             application: kube-job-cleaner
-            version: "master-11"
+            version: "master-12"
         spec:
           serviceAccountName: system
           restartPolicy: Never
           containers:
           - name: cleaner
             # delete all completed jobs
-            image: registry.opensource.zalan.do/teapot/kube-job-cleaner:master-11
+            image: registry.opensource.zalan.do/teapot/kube-job-cleaner:master-12
             resources:
               limits:
                 cpu: 100m


### PR DESCRIPTION
*Actually* fix the crash on pods with failed init containers.