### PR TITLE
Added more instance storage types

### DIFF
--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -83,7 +83,7 @@ clusters:
     min_size: 1
     max_size: 21
   - discount_strategy: spot_max_price
-    instance_types: ["m5d.large"]
+    instance_types: ["m5d.large", "m5d.xlarge", "m5d.2xlarge"]
     name: worker-instance-storage
     profile: ${WORKER_PROFILE}-default
     min_size: 1


### PR DESCRIPTION
With more instance types available for the spot pool the cluster should be ready faster. Should cut down some of the time needed to finish the E2E.