### PR TITLE
beta to stable

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -62,6 +62,7 @@ image_policy: "trusted"
 {{else}}
 image_policy: "dev"
 {{end}}
+compliance_checker_enabled: "false"
 
 # Egress configuration
 nat_cidr_blocks: "172.31.64.0/28,172.31.64.16/28,172.31.64.32/28"

--- a/cluster/manifests/kube-downscaler/deployment.yaml
+++ b/cluster/manifests/kube-downscaler/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-downscaler
-    version: v0.6
+    version: v0.12
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-downscaler
-        version: v0.7
+        version: v0.12
     spec:
       dnsConfig:
         options:
@@ -26,7 +26,7 @@ spec:
       containers:
       - name: downscaler
         # see https://github.com/hjacobs/kube-downscaler/releases
-        image: registry.opensource.zalan.do/teapot/kube-downscaler:0.7
+        image: registry.opensource.zalan.do/teapot/kube-downscaler:0.12
         args:
           - --interval=30
           - --exclude-namespaces=kube-system,visibility

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -80,6 +80,7 @@ spec:
           - "-api-usage-monitoring-realm-keys=https://identity.zalando.com/realm"
           - "-api-usage-monitoring-client-keys=https://identity.zalando.com/managed-id,sub"
           - "-api-usage-monitoring-default-client-tracking-pattern=services[.].*"
+          - "-default-filters-dir=/etc/config/default-filters"
 {{ end }}
           - "-max-audit-body=0"
 {{ if eq .ConfigItems.skipper_clusterratelimit "true"}}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.10.195
+    version: v0.10.200
     component: ingress
 spec:
   strategy:
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.10.195
+        version: v0.10.200
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -42,7 +42,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.195
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.200
         ports:
         - name: ingress-port
           containerPort: 9999

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -501,7 +501,7 @@ storage:
                 value: https://identity.zalando.com/.well-known/openid-configuration
               - name: ENABLE_INTROSPECTION
                 value: "true"
-          - image: registry.opensource.zalan.do/teapot/image-policy-webhook:v0.4.1
+          - image: registry.opensource.zalan.do/teapot/image-policy-webhook:{{if eq .Cluster.ConfigItems.compliance_checker_enabled "true"}}master-44{{else}}v0.4.1{{end}}
             name: image-policy-webhook
             args:
             - --policy={{ .Cluster.ConfigItems.image_policy }}

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -2,6 +2,8 @@ version: "2017-09-20"
 allow_concurrent_steps: true
 pipeline:
 - id: build
+  when:
+    event: pull_request
   vm: large # speed up building kubernetes/kubernetes
   overlay: ci/golang
   cache:
@@ -15,6 +17,8 @@ pipeline:
       VERSION="$CDP_BUILD_VERSION" make -C test/e2e build.push
 
 - id: e2e-tests
+  when:
+    event: pull_request
   depends_on: [build]
   type: process
   desc: "Kubernetes e2e tests"


### PR DESCRIPTION
* **feat: upgrade skipper to v0.10.200 (#1965)**
   <sup>Merge pull request #1966 from zalando-incubator/1965-upgrade-skipper-to-v0.10.200</sup>
* **kube-downscaler v0.12**
   <sup>Merge pull request #1972 from zalando-incubator/kube-downscaler-v0.12</sup>
* **Only run e2e on PR**
   <sup>Merge pull request #1973 from zalando-incubator/e2e-pr-only</sup>
* **Add a config item for compliance checker integration**
   <sup>Merge pull request #1989 from zalando-incubator/compliance-checker-to-beta</sup>