### PR TITLE
Reduce CPU requests for master components

### DIFF
--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -540,7 +540,7 @@ storage:
               failureThreshold: 2
             resources:
               requests:
-                cpu: 100m
+                cpu: 50m
                 memory: 20Mi
             env:
               - name: OPENID_PROVIDER_CONFIGURATION_URL
@@ -566,7 +566,7 @@ storage:
               failureThreshold: 2
             resources:
               requests:
-                cpu: 100m
+                cpu: 50m
                 memory: 20Mi
             env:
             - name: OPENID_PROVIDER_CONFIGURATION_URL
@@ -624,7 +624,7 @@ storage:
             - containerPort: 8082
             resources:
               requests:
-                cpu: 50m
+                cpu: 5m
                 memory: 50Mi
             volumeMounts:
             - name: config-volume

--- a/cluster/node-pools/master-ubuntu-default/userdata.yaml
+++ b/cluster/node-pools/master-ubuntu-default/userdata.yaml
@@ -277,7 +277,7 @@ write_files:
             failureThreshold: 2
           resources:
             requests:
-              cpu: 100m
+              cpu: 50m
               memory: 20Mi
           env:
             - name: OPENID_PROVIDER_CONFIGURATION_URL
@@ -303,7 +303,7 @@ write_files:
             failureThreshold: 2
           resources:
             requests:
-              cpu: 100m
+              cpu: 50m
               memory: 20Mi
           env:
           - name: OPENID_PROVIDER_CONFIGURATION_URL
@@ -361,7 +361,7 @@ write_files:
           - containerPort: 8082
           resources:
             requests:
-              cpu: 50m
+              cpu: 5m
               memory: 50Mi
           volumeMounts:
           - name: config-volume


### PR DESCRIPTION
This reduces CPU requests for `tokeninfo` and `image-policy-webhook`  based on metrics from the last 7 days.

The reason for this is that the components don't use as much CPU as requested and we now have to many containers on the master that all the things can not fit on smaller instance types.

tokeninfo CPU 7 days

![image](https://user-images.githubusercontent.com/128566/60768992-dfcb6e80-a0ca-11e9-8f8a-9b0dd085aeba.png)

image-policy-webhook 7 days

![image](https://user-images.githubusercontent.com/128566/60769002-14d7c100-a0cb-11e9-9fa4-d39cd4b2c5e0.png)
