### PR TITLE
Increasing the limit of inotify watches on worker nodes

### DIFF
--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -415,6 +415,13 @@ storage:
         PrintMotd no    # handled by PAM
 
   - filesystem: root
+    path: /etc/sysctl.d/01-max-user-watches.conf
+    mode: 0644
+    contents:
+      inline: |
+        fs.inotify.max_user_watches=100000
+
+  - filesystem: root
     path: /opt/bin/drain-node
     mode: 0755
     contents:


### PR DESCRIPTION
Increasing the limit of inotify watches from 8192 to 100.000 on worker nodes in
light of issues with user pods keeping Heapster from starting up

**Note** this will cause nodes to roll. 

Signed-off-by: Muhammad Muaaz Saleem <muhammad.muaaz.saleem@zalando.de>