### PR TITLE
kube-downscaler v0.12

### DIFF
--- a/cluster/manifests/kube-downscaler/deployment.yaml
+++ b/cluster/manifests/kube-downscaler/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-downscaler
-    version: v0.6
+    version: v0.12
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-downscaler
-        version: v0.7
+        version: v0.12
     spec:
       dnsConfig:
         options:
@@ -26,7 +26,7 @@ spec:
       containers:
       - name: downscaler
         # see https://github.com/hjacobs/kube-downscaler/releases
-        image: registry.opensource.zalan.do/teapot/kube-downscaler:0.7
+        image: registry.opensource.zalan.do/teapot/kube-downscaler:0.12
         args:
           - --interval=30
           - --exclude-namespaces=kube-system,visibility


### PR DESCRIPTION
New version of Kubernetes Downscaler: https://github.com/hjacobs/kube-downscaler/releases/tag/0.12

Relevant changes:

* scales up when `downscaler/exclude` annotation is set
* support the `downscaler/downtime-replicas` annotation to scale down to an arbitrary number of replicas
* support downscaler annotations on namespace level