### PR TITLE
Override kube-proxy hostname from downward API

### DIFF
--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -33,8 +33,14 @@ spec:
       - name: kube-proxy
         image: registry.opensource.zalan.do/teapot/kube-proxy:v1.13.7
         args:
+        - --hostname-override=${HOSTNAME_OVERRIDE}
         - --config=/config/kube-proxy.yaml
         - --v=2
+        env:
+        - name: HOSTNAME_OVERRIDE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         securityContext:
           privileged: true
         resources:


### PR DESCRIPTION
Since we got rid of the hack which makes the local hostname match the AWS hostname kube-proxy cannot create the correct routes _(affects Ubuntu only)_.