### PR TITLE
Update pdb-controller to v0.0.9

### DIFF
--- a/cluster/manifests/pdb-controller/deployment.yaml
+++ b/cluster/manifests/pdb-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: pdb-controller
-    version: v0.0.8
+    version: v0.0.9
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: pdb-controller
-        version: v0.0.8
+        version: v0.0.9
     spec:
       dnsConfig:
         options:
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: system
       containers:
       - name: pdb-controller
-        image: registry.opensource.zalan.do/teapot/pdb-controller:v0.0.8
+        image: registry.opensource.zalan.do/teapot/pdb-controller:v0.0.9
         args:
         - --debug
         {{ if or (index .ConfigItems "pdb_non_ready_ttl") (eq .Environment "test") }}

--- a/cluster/manifests/prometheus/statefulset.yaml
+++ b/cluster/manifests/prometheus/statefulset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations:
+    pdb-controller.zalando.org/non-ready-ttl: "5m"
   labels:
     application: prometheus
     version: v2.9.2


### PR DESCRIPTION
Updates the pdb-controller to v0.0.9 which allows setting an annotation on deployments to remove the PDB if the pods of a deployment/statefulset is not getting ready.

Set the value for `5m` for prometheus as I think this is a reasonable time for when the pdb should be removed, such that the VPA can recover Prometheus.

[All changes since v0.0.8](https://github.com/mikkeloscar/pdb-controller/compare/v0.0.8...v0.0.9)