### PR TITLE
Update log-watcher version to activate JWT redaction

### DIFF
--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     application: logging-agent
-    version: v0.26
+    version: v0.27
     component: logging
 spec:
   selector:
@@ -19,7 +19,7 @@ spec:
       name: logging-agent
       labels:
         application: logging-agent
-        version: v0.26
+        version: v0.27
         component: logging
       annotations:
         iam.amazonaws.com/role: {{.LocalID}}-app-logging-agent
@@ -83,7 +83,7 @@ spec:
           mountPath: /mnt/scalyr-checkpoint
       containers:
       - name: log-watcher
-        image: registry.opensource.zalan.do/logging/kubernetes-log-watcher:0.26
+        image: registry.opensource.zalan.do/logging/kubernetes-log-watcher:0.27
         env:
         - name: CLUSTER_NODE_NAME
           valueFrom:


### PR DESCRIPTION
Update the version of the `kubernetes-log-watcher` in the
`logging-agent` DeamonSet to version 0.27.

This version automatically adds Scalyr redaction rules to the
configuration of each container, which redact JWT tokens from logs.

See zalando-incubator/kubernetes-log-watcher#82