### PR TITLE
Update to newer version of kube-metrics-adapter

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:master-18
+        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:master-19
         args:
         - --prometheus-server=http://prometheus.kube-system.svc.cluster.local
         - --skipper-ingress-metrics


### PR DESCRIPTION
This version of `kube-metrics-adapter` does not break compatibility with current HPAs which use `request-per-second` metric.