### PR TITLE
Set Fluentd flush thread settings back to default

### DIFF
--- a/cluster/manifests/logging-agent/config.yaml
+++ b/cluster/manifests/logging-agent/config.yaml
@@ -83,8 +83,6 @@ data:
         chunk_limit_size 4MB
         total_limit_size 1GB
         flush_at_shutdown true
-        flush_thread_count 10
-        flush_thread_burst_interval 0.1
       </buffer>
       <format>
         @type csv


### PR DESCRIPTION
Flush thread settings were customized before in an attempt to go
through a backlog of logs more quickly. We now avoid having a large
backlog by discarding logs older than 4 hours.

We go back to the default settings to reduce memory usage and CPU
spikes.

Signed-off-by: Christian Berg <christian.berg@zalando.de>