### PR TITLE
nvme: set timeout to max

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -180,7 +180,7 @@ dynamodb_service_link_enabled: "false"
 cluster_dns: "coredns"
 coredns_log_svc_names: "true"
 
-coreos_image: "ami-00946a0f23931daac" # Container Linux 1967.6.0 (HVM, eu-central-1)
+coreos_image: "ami-012abdf0d2781f0a5" # Container Linux 2023.5.0 (HVM, eu-central-1)
 
 # Temporary feature toggle for the new flannel awaiter
 experimental_flannel_awaiter: "true"

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -43,7 +43,7 @@ systemd:
       [Install]
       WantedBy=multi-user.target
 
-  - name: disable-thp.service
+  - name: update-system-settings.service
     enable: true
     contents: |
       [Unit]
@@ -53,6 +53,7 @@ systemd:
       Type=simple
       Restart=on-failure
       RestartSec=1
+      ExecStartPre=/bin/sh -c '/usr/bin/echo 4294967295 > /sys/module/nvme_core/parameters/io_timeout'
       ExecStart=/bin/sh -c '/usr/bin/echo madvise > /sys/kernel/mm/transparent_hugepage/enabled'
 
       [Install]

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -53,7 +53,7 @@ systemd:
       Type=simple
       Restart=on-failure
       RestartSec=1
-      ExecStartPre=/bin/sh -c '/usr/bin/echo 4294967295 > /sys/module/nvme_core/parameters/io_timeout'
+      ExecStartPre=/bin/sh -c 'test -f /sys/module/nvme_core/parameters/io_timeout && /usr/bin/echo 4294967295 > /sys/module/nvme_core/parameters/io_timeout'
       ExecStart=/bin/sh -c '/usr/bin/echo madvise > /sys/kernel/mm/transparent_hugepage/enabled'
 
       [Install]

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -69,7 +69,7 @@ systemd:
       Type=simple
       Restart=on-failure
       RestartSec=1
-      ExecStartPre=/bin/sh -c '/usr/bin/echo 4294967295 > /sys/module/nvme_core/parameters/io_timeout'
+      ExecStartPre=/bin/sh -c 'test -f /sys/module/nvme_core/parameters/io_timeout && /usr/bin/echo 4294967295 > /sys/module/nvme_core/parameters/io_timeout'
       ExecStart=/bin/sh -c '/usr/bin/echo madvise > /sys/kernel/mm/transparent_hugepage/enabled'
 
       [Install]

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -59,7 +59,7 @@ systemd:
       [Install]
       WantedBy=multi-user.target
 
-  - name: disable-thp.service
+  - name: update-system-settings.service
     enable: true
     contents: |
       [Unit]
@@ -69,6 +69,7 @@ systemd:
       Type=simple
       Restart=on-failure
       RestartSec=1
+      ExecStartPre=/bin/sh -c '/usr/bin/echo 4294967295 > /sys/module/nvme_core/parameters/io_timeout'
       ExecStart=/bin/sh -c '/usr/bin/echo madvise > /sys/kernel/mm/transparent_hugepage/enabled'
 
       [Install]


### PR DESCRIPTION
This should fix issues with EBS on fifth generation instances, and AWS explicitly [recommends doing it](https://forums.aws.amazon.com/message.jspa?messageID=820271#jive-message-834572).