### PR TITLE
API server: increase the ELB timeout

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -45,7 +45,7 @@ Resources:
         Enabled: true
         Timeout: 60
       ConnectionSettings:
-        IdleTimeout: 300
+        IdleTimeout: 3600
       CrossZone: 'true'
       HealthCheck:
         HealthyThreshold: '2'


### PR DESCRIPTION
The ELB timeout causes stuff like `exec` or `port-forward` to stop working after 5 minutes if there's no activity. Let's increase it to the max. value (4k seconds) to avoid it.