### PR TITLE
master nodes: add missing tag

### DIFF
--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -26,6 +26,9 @@ Resources:
       - Key: Name
         PropagateAtLaunch: true
         Value: "{{ .NodePool.Name }} ({{ .Cluster.ID }})"
+      - Key: kubernetes.io/role
+        PropagateAtLaunch: true
+        Value: master
       VPCZoneIdentifier: !Split [",", "{{ .Cluster.ConfigItems.subnets }}"]
     Type: 'AWS::AutoScaling::AutoScalingGroup'
   LaunchTemplate:


### PR DESCRIPTION
This is used by some of the alerts but we don't tag the instances for some reason. ¯\\\_(ツ)\_/¯