### PR TITLE
dev-to-kube-1.12

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1104,6 +1104,9 @@ Resources:
               - Action: 'sqs:ListQueues'
                 Effect: Allow
                 Resource: '*'
+              - Action: 'sts:AssumeRole'
+                Effect: Allow
+                Resource: '*'
             Version: 2012-10-17
           PolicyName: root
       RoleName: "{{.Cluster.LocalID}}-app-zmon"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -36,13 +36,12 @@ skipper_timeout_backend: "1m"
 skipper_tls_timeout_backend: "1m"
 
 # skipper api GW features
+enable_apimonitoring: "true"
 {{if eq .Environment "production"}}
 skipper_clusterratelimit: "false"
-enable_apimonitoring: "false"
 enable_skipper_eastwest: "false"
 {{else}}
 skipper_clusterratelimit: "true"
-enable_apimonitoring: "true"
 enable_skipper_eastwest: "true"
 {{end}}
 

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -41,7 +41,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.150
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.159
         ports:
         - name: ingress-port
           containerPort: 9999


### PR DESCRIPTION
* **update skipper - 2 bugfixes, 2 features to decrease logs**
   <sup>Merge pull request #1766 from zalando-incubator/update/skipper</sup>
* **enable apimonitoring as default**
   <sup>Merge pull request #1761 from zalando-incubator/enable/apimonitoring</sup>
* **add assumerole for zmon to access cross account**
   <sup>Merge pull request #1764 from zalando-incubator/fix/zmon-cross-account-access</sup>