### PR TITLE
Update ExternalDNS to v0.5.10

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: external-dns
-    version: pr-880-2
+    version: pr-876-1
 spec:
   strategy:
     type: Recreate
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: external-dns
-        version: pr-880-2
+        version: pr-876-1
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
     spec:
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns-test:pr-880-2
+        image: registry.opensource.zalan.do/teapot/external-dns-test:pr-876-1
         args:
         - --source=service
         - --source=ingress

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: external-dns
-    version: pr-876-1
+    version: pr-880-2
 spec:
   strategy:
     type: Recreate
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: external-dns
-        version: pr-876-1
+        version: pr-880-2
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
     spec:
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns-test:pr-876-1
+        image: registry.opensource.zalan.do/teapot/external-dns-test:pr-880-2
         args:
         - --source=service
         - --source=ingress

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: external-dns
-    version: v0.5.9
+    version: v0.5.10
 spec:
   strategy:
     type: Recreate
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: external-dns
-        version: v0.5.9
+        version: v0.5.10
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
     spec:
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.5.9
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.5.10
         args:
         - --source=service
         - --source=ingress

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: external-dns
-    version: v0.5.10
+    version: pr-876-1
 spec:
   strategy:
     type: Recreate
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: external-dns
-        version: v0.5.10
+        version: pr-876-1
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
     spec:
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.5.10
+        image: registry.opensource.zalan.do/teapot/external-dns-test:pr-876-1
         args:
         - --source=service
         - --source=ingress


### PR DESCRIPTION
Full list of changes: https://github.com/kubernetes-incubator/external-dns/releases/tag/v0.5.10

Highlights for us:
* #858 Adds a flag `--aws-api-retries` which allows overriding the number of retries (viafoura)
* #839 Change default `AWSBatchChangeSize` to 1000 (medzin)
* #793 Expose managed resources and records as metrics (linki)

@njuettner Let's test the following changes more in-depth:
* #833 Normalize DNS names during planning (justinsb)