### PR TITLE
Disable external service accounts by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -248,7 +248,7 @@ node_cidr_mask_size: "24" # Default: 24
 apiserver_proxy: "true"
 # when set to true, service account tokens can be used from outside the cluster
 # requires apiserver_proxy to be set to "true"
-allow_external_service_accounts: "true"
+allow_external_service_accounts: "false"
 
 # use kube-aws-iam-controller for kube-system components
 kube_aws_iam_controller_kube_system_enable: "true"


### PR DESCRIPTION
All clusters override this config so we can safely enable this by default.
New clusters will therefore be created with the enforcement in place from the beginning.