### PR TITLE
alpha-to-beta

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -99,7 +99,6 @@ zmon_worker_mem: "4Gi"
 zmon_worker_cpu: "750m"
 zmon_worker_count: "16"
 {{end}}
-logging_fluentd_enabled: "false"
 logging_watcher_mem: "200Mi"
 logging_scalyr_mem: "200Mi"
 logging_fluentd_mem: "300Mi"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -63,6 +63,9 @@ image_policy: "trusted"
 image_policy: "dev"
 {{end}}
 
+# Egress configuration
+nat_cidr_blocks: "172.31.64.0/28,172.31.64.16/28,172.31.64.32/28"
+
 # cadvisor settings
 cadvisor_cpu: "150m"
 cadvisor_memory: "150Mi"

--- a/cluster/manifests/admission-control/daemonset.yaml
+++ b/cluster/manifests/admission-control/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cluster-autoscaler
-        image: registry.opensource.zalan.do/teapot/admission-controller:master-13
+        image: registry.opensource.zalan.do/teapot/admission-controller:master-14
         command:
           - /registry-proxy
           - --address=127.0.0.1:8285

--- a/cluster/manifests/coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/coredns-local/daemonset-coredns.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: coredns
-    version: v1.2.0
+    version: v1.4.0
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
     component: cluster-dns
@@ -21,7 +21,7 @@ spec:
       labels:
         application: coredns
         instance: node-dns
-        version: v1.2.0
+        version: v1.4.0
         component: cluster-dns
     spec:
       containers:
@@ -92,7 +92,7 @@ spec:
             cpu: 10m
             memory: 45Mi
       - name: coredns
-        image: registry.opensource.zalan.do/teapot/coredns:1.2.0
+        image: registry.opensource.zalan.do/teapot/coredns:1.4.0
         args: [ "-conf", "/etc/coredns/Corefile" ]
         volumeMounts:
         - name: config-volume

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -3,22 +3,8 @@ pre_apply: []
 
 # everything defined under here will be deleted after applying the manifests
 post_apply:
-# drop old DNS setup
-- name: coredns
-  namespace: kube-system
-  kind: Deployment
-- name: coredns
-  namespace: kube-system
-  kind: PodDisruptionBudget
-- name: coredns
-  namespace: kube-system
-  kind: ConfigMap
-- name: dnsmasq-node
-  namespace: kube-system
-  kind: DaemonSet
-- name: dnsmasq-node
-  namespace: kube-system
-  kind: DaemonSet
-- name: kube-dns-local
-  namespace: kube-system
-  kind: Service
+{{ if eq .ConfigItems.teapot_admission_controller_process_resources "true" }}
+- name: limits
+  namespace: default
+  kind: LimitRange
+{{ end }}

--- a/cluster/manifests/emergency-access-service/deployment.yaml
+++ b/cluster/manifests/emergency-access-service/deployment.yaml
@@ -50,7 +50,6 @@ spec:
         - --community={{ .Owner }}
         - --cluster-id={{ .ID }}
         - --teams-api-url=https://teams.auth.zalando.com
-        - --debug
         # TODO(mlarsen): Rename this flag to tokeninfo-url to reflect that it's
         # not the OAuth2 token URL.
         - --token-url=https://info.services.auth.zalando.com/oauth2/tokeninfo

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-proxy
-    version: v1.12.6
+    version: v1.12.7
 spec:
   selector:
     matchLabels:
@@ -17,7 +17,7 @@ spec:
       name: kube-proxy
       labels:
         application: kube-proxy
-        version: v1.12.6
+        version: v1.12.7
       annotations:
         config/hash: {{"configmap.yaml" | manifestHash}}
     spec:
@@ -31,7 +31,7 @@ spec:
       hostNetwork: true
       containers:
       - name: kube-proxy
-        image: registry.opensource.zalan.do/teapot/kube-proxy:v1.12.6
+        image: registry.opensource.zalan.do/teapot/kube-proxy:v1.12.7
         args:
         - --config=/config/kube-proxy.yaml
         - --v=2

--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-static-egress-controller
-    version: v0.1.4
+    version: v0.1.5
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-static-egress-controller
-        version: v0.1.4
+        version: v0.1.5
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-static-egress-controller"
     spec:
@@ -26,7 +26,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-static-egress-controller:v0.1.4
+        image: registry.opensource.zalan.do/teapot/kube-static-egress-controller:v0.1.5
         args:
         - "--log-level=debug"
         - "--provider=aws"

--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -30,9 +30,9 @@ spec:
         args:
         - "--log-level=debug"
         - "--provider=aws"
-        - "--aws-nat-cidr-block=172.31.64.0/28"
-        - "--aws-nat-cidr-block=172.31.64.16/28"
-        - "--aws-nat-cidr-block=172.31.64.32/28"
+{{- range $index, $element := split .Cluster.ConfigItems.nat_cidr_blocks "," }}
+        - "--aws-nat-cidr-block={{ $element }}"
+{{- end }}
         - "--aws-az=eu-central-1a"
         - "--aws-az=eu-central-1b"
         - "--aws-az=eu-central-1c"

--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         args:
         - "--log-level=debug"
         - "--provider=aws"
-{{- range $index, $element := split .Cluster.ConfigItems.nat_cidr_blocks "," }}
+{{- range $index, $element := split .ConfigItems.nat_cidr_blocks "," }}
         - "--aws-nat-cidr-block={{ $element }}"
 {{- end }}
         - "--aws-az=eu-central-1a"

--- a/cluster/manifests/logging-agent/config.yaml
+++ b/cluster/manifests/logging-agent/config.yaml
@@ -1,4 +1,3 @@
-{{ if eq .ConfigItems.logging_fluentd_enabled "true" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -90,4 +89,3 @@ data:
         fields time,log
       </format>
     </match>
-{{ end }}

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -91,6 +91,8 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_ENVIRONMENT
           value: "{{ .Environment }}"
+        - name: CLUSTER_ALIAS
+          value: "{{ .Alias }}"
         - name: WATCHER_AGENTS
           value: scalyr{{if eq .ConfigItems.logging_fluentd_enabled "true"}},symlinker{{end}}
         - name: WATCHER_SCALYR_API_KEY

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     application: logging-agent
-    version: v0.25
+    version: v0.26
     component: logging
 spec:
   selector:
@@ -19,7 +19,7 @@ spec:
       name: logging-agent
       labels:
         application: logging-agent
-        version: v0.25
+        version: v0.26
         component: logging
       annotations:
         iam.amazonaws.com/role: {{.LocalID}}-app-logging-agent
@@ -83,7 +83,7 @@ spec:
           mountPath: /mnt/scalyr-checkpoint
       containers:
       - name: log-watcher
-        image: registry.opensource.zalan.do/logging/kubernetes-log-watcher:0.25
+        image: registry.opensource.zalan.do/logging/kubernetes-log-watcher:0.26
         env:
         - name: CLUSTER_NODE_NAME
           valueFrom:

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -92,7 +92,7 @@ spec:
         - name: CLUSTER_ENVIRONMENT
           value: "{{ .Environment }}"
         - name: WATCHER_AGENTS
-          value: scalyr{{if eq .ConfigItems.logging_fluentd_enabled "true"}},symlinker{{end}}
+          value: scalyr,symlinker
         - name: WATCHER_SCALYR_API_KEY
           valueFrom:
             secretKeyRef:
@@ -112,10 +112,8 @@ spec:
           value: "200000"
         - name: WATCHER_SCALYR_JOURNALD_WRITE_BURST
           value: "3000000"
-{{ if eq .ConfigItems.logging_fluentd_enabled "true" }}
         - name: WATCHER_SYMLINK_DIR
           value: /mnt/fluentd-logs
-{{ end }}
 
         resources:
           limits:
@@ -134,10 +132,8 @@ spec:
           readOnly: false
         - name: scalyr-config
           mountPath: /mnt/scalyr-config
-{{ if eq .ConfigItems.logging_fluentd_enabled "true" }}
         - name: fluentd-logs
           mountPath: /mnt/fluentd-logs
-{{ end }}
 
       - name: scalyr-agent
 
@@ -179,7 +175,6 @@ spec:
             cpu: "{{ .ConfigItems.logging_scalyr_cpu }}"
             memory: "{{ .ConfigItems.logging_scalyr_mem }}"
 
-{{ if eq .ConfigItems.logging_fluentd_enabled "true" }}
       - name: fluentd
 
         image: pierone.stups.zalan.do/logging/fluentd:v1.3.3-zal-master-9
@@ -212,7 +207,6 @@ spec:
           requests:
             cpu: "{{ .ConfigItems.logging_fluentd_cpu }}"
             memory: "{{ .ConfigItems.logging_fluentd_mem }}"
-{{ end }}
 
       volumes:
       - name: containerlogs
@@ -235,7 +229,6 @@ spec:
         hostPath:
           path: /var/log/scalyr-agent
 
-{{ if eq .ConfigItems.logging_fluentd_enabled "true" }}
       - name: fluentd-config
         configMap:
           name: fluentd-config
@@ -249,5 +242,4 @@ spec:
       - name: fluentd-posfiles
         hostPath:
           path: /var/lib/fluentd
-{{ end }}
 {{ end }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.10.192
+    version: v0.10.195
     component: ingress
 spec:
   strategy:
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.10.192
+        version: v0.10.195
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -42,7 +42,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.192
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.195
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -95,7 +95,7 @@ spec:
           - "-response-header-timeout-backend={{ .ConfigItems.skipper_response_header_timeout_backend }}"
           - "-timeout-backend={{ .ConfigItems.skipper_timeout_backend }}"
           - "-tls-timeout-backend={{ .ConfigItems.skipper_tls_timeout_backend }}"
-          - "-access-log-disabled"
+          - "-default-filters-prepend=enableAccessLog(4,5)"
         resources:
           limits:
             cpu: "{{ .ConfigItems.skipper_ingress_cpu }}"

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -177,7 +177,7 @@ systemd:
       After=docker.service dockercfg.service meta-data-iptables.service private-ipv4.service
 
       [Service]
-      Environment=KUBELET_IMAGE_TAG=v1.12.6
+      Environment=KUBELET_IMAGE_TAG=v1.12.7
       Environment=KUBELET_IMAGE_ARGS=--exec=/kube-component
       Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/kubelet
       Environment="RKT_RUN_ARGS=--insecure-options=image \
@@ -320,7 +320,7 @@ storage:
           namespace: kube-system
           labels:
             application: kube-apiserver
-            version: v1.12.6
+            version: v1.12.7
           annotations:
             kubernetes-log-watcher/scalyr-parser: |
               [{"container": "webhook", "parser": "json-structured-log"}]
@@ -332,7 +332,7 @@ storage:
           hostNetwork: true
           containers:
           - name: kube-apiserver
-            image: registry.opensource.zalan.do/teapot/kube-apiserver:v1.12.6
+            image: registry.opensource.zalan.do/teapot/kube-apiserver:v1.12.7
             args:
             - --apiserver-count={{ .Values.apiserver_count }}
             - --bind-address=0.0.0.0
@@ -545,7 +545,7 @@ storage:
           namespace: kube-system
           labels:
             application: kube-controller-manager
-            version: v1.12.6
+            version: v1.12.7
         spec:
           priorityClassName: system-node-critical
           tolerations:
@@ -553,7 +553,7 @@ storage:
             effect: NoSchedule
           containers:
           - name: kube-controller-manager
-            image: registry.opensource.zalan.do/teapot/kube-controller-manager:v1.12.6
+            image: registry.opensource.zalan.do/teapot/kube-controller-manager:v1.12.7
             args:
             - --kubeconfig=/etc/kubernetes/controller-kubeconfig
             - --leader-elect=true
@@ -616,7 +616,7 @@ storage:
           namespace: kube-system
           labels:
             application: kube-scheduler
-            version: v1.12.6
+            version: v1.12.7
         spec:
           priorityClassName: system-node-critical
           tolerations:
@@ -625,7 +625,7 @@ storage:
           hostNetwork: true
           containers:
           - name: kube-scheduler
-            image: registry.opensource.zalan.do/teapot/kube-scheduler:v1.12.6
+            image: registry.opensource.zalan.do/teapot/kube-scheduler:v1.12.7
             args:
             - --master=http://127.0.0.1:8080
             - --leader-elect=true
@@ -1057,7 +1057,7 @@ storage:
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
           --net=host \
-          docker://registry.opensource.zalan.do/teapot/kubectl:v1.12.6 \
+          docker://registry.opensource.zalan.do/teapot/kubectl:v1.12.7 \
           --exec=/kube-component -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           label node "$(hostname)" \
@@ -1070,7 +1070,7 @@ storage:
           --net=host \
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
-          docker://registry.opensource.zalan.do/teapot/kubectl:v1.12.6 \
+          docker://registry.opensource.zalan.do/teapot/kubectl:v1.12.7 \
           --exec=/kube-component -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           drain "$(hostname)" \

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -399,7 +399,7 @@ storage:
               requests:
                 cpu: 100m
                 memory: 200Mi
-          - image: registry.opensource.zalan.do/teapot/admission-controller:master-13
+          - image: registry.opensource.zalan.do/teapot/admission-controller:master-14
             name: admission-controller
             readinessProbe:
               httpGet:

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -178,7 +178,7 @@ systemd:
       After=docker.service dockercfg.service meta-data-iptables.service private-ipv4.service collect-instance-metadata.service
 
       [Service]
-      Environment=KUBELET_IMAGE_TAG=v1.12.6
+      Environment=KUBELET_IMAGE_TAG=v1.12.7
       Environment=KUBELET_IMAGE_ARGS=--exec=/kube-component
       Environment=KUBELET_IMAGE_URL=docker://registry.opensource.zalan.do/teapot/kubelet
       Environment="RKT_RUN_ARGS=--insecure-options=image \
@@ -451,7 +451,7 @@ storage:
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
           --net=host \
-          docker://registry.opensource.zalan.do/teapot/kubectl:v1.12.6 \
+          docker://registry.opensource.zalan.do/teapot/kubectl:v1.12.7 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           label node "$(hostname)" \
@@ -464,7 +464,7 @@ storage:
           --net=host \
           --volume dns,kind=host,source=/run/systemd/resolve/resolv.conf,readOnly=true \
           --mount volume=dns,target=/etc/resolv.conf \
-          docker://registry.opensource.zalan.do/teapot/kubectl:v1.12.6 \
+          docker://registry.opensource.zalan.do/teapot/kubectl:v1.12.7 \
           --exec=/kubectl -- \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           drain "$(hostname)" \

--- a/docs/admin-guide/public-presentations.rst
+++ b/docs/admin-guide/public-presentations.rst
@@ -4,8 +4,9 @@
 Public Presentations
 ====================
 
-* `DevOps Gathering 2019: Ensuring Kubernetes Cost Efficiency across (many) Clusters <https://www.slideshare.net/try_except_/ensuring-kubernetes-cost-efficiency-across-many-clusters-devops-gathering-2019>`_
-* `HighLoad++ Moscow 2018: Optimizing Kubernetes Resource Requests/Limits for Cost-Efficiency and Latency <https://www.youtube.com/watch?v=eBChCFD9hfs>`_
+* `DevOps Gathering 2019: Ensuring Kubernetes Cost Efficiency across (many) Clusters <https://www.youtube.com/watch?v=4QyecOoPsGU>`_ (`slides <https://www.slideshare.net/try_except_/ensuring-kubernetes-cost-efficiency-across-many-clusters-devops-gathering-2019>`_)
+* `DevOpsCon Munich 2018: Running Kubernetes in Production: A Million Ways to Crash Your Cluster <https://www.slideshare.net/try_except_/running-kubernetes-in-production-a-million-ways-to-crash-your-cluster-devopscon-munich-2018>`_
+* `HighLoad++ Moscow 2018: Optimizing Kubernetes Resource Requests/Limits for Cost-Efficiency and Latency <https://www.youtube.com/watch?v=eBChCFD9hfs>`_ (`slides <https://www.slideshare.net/try_except_/optimizing-kubernetes-resource-requestslimits-for-costefficiency-and-latency-highload>`_)
 * `DevOps Lisbon Meetup 2018: Kubernetes at Zalando <https://www.youtube.com/watch?v=NsjYhSxgeP0>`_
 * `Container Camp UK 2018: Running Kubernetes in Production: A Million Ways to Crash Your Cluster <https://www.slideshare.net/try_except_/running-kubernetes-in-production-a-million-ways-to-crash-your-cluster-container-camp-uk>`_
 * `KubeCon Copenhagen 2018: Continuously Deliver your Kubernetes Infrastructure <https://www.youtube.com/watch?v=1xHmCrd8Qn8>`_

--- a/docs/admin-guide/public-presentations.rst
+++ b/docs/admin-guide/public-presentations.rst
@@ -4,6 +4,7 @@
 Public Presentations
 ====================
 
+* `DevOps Gathering 2019: Ensuring Kubernetes Cost Efficiency across (many) Clusters <https://www.slideshare.net/try_except_/ensuring-kubernetes-cost-efficiency-across-many-clusters-devops-gathering-2019>`_
 * `HighLoad++ Moscow 2018: Optimizing Kubernetes Resource Requests/Limits for Cost-Efficiency and Latency <https://www.youtube.com/watch?v=eBChCFD9hfs>`_
 * `DevOps Lisbon Meetup 2018: Kubernetes at Zalando <https://www.youtube.com/watch?v=NsjYhSxgeP0>`_
 * `Container Camp UK 2018: Running Kubernetes in Production: A Million Ways to Crash Your Cluster <https://www.slideshare.net/try_except_/running-kubernetes-in-production-a-million-ways-to-crash-your-cluster-container-camp-uk>`_


### PR DESCRIPTION
* **dev-to-alpha**
   <sup>Merge pull request #1946 from zalando-incubator/dev-to-alpha</sup>
* **Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>
  **
   <sup>Merge branch 'dev' into dev-to-alpha</sup>
* **only log accesslogs for 4xx 5xx as default**
   <sup>Merge pull request #1938 from zalando-incubator/feature/only-accesslogs-45xx</sup>
* **dev-to-alpha**
   <sup>Merge pull request #1940 from zalando-incubator/dev-to-alpha</sup>
* **Update to Kubernetes v1.12.7**
   <sup>Merge pull request #1943 from zalando-incubator/kubernetes-v1.12.7</sup>
* **Update admission controller**
   <sup>Merge pull request #1941 from zalando-incubator/admission-controller</sup>
* **Introduce server fields for Scalyr Agent**
   <sup>Merge pull request #1931 from zalando-incubator/add-server-fields</sup>
* **Make it possible to configure nat CIDR blocks per cluster**
   <sup>Merge pull request #1932 from zalando-incubator/fix-kube-static-egress-controller</sup>
* **Delete the default limits if process_resources is enabled**
   <sup>Merge pull request #1942 from zalando-incubator/delete-limits</sup>
* **Signed-off-by: njuettner <nick@zalando.de>
  **
   <sup>Merge branch 'dev' into dev-to-alpha</sup>
* **Remove logging_fluentd_enabled**
   <sup>Merge pull request #1939 from zalando-incubator/fluentd-always-enabled</sup>
* **Remove debug logging for production clusters**
   <sup>Merge pull request #1937 from zalando-incubator/eas-logging</sup>
* **Talks: link DevOps Gathering video, add DevOpsCon**
   <sup>Merge pull request #1935 from zalando-incubator/talks</sup>
* **DevOps Gathering talk**
   <sup>Merge pull request #1934 from zalando-incubator/devops-gathering-talk</sup>
* **Update CoreDNS to v1.4.0**
   <sup>Merge pull request #1916 from zalando-incubator/update-coredns</sup>