### PR TITLE
Make external service account token usage configurable

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -242,5 +242,9 @@ node_cidr_mask_size: "24" # Default: 24
 
 # when set to true, routes external traffic to the apiserver through a skipper sidecar
 apiserver_proxy: "true"
+# when set to true, service account tokens can be used from outside the cluster
+# requires apiserver_proxy to be set to "true"
+allow_external_service_accounts: "true"
+
 # use kube-aws-iam-controller for kube-system components
 kube_aws_iam_controller_kube_system_enable: "false"

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -575,7 +575,7 @@ storage:
             - -enable-prometheus-metrics
             - -write-timeout-server=60m
             - -inline-routes
-            - 'z: JWTPayloadAnyKV("iss", "kubernetes/serviceaccount") -> enableAccessLog() -> "https://127.0.0.1:443"; h: Path("/kube-system/healthz") -> setPath("/healthz") -> disableAccessLog() -> "http://127.0.0.1:8080"; all: * -> disableAccessLog() -> "https://127.0.0.1:443";'
+            - 's: JWTPayloadAllKV("iss", "kubernetes/serviceaccount") -> enableAccessLog() -> {{ if eq .ConfigItems.allow_external_service_accounts "true" }}"https://127.0.0.1:443"{{ else }}status(401) -> <shunt>{{ end }}; h: Path("/kube-system/healthz") -> setPath("/healthz") -> disableAccessLog() -> "http://127.0.0.1:8080"; all: * -> disableAccessLog() -> "https://127.0.0.1:443";'
             ports:
             - containerPort: 8443
             readinessProbe:

--- a/cluster/node-pools/master-ubuntu-default/userdata.yaml
+++ b/cluster/node-pools/master-ubuntu-default/userdata.yaml
@@ -311,7 +311,7 @@ write_files:
           - -enable-prometheus-metrics
           - -write-timeout-server=60m
           - -inline-routes
-          - 'z: JWTPayloadAnyKV("iss", "kubernetes/serviceaccount") -> enableAccessLog() -> "https://127.0.0.1:443"; h: Path("/kube-system/healthz") -> setPath("/healthz") -> disableAccessLog() -> "http://127.0.0.1:8080"; all: * -> disableAccessLog() -> "https://127.0.0.1:443";'
+          - 's: JWTPayloadAllKV("iss", "kubernetes/serviceaccount") -> enableAccessLog() -> {{ if eq .ConfigItems.allow_external_service_accounts "true" }}"https://127.0.0.1:443"{{ else }}status(401) -> <shunt>{{ end }}; h: Path("/kube-system/healthz") -> setPath("/healthz") -> disableAccessLog() -> "http://127.0.0.1:8080"; all: * -> disableAccessLog() -> "https://127.0.0.1:443";'
           ports:
           - containerPort: 8443
           readinessProbe:


### PR DESCRIPTION
This allows to disable external service account token per cluster.

The skipper rule works like that:
* intercept requests with service account tokens
  * toggleable via config item
  * token validation happens at apiserver if not intercepted
* forward custom health check to apiserver's `/healthz`
* forward everything else to apiserver
  * token validation happens at apiserver
