### PR TITLE
Allow both master and worker nodes to assume etcd role

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -922,11 +922,15 @@ Resources:
               AWS: !Join
                 - ''
                 - - 'arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/'
-{{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
                   - !Ref WorkerIAMRole
-{{ else }}
+          - Action:
+              - 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              AWS: !Join
+                - ''
+                - - 'arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/'
                   - !Ref MasterIAMRole
-{{ end }}
         Version: 2012-10-17
       Path: /
       Policies:


### PR DESCRIPTION
Allow both master and worker to assume this role so that AWS credentials can be provisioned by both `kube2iam` and `kube-aws-iam-controller`. 