### PR TITLE
Updated the version of kube-metrics-adapter

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:master-20
+        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:master-24
         args:
         - --prometheus-server=http://prometheus.kube-system.svc.cluster.local
         - --skipper-ingress-metrics


### PR DESCRIPTION
This version of kube-metrics-adapter is based on the newer autoscaling/v2beta2 package and has uses an updated version of the custom-metrics-server.