### PR TITLE
Skipper: delay readiness probe

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -119,7 +119,7 @@ spec:
           httpGet:
             path: /kube-system/healthz
             port: 9999
-          initialDelaySeconds: 5
+          initialDelaySeconds: 60
           timeoutSeconds: 5
         securityContext:
           readOnlyRootFilesystem: true


### PR DESCRIPTION
Ideally, the readiness check should tie in to the ELB healthiness to avoid situations where the rollout proceeds with pod deletion before new replicas are added back to the ELB. This is a quick and dirty fix to avoid this situation in most cases.