### PR TITLE
Add flag to disable skipper access logs

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -16,6 +16,9 @@ skipper_limits_mem: "250Mi"
 skipper_requests_cpu: "150m"
 skipper_requests_mem: "50Mi"
 
+# skipper general settings
+skipper_disable_access_logs: "false"
+
 # skipper ingress settings
 skipper_ingress_target_average_utilization_cpu: "100"
 skipper_ingress_target_average_utilization_memory: "80"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -108,6 +108,9 @@ spec:
           - "-response-header-timeout-backend={{ .ConfigItems.skipper_response_header_timeout_backend }}"
           - "-timeout-backend={{ .ConfigItems.skipper_timeout_backend }}"
           - "-tls-timeout-backend={{ .ConfigItems.skipper_tls_timeout_backend }}"
+{{ if eq .ConfigItems.skipper_disable_access_logs "true" }}
+          - "-access-log-disabled"
+{{ end }}
         resources:
           limits:
             cpu: "{{ .ConfigItems.skipper_ingress_cpu }}"


### PR DESCRIPTION
Allow access logging on the skipper ingress to be turned of by settings `skipper_disable_access_logs` to `true`.