### PR TITLE
Janitor cleanup rules: application label & CDP namespaces

### DIFF
--- a/cluster/manifests/kube-janitor/deployment.yaml
+++ b/cluster/manifests/kube-janitor/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-janitor
-    version: v0.2.2
+    version: v0.5
 spec:
   replicas: 1
   selector:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: kube-janitor
-        version: v0.2.2
+        version: v0.5
     spec:
       dnsConfig:
         options:
@@ -27,7 +27,7 @@ spec:
       containers:
       - name: janitor
         # see https://github.com/hjacobs/kube-janitor/releases
-        image: registry.opensource.zalan.do/teapot/kube-janitor:0.2.2
+        image: registry.opensource.zalan.do/teapot/kube-janitor:0.5
         args:
           # run every minute
           - --interval=60

--- a/cluster/manifests/kube-janitor/deployment.yaml
+++ b/cluster/manifests/kube-janitor/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-janitor
-    version: v0.5
+    version: v0.7
 spec:
   replicas: 1
   selector:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: kube-janitor
-        version: v0.5
+        version: v0.7
     spec:
       dnsConfig:
         options:
@@ -27,7 +27,7 @@ spec:
       containers:
       - name: janitor
         # see https://github.com/hjacobs/kube-janitor/releases
-        image: registry.opensource.zalan.do/teapot/kube-janitor:0.5
+        image: registry.opensource.zalan.do/teapot/kube-janitor:0.7
         args:
           # run every minute
           - --interval=60

--- a/cluster/manifests/kube-janitor/rules-config.yaml
+++ b/cluster/manifests/kube-janitor/rules-config.yaml
@@ -12,21 +12,17 @@ data:
       - id: require-application-label
         # remove deployments and statefulsets without a label "application"
         resources:
-          # resources are prefixed with "XXX" to make sure they are not active by accident
-          # modify the rule as needed and remove the "XXX" prefix to activate
-          - XXXdeployments
-          - XXXstatefulsets
+          - deployments
+          - statefulsets
         # see http://jmespath.org/specification.html
-        jmespath: "!(spec.template.metadata.labels.application)"
-        ttl: 4d
-      - id: temporary-pr-namespaces
-        # delete all namespaces with a name starting with "pr-*"
+        jmespath: "!(spec.template.metadata.labels.application) && metadata.creationTimestamp > '2019-04-15'"
+        ttl: 7d
+      - id: temporary-cdp-namespaces
+        # delete all temporary e2e namespaces (created by CDP) with a name starting with "d-*"
         resources:
-          # resources are prefixed with "XXX" to make sure they are not active by accident
-          # modify the rule as needed and remove the "XXX" prefix to activate
-          - XXXnamespaces
+          - namespaces
         # this uses JMESPath's built-in "starts_with" function
         # see http://jmespath.org/specification.html#starts-with
-        jmespath: "starts_with(metadata.name, 'pr-')"
-        ttl: 4h
+        jmespath: "starts_with(metadata.name, 'd-')"
+        ttl: 24h
 {{ end }}


### PR DESCRIPTION
Activate janitor rules for test clusters:

* clean up (new) deployments and statefulsets without application label (only applies for resources created after 2019-04-15)
* clean up temporary CDP e2e namespaces
* update to Kubernetes Janitor [v0.5](https://github.com/hjacobs/kube-janitor/releases/tag/0.5)

I already tried these rules in our cluster:

```
INFO: Janitor v0.2.2 started with config Namespace(debug=False, dry_run=False, exclude_namespaces='kube-system,visibility', exclude_resources='events,controllerrevisions', include_namespaces='all', include_resources='all', interval=60, once=False, rules_file='/config/rul..
INFO: Loaded 2 rules from file /config/rules.yaml
INFO: Namespace d-26f3uxxcro63tdvozphzn18cg6 with TTL of 24h is 3w3d19h45m20s old and will be deleted
INFO: Deleting Namespace None/d-26f3uxxcro63tdvozphzn18cg6..
INFO: Namespace d-2nz28c4trnp3bn4zw8d96naro4 with TTL of 24h is 3w1d21h35m2s old and will be deleted
INFO: Deleting Namespace None/d-2nz28c4trnp3bn4zw8d96naro4..
INFO: Namespace d-vgfyzyo9n7p1cuvabm7mkcnzd with TTL of 24h is 4w1d17h53m41s old and will be deleted
INFO: Deleting Namespace None/d-vgfyzyo9n7p1cuvabm7mkcnzd..
INFO: Namespace d-way4ypy6kew6tie25ujzira83 with TTL of 24h is 1w4d27m33s old and will be deleted
INFO: Deleting Namespace None/d-way4ypy6kew6tie25ujzira83..
INFO: Clean up run completed: resources-processed=2610, rule-temporary-cdp-namespaces-matches=4, namespaces-with-ttl=4, namespaces-deleted=4
```

