### PR TITLE
Fixed the VPA recommender for missing keys

### DIFF
--- a/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: vpa-recommender
-    version: patched-0.5.1-master-15
+    version: patched-0.5.1-master-16
     component: vpa
 spec:
   replicas: 1
@@ -16,14 +16,14 @@ spec:
     metadata:
       labels:
         application: vpa-recommender
-        version: patched-0.5.1-master-15
+        version: patched-0.5.1-master-16
         component: vpa
     spec:
       serviceAccountName: system
       priorityClassName: system-cluster-critical
       containers:
       - name: recommender
-        image: registry.opensource.zalan.do/teapot/vpa-recommender:patched-0.5.1-master-15
+        image: registry.opensource.zalan.do/teapot/vpa-recommender:patched-0.5.1-master-16
         args:
         - --stderrthreshold=info
         - --v=5


### PR DESCRIPTION
The VPA recommender runs with a _memory saver_ mode which only stores metrics for pods with matching VPAs. But the new version prints an error whenever there metrics for which there are no corresponding pods, which is a majority of the pods. So the logs are cluttered with error logs. This fix suppressed that logs whenever the recommender is running memory-saver mode.