### PR TITLE
Secure kubelet port with authentication/authorization

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -235,6 +235,17 @@ Resources:
           Value: owned
       ToPort: 10255
     Type: 'AWS::EC2::SecurityGroupIngress'
+  MasterSecurityGroupIngressFromWorkerToMasterKubelet:
+    Properties:
+      FromPort: 10250
+      GroupId: !Ref MasterSecurityGroup
+      IpProtocol: tcp
+      SourceSecurityGroupId: !Ref WorkerSecurityGroup
+      Tags:
+        - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
+          Value: owned
+      ToPort: 10250
+    Type: 'AWS::EC2::SecurityGroupIngress'
   WorkerIAMRole:
     Properties:
       AssumeRolePolicyDocument:
@@ -334,6 +345,10 @@ Resources:
           IpProtocol: tcp
           ToPort: 10255
         - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+          FromPort: 10250
+          IpProtocol: tcp
+          ToPort: 10250
+        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
           FromPort: 30000
           IpProtocol: tcp
           ToPort: 32767
@@ -404,6 +419,17 @@ Resources:
         - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
           Value: owned
       ToPort: 10255
+    Type: 'AWS::EC2::SecurityGroupIngress'
+  WorkerSecurityGroupIngressFromWorkerToWorkerKubelet:
+    Properties:
+      FromPort: 10250
+      GroupId: !Ref WorkerSecurityGroup
+      IpProtocol: tcp
+      SourceSecurityGroupId: !Ref WorkerSecurityGroup
+      Tags:
+        - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
+          Value: owned
+      ToPort: 10250
     Type: 'AWS::EC2::SecurityGroupIngress'
   WorkerSecurityGroupIngressFromWorkerToWorkerSkipperMetrics:
     Properties:

--- a/cluster/manifests/metrics-server/deployment.yaml
+++ b/cluster/manifests/metrics-server/deployment.yaml
@@ -27,12 +27,6 @@ spec:
       containers:
       - name: metrics-server
         image: registry.opensource.zalan.do/teapot/metrics-server:v0.3.2
-        args:
-        # Connect to kubelet on 'completely insecure' port.
-        # We need to configure kubelet differently to be able to use the secure
-        # port 10250.
-        - --deprecated-kubelet-completely-insecure
-        - --kubelet-port=10255
         resources:
           limits:
             cpu: "{{.ConfigItems.metrics_service_cpu}}"

--- a/cluster/manifests/roles/apiserver-kubelet-binding.yaml
+++ b/cluster/manifests/roles/apiserver-kubelet-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: system:kube-apiserver
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:kubelet-api-admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: kube-apiserver-kubelet-client

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -204,25 +204,11 @@ systemd:
       --node-labels=cluster-lifecycle-controller.zalan.do/replacement-strategy=ensure-minimum-healthy-nodes \
       --node-labels=kubernetes.io/node-pool={{ .NodePool.Name }}{{if index .NodePool.ConfigItems "labels"}},{{.NodePool.ConfigItems.labels}}{{end}} \
       --node-labels={{ .Values.node_labels }} \
-      --pod-manifest-path=/etc/kubernetes/manifests \
       --cluster-dns=${PRIVATE_EC2_IPV4} \
-      --cluster-domain=cluster.local \
-      --max-pods={{ .Cluster.ConfigItems.node_max_pods }} \
       --kubeconfig=/etc/kubernetes/kubeconfig \
-      --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
-      --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \
       --cloud-provider=aws \
-      --feature-gates=TaintBasedEvictions=true,TaintNodesByCondition={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},ScheduleDaemonSetPods={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}} \
       --pod-infra-container-image=registry.opensource.zalan.do/teapot/pause-amd64:3.1 \
-{{- if not (index .Cluster.ConfigItems "enable_cfs_quota") }}
-      --cpu-cfs-quota=false \
-{{- end }}
-      --system-reserved=cpu=100m,memory=164Mi \
-      --kube-reserved=cpu=100m,memory=282Mi \
-      --client-ca-file=/etc/kubernetes/ssl/ca.pem \
-      --anonymous-auth=false \
-      --authentication-token-webhook=true \
-      --authorization-mode=Webhook
+      --config=/etc/kubernetes/config/kubelet.yaml
       ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
       Restart=always
       RestartSec=10
@@ -266,6 +252,45 @@ storage:
         - context:
             cluster: local
             user: kubelet
+
+  - filesystem: root
+    path: /etc/kubernetes/config/kubelet.yaml
+    mode: 0644
+    contents:
+      inline: |
+        # https://github.com/kubernetes/kubernetes/blob/v1.13.6/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+        apiVersion: kubelet.config.k8s.io/v1beta1
+        kind: KubeletConfiguration
+        staticPodPath: "/etc/kubernetes/manifests"
+        clusterDomain: cluster.local
+{{- if not (index .Cluster.ConfigItems "enable_cfs_quota") }}
+        cpuCFSQuota: false
+{{- end }}
+        maxPods: {{ .Cluster.ConfigItems.node_max_pods }}
+        healthzPort: 10248
+        healthzBindAddress: "0.0.0.0"
+        tlsCertFile: "/etc/kubernetes/ssl/worker.pem"
+        tlsPrivateKeyFile: "/etc/kubernetes/ssl/worker-key.pem"
+        systemReserved:
+          cpu: "100m"
+          memory: "164Mi"
+        kubeReserved:
+          cpu: "100m"
+          memory: "282Mi"
+        authentication:
+          anonymous:
+            enabled: false
+          webhook:
+            enabled: true
+            cacheTTL: "2m"
+          x509:
+            clientCAFile: "/etc/kubernetes/ssl/ca.pem"
+        authorization:
+          mode: Webhook
+          webhook:
+            cacheAuthorizedTTL: "5m"
+            cacheUnauthorizedTTL: "30s"
+        readOnlyPort: 10255 # TODO: remove after complete rollout of webhook auth
 
   - filesystem: root
     path: /etc/kubernetes/config/authn.yaml
@@ -360,7 +385,7 @@ storage:
             - --authorization-mode=Webhook,RBAC
             - --authorization-webhook-config-file=/etc/kubernetes/config/authz.yaml
             - --admission-control-config-file=/etc/kubernetes/config/image-policy-webhook.yaml
-            - --feature-gates=TaintBasedEvictions=true,TaintNodesByCondition={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},ScheduleDaemonSetPods={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},TTLAfterFinished=true
+            - --feature-gates=TaintNodesByCondition={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},ScheduleDaemonSetPods={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},TTLAfterFinished=true
             - --anonymous-auth=false
             {{ if or (eq .Cluster.Environment "production") (index .Cluster.ConfigItems "audittrail_url") }}
             - --audit-webhook-config-file=/etc/kubernetes/config/audit.yaml
@@ -577,7 +602,7 @@ storage:
             - --root-ca-file=/etc/kubernetes/ssl/ca.pem
             - --cloud-provider=aws
             - --cloud-config=/etc/kubernetes/cloud-config.ini
-            - --feature-gates=TaintBasedEvictions=true,TaintNodesByCondition={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},ScheduleDaemonSetPods={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},TTLAfterFinished=true
+            - --feature-gates=TaintNodesByCondition={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},ScheduleDaemonSetPods={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},TTLAfterFinished=true
             - --horizontal-pod-autoscaler-use-rest-clients=true
             - --use-service-account-credentials=true
             - --configure-cloud-routes=false

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -218,7 +218,11 @@ systemd:
       --cpu-cfs-quota=false \
 {{- end }}
       --system-reserved=cpu=100m,memory=164Mi \
-      --kube-reserved=cpu=100m,memory=282Mi
+      --kube-reserved=cpu=100m,memory=282Mi \
+      --client-ca-file=/etc/kubernetes/ssl/ca.pem \
+      --anonymous-auth=false \
+      --authentication-token-webhook=true \
+      --authorization-mode=Webhook
       ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
       Restart=always
       RestartSec=10
@@ -379,6 +383,10 @@ storage:
             - --requestheader-username-headers=X-Remote-User
             - --proxy-client-cert-file=/etc/kubernetes/ssl/proxy-client.pem
             - --proxy-client-key-file=/etc/kubernetes/ssl/proxy-client-key.pem
+            # kubelet authentication
+            - --kubelet-certificate-authority=/etc/kubernetes/ssl/ca.pem
+            - --kubelet-client-certificate=/etc/kubernetes/ssl/kubelet-client.pem
+            - --kubelet-client-key=/etc/kubernetes/ssl/kubelet-client-key.pem
             livenessProbe:
               httpGet:
                 host: 127.0.0.1
@@ -928,6 +936,20 @@ storage:
     contents:
       remote:
         url: "data:text/plain;base64,{{ .Cluster.ConfigItems.proxy_client_key }}"
+
+  - filesystem: root
+    path: /etc/kubernetes/ssl/kubelet-client.pem
+    mode: 0664
+    contents:
+      remote:
+        url: "data:text/plain;base64,{{ .Cluster.ConfigItems.kubelet_client_cert }}"
+
+  - filesystem: root
+    path: /etc/kubernetes/ssl/kubelet-client-key.pem
+    mode: 0664
+    contents:
+      remote:
+        url: "data:text/plain;base64,{{ .Cluster.ConfigItems.kubelet_client_key }}"
 
   - filesystem: root
     path: /etc/kubernetes/ssl/admission-controller.pem

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -939,14 +939,14 @@ storage:
     mode: 0664
     contents:
       remote:
-        url: "data:text/plain;base64,{{ .Cluster.ConfigItems.worker_cert_decompressed }}"
+        url: "data:text/plain;base64,{{ .Cluster.ConfigItems.worker_cert }}"
 
   - filesystem: root
     path: /etc/kubernetes/ssl/worker-key.pem
     mode: 0664
     contents:
       remote:
-        url: "data:text/plain;base64,{{ .Cluster.ConfigItems.worker_key_decompressed }}"
+        url: "data:text/plain;base64,{{ .Cluster.ConfigItems.worker_key }}"
 
   - filesystem: root
     path: /etc/kubernetes/ssl/proxy-client.pem

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -340,14 +340,14 @@ storage:
     mode: 0664
     contents:
       remote:
-        url: "data:text/plain;base64,{{ .Cluster.ConfigItems.worker_cert_decompressed }}"
+        url: "data:text/plain;base64,{{ .Cluster.ConfigItems.worker_cert }}"
 
   - filesystem: root
     path: /etc/kubernetes/ssl/worker-key.pem
     mode: 0664
     contents:
       remote:
-        url: "data:text/plain;base64,{{ .Cluster.ConfigItems.worker_key_decompressed }}"
+        url: "data:text/plain;base64,{{ .Cluster.ConfigItems.worker_key }}"
 
   - filesystem: root
     path: /etc/kubernetes/ssl/ca.pem

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -229,7 +229,11 @@ systemd:
       --cpu-cfs-quota=false \
 {{- end }}
       --system-reserved=cpu=100m,memory=164Mi \
-      --kube-reserved=cpu=100m,memory=282Mi
+      --kube-reserved=cpu=100m,memory=282Mi \
+      --client-ca-file=/etc/kubernetes/ssl/ca.pem \
+      --anonymous-auth=false \
+      --authentication-token-webhook=true \
+      --authorization-mode=Webhook
       ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
       Restart=always
       RestartSec=10

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -215,25 +215,10 @@ systemd:
 {{- end }}
       --node-labels={{ .Values.node_labels }} \
       --cluster-dns=${PRIVATE_EC2_IPV4} \
-      --cluster-domain=cluster.local \
-      --max-pods={{ .Cluster.ConfigItems.node_max_pods }} \
       --kubeconfig=/etc/kubernetes/kubeconfig \
-      --healthz-bind-address=0.0.0.0 \
-      --healthz-port=10248 \
-      --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
-      --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \
       --cloud-provider=aws \
-      --feature-gates=TaintBasedEvictions=true \
       --pod-infra-container-image=registry.opensource.zalan.do/teapot/pause-amd64:3.1 \
-{{- if not (index .Cluster.ConfigItems "enable_cfs_quota") }}
-      --cpu-cfs-quota=false \
-{{- end }}
-      --system-reserved=cpu=100m,memory=164Mi \
-      --kube-reserved=cpu=100m,memory=282Mi \
-      --client-ca-file=/etc/kubernetes/ssl/ca.pem \
-      --anonymous-auth=false \
-      --authentication-token-webhook=true \
-      --authorization-mode=Webhook
+      --config=/etc/kubernetes/config/kubelet.yaml
       ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
       Restart=always
       RestartSec=10
@@ -303,6 +288,44 @@ storage:
             user: kubelet
           name: kubelet-context
         current-context: kubelet-context
+
+  - filesystem: root
+    path: /etc/kubernetes/config/kubelet.yaml
+    mode: 0644
+    contents:
+      inline: |
+        # https://github.com/kubernetes/kubernetes/blob/v1.13.6/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+        apiVersion: kubelet.config.k8s.io/v1beta1
+        kind: KubeletConfiguration
+        clusterDomain: cluster.local
+{{- if not (index .Cluster.ConfigItems "enable_cfs_quota") }}
+        cpuCFSQuota: false
+{{- end }}
+        maxPods: {{ .Cluster.ConfigItems.node_max_pods }}
+        healthzPort: 10248
+        healthzBindAddress: "0.0.0.0"
+        tlsCertFile: "/etc/kubernetes/ssl/worker.pem"
+        tlsPrivateKeyFile: "/etc/kubernetes/ssl/worker-key.pem"
+        systemReserved:
+          cpu: "100m"
+          memory: "164Mi"
+        kubeReserved:
+          cpu: "100m"
+          memory: "282Mi"
+        authentication:
+          anonymous:
+            enabled: false
+          webhook:
+            enabled: true
+            cacheTTL: "2m"
+          x509:
+            clientCAFile: "/etc/kubernetes/ssl/ca.pem"
+        authorization:
+          mode: Webhook
+          webhook:
+            cacheAuthorizedTTL: "5m"
+            cacheUnauthorizedTTL: "30s"
+        readOnlyPort: 10255 # TODO: remove after complete rollout of webhook auth
 
   - filesystem: root
     path: /etc/kubernetes/cni/docker_opts_cni.env

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -26,8 +26,8 @@ clusters:
     ca_cert_decompressed: ${CA_CERT}
     apiserver_key_decompressed: ${APISERVER_KEY}
     apiserver_cert_decompressed: ${APISERVER_CERT}
-    worker_key_decompressed: ${WORKER_KEY}
-    worker_cert_decompressed: ${WORKER_CERT}
+    worker_key: ${WORKER_KEY}
+    worker_cert: ${WORKER_CERT}
     proxy_client_key: ${PROXY_CLIENT_KEY}
     proxy_client_cert: ${PROXY_CLIENT_CERT}
     kubelet_client_key: ${KUBELET_CLIENT_KEY}

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -30,6 +30,8 @@ clusters:
     worker_cert_decompressed: ${WORKER_CERT}
     proxy_client_key: ${PROXY_CLIENT_KEY}
     proxy_client_cert: ${PROXY_CLIENT_CERT}
+    kubelet_client_key: ${KUBELET_CLIENT_KEY}
+    kubelet_client_cert: ${KUBELET_CLIENT_CERT}
     admission_controller_cert: ${ADMISSION_CONTROLLER_CERT}
     admission_controller_key: ${ADMISSION_CONTROLLER_KEY}
     vpa_webhook_key: ${VPA_WEBHOOK_KEY}


### PR DESCRIPTION
Enables authentication for the secured kubelet port such that not every use can control the kubelet. It provisions a `kubelet-client` cert on the apiserver which should provide the identity `kube-apiserver-kubelet-client` to allow the apiserver access to kubelet for `kubectl logs,exec` etc.

https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet-authentication-authorization/

This also moves the kubelet flags to a config file which is becoming the standard for configuring kubelet and allows easier migration to Dynamic kubelet config in the future.

https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/

https://kubernetes.io/docs/tasks/administer-cluster/reconfigure-kubelet/

## TODO:

* [x] Provision `kubelet-client` cert/key for e2e (internal PR)
* [x] Provision `kubelet-client` cert/key for all clusters
* [x] ~Figure out how to handle rollout for `metrics-server` (How can it work for both old and new kubelets?)~ During the rollout it will work fine going to the readOnly port, and after everything is upgraded it will go to the secured port.
* [x] Roll out valid worker certificates