### PR TITLE
Enable logging of .svc DNS names in CoreDNS

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -178,6 +178,7 @@ etcd_instance_count: "3"
 dynamodb_service_link_enabled: "false"
 
 cluster_dns: "coredns"
+coredns_log_svc_names: "true"
 
 coreos_image: "ami-00946a0f23931daac" # Container Linux 1967.6.0 (HVM, eu-central-1)
 

--- a/cluster/manifests/coredns-local/configmap-local.yaml
+++ b/cluster/manifests/coredns-local/configmap-local.yaml
@@ -22,6 +22,9 @@ data:
             fallthrough
         }
 {{ end }}
+{{ if eq .ConfigItems.coredns_log_svc_names "true"}}
+        log svc.svc.cluster.local.
+{{ end }}
         prometheus :9153
         proxy . /etc/resolv.conf
         pprof 127.0.0.1:9155


### PR DESCRIPTION
This enables logging of names that end on `.svc` from the client side.
This is to be able to find all the occurances of clients calling names
like `name.namespace.svc` which would stop working if we enforce
`ndots:2` by default for all pods.

We can detect the usage of `.svc` names by logging any occurance of
`svc.svc.cluster.local` lookups in CoreDNS.