### PR TITLE
Make cadvisor resources configurable

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -56,6 +56,10 @@ image_policy: "trusted"
 image_policy: "dev"
 {{end}}
 
+# cadvisor settings
+cadvisor_cpu: "150m"
+cadvisor_memory: "150Mi"
+
 # Monitoring settings
 {{if eq .Environment "e2e"}}
 logging_agent_enabled: "false"

--- a/cluster/manifests/cadvisor/daemonset.yaml
+++ b/cluster/manifests/cadvisor/daemonset.yaml
@@ -33,17 +33,17 @@ spec:
         - --max_housekeeping_interval=15s
         - --event_storage_event_limit=default=0
         - --event_storage_age_limit=default=0
-        - --disable_metrics=percpu,tcp,udp
+        - --disable_metrics=process,disk,network,sched,percpu,tcp,udp
         - --docker_only
         - --store_container_labels=false
         - --whitelisted_container_labels=io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace,io.kubernetes.pod.uid,application
         resources:
-          requests:
-            memory: 150Mi
-            cpu: 150m
           limits:
-            memory: 150Mi
-            cpu: 150m
+            cpu: "{{ .ConfigItems.cadvisor_cpu }}"
+            memory: "{{ .ConfigItems.cadvisor_memory }}"
+          requests:
+            cpu: "{{ .ConfigItems.cadvisor_cpu }}"
+            memory: "{{ .ConfigItems.cadvisor_memory }}"
         securityContext:
           privileged: true # allows reading /dev/kmsg
         volumeMounts:


### PR DESCRIPTION
Some clusters require more resources for cadvisor. Therefore introduce the following changes to work around the problem:

* Make cadvisor resources configurable per cluster.
* Disable metrics we don't use to save on CPU and a bit on memory.

Graph from `merchant-center` cluster:

![image](https://user-images.githubusercontent.com/128566/51024911-02048980-158b-11e9-80d1-1d0aa36e7c20.png)
