### PR TITLE
kube-metrics-adapter: Reduce default CPU and add VPA

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -43,10 +43,10 @@ spec:
         {{ end }}
         resources:
           limits:
-            cpu: 100m
+            cpu: 10m
             memory: 100Mi
           requests:
-            cpu: 100m
+            cpu: 10m
             memory: 100Mi
       {{ if eq .Environment "production" }}
       volumes:

--- a/cluster/manifests/kube-metrics-adapter/vpa.yaml
+++ b/cluster/manifests/kube-metrics-adapter/vpa.yaml
@@ -1,0 +1,17 @@
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: kube-metrics-adapter
+  namespace: kube-system
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: kube-metrics-adapter
+  updatePolicy:
+    updateMode: Auto
+  resourcePolicy:
+    containerPolicies:
+    - containerName: kube-metrics-adapter
+      maxAllowed:
+        memory: 200Mi


### PR DESCRIPTION
The `kube-metrics-adapter` consistenly uses less than the requested resources across all clusters.

* Reduce default CPU to `10m` (avg usage last 7 days is `1m` with a few spikes to `~60m`).
* Add VPA to allow using less Memory.

CPU last 7 days:

![image](https://user-images.githubusercontent.com/128566/57587216-d1653a00-7501-11e9-8ec4-1a617e64b4a7.png)


Memory last 7 days:

![image](https://user-images.githubusercontent.com/128566/57587207-b85c8900-7501-11e9-839a-6c9bccc45b60.png)


