### PR TITLE
Explicitly set the root EBS volume to delete on termination

### DIFF
--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -57,6 +57,7 @@ Resources:
         BlockDeviceMappings:
         - DeviceName: /dev/xvda
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 20
             VolumeType: standard
         EbsOptimized: false

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -114,6 +114,7 @@ Resources:
         BlockDeviceMappings:
         - DeviceName: /dev/xvda
           Ebs:
+            DeleteOnTermination: true
             VolumeSize: 50
             VolumeType: standard
         EbsOptimized: false


### PR DESCRIPTION
This property is inherited from the EBS volume which was used to build the AMI. If it is false then the volumes are left behind after the instances are terminated.