### PR TITLE
Setting prometheus max memory to max of the Node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 *.egg*
 test/e2e/e2e.test
 test/e2e_modules
+.idea

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -130,7 +130,6 @@ zmon_aws_agent_cpu: "100m"
 prometheus_cpu: "1000m"
 prometheus_mem: "4Gi"
 prometheus_mem_min: "512Mi"
-prometheus_mem_max: "10Gi"
 
 metrics_service_cpu: "100m"
 metrics_service_mem: "200Mi"

--- a/cluster/manifests/prometheus/prometheus-vpa.yaml
+++ b/cluster/manifests/prometheus/prometheus-vpa.yaml
@@ -13,7 +13,10 @@ spec:
   resourcePolicy:
     containerPolicies:
     - containerName: prometheus
+  {{ with $resources := autoscalingBufferSettings $data.Cluster }}
       minAllowed:
         memory: {{.ConfigItems.prometheus_mem_min}}
       maxAllowed:
-        memory: {{.ConfigItems.prometheus_mem_max}}
+        # Set the max memory to max available on the Node
+        memory: {{$resources.Memory}}
+  {{ end }}

--- a/cluster/manifests/prometheus/prometheus-vpa.yaml
+++ b/cluster/manifests/prometheus/prometheus-vpa.yaml
@@ -13,10 +13,10 @@ spec:
   resourcePolicy:
     containerPolicies:
     - containerName: prometheus
-  {{ with $resources := autoscalingBufferSettings $data.Cluster }}
       minAllowed:
         memory: {{.ConfigItems.prometheus_mem_min}}
       maxAllowed:
+  {{ with $resources := autoscalingBufferSettings .Cluster }}
         # Set the max memory to max available on the Node
         memory: {{$resources.Memory}}
   {{ end }}


### PR DESCRIPTION
We often have problems of the VPA not being able to scale prometheus
up even though memory is available on the Node so set max possible memory
to max memory available on the Node.

ref: https://github.bus.zalan.do/teapot/issues/issues/1933
Signed-off-by: Muhammad Muaaz Saleem <muhammad.muaaz.saleem@zalando.de>