### PR TITLE
Only run e2e on PR

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -2,6 +2,8 @@ version: "2017-09-20"
 allow_concurrent_steps: true
 pipeline:
 - id: build
+  when:
+    event: pull_request
   vm: large # speed up building kubernetes/kubernetes
   overlay: ci/golang
   cache:
@@ -15,6 +17,8 @@ pipeline:
       VERSION="$CDP_BUILD_VERSION" make -C test/e2e build.push
 
 - id: e2e-tests
+  when:
+    event: pull_request
   depends_on: [build]
   type: process
   desc: "Kubernetes e2e tests"


### PR DESCRIPTION
Avoid running e2e an extra time after we merge to a branch