### PR TITLE
Fixed parens for env var in kube-proxy

### DIFF
--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
       - name: kube-proxy
         image: registry.opensource.zalan.do/teapot/kube-proxy:v1.13.7
         args:
-        - --hostname-override=${HOSTNAME_OVERRIDE}
+        - --hostname-override=$(HOSTNAME_OVERRIDE)
         - --config=/config/kube-proxy.yaml
         - --v=2
         env:


### PR DESCRIPTION
Parenthesis should be used to interpolate environment variable into the command instead of curly braces.