### PR TITLE
Updated kube-metrics-adapter with fix

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:master-19
+        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:master-20
         args:
         - --prometheus-server=http://prometheus.kube-system.svc.cluster.local
         - --skipper-ingress-metrics


### PR DESCRIPTION
This release of the metrics-adapter fixes the case when the backend weights are present only in some annotations and not the others.

Signed-off-by: Arjun Naik <arjun.rn@gmail.com>