### PR TITLE
Disable --configure-cloud-routes

### DIFF
--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -570,6 +570,7 @@ storage:
             - --feature-gates=TaintBasedEvictions=true,TaintNodesByCondition={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},ScheduleDaemonSetPods={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},TTLAfterFinished=true
             - --horizontal-pod-autoscaler-use-rest-clients=true
             - --use-service-account-credentials=true
+            - --configure-cloud-routes=false
             - --allocate-node-cidrs=true
             - --cluster-cidr=10.2.0.0/16
             - --horizontal-pod-autoscaler-use-rest-clients=true


### PR DESCRIPTION
We don't use them anyway, and this performs a lot of calls so we get rate limited.