### PR TITLE
Update CoreOS to 2023.5.0

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -180,7 +180,7 @@ dynamodb_service_link_enabled: "false"
 cluster_dns: "coredns"
 coredns_log_svc_names: "true"
 
-coreos_image: "ami-00946a0f23931daac" # Container Linux 1967.6.0 (HVM, eu-central-1)
+coreos_image: "ami-012abdf0d2781f0a5" # Container Linux 2023.5.0 (HVM, eu-central-1)
 
 # Temporary feature toggle for the new flannel awaiter
 experimental_flannel_awaiter: "true"


### PR DESCRIPTION
This should fix the EBS issues on fifth generation instances.