### PR TITLE
dev-to-alpha

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -63,6 +63,9 @@ image_policy: "trusted"
 image_policy: "dev"
 {{end}}
 
+# Egress configuration
+nat_cidr_blocks: "172.31.64.0/28,172.31.64.16/28,172.31.64.32/28"
+
 # cadvisor settings
 cadvisor_cpu: "150m"
 cadvisor_memory: "150Mi"

--- a/cluster/manifests/admission-control/daemonset.yaml
+++ b/cluster/manifests/admission-control/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cluster-autoscaler
-        image: registry.opensource.zalan.do/teapot/admission-controller:master-13
+        image: registry.opensource.zalan.do/teapot/admission-controller:master-14
         command:
           - /registry-proxy
           - --address=127.0.0.1:8285

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -3,22 +3,8 @@ pre_apply: []
 
 # everything defined under here will be deleted after applying the manifests
 post_apply:
-# drop old DNS setup
-- name: coredns
-  namespace: kube-system
-  kind: Deployment
-- name: coredns
-  namespace: kube-system
-  kind: PodDisruptionBudget
-- name: coredns
-  namespace: kube-system
-  kind: ConfigMap
-- name: dnsmasq-node
-  namespace: kube-system
-  kind: DaemonSet
-- name: dnsmasq-node
-  namespace: kube-system
-  kind: DaemonSet
-- name: kube-dns-local
-  namespace: kube-system
-  kind: Service
+{{ if eq .ConfigItems.teapot_admission_controller_process_resources "true" }}
+- name: limits
+  namespace: default
+  kind: LimitRange
+{{ end }}

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-proxy
-    version: v1.12.6
+    version: v1.12.7
 spec:
   selector:
     matchLabels:
@@ -17,7 +17,7 @@ spec:
       name: kube-proxy
       labels:
         application: kube-proxy
-        version: v1.12.6
+        version: v1.12.7
       annotations:
         config/hash: {{"configmap.yaml" | manifestHash}}
     spec:
@@ -31,7 +31,7 @@ spec:
       hostNetwork: true
       containers:
       - name: kube-proxy
-        image: registry.opensource.zalan.do/teapot/kube-proxy:v1.12.6
+        image: registry.opensource.zalan.do/teapot/kube-proxy:v1.12.7
         args:
         - --config=/config/kube-proxy.yaml
         - --v=2

--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-static-egress-controller
-    version: v0.1.4
+    version: v0.1.5
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-static-egress-controller
-        version: v0.1.4
+        version: v0.1.5
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-static-egress-controller"
     spec:
@@ -26,7 +26,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-static-egress-controller:v0.1.4
+        image: registry.opensource.zalan.do/teapot/kube-static-egress-controller:v0.1.5
         args:
         - "--log-level=debug"
         - "--provider=aws"

--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -30,9 +30,9 @@ spec:
         args:
         - "--log-level=debug"
         - "--provider=aws"
-        - "--aws-nat-cidr-block=172.31.64.0/28"
-        - "--aws-nat-cidr-block=172.31.64.16/28"
-        - "--aws-nat-cidr-block=172.31.64.32/28"
+{{- range $index, $element := split .Cluster.ConfigItems.nat_cidr_blocks "," }}
+        - "--aws-nat-cidr-block={{ $element }}"
+{{- end }}
         - "--aws-az=eu-central-1a"
         - "--aws-az=eu-central-1b"
         - "--aws-az=eu-central-1c"

--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         args:
         - "--log-level=debug"
         - "--provider=aws"
-{{- range $index, $element := split .Cluster.ConfigItems.nat_cidr_blocks "," }}
+{{- range $index, $element := split .ConfigItems.nat_cidr_blocks "," }}
         - "--aws-nat-cidr-block={{ $element }}"
 {{- end }}
         - "--aws-az=eu-central-1a"

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -91,6 +91,8 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_ENVIRONMENT
           value: "{{ .Environment }}"
+        - name: CLUSTER_ALIAS
+          value: "{{ .Alias }}"
         - name: WATCHER_AGENTS
           value: scalyr{{if eq .ConfigItems.logging_fluentd_enabled "true"}},symlinker{{end}}
         - name: WATCHER_SCALYR_API_KEY

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     application: logging-agent
-    version: v0.25
+    version: v0.26
     component: logging
 spec:
   selector:
@@ -19,7 +19,7 @@ spec:
       name: logging-agent
       labels:
         application: logging-agent
-        version: v0.25
+        version: v0.26
         component: logging
       annotations:
         iam.amazonaws.com/role: {{.LocalID}}-app-logging-agent
@@ -83,7 +83,7 @@ spec:
           mountPath: /mnt/scalyr-checkpoint
       containers:
       - name: log-watcher
-        image: registry.opensource.zalan.do/logging/kubernetes-log-watcher:0.25
+        image: registry.opensource.zalan.do/logging/kubernetes-log-watcher:0.26
         env:
         - name: CLUSTER_NODE_NAME
           valueFrom:

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.10.192
+    version: v0.10.195
     component: ingress
 spec:
   strategy:
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.10.192
+        version: v0.10.195
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -42,7 +42,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.192
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.195
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -95,7 +95,7 @@ spec:
           - "-response-header-timeout-backend={{ .ConfigItems.skipper_response_header_timeout_backend }}"
           - "-timeout-backend={{ .ConfigItems.skipper_timeout_backend }}"
           - "-tls-timeout-backend={{ .ConfigItems.skipper_tls_timeout_backend }}"
-          - "-access-log-disabled"
+          - "-default-filters-prepend=enableAccessLog(4,5)"
         resources:
           limits:
             cpu: "{{ .ConfigItems.skipper_ingress_cpu }}"

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -177,7 +177,7 @@ systemd:
       After=docker.service dockercfg.service meta-data-iptables.service private-ipv4.service
 
       [Service]
-      Environment=KUBELET_IMAGE_TAG=v1.12.6
+      Environment=KUBELET_IMAGE_TAG=v1.12.7
       Environment=KUBELET_IMAGE_ARGS=--exec=/kube-component
       Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/kubelet
       Environment="RKT_RUN_ARGS=--insecure-options=image \
@@ -320,7 +320,7 @@ storage:
           namespace: kube-system
           labels:
             application: kube-apiserver
-            version: v1.12.6
+            version: v1.12.7
           annotations:
             kubernetes-log-watcher/scalyr-parser: |
               [{"container": "webhook", "parser": "json-structured-log"}]
@@ -332,7 +332,7 @@ storage:
           hostNetwork: true
           containers:
           - name: kube-apiserver
-            image: registry.opensource.zalan.do/teapot/kube-apiserver:v1.12.6
+            image: registry.opensource.zalan.do/teapot/kube-apiserver:v1.12.7
             args:
             - --apiserver-count={{ .Values.apiserver_count }}
             - --bind-address=0.0.0.0
@@ -545,7 +545,7 @@ storage:
           namespace: kube-system
           labels:
             application: kube-controller-manager
-            version: v1.12.6
+            version: v1.12.7
         spec:
           priorityClassName: system-node-critical
           tolerations:
@@ -553,7 +553,7 @@ storage:
             effect: NoSchedule
           containers:
           - name: kube-controller-manager
-            image: registry.opensource.zalan.do/teapot/kube-controller-manager:v1.12.6
+            image: registry.opensource.zalan.do/teapot/kube-controller-manager:v1.12.7
             args:
             - --kubeconfig=/etc/kubernetes/controller-kubeconfig
             - --leader-elect=true
@@ -616,7 +616,7 @@ storage:
           namespace: kube-system
           labels:
             application: kube-scheduler
-            version: v1.12.6
+            version: v1.12.7
         spec:
           priorityClassName: system-node-critical
           tolerations:
@@ -625,7 +625,7 @@ storage:
           hostNetwork: true
           containers:
           - name: kube-scheduler
-            image: registry.opensource.zalan.do/teapot/kube-scheduler:v1.12.6
+            image: registry.opensource.zalan.do/teapot/kube-scheduler:v1.12.7
             args:
             - --master=http://127.0.0.1:8080
             - --leader-elect=true
@@ -1057,7 +1057,7 @@ storage:
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
           --net=host \
-          docker://registry.opensource.zalan.do/teapot/kubectl:v1.12.6 \
+          docker://registry.opensource.zalan.do/teapot/kubectl:v1.12.7 \
           --exec=/kube-component -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           label node "$(hostname)" \
@@ -1070,7 +1070,7 @@ storage:
           --net=host \
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
-          docker://registry.opensource.zalan.do/teapot/kubectl:v1.12.6 \
+          docker://registry.opensource.zalan.do/teapot/kubectl:v1.12.7 \
           --exec=/kube-component -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           drain "$(hostname)" \

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -399,7 +399,7 @@ storage:
               requests:
                 cpu: 100m
                 memory: 200Mi
-          - image: registry.opensource.zalan.do/teapot/admission-controller:master-13
+          - image: registry.opensource.zalan.do/teapot/admission-controller:master-14
             name: admission-controller
             readinessProbe:
               httpGet:

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -178,7 +178,7 @@ systemd:
       After=docker.service dockercfg.service meta-data-iptables.service private-ipv4.service collect-instance-metadata.service
 
       [Service]
-      Environment=KUBELET_IMAGE_TAG=v1.12.6
+      Environment=KUBELET_IMAGE_TAG=v1.12.7
       Environment=KUBELET_IMAGE_ARGS=--exec=/kube-component
       Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/kubelet
       Environment="RKT_RUN_ARGS=--insecure-options=image \
@@ -451,7 +451,7 @@ storage:
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
           --net=host \
-          docker://registry.opensource.zalan.do/teapot/kubectl:v1.12.6 \
+          docker://registry.opensource.zalan.do/teapot/kubectl:v1.12.7 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           label node "$(hostname)" \
@@ -464,7 +464,7 @@ storage:
           --net=host \
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
-          docker://registry.opensource.zalan.do/teapot/kubectl:v1.12.6 \
+          docker://registry.opensource.zalan.do/teapot/kubectl:v1.12.7 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           drain "$(hostname)" \


### PR DESCRIPTION
* **only log accesslogs for 4xx 5xx as default**
   <sup>Merge pull request #1938 from zalando-incubator/feature/only-accesslogs-45xx</sup>
* **Update to Kubernetes v1.12.7**
   <sup>Merge pull request #1943 from zalando-incubator/kubernetes-v1.12.7</sup>
* **Update admission controller**
   <sup>Merge pull request #1941 from zalando-incubator/admission-controller</sup>
* **Introduce server fields for Scalyr Agent**
   <sup>Merge pull request #1931 from zalando-incubator/add-server-fields</sup>
* **Make it possible to configure nat CIDR blocks per cluster**
   <sup>Merge pull request #1932 from zalando-incubator/fix-kube-static-egress-controller</sup>
* **Delete the default limits if process_resources is enabled**
   <sup>Merge pull request #1942 from zalando-incubator/delete-limits</sup>