### PR TITLE
Updated VPA to version 0.5.1

### DIFF
--- a/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: kube-system
   labels:
     application: vpa-admission-controller
-    version: patched-0.4.0-master-14
+    version: patched-0.5.1-master-15
     component: vpa
 spec:
   replicas: 1
@@ -30,14 +30,14 @@ spec:
     metadata:
       labels:
         application: vpa-admission-controller
-        version: patched-0.4.0-master-14
+        version: patched-0.5.1-master-15
         component: vpa
     spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: system
       containers:
       - name: admission-controller
-        image: registry.opensource.zalan.do/teapot/vpa-admission-controller:patched-0.4.0-master-14
+        image: registry.opensource.zalan.do/teapot/vpa-admission-controller:patched-0.5.1-master-15
         volumeMounts:
           - name: tls-certs
             mountPath: "/etc/tls-certs"

--- a/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: vpa-recommender
-    version: patched-0.4.0-master-14
+    version: patched-0.5.1-master-15
     component: vpa
 spec:
   replicas: 1
@@ -16,14 +16,14 @@ spec:
     metadata:
       labels:
         application: vpa-recommender
-        version: patched-0.4.0-master-14
+        version: patched-0.5.1-master-15
         component: vpa
     spec:
       serviceAccountName: system
       priorityClassName: system-cluster-critical
       containers:
       - name: recommender
-        image: registry.opensource.zalan.do/teapot/vpa-recommender:patched-0.4.0-master-14
+        image: registry.opensource.zalan.do/teapot/vpa-recommender:patched-0.5.1-master-15
         args:
         - --stderrthreshold=info
         - --v=5

--- a/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: vpa-updater
-    version: patched-0.4.0-master-14
+    version: patched-0.5.1-master-15
     component: vpa
 spec:
   replicas: 1
@@ -16,14 +16,14 @@ spec:
     metadata:
       labels:
         application: vpa-updater
-        version: patched-0.4.0-master-14
+        version: patched-0.5.1-master-15
         component: vpa
     spec:
       serviceAccountName: system
       priorityClassName: system-cluster-critical
       containers:
       - name: updater
-        image: registry.opensource.zalan.do/teapot/vpa-updater:patched-0.4.0-master-14
+        image: registry.opensource.zalan.do/teapot/vpa-updater:patched-0.5.1-master-15
         args:
           - ./updater
           - --v=4


### PR DESCRIPTION
Release notes are [here](https://github.com/kubernetes/autoscaler/releases/tag/vertical-pod-autoscaler-0.5.1). No changes to the CRD seem to be required. 