### PR TITLE
Skipper redis: add a priority

### DIFF
--- a/cluster/manifests/skipper/skipper-redis.yaml
+++ b/cluster/manifests/skipper/skipper-redis.yaml
@@ -18,6 +18,7 @@ spec:
         application: skipper-ingress-redis
         version: v4.0.9
     spec:
+      priorityClassName: system-cluster-critical
       containers:
       - image: registry.opensource.zalan.do/zmon/redis:4.0.9-master-6
         name: skipper-ingress-redis


### PR DESCRIPTION
We shouldn't be evictable by user pods.