### PR TITLE
Allow DynamoDB DAX Service on AWS-Accounts

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -581,6 +581,7 @@ Resources:
                   - 'cloudwatch:*'
                   - 'config:*'
                   - 'datapipeline:*'
+                  - 'dax:*'
                   - 'devicefarm:*'
                   - 'dynamodb:*'
                   - 'ec2:*'


### PR DESCRIPTION
DynamoDB DAX has been whitelisted so enable it for the deployment role

Internal issue: https://github.bus.zalan.do/teapot/issues/issues/1897

replaces: #2143