### PR TITLE
Update kube2iam to v0.10.7

### DIFF
--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube2iam
-    version: master-6
+    version: 0.10.7
 spec:
   updateStrategy:
     type: OnDelete
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         application: kube2iam
-        version: master-6
+        version: 0.10.7
     spec:
       dnsConfig:
         options:
@@ -33,8 +33,7 @@ spec:
         effect: NoExecute
       hostNetwork: true
       containers:
-      # kube2iam 0.9.0 with these patchs https://github.com/jtblin/kube2iam/pull/108, https://github.com/jtblin/kube2iam/pull/130
-      - image: registry.opensource.zalan.do/teapot/kube2iam:master-6
+      - image: registry.opensource.zalan.do/teapot/kube2iam:0.10.7
         name: kube2iam
         args:
         - --auto-discover-base-arn


### PR DESCRIPTION
This switches `kube2iam` to use the official image from dockerhub (mirrored to pierone).
Previously, we relied on a fork that included two open PRs in the upstream repo. Those PRs have been merged meanwhile.

List of changes with `0.10.x`:
* none
  * i.e.: refactorings or features we don't use
  * `--node-name` flag that was already present in the fork
