### PR TITLE
Inject ndots in each pod by using admission controller flag `--pod-dns-ndots`

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -161,7 +161,6 @@ experimental_cluster_lifecycle_controller: "false"
 teapot_admission_controller_default_cpu_request: "25m"
 teapot_admission_controller_default_memory_request: "100Mi"
 teapot_admission_controller_process_resources: "true"
-teapot_admission_controller_ndots: "2"
 
 {{if eq .Environment "e2e"}}
 teapot_admission_controller_enabled: "true"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -161,6 +161,7 @@ experimental_cluster_lifecycle_controller: "false"
 teapot_admission_controller_default_cpu_request: "25m"
 teapot_admission_controller_default_memory_request: "100Mi"
 teapot_admission_controller_process_resources: "true"
+teapot_admission_controller_ndots: "2"
 
 {{if eq .Environment "e2e"}}
 teapot_admission_controller_enabled: "true"

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -384,7 +384,7 @@ storage:
               requests:
                 cpu: 100m
                 memory: 200Mi
-          - image: registry.opensource.zalan.do/teapot/admission-controller:master-9
+          - image: registry.opensource.zalan.do/teapot/admission-controller:master-10
             name: admission-controller
             readinessProbe:
               httpGet:

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -404,6 +404,7 @@ storage:
               - --pod-default-cpu-request={{ .Cluster.ConfigItems.teapot_admission_controller_default_cpu_request }}
               - --pod-default-memory-request={{ .Cluster.ConfigItems.teapot_admission_controller_default_memory_request }}
               - --pod-ignore-namespaces={{ .Cluster.ConfigItems.teapot_admission_controller_ignore_namespaces }}
+              - --pod-dns-ndots={{ .Cluster.ConfigItems.teapot_admission_controller_ndots }}
 {{- if eq .Cluster.ConfigItems.teapot_admission_controller_process_resources "true" }}
               - --pod-process-resources
 {{- end }}

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -404,7 +404,7 @@ storage:
               - --pod-default-cpu-request={{ .Cluster.ConfigItems.teapot_admission_controller_default_cpu_request }}
               - --pod-default-memory-request={{ .Cluster.ConfigItems.teapot_admission_controller_default_memory_request }}
               - --pod-ignore-namespaces={{ .Cluster.ConfigItems.teapot_admission_controller_ignore_namespaces }}
-{{- if index .NodePool.ConfigItems "teapot_admission_controller_ndots" }}
+{{- if index .Cluster.ConfigItems "teapot_admission_controller_ndots" }}
               - --pod-dns-ndots={{ .Cluster.ConfigItems.teapot_admission_controller_ndots }}
 {{- end }}
 {{- if eq .Cluster.ConfigItems.teapot_admission_controller_process_resources "true" }}

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -404,7 +404,9 @@ storage:
               - --pod-default-cpu-request={{ .Cluster.ConfigItems.teapot_admission_controller_default_cpu_request }}
               - --pod-default-memory-request={{ .Cluster.ConfigItems.teapot_admission_controller_default_memory_request }}
               - --pod-ignore-namespaces={{ .Cluster.ConfigItems.teapot_admission_controller_ignore_namespaces }}
+{{- if index .NodePool.ConfigItems "teapot_admission_controller_ndots" }}
               - --pod-dns-ndots={{ .Cluster.ConfigItems.teapot_admission_controller_ndots }}
+{{- end }}
 {{- if eq .Cluster.ConfigItems.teapot_admission_controller_process_resources "true" }}
               - --pod-process-resources
 {{- end }}


### PR DESCRIPTION
The purpose of this PR is to downsize the amount of DNS requests
by changing the default ndots 5 to ndots 2 for each pod.

* Mutate the Pod Spec DNSConfig if not set by adding ndots 2

Further documentation: [Pod's DNS Config](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-config)