### PR TITLE
Update skipper with redis based cluster rate limiting

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.10.180
+    version: v0.10.186
     component: ingress
 spec:
   strategy:
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.10.180
+        version: v0.10.186
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -41,7 +41,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.180
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.186
         ports:
         - name: ingress-port
           containerPort: 9999


### PR DESCRIPTION
Release notes are [here](https://github.com/zalando/skipper/releases/tag/v0.10.186)