### PR TITLE
Add config item to control which coredns pods are in the coredns service (10.3.0.11)

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -182,6 +182,10 @@ coredns_cpu: "150m"
 coredns_memory: "100Mi"
 coredns_replicas: "2"
 
+# temporary flag for the DNS rollout, when set to true, only the Deployment
+# based CoreDNS pods will be added to the central CoreDNS service (10.3.0.11)
+coredns_cluster_wide: "true"
+
 cluster_dns: "dnsmasq"
 
 coreos_image: "ami-00946a0f23931daac" # Container Linux 1967.6.0 (HVM, eu-central-1)

--- a/cluster/manifests/coredns/service-coredns.yaml
+++ b/cluster/manifests/coredns/service-coredns.yaml
@@ -14,6 +14,9 @@ metadata:
 spec:
   selector:
     application: coredns
+{{ if eq .ConfigItems.coredns_cluster_wide "true"}}
+    instance: cluster-dns
+{{ end }}
   clusterIP: 10.3.0.11
   ports:
   - name: dns


### PR DESCRIPTION
Add temporary flag for the DNS rollout, when set to true, only the Deployment based CoreDNS pods will be added to the central CoreDNS service (10.3.0.11).

This will prevent new daemonset based CoreDNS pods from being added to the central service before the node is ready. This is assumed to be a problem only during the rolling update because with the new DNS setup going to the central service endpoint will only happen if the local CoreDNS is down.