### PR TITLE
Add a feature toggle for disabling kube-job-cleaner

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -196,6 +196,9 @@ coreos_image: "ami-012abdf0d2781f0a5" # Container Linux 2023.5.0 (HVM, eu-centra
 # Feature toggle to allow gradual decommissioning of ingress-template-controller
 enable_ingress_template_controller: "false"
 
+# Feature toggle to allow decommissioning of kube-job-cleaner
+kube_job_cleaner_enabled: "true"
+
 # Temporary feature toggle for the new daemonset scheduler
 {{if eq .Environment "e2e"}}
 experimental_schedule_daemonset_pods: "true"

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -8,6 +8,11 @@ post_apply:
   namespace: default
   kind: LimitRange
 {{ end }}
+{{ if ne .Cluster.ConfigItems.kube_job_cleaner_enabled "true" }}
+- name: kube-job-cleaner
+  namespace: kube-system
+  kind: CronJob
+{{ end }}
 {{ if ne .ConfigItems.enable_ingress_template_controller "true" }}
 - name: ingresstemplates.zalando.org
   kind: CustomResourceDefinition

--- a/cluster/manifests/kube-job-cleaner/cronjob.yaml
+++ b/cluster/manifests/kube-job-cleaner/cronjob.yaml
@@ -1,3 +1,4 @@
+{{ if eq .Cluster.ConfigItems.kube_job_cleaner_enabled "true" }}
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
@@ -37,3 +38,4 @@ spec:
               requests:
                 cpu: 100m
                 memory: 100Mi
+{{ end }}


### PR DESCRIPTION
It's most likely no longer needed with the admission hook we added for Jobs, so let's try removing it.