### PR TITLE
Kubernetes Janitor

### DIFF
--- a/cluster/manifests/kube-janitor/deployment.yaml
+++ b/cluster/manifests/kube-janitor/deployment.yaml
@@ -1,0 +1,50 @@
+{{ if ne .Environment "production" }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-janitor
+  namespace: kube-system
+  labels:
+    application: kube-janitor
+    version: v0.2.2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      application: kube-janitor
+  template:
+    metadata:
+      labels:
+        application: kube-janitor
+        version: v0.2.2
+    spec:
+      serviceAccountName: system
+      containers:
+      - name: janitor
+        # see https://github.com/hjacobs/kube-janitor/releases
+        image: registry.opensource.zalan.do/teapot/kube-janitor:0.2.2
+        args:
+          # run every minute
+          - --interval=60
+          # do not touch system/infra namespaces
+          - --exclude-namespaces=kube-system,visibility
+          - --rules-file=/config/rules.yaml
+        resources:
+          limits:
+            memory: 150Mi
+          requests:
+            # this is a background app ==> low priority, low CPU requests
+            cpu: 5m
+            memory: 150Mi
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
+        volumeMounts:
+          - name: config-volume
+            mountPath: /config
+      volumes:
+      - name: config-volume
+        configMap:
+          name: kube-janitor
+{{ end }}

--- a/cluster/manifests/kube-janitor/rules-config.yaml
+++ b/cluster/manifests/kube-janitor/rules-config.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-janitor
+  namespace: kube-system
+data:
+  rules.yaml: |-
+    # example rules configuration to set TTL for arbitrary objects
+    # see https://github.com/hjacobs/kube-janitor for details
+    rules:
+      - id: require-application-label
+        # remove deployments and statefulsets without a label "application"
+        resources:
+          # resources are prefixed with "XXX" to make sure they are not active by accident
+          # modify the rule as needed and remove the "XXX" prefix to activate
+          - XXXdeployments
+          - XXXstatefulsets
+        # see http://jmespath.org/specification.html
+        jmespath: "!(spec.template.metadata.labels.application)"
+        ttl: 4d
+      - id: temporary-pr-namespaces
+        # delete all namespaces with a name starting with "pr-*"
+        resources:
+          # resources are prefixed with "XXX" to make sure they are not active by accident
+          # modify the rule as needed and remove the "XXX" prefix to activate
+          - XXXnamespaces
+        # this uses JMESPath's built-in "starts_with" function
+        # see http://jmespath.org/specification.html#starts-with
+        jmespath: "starts_with(metadata.name, 'pr-')"
+        ttl: 4h

--- a/cluster/manifests/kube-janitor/rules-config.yaml
+++ b/cluster/manifests/kube-janitor/rules-config.yaml
@@ -1,3 +1,4 @@
+{{ if ne .Environment "production" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -28,3 +29,4 @@ data:
         # see http://jmespath.org/specification.html#starts-with
         jmespath: "starts_with(metadata.name, 'pr-')"
         ttl: 4h
+{{ end }}


### PR DESCRIPTION
Run [kube-janitor](https://github.com/hjacobs/kube-janitor) in non-prod clusters.

This is a first iteration to try out different use cases, e.g. to add annotations for temporary PR deployments (from CDP). The deployment itself will not do anything right now unless resources are annotated with `janitor/ttl`. I added an `if` to make sure it does not accidentally run in production (yet).

`kube-janitor` is already running in our platform test cluster and I observed the resource consumption (it's stable below 100Mi memory). We can consider moving to a CronJob and a less frequent schedule to limit the impact on the Kubernetes API server (as `kube-janitor` lists nearly all resources periodically), but I don't see any problems right now.

The ConfigMap is currently only an example and will not do anything (no active rules defined).
I included it to make clear how this would look like and make it easy to start adding rules if we later want to.