### PR TITLE
Added separate kms keys for encryption of master and worker nodes

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1302,6 +1302,74 @@ Resources:
             Resource: "*"
             Action:
             - "kms:Decrypt"
+  MasterFilesEncryptionKey:
+    Type: "AWS::KMS::Key"
+    Properties:
+      Description: The KMS key for encryption of remote files for master nodes
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: "2012-10-17"
+        Id: "master-key-policy"
+        Statement:
+          - Sid: "Enable IAM User Permissions"
+            Effect: "Allow"
+            Principal:
+              AWS: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:root"
+            Action: "kms:*"
+            Resource: "*"
+          - Sid: "Allow encryption with the key for CLM"
+            Effect: "Allow"
+            Principal:
+              AWS: "arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/cluster-lifecycle-manager-entrypoint"
+            Action:
+            - "kms:Describe"
+            - "kms:Get*"
+            - "kms:Encrypt"
+            Resource: "*"
+          - Sid: "Enable master nodes to decrypt the remote files"
+            Effect: "Allow"
+            Principal:
+              AWS:
+                - "Fn::GetAtt":
+                  - "MasterIAMRole"
+                  - "Arn"
+            Resource: "*"
+            Action:
+            - "kms:Decrypt"
+  WorkerFilesEncryptionKey:
+    Type: "AWS::KMS::Key"
+    Properties:
+      Description: The KMS key for encryption of remote files for worker nodes
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: "2012-10-17"
+        Id: "worker-key-policy"
+        Statement:
+          - Sid: "Enable IAM User Permissions"
+            Effect: "Allow"
+            Principal:
+              AWS: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:root"
+            Action: "kms:*"
+            Resource: "*"
+          - Sid: "Allow encryption with the key for CLM"
+            Effect: "Allow"
+            Principal:
+              AWS: "arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/cluster-lifecycle-manager-entrypoint"
+            Action:
+            - "kms:Describe"
+            - "kms:Get*"
+            - "kms:Encrypt"
+            Resource: "*"
+          - Sid: "Enable worker nodes to decrypt the remote files"
+            Effect: "Allow"
+            Principal:
+              AWS:
+                - "Fn::GetAtt":
+                  - "WorkerIAMRole"
+                  - "Arn"
+            Resource: "*"
+            Action:
+            - "kms:Decrypt"
 Outputs:
   MasterIAMRole:
     Export:
@@ -1327,3 +1395,11 @@ Outputs:
     Export:
       Name: '{{ .Cluster.ID}}:remote-files-encryption-key'
     Value: !Ref RemoteFilesEncryptionKey
+  WorkerFilesEncryptionKey:
+    Export:
+      Name: '{{ .Cluster.ID}}:worker-files-encryption-key'
+    Value: !Ref WorkerFilesEncryptionKey
+  MasterFilesEncryptionKey:
+    Export:
+      Name: '{{ .Cluster.ID}}:master-files-encryption-key'
+    Value: !Ref MasterFilesEncryptionKey


### PR DESCRIPTION
Added separate keys for master and worker nodes so that worker nodes cannot decrypt files for master. Also keep the existing keys till when CLM is updated.