### PR TITLE
Updated the VPAs to v1beta2

### DIFF
--- a/cluster/manifests/external-dns/vpa.yaml
+++ b/cluster/manifests/external-dns/vpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling.k8s.io/v1beta1
+apiVersion: autoscaling.k8s.io/v1beta2
 kind: VerticalPodAutoscaler
 metadata:
   name: external-dns

--- a/cluster/manifests/heapster/vpa.yaml
+++ b/cluster/manifests/heapster/vpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling.k8s.io/v1beta1
+apiVersion: autoscaling.k8s.io/v1beta2
 kind: VerticalPodAutoscaler
 metadata:
   name: heapster

--- a/cluster/manifests/ingress-controller/vpa.yaml
+++ b/cluster/manifests/ingress-controller/vpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling.k8s.io/v1beta1
+apiVersion: autoscaling.k8s.io/v1beta2
 kind: VerticalPodAutoscaler
 metadata:
   name: kube-ingress-aws-controller

--- a/cluster/manifests/kubernetes-lifecycle-metrics/vpa.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/vpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling.k8s.io/v1beta1
+apiVersion: autoscaling.k8s.io/v1beta2
 kind: VerticalPodAutoscaler
 metadata:
   name: kubernetes-lifecycle-metrics-vpa

--- a/cluster/manifests/metrics-server/metrics-server-vpa.yaml
+++ b/cluster/manifests/metrics-server/metrics-server-vpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling.k8s.io/v1beta1
+apiVersion: autoscaling.k8s.io/v1beta2
 kind: VerticalPodAutoscaler
 metadata:
   name: metrics-server-vpa

--- a/cluster/manifests/prometheus/prometheus-vpa.yaml
+++ b/cluster/manifests/prometheus/prometheus-vpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling.k8s.io/v1beta1
+apiVersion: autoscaling.k8s.io/v1beta2
 kind: VerticalPodAutoscaler
 metadata:
   name: prometheus-vpa


### PR DESCRIPTION
This is the right version of the VPAs because feature for object reference was only introduced in v1beta2.