### PR TITLE
add oauth2 token config for the zmon-worker

### DIFF
--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -96,6 +96,10 @@ spec:
               value: https://token.services.auth.zalando.com/oauth2/access_token?realm=/services
             - name: CREDENTIALS_DIR
               value: /meta/credentials
+{{ if index .ConfigItems "zmon_worker_oauth2_scopes"}}
+            - name: WORKER_PLUGIN_HTTP_OAUTH2_TOKENS
+              value: {{.ConfigItems.zmon_worker_oauth2_scopes }}
+{{ end }}
 
           volumeMounts:
             - name: credentials


### PR DESCRIPTION
if unset in the CR for a cluster, same as before. With the CR setting the format
of the value is `NAME1=SCOPE1,SCOPE2:NAME2=SCOPE3,SCOPE4` which then can be used
in the `http()` call like `http(URL, oauth2=True, oauth2_token_name='NAME1').json()`
to do an http call with a token which has the SCOPE1 and SCOPE2 oauth2 scopes.

see also https://docs.zmon.io/en/latest/installation/configuration.html#essential-options
and https://github.com/zalando-zmon/zmon-worker/blob/master/zmon_worker_monitor/builtins/plugins/http.py#L41