### PR TITLE
Update to latest stable version of Container Linux (1967.4.0)

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -176,7 +176,7 @@ coredns_replicas: "2"
 
 cluster_dns: "dnsmasq"
 
-coreos_image: "ami-03ee0a0310474a00e"
+coreos_image: "ami-02e8612b42a40844a" # Container Linux 1967.4.0 (HVM, eu-central-1)
 
 # Temporary feature toggle for the new flannel awaiter
 experimental_flannel_awaiter: "false"

--- a/cluster/node-pools/worker-default/stack.yaml
+++ b/cluster/node-pools/worker-default/stack.yaml
@@ -4,7 +4,7 @@ Description: Kubernetes default worker node pool
 Mappings:
   Images:
     eu-central-1:
-      StableCoreOSImage: ami-03ee0a0310474a00e
+      StableCoreOSImage: '{{ .Cluster.ConfigItems.coreos_image }}'
 
 Resources:
   AutoScalingGroup:


### PR DESCRIPTION
Updates to latest stable version released Jan 29th, 2019:
https://coreos.com/releases/#1967.4.0

We are currently running an "old" version from August 16, 2018:
https://coreos.com/releases/#1800.7.0

Changes:

Linux: `4.14.63` -> `4.14.96`
Docker: `18.03.1` -> `18.06.1`
Ignition: `0.25.1` -> `0.28.0`