### PR TITLE
Drop reflector metrics from Kubelet

### DIFF
--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -134,4 +134,7 @@ data:
         target_label: __address__
         regex: (.*)
         replacement: $1:10255
-
+      metric_relabel_configs:
+       - source_labels: [ __name__ ]
+         regex: 'reflector.*'
+         action: drop


### PR DESCRIPTION
For some reason, on 1.12 these metrics contain ~100-150 series for every single resource in the cluster. Let's just drop them completely.