### PR TITLE
add lifo filters to all routes 

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -26,7 +26,7 @@ skipper_ingress_memory: "500Mi"
 skipper_ingress_tracing_buffer: "16384"
 
 # skipper default filters
-skipper_default_filters: enableAccessLog(4,5) -> lifo(100, 100, "10s")
+skipper_default_filters: "enableAccessLog(4,5) -> lifo(1000, 1000, \"10s\")"
 
 # skipper backend timeout defaults
 skipper_expect_continue_timeout_backend: "30s"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -25,6 +25,9 @@ skipper_ingress_cpu: "500m"
 skipper_ingress_memory: "500Mi"
 skipper_ingress_tracing_buffer: "16384"
 
+# skipper default filters
+skipper_default_filters: enableAccessLog(4,5) -> lifo(100, 100, "10s")
+
 # skipper backend timeout defaults
 skipper_expect_continue_timeout_backend: "30s"
 skipper_keepalive_backend: "30s"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -26,7 +26,7 @@ skipper_ingress_memory: "500Mi"
 skipper_ingress_tracing_buffer: "16384"
 
 # skipper default filters
-skipper_default_filters: 'enableAccessLog(4,5) -> lifo(1000, 1000, "10s")'
+skipper_default_filters: 'enableAccessLog(4,5) -> lifo(2000,20000,"10s")'
 
 # skipper backend timeout defaults
 skipper_expect_continue_timeout_backend: "30s"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -26,7 +26,7 @@ skipper_ingress_memory: "500Mi"
 skipper_ingress_tracing_buffer: "16384"
 
 # skipper default filters
-skipper_default_filters: "enableAccessLog(4,5) -> lifo(1000, 1000, \"10s\")"
+skipper_default_filters: 'enableAccessLog(4,5) -> lifo(1000, 1000, "10s")'
 
 # skipper backend timeout defaults
 skipper_expect_continue_timeout_backend: "30s"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -96,7 +96,7 @@ spec:
           - "-response-header-timeout-backend={{ .ConfigItems.skipper_response_header_timeout_backend }}"
           - "-timeout-backend={{ .ConfigItems.skipper_timeout_backend }}"
           - "-tls-timeout-backend={{ .ConfigItems.skipper_tls_timeout_backend }}"
-          - "-default-filters-prepend={{ .ConfigItems.skipper_default_filters }}"
+          - '-default-filters-prepend={{ .ConfigItems.skipper_default_filters }}'
         resources:
           limits:
             cpu: "{{ .ConfigItems.skipper_ingress_cpu }}"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -96,7 +96,7 @@ spec:
           - "-response-header-timeout-backend={{ .ConfigItems.skipper_response_header_timeout_backend }}"
           - "-timeout-backend={{ .ConfigItems.skipper_timeout_backend }}"
           - "-tls-timeout-backend={{ .ConfigItems.skipper_tls_timeout_backend }}"
-          - "-default-filters-prepend=enableAccessLog(4,5)"
+          - "-default-filters-prepend={{ .ConfigItems.skipper_default_filters }}"
         resources:
           limits:
             cpu: "{{ .ConfigItems.skipper_ingress_cpu }}"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.10.203
+    version: v0.10.210
     component: ingress
 spec:
   strategy:
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.10.203
+        version: v0.10.210
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -42,7 +42,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.203
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.210
         ports:
         - name: ingress-port
           containerPort: 9999


### PR DESCRIPTION
Add preconfigured default lifo filters to all routes. This will omit memory spikes and cluster ingress downtime, caused by one or a few failing routes.

## load test data

- 1 ingress that targets a deployment with high latency
- 1 ingress that targets a deployment without additional latency

The 2 data paths should not affect the shared infrastructure and should not be visible in the latency of the "good application" ingress metrics.

### skipper-ingress cluster overview

![image](https://user-images.githubusercontent.com/50872/57285953-9653a880-70b4-11e9-9177-37c05ebcacb2.png)
![image](https://user-images.githubusercontent.com/50872/57286009-b2efe080-70b4-11e9-8830-eb498ab9e6cf.png)

### application targets

traffic without latency should not be affected
![image](https://user-images.githubusercontent.com/50872/57286099-e03c8e80-70b4-11e9-90ce-22f3671ea926.png)

high latency, leading to timeouts
![image](https://user-images.githubusercontent.com/50872/57286163-fd715d00-70b4-11e9-9898-20474c757b66.png)


Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>