### PR TITLE
Fluentd config: turn off S3 bucket checks

### DIFF
--- a/cluster/manifests/logging-agent/config.yaml
+++ b/cluster/manifests/logging-agent/config.yaml
@@ -69,6 +69,8 @@ data:
       @type s3
       s3_bucket {{ index .ConfigItems "logging_s3_bucket" }}
       s3_region eu-central-1
+      auto_create_bucket false
+      check_bucket false
       <instance_profile_credentials>
         retries 10
       </instance_profile_credentials>


### PR DESCRIPTION
Turn off the feature to create the S3 bucket and to check for S3
bucket existence at startup. The logging-agent doesn't have permission
to create S3 buckets, and the check causes the Fluentd worker to fail
and restart if the bucket is not present. Constant restarting leads to
high CPU consumption.

Instead we choose to keep the worker running and try to ship logs to
S3. This will fail if the bucket does not exist, but the buffer size
is limited and we can alert on buffer size and errors and the CPU
consumption stays low.