### PR TITLE
Prometheus: record etcd metrics

### DIFF
--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -51,6 +51,13 @@ data:
         target_label: node_name
       - action: labeldrop
         regex: "^(pod|node|container)$"
+    - job_name: 'etcd-servers'
+      scheme: http
+      dns_sd_configs:
+      - names:
+        - "{{ with $hostPort := splitHostPort .ConfigItems.etcd_endpoints }}{{ .Host }}{{ end }}"
+        type: "A"
+        port: 2381
     - job_name: 'kubernetes-service-endpoints'
       scheme: http
       kubernetes_sd_configs:


### PR DESCRIPTION
They're pretty useful to investigate latency issues and we don't record them at all. Depends on https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/127.