### PR TITLE
fix ALB 5xx caused by same idle timeouts ALB vs skipper

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -36,7 +36,7 @@ skipper_response_header_timeout_backend: "1m"
 skipper_timeout_backend: "1m"
 skipper_tls_timeout_backend: "1m"
 skipper_close_idle_conns_period: "20s"
-skipper_idle_timeout_server: "60s"
+skipper_idle_timeout_server: "62s"
 
 # skipper api GW features
 enable_apimonitoring: "true"


### PR DESCRIPTION
fix ALB 5xx caused by same server idle timeouts of skipper to client idle timeouts from alb

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>