### PR TITLE
Disallow SSH from the outside

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -112,7 +112,7 @@ Resources:
           FromPort: -1
           IpProtocol: icmp
           ToPort: -1
-        - CidrIp: 0.0.0.0/0
+        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
           FromPort: 22
           IpProtocol: tcp
           ToPort: 22
@@ -283,7 +283,7 @@ Resources:
           FromPort: -1
           IpProtocol: icmp
           ToPort: -1
-        - CidrIp: 0.0.0.0/0
+        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
           FromPort: 22
           IpProtocol: tcp
           ToPort: 22


### PR DESCRIPTION
This still allows connecting via the Odd host, but closes access from the outside.