### PR TITLE
Upgrade ZMON worker

### DIFF
--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: visibility
   labels:
     application: zmon-worker
-    version: "v206-zv249-2-g674c2e0"
+    version: "v207-py2eol-zv250-py2eol-2-gbe56be1"
 spec:
   replicas: {{.ConfigItems.zmon_worker_replicas}}
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: zmon-worker
-        version: "v206-zv249-2-g674c2e0"
+        version: "v207-py2eol-zv250-py2eol-2-gbe56be1"
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
     spec:
@@ -46,7 +46,7 @@ spec:
             readOnly: false
       containers:
         - name: zmon-worker
-          image: "pierone.stups.zalan.do/zmon/zmon-worker:v206-zv249-2-g674c2e0"
+          image: "pierone.stups.zalan.do/zmon/zmon-worker:v207-py2eol-zv250-py2eol-2-gbe56be1"
           resources:
             limits:
               cpu: {{.ConfigItems.zmon_worker_cpu}}


### PR DESCRIPTION
*Changes*:

- Add support for `component` tag to be queried in KairosDB
- Add zrange to redis wrapper
- Add cleanup entities to worker cleanup task
- Add timeout for exasol process to avoid leaking stuck processes

Signed-off-by: Mohab Usama <mohab.abdelhameed@zalando.de>