### PR TITLE
Updated the version of kube-metrics-adapter

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:master-20
+        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:master-25
         args:
         - --prometheus-server=http://prometheus.kube-system.svc.cluster.local
         - --skipper-ingress-metrics

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -45,7 +45,7 @@ pipeline:
           resources: &resources
             limits:
               cpu: 500m
-              memory: 2Gi
+              memory: 4Gi
             requests:
               cpu: 500m
-              memory: 2Gi
+              memory: 4Gi


### PR DESCRIPTION
This version of kube-metrics-adapter is based on the newer autoscaling/v2beta2 package and has uses an updated version of the custom-metrics-server.

Also increased the memory for the e2e pods because it kept getting oom-killed.