### PR TITLE
Allow updating kube-node-ready/kube-proxy

### DIFF
--- a/cluster/manifests/kube-node-ready/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     version: {{$version}}
 spec:
   updateStrategy:
-    type: OnDelete
+    type: RollingUpdate
   selector:
     matchLabels:
       application: kube-node-ready

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -11,7 +11,7 @@ spec:
     matchLabels:
       application: kube-proxy
   updateStrategy:
-    type: OnDelete
+    type: RollingUpdate
   template:
     metadata:
       name: kube-proxy


### PR DESCRIPTION
We're probably not going to change their resource requirements any time soon, so `OnDelete` is no longer necessary.