### PR TITLE
Enable new daemonset scheduling

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -180,3 +180,6 @@ coreos_image: "ami-02e8612b42a40844a" # Container Linux 1967.4.0 (HVM, eu-centra
 
 # Temporary feature toggle for the new flannel awaiter
 experimental_flannel_awaiter: "false"
+
+# Temporary feature toggle for the new daemonset scheduler
+experimental_schedule_daemonset_pods: "false"

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -194,7 +194,7 @@ systemd:
       --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
       --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \
       --cloud-provider=aws \
-      --feature-gates=TaintBasedEvictions=true,TaintNodesByCondition=false,ScheduleDaemonSetPods=false \
+      --feature-gates=TaintBasedEvictions=true,TaintNodesByCondition={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},ScheduleDaemonSetPods={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}} \
       --pod-infra-container-image=registry.opensource.zalan.do/teapot/pause-amd64:3.1 \
 {{- if not (index .Cluster.ConfigItems "enable_cfs_quota") }}
       --cpu-cfs-quota=false \
@@ -340,7 +340,7 @@ storage:
             - --authorization-mode=Webhook,RBAC
             - --authorization-webhook-config-file=/etc/kubernetes/config/authz.yaml
             - --admission-control-config-file=/etc/kubernetes/config/image-policy-webhook.yaml
-            - --feature-gates=TaintBasedEvictions=true,TaintNodesByCondition=false,ScheduleDaemonSetPods=false,TTLAfterFinished=true
+            - --feature-gates=TaintBasedEvictions=true,TaintNodesByCondition={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},ScheduleDaemonSetPods={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},TTLAfterFinished=true
             - --anonymous-auth=false
             {{ if or (eq .Cluster.Environment "production") (index .Cluster.ConfigItems "audittrail_url") }}
             - --audit-webhook-config-file=/etc/kubernetes/config/audit.yaml
@@ -406,6 +406,9 @@ storage:
               - --pod-ignore-namespaces={{ .Cluster.ConfigItems.teapot_admission_controller_ignore_namespaces }}
 {{- if eq .Cluster.ConfigItems.teapot_admission_controller_process_resources "true" }}
               - --pod-process-resources
+{{- end }}
+{{- if eq .Cluster.ConfigItems.experimental_schedule_daemonset_pods "true" }}
+              - --node-add-not-ready-taint
 {{- end }}
             ports:
               - containerPort: 8085
@@ -537,7 +540,7 @@ storage:
             - --root-ca-file=/etc/kubernetes/ssl/ca.pem
             - --cloud-provider=aws
             - --cloud-config=/etc/kubernetes/cloud-config.ini
-            - --feature-gates=TaintBasedEvictions=true,TaintNodesByCondition=false,ScheduleDaemonSetPods=false,TTLAfterFinished=true
+            - --feature-gates=TaintBasedEvictions=true,TaintNodesByCondition={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},ScheduleDaemonSetPods={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},TTLAfterFinished=true
             - --horizontal-pod-autoscaler-use-rest-clients=true
             - --use-service-account-credentials=true
             - --allocate-node-cidrs=true
@@ -607,7 +610,7 @@ storage:
             - scheduler
             - --master=http://127.0.0.1:8080
             - --leader-elect=true
-            - --feature-gates=TaintBasedEvictions=true,TaintNodesByCondition=false,ScheduleDaemonSetPods=false
+            - --feature-gates=TaintBasedEvictions=true,TaintNodesByCondition={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},ScheduleDaemonSetPods={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}}
             env:
             - name: KUBE_MAX_PD_VOLS
               value: "26"


### PR DESCRIPTION
If `experimental_schedule_daemonset_pods` is set to `true`, enable `TaintNodesByCondition`/`ScheduleDaemonSetPods` and the addition of the taint in the node admission hook.