### PR TITLE
adjust lifo timeout from 10s to 3s

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -33,7 +33,7 @@ skipper_ingress_memory: "1Gi"
 skipper_ingress_tracing_buffer: "8192"
 
 # skipper default filters
-skipper_default_filters: 'enableAccessLog(4,5) -> lifo(2000,20000,"10s")'
+skipper_default_filters: 'enableAccessLog(4,5) -> lifo(2000,20000,"3s")'
 
 # skipper backend timeout defaults
 skipper_expect_continue_timeout_backend: "30s"


### PR DESCRIPTION
I measured in our internal issue tracker, in issue 1960, that 10s -> 3s fix the stdlib based buffio memory usage on huge connection spikes caused by retries

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>