### PR TITLE
Fix daemonset requests

### DIFF
--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-cluster-autoscaler
-    version: v1.12.2-internal37
+    version: v1.12.2-internal49
 spec:
   selector:
     matchLabels:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: kube-cluster-autoscaler
-        version: v1.12.2-internal37
+        version: v1.12.2-internal49
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-autoscaler"
         config/pool-sizes: "{{range .NodePools}}{{.Name}}-{{.MinSize}}-{{.MaxSize}} {{end}}"
@@ -33,7 +33,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cluster-autoscaler
-        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.12.2-internal37
+        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.12.2-internal49
         command:
           - ./cluster-autoscaler
           - --v=4

--- a/cluster/manifests/nvidia/nvidia-driver-installer.yaml
+++ b/cluster/manifests/nvidia/nvidia-driver-installer.yaml
@@ -51,8 +51,12 @@ spec:
       - name: nvidia-driver-installer
         image: registry.opensource.zalan.do/teapot/coreos-nvidia-driver-installer:c117d39
         resources:
+          limits:
+            cpu: 150m
+            memory: 256Mi
           requests:
-            cpu: 0.15
+            cpu: 150m
+            memory: 256Mi
         securityContext:
           privileged: true
         env:
@@ -74,3 +78,11 @@ spec:
       containers:
       - image: registry.opensource.zalan.do/teapot/pause-amd64:3.1
         name: pause
+        # Needs to be the same as the init container, because CA doesn't pay any attention to init containers at all
+        resources:
+          limits:
+            cpu: 150m
+            memory: 256Mi
+          requests:
+            cpu: 150m
+            memory: 256Mi


### PR DESCRIPTION
 * Update CA to v1.12.2-internal49: correctly handle daemonsets with limits but no requests
 * Add explicit requests to all our daemonsets