### PR TITLE
Remove quotes from arguments for kube-metrics-adapter

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -27,8 +27,8 @@ spec:
         - --aws-external-metrics
         - --aws-region=eu-central-1
         - --aws-region=eu-west-1
-        - --skipper-backends-annotation="zalando.org/stack-traffic-weights"
-        - --skipper-backends-annotation="zalando.org/backend-weights"
+        - --skipper-backends-annotation=zalando.org/stack-traffic-weights
+        - --skipper-backends-annotation=zalando.org/backend-weights
         {{ if eq .Environment "production" }}
         - --zmon-kariosdb-endpoint=https://data-service.zmon.zalan.do/kairosdb-proxy
         volumeMounts:


### PR DESCRIPTION
These quotes were being passed to the command directly.

_Note to Self_: There is no shell interpretation in the arguments.