### PR TITLE
Zappr: ensure that only maintainers can approve

### DIFF
--- a/.zappr.yaml
+++ b/.zappr.yaml
@@ -1,10 +1,17 @@
 # for github.com
 approvals:
-  groups:
-    zalando:
-      minimum: 2
-      from:
-        orgs:
-          - "zalando"
+  minimum: 2
+  from:
+    users:
+      - aermakov-zalando
+      - arjunrn
+      - gargravarr
+      - hjacobs
+      - jrake-revelant
+      - linki
+      - mikkeloscar
+      - muaazsaleem
+      - njuettner
+      - szuecs
 
 X-Zalando-Team: "teapot"


### PR DESCRIPTION
We have too many other people with write access now.