### PR TITLE
dnsmasq: fix configuration to ignore resolv.conf

### DIFF
--- a/cluster/manifests/coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/coredns-local/daemonset-coredns.yaml
@@ -53,7 +53,8 @@ spec:
         - -configDir=/etc/k8s/dns/dnsmasq-nanny
         - -restartDnsmasq=true
         - --
-        - -k
+        - --no-resolv
+        - --keep-in-foreground
         - --cache-size=50000
         - --dns-forward-max=100
         - --neg-ttl=60


### PR DESCRIPTION
This fixes resolution of in-cluster names.