### PR TITLE
Update version of kube-downscaler

### DIFF
--- a/cluster/manifests/kube-downscaler/deployment.yaml
+++ b/cluster/manifests/kube-downscaler/deployment.yaml
@@ -15,13 +15,13 @@ spec:
     metadata:
       labels:
         application: kube-downscaler
-        version: v0.6
+        version: v0.7
     spec:
       serviceAccountName: system
       containers:
       - name: downscaler
         # see https://github.com/hjacobs/kube-downscaler/releases
-        image: registry.opensource.zalan.do/teapot/kube-downscaler:0.6
+        image: registry.opensource.zalan.do/teapot/kube-downscaler:0.7
         args:
           - --interval=30
           - --exclude-namespaces=kube-system,visibility


### PR DESCRIPTION
This version of `kube-downscaler` has the fix for the thrashing issue with stacksets and deployments.