### PR TITLE
Put CoreDNS DaemonSet in Guaranteed QoS class

### DIFF
--- a/cluster/manifests/coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/coredns-local/daemonset-coredns.yaml
@@ -66,10 +66,8 @@ spec:
           successThreshold: 1
           failureThreshold: 3
         resources:
-          requests:
-            cpu: 150m
-            memory: 100Mi
           limits:
+            cpu: 150m
             memory: 100Mi
       priorityClassName: system-node-critical
 {{ if index .ConfigItems "enable_rbac"}}

--- a/cluster/manifests/coredns/deployment-coredns.yaml
+++ b/cluster/manifests/coredns/deployment-coredns.yaml
@@ -84,9 +84,6 @@ spec:
           limits:
             cpu: "{{ .ConfigItems.coredns_cpu }}"
             memory: "{{ .ConfigItems.coredns_memory }}"
-          requests:
-            cpu: "{{ .ConfigItems.coredns_cpu }}"
-            memory: "{{ .ConfigItems.coredns_memory }}"
       dnsPolicy: Default
       volumes:
       - name: config-volume


### PR DESCRIPTION
This puts the CoreDNS DaemonSet in Guaranteed QoS class as well.

Since we want to set `limits=requests` I would propose to just specify `limits` which will automatically set `requests` to the same value. This simplifies the yaml a little and avoids putting different numbers accidentally.