### PR TITLE
Disable admission controller for statefulset e2e namespace

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -157,7 +157,7 @@ teapot_admission_controller_process_resources: "true"
 
 {{if eq .Environment "e2e"}}
 teapot_admission_controller_enabled: "true"
-teapot_admission_controller_ignore_namespaces: "^kube-system|(e2e-tests-(downward-api|kubectl|projected)-.*)$"
+teapot_admission_controller_ignore_namespaces: "^kube-system|(e2e-tests-(downward-api|kubectl|projected|statefulset)-.*)$"
 {{else}}
 teapot_admission_controller_enabled: "false"
 teapot_admission_controller_ignore_namespaces: "^kube-system$"


### PR DESCRIPTION
Avoids OOM kills for statefulset tests as well.