### PR TITLE
Use the correct size for buffer pods

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -3,7 +3,7 @@ autoscaling_scale_down_enabled: "true"
 autoscaling_buffer_pools: "default-worker"
 autoscaling_buffer_cpu_scale: "1"
 autoscaling_buffer_memory_scale: "0.85"
-autoscaling_buffer_cpu_reserved: "1"
+autoscaling_buffer_cpu_reserved: "1250m"
 autoscaling_buffer_memory_reserved: "3Gi"
 {{if eq .Environment "production"}}
 autoscaling_buffer_pods: "1"


### PR DESCRIPTION
We use ~1032m CPU now, let's bump it to 1250m (and automate it!).