### PR TITLE
enabling default encryption of EBS

### DIFF
--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -54,6 +54,7 @@ Resources:
           Ebs:
             VolumeSize: 20
             VolumeType: standard
+            Encrypted: true
         EbsOptimized: false
         IamInstanceProfile:
           Name: !Ref AutoScalingInstanceProfile

--- a/cluster/node-pools/worker-default/stack.yaml
+++ b/cluster/node-pools/worker-default/stack.yaml
@@ -100,6 +100,7 @@ Resources:
           Ebs:
             VolumeSize: 50
             VolumeType: standard
+            Encrypted: true
         EbsOptimized: false
         IamInstanceProfile:
           Name: !Ref AutoScalingInstanceProfile

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -111,6 +111,7 @@ Resources:
           Ebs:
             VolumeSize: 50
             VolumeType: standard
+            Encrypted: true
         EbsOptimized: false
         IamInstanceProfile:
           Name: !Ref AutoScalingInstanceProfile


### PR DESCRIPTION
AWS allows us to encrypt data at rest by default without performance penalty. this PR enables it.