### PR TITLE
Add VPA to kube-state-metrics

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -127,6 +127,9 @@ metrics_service_cpu: "100m"
 metrics_service_mem: "200Mi"
 metrics_service_mem_max: "1Gi"
 
+kube_state_metrics_cpu: "100m"
+kube_state_metrics_mem: "200Mi"
+kube_state_metrics_mem_max: "1Gi"
 
 # Kubernetes Downscaler (for non-production clusters)
 {{if eq .Environment "test"}}

--- a/cluster/manifests/kube-state-metrics/deployment.yaml
+++ b/cluster/manifests/kube-state-metrics/deployment.yaml
@@ -33,8 +33,8 @@ spec:
         - --port=8080
         resources:
           limits:
-            cpu: 300m
-            memory: 300Mi
+            cpu: "{{.ConfigItems.kube_state_metrics_cpu}}"
+            memory: "{{.ConfigItems.kube_state_metrics_mem}}"
           requests:
-            cpu: 300m
-            memory: 300Mi
+            cpu: "{{.ConfigItems.kube_state_metrics_cpu}}"
+            memory: "{{.ConfigItems.kube_state_metrics_mem}}"

--- a/cluster/manifests/kube-state-metrics/vpa.yaml
+++ b/cluster/manifests/kube-state-metrics/vpa.yaml
@@ -1,0 +1,17 @@
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: kube-state-metrics
+  namespace: kube-system
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: kube-state-metrics
+  updatePolicy:
+    updateMode: "Auto"
+  resourcePolicy:
+    containerPolicies:
+    - containerName: kube-state-metrics
+      maxAllowed:
+        memory: {{.ConfigItems.kube_state_metrics_mem_max}}


### PR DESCRIPTION
Adds VPA to [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) which is crashing with the default resource setting in big clusters like `search`.