### PR TITLE
Run CLC without dependencies

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -458,54 +458,6 @@ Resources:
           PolicyName: root
       RoleName: "{{.Cluster.LocalID}}-app-autoscaler"
     Type: 'AWS::IAM::Role'
-  ClusterLifecycleControllerIAMRole:
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-          - Action:
-              - 'sts:AssumeRole'
-            Effect: Allow
-            Principal:
-              Service:
-                - ec2.amazonaws.com
-          - Action:
-              - 'sts:AssumeRole'
-            Effect: Allow
-            Principal:
-              AWS: !Join
-                - ''
-                - - 'arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/'
-                  - !Ref MasterIAMRole
-        Version: 2012-10-17
-      Path: /
-      Policies:
-        - PolicyDocument:
-            Statement:
-              - Action: 'ec2:DescribeInstanceStatus'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'autoscaling:DescribeAutoScalingGroups'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'autoscaling:DescribeAutoScalingInstances'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'autoscaling:DescribeLoadBalancers'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'autoscaling:SetDesiredCapacity'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'elasticloadbalancing:DescribeInstanceHealth'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'autoscaling:TerminateInstanceInAutoScalingGroup'
-                Effect: Allow
-                Resource: '*'
-            Version: 2012-10-17
-          PolicyName: root
-      RoleName: "{{.Cluster.LocalID}}-app-cluster-lifecycle-controller"
-    Type: 'AWS::IAM::Role'
   DeploymentIAMRole:
     Properties:
       AssumeRolePolicyDocument:
@@ -861,6 +813,29 @@ Resources:
               - Action: 'ec2:*'
                 Effect: Allow
                 Resource: '*'
+              # CLC
+              - Action: 'ec2:DescribeInstanceStatus'
+                Effect: Allow
+                Resource: '*'
+              - Action: 'autoscaling:DescribeAutoScalingGroups'
+                Effect: Allow
+                Resource: '*'
+              - Action: 'autoscaling:DescribeAutoScalingInstances'
+                Effect: Allow
+                Resource: '*'
+              - Action: 'autoscaling:DescribeLoadBalancers'
+                Effect: Allow
+                Resource: '*'
+              - Action: 'autoscaling:SetDesiredCapacity'
+                Effect: Allow
+                Resource: '*'
+              - Action: 'elasticloadbalancing:DescribeInstanceHealth'
+                Effect: Allow
+                Resource: '*'
+              - Action: 'autoscaling:TerminateInstanceInAutoScalingGroup'
+                Effect: Allow
+                Resource: '*'
+              # End CLC
               - Action: 'elasticloadbalancing:*'
                 Effect: Allow
                 Resource: '*'

--- a/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
@@ -18,12 +18,11 @@ spec:
       labels:
         application: cluster-lifecycle-controller
         version: master-1
-      annotations:
-        iam.amazonaws.com/role: "{{ .LocalID }}-app-cluster-lifecycle-controller"
     spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: system
       dnsPolicy: Default
+      hostNetwork: true
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule


### PR DESCRIPTION
It doesn't need the pod network, and it should be able to repair things in the cluster even if that's down.