### PR TITLE
zmon-aws-agent: fix spurious describe_images calls

### DIFF
--- a/cluster/manifests/zmon-aws-agent/deployment.yaml
+++ b/cluster/manifests/zmon-aws-agent/deployment.yaml
@@ -47,7 +47,7 @@ spec:
 
       containers:
         - name: zmon-aws-agent
-          image: pierone.stups.zalan.do/zmon/zmon-aws-agent:v76-zv155
+          image: pierone.stups.zalan.do/zmon/zmon-aws-agent:v76-3-g3d635f3-zv155-2-g66e06ab
           resources:
             limits:
               cpu: {{.ConfigItems.zmon_aws_agent_cpu}}


### PR DESCRIPTION
This causes rate limit issues in all clusters.