### PR TITLE
dev-to-kube-1.12

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -16,6 +16,9 @@ skipper_limits_mem: "250Mi"
 skipper_requests_cpu: "150m"
 skipper_requests_mem: "50Mi"
 
+# skipper general settings
+skipper_disable_access_logs: "false"
+
 # skipper ingress settings
 skipper_ingress_target_average_utilization_cpu: "100"
 skipper_ingress_target_average_utilization_memory: "80"

--- a/cluster/manifests/cadvisor/daemonset.yaml
+++ b/cluster/manifests/cadvisor/daemonset.yaml
@@ -19,11 +19,7 @@ spec:
         version: v0.32.0
     spec:
       priorityClassName: system-node-critical
-{{ if index .ConfigItems "enable_rbac"}}
       serviceAccountName: cadvisor
-{{ else }}
-      serviceAccountName: system
-{{ end }}
       containers:
       - name: cadvisor
         # images including https://github.com/google/cadvisor/pull/2113

--- a/cluster/manifests/coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/coredns-local/daemonset-coredns.yaml
@@ -70,11 +70,7 @@ spec:
             cpu: 150m
             memory: 100Mi
       priorityClassName: system-node-critical
-{{ if index .ConfigItems "enable_rbac"}}
       serviceAccountName: coredns
-{{ else }}
-      serviceAccountName: system
-{{ end }}
       hostNetwork: true
       dnsPolicy: Default
       tolerations:

--- a/cluster/manifests/coredns-local/rbac.yaml
+++ b/cluster/manifests/coredns-local/rbac.yaml
@@ -1,4 +1,3 @@
-{{ if index .ConfigItems "enable_rbac"}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -40,4 +39,3 @@ subjects:
 - kind: ServiceAccount
   name: coredns
   namespace: kube-system
-{{ end }}

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -21,9 +21,7 @@ spec:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
     spec:
       priorityClassName: system-cluster-critical
-{{ if index .ConfigItems "enable_rbac"}}
       serviceAccountName: external-dns
-{{ end }}
       containers:
       - name: external-dns
         image: registry.opensource.zalan.do/teapot/external-dns:v0.5.9

--- a/cluster/manifests/external-dns/rbac.yaml
+++ b/cluster/manifests/external-dns/rbac.yaml
@@ -1,4 +1,3 @@
-{{ if index .ConfigItems "enable_rbac"}}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -37,4 +36,3 @@ subjects:
 - kind: ServiceAccount
   name: external-dns
   namespace: kube-system
-{{ end }}

--- a/cluster/manifests/heapster/deployment.yaml
+++ b/cluster/manifests/heapster/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         version: v1.5.4
     spec:
       priorityClassName: system-cluster-critical
-      serviceAccountName: {{if index .ConfigItems "enable_rbac"}}heapster{{else}}system{{end}}
+      serviceAccountName: heapster
       containers:
         - image: registry.opensource.zalan.do/teapot/heapster:v1.5.4
           name: heapster

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -20,11 +20,7 @@ spec:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
     spec:
       priorityClassName: system-cluster-critical
-{{ if index .ConfigItems "enable_rbac"}}
       serviceAccountName: kube-ingress-aws-controller
-{{ else }}
-      serviceAccountName: system
-{{ end }}
       containers:
       - name: controller
         image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.8.1

--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -17,11 +17,7 @@ spec:
       labels:
         application: kube-metrics-adapter
     spec:
-{{ if index .ConfigItems "enable_rbac"}}
       serviceAccountName: custom-metrics-apiserver
-{{ else }}
-      serviceAccountName: system
-{{ end }}
       containers:
       - name: kube-metrics-adapter
         image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:master-15

--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -24,13 +24,15 @@ spec:
 {{ end }}
       containers:
       - name: kube-metrics-adapter
-        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:master-15
+        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:master-18
         args:
         - --prometheus-server=http://prometheus.kube-system.svc.cluster.local
         - --skipper-ingress-metrics
         - --aws-external-metrics
         - --aws-region=eu-central-1
         - --aws-region=eu-west-1
+        - --skipper-backends-annotation="zalando.org/stack-traffic-weights"
+        - --skipper-backends-annotation="zalando.org/backend-weights"
         {{ if eq .Environment "production" }}
         - --zmon-kariosdb-endpoint=https://data-service.zmon.zalan.do/kairosdb-proxy
         volumeMounts:

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -22,11 +22,7 @@ spec:
         config/hash: {{"configmap.yaml" | manifestHash}}
     spec:
       priorityClassName: system-node-critical
-{{ if index .ConfigItems "enable_rbac"}}
       serviceAccountName: kube-proxy
-{{ else }}
-      serviceAccountName: system
-{{ end }}
       tolerations:
       - operator: Exists
         effect: NoSchedule

--- a/cluster/manifests/kube-state-metrics/deployment.yaml
+++ b/cluster/manifests/kube-state-metrics/deployment.yaml
@@ -18,11 +18,7 @@ spec:
         version: v1.3.0
     spec:
       priorityClassName: system-cluster-critical
-{{ if index .ConfigItems "enable_rbac"}}
       serviceAccountName: kube-state-metrics
-{{ else }}
-      serviceAccountName: system
-{{ end }}
       containers:
       - image: registry.opensource.zalan.do/teapot/kube-state-metrics:v1.3.0
         name: kube-state-metrics

--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -21,11 +21,7 @@ spec:
         version: master-6
     spec:
       priorityClassName: system-node-critical
-{{ if index .ConfigItems "enable_rbac"}}
       serviceAccountName: kube2iam
-{{ else }}
-      serviceAccountName: system
-{{ end }}
       tolerations:
       - operator: Exists
         effect: NoSchedule

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -23,11 +23,7 @@ spec:
         component: logging
     spec:
       priorityClassName: system-node-critical
-{{ if index .ConfigItems "enable_rbac"}}
       serviceAccountName: logging-agent
-{{ else }}
-      serviceAccountName: system
-{{ end }}
       tolerations:
       - operator: Exists
         effect: NoSchedule

--- a/cluster/manifests/nvidia/nvidia-driver-installer.yaml
+++ b/cluster/manifests/nvidia/nvidia-driver-installer.yaml
@@ -22,11 +22,7 @@ spec:
         application: nvidia-driver-installer
         version: c117d39
     spec:
-{{ if index .ConfigItems "enable_rbac"}}
       serviceAccountName: nvidia
-{{ else }}
-      serviceAccountName: system
-{{ end }}
       tolerations:
       - key: nvidia.com/gpu
         effect: NoSchedule

--- a/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
+++ b/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
@@ -22,11 +22,7 @@ spec:
         application: nvidia-gpu-device-plugin
         version: cb2bdea5eb507a9577ce11ff058a2dfa84f54263
     spec:
-{{ if index .ConfigItems "enable_rbac"}}
       serviceAccountName: nvidia
-{{ else }}
-      serviceAccountName: system
-{{ end }}
       tolerations:
       - operator: Exists
         effect: NoExecute

--- a/cluster/manifests/prometheus-node-exporter/daemonset.yaml
+++ b/cluster/manifests/prometheus-node-exporter/daemonset.yaml
@@ -22,11 +22,7 @@ spec:
         component: node-exporter
     spec:
       priorityClassName: system-node-critical
-{{ if index .ConfigItems "enable_rbac"}}
       serviceAccountName: prometheus-node-exporter
-{{ else }}
-      serviceAccountName: system
-{{ end }}
       tolerations:
       - operator: Exists
         effect: NoSchedule

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -108,6 +108,9 @@ spec:
           - "-response-header-timeout-backend={{ .ConfigItems.skipper_response_header_timeout_backend }}"
           - "-timeout-backend={{ .ConfigItems.skipper_timeout_backend }}"
           - "-tls-timeout-backend={{ .ConfigItems.skipper_tls_timeout_backend }}"
+{{ if eq .ConfigItems.skipper_disable_access_logs "true" }}
+          - "-access-log-disabled"
+{{ end }}
         resources:
           limits:
             cpu: "{{ .ConfigItems.skipper_ingress_cpu }}"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -35,11 +35,7 @@ spec:
                   - skipper-ingress
               topologyKey: kubernetes.io/hostname
       priorityClassName: system-cluster-critical
-{{ if index .ConfigItems "enable_rbac"}}
       serviceAccountName: skipper-ingress
-{{ else }}
-      serviceAccountName: system
-{{ end }}
       nodeSelector:
         kubernetes.io/role: worker
       hostNetwork: true

--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -20,11 +20,7 @@ spec:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
     spec:
       priorityClassName: visibility-zmon
-{{ if index .ConfigItems "enable_rbac"}}
       serviceAccountName: zmon
-{{ else }}
-      serviceAccountName: default
-{{ end }}
       initContainers:
       - name: gerry-init
         image: registry.opensource.zalan.do/teapot/gerry:v0.0.14

--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -20,11 +20,7 @@ spec:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
     spec:
       priorityClassName: visibility-zmon
-{{ if index .ConfigItems "enable_rbac"}}
       serviceAccountName: zmon
-{{ else }}
-      serviceAccountName: default
-{{ end }}
       initContainers:
       - name: gerry-init
         image: registry.opensource.zalan.do/teapot/gerry:v0.0.14

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -326,11 +326,7 @@ storage:
             - --authentication-token-webhook-config-file=/etc/kubernetes/config/authn.yaml
             - --authentication-token-webhook-cache-ttl=10s
             - --cloud-provider=aws
-            {{ if index .Cluster.ConfigItems "enable_rbac"}}
             - --authorization-mode=Webhook,RBAC
-            {{ else }}
-            - --authorization-mode=Webhook
-            {{ end }}
             - --authorization-webhook-config-file=/etc/kubernetes/config/authz.yaml
             - --admission-control-config-file=/etc/kubernetes/config/image-policy-webhook.yaml
             - --feature-gates=TaintBasedEvictions=true,TaintNodesByCondition=false,ScheduleDaemonSetPods=false
@@ -406,11 +402,7 @@ storage:
               - mountPath: /etc/kubernetes/ssl
                 name: ssl-certs-kubernetes
                 readOnly: true
-          {{ if index .Cluster.ConfigItems "enable_rbac"}}
           - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.5.0
-          {{ else }}
-          - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.4.5
-          {{ end }}
             name: webhook
             ports:
             - containerPort: 8081
@@ -678,11 +670,7 @@ storage:
             token: ${token}
         EOF
 
-        {{ if index .Cluster.ConfigItems "enable_rbac"}}
         echo "${token},system:kube-controller-manager,system:kube-controller-manager" >> /etc/kubernetes/config/tokenfile.csv
-        {{ else }}
-        echo "${token},kube-controller-manager,kube-controller-manager" >> /etc/kubernetes/config/tokenfile.csv
-        {{ end }}
 
   - filesystem: root
     path: /etc/kubernetes/config/tokenfile.csv


### PR DESCRIPTION
* **Add flag to disable skipper access logs**
   <sup>Merge pull request #1740 from zalando-incubator/feature/access-log-disable-flag</sup>
* **Updated kube-metrics-adapter with support for weighted backends**
   <sup>Merge pull request #1738 from zalando-incubator/feature/kube-metrics-weighted-backends</sup>
* **Remove rbac_enable feature flag and make it default**
   <sup>Merge pull request #1737 from zalando-incubator/rbac-default</sup>
* **Revert "API server: increase the ELB timeout"**
   <sup>Merge pull request #1736 from zalando-incubator/revert-1732-increase-elb-timeout</sup>
* **API server: increase the ELB timeout

  Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>
  **
   <sup>Merge pull request #1732 from zalando-incubator/increase-elb-timeout</sup>
* **API server: increase the ELB timeout**
   <sup>Merge pull request #1732 from zalando-incubator/increase-elb-timeout</sup>