### PR TITLE
Hotfix[beta]: Revert "SSL policy >= 1.2"

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -11,13 +11,6 @@ autoscaling_buffer_pods: "1"
 autoscaling_buffer_pods: "0"
 {{end}}
 
-# ALB config created by kube-aws-ingress-controller
-{{if eq .Environment "test"}}
-kube_aws_ingress_controller_ssl_policy: "ELBSecurityPolicy-TLS-1-2-2017-01"
-{{else}}
-kube_aws_ingress_controller_ssl_policy: "ELBSecurityPolicy-2016-08"
-{{end}}
-
 # skipper resource settings
 skipper_limits_mem: "250Mi"
 skipper_requests_cpu: "150m"

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.8.8
+    version: v0.8.6
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.8.8
+        version: v0.8.6
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "false"}}
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
@@ -29,10 +29,9 @@ spec:
       serviceAccountName: kube-ingress-aws-controller
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.8.8
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.8.6
         args:
         - -stack-termination-protection
-        - -ssl-policy={{ .ConfigItems.kube_aws_ingress_controller_ssl_policy }}
         env:
         - name: AWS_REGION
           value: {{ .Region }}


### PR DESCRIPTION
Reverts zalando-incubator/kubernetes-on-aws#2255

Hotfix for beta of https://github.com/zalando-incubator/kubernetes-on-aws/pull/2280

In order to unblock "beta-to-stable" this reverts the SSLPolicy related changes. 