### PR TITLE
Put ingress-template-controller behind feature toggle to gradually decommission it

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -189,5 +189,8 @@ coreos_image: "ami-012abdf0d2781f0a5" # Container Linux 2023.5.0 (HVM, eu-centra
 # Temporary feature toggle for the new flannel awaiter
 experimental_flannel_awaiter: "true"
 
+# Feature toggle to allow gradual decommissioning of ingress-template-controller
+enable_ingress_template_controller: "false"
+
 # Temporary feature toggle for the new daemonset scheduler
 experimental_schedule_daemonset_pods: "false"

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -8,3 +8,7 @@ post_apply:
   namespace: default
   kind: LimitRange
 {{ end }}
+{{ if ne .ConfigItems.enable_ingress_template_controller "true" }}
+- name: ingresstemplates.zalando.org
+  kind: CustomResourceDefinition
+{{ end }}

--- a/cluster/manifests/ingress-template-controller/crd.yaml
+++ b/cluster/manifests/ingress-template-controller/crd.yaml
@@ -1,3 +1,4 @@
+{{ if eq .ConfigItems.enable_ingress_template_controller "true"}}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -14,3 +15,4 @@ spec:
     - it
     categories:
       - all
+{{ end }}

--- a/cluster/manifests/ingress-template-controller/deployment.yaml
+++ b/cluster/manifests/ingress-template-controller/deployment.yaml
@@ -1,3 +1,4 @@
+{{ if eq .ConfigItems.enable_ingress_template_controller "true"}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -33,3 +34,4 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+{{ end }}


### PR DESCRIPTION
This puts the `ingress-template-controller` resources behind a toggle such that we can gradually decommission it from clusters which are not using it anymore.

The motivation for this is that stacksets solves the same problem much better and should be the only thing we support for traffic switching, since it doesn't make sense to support two implementations.

I will add the `enable_ingress_template_controller: "true"` config-item to all clusters which currently has `IngressTemplates` deployed before we merge this.

[Internal issue](https://github.bus.zalan.do/teapot/issues/issues/1715)