### PR TITLE
Update Skipper to rollout changes in API monitoring

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.10.168
+    version: v0.10.169
     component: ingress
 spec:
   strategy:
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.10.168
+        version: v0.10.169
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -41,7 +41,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.168
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.169
         ports:
         - name: ingress-port
           containerPort: 9999


### PR DESCRIPTION
We need to roll out the latest skipper release improve API usage monitoring (see zalando/skipper#950).