### PR TITLE
dev-to-alpha

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1104,6 +1104,9 @@ Resources:
               - Action: 'sqs:ListQueues'
                 Effect: Allow
                 Resource: '*'
+              - Action: 'sts:AssumeRole'
+                Effect: Allow
+                Resource: '*'
             Version: 2012-10-17
           PolicyName: root
       RoleName: "{{.Cluster.LocalID}}-app-zmon"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -36,13 +36,12 @@ skipper_timeout_backend: "1m"
 skipper_tls_timeout_backend: "1m"
 
 # skipper api GW features
+enable_apimonitoring: "true"
 {{if eq .Environment "production"}}
 skipper_clusterratelimit: "false"
-enable_apimonitoring: "false"
 enable_skipper_eastwest: "false"
 {{else}}
 skipper_clusterratelimit: "true"
-enable_apimonitoring: "true"
 enable_skipper_eastwest: "true"
 {{end}}
 

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -16,6 +16,9 @@ skipper_limits_mem: "250Mi"
 skipper_requests_cpu: "150m"
 skipper_requests_mem: "50Mi"
 
+# skipper general settings
+skipper_disable_access_logs: "false"
+
 # skipper ingress settings
 skipper_ingress_target_average_utilization_cpu: "100"
 skipper_ingress_target_average_utilization_memory: "80"

--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -27,8 +27,8 @@ spec:
         - --aws-external-metrics
         - --aws-region=eu-central-1
         - --aws-region=eu-west-1
-        - --skipper-backends-annotation="zalando.org/stack-traffic-weights"
-        - --skipper-backends-annotation="zalando.org/backend-weights"
+        - --skipper-backends-annotation=zalando.org/stack-traffic-weights
+        - --skipper-backends-annotation=zalando.org/backend-weights
         {{ if eq .Environment "production" }}
         - --zmon-kariosdb-endpoint=https://data-service.zmon.zalan.do/kairosdb-proxy
         volumeMounts:

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -41,7 +41,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.150
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.159
         ports:
         - name: ingress-port
           containerPort: 9999

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -108,6 +108,9 @@ spec:
           - "-response-header-timeout-backend={{ .ConfigItems.skipper_response_header_timeout_backend }}"
           - "-timeout-backend={{ .ConfigItems.skipper_timeout_backend }}"
           - "-tls-timeout-backend={{ .ConfigItems.skipper_tls_timeout_backend }}"
+{{ if eq .ConfigItems.skipper_disable_access_logs "true" }}
+          - "-access-log-disabled"
+{{ end }}
         resources:
           limits:
             cpu: "{{ .ConfigItems.skipper_ingress_cpu }}"


### PR DESCRIPTION
* **update skipper - 2 bugfixes, 2 features to decrease logs**
   <sup>Merge pull request #1766 from zalando-incubator/update/skipper</sup>
* **enable apimonitoring as default**
   <sup>Merge pull request #1761 from zalando-incubator/enable/apimonitoring</sup>
* **add assumerole for zmon to access cross account**
   <sup>Merge pull request #1764 from zalando-incubator/fix/zmon-cross-account-access</sup>
* **Remove quotes from arguments for kube-metrics-adapter**
   <sup>Merge pull request #1747 from zalando-incubator/remove-double-quotes</sup>
* **Add flag to disable skipper access logs**
   <sup>Merge pull request #1740 from zalando-incubator/feature/access-log-disable-flag</sup>