### PR TITLE
Update CoreDNS to v1.4.0

### DIFF
--- a/cluster/manifests/coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/coredns-local/daemonset-coredns.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: coredns
-    version: v1.2.0
+    version: v1.4.0
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
     component: cluster-dns
@@ -21,7 +21,7 @@ spec:
       labels:
         application: coredns
         instance: node-dns
-        version: v1.2.0
+        version: v1.4.0
         component: cluster-dns
     spec:
       containers:
@@ -92,7 +92,7 @@ spec:
             cpu: 10m
             memory: 45Mi
       - name: coredns
-        image: registry.opensource.zalan.do/teapot/coredns:1.2.0
+        image: registry.opensource.zalan.do/teapot/coredns:1.4.0
         args: [ "-conf", "/etc/coredns/Corefile" ]
         volumeMounts:
         - name: config-volume


### PR DESCRIPTION
Update to latest stable release:

https://coredns.io/2019/03/03/coredns-1.4.0-release/