### PR TITLE
Enable no overcommit enforcement by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -178,7 +178,7 @@ teapot_admission_controller_validate_application_label: "false"
 teapot_admission_controller_application_min_creation_time: "2999-12-31T23:59:59Z"
 
 {{if eq .Environment "e2e"}}
-teapot_admission_controller_ignore_namespaces: "^kube-system|(e2e-tests-(downward-api|kubectl|projected|statefulset)-.*)$"
+teapot_admission_controller_ignore_namespaces: "^kube-system|(e2e-tests-(downward-api|kubectl|projected|statefulset|pod-network)-.*)$"
 {{else}}
 teapot_admission_controller_ignore_namespaces: "^kube-system$"
 {{end}}

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -173,7 +173,7 @@ experimental_cluster_lifecycle_controller: "false"
 # Teapot admission controller
 teapot_admission_controller_default_cpu_request: "25m"
 teapot_admission_controller_default_memory_request: "100Mi"
-teapot_admission_controller_process_resources: "false"
+teapot_admission_controller_process_resources: "true"
 teapot_admission_controller_validate_application_label: "false"
 teapot_admission_controller_application_min_creation_time: "2999-12-31T23:59:59Z"
 


### PR DESCRIPTION
Enable no-overcommit by default.

## TODO

* [x] Set `teapot_admission_controller_process_resources: "false"` for all cluster currently not ready for this.