### PR TITLE
Update prometheus to v2.8.1

### DIFF
--- a/cluster/manifests/prometheus/statefulset.yaml
+++ b/cluster/manifests/prometheus/statefulset.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
   labels:
     application: prometheus
-    version: v2.6.0
+    version: v2.8.1
   name: prometheus
   namespace: kube-system
 spec:
@@ -17,7 +17,7 @@ spec:
     metadata:
       labels:
         application: prometheus
-        version: v2.6.0
+        version: v2.8.1
       annotations:
         config/hash: {{"configmap.yaml" | manifestHash}}
     spec:
@@ -28,7 +28,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
       - name: prometheus
-        image: registry.opensource.zalan.do/teapot/prometheus:v2.6.0
+        image: registry.opensource.zalan.do/teapot/prometheus:v2.8.1
         args:
         - "--config.file=/etc/prometheus/prometheus.yml"
         - "--storage.tsdb.path=/prometheus/"


### PR DESCRIPTION
https://github.com/prometheus/prometheus/releases

Some of these changes seem to be interesting enough to update

[ENHANCEMENT] Query performance improvements. prometheus/tsdb#531
[BUGFIX] Scrape: catch errors when creating HTTP clients #5182. Adds new metrics: prometheus_target_scrape_pools_*
deprecating the flag storage.tsdb.retention -> use storage.tsdb.retention.time
[FEATURE] Add subqueries to PromQL.
[ENHANCEMENT] Kubernetes SD: Add service external IP and external name to the discovery metadata. #4940
[ENHANCEMENT] Add metric for number of rule groups loaded. #5090
BUGFIX] Make sure the retention period does not overflow. #5112
[BUGFIX] Make sure the blocks do not get very large. #5112
[BUGFIX] Do not generate blocks with no samples. prometheus/tsdb#374
[BUGFIX] Reintroduce metric for WAL corruptions. prometheus/tsdb#473