### PR TITLE
PCS: validate application name

### DIFF
--- a/cluster/manifests/01-platformcredentialsset/customresourcedefinition.yaml
+++ b/cluster/manifests/01-platformcredentialsset/customresourcedefinition.yaml
@@ -13,7 +13,7 @@ spec:
     plural: platformcredentialssets
     singular: platformcredentialsset
     shortNames:
-    - pcs
+      - pcs
     categories:
       - all
   validation:
@@ -27,6 +27,7 @@ spec:
           properties:
             application:
               type: string
+              pattern: "^[a-z][a-z0-9-]*[a-z0-9]$"
             clients:
               type: object
               additionalProperties:


### PR DESCRIPTION
For some reason, Kio returns a `400` instead of a `404` when you GET an application with an invalid name. This is considered a fatal error in credentials-provider and triggers a 24x7 alert. Validate the application name to prevent this.