### PR TITLE
update skipper to v0.10.241

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.10.233
+    version: v0.10.241
     component: ingress
 spec:
   strategy:
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.10.233
+        version: v0.10.241
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -42,7 +42,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.233
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.241
         ports:
         - name: ingress-port
           containerPort: 9999


### PR DESCRIPTION
Feature: support ingress with service type ExternalName https://github.com/zalando/skipper/issues/549
Feature: opentracing add roundtrip start/end span logs
Feature: unverifiedAuditLog filter with varargs https://github.com/zalando/skipper/issues/1090
Fix: oauthOidc* -filters store cookies on the client. These cookies are missing the Secure -flag regardless if HTTPS is used or not. Now we set secure directive if request is received on https. https://github.com/zalando/skipper/issues/1085
Fix: apiusagemonitoring filters use path from request chain https://github.com/zalando/skipper/issues/1094

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>