### PR TITLE
Enable DS scheduling for e2e

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -191,4 +191,8 @@ coreos_image: "ami-012abdf0d2781f0a5" # Container Linux 2023.5.0 (HVM, eu-centra
 enable_ingress_template_controller: "false"
 
 # Temporary feature toggle for the new daemonset scheduler
+{{if eq .Environment "e2e"}}
+experimental_schedule_daemonset_pods: "true"
+{{else}}
 experimental_schedule_daemonset_pods: "false"
+{{end}}


### PR DESCRIPTION
This should fix the scheduling issues causing e2e to fail occasionally.