### PR TITLE
flannel: init once all nodes are reachable

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -175,3 +175,6 @@ coredns_replicas: "2"
 cluster_dns: "dnsmasq"
 
 coreos_image: "ami-03ee0a0310474a00e"
+
+# Temporary feature toggle for the new flannel awaiter
+experimental_flannel_awaiter: "false"

--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -21,6 +21,30 @@ spec:
       priorityClassName: system-node-critical
       serviceAccountName: system
       containers:
+{{ if eq .ConfigItems.experimental_flannel_awaiter "true" }}
+      - name: delayed-install-cni
+        image: registry.opensource.zalan.do/teapot/flannel-awaiter:master-2
+        command:
+        - /await-and-copy
+        stdin: true
+        volumeMounts:
+        - name: cni
+          mountPath: /etc/cni/net.d
+        - name: flannel-cfg
+          mountPath: /etc/kube-flannel/
+        env:
+          - name: CNI_CONFIG_SOURCE
+            value: /etc/kube-flannel/cni-conf.json
+          - name: CNI_CONFIG_TARGET
+            value: /etc/cni/net.d/10-flannel.conf
+        resources:
+          requests:
+            cpu: 25m
+            memory: 50Mi
+          limits:
+            cpu: 25m
+            memory: 50Mi
+{{ else }}
       - name: delayed-install-cni
         image: registry.opensource.zalan.do/teapot/flannel:v0.10.0-8
         command:
@@ -41,6 +65,7 @@ spec:
           limits:
             cpu: 25m
             memory: 25Mi
+{{ end }}
       - name: apiserver-proxy
         image: registry.opensource.zalan.do/teapot/etcd-proxy:master-3
         command:


### PR DESCRIPTION
Add `experimental_flannel_awaiter` feature flag. If enabled, check that all nodes are reachable and return immediately instead of always waiting for 2 minutes.