### PR TITLE
Enable cadvsior disk metrics

### DIFF
--- a/cluster/manifests/cadvisor/daemonset.yaml
+++ b/cluster/manifests/cadvisor/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         - --max_housekeeping_interval=15s
         - --event_storage_event_limit=default=0
         - --event_storage_age_limit=default=0
-        - --disable_metrics=process,disk,sched,percpu,tcp,udp
+        - --disable_metrics=process,sched,percpu,tcp,udp
         - --docker_only
         - --store_container_labels=false
         - --whitelisted_container_labels=io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace,io.kubernetes.pod.uid,application

--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -132,7 +132,7 @@ data:
         target_label: uid
       - source_labels: [__name__]
         action: keep
-        regex: '(container_cpu_cfs_throttled_seconds_total|container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_memory_rss|container_memory_cache|container_network_receive_bytes_total|container_network_transmit_bytes_total)'
+        regex: '(container_cpu_cfs_throttled_seconds_total|container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_memory_rss|container_memory_cache|container_network_receive_bytes_total|container_network_transmit_bytes_total|container_fs_usage_bytes|container_fs_limit_bytes|container_fs_reads_bytes_total|container_fs_writes_bytes_total)'
     - job_name: 'kubelet-metrics'
       kubernetes_sd_configs:
       - role: node


### PR DESCRIPTION
By enabling disk metrics, we can get the current disk usage from containers and disk read and write operations.

* Allow prometheus to scrape
   - `container_fs_usage_bytes` # Number of bytes that are consumed by the container on this filesystem.
   - `container_fs_limit_bytes` # Number of bytes that can be consumed by the container on this filesystem.
   - `container_fs_reads_bytes_total` # Cumulative count of bytes read
   - `container_fs_writes_bytes_total` # Cumulative count of bytes written

`container_fs_io_current` does return 0, see issue
https://github.com/google/cadvisor/issues/1403

I've enabled it one cluster and it seems it slightly needs more CPU:

![image](https://user-images.githubusercontent.com/1936982/53022397-5f79d900-345b-11e9-95d1-7bef84f2a675.png)

Memory consumption hasn't changed so far:

![image](https://user-images.githubusercontent.com/1936982/53022420-6e608b80-345b-11e9-86c8-d42d17467752.png)
