### PR TITLE
Add category: all to CRDs

### DIFF
--- a/cluster/manifests/01-platformcredentialsset/customresourcedefinition.yaml
+++ b/cluster/manifests/01-platformcredentialsset/customresourcedefinition.yaml
@@ -14,5 +14,7 @@ spec:
     singular: platformcredentialsset
     shortNames:
     - pcs
+    categories:
+      - all
   subresources:
     status: {}

--- a/cluster/manifests/01-vertical-pod-autoscaler/01-crd.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/01-crd.yaml
@@ -14,6 +14,8 @@ spec:
     kind: VerticalPodAutoscaler
     shortNames:
     - vpa
+    categories:
+      - all
   validation:
     # openAPIV3Schema is the schema for validating custom objects.
     openAPIV3Schema:

--- a/cluster/manifests/audittrail-adapter/credentials.yaml
+++ b/cluster/manifests/audittrail-adapter/credentials.yaml
@@ -1,24 +1,4 @@
 {{ if eq .Environment "production" }}
-# from: ../platformcredentialsset/customresourcedefinition.yaml
-# This is a hack put in place to ensure that the CustomResourceDefinition will
-# be created before the actual PlatformCredentialsSet resource.
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: platformcredentialssets.zalando.org
-spec:
-  scope: Namespaced
-  group: zalando.org
-  version: v1
-  names:
-    kind: PlatformCredentialsSet
-    plural: platformcredentialssets
-    singular: platformcredentialsset
-    shortNames:
-    - pcs
-
----
-
 apiVersion: "zalando.org/v1"
 kind: PlatformCredentialsSet
 metadata:

--- a/cluster/manifests/emergency-access-service/credentials.yaml
+++ b/cluster/manifests/emergency-access-service/credentials.yaml
@@ -1,24 +1,4 @@
 {{ if eq .Environment "production" }}
-# from: ../platformcredentialsset/customresourcedefinition.yaml
-# This is a hack put in place to ensure that the CustomResourceDefinition will
-# be created before the actual PlatformCredentialsSet resource.
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: platformcredentialssets.zalando.org
-spec:
-  scope: Namespaced
-  group: zalando.org
-  version: v1
-  names:
-    kind: PlatformCredentialsSet
-    plural: platformcredentialssets
-    singular: platformcredentialsset
-    shortNames:
-    - pcs
-
----
-
 apiVersion: "zalando.org/v1"
 kind: PlatformCredentialsSet
 metadata:

--- a/cluster/manifests/ingress-template-controller/crd.yaml
+++ b/cluster/manifests/ingress-template-controller/crd.yaml
@@ -12,3 +12,5 @@ spec:
     plural: ingresstemplates
     shortNames:
     - it
+    categories:
+      - all


### PR DESCRIPTION
 * Show PCS, ingress templates, VPAs by default in `get all`
 * Fix the hack causing PCS definitions to be duplicated