### PR TITLE
Drop pod quotas in 'default' and 'kube-system'

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -3,6 +3,12 @@ pre_apply: []
 
 # everything defined under here will be deleted after applying the manifests
 post_apply:
+- name: compute-resources
+  namespace: default
+  kind: ResourceQuota
+- name: compute-resources
+  namespace: kube-system
+  kind: ResourceQuota
 {{ if eq .ConfigItems.teapot_admission_controller_process_resources "true" }}
 - name: limits
   namespace: default

--- a/cluster/manifests/quota/resource_quota.yaml
+++ b/cluster/manifests/quota/resource_quota.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ResourceQuota
-metadata:
-  name: compute-resources
-spec:
-  hard:
-    pods: "1500"

--- a/cluster/manifests/quota/resource_quota_kubesystem.yaml
+++ b/cluster/manifests/quota/resource_quota_kubesystem.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: ResourceQuota
-metadata:
-  namespace: kube-system
-  name: compute-resources
-spec:
-  hard:
-    pods: "1500"


### PR DESCRIPTION
Drops the `1500` limit pod quotas from `default` and `kube-system` namespace. These quotas was put in place long ago to protect the API server against broken cronjobs. This is no longer an issue as cronjob behavior has been fixed upstream and the therefore don't provide a meaningful value.
The quotas are rather causing problems for big clusters with more that `1500` pods in `kube-system` namespace so drop them to avoid that.