### PR TITLE
Enable Teapot admission controller for test clusters

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -165,8 +165,11 @@ teapot_admission_controller_process_resources: "true"
 {{if eq .Environment "e2e"}}
 teapot_admission_controller_enabled: "true"
 teapot_admission_controller_ignore_namespaces: "^kube-system|(e2e-tests-(downward-api|kubectl|projected|statefulset)-.*)$"
-{{else}}
+{{else if eq .Environment "production"}}
 teapot_admission_controller_enabled: "false"
+teapot_admission_controller_ignore_namespaces: "^kube-system$"
+{{else}}
+teapot_admission_controller_enabled: "true"
 teapot_admission_controller_ignore_namespaces: "^kube-system$"
 {{end}}
 


### PR DESCRIPTION
This enables the admission controller itself, but doesn't enable the `process-resources` mode. I thought we did this long ago, but apparently not.