### PR TITLE
Kubelet: use authenticated API by default [2/3]

### DIFF
--- a/cluster/manifests/metrics-server/deployment.yaml
+++ b/cluster/manifests/metrics-server/deployment.yaml
@@ -27,12 +27,6 @@ spec:
       containers:
       - name: metrics-server
         image: registry.opensource.zalan.do/teapot/metrics-server:v0.3.2
-        args:
-        # Connect to kubelet on 'completely insecure' port.
-        # We need to configure kubelet differently to be able to use the secure
-        # port 10250.
-        - --deprecated-kubelet-completely-insecure
-        - --kubelet-port=10255
         resources:
           limits:
             cpu: "{{.ConfigItems.metrics_service_cpu}}"

--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -14,7 +14,10 @@ data:
     scrape_configs:
     # scrape from kube-apiserver pods
     - job_name: 'kubernetes-apiservers'
-      scheme: http
+      scheme: https
+      tls_config:
+        insecure_skip_verify: true
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
       kubernetes_sd_configs:
       - role: pod
         namespaces:
@@ -23,7 +26,7 @@ data:
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_label_application, __meta_kubernetes_pod_container_port_number]
         action: keep
-        regex: kube-apiserver;8082
+        regex: kube-apiserver;443
       - action: replace
         source_labels: ['__meta_kubernetes_pod_label_application']
         target_label: application
@@ -150,13 +153,17 @@ data:
         action: keep
         regex: '(container_cpu_cfs_throttled_seconds_total|container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_memory_rss|container_memory_cache|container_network_receive_bytes_total|container_network_transmit_bytes_total|container_fs_usage_bytes|container_fs_limit_bytes|container_fs_reads_bytes_total|container_fs_writes_bytes_total)'
     - job_name: 'kubelet-metrics'
+      scheme: https
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
       kubernetes_sd_configs:
       - role: node
       relabel_configs:
-      - source_labels: [__meta_kubernetes_node_address_InternalIP]
+      - source_labels: [__meta_kubernetes_node_address_Hostname]
         target_label: __address__
         regex: (.*)
-        replacement: $1:10255
+        replacement: $1:10250
       metric_relabel_configs:
        - source_labels: [ __name__ ]
          regex: 'reflector.*'

--- a/cluster/manifests/prometheus/rbac.yaml
+++ b/cluster/manifests/prometheus/rbac.yaml
@@ -1,0 +1,39 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: prometheus
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - nodes/metrics
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+- kind: ServiceAccount
+  name: prometheus
+  namespace: kube-system

--- a/cluster/manifests/prometheus/statefulset.yaml
+++ b/cluster/manifests/prometheus/statefulset.yaml
@@ -22,6 +22,7 @@ spec:
       annotations:
         config/hash: {{"configmap.yaml" | manifestHash}}
     spec:
+      serviceAccountName: prometheus
       dnsConfig:
         options:
           - name: ndots

--- a/cluster/manifests/roles/apiserver-kubelet-binding.yaml
+++ b/cluster/manifests/roles/apiserver-kubelet-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: system:kube-apiserver
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:kubelet-api-admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: kube-apiserver-kubelet-client

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -408,6 +408,10 @@ storage:
             - --requestheader-username-headers=X-Remote-User
             - --proxy-client-cert-file=/etc/kubernetes/ssl/proxy-client.pem
             - --proxy-client-key-file=/etc/kubernetes/ssl/proxy-client-key.pem
+            # kubelet authentication
+            - --kubelet-certificate-authority=/etc/kubernetes/ssl/ca.pem
+            - --kubelet-client-certificate=/etc/kubernetes/ssl/kubelet-client.pem
+            - --kubelet-client-key=/etc/kubernetes/ssl/kubelet-client-key.pem
             livenessProbe:
               httpGet:
                 host: 127.0.0.1


### PR DESCRIPTION
Update API server & metrics-server to use the secure Kubelet endpoint.

**NOTE**: do not merge until #2153 is fully rolled out.