### PR TITLE
Increase QPS for kubelet, controller-manager

### DIFF
--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -271,6 +271,10 @@ storage:
         healthzBindAddress: "0.0.0.0"
         tlsCertFile: "/etc/kubernetes/ssl/worker.pem"
         tlsPrivateKeyFile: "/etc/kubernetes/ssl/worker-key.pem"
+        eventRecordQPS: 50
+        eventBurst: 50
+        kubeAPIQPS: 50
+        kubeAPIBurst: 50
         systemReserved:
           cpu: "100m"
           memory: "164Mi"
@@ -641,6 +645,7 @@ storage:
             - --cluster-cidr=10.2.0.0/16
             - --node-cidr-mask-size={{ .Cluster.ConfigItems.node_cidr_mask_size }}
             - --terminated-pod-gc-threshold=500
+            - --kube-api-qps=50
             - --horizontal-pod-autoscaler-use-rest-clients=true
             - --horizontal-pod-autoscaler-downscale-delay={{ .Cluster.ConfigItems.horizontal_pod_autoscaler_downscale_delay }}
             - --horizontal-pod-autoscaler-sync-period={{ .Cluster.ConfigItems.horizontal_pod_autoscaler_sync_period }}

--- a/cluster/node-pools/master-ubuntu-default/userdata.yaml
+++ b/cluster/node-pools/master-ubuntu-default/userdata.yaml
@@ -55,6 +55,10 @@ write_files:
       healthzBindAddress: "0.0.0.0"
       tlsCertFile: "/etc/kubernetes/ssl/worker.pem"
       tlsPrivateKeyFile: "/etc/kubernetes/ssl/worker-key.pem"
+      eventRecordQPS: 50
+      eventBurst: 50
+      kubeAPIQPS: 50
+      kubeAPIBurst: 50
       systemReserved:
         cpu: "100m"
         memory: "164Mi"
@@ -373,6 +377,7 @@ write_files:
           - --allocate-node-cidrs=true
           - --cluster-cidr=10.2.0.0/16
           - --node-cidr-mask-size={{ .Cluster.ConfigItems.node_cidr_mask_size }}
+          - --kube-api-qps=50
           - --terminated-pod-gc-threshold=500
           - --horizontal-pod-autoscaler-use-rest-clients=true
           - --horizontal-pod-autoscaler-downscale-delay={{ .Cluster.ConfigItems.horizontal_pod_autoscaler_downscale_delay }}

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -306,6 +306,10 @@ storage:
         healthzBindAddress: "0.0.0.0"
         tlsCertFile: "/etc/kubernetes/ssl/worker.pem"
         tlsPrivateKeyFile: "/etc/kubernetes/ssl/worker-key.pem"
+        eventRecordQPS: 50
+        eventBurst: 50
+        kubeAPIQPS: 50
+        kubeAPIBurst: 50
         systemReserved:
           cpu: "100m"
           memory: "164Mi"

--- a/cluster/node-pools/worker-ubuntu-default/userdata.yaml
+++ b/cluster/node-pools/worker-ubuntu-default/userdata.yaml
@@ -53,6 +53,10 @@ write_files:
       healthzBindAddress: "0.0.0.0"
       tlsCertFile: "/etc/kubernetes/ssl/worker.pem"
       tlsPrivateKeyFile: "/etc/kubernetes/ssl/worker-key.pem"
+      eventRecordQPS: 50
+      eventBurst: 50
+      kubeAPIQPS: 50
+      kubeAPIBurst: 50
       systemReserved:
         cpu: "100m"
         memory: "164Mi"


### PR DESCRIPTION
The default for kubelet is ridiculously low, causing 5+ minute long delays when 20 pods are started at the same time.