### PR TITLE
skipper lightstep params via config items - stable

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -51,6 +51,11 @@ enable_skipper_eastwest: "true"
 {{end}}
 
 # lightstep
+skipper_ingress_lightstep_grpc_max_msg_size: 16384000
+skipper_ingress_lightstep_min_period: "500ms"
+skipper_ingress_lightstep_max_period: "2500ms"
+# set to "log-events" to enable
+skipper_ingress_lightstep_log_events: ""
 {{if eq .Environment "production"}}
 lightstep_token: "aws:kms:AQICAHgrx06TPoR1aNmcPHJjFu5mmoICT5KJkx2fsTJpmXmbNAH+8Ml18b8ZkUO/0KAwtIZTAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMSf79AuT/RI5rvWWjAgEQgDuN7obV7JD4iBMnOJ4Th93DfM5j572dXjf+gWmHx4JKMTTJPX2w6hgfQXX3LjI49l0p479a6IXIlZJOSg=="
 {{else}}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.10.216
+    version: v0.10.220
     component: ingress
 spec:
   strategy:
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.10.216
+        version: v0.10.220
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -42,7 +42,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.216
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.220
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -89,7 +89,7 @@ spec:
 {{ end }}
           - "-oauth2-tokeninfo-url={{ .ConfigItems.tokeninfo_url }}"
           - "-histogram-metric-buckets=.0001,.00025,.0005,.00075,.001,.0025,.005,.0075,.01,.025,.05,.075,.1,.2,.3,.4,.5,.75,1,2,3,4,5,7,10,15,20,30,60,120,300,600"
-          - "-opentracing=lightstep component-name=skipper-ingress token=$(LIGHTSTEP_TOKEN) collector=tracing.stups.zalan.do:8444 cmd-line=skipper-ingress max-buffered-spans={{ .ConfigItems.skipper_ingress_tracing_buffer }} tag=cluster={{ .Cluster.Alias }}"
+          - "-opentracing=lightstep component-name=skipper-ingress token=$(LIGHTSTEP_TOKEN) collector=tracing.stups.zalan.do:8444 cmd-line=skipper-ingress max-buffered-spans={{ .ConfigItems.skipper_ingress_tracing_buffer }} tag=cluster={{ .Cluster.Alias }} grpc-max-msg-size={{ .ConfigItems.skipper_ingress_lightstep_grpc_max_msg_size }} max-period={{ .ConfigItems.skipper_ingress_lightstep_max_period }} min-period={{ .ConfigItems.skipper_ingress_lightstep_min_period }} {{ .Cluster.ConfigItems.skipper_ingress_lightstep_log_events }}"
           - "-expect-continue-timeout-backend={{ .ConfigItems.skipper_expect_continue_timeout_backend }}"
           - "-keepalive-backend={{ .ConfigItems.skipper_keepalive_backend }}"
           - "-max-idle-connection-backend={{ .ConfigItems.skipper_max_idle_connection_backend }}"


### PR DESCRIPTION
feature: set lightstep params via config items to fix ongoing problems with satellites

feature: tokeninfo/tokenintrospection AnyKV filters to support multiple same keys

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>