### PR TITLE
Enable kube-aws-iam-controller by default for kube-system components

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -257,4 +257,4 @@ apiserver_proxy: "true"
 allow_external_service_accounts: "true"
 
 # use kube-aws-iam-controller for kube-system components
-kube_aws_iam_controller_kube_system_enable: "false"
+kube_aws_iam_controller_kube_system_enable: "true"

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -49,7 +49,6 @@ clusters:
     enable_rbac: "true"
     dynamodb_service_link_enabled: "false"
     skipper_ingress_cpu: 100m
-    kube_aws_iam_controller_kube_system_enable: "true"
   criticality_level: 1
   environment: e2e
   id: ${CLUSTER_ID}


### PR DESCRIPTION
Enable in all clusters by default, with the option of still disabling it per cluster via cluster-registry.

Note: So far only the components checked off in #2219 are using this.