### PR TITLE
Reduce terminated-pod-gc-threshold to 500

### DIFF
--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -572,6 +572,7 @@ storage:
             - --use-service-account-credentials=true
             - --allocate-node-cidrs=true
             - --cluster-cidr=10.2.0.0/16
+            - --terminated-pod-gc-threshold=500
             - --horizontal-pod-autoscaler-use-rest-clients=true
             - --horizontal-pod-autoscaler-downscale-delay={{ .Cluster.ConfigItems.horizontal_pod_autoscaler_downscale_delay }}
             - --horizontal-pod-autoscaler-sync-period={{ .Cluster.ConfigItems.horizontal_pod_autoscaler_sync_period }}


### PR DESCRIPTION
The default is 12500 which is way too high. Keeping just 500 recently terminated pods is more than enough.