### PR TITLE
skipper: disable lifo by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -26,7 +26,7 @@ skipper_ingress_memory: "500Mi"
 skipper_ingress_tracing_buffer: "8192"
 
 # skipper default filters
-skipper_default_filters: 'enableAccessLog(4,5) -> lifo(2000,20000,"10s")'
+skipper_default_filters: 'enableAccessLog(4,5)'
 
 # skipper backend timeout defaults
 skipper_expect_continue_timeout_backend: "30s"


### PR DESCRIPTION
There are issues with downscaled services, so let's disable it for now.