### PR TITLE
Update metrics-server to v0.3.2, use RBAC

### DIFF
--- a/cluster/manifests/metrics-server/deployment.yaml
+++ b/cluster/manifests/metrics-server/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: metrics-server
-    version: v0.2.1
+    version: v0.3.2
 spec:
   replicas: 1
   selector:
@@ -16,20 +16,23 @@ spec:
       name: metrics-server
       labels:
         application: metrics-server
-        version: v0.2.1
+        version: v0.3.2
     spec:
       dnsConfig:
         options:
           - name: ndots
             value: "1"
       priorityClassName: system-cluster-critical
-      serviceAccountName: system
+      serviceAccountName: metrics-server
       containers:
       - name: metrics-server
-        image: registry.opensource.zalan.do/teapot/metrics-server:v0.2.1
-        command:
-        - /metrics-server
-        - --source=kubernetes.summary_api:''
+        image: registry.opensource.zalan.do/teapot/metrics-server:v0.3.2
+        args:
+        # Connect to kubelet on 'completely insecure' port.
+        # We need to configure kubelet differently to be able to use the secure
+        # port 10250.
+        - --deprecated-kubelet-completely-insecure
+        - --kubelet-port=10255
         resources:
           limits:
             cpu: "{{.ConfigItems.metrics_service_cpu}}"
@@ -37,3 +40,10 @@ spec:
           requests:
             cpu: "{{.ConfigItems.metrics_service_cpu}}"
             memory: "{{.ConfigItems.metrics_service_mem}}"
+        volumeMounts:
+        - name: tmp-dir
+          mountPath: /tmp
+      volumes:
+      # mount in tmp so we can safely use from-scratch images and/or read-only containers
+      - name: tmp-dir
+        emptyDir: {}

--- a/cluster/manifests/metrics-server/rbac.yaml
+++ b/cluster/manifests/metrics-server/rbac.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:metrics-server
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  - nodes/stats
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:metrics-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:metrics-server
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: metrics-server-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: metrics-server:system:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system


### PR DESCRIPTION
* https://github.com/kubernetes-incubator/metrics-server/releases/tag/v0.3.0
* https://github.com/kubernetes-incubator/metrics-server/releases/tag/v0.3.2

The metrics-server is configured with `--deprecated-kubelet-completely-insecure` because of how we currently configure kubelet. This is no change from how metrics-server has been configured in our setup until now.