### PR TITLE
Keep files.yaml out of non-ubuntu based node pools

### DIFF
--- a/cluster/node-pools/worker-splitaz/files.yaml
+++ b/cluster/node-pools/worker-splitaz/files.yaml
@@ -1,3 +1,0 @@
-worker.pem: {{ .Cluster.ConfigItems.worker_cert }}
-worker-key.pem: {{ .Cluster.ConfigItems.worker_key }}
-ca.pem: {{ .Cluster.ConfigItems.ca_cert_decompressed }}

--- a/cluster/node-pools/worker-ubuntu-default/files.yaml
+++ b/cluster/node-pools/worker-ubuntu-default/files.yaml
@@ -1,1 +1,3 @@
-../worker-splitaz/files.yaml
+worker.pem: {{ .Cluster.ConfigItems.worker_cert }}
+worker-key.pem: {{ .Cluster.ConfigItems.worker_key }}
+ca.pem: {{ .Cluster.ConfigItems.ca_cert_decompressed }}

--- a/cluster/node-pools/worker-ubuntu-splitaz/files.yaml
+++ b/cluster/node-pools/worker-ubuntu-splitaz/files.yaml
@@ -1,1 +1,1 @@
-../worker-splitaz/files.yaml
+../worker-ubuntu-default/files.yaml


### PR DESCRIPTION
It's not used in CoreOS pools and messes with the tool that determines whether a pool needs to be updated.

/cc @aermakov-zalando 