### PR TITLE
coredns: enable pprof

### DIFF
--- a/cluster/manifests/coredns-local/configmap.yaml
+++ b/cluster/manifests/coredns-local/configmap.yaml
@@ -17,6 +17,7 @@ data:
         }
         prometheus :9153
         proxy . /etc/resolv.conf
+        pprof 127.0.0.1:9155
         cache 30
         reload
     }


### PR DESCRIPTION
This way we can find out what's using so much memory.