### PR TITLE
Disable automatic transparent hugepages

### DIFF
--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -43,6 +43,21 @@ systemd:
       [Install]
       WantedBy=multi-user.target
 
+  - name: disable-thp.service
+    enable: true
+    contents: |
+      [Unit]
+      Before=docker.service
+
+      [Service]
+      Type=simple
+      Restart=on-failure
+      RestartSec=1
+      ExecStart=/bin/sh -c '/usr/bin/echo madvise > /sys/kernel/mm/transparent_hugepage/enabled'
+
+      [Install]
+      WantedBy=multi-user.target
+
   - name: etcd-member.service
     enable: true
     contents: |

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -59,6 +59,21 @@ systemd:
       [Install]
       WantedBy=multi-user.target
 
+  - name: disable-thp.service
+    enable: true
+    contents: |
+      [Unit]
+      Before=docker.service
+
+      [Service]
+      Type=simple
+      Restart=on-failure
+      RestartSec=1
+      ExecStart=/bin/sh -c '/usr/bin/echo madvise > /sys/kernel/mm/transparent_hugepage/enabled'
+
+      [Install]
+      WantedBy=multi-user.target
+
   - name: docker.service
     dropins:
     - name: 40-flannel.conf


### PR DESCRIPTION
Transparent hugepages are [problematic](https://www.google.com/search?client=safari&rls=en&q=transparent+hugepage+issues&ie=UTF-8&oe=UTF-8) and the common recommendation is to disable them. Setting the corresponding flag to `madvise` disables the fully-automatic behaviour but allows applications to opt-in by using `mmap`.