### PR TITLE
hotfix audit events

### DIFF
--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -360,6 +360,7 @@ storage:
             {{ if or (eq .Cluster.Environment "production") (index .Cluster.ConfigItems "audittrail_url") }}
             - --audit-webhook-config-file=/etc/kubernetes/config/audit.yaml
             - --audit-webhook-mode=batch
+            - --audit-webhook-version=audit.k8s.io/v1beta1
             - --audit-policy-file=/etc/kubernetes/config/audit-policy.yaml
             {{ end }}
             {{ if eq .Cluster.Environment "e2e" }}


### PR DESCRIPTION
hotfix audit events, because our tool does not support audit.k8s.io/v1 which were introduced in https://github.com/kubernetes/kubernetes/pull/70476

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>