### PR TITLE
Autoscaling buffer: bump to 2750Mi

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -4,7 +4,7 @@ autoscaling_buffer_pools: "default-worker"
 autoscaling_buffer_cpu_scale: "1"
 autoscaling_buffer_memory_scale: "0.85"
 autoscaling_buffer_cpu_reserved: "1"
-autoscaling_buffer_memory_reserved: "2000Mi"
+autoscaling_buffer_memory_reserved: "2750Mi"
 {{if eq .Environment "production"}}
 autoscaling_buffer_pods: "1"
 {{else}}


### PR DESCRIPTION
`2000Mi` is not enough with the daemonsets we have now. :(