### PR TITLE
Update kube-metrics-adapter with support for weighted backends

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -24,13 +24,15 @@ spec:
 {{ end }}
       containers:
       - name: kube-metrics-adapter
-        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:master-15
+        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:master-19
         args:
         - --prometheus-server=http://prometheus.kube-system.svc.cluster.local
         - --skipper-ingress-metrics
         - --aws-external-metrics
         - --aws-region=eu-central-1
         - --aws-region=eu-west-1
+        - --skipper-backends-annotation=zalando.org/stack-traffic-weights
+        - --skipper-backends-annotation=zalando.org/backend-weights
         {{ if eq .Environment "production" }}
         - --zmon-kariosdb-endpoint=https://data-service.zmon.zalan.do/kairosdb-proxy
         volumeMounts:


### PR DESCRIPTION
Update the `kube-metrics-adapter` for the current beta channel. This is needed because the latest version of `stackset-controller` needs some features present only in this release.