### PR TITLE
disallow ssh password login

### DIFF
--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -985,7 +985,7 @@ storage:
     contents:
       inline: |
         Subsystem sftp internal-sftp
-        ClientAliveInterval 600
+        ClientAliveInterval 180
         AuthenticationMethods publickey
         UseDNS no
         UsePAM yes

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -980,6 +980,19 @@ storage:
         NTP=169.254.169.123
 
   - filesystem: root
+    path: /etc/ssh/sshd_config
+    mode: 0400
+    contents:
+      inline: |
+        Subsystem sftp internal-sftp
+        ClientAliveInterval 600
+        AuthenticationMethods publickey
+        UseDNS no
+        UsePAM yes
+        PrintLastLog no # handled by PAM
+        PrintMotd no    # handled by PAM
+
+  - filesystem: root
     path: /opt/bin/dns-conntrack-iptables
     mode: 0755
     contents:

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -402,6 +402,19 @@ storage:
         NTP=169.254.169.123
 
   - filesystem: root
+    path: /etc/ssh/sshd_config
+    mode: 0400
+    contents:
+      inline: |
+        Subsystem sftp internal-sftp
+        ClientAliveInterval 600
+        AuthenticationMethods publickey
+        UseDNS no
+        UsePAM yes
+        PrintLastLog no # handled by PAM
+        PrintMotd no    # handled by PAM
+
+  - filesystem: root
     path: /opt/bin/drain-node
     mode: 0755
     contents:

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -407,7 +407,7 @@ storage:
     contents:
       inline: |
         Subsystem sftp internal-sftp
-        ClientAliveInterval 600
+        ClientAliveInterval 180
         AuthenticationMethods publickey
         UseDNS no
         UsePAM yes


### PR DESCRIPTION
Adds `AuthenticationMethods publickey` to the default `/etc/ssh/sshd_config` to only allow logins with `publickey`.

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>