### PR TITLE
Enable apiserver skipper proxy by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -241,6 +241,6 @@ node_max_pods: "110" # Default: 110
 node_cidr_mask_size: "24" # Default: 24
 
 # when set to true, routes external traffic to the apiserver through a skipper sidecar
-apiserver_proxy: "false"
+apiserver_proxy: "true"
 # use kube-aws-iam-controller for kube-system components
 kube_aws_iam_controller_kube_system_enable: "false"

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -562,7 +562,7 @@ storage:
             - name: config-volume
               mountPath: /etc/nginx
           - name: skipper-proxy
-            image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.235
+            image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.243
             args:
             - skipper
             - -address=:8443

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -574,7 +574,7 @@ storage:
             - -enable-connection-metrics
             - -enable-prometheus-metrics
             - -inline-routes
-            - 'z: JWTPayloadAnyKV("iss", "kubernetes/serviceaccount") -> enableAccessLog() -> "https://127.0.0.1:443"; h: Path("/kube-system/healthz") -> setPath("/healthz") -> "http://127.0.0.1:8080"; all: * -> disableAccessLog() -> "https://127.0.0.1:443";'
+            - 'z: JWTPayloadAnyKV("iss", "kubernetes/serviceaccount") -> enableAccessLog() -> "https://127.0.0.1:443"; h: Path("/kube-system/healthz") -> setPath("/healthz") -> disableAccessLog() -> "http://127.0.0.1:8080"; all: * -> disableAccessLog() -> "https://127.0.0.1:443";'
             ports:
             - containerPort: 8443
             readinessProbe:

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -573,6 +573,7 @@ storage:
             - -runtime-metrics
             - -enable-connection-metrics
             - -enable-prometheus-metrics
+            - -write-timeout-server=60m
             - -inline-routes
             - 'z: JWTPayloadAnyKV("iss", "kubernetes/serviceaccount") -> enableAccessLog() -> "https://127.0.0.1:443"; h: Path("/kube-system/healthz") -> setPath("/healthz") -> disableAccessLog() -> "http://127.0.0.1:8080"; all: * -> disableAccessLog() -> "https://127.0.0.1:443";'
             ports:

--- a/cluster/node-pools/master-ubuntu-default/userdata.yaml
+++ b/cluster/node-pools/master-ubuntu-default/userdata.yaml
@@ -298,7 +298,7 @@ write_files:
           - name: config-volume
             mountPath: /etc/nginx
         - name: skipper-proxy
-          image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.235
+          image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.243
           args:
           - skipper
           - -address=:8443

--- a/cluster/node-pools/master-ubuntu-default/userdata.yaml
+++ b/cluster/node-pools/master-ubuntu-default/userdata.yaml
@@ -310,7 +310,7 @@ write_files:
           - -enable-connection-metrics
           - -enable-prometheus-metrics
           - -inline-routes
-          - 'z: JWTPayloadAnyKV("iss", "kubernetes/serviceaccount") -> enableAccessLog() -> "https://127.0.0.1:443"; h: Path("/kube-system/healthz") -> setPath("/healthz") -> "http://127.0.0.1:8080"; all: * -> disableAccessLog() -> "https://127.0.0.1:443";'
+          - 'z: JWTPayloadAnyKV("iss", "kubernetes/serviceaccount") -> enableAccessLog() -> "https://127.0.0.1:443"; h: Path("/kube-system/healthz") -> setPath("/healthz") -> disableAccessLog() -> "http://127.0.0.1:8080"; all: * -> disableAccessLog() -> "https://127.0.0.1:443";'
           ports:
           - containerPort: 8443
           readinessProbe:

--- a/cluster/node-pools/master-ubuntu-default/userdata.yaml
+++ b/cluster/node-pools/master-ubuntu-default/userdata.yaml
@@ -309,6 +309,7 @@ write_files:
           - -runtime-metrics
           - -enable-connection-metrics
           - -enable-prometheus-metrics
+          - -write-timeout-server=60m
           - -inline-routes
           - 'z: JWTPayloadAnyKV("iss", "kubernetes/serviceaccount") -> enableAccessLog() -> "https://127.0.0.1:443"; h: Path("/kube-system/healthz") -> setPath("/healthz") -> disableAccessLog() -> "http://127.0.0.1:8080"; all: * -> disableAccessLog() -> "https://127.0.0.1:443";'
           ports:


### PR DESCRIPTION
This enables the API server proxy by default.
* reconfigures apiserver ELB to go to another port
* changes security groups according to the new ports being used

Also:
* update skipper-proxy to a version that correctly handles watches
  * allows to watch initially empty lists often used in e2e tests
* increase timeout from skipper to clients to 60m
  * allows to `kubectl logs` up to 60 minutes. Seems like apiserver's timeout is slighly less than that.
* do not access log kube-probe requests
  * avoids distracting output