### PR TITLE
dev-to-kube-1.12

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -29,6 +29,14 @@ skipper_clusterratelimit: "false"
 skipper_clusterratelimit: "true"
 {{end}}
 
+# skipper backend timeout defaults
+skipper_expect_continue_timeout_backend: "30s"
+skipper_keepalive_backend: "30s"
+skipper_max_idle_connection_backend: 0
+skipper_response_header_timeout_backend: "1m"
+skipper_timeout_backend: "1m"
+skipper_tls_timeout_backend: "1m"
+
 {{if eq .Environment "production"}}
 enable_apimonitoring: "false"
 {{else}}

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -4,7 +4,7 @@ autoscaling_buffer_pools: "default-worker"
 autoscaling_buffer_cpu_scale: "1"
 autoscaling_buffer_memory_scale: "0.85"
 autoscaling_buffer_cpu_reserved: "1"
-autoscaling_buffer_memory_reserved: "2000Mi"
+autoscaling_buffer_memory_reserved: "2750Mi"
 {{if eq .Environment "production"}}
 autoscaling_buffer_pods: "1"
 {{else}}

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -167,6 +167,11 @@ etcd_instance_count: "3"
 
 dynamodb_service_link_enabled: "false"
 
+# coredns resource and replica settings
+coredns_cpu: "150m"
+coredns_memory: "100Mi"
+coredns_replicas: "2"
+
 cluster_dns: "dnsmasq"
 
 coreos_image: "ami-03ee0a0310474a00e"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -32,7 +32,7 @@ skipper_clusterratelimit: "true"
 # skipper backend timeout defaults
 skipper_expect_continue_timeout_backend: "30s"
 skipper_keepalive_backend: "30s"
-skipper_max_idle_connection_backend: 0
+skipper_max_idle_connection_backend: "0"
 skipper_response_header_timeout_backend: "1m"
 skipper_timeout_backend: "1m"
 skipper_tls_timeout_backend: "1m"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -4,7 +4,7 @@ autoscaling_buffer_pools: "default-worker"
 autoscaling_buffer_cpu_scale: "1"
 autoscaling_buffer_memory_scale: "0.85"
 autoscaling_buffer_cpu_reserved: "1"
-autoscaling_buffer_memory_reserved: "2750Mi"
+autoscaling_buffer_memory_reserved: "3Gi"
 {{if eq .Environment "production"}}
 autoscaling_buffer_pods: "1"
 {{else}}

--- a/cluster/manifests/coredns/deployment-coredns.yaml
+++ b/cluster/manifests/coredns/deployment-coredns.yaml
@@ -10,7 +10,7 @@ metadata:
     kubernetes.io/name: "CoreDNS"
     component: cluster-dns
 spec:
-  replicas: 2
+  replicas: {{ .ConfigItems.coredns_replicas }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -51,10 +51,6 @@ spec:
       containers:
       - name: coredns
         image: registry.opensource.zalan.do/teapot/coredns:1.2.0
-        resources:
-          requests:
-            cpu: 250m
-            memory: 100Mi
         args: [ "-conf", "/etc/coredns/Corefile" ]
         volumeMounts:
         - name: config-volume
@@ -85,11 +81,12 @@ spec:
           successThreshold: 1
           failureThreshold: 3
         resources:
-          requests:
-            cpu: 150m
-            memory: 100Mi
           limits:
-            memory: 100Mi
+            cpu: "{{ .ConfigItems.coredns_cpu }}"
+            memory: "{{ .ConfigItems.coredns_memory }}"
+          requests:
+            cpu: "{{ .ConfigItems.coredns_cpu }}"
+            memory: "{{ .ConfigItems.coredns_memory }}"
       dnsPolicy: Default
       volumes:
       - name: config-volume

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -98,6 +98,12 @@ spec:
           - "-oauth2-tokeninfo-url={{ .ConfigItems.tokeninfo_url }}"
           - "-histogram-metric-buckets=.01,.025,.05,.075,.1,.2,.3,.4,.5,.75,1,2,3,4,5,7,10,15,20,30,60,120,300,600"
           - "-opentracing=lightstep component-name=skipper-ingress token=$(LIGHTSTEP_TOKEN) collector=tracing.zmon.zalan.do:8444 cmd-line=skipper-ingress max-buffered-spans=4096"
+          - "-expect-continue-timeout-backend={{ .ConfigItems.skipper_expect_continue_timeout_backend }}"
+          - "-keepalive-backend={{ .ConfigItems.skipper_keepalive_backend }}"
+          - "-max-idle-connection-backend={{ .ConfigItems.skipper_max_idle_connection_backend }}"
+          - "-response-header-timeout-backend={{ .ConfigItems.skipper_response_header_timeout_backend }}"
+          - "-timeout-backend={{ .ConfigItems.skipper_timeout_backend }}"
+          - "-tls-timeout-backend={{ .ConfigItems.skipper_tls_timeout_backend }}"
         resources:
           limits:
             cpu: "{{ .ConfigItems.skipper_ingress_cpu }}"


### PR DESCRIPTION
* **Make coredns resources configurable per cluster**
   <sup>Merge pull request #1696 from zalando-incubator/coredns-per-cluster-resource-config</sup>
* **configure backend connection pool settings via CR**
   <sup>Merge pull request #1691 from zalando-incubator/feature/parameterize-backend-timeouts</sup>
* **Autoscaling buffer: bump to 2750Mi**
   <sup>Merge pull request #1693 from zalando-incubator/bump-autoscaling-buffer</sup>