### PR TITLE
PCS validation: don't validate token

### DIFF
--- a/cluster/manifests/01-platformcredentialsset/customresourcedefinition.yaml
+++ b/cluster/manifests/01-platformcredentialsset/customresourcedefinition.yaml
@@ -51,11 +51,6 @@ spec:
               type: object
               additionalProperties:
                 type: object
-                properties:
-                  privileges:
-                    type: array
-                    items:
-                      type: string
             token_version:
               type: string
               enum:


### PR DESCRIPTION
Apparently `type: array` doesn't validate `null`. I was testing it with `kubectl apply` but it looks like it was not doing anything in the background so I didn't notice. Unfortunately there's no clean way to validate `null|["a","b"]`, and _a lot_ of PCSes have `privileges: null`. Let's relax the validation for now and then slowly migrate the users to something more sane.