### PR TITLE
fix skipper routes being able to do DNS based traffic switching 

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.10.186
+    version: v0.10.192
     component: ingress
 spec:
   strategy:
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.10.186
+        version: v0.10.192
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -42,7 +42,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.186
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.192
         ports:
         - name: ingress-port
           containerPort: 9999


### PR DESCRIPTION
fix skipper routes being able to do DNS based traffic switching as used in stups setups with route53 weighted records

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>