### PR TITLE
Add a config item for compliance checker integration

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -62,6 +62,7 @@ image_policy: "trusted"
 {{else}}
 image_policy: "dev"
 {{end}}
+compliance_checker_enabled: "false"
 
 # Egress configuration
 nat_cidr_blocks: "172.31.64.0/28,172.31.64.16/28,172.31.64.32/28"

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -501,7 +501,7 @@ storage:
                 value: https://identity.zalando.com/.well-known/openid-configuration
               - name: ENABLE_INTROSPECTION
                 value: "true"
-          - image: registry.opensource.zalan.do/teapot/image-policy-webhook:v0.4.1
+          - image: registry.opensource.zalan.do/teapot/image-policy-webhook:{{if eq .Cluster.ConfigItems.compliance_checker_enabled "true"}}master-44{{else}}v0.4.1{{end}}
             name: image-policy-webhook
             args:
             - --policy={{ .Cluster.ConfigItems.image_policy }}


### PR DESCRIPTION
Add `compliance_checker_enabled` in preparation for the rollout next week (disabled by default).