### PR TITLE
add assumerole for zmon to access cross account

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1104,6 +1104,9 @@ Resources:
               - Action: 'sqs:ListQueues'
                 Effect: Allow
                 Resource: '*'
+              - Action: 'sts:AssumeRole'
+                Effect: Allow
+                Resource: '*'
             Version: 2012-10-17
           PolicyName: root
       RoleName: "{{.Cluster.LocalID}}-app-zmon"


### PR DESCRIPTION
add assumerole for zmon to access cross account to get data for example cloudwatch

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>