### PR TITLE
Introduce server fields for Scalyr Agent

### DIFF
--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     application: logging-agent
-    version: v0.25
+    version: v0.26
     component: logging
 spec:
   selector:
@@ -19,7 +19,7 @@ spec:
       name: logging-agent
       labels:
         application: logging-agent
-        version: v0.25
+        version: v0.26
         component: logging
       annotations:
         iam.amazonaws.com/role: {{.LocalID}}-app-logging-agent
@@ -83,7 +83,7 @@ spec:
           mountPath: /mnt/scalyr-checkpoint
       containers:
       - name: log-watcher
-        image: registry.opensource.zalan.do/logging/kubernetes-log-watcher:0.25
+        image: registry.opensource.zalan.do/logging/kubernetes-log-watcher:0.26
         env:
         - name: CLUSTER_NODE_NAME
           valueFrom:


### PR DESCRIPTION
This introduces the fields cluster_alias and cluster_environment to the Scalyr Agent.