### PR TITLE
Bump CoreOS again

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -176,7 +176,7 @@ coredns_replicas: "2"
 
 cluster_dns: "dnsmasq"
 
-coreos_image: "ami-0f46c2ed46d8157aa" # Container Linux 1967.5.0 (HVM, eu-central-1)
+coreos_image: "ami-00946a0f23931daac" # Container Linux 1967.6.0 (HVM, eu-central-1)
 
 # Temporary feature toggle for the new flannel awaiter
 experimental_flannel_awaiter: "true"


### PR DESCRIPTION
Fixes a regression with Posix timers (https://github.com/coreos/bugs/issues/2549).