### PR TITLE
Allow Test tokens to access test clusters

### DIFF
--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -511,7 +511,7 @@ storage:
               - name: CLUSTER_ID
                 value: {{if index .Cluster.ConfigItems "webhook_id"}}{{ .Cluster.ConfigItems.webhook_id }}{{else}}{{ .Cluster.ID }}{{end}}
               - name: TOKEN_INTROSPECTION_URL
-                value: http://127.0.0.1:9021/oauth2/introspect
+                value: http://127.0.0.1:{{ if eq .Cluster.Environment "production" }}9021{{else}}9023{{end}}/oauth2/introspect
               - name: USER_GROUPS
                 value: credentials-provider=Administrator,credprov-kube-ops-view-read-only-token=ReadOnly,credprov-cluster-lifecycle-manager-cluster-rw-token=Administrator,stups_cluster-lifecycle-manager=Administrator,credprov-cluster-lifecycle-manager-test-cluster-rw-token=Administrator,credprov-cdp-controller-cluster-token=PowerUser,stups_deployment-discovery=ReadOnly,stups_cockpit-skipper=ReadOnly,stups_zmon-zmon=ReadOnly,stups_kube-resource-report=ReadOnly,stups_oxygen=ReadOnly,kubelet=system:masters
               - name: BUSINESS_PARTNER_IDS
@@ -545,6 +545,64 @@ storage:
                 value: https://identity.zalando.com/.well-known/openid-configuration
               - name: ENABLE_INTROSPECTION
                 value: "true"
+{{ if ne .Cluster.Environment "production" }}
+          - name: tokeninfo-sandbox
+            image: registry.opensource.zalan.do/foundation/platform-iam-tokeninfo:2fca26c
+            ports:
+            - containerPort: 9022
+            livenessProbe:
+              httpGet:
+                path: /health
+                port: 9022
+              periodSeconds: 3
+              failureThreshold: 2
+            readinessProbe:
+              httpGet:
+                path: /health
+                port: 9022
+              periodSeconds: 3
+              failureThreshold: 2
+            resources:
+              requests:
+                cpu: 100m
+                memory: 20Mi
+            env:
+            - name: OPENID_PROVIDER_CONFIGURATION_URL
+              value: https://sandbox.identity.zalando.com/.well-known/openid-configuration
+            - name: ENABLE_INTROSPECTION
+              value: "true"
+            - name: ISSUER
+              value: "https://sandbox.identity.zalando.com"
+            - name: LISTEN_ADDRESS
+              value: ":9022"
+          - name: skipper-tokeinfo-bridge
+            image: registry.opensource.zalan.do/foundation/platform-iam-tokeninfo:2fca26c
+            args:
+            - skipper
+            - -address=:9023
+            - -inline-routes
+            - |
+              q2h: Path("/oauth2/tokeninfo") && QueryParam("access_token")
+                -> queryToHeader("access_token", "Authorization", "Bearer %s")
+                -> dropQuery("access_token")
+                -> <loopback>;
+              prod: Path("/oauth2/introspect") && JWTPayloadAllKV("iss", "https://identity.zalando.com")
+                -> "http://127.0.0.1:9021/oauth2/introspect";
+              sandbox: Path("/oauth2/introspect") && JWTPayloadAllKV("iss", "https://sandbox.identity.zalando.com")
+                -> "http://127.0.0.1:9022/oauth2/introspect";
+              fallback: Path("/oauth2/introspect") -> status(400) -> <shunt>;
+            ports:
+            - containerPort: 9023
+            readinessProbe:
+              httpGet:
+                path: /kube-system/healthz
+                port: 9023
+              timeoutSeconds: 5
+            resources:
+              requests:
+                cpu: 100m
+                memory: 20Mi
+{{ end }}
           - image: registry.opensource.zalan.do/teapot/image-policy-webhook:{{if eq .Cluster.ConfigItems.compliance_checker_enabled "true"}}master-44{{else}}v0.4.1{{end}}
             name: image-policy-webhook
             args:
@@ -577,7 +635,17 @@ storage:
             - -enable-prometheus-metrics
             - -write-timeout-server=60m
             - -inline-routes
-            - 's: JWTPayloadAllKV("iss", "kubernetes/serviceaccount") -> enableAccessLog() -> {{ if eq .ConfigItems.allow_external_service_accounts "true" }}"https://127.0.0.1:443"{{ else }}status(401) -> <shunt>{{ end }}; h: Path("/kube-system/healthz") -> setPath("/healthz") -> disableAccessLog() -> "http://127.0.0.1:8080"; all: * -> disableAccessLog() -> "https://127.0.0.1:443";'
+            - |
+              s: JWTPayloadAllKV("iss", "kubernetes/serviceaccount")
+                -> enableAccessLog()
+                -> {{ if eq .ConfigItems.allow_external_service_accounts "true" }}"https://127.0.0.1:443"{{ else }}status(401) -> <shunt>{{ end }};
+              h: Path("/kube-system/healthz")
+                -> setPath("/healthz")
+                -> disableAccessLog()
+                -> "http://127.0.0.1:8080";
+              all: *
+                -> disableAccessLog()
+                -> "https://127.0.0.1:443";
             ports:
             - containerPort: 8443
             readinessProbe:

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -575,13 +575,14 @@ storage:
               value: "https://sandbox.identity.zalando.com"
             - name: LISTEN_ADDRESS
               value: ":9022"
-          - name: skipper-tokeinfo-bridge
-            image: registry.opensource.zalan.do/foundation/platform-iam-tokeninfo:2fca26c
+          - name: skipper-tokeninfo-bridge
+            image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.243
             args:
             - skipper
             - -address=:9023
             - -inline-routes
             - |
+              health: Path("/healthz") -> inlineContent("ok") -> <shunt>;
               q2h: Path("/oauth2/tokeninfo") && QueryParam("access_token")
                 -> queryToHeader("access_token", "Authorization", "Bearer %s")
                 -> dropQuery("access_token")
@@ -595,7 +596,7 @@ storage:
             - containerPort: 9023
             readinessProbe:
               httpGet:
-                path: /kube-system/healthz
+                path: /healthz
                 port: 9023
               timeoutSeconds: 5
             resources:

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -588,10 +588,10 @@ storage:
                 -> queryToHeader("token", "Authorization", "Bearer %s")
                 -> setRequestHeader("X-Checking-JWT", "true")
                 -> <loopback>;
-              prod: Path("/oauth2/introspect") && Header("X-Checking-JWT", "true") && JWTPayloadAllKV("iss", "https://identity.zalando.com")
+              prod: Path("/oauth2/introspect") && QueryParam("token") && Header("X-Checking-JWT", "true") && JWTPayloadAllKV("iss", "https://identity.zalando.com")
                 -> dropRequestHeader("Authorization") -> dropRequestHeader("X-Checking-JWT")
                 -> "http://127.0.0.1:9021/oauth2/introspect";
-              sandbox: Path("/oauth2/introspect") && Header("X-Checking-JWT", "true") && JWTPayloadAllKV("iss", "https://sandbox.identity.zalando.com")
+              sandbox: Path("/oauth2/introspect") && QueryParam("token") && Header("X-Checking-JWT", "true") && JWTPayloadAllKV("iss", "https://sandbox.identity.zalando.com")
                 -> dropRequestHeader("Authorization") -> dropRequestHeader("X-Checking-JWT")
                 -> "http://127.0.0.1:9022/oauth2/introspect";
               fallback1: Path("/oauth2/introspect") && QueryParam("token") && Header("X-Checking-JWT", "true")

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -594,7 +594,9 @@ storage:
               sandbox: Path("/oauth2/introspect") && Header("X-Checking-JWT", "true") && JWTPayloadAllKV("iss", "https://sandbox.identity.zalando.com")
                 -> dropRequestHeader("Authorization") -> dropRequestHeader("X-Checking-JWT")
                 -> "http://127.0.0.1:9022/oauth2/introspect";
-              fallback: Path("/oauth2/introspect") && QueryParam("token") && Header("X-Checking-JWT", "true")
+              fallback1: Path("/oauth2/introspect") && QueryParam("token") && Header("X-Checking-JWT", "true")
+                -> inlineContent("{\"active\":false}") -> <shunt>;
+              fallback2: Path("/oauth2/introspect")
                 -> inlineContent("{\"active\":false}") -> <shunt>;
             ports:
             - containerPort: 9023

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -593,9 +593,7 @@ storage:
               sandbox: Path("/oauth2/introspect") && Header("X-Checking-JWT", "true") && JWTPayloadAllKV("iss", "https://sandbox.identity.zalando.com")
                 -> dropRequestHeader("Authorization") -> dropRequestHeader("X-Checking-JWT")
                 -> "http://127.0.0.1:9022/oauth2/introspect";
-              fallback1: Path("/oauth2/introspect") && QueryParam("token") && Header("X-Checking-JWT", "true")
-                -> inlineContent("{\"active\":false}") -> <shunt>;
-              fallback2: Path("/oauth2/introspect")
+              fallback: Path("/oauth2/introspect") && QueryParam("token") && Header("X-Checking-JWT", "true")
                 -> inlineContent("{\"active\":false}") -> <shunt>;
             ports:
             - containerPort: 9023

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -484,7 +484,7 @@ storage:
               - mountPath: /etc/kubernetes/ssl
                 name: ssl-certs-kubernetes
                 readOnly: true
-          - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.5.5
+          - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.5.6
             name: webhook
             ports:
             - containerPort: 8081

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -583,15 +583,20 @@ storage:
             - -inline-routes
             - |
               health: Path("/healthz") -> inlineContent("ok") -> <shunt>;
-              q2h: Path("/oauth2/tokeninfo") && QueryParam("access_token")
-                -> queryToHeader("access_token", "Authorization", "Bearer %s")
-                -> dropQuery("access_token")
+              q2h: Path("/oauth2/introspect") && QueryParam("token")
+                -> queryToHeader("token", "Authorization", "Bearer %s")
+                -> setRequestHeader("X-Checking-JWT", "true")
                 -> <loopback>;
-              prod: Path("/oauth2/introspect") && JWTPayloadAllKV("iss", "https://identity.zalando.com")
+              prod: Path("/oauth2/introspect") && Header("X-Checking-JWT", "true") && JWTPayloadAllKV("iss", "https://identity.zalando.com")
+                -> dropRequestHeader("Authorization") -> dropRequestHeader("X-Checking-JWT")
                 -> "http://127.0.0.1:9021/oauth2/introspect";
-              sandbox: Path("/oauth2/introspect") && JWTPayloadAllKV("iss", "https://sandbox.identity.zalando.com")
+              sandbox: Path("/oauth2/introspect") && Header("X-Checking-JWT", "true") && JWTPayloadAllKV("iss", "https://sandbox.identity.zalando.com")
+                -> dropRequestHeader("Authorization") -> dropRequestHeader("X-Checking-JWT")
                 -> "http://127.0.0.1:9022/oauth2/introspect";
-              fallback: Path("/oauth2/introspect") -> status(400) -> <shunt>;
+              fallback1: Path("/oauth2/introspect") && QueryParam("token") && Header("X-Checking-JWT", "true")
+                -> inlineContent("{\"active\":false}") -> <shunt>;
+              fallback2: Path("/oauth2/introspect")
+                -> inlineContent("{\"active\":false}") -> <shunt>;
             ports:
             - containerPort: 9023
             readinessProbe:

--- a/cluster/node-pools/master-ubuntu-default/userdata.yaml
+++ b/cluster/node-pools/master-ubuntu-default/userdata.yaml
@@ -332,7 +332,9 @@ write_files:
             sandbox: Path("/oauth2/introspect") && Header("X-Checking-JWT", "true") && JWTPayloadAllKV("iss", "https://sandbox.identity.zalando.com")
               -> dropRequestHeader("Authorization") -> dropRequestHeader("X-Checking-JWT")
               -> "http://127.0.0.1:9022/oauth2/introspect";
-            fallback: Path("/oauth2/introspect") && QueryParam("token") && Header("X-Checking-JWT", "true")
+            fallback1: Path("/oauth2/introspect") && QueryParam("token") && Header("X-Checking-JWT", "true")
+              -> inlineContent("{\"active\":false}") -> <shunt>;
+            fallback2: Path("/oauth2/introspect")
               -> inlineContent("{\"active\":false}") -> <shunt>;
           ports:
           - containerPort: 9023

--- a/cluster/node-pools/master-ubuntu-default/userdata.yaml
+++ b/cluster/node-pools/master-ubuntu-default/userdata.yaml
@@ -326,10 +326,10 @@ write_files:
               -> queryToHeader("token", "Authorization", "Bearer %s")
               -> setRequestHeader("X-Checking-JWT", "true")
               -> <loopback>;
-            prod: Path("/oauth2/introspect") && Header("X-Checking-JWT", "true") && JWTPayloadAllKV("iss", "https://identity.zalando.com")
+            prod: Path("/oauth2/introspect") && QueryParam("token") && Header("X-Checking-JWT", "true") && JWTPayloadAllKV("iss", "https://identity.zalando.com")
               -> dropRequestHeader("Authorization") -> dropRequestHeader("X-Checking-JWT")
               -> "http://127.0.0.1:9021/oauth2/introspect";
-            sandbox: Path("/oauth2/introspect") && Header("X-Checking-JWT", "true") && JWTPayloadAllKV("iss", "https://sandbox.identity.zalando.com")
+            sandbox: Path("/oauth2/introspect") && QueryParam("token") && Header("X-Checking-JWT", "true") && JWTPayloadAllKV("iss", "https://sandbox.identity.zalando.com")
               -> dropRequestHeader("Authorization") -> dropRequestHeader("X-Checking-JWT")
               -> "http://127.0.0.1:9022/oauth2/introspect";
             fallback1: Path("/oauth2/introspect") && QueryParam("token") && Header("X-Checking-JWT", "true")

--- a/cluster/node-pools/master-ubuntu-default/userdata.yaml
+++ b/cluster/node-pools/master-ubuntu-default/userdata.yaml
@@ -284,63 +284,63 @@ write_files:
             - name: ENABLE_INTROSPECTION
               value: "true"
 {{ if ne .Cluster.Environment "production" }}
-          - name: tokeninfo-sandbox
-            image: registry.opensource.zalan.do/foundation/platform-iam-tokeninfo:2fca26c
-            ports:
-            - containerPort: 9022
-            livenessProbe:
-              httpGet:
-                path: /health
-                port: 9022
-              periodSeconds: 3
-              failureThreshold: 2
-            readinessProbe:
-              httpGet:
-                path: /health
-                port: 9022
-              periodSeconds: 3
-              failureThreshold: 2
-            resources:
-              requests:
-                cpu: 100m
-                memory: 20Mi
-            env:
-            - name: OPENID_PROVIDER_CONFIGURATION_URL
-              value: https://sandbox.identity.zalando.com/.well-known/openid-configuration
-            - name: ENABLE_INTROSPECTION
-              value: "true"
-            - name: ISSUER
-              value: "https://sandbox.identity.zalando.com"
-            - name: LISTEN_ADDRESS
-              value: ":9022"
-          - name: skipper-tokeninfo-bridge
-            image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.243
-            args:
-            - skipper
-            - -address=:9023
-            - -inline-routes
-            - |
-              health: Path("/healthz") -> inlineContent("ok") -> <shunt>;
-              q2h: Path("/oauth2/tokeninfo") && QueryParam("access_token")
-                -> queryToHeader("access_token", "Authorization", "Bearer %s")
-                -> dropQuery("access_token")
-                -> <loopback>;
-              prod: Path("/oauth2/introspect") && JWTPayloadAllKV("iss", "https://identity.zalando.com")
-                -> "http://127.0.0.1:9021/oauth2/introspect";
-              sandbox: Path("/oauth2/introspect") && JWTPayloadAllKV("iss", "https://sandbox.identity.zalando.com")
-                -> "http://127.0.0.1:9022/oauth2/introspect";
-              fallback: Path("/oauth2/introspect") -> status(400) -> <shunt>;
-            ports:
-            - containerPort: 9023
-            readinessProbe:
-              httpGet:
-                path: /healthz
-                port: 9023
-              timeoutSeconds: 5
-            resources:
-              requests:
-                cpu: 100m
-                memory: 20Mi
+        - name: tokeninfo-sandbox
+          image: registry.opensource.zalan.do/foundation/platform-iam-tokeninfo:2fca26c
+          ports:
+          - containerPort: 9022
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 9022
+            periodSeconds: 3
+            failureThreshold: 2
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 9022
+            periodSeconds: 3
+            failureThreshold: 2
+          resources:
+            requests:
+              cpu: 100m
+              memory: 20Mi
+          env:
+          - name: OPENID_PROVIDER_CONFIGURATION_URL
+            value: https://sandbox.identity.zalando.com/.well-known/openid-configuration
+          - name: ENABLE_INTROSPECTION
+            value: "true"
+          - name: ISSUER
+            value: "https://sandbox.identity.zalando.com"
+          - name: LISTEN_ADDRESS
+            value: ":9022"
+        - name: skipper-tokeninfo-bridge
+          image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.243
+          args:
+          - skipper
+          - -address=:9023
+          - -inline-routes
+          - |
+            health: Path("/healthz") -> inlineContent("ok") -> <shunt>;
+            q2h: Path("/oauth2/tokeninfo") && QueryParam("access_token")
+              -> queryToHeader("access_token", "Authorization", "Bearer %s")
+              -> dropQuery("access_token")
+              -> <loopback>;
+            prod: Path("/oauth2/introspect") && JWTPayloadAllKV("iss", "https://identity.zalando.com")
+              -> "http://127.0.0.1:9021/oauth2/introspect";
+            sandbox: Path("/oauth2/introspect") && JWTPayloadAllKV("iss", "https://sandbox.identity.zalando.com")
+              -> "http://127.0.0.1:9022/oauth2/introspect";
+            fallback: Path("/oauth2/introspect") -> status(400) -> <shunt>;
+          ports:
+          - containerPort: 9023
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 9023
+            timeoutSeconds: 5
+          resources:
+            requests:
+              cpu: 100m
+              memory: 20Mi
 {{ end }}
         - image: registry.opensource.zalan.do/teapot/image-policy-webhook:{{if eq .Cluster.ConfigItems.compliance_checker_enabled "true"}}master-44{{else}}v0.4.1{{end}}
           name: image-policy-webhook

--- a/cluster/node-pools/master-ubuntu-default/userdata.yaml
+++ b/cluster/node-pools/master-ubuntu-default/userdata.yaml
@@ -249,7 +249,7 @@ write_files:
             - name: CLUSTER_ID
               value: {{if index .Cluster.ConfigItems "webhook_id"}}{{ .Cluster.ConfigItems.webhook_id }}{{else}}{{ .Cluster.ID }}{{end}}
             - name: TOKEN_INTROSPECTION_URL
-              value: http://127.0.0.1:9021/oauth2/introspect
+              value: http://127.0.0.1:{{ if eq .Cluster.Environment "production" }}9021{{else}}9023{{end}}/oauth2/introspect
             - name: USER_GROUPS
               value: credentials-provider=Administrator,credprov-kube-ops-view-read-only-token=ReadOnly,credprov-cluster-lifecycle-manager-cluster-rw-token=Administrator,stups_cluster-lifecycle-manager=Administrator,credprov-cluster-lifecycle-manager-test-cluster-rw-token=Administrator,credprov-cdp-controller-cluster-token=PowerUser,stups_deployment-discovery=ReadOnly,stups_cockpit-skipper=ReadOnly,stups_zmon-zmon=ReadOnly,stups_kube-resource-report=ReadOnly,stups_oxygen=ReadOnly,kubelet=system:masters
             - name: BUSINESS_PARTNER_IDS
@@ -283,6 +283,64 @@ write_files:
               value: https://identity.zalando.com/.well-known/openid-configuration
             - name: ENABLE_INTROSPECTION
               value: "true"
+{{ if ne .Cluster.Environment "production" }}
+          - name: tokeninfo-sandbox
+            image: registry.opensource.zalan.do/foundation/platform-iam-tokeninfo:2fca26c
+            ports:
+            - containerPort: 9022
+            livenessProbe:
+              httpGet:
+                path: /health
+                port: 9022
+              periodSeconds: 3
+              failureThreshold: 2
+            readinessProbe:
+              httpGet:
+                path: /health
+                port: 9022
+              periodSeconds: 3
+              failureThreshold: 2
+            resources:
+              requests:
+                cpu: 100m
+                memory: 20Mi
+            env:
+            - name: OPENID_PROVIDER_CONFIGURATION_URL
+              value: https://sandbox.identity.zalando.com/.well-known/openid-configuration
+            - name: ENABLE_INTROSPECTION
+              value: "true"
+            - name: ISSUER
+              value: "https://sandbox.identity.zalando.com"
+            - name: LISTEN_ADDRESS
+              value: ":9022"
+          - name: skipper-tokeinfo-bridge
+            image: registry.opensource.zalan.do/foundation/platform-iam-tokeninfo:2fca26c
+            args:
+            - skipper
+            - -address=:9023
+            - -inline-routes
+            - |
+              q2h: Path("/oauth2/tokeninfo") && QueryParam("access_token")
+                -> queryToHeader("access_token", "Authorization", "Bearer %s")
+                -> dropQuery("access_token")
+                -> <loopback>;
+              prod: Path("/oauth2/introspect") && JWTPayloadAllKV("iss", "https://identity.zalando.com")
+                -> "http://127.0.0.1:9021/oauth2/introspect";
+              sandbox: Path("/oauth2/introspect") && JWTPayloadAllKV("iss", "https://sandbox.identity.zalando.com")
+                -> "http://127.0.0.1:9022/oauth2/introspect";
+              fallback: Path("/oauth2/introspect") -> status(400) -> <shunt>;
+            ports:
+            - containerPort: 9023
+            readinessProbe:
+              httpGet:
+                path: /kube-system/healthz
+                port: 9023
+              timeoutSeconds: 5
+            resources:
+              requests:
+                cpu: 100m
+                memory: 20Mi
+{{ end }}
         - image: registry.opensource.zalan.do/teapot/image-policy-webhook:{{if eq .Cluster.ConfigItems.compliance_checker_enabled "true"}}master-44{{else}}v0.4.1{{end}}
           name: image-policy-webhook
           args:
@@ -315,7 +373,17 @@ write_files:
           - -enable-prometheus-metrics
           - -write-timeout-server=60m
           - -inline-routes
-          - 's: JWTPayloadAllKV("iss", "kubernetes/serviceaccount") -> enableAccessLog() -> {{ if eq .ConfigItems.allow_external_service_accounts "true" }}"https://127.0.0.1:443"{{ else }}status(401) -> <shunt>{{ end }}; h: Path("/kube-system/healthz") -> setPath("/healthz") -> disableAccessLog() -> "http://127.0.0.1:8080"; all: * -> disableAccessLog() -> "https://127.0.0.1:443";'
+          - |
+            s: JWTPayloadAllKV("iss", "kubernetes/serviceaccount")
+              -> enableAccessLog()
+              -> {{ if eq .ConfigItems.allow_external_service_accounts "true" }}"https://127.0.0.1:443"{{ else }}status(401) -> <shunt>{{ end }};
+            h: Path("/kube-system/healthz")
+              -> setPath("/healthz")
+              -> disableAccessLog()
+              -> "http://127.0.0.1:8080";
+            all: *
+              -> disableAccessLog()
+              -> "https://127.0.0.1:443";
           ports:
           - containerPort: 8443
           readinessProbe:

--- a/cluster/node-pools/master-ubuntu-default/userdata.yaml
+++ b/cluster/node-pools/master-ubuntu-default/userdata.yaml
@@ -222,7 +222,7 @@ write_files:
             - mountPath: /etc/kubernetes/ssl
               name: ssl-certs-kubernetes
               readOnly: true
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.5.5
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.5.6
           name: webhook
           ports:
           - containerPort: 8081

--- a/cluster/node-pools/master-ubuntu-default/userdata.yaml
+++ b/cluster/node-pools/master-ubuntu-default/userdata.yaml
@@ -321,15 +321,20 @@ write_files:
           - -inline-routes
           - |
             health: Path("/healthz") -> inlineContent("ok") -> <shunt>;
-            q2h: Path("/oauth2/tokeninfo") && QueryParam("access_token")
-              -> queryToHeader("access_token", "Authorization", "Bearer %s")
-              -> dropQuery("access_token")
+            q2h: Path("/oauth2/introspect") && QueryParam("token")
+              -> queryToHeader("token", "Authorization", "Bearer %s")
+              -> setRequestHeader("X-Checking-JWT", "true")
               -> <loopback>;
-            prod: Path("/oauth2/introspect") && JWTPayloadAllKV("iss", "https://identity.zalando.com")
+            prod: Path("/oauth2/introspect") && Header("X-Checking-JWT", "true") && JWTPayloadAllKV("iss", "https://identity.zalando.com")
+              -> dropRequestHeader("Authorization") -> dropRequestHeader("X-Checking-JWT")
               -> "http://127.0.0.1:9021/oauth2/introspect";
-            sandbox: Path("/oauth2/introspect") && JWTPayloadAllKV("iss", "https://sandbox.identity.zalando.com")
+            sandbox: Path("/oauth2/introspect") && Header("X-Checking-JWT", "true") && JWTPayloadAllKV("iss", "https://sandbox.identity.zalando.com")
+              -> dropRequestHeader("Authorization") -> dropRequestHeader("X-Checking-JWT")
               -> "http://127.0.0.1:9022/oauth2/introspect";
-            fallback: Path("/oauth2/introspect") -> status(400) -> <shunt>;
+            fallback1: Path("/oauth2/introspect") && QueryParam("token") && Header("X-Checking-JWT", "true")
+              -> inlineContent("{\"active\":false}") -> <shunt>;
+            fallback2: Path("/oauth2/introspect")
+              -> inlineContent("{\"active\":false}") -> <shunt>;
           ports:
           - containerPort: 9023
           readinessProbe:

--- a/cluster/node-pools/master-ubuntu-default/userdata.yaml
+++ b/cluster/node-pools/master-ubuntu-default/userdata.yaml
@@ -331,9 +331,7 @@ write_files:
             sandbox: Path("/oauth2/introspect") && Header("X-Checking-JWT", "true") && JWTPayloadAllKV("iss", "https://sandbox.identity.zalando.com")
               -> dropRequestHeader("Authorization") -> dropRequestHeader("X-Checking-JWT")
               -> "http://127.0.0.1:9022/oauth2/introspect";
-            fallback1: Path("/oauth2/introspect") && QueryParam("token") && Header("X-Checking-JWT", "true")
-              -> inlineContent("{\"active\":false}") -> <shunt>;
-            fallback2: Path("/oauth2/introspect")
+            fallback: Path("/oauth2/introspect") && QueryParam("token") && Header("X-Checking-JWT", "true")
               -> inlineContent("{\"active\":false}") -> <shunt>;
           ports:
           - containerPort: 9023

--- a/cluster/node-pools/master-ubuntu-default/userdata.yaml
+++ b/cluster/node-pools/master-ubuntu-default/userdata.yaml
@@ -313,13 +313,14 @@ write_files:
               value: "https://sandbox.identity.zalando.com"
             - name: LISTEN_ADDRESS
               value: ":9022"
-          - name: skipper-tokeinfo-bridge
-            image: registry.opensource.zalan.do/foundation/platform-iam-tokeninfo:2fca26c
+          - name: skipper-tokeninfo-bridge
+            image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.243
             args:
             - skipper
             - -address=:9023
             - -inline-routes
             - |
+              health: Path("/healthz") -> inlineContent("ok") -> <shunt>;
               q2h: Path("/oauth2/tokeninfo") && QueryParam("access_token")
                 -> queryToHeader("access_token", "Authorization", "Bearer %s")
                 -> dropQuery("access_token")
@@ -333,7 +334,7 @@ write_files:
             - containerPort: 9023
             readinessProbe:
               httpGet:
-                path: /kube-system/healthz
+                path: /healthz
                 port: 9023
               timeoutSeconds: 5
             resources:


### PR DESCRIPTION
Introduces the `sandbox-bridge` for test clusters.

This allows Zalando PlatformIAM tokens of `test` services to access the Kubernetes API server of `test` clusters.