### PR TITLE
Update ExternalDNS to v0.5.15

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: external-dns
-    version: v0.5.14
+    version: v0.5.15
 spec:
   strategy:
     type: Recreate
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: external-dns
-        version: v0.5.14
+        version: v0.5.15
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
     spec:
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: pierone.stups.zalan.do/teapot/external-dns:v0.5.14
+        image: pierone.stups.zalan.do/teapot/external-dns:v0.5.15
         args:
         - --source=service
         - --source=ingress


### PR DESCRIPTION
Release notes: https://github.com/kubernetes-incubator/external-dns/releases/tag/v0.5.15

Mostly for running e2e for ExternalDNS :smile: 