### PR TITLE
skipper default resource adjustments and cpu hpa

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -17,12 +17,12 @@ skipper_requests_cpu: "150m"
 skipper_requests_mem: "50Mi"
 
 # skipper ingress settings
-skipper_ingress_target_average_utilization_cpu: "100"
+skipper_ingress_target_average_utilization_cpu: "90"
 skipper_ingress_target_average_utilization_memory: "80"
 skipper_ingress_max_replicas: "30"
 skipper_ingress_min_replicas: "3"
-skipper_ingress_cpu: "500m"
-skipper_ingress_memory: "500Mi"
+skipper_ingress_cpu: "1000m"
+skipper_ingress_memory: "1Gi"
 skipper_ingress_tracing_buffer: "8192"
 
 # skipper default filters


### PR DESCRIPTION
With introduction of the lifo queue, we want to be able to absorb trafficon failing backends that can harm other routes.
In this case we need to have more memory and cpu resources.
At the same time it makes sense to scale up via hpa faster and reduce the cpu scaling to 90%

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>