### PR TITLE
SSL policy >= 1.2

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -11,6 +11,11 @@ autoscaling_buffer_pods: "1"
 autoscaling_buffer_pods: "0"
 {{end}}
 
+# ALB config created by kube-aws-ingress-controller
+{{if eq .Environment "test"}}
+kube_aws_ingress_controller_ssl_policy: "ELBSecurityPolicy-TLS-1-2-2017-01"
+{{end}}
+
 # skipper resource settings
 skipper_limits_mem: "250Mi"
 skipper_requests_cpu: "150m"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -14,6 +14,8 @@ autoscaling_buffer_pods: "0"
 # ALB config created by kube-aws-ingress-controller
 {{if eq .Environment "test"}}
 kube_aws_ingress_controller_ssl_policy: "ELBSecurityPolicy-TLS-1-2-2017-01"
+{{else}}
+kube_aws_ingress_controller_ssl_policy: "ELBSecurityPolicy-2016-08"
 {{end}}
 
 # skipper resource settings

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.8.7
+    version: v0.8.8
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.8.7
+        version: v0.8.8
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "false"}}
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
@@ -29,12 +29,10 @@ spec:
       serviceAccountName: kube-ingress-aws-controller
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.8.7
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.8.8
         args:
         - -stack-termination-protection
-{{ if index .ConfigItems "kube_aws_ingress_controller_ssl_policy" }}
         - -ssl-policy={{ .ConfigItems.kube_aws_ingress_controller_ssl_policy }}
-{{ end }}
         env:
         - name: AWS_REGION
           value: {{ .Region }}

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.8.6
+    version: v0.8.7
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.8.6
+        version: v0.8.7
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "false"}}
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
@@ -29,9 +29,12 @@ spec:
       serviceAccountName: kube-ingress-aws-controller
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.8.6
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.8.7
         args:
         - -stack-termination-protection
+{{ if index .ConfigItems "kube_aws_ingress_controller_ssl_policy" }}
+        - -ssl-policy={{ .ConfigItems.kube_aws_ingress_controller_ssl_policy }}
+{{ end }}
         env:
         - name: AWS_REGION
           value: {{ .Region }}


### PR DESCRIPTION
roll out restrictive TLS policy to only support >= TLS1.2 to test clusters
see also https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies 
Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>