### PR TITLE
kube-metrics-adapter-to-kube-1.12-beta

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -17,6 +17,9 @@ skipper_limits_mem: "250Mi"
 skipper_requests_cpu: "150m"
 skipper_requests_mem: "50Mi"
 
+# skipper general settings
+skipper_disable_access_logs: "false"
+
 # skipper ingress settings
 skipper_ingress_target_average_utilization_cpu: "100"
 skipper_ingress_target_average_utilization_memory: "80"

--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -24,13 +24,15 @@ spec:
 {{ end }}
       containers:
       - name: kube-metrics-adapter
-        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:master-15
+        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:master-18
         args:
         - --prometheus-server=http://prometheus.kube-system.svc.cluster.local
         - --skipper-ingress-metrics
         - --aws-external-metrics
         - --aws-region=eu-central-1
         - --aws-region=eu-west-1
+        - --skipper-backends-annotation="zalando.org/stack-traffic-weights"
+        - --skipper-backends-annotation="zalando.org/backend-weights"
         {{ if eq .Environment "production" }}
         - --zmon-kariosdb-endpoint=https://data-service.zmon.zalan.do/kairosdb-proxy
         volumeMounts:

--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -31,8 +31,8 @@ spec:
         - --aws-external-metrics
         - --aws-region=eu-central-1
         - --aws-region=eu-west-1
-        - --skipper-backends-annotation="zalando.org/stack-traffic-weights"
-        - --skipper-backends-annotation="zalando.org/backend-weights"
+        - --skipper-backends-annotation=zalando.org/stack-traffic-weights
+        - --skipper-backends-annotation=zalando.org/backend-weights
         {{ if eq .Environment "production" }}
         - --zmon-kariosdb-endpoint=https://data-service.zmon.zalan.do/kairosdb-proxy
         volumeMounts:

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -108,6 +108,9 @@ spec:
           - "-response-header-timeout-backend={{ .ConfigItems.skipper_response_header_timeout_backend }}"
           - "-timeout-backend={{ .ConfigItems.skipper_timeout_backend }}"
           - "-tls-timeout-backend={{ .ConfigItems.skipper_tls_timeout_backend }}"
+{{ if eq .ConfigItems.skipper_disable_access_logs "true" }}
+          - "-access-log-disabled"
+{{ end }}
         resources:
           limits:
             cpu: "{{ .ConfigItems.skipper_ingress_cpu }}"


### PR DESCRIPTION
Hotfix for `kube-metrics-adapter` with changes for supporting weighted backends.

Also skipper option to disable access logs cluster wide.