### PR TITLE
Disabling kube-job-cleaner in test clusters

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -199,7 +199,11 @@ coreos_image: "ami-012abdf0d2781f0a5" # Container Linux 2023.5.0 (HVM, eu-centra
 enable_ingress_template_controller: "false"
 
 # Feature toggle to allow decommissioning of kube-job-cleaner
+{{if eq .Environment "test"}}
+kube_job_cleaner_enabled: "false"
+{{else}}
 kube_job_cleaner_enabled: "true"
+{{end}}
 
 # Temporary feature toggle for the new daemonset scheduler
 {{if eq .Environment "e2e"}}


### PR DESCRIPTION
Since we have a lower limit for "terminated-pod-gc" now we can get rid
of the kube-job-cleaner

Signed-off-by: Muhammad Muaaz Saleem <muhammad.muaaz.saleem@zalando.de>