### PR TITLE
parameterize idle-timeout-server

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -36,6 +36,7 @@ skipper_response_header_timeout_backend: "1m"
 skipper_timeout_backend: "1m"
 skipper_tls_timeout_backend: "1m"
 skipper_close_idle_conns_period: "20s"
+skipper_idle_timeout_server: "60s"
 
 # skipper api GW features
 enable_apimonitoring: "true"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -97,6 +97,7 @@ spec:
           - "-timeout-backend={{ .ConfigItems.skipper_timeout_backend }}"
           - "-tls-timeout-backend={{ .ConfigItems.skipper_tls_timeout_backend }}"
           - "-close-idle-conns-period={{ .ConfigItems.skipper_close_idle_conns_period }}"
+          - "-idle-timeout-server={{ .ConfigItems.skipper_idle_timeout_server }}"
           - '-default-filters-prepend={{ .ConfigItems.skipper_default_filters }}'
         resources:
           limits:


### PR DESCRIPTION
set the default from skipper first and increase this in some clusters later to >60s to test if the idle conn problem disappears

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>