### PR TITLE
ExternalDNS v0.5.11

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: external-dns
-    version: v0.5.9
+    version: v0.5.11
 spec:
   strategy:
     type: Recreate
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: external-dns
-        version: v0.5.9
+        version: v0.5.11
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
     spec:
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.5.9
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.5.11
         args:
         - --source=service
         - --source=ingress


### PR DESCRIPTION
Let's skip the broken version v0.5.10 and use the latest: https://github.com/kubernetes-incubator/external-dns/releases/tag/v0.5.11