### PR TITLE
Don't allow downscaling prometheus too much

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -120,6 +120,7 @@ zmon_aws_agent_cpu: "100m"
 
 prometheus_cpu: "1000m"
 prometheus_mem: "4Gi"
+prometheus_mem_min: "512Mi"
 prometheus_mem_max: "10Gi"
 
 metrics_service_cpu: "100m"

--- a/cluster/manifests/prometheus/prometheus-vpa.yaml
+++ b/cluster/manifests/prometheus/prometheus-vpa.yaml
@@ -13,5 +13,7 @@ spec:
   resourcePolicy:
     containerPolicies:
     - containerName: prometheus
+      minAllowed:
+        memory: {{.ConfigItems.prometheus_mem_min}}
       maxAllowed:
         memory: {{.ConfigItems.prometheus_mem_max}}


### PR DESCRIPTION
Since the VPA still can't deal with OOMs correctly, just forbid it from downscaling Prometheus to the minimum. This should allow our E2E tests to run.