### PR TITLE
ExternalDNS: reduce Route53 batch size to 100

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - --provider=aws
         - --registry=txt
         - --txt-owner-id={{ .Region }}:{{ .LocalID }}
-        - --aws-batch-change-size=350
+        - --aws-batch-change-size=100
         resources:
           limits:
             cpu: 50m


### PR DESCRIPTION
With the recent [SSL Policy feature in Ingress Controller](https://github.com/zalando-incubator/kube-ingress-aws-controller/pull/259) all Ingress DNS records were changed. This lead to a too large batch size and blocked all DNS updates.

```console
...
time="2019-06-27T09:04:22Z" level=info msg="Desired change: UPSERT redacted1.zalan.do TXT"
time="2019-06-27T09:04:22Z" level=info msg="Desired change: UPSERT redacted2.zalan.do TXT"
time="2019-06-27T09:04:22Z" level=info msg="Desired change: UPSERT redacted3.zalan.do TXT"
time="2019-06-27T09:04:22Z" level=info msg="Desired change: UPSERT redacted4.zalan.do TXT"
time="2019-06-27T09:04:22Z" level=info msg="Desired change: UPSERT redacted5.zalan.do TXT"
time="2019-06-27T09:04:22Z" level=info msg="Desired change: DELETE redacted6.zalan.do A"
time="2019-06-27T09:04:22Z" level=info msg="Desired change: DELETE redacted7.zalan.do A"
time="2019-06-27T09:04:22Z" level=info msg="Desired change: DELETE redacted6.zalan.do TXT"
time="2019-06-27T09:04:22Z" level=info msg="Desired change: DELETE redacted7.zalan.do TXT"
time="2019-06-27T09:04:24Z" level=error msg="InvalidChangeBatch: [RDATA character limit of 32000 exceeded.]\n\tstatus code: 400, request id: 12345678-98ba-11e9-a32b-7937884b0ed5"
time="2019-06-27T09:04:24Z" level=error msg="Failed to submit all changes for the following zones: [/hostedzone/Z1H...7J]"
```

**Since the old load balancer was phased out already all DNS records in our test cluster were defunct.**

Quick fix is to reduce the batch size even further.