### PR TITLE
Admission controller: application label check

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -116,6 +116,10 @@ Resources:
           IpProtocol: tcp
           ToPort: 8082
         - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+          FromPort: 8085
+          IpProtocol: tcp
+          ToPort: 8085
+        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
           FromPort: 7980
           IpProtocol: tcp
           ToPort: 7980

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -158,6 +158,8 @@ experimental_cluster_lifecycle_controller: "false"
 teapot_admission_controller_default_cpu_request: "25m"
 teapot_admission_controller_default_memory_request: "100Mi"
 teapot_admission_controller_process_resources: "false"
+teapot_admission_controller_validate_application_label: "false"
+teapot_admission_controller_application_min_creation_time: "2999-12-31T23:59:59Z"
 
 {{if eq .Environment "e2e"}}
 teapot_admission_controller_enabled: "true"

--- a/cluster/manifests/admission-control/credentials.yaml
+++ b/cluster/manifests/admission-control/credentials.yaml
@@ -1,0 +1,14 @@
+{{ if eq .Environment "production" }}
+apiVersion: "zalando.org/v1"
+kind: PlatformCredentialsSet
+metadata:
+   name: admission-controller-proxy
+   namespace: kube-system
+   labels:
+     application: admission-controller-proxy
+spec:
+   application: admission-controller-proxy
+   tokens:
+     admission-controller:
+       privileges: []
+{{ end }}

--- a/cluster/manifests/admission-control/daemonset.yaml
+++ b/cluster/manifests/admission-control/daemonset.yaml
@@ -1,0 +1,56 @@
+{{ if eq .Environment "production" }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: admission-controller-proxy
+  namespace: kube-system
+  labels:
+    application: admission-controller-proxy
+spec:
+  selector:
+    matchLabels:
+      application: admission-controller-proxy
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        application: admission-controller-proxy
+    spec:
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+      priorityClassName: system-cluster-critical
+      serviceAccountName: system
+      dnsPolicy: Default
+      hostNetwork: true
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      containers:
+      - name: cluster-autoscaler
+        image: registry.opensource.zalan.do/teapot/admission-controller:master-13
+        command:
+          - /registry-proxy
+          - --address=127.0.0.1:8285
+          - --token-secret=/meta/credentials/admission-controller-token-secret
+          - --token-type=/meta/credentials/admission-controller-token-type
+        resources:
+          limits:
+            cpu: 25m
+            memory: 50Mi
+          requests:
+            cpu: 25m
+            memory: 50Mi
+        volumeMounts:
+          - name: credentials
+            mountPath: /meta/credentials
+            readOnly: true
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      volumes:
+        - name: credentials
+          secret:
+            secretName: "admission-controller-proxy"
+{{ end }}

--- a/cluster/manifests/admission-control/teapot.yaml
+++ b/cluster/manifests/admission-control/teapot.yaml
@@ -24,7 +24,7 @@ webhooks:
     rules:
       - operations: [ "CREATE" ]
         apiGroups: ["storage.k8s.io"]
-        apiVersions: ["v1"]
+        apiVersions: ["v1", "v1beta1"]
         resources: ["storageclasses"]
   - name: node-admitter.teapot.zalan.do
     clientConfig:
@@ -36,4 +36,54 @@ webhooks:
         apiGroups: [""]
         apiVersions: ["v1"]
         resources: ["nodes"]
+  - name: cronjob-admitter.teapot.zalan.do
+    clientConfig:
+      url: "https://localhost:8085/cronjob"
+      caBundle: "{{ .ConfigItems.ca_cert_decompressed }}"
+    failurePolicy: Fail
+    rules:
+      - operations: [ "CREATE", "UPDATE" ]
+        apiGroups: ["batch"]
+        apiVersions: ["v1beta1", "v2alpha1"]
+        resources: ["cronjobs"]
+  - name: job-admitter.teapot.zalan.do
+    clientConfig:
+      url: "https://localhost:8085/job"
+      caBundle: "{{ .ConfigItems.ca_cert_decompressed }}"
+    failurePolicy: Fail
+    rules:
+      - operations: [ "CREATE", "UPDATE" ]
+        apiGroups: ["batch"]
+        apiVersions: ["v1"]
+        resources: ["jobs"]
+  - name: deployment-admitter.teapot.zalan.do
+    clientConfig:
+      url: "https://localhost:8085/deployment"
+      caBundle: "{{ .ConfigItems.ca_cert_decompressed }}"
+    failurePolicy: Fail
+    rules:
+      - operations: [ "CREATE", "UPDATE" ]
+        apiGroups: ["apps"]
+        apiVersions: ["v1", "v1beta2", "v1beta1"]
+        resources: ["deployments"]
+  - name: deployment-legacy-admitter.teapot.zalan.do
+    clientConfig:
+      url: "https://localhost:8085/deployment"
+      caBundle: "{{ .ConfigItems.ca_cert_decompressed }}"
+    failurePolicy: Fail
+    rules:
+      - operations: [ "CREATE", "UPDATE" ]
+        apiGroups: ["extensions"]
+        apiVersions: ["v1beta1"]
+        resources: ["deployments"]
+  - name: statefulset-admitter.teapot.zalan.do
+    clientConfig:
+      url: "https://localhost:8085/statefulset"
+      caBundle: "{{ .ConfigItems.ca_cert_decompressed }}"
+    failurePolicy: Fail
+    rules:
+      - operations: [ "CREATE", "UPDATE" ]
+        apiGroups: ["apps"]
+        apiVersions: ["v1", "v1beta2", "v1beta1"]
+        resources: ["statefulsets"]
 {{ end }}

--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -27,6 +27,22 @@ data:
       - action: replace
         source_labels: ['__meta_kubernetes_pod_label_application']
         target_label: application
+    - job_name: 'teapot-admission-controller'
+      scheme: https
+      tls_config:
+        insecure_skip_verify: true
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+            - kube-system
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_application, __meta_kubernetes_pod_container_port_number]
+        action: keep
+        regex: kube-apiserver;8085
+      - action: replace
+        source_labels: ['__meta_kubernetes_pod_label_application']
+        target_label: application
     - job_name: 'kube-state-metrics'
       scheme: http
       honor_labels: true

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -399,7 +399,7 @@ storage:
               requests:
                 cpu: 100m
                 memory: 200Mi
-          - image: registry.opensource.zalan.do/teapot/admission-controller:master-10
+          - image: registry.opensource.zalan.do/teapot/admission-controller:master-13
             name: admission-controller
             readinessProbe:
               httpGet:
@@ -411,7 +411,7 @@ storage:
             resources:
               requests:
                 cpu: 50m
-                memory: 50Mi
+                memory: 100Mi
             args:
               - --address=:8085
               - --tls-cert-file=/etc/kubernetes/ssl/admission-controller.pem
@@ -427,6 +427,11 @@ storage:
 {{- end }}
 {{- if eq .Cluster.ConfigItems.experimental_schedule_daemonset_pods "true" }}
               - --node-add-not-ready-taint
+{{- end }}
+{{- if eq .Cluster.ConfigItems.teapot_admission_controller_validate_application_label "true" }}
+              - --validate-application-label
+              - --validate-application-label-min-creation-time={{ .Cluster.ConfigItems.teapot_admission_controller_application_min_creation_time }}
+              - --application-registry-url=http://127.0.0.1:8285/
 {{- end }}
             ports:
               - containerPort: 8085


### PR DESCRIPTION
* Admission controller: update to the latest version
* Production deployments: deploy PCS & daemonset for the Kio proxy
* If `teapot_admission_controller_validate_application_label` is set to `true`, enable application label validation