### PR TITLE
Use kube-aws-iam-controller for external-dns

### DIFF
--- a/cluster/manifests/external-dns/aws-iam-role.yaml
+++ b/cluster/manifests/external-dns/aws-iam-role.yaml
@@ -1,0 +1,9 @@
+{{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
+apiVersion: zalando.org/v1
+kind: AWSIAMRole
+metadata:
+  name: external-dns-aws-iam-credentials
+  namespace: kube-system
+spec:
+  roleReference: {{ .LocalID }}-app-external-dns
+{{ end }}

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -17,8 +17,10 @@ spec:
       labels:
         application: external-dns
         version: v0.5.15
+{{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "false"}}
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
+{{ end }}
     spec:
       dnsConfig:
         options:
@@ -36,6 +38,12 @@ spec:
         - --registry=txt
         - --txt-owner-id={{ .Region }}:{{ .LocalID }}
         - --aws-batch-change-size=100
+{{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
+        env:
+        # must be set for the AWS SDK/AWS CLI to find the credentials file.
+        - name: AWS_SHARED_CREDENTIALS_FILE # used by golang SDK
+          value: /meta/aws-iam/credentials.process
+{{ end }}
         resources:
           limits:
             cpu: 50m
@@ -44,9 +52,21 @@ spec:
           httpGet:
             path: /healthz
             port: 7979
+{{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
+        volumeMounts:
+        - name: aws-iam-credentials
+          mountPath: /meta/aws-iam
+          readOnly: true
+{{ end }}
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 65534
           capabilities:
             drop: ["ALL"]
+{{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
+      volumes:
+      - name: aws-iam-credentials
+        secret:
+          secretName: external-dns-aws-iam-credentials
+{{ end }}


### PR DESCRIPTION
Switch external-dns to consume AWS IAM roles using kube-aws-iam-controller. This works now that external-dns has been upgraded.