### PR TITLE
Increase memory for NVidia driver installer

### DIFF
--- a/cluster/manifests/nvidia/nvidia-driver-installer.yaml
+++ b/cluster/manifests/nvidia/nvidia-driver-installer.yaml
@@ -53,10 +53,10 @@ spec:
         resources:
           limits:
             cpu: 150m
-            memory: 256Mi
+            memory: 512Mi
           requests:
             cpu: 150m
-            memory: 256Mi
+            memory: 512Mi
         securityContext:
           privileged: true
         env:
@@ -82,7 +82,7 @@ spec:
         resources:
           limits:
             cpu: 150m
-            memory: 256Mi
+            memory: 512Mi
           requests:
             cpu: 150m
-            memory: 256Mi
+            memory: 512Mi


### PR DESCRIPTION
`256Mi` is not enough apparently.