### PR TITLE
Make it possible to configure max-pods and node-cidr-mask-size per cluster

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -206,3 +206,17 @@ experimental_schedule_daemonset_pods: "false"
 
 # Feature toggle for auditing events
 audit_pod_events: "true"
+
+# CIDR configuration for nodes and pods
+# Changing this will change the number of nodes and pods we can schedule in the
+# cluster
+# The two flags should be changed together to have the right balance between
+# available pod IP addresses per node and maximum pods per node. Roughly the
+# double amount of IP addresses should be available.
+# https://cloud.google.com/kubernetes-engine/docs/how-to/flexible-pod-cidr
+# flag passed to kubelet
+# TODO: pass this flag to worker kublets (will do it with 1.13 to prevent extra
+# rolling of nodes)
+node_max_pods: "110" # Default: 110
+# flag passed to controller-manager
+node_cidr_mask_size: "24" # Default: 24

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -207,6 +207,7 @@ systemd:
       --pod-manifest-path=/etc/kubernetes/manifests \
       --cluster-dns=${PRIVATE_EC2_IPV4} \
       --cluster-domain=cluster.local \
+      --max-pods={{ .Cluster.ConfigItems.node_max_pods }} \
       --kubeconfig=/etc/kubernetes/kubeconfig \
       --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
       --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \
@@ -574,6 +575,7 @@ storage:
             - --configure-cloud-routes=false
             - --allocate-node-cidrs=true
             - --cluster-cidr=10.2.0.0/16
+            - --node-cidr-mask-size={{ .Cluster.ConfigItems.node_cidr_mask_size }}
             - --terminated-pod-gc-threshold=500
             - --horizontal-pod-autoscaler-use-rest-clients=true
             - --horizontal-pod-autoscaler-downscale-delay={{ .Cluster.ConfigItems.horizontal_pod_autoscaler_downscale_delay }}


### PR DESCRIPTION
This enables us to change the configuration per cluster.

We want to change the configuration because the current settings limits us to `256` nodes when each node has a `/24`. Setting this to `/25` would allow around `~510` nodes at the cost of limiting the number of pods per node to `~62`.

Note I didn't pass the `max-pods` flag for the worker kubelet to prevent another rolling upgrade. Will add this to the v1.13 branch.