### PR TITLE
external-dns v0.5.14

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: external-dns
-    version: v0.5.12
+    version: v0.5.14
 spec:
   strategy:
     type: Recreate
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: external-dns
-        version: v0.5.12
+        version: v0.5.14
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
     spec:
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.5.12
+        image: pierone.stups.zalan.do/teapot/external-dns:v0.5.14
         args:
         - --source=service
         - --source=ingress


### PR DESCRIPTION
Registry had to be changed in order to satisfy compliance checker.

Major changes:

* Cache the endpoints on the controller loop
* Streamline ApplyChanges

which reduces the number of calls to AWS.

List of all changes:
* https://github.com/kubernetes-incubator/external-dns/releases/tag/v0.5.14
* https://github.com/kubernetes-incubator/external-dns/releases/tag/v0.5.13