### PR TITLE
Increase Fluentd Buffer Queue Size

### DIFF
--- a/cluster/manifests/logging-agent/config.yaml
+++ b/cluster/manifests/logging-agent/config.yaml
@@ -82,6 +82,7 @@ data:
         timekey_use_utc true
         chunk_limit_size 4MB
         total_limit_size 1GB
+        queued_chunks_limit_size 100
         flush_at_shutdown true
       </buffer>
       <format>


### PR DESCRIPTION
This increases the number of chunks that can be queued to be sent to
S3. The [documentation][1] claims that this number is unlimited when
not set, but the default was in fact [recently set][2] to `1`, which
causes a backlog of chunks to build up when there is a larger number
of log files.

[1]: https://docs.fluentd.org/v1.0/articles/buffer-section#buffering-parameters
[2]: https://github.com/fluent/fluentd/pull/2173