### PR TITLE
NVME timeout: fix the systemd unit

### DIFF
--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -53,7 +53,7 @@ systemd:
       Type=simple
       Restart=on-failure
       RestartSec=1
-      ExecStartPre=/bin/sh -c 'test -f /sys/module/nvme_core/parameters/io_timeout && /usr/bin/echo 4294967295 > /sys/module/nvme_core/parameters/io_timeout'
+      ExecStartPre=/bin/sh -c 'test -f /sys/module/nvme_core/parameters/io_timeout && /usr/bin/echo 4294967295 > /sys/module/nvme_core/parameters/io_timeout || true'
       ExecStart=/bin/sh -c '/usr/bin/echo madvise > /sys/kernel/mm/transparent_hugepage/enabled'
 
       [Install]

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -69,7 +69,7 @@ systemd:
       Type=simple
       Restart=on-failure
       RestartSec=1
-      ExecStartPre=/bin/sh -c 'test -f /sys/module/nvme_core/parameters/io_timeout && /usr/bin/echo 4294967295 > /sys/module/nvme_core/parameters/io_timeout'
+      ExecStartPre=/bin/sh -c 'test -f /sys/module/nvme_core/parameters/io_timeout && /usr/bin/echo 4294967295 > /sys/module/nvme_core/parameters/io_timeout || true'
       ExecStart=/bin/sh -c '/usr/bin/echo madvise > /sys/kernel/mm/transparent_hugepage/enabled'
 
       [Install]


### PR DESCRIPTION
Currently it always fails on non-NVME nodes.