### PR TITLE
Change custom parser for kubernetes-lifecycle-metrics logs

### DIFF
--- a/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         application: kubernetes-lifecycle-metrics
         version: master-1
       annotations:
-        kubernetes-log-watcher/scalyr-parser: '[{"container": "kubernetes-lifecycle-metrics", "parser": "json"}]'
+        kubernetes-log-watcher/scalyr-parser: '[{"container": "kubernetes-lifecycle-metrics", "parser": "system-json-escaped-json"}]'
     spec:
       priorityClassName: system-cluster-critical
       containers:


### PR DESCRIPTION
Adds a "stable" log parser for the kubernetes-lifecycle-metrics logs. This is to make it easier to find the slow scheduling pods and investigate!