### PR TITLE
Add RBAC for Zalando IAM users [1/2]

### DIFF
--- a/cluster/manifests/roles/cdp-controller-rbac.yaml
+++ b/cluster/manifests/roles/cdp-controller-rbac.yaml
@@ -1,0 +1,49 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cdp-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - namespaces
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "extensions"
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cdp-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cdp-controller
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: zalando-iam:zalando:service:credprov-cdp-controller-cluster-token

--- a/cluster/manifests/roles/cluster-lifecycle-manager-binding.yaml
+++ b/cluster/manifests/roles/cluster-lifecycle-manager-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-lifecycle-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: zalando-iam:zalando:service:stups_cluster-lifecycle-manager

--- a/cluster/manifests/roles/compliance-tool-oxygen-rbac.yaml
+++ b/cluster/manifests/roles/compliance-tool-oxygen-rbac.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: compliance-db-checker-oxygen
+rules:
+- apiGroups:
+  - "acid.zalan.do"
+  resources:
+  - postgresqls
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: compliance-db-checker-oxygen
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: compliance-db-checker-oxygen
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: zalando-iam:zalando:service:stups_oxygen

--- a/cluster/manifests/roles/credentials-provider-rbac.yaml
+++ b/cluster/manifests/roles/credentials-provider-rbac.yaml
@@ -1,0 +1,40 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: credentials-provider
+rules:
+- apiGroups:
+  - "zalando.org"
+  resources:
+  - platformcredentialssets
+  - platformcredentialssets/status
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: credentials-provider
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: credentials-provider
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: zalando-iam:zalando:service:credentials-provider

--- a/cluster/manifests/roles/deployment-discovery-rbac.yaml
+++ b/cluster/manifests/roles/deployment-discovery-rbac.yaml
@@ -1,0 +1,36 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: deployment-discovery
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - endpoints
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "extensions"
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: deployment-discovery
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: deployment-discovery
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: zalando-iam:zalando:service:stups_deployment-discovery

--- a/cluster/manifests/roles/kube-resource-report-rbac.yaml
+++ b/cluster/manifests/roles/kube-resource-report-rbac.yaml
@@ -1,0 +1,32 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kube-resource-report
+rules:
+- apiGroups: [""]
+  resources: ["nodes", "pods", "namespaces", "services"]
+  verbs:
+  - get
+  - list
+- apiGroups: ["extensions"]
+  resources: ["ingresses"]
+  verbs:
+  - list
+- apiGroups: ["metrics.k8s.io"]
+  resources: ["nodes", "pods"]
+  verbs:
+  - get
+  - list
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kube-resource-report
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-resource-report
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: zalando-iam:zalando:service:stups_kube-resource-report

--- a/cluster/manifests/roles/zmon-binding.yaml
+++ b/cluster/manifests/roles/zmon-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: zmon-external
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: zalando-iam:zalando:service:stups_zmon-zmon


### PR DESCRIPTION
Replace the static mapping of Zalando IAM user to group with finer grained permissions possible with RBAC. I.e. instead of giving `credentials-provider` `Administrator` access, just give it access to Platformcredentialssets and secrets.

## Status

* [x] CLM
* [x] Credentials Provider
* [x] Reduce CDP Controller permissions from `PowerUser` to what is actually needed.
* [x] `deployment-discovery`
* [x] `stups_zmon-zmon`
* [x] `stups_kube-resource-report`
* [x] `stups_oxygen`

This change is 1/2. First we need to roll out all the RBAC roles/bindings, and then we need to change the authnz webhook to not set groups manually. I'll make another PR with the second step.