### PR TITLE
update skipper - 2 bugfixes, 2 features to decrease logs

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -41,7 +41,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.150
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.159
         ports:
         - name: ingress-port
           containerPort: 9999


### PR DESCRIPTION
update skipper to fix bugs in cluster ratelimit and upgrade connections, enable variadic filters to enable and disable access logs

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>