### PR TITLE
Update kube-log-watcher version

### DIFF
--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     application: logging-agent
-    version: v0.24
+    version: v0.25
     component: logging
 spec:
   selector:
@@ -19,7 +19,7 @@ spec:
       name: logging-agent
       labels:
         application: logging-agent
-        version: v0.24
+        version: v0.25
         component: logging
       annotations:
         iam.amazonaws.com/role: {{.LocalID}}-app-logging-agent
@@ -79,7 +79,7 @@ spec:
           mountPath: /mnt/scalyr-checkpoint
       containers:
       - name: log-watcher
-        image: registry.opensource.zalan.do/logging/kubernetes-log-watcher:0.24
+        image: registry.opensource.zalan.do/logging/kubernetes-log-watcher:0.25
         env:
         - name: CLUSTER_NODE_NAME
           valueFrom:


### PR DESCRIPTION
Version 0.25 cleans up dangling symlinks to logfiles of deleted
containers, which cause warning messages in Fluentd.