### PR TITLE
Drop secondary nameserver from /etc/resolv.conf

### DIFF
--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -188,7 +188,7 @@ systemd:
       --node-labels=cluster-dns={{ .Cluster.ConfigItems.cluster_dns }} \
       --node-labels={{ .Values.node_labels }} \
       --pod-manifest-path=/etc/kubernetes/manifests \
-      --cluster-dns=${PRIVATE_EC2_IPV4},10.3.0.11 \
+      --cluster-dns=${PRIVATE_EC2_IPV4} \
       --cluster-domain=cluster.local \
       --kubeconfig=/etc/kubernetes/kubeconfig \
       --tls-cert-file=/etc/kubernetes/ssl/worker.pem \

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -198,7 +198,7 @@ systemd:
       --node-labels=${REPLACEMENT_STRATEGY_LABEL} \
 {{- end }}
       --node-labels={{ .Values.node_labels }} \
-      --cluster-dns=${PRIVATE_EC2_IPV4},10.3.0.11 \
+      --cluster-dns=${PRIVATE_EC2_IPV4} \
       --cluster-domain=cluster.local \
       --kubeconfig=/etc/kubernetes/kubeconfig \
       --healthz-bind-address=0.0.0.0 \


### PR DESCRIPTION
To understand the usefulness of a second nameserver as we currently have it, I conducted the following test:

* Tests were run in a test cluster using a dedicated node marked with a label `dns-load-test=true`.
* I spawned **3** [go-dnsperf](https://github.com/mikkeloscar/go-dnsperf) pods on the node each running with 100 RPS:
  * One pod was using ubuntu as base image and therefore GNU libc for DNS resolution.
  * One pod was using alpine as base image and therefore musl libc for DNS resolution.
  * One pod was using a statically linked go binary of `go-dnsperf` therefore using the pure go DNS resolver.

The test was conducted like this:

1. Spawn the pods, and let them run for a bit
2. Add anti-affinity to the `coredns` daemonset such that the DNS pod is removed from the test node, i.e. forcing DNS to use the backup nameserver from `/etc/resolv.conf`:

    ```yaml
    affinity:
      nodeAffinity:
        requiredDuringSchedulingIgnoredDuringExecution:
          nodeSelectorTerms:
          - matchExpressions:
            # ...
            # add this expression
            - key: dns-load-test
              operator: NotIn
              values:
              - "true"
    ```
3. Wait some time and drop the anti-affinity to reschedule the DNS pod on the node.

I observed the following:

Graph showing error rate in the three different pods. All errors are timeout errors.
![image](https://user-images.githubusercontent.com/128566/53081610-7cfe7f80-34fb-11e9-8aed-53a7121136ae.png)


Graph showing successful DNS lookups for the three different pods:
![image](https://user-images.githubusercontent.com/128566/53081623-838cf700-34fb-11e9-823e-86919e5ad0e8.png)

both the GNU libc (ubuntu) based pod and the Go DNS based one experienced 100% error rate while the DNS pod was away from the node, meaning the fallback nameserver in `/etc/resolv.conf` had *NO* effect at all. I even ran the two failing pods with a `10s` DNS lookup timeout just to prove that it doesn't work. While the musl libc based pod ran with a `100ms` timeout for DNS lookups, and only had 2 errors in **Total** during that time (with 100 RPS).

In conclusion we should drop the second nameserver as it only has an effect for alpine based images and results in the double amount of DNS queries from alpine based containers when both nameservers are available.