### PR TITLE
Preparation steps for TaintNodesByCondition

### DIFF
--- a/cluster/manifests/admission-control/teapot.yaml
+++ b/cluster/manifests/admission-control/teapot.yaml
@@ -26,4 +26,14 @@ webhooks:
         apiGroups: ["storage.k8s.io"]
         apiVersions: ["v1"]
         resources: ["storageclasses"]
+  - name: node-admitter.teapot.zalan.do
+    clientConfig:
+      url: "https://localhost:8085/node"
+      caBundle: "{{ .ConfigItems.ca_cert_decompressed }}"
+    failurePolicy: Fail
+    rules:
+      - operations: [ "CREATE" ]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["nodes"]
 {{ end }}

--- a/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
@@ -26,6 +26,8 @@ spec:
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
       containers:
       - name: cluster-autoscaler
         image: registry.opensource.zalan.do/teapot/cluster-lifecycle-controller:master-1

--- a/cluster/manifests/default-limits/limits.yaml
+++ b/cluster/manifests/default-limits/limits.yaml
@@ -1,4 +1,4 @@
-{{ if ne .ConfigItems.teapot_admission_controller_enabled "true" }}
+{{ if ne .ConfigItems.teapot_admission_controller_process_resources "true" }}
 apiVersion: "v1"
 kind: "LimitRange"
 metadata:

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -370,7 +370,7 @@ storage:
               requests:
                 cpu: 100m
                 memory: 200Mi
-          - image: registry.opensource.zalan.do/teapot/admission-controller:master-7
+          - image: registry.opensource.zalan.do/teapot/admission-controller:master-9
             name: admission-controller
             readinessProbe:
               httpGet:


### PR DESCRIPTION
 * CLC: add a toleration for `not-ready`. This will make sure that we can safely enable `TaintNodesByCondition` even in clusters running CLC.
 * Use the correct feature flag in `default-limits`.
 * Update the admission controller to include the node admitter.
 * Admission controller: handle node `CREATE`s