### PR TITLE
Remove cluster-dns label from nodes

### DIFF
--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -185,7 +185,6 @@ systemd:
       --node-labels=node-role.kubernetes.io/master,kubernetes.io/role=master,master=true \
       --node-labels=cluster-lifecycle-controller.zalan.do/replacement-strategy=ensure-minimum-healthy-nodes \
       --node-labels=kubernetes.io/node-pool={{ .NodePool.Name }}{{if index .NodePool.ConfigItems "labels"}},{{.NodePool.ConfigItems.labels}}{{end}} \
-      --node-labels=cluster-dns={{ .Cluster.ConfigItems.cluster_dns }} \
       --node-labels={{ .Values.node_labels }} \
       --pod-manifest-path=/etc/kubernetes/manifests \
       --cluster-dns=${PRIVATE_EC2_IPV4} \

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -193,7 +193,6 @@ systemd:
       --node-labels=kubernetes.io/role=worker \
       --node-labels=kubernetes.io/node-pool={{ .NodePool.Name }}{{if index .NodePool.ConfigItems "labels"}},{{.NodePool.ConfigItems.labels}}{{end}} \
       --node-labels=${SPOT_LABEL} \
-      --node-labels=cluster-dns={{ .Cluster.ConfigItems.cluster_dns }} \
 {{- if eq .Cluster.ConfigItems.node_update_prepare_replacement_node "true" }}
       --node-labels=${REPLACEMENT_STRATEGY_LABEL} \
 {{- end }}


### PR DESCRIPTION
Cleanup `cluster-dns` label from nodes as it is not used anymore.

Note: this will require a rolling node update and could be done along with other changes, it's not super important.