### PR TITLE
Update version of kube-metrics-adapter

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:master-25
+        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:master-26
         args:
         - --prometheus-server=http://prometheus.kube-system.svc.cluster.local
         - --skipper-ingress-metrics


### PR DESCRIPTION
This version of `kube-metrics-adapter` has a fix for broken ZMON based metrics from the PR [here](https://github.com/zalando-incubator/kube-metrics-adapter/pull/46).