### PR TITLE
Adding vpa to kubernetes-lifeycle-metrics

### DIFF
--- a/cluster/manifests/kubernetes-lifecycle-metrics/vpa.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/vpa.yaml
@@ -13,4 +13,4 @@ spec:
     containerPolicies:
     - containerName: kubernetes-lifecycle-metrics
       maxAllowed:
-        memory: 600Mi
+        memory: 1Gi

--- a/cluster/manifests/kubernetes-lifecycle-metrics/vpa.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/vpa.yaml
@@ -1,0 +1,11 @@
+apiVersion: autoscaling.k8s.io/v1beta1
+kind: VerticalPodAutoscaler
+metadata:
+  name: kubernetes-lifecycle-metrics-vpa
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      application: kubernetes-lifecycle-metrics
+  updatePolicy:
+    updateMode: Auto

--- a/cluster/manifests/kubernetes-lifecycle-metrics/vpa.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/vpa.yaml
@@ -9,3 +9,8 @@ spec:
       application: kubernetes-lifecycle-metrics
   updatePolicy:
     updateMode: Auto
+  resourcePolicy:
+    containerPolicies:
+    - containerName: kubernetes-lifecycle-metrics
+      maxAllowed:
+        memory: 600Mi

--- a/cluster/manifests/kubernetes-lifecycle-metrics/vpa.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/vpa.yaml
@@ -14,3 +14,4 @@ spec:
     - containerName: kubernetes-lifecycle-metrics
       maxAllowed:
         memory: 1Gi
+ 


### PR DESCRIPTION
The memory requirments can differ on different cluster.
To avoid the container running out of memory adding vpa to the klm