### PR TITLE
Update Container Linux to 1967.5.0 (Fix CVE-2019-5736)

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -176,7 +176,7 @@ coredns_replicas: "2"
 
 cluster_dns: "dnsmasq"
 
-coreos_image: "ami-02e8612b42a40844a" # Container Linux 1967.4.0 (HVM, eu-central-1)
+coreos_image: "ami-0f46c2ed46d8157aa" # Container Linux 1967.5.0 (HVM, eu-central-1)
 
 # Temporary feature toggle for the new flannel awaiter
 experimental_flannel_awaiter: "true"


### PR DESCRIPTION
https://coreos.com/releases/#1967.5.0