### PR TITLE
Always enable teapot admission controller

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -163,7 +163,7 @@ node_update_prepare_replacement_node: "false" # don't wait for a replacement ins
 # Temporary feature toggles for the cluster lifecycle controller
 experimental_cluster_lifecycle_controller: "false"
 
-# Teapot webhook: gradual rollout
+# Teapot admission controller
 teapot_admission_controller_default_cpu_request: "25m"
 teapot_admission_controller_default_memory_request: "100Mi"
 teapot_admission_controller_process_resources: "false"
@@ -171,13 +171,8 @@ teapot_admission_controller_validate_application_label: "false"
 teapot_admission_controller_application_min_creation_time: "2999-12-31T23:59:59Z"
 
 {{if eq .Environment "e2e"}}
-teapot_admission_controller_enabled: "true"
 teapot_admission_controller_ignore_namespaces: "^kube-system|(e2e-tests-(downward-api|kubectl|projected|statefulset)-.*)$"
-{{else if eq .Environment "production"}}
-teapot_admission_controller_enabled: "false"
-teapot_admission_controller_ignore_namespaces: "^kube-system$"
 {{else}}
-teapot_admission_controller_enabled: "true"
 teapot_admission_controller_ignore_namespaces: "^kube-system$"
 {{end}}
 

--- a/cluster/manifests/admission-control/teapot.yaml
+++ b/cluster/manifests/admission-control/teapot.yaml
@@ -1,4 +1,3 @@
-{{ if eq .ConfigItems.teapot_admission_controller_enabled "true" }}
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -86,4 +85,3 @@ webhooks:
         apiGroups: ["apps"]
         apiVersions: ["v1", "v1beta2", "v1beta1"]
         resources: ["statefulsets"]
-{{ end }}


### PR DESCRIPTION
It hasn't caused any issues so far, and we have to enable it for compliance checks anyway.