### PR TITLE
Reenable network metrics in cadvisor

### DIFF
--- a/cluster/manifests/cadvisor/daemonset.yaml
+++ b/cluster/manifests/cadvisor/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         - --max_housekeeping_interval=15s
         - --event_storage_event_limit=default=0
         - --event_storage_age_limit=default=0
-        - --disable_metrics=process,disk,network,sched,percpu,tcp,udp
+        - --disable_metrics=process,disk,sched,percpu,tcp,udp
         - --docker_only
         - --store_container_labels=false
         - --whitelisted_container_labels=io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace,io.kubernetes.pod.uid,application


### PR DESCRIPTION
Was a mistake to disable `network` metrics in #1684 We use this for the application dashboard.