### PR TITLE
Merge pull request #2289 from zalando-incubator/fix/intermittenly-failing-etcd-backups

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -922,11 +922,15 @@ Resources:
               AWS: !Join
                 - ''
                 - - 'arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/'
-{{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
                   - !Ref WorkerIAMRole
-{{ else }}
+          - Action:
+              - 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              AWS: !Join
+                - ''
+                - - 'arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/'
                   - !Ref MasterIAMRole
-{{ end }}
         Version: 2012-10-17
       Path: /
       Policies:


### PR DESCRIPTION
Allow both master and worker nodes to assume etcd role

(cherry picked from commit 65924de499779d6676790f63294fc9d0396efe5c)
Signed-off-by: Rodrigo Reis <rodrigo@zalando.de>