### PR TITLE
Make max-pods configurable on worker nodes

### DIFF
--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -216,6 +216,7 @@ systemd:
       --node-labels={{ .Values.node_labels }} \
       --cluster-dns=${PRIVATE_EC2_IPV4} \
       --cluster-domain=cluster.local \
+      --max-pods={{ .Cluster.ConfigItems.node_max_pods }} \
       --kubeconfig=/etc/kubernetes/kubeconfig \
       --healthz-bind-address=0.0.0.0 \
       --healthz-port=10248 \


### PR DESCRIPTION
Follow up to #2090 for worker nodes. Rolling out with v1.13 to reduce number of times we roll nodes.