### PR TITLE
alpha-to-beta

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -116,6 +116,10 @@ Resources:
           IpProtocol: tcp
           ToPort: 8082
         - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+          FromPort: 8085
+          IpProtocol: tcp
+          ToPort: 8085
+        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
           FromPort: 7980
           IpProtocol: tcp
           ToPort: 7980

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -158,6 +158,8 @@ experimental_cluster_lifecycle_controller: "false"
 teapot_admission_controller_default_cpu_request: "25m"
 teapot_admission_controller_default_memory_request: "100Mi"
 teapot_admission_controller_process_resources: "false"
+teapot_admission_controller_validate_application_label: "false"
+teapot_admission_controller_application_min_creation_time: "2999-12-31T23:59:59Z"
 
 {{if eq .Environment "e2e"}}
 teapot_admission_controller_enabled: "true"

--- a/cluster/etcd-cluster.yaml
+++ b/cluster/etcd-cluster.yaml
@@ -25,7 +25,6 @@ SenzaComponents:
           filesystem: tmpfs
           erase_on_boot: false
           options: size=2g
-      appdynamics_application: 'etcd-cluster-{{Arguments.version}}'
     Type: Senza::TaupageAutoScalingGroup
     AutoScaling:
       Minimum: "{{Arguments.InstanceCount}}"

--- a/cluster/manifests/admission-control/credentials.yaml
+++ b/cluster/manifests/admission-control/credentials.yaml
@@ -1,0 +1,14 @@
+{{ if eq .Environment "production" }}
+apiVersion: "zalando.org/v1"
+kind: PlatformCredentialsSet
+metadata:
+   name: admission-controller-proxy
+   namespace: kube-system
+   labels:
+     application: admission-controller-proxy
+spec:
+   application: admission-controller-proxy
+   tokens:
+     admission-controller:
+       privileges: []
+{{ end }}

--- a/cluster/manifests/admission-control/daemonset.yaml
+++ b/cluster/manifests/admission-control/daemonset.yaml
@@ -1,0 +1,56 @@
+{{ if eq .Environment "production" }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: admission-controller-proxy
+  namespace: kube-system
+  labels:
+    application: admission-controller-proxy
+spec:
+  selector:
+    matchLabels:
+      application: admission-controller-proxy
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        application: admission-controller-proxy
+    spec:
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+      priorityClassName: system-cluster-critical
+      serviceAccountName: system
+      dnsPolicy: Default
+      hostNetwork: true
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      containers:
+      - name: cluster-autoscaler
+        image: registry.opensource.zalan.do/teapot/admission-controller:master-13
+        command:
+          - /registry-proxy
+          - --address=127.0.0.1:8285
+          - --token-secret=/meta/credentials/admission-controller-token-secret
+          - --token-type=/meta/credentials/admission-controller-token-type
+        resources:
+          limits:
+            cpu: 25m
+            memory: 50Mi
+          requests:
+            cpu: 25m
+            memory: 50Mi
+        volumeMounts:
+          - name: credentials
+            mountPath: /meta/credentials
+            readOnly: true
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      volumes:
+        - name: credentials
+          secret:
+            secretName: "admission-controller-proxy"
+{{ end }}

--- a/cluster/manifests/admission-control/teapot.yaml
+++ b/cluster/manifests/admission-control/teapot.yaml
@@ -24,7 +24,7 @@ webhooks:
     rules:
       - operations: [ "CREATE" ]
         apiGroups: ["storage.k8s.io"]
-        apiVersions: ["v1"]
+        apiVersions: ["v1", "v1beta1"]
         resources: ["storageclasses"]
   - name: node-admitter.teapot.zalan.do
     clientConfig:
@@ -36,4 +36,54 @@ webhooks:
         apiGroups: [""]
         apiVersions: ["v1"]
         resources: ["nodes"]
+  - name: cronjob-admitter.teapot.zalan.do
+    clientConfig:
+      url: "https://localhost:8085/cronjob"
+      caBundle: "{{ .ConfigItems.ca_cert_decompressed }}"
+    failurePolicy: Fail
+    rules:
+      - operations: [ "CREATE", "UPDATE" ]
+        apiGroups: ["batch"]
+        apiVersions: ["v1beta1", "v2alpha1"]
+        resources: ["cronjobs"]
+  - name: job-admitter.teapot.zalan.do
+    clientConfig:
+      url: "https://localhost:8085/job"
+      caBundle: "{{ .ConfigItems.ca_cert_decompressed }}"
+    failurePolicy: Fail
+    rules:
+      - operations: [ "CREATE", "UPDATE" ]
+        apiGroups: ["batch"]
+        apiVersions: ["v1"]
+        resources: ["jobs"]
+  - name: deployment-admitter.teapot.zalan.do
+    clientConfig:
+      url: "https://localhost:8085/deployment"
+      caBundle: "{{ .ConfigItems.ca_cert_decompressed }}"
+    failurePolicy: Fail
+    rules:
+      - operations: [ "CREATE", "UPDATE" ]
+        apiGroups: ["apps"]
+        apiVersions: ["v1", "v1beta2", "v1beta1"]
+        resources: ["deployments"]
+  - name: deployment-legacy-admitter.teapot.zalan.do
+    clientConfig:
+      url: "https://localhost:8085/deployment"
+      caBundle: "{{ .ConfigItems.ca_cert_decompressed }}"
+    failurePolicy: Fail
+    rules:
+      - operations: [ "CREATE", "UPDATE" ]
+        apiGroups: ["extensions"]
+        apiVersions: ["v1beta1"]
+        resources: ["deployments"]
+  - name: statefulset-admitter.teapot.zalan.do
+    clientConfig:
+      url: "https://localhost:8085/statefulset"
+      caBundle: "{{ .ConfigItems.ca_cert_decompressed }}"
+    failurePolicy: Fail
+    rules:
+      - operations: [ "CREATE", "UPDATE" ]
+        apiGroups: ["apps"]
+        apiVersions: ["v1", "v1beta2", "v1beta1"]
+        resources: ["statefulsets"]
 {{ end }}

--- a/cluster/manifests/nvidia/nvidia-driver-installer.yaml
+++ b/cluster/manifests/nvidia/nvidia-driver-installer.yaml
@@ -53,10 +53,10 @@ spec:
         resources:
           limits:
             cpu: 150m
-            memory: 256Mi
+            memory: 512Mi
           requests:
             cpu: 150m
-            memory: 256Mi
+            memory: 512Mi
         securityContext:
           privileged: true
         env:
@@ -82,7 +82,7 @@ spec:
         resources:
           limits:
             cpu: 150m
-            memory: 256Mi
+            memory: 512Mi
           requests:
             cpu: 150m
-            memory: 256Mi
+            memory: 512Mi

--- a/cluster/manifests/nvidia/nvidia-driver-installer.yaml
+++ b/cluster/manifests/nvidia/nvidia-driver-installer.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: kube-system
   labels:
     application: nvidia-driver-installer
-    version: c117d39
+    version: 162d624
 spec:
   updateStrategy:
     type: RollingUpdate
@@ -20,7 +20,7 @@ spec:
     metadata:
       labels:
         application: nvidia-driver-installer
-        version: c117d39
+        version: 162d624
     spec:
       serviceAccountName: nvidia
       tolerations:
@@ -49,7 +49,7 @@ spec:
           path: /
       initContainers:
       - name: nvidia-driver-installer
-        image: registry.opensource.zalan.do/teapot/coreos-nvidia-driver-installer:c117d39
+        image: registry.opensource.zalan.do/teapot/coreos-nvidia-driver-installer:162d624
         resources:
           limits:
             cpu: 150m
@@ -67,7 +67,7 @@ spec:
         - name: ROOT_MOUNT_DIR
           value: /root
         - name: NVIDIA_DRIVER_VERSION
-          value: "396.26"
+          value: "410.78"
         volumeMounts:
         - name: nvidia-install-dir-host
           mountPath: /usr/local/nvidia

--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -27,6 +27,22 @@ data:
       - action: replace
         source_labels: ['__meta_kubernetes_pod_label_application']
         target_label: application
+    - job_name: 'teapot-admission-controller'
+      scheme: https
+      tls_config:
+        insecure_skip_verify: true
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+            - kube-system
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_application, __meta_kubernetes_pod_container_port_number]
+        action: keep
+        regex: kube-apiserver;8085
+      - action: replace
+        source_labels: ['__meta_kubernetes_pod_label_application']
+        target_label: application
     - job_name: 'kube-state-metrics'
       scheme: http
       honor_labels: true

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.10.186
+    version: v0.10.192
     component: ingress
 spec:
   strategy:
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.10.186
+        version: v0.10.192
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -42,7 +42,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.186
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.192
         ports:
         - name: ingress-port
           containerPort: 9999

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -87,7 +87,7 @@ spec:
           - "-swarm-redis-urls=skipper-ingress-redis-0.skipper-ingress-redis.kube-system.svc.cluster.local:6379,skipper-ingress-redis-1.skipper-ingress-redis.kube-system.svc.cluster.local:6379"
 {{ end }}
           - "-oauth2-tokeninfo-url={{ .ConfigItems.tokeninfo_url }}"
-          - "-histogram-metric-buckets=.01,.025,.05,.075,.1,.2,.3,.4,.5,.75,1,2,3,4,5,7,10,15,20,30,60,120,300,600"
+          - "-histogram-metric-buckets=.0001,.00025,.0005,.00075,.001,.0025,.005,.0075,.01,.025,.05,.075,.1,.2,.3,.4,.5,.75,1,2,3,4,5,7,10,15,20,30,60,120,300,600"
           - "-opentracing=lightstep component-name=skipper-ingress token=$(LIGHTSTEP_TOKEN) collector=tracing.stups.zalan.do:8444 cmd-line=skipper-ingress max-buffered-spans=4096"
           - "-expect-continue-timeout-backend={{ .ConfigItems.skipper_expect_continue_timeout_backend }}"
           - "-keepalive-backend={{ .ConfigItems.skipper_keepalive_backend }}"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -73,7 +73,7 @@ spec:
           - "-metrics-exp-decay-sample"
           - "-reverse-source-predicate"
           - "-lb-healthcheck-interval=3s"
-          - "-metrics-flavour=codahale,prometheus"
+          - "-metrics-flavour=prometheus"
           - "-enable-connection-metrics"
 {{ if eq .ConfigItems.enable_apimonitoring "true"}}
           - "-enable-api-usage-monitoring"

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -399,7 +399,7 @@ storage:
               requests:
                 cpu: 100m
                 memory: 200Mi
-          - image: registry.opensource.zalan.do/teapot/admission-controller:master-10
+          - image: registry.opensource.zalan.do/teapot/admission-controller:master-13
             name: admission-controller
             readinessProbe:
               httpGet:
@@ -411,7 +411,7 @@ storage:
             resources:
               requests:
                 cpu: 50m
-                memory: 50Mi
+                memory: 100Mi
             args:
               - --address=:8085
               - --tls-cert-file=/etc/kubernetes/ssl/admission-controller.pem
@@ -427,6 +427,11 @@ storage:
 {{- end }}
 {{- if eq .Cluster.ConfigItems.experimental_schedule_daemonset_pods "true" }}
               - --node-add-not-ready-taint
+{{- end }}
+{{- if eq .Cluster.ConfigItems.teapot_admission_controller_validate_application_label "true" }}
+              - --validate-application-label
+              - --validate-application-label-min-creation-time={{ .Cluster.ConfigItems.teapot_admission_controller_application_min_creation_time }}
+              - --application-registry-url=http://127.0.0.1:8285/
 {{- end }}
             ports:
               - containerPort: 8085

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -53,7 +53,7 @@ systemd:
       Type=simple
       Restart=on-failure
       RestartSec=1
-      ExecStartPre=/bin/sh -c 'test -f /sys/module/nvme_core/parameters/io_timeout && /usr/bin/echo 4294967295 > /sys/module/nvme_core/parameters/io_timeout'
+      ExecStartPre=/bin/sh -c 'test -f /sys/module/nvme_core/parameters/io_timeout && /usr/bin/echo 4294967295 > /sys/module/nvme_core/parameters/io_timeout || true'
       ExecStart=/bin/sh -c '/usr/bin/echo madvise > /sys/kernel/mm/transparent_hugepage/enabled'
 
       [Install]

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -69,7 +69,7 @@ systemd:
       Type=simple
       Restart=on-failure
       RestartSec=1
-      ExecStartPre=/bin/sh -c 'test -f /sys/module/nvme_core/parameters/io_timeout && /usr/bin/echo 4294967295 > /sys/module/nvme_core/parameters/io_timeout'
+      ExecStartPre=/bin/sh -c 'test -f /sys/module/nvme_core/parameters/io_timeout && /usr/bin/echo 4294967295 > /sys/module/nvme_core/parameters/io_timeout || true'
       ExecStart=/bin/sh -c '/usr/bin/echo madvise > /sys/kernel/mm/transparent_hugepage/enabled'
 
       [Install]


### PR DESCRIPTION
* **dev-to-alpha**
   <sup>Merge pull request #1926 from zalando-incubator/dev-to-alpha</sup>
* **Signed-off-by: Alexey Ermakov <alexey.ermakov@zalando.de>
  **
   <sup>Merge branch 'dev' into dev-to-alpha</sup>
* **Increase memory for NVidia driver installer**
   <sup>Merge pull request #1928 from zalando-incubator/bump-driver-installer</sup>
* **Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>
  **
   <sup>Merge branch 'dev' into dev-to-alpha</sup>
* **NVME timeout: fix the systemd unit**
   <sup>Merge pull request #1924 from zalando-incubator/fix-nvme-io-timeout</sup>
* **fix skipper routes being able to do DNS based traffic switching **
   <sup>Merge pull request #1920 from zalando-incubator/fix/skipper-calls-dns-based-traffic-switching</sup>
* **Update NVidia driver installer**
   <sup>Merge pull request #1922 from zalando-incubator/cherrypick-gpu-alpha</sup>
* **Update NVidia driver installer**
   <sup>Merge pull request #1919 from zalando-incubator/fix-nvidia-installer</sup>
* **Admission controller: application label check**
   <sup>Merge pull request #1915 from zalando-incubator/app-admission</sup>
* **etcd: remove appdynamics**
   <sup>Merge pull request #1917 from zalando-incubator/remove-appdynamics</sup>
* **remove codahale metrics from skipper-ingress**
   <sup>Merge pull request #1911 from zalando-incubator/remove/skipper-codahale-metrics</sup>
* **skipper prometheus bucket config down to 100us instead of 10ms**
   <sup>Merge pull request #1910 from zalando-incubator/feature/skipper-metrics-down-to100us</sup>