### PR TITLE
Kubernetes v1.12.6 + Use Docker images for individual components instead of hyperkube

### DIFF
--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -31,10 +31,8 @@ spec:
       hostNetwork: true
       containers:
       - name: kube-proxy
-        image: registry.opensource.zalan.do/teapot/hyperkube:v1.12.5
-        command:
-        - /hyperkube
-        - proxy
+        image: registry.opensource.zalan.do/teapot/kube-proxy:v1.12.5-1
+        args:
         - --config=/config/kube-proxy.yaml
         - --v=2
         securityContext:

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-proxy
-    version: v1.12.5
+    version: v1.12.6
 spec:
   selector:
     matchLabels:
@@ -17,7 +17,7 @@ spec:
       name: kube-proxy
       labels:
         application: kube-proxy
-        version: v1.12.5
+        version: v1.12.6
       annotations:
         config/hash: {{"configmap.yaml" | manifestHash}}
     spec:
@@ -31,7 +31,7 @@ spec:
       hostNetwork: true
       containers:
       - name: kube-proxy
-        image: registry.opensource.zalan.do/teapot/kube-proxy:v1.12.5-1
+        image: registry.opensource.zalan.do/teapot/kube-proxy:v1.12.6
         args:
         - --config=/config/kube-proxy.yaml
         - --v=2

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -161,7 +161,7 @@ systemd:
       After=docker.service dockercfg.service meta-data-iptables.service private-ipv4.service
 
       [Service]
-      Environment=KUBELET_IMAGE_TAG=v1.12.5-1
+      Environment=KUBELET_IMAGE_TAG=v1.12.6
       Environment=KUBELET_IMAGE_ARGS=--exec=/kube-component
       Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/kubelet
       Environment="RKT_RUN_ARGS=--insecure-options=image \
@@ -303,7 +303,7 @@ storage:
           namespace: kube-system
           labels:
             application: kube-apiserver
-            version: v1.12.5
+            version: v1.12.6
           annotations:
             kubernetes-log-watcher/scalyr-parser: |
               [{"container": "webhook", "parser": "json-structured-log"}]
@@ -315,7 +315,7 @@ storage:
           hostNetwork: true
           containers:
           - name: kube-apiserver
-            image: registry.opensource.zalan.do/teapot/kube-apiserver:v1.12.5-1
+            image: registry.opensource.zalan.do/teapot/kube-apiserver:v1.12.6
             args:
             - --apiserver-count={{ .Values.apiserver_count }}
             - --bind-address=0.0.0.0
@@ -520,7 +520,7 @@ storage:
           namespace: kube-system
           labels:
             application: kube-controller-manager
-            version: v1.12.5
+            version: v1.12.6
         spec:
           priorityClassName: system-node-critical
           tolerations:
@@ -528,7 +528,7 @@ storage:
             effect: NoSchedule
           containers:
           - name: kube-controller-manager
-            image: registry.opensource.zalan.do/teapot/kube-controller-manager:v1.12.5-1
+            image: registry.opensource.zalan.do/teapot/kube-controller-manager:v1.12.6
             args:
             - --kubeconfig=/etc/kubernetes/controller-kubeconfig
             - --leader-elect=true
@@ -591,7 +591,7 @@ storage:
           namespace: kube-system
           labels:
             application: kube-scheduler
-            version: v1.12.5
+            version: v1.12.6
         spec:
           priorityClassName: system-node-critical
           tolerations:
@@ -600,7 +600,7 @@ storage:
           hostNetwork: true
           containers:
           - name: kube-scheduler
-            image: registry.opensource.zalan.do/teapot/kube-scheduler:v1.12.5-1
+            image: registry.opensource.zalan.do/teapot/kube-scheduler:v1.12.6
             args:
             - --master=http://127.0.0.1:8080
             - --leader-elect=true
@@ -1032,7 +1032,7 @@ storage:
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
           --net=host \
-          docker://registry.opensource.zalan.do/teapot/kubectl:v1.12.5-1 \
+          docker://registry.opensource.zalan.do/teapot/kubectl:v1.12.6 \
           --exec=/kube-component -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           label node "$(hostname)" \
@@ -1045,7 +1045,7 @@ storage:
           --net=host \
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
-          docker://registry.opensource.zalan.do/teapot/kubectl:v1.12.5-1 \
+          docker://registry.opensource.zalan.do/teapot/kubectl:v1.12.6 \
           --exec=/kube-component -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           drain "$(hostname)" \

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -161,8 +161,9 @@ systemd:
       After=docker.service dockercfg.service meta-data-iptables.service private-ipv4.service
 
       [Service]
-      Environment=KUBELET_IMAGE_TAG=v1.12.5_custom.master-1
-      Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
+      Environment=KUBELET_IMAGE_TAG=v1.12.5-1
+      Environment=KUBELET_IMAGE_ARGS=--exec=/kube-component
+      Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/kubelet
       Environment="RKT_RUN_ARGS=--insecure-options=image \
       --uuid-file-save=/var/run/kubelet-pod.uuid \
       --volume dns,kind=host,source=/etc/resolv.conf \
@@ -314,10 +315,8 @@ storage:
           hostNetwork: true
           containers:
           - name: kube-apiserver
-            image: registry.opensource.zalan.do/teapot/hyperkube:v1.12.5
-            command:
-            - /hyperkube
-            - apiserver
+            image: registry.opensource.zalan.do/teapot/kube-apiserver:v1.12.5-1
+            args:
             - --apiserver-count={{ .Values.apiserver_count }}
             - --bind-address=0.0.0.0
             - --insecure-bind-address=0.0.0.0
@@ -529,10 +528,8 @@ storage:
             effect: NoSchedule
           containers:
           - name: kube-controller-manager
-            image: registry.opensource.zalan.do/teapot/hyperkube:v1.12.5
-            command:
-            - /hyperkube
-            - controller-manager
+            image: registry.opensource.zalan.do/teapot/kube-controller-manager:v1.12.5-1
+            args:
             - --kubeconfig=/etc/kubernetes/controller-kubeconfig
             - --leader-elect=true
             - --service-account-private-key-file=/etc/kubernetes/ssl/service-account-private-key.pem
@@ -603,10 +600,8 @@ storage:
           hostNetwork: true
           containers:
           - name: kube-scheduler
-            image: registry.opensource.zalan.do/teapot/hyperkube:v1.12.5
-            command:
-            - /hyperkube
-            - scheduler
+            image: registry.opensource.zalan.do/teapot/kube-scheduler:v1.12.5-1
+            args:
             - --master=http://127.0.0.1:8080
             - --leader-elect=true
             - --feature-gates=TaintBasedEvictions=true,TaintNodesByCondition={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},ScheduleDaemonSetPods={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}}
@@ -1037,8 +1032,8 @@ storage:
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
           --net=host \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.12.5 \
-          --exec=/kubectl -- \
+          docker://registry.opensource.zalan.do/teapot/kubectl:v1.12.5-1 \
+          --exec=/kube-component -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           label node "$(hostname)" \
           lifecycle-status=draining \
@@ -1050,8 +1045,8 @@ storage:
           --net=host \
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.12.5 \
-          --exec=/kubectl -- \
+          docker://registry.opensource.zalan.do/teapot/kubectl:v1.12.5-1 \
+          --exec=/kube-component -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           drain "$(hostname)" \
           --ignore-daemonsets \

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -162,8 +162,9 @@ systemd:
       After=docker.service dockercfg.service meta-data-iptables.service private-ipv4.service collect-instance-metadata.service
 
       [Service]
-      Environment=KUBELET_IMAGE_TAG=v1.12.5_custom.master-1
-      Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/hyperkube
+      Environment=KUBELET_IMAGE_TAG=v1.12.5-1
+      Environment=KUBELET_IMAGE_ARGS=--exec=/kube-component
+      Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/kubelet
       Environment="RKT_RUN_ARGS=--insecure-options=image \
       --uuid-file-save=/var/run/kubelet-pod.uuid \
       --volume dns,kind=host,source=/etc/resolv.conf \
@@ -434,7 +435,7 @@ storage:
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
           --net=host \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.12.5 \
+          docker://registry.opensource.zalan.do/teapot/kubectl:v1.12.5-1 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           label node "$(hostname)" \
@@ -447,7 +448,7 @@ storage:
           --net=host \
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
-          docker://registry.opensource.zalan.do/teapot/hyperkube:v1.12.5 \
+          docker://registry.opensource.zalan.do/teapot/kubectl:v1.12.5-1 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           drain "$(hostname)" \

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -162,7 +162,7 @@ systemd:
       After=docker.service dockercfg.service meta-data-iptables.service private-ipv4.service collect-instance-metadata.service
 
       [Service]
-      Environment=KUBELET_IMAGE_TAG=v1.12.5-1
+      Environment=KUBELET_IMAGE_TAG=v1.12.6
       Environment=KUBELET_IMAGE_ARGS=--exec=/kube-component
       Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/kubelet
       Environment="RKT_RUN_ARGS=--insecure-options=image \
@@ -435,7 +435,7 @@ storage:
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
           --net=host \
-          docker://registry.opensource.zalan.do/teapot/kubectl:v1.12.5-1 \
+          docker://registry.opensource.zalan.do/teapot/kubectl:v1.12.6 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           label node "$(hostname)" \
@@ -448,7 +448,7 @@ storage:
           --net=host \
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
-          docker://registry.opensource.zalan.do/teapot/kubectl:v1.12.5-1 \
+          docker://registry.opensource.zalan.do/teapot/kubectl:v1.12.6 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           drain "$(hostname)" \


### PR DESCRIPTION
This includes two changes:

* Update to Kubernetes `v1.12.6` (https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.12.md#downloads-for-v1126)
* Use individual images for Kubernetes components. We are making this change away from `hyperkube` because it doesn't seem to be widely used for running Kubernetes and we run into issues like: https://github.com/kubernetes/kubernetes/issues/73587. There's also talk about removing support for `hyperkube`: https://github.com/kubernetes/kubernetes/issues/74148