### PR TITLE
Egress controller should be allowed to delete tags

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1000,6 +1000,9 @@ Resources:
               - Action: 'ec2:CreateTags'
                 Effect: Allow
                 Resource: '*'
+              - Action: 'ec2:DeleteTags'
+                Effect: Allow
+                Resource: '*'
               - Action: 'ec2:ReleaseAddress'
                 Effect: Allow
                 Resource: '*'


### PR DESCRIPTION
New version of egress controller uses tags for storing Egress IPs. Allow deleting tags when resources are cleaned up.

Follow up to #2273 