### PR TITLE
Remove debug logging for production clusters

### DIFF
--- a/cluster/manifests/emergency-access-service/deployment.yaml
+++ b/cluster/manifests/emergency-access-service/deployment.yaml
@@ -50,7 +50,6 @@ spec:
         - --community={{ .Owner }}
         - --cluster-id={{ .ID }}
         - --teams-api-url=https://teams.auth.zalando.com
-        - --debug
         # TODO(mlarsen): Rename this flag to tokeninfo-url to reflect that it's
         # not the OAuth2 token URL.
         - --token-url=https://info.services.auth.zalando.com/oauth2/tokeninfo


### PR DESCRIPTION
By default debug logging should not be enabled