### PR TITLE
Update VPA to 0.4.0

### DIFF
--- a/cluster/manifests/01-vertical-pod-autoscaler/01-crd.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/01-crd.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -6,7 +7,6 @@ metadata:
     component: vpa
 spec:
   group: autoscaling.k8s.io
-  version: v1beta1
   scope: Namespaced
   names:
     plural: verticalpodautoscalers
@@ -14,17 +14,21 @@ spec:
     kind: VerticalPodAutoscaler
     shortNames:
     - vpa
-    categories:
-      - all
+  versions:
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1beta2
+    served: true
+    storage: true
   validation:
     # openAPIV3Schema is the schema for validating custom objects.
     openAPIV3Schema:
       properties:
         spec:
-          required:
-            - selector
+          required: []
           properties:
-            selector:
+            targetRef:
               type: object
             updatePolicy:
               properties:
@@ -43,7 +47,6 @@ metadata:
     component: vpa
 spec:
   group: autoscaling.k8s.io
-  version: v1beta1
   scope: Namespaced
   names:
     plural: verticalpodautoscalercheckpoints
@@ -51,3 +54,11 @@ spec:
     kind: VerticalPodAutoscalerCheckpoint
     shortNames:
     - vpacheckpoint
+  versions:
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1beta2
+    served: true
+    storage: true
+

--- a/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: kube-system
   labels:
     application: vpa-admission-controller
-    version: patched-0.3.0-master-9
+    version: patched-0.4.0-master-14
     component: vpa
 spec:
   replicas: 1
@@ -30,18 +30,23 @@ spec:
     metadata:
       labels:
         application: vpa-admission-controller
-        version: patched-0.3.0-master-9
+        version: patched-0.4.0-master-14
         component: vpa
     spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: system
       containers:
       - name: admission-controller
-        image: registry.opensource.zalan.do/teapot/vpa-admission-controller:patched-0.3.0-master-9
+        image: registry.opensource.zalan.do/teapot/vpa-admission-controller:patched-0.4.0-master-14
         volumeMounts:
           - name: tls-certs
             mountPath: "/etc/tls-certs"
             readOnly: true
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         resources:
           limits:
             cpu: 200m

--- a/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: vpa-recommender
-    version: patched-0.3.0-master-12
+    version: patched-0.4.0-master-14
     component: vpa
 spec:
   replicas: 1
@@ -16,14 +16,14 @@ spec:
     metadata:
       labels:
         application: vpa-recommender
-        version: patched-0.3.0-master-12
+        version: patched-0.4.0-master-14
         component: vpa
     spec:
       serviceAccountName: system
       priorityClassName: system-cluster-critical
       containers:
       - name: recommender
-        image: registry.opensource.zalan.do/teapot/vpa-recommender:patched-0.3.0-master-12
+        image: registry.opensource.zalan.do/teapot/vpa-recommender:patched-0.4.0-master-14
         args:
         - --stderrthreshold=info
         - --v=5

--- a/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: vpa-updater
-    version: patched-0.3.0-master-9
+    version: patched-0.4.0-master-14
     component: vpa
 spec:
   replicas: 1
@@ -16,14 +16,14 @@ spec:
     metadata:
       labels:
         application: vpa-updater
-        version: patched-0.3.0-master-9
+        version: patched-0.4.0-master-14
         component: vpa
     spec:
       serviceAccountName: system
       priorityClassName: system-cluster-critical
       containers:
       - name: updater
-        image: registry.opensource.zalan.do/teapot/vpa-updater:patched-0.3.0-master-9
+        image: registry.opensource.zalan.do/teapot/vpa-updater:patched-0.4.0-master-14
         args:
           - ./updater
           - --v=4

--- a/cluster/manifests/external-dns/vpa.yaml
+++ b/cluster/manifests/external-dns/vpa.yaml
@@ -6,9 +6,10 @@ metadata:
   labels:
     application: external-dns
 spec:
-  selector:
-    matchLabels:
-      application: external-dns
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: external-dns
   updatePolicy:
     updateMode: Auto
   resourcePolicy:

--- a/cluster/manifests/heapster/vpa.yaml
+++ b/cluster/manifests/heapster/vpa.yaml
@@ -4,9 +4,10 @@ metadata:
   name: heapster
   namespace: kube-system
 spec:
-  selector:
-    matchLabels:
-      application: heapster
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: heapster
   updatePolicy:
     updateMode: Auto
   resourcePolicy:

--- a/cluster/manifests/kubernetes-lifecycle-metrics/vpa.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/vpa.yaml
@@ -4,9 +4,10 @@ metadata:
   name: kubernetes-lifecycle-metrics-vpa
   namespace: kube-system
 spec:
-  selector:
-    matchLabels:
-      application: kubernetes-lifecycle-metrics
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: kubernetes-lifecycle-metrics
   updatePolicy:
     updateMode: Auto
   resourcePolicy:

--- a/cluster/manifests/metrics-server/metrics-server-vpa.yaml
+++ b/cluster/manifests/metrics-server/metrics-server-vpa.yaml
@@ -4,9 +4,10 @@ metadata:
   name: metrics-server-vpa
   namespace: kube-system
 spec:
-  selector:
-    matchLabels:
-      application: metrics-server
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: metrics-server
   updatePolicy:
     updateMode: "Auto"
   resourcePolicy:

--- a/cluster/manifests/prometheus/prometheus-vpa.yaml
+++ b/cluster/manifests/prometheus/prometheus-vpa.yaml
@@ -4,9 +4,10 @@ metadata:
   name: prometheus-vpa
   namespace: kube-system
 spec:
-  selector:
-    matchLabels:
-      application: prometheus
+  targetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: prometheus
   updatePolicy:
     updateMode: Auto
   resourcePolicy:


### PR DESCRIPTION
Updated our patched version of the VPA controller components to version [_0.4.0_](https://github.com/kubernetes/autoscaler/releases/tag/vertical-pod-autoscaler-0.4.0). Also updated the VPA objects associated with various deployments and stateful sets.