### PR TITLE
Make it possible to configure nat CIDR blocks per cluster

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -63,6 +63,9 @@ image_policy: "trusted"
 image_policy: "dev"
 {{end}}
 
+# Egress configuration
+nat_cidr_blocks: "172.31.64.0/28,172.31.64.16/28,172.31.64.32/28"
+
 # cadvisor settings
 cadvisor_cpu: "150m"
 cadvisor_memory: "150Mi"

--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-static-egress-controller
-    version: v0.1.4
+    version: v0.1.5
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-static-egress-controller
-        version: v0.1.4
+        version: v0.1.5
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-static-egress-controller"
     spec:
@@ -26,7 +26,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-static-egress-controller:v0.1.4
+        image: registry.opensource.zalan.do/teapot/kube-static-egress-controller:v0.1.5
         args:
         - "--log-level=debug"
         - "--provider=aws"

--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -30,9 +30,9 @@ spec:
         args:
         - "--log-level=debug"
         - "--provider=aws"
-        - "--aws-nat-cidr-block=172.31.64.0/28"
-        - "--aws-nat-cidr-block=172.31.64.16/28"
-        - "--aws-nat-cidr-block=172.31.64.32/28"
+{{- range $index, $element := split .Cluster.ConfigItems.nat_cidr_blocks "," }}
+        - "--aws-nat-cidr-block={{ $element }}"
+{{- end }}
         - "--aws-az=eu-central-1a"
         - "--aws-az=eu-central-1b"
         - "--aws-az=eu-central-1c"

--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         args:
         - "--log-level=debug"
         - "--provider=aws"
-{{- range $index, $element := split .Cluster.ConfigItems.nat_cidr_blocks "," }}
+{{- range $index, $element := split .ConfigItems.nat_cidr_blocks "," }}
         - "--aws-nat-cidr-block={{ $element }}"
 {{- end }}
         - "--aws-az=eu-central-1a"


### PR DESCRIPTION
This will make it possible to use Egress feature in clusters with custom subnets for VPN.

Discussed with @szuecs that it makes sense to just do the manual definition of CIDRs for now. 

~This PR should also include the fixes from: https://github.com/szuecs/kube-static-egress-controller/pull/21 I'll update it when the image is built.~ done