### PR TITLE
Allow Egress controller to delete tags

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1004,6 +1004,9 @@ Resources:
               - Action: 'ec2:CreateTags'
                 Effect: Allow
                 Resource: '*'
+              - Action: 'ec2:DeleteTags'
+                Effect: Allow
+                Resource: '*'
               - Action: 'ec2:ReleaseAddress'
                 Effect: Allow
                 Resource: '*'


### PR DESCRIPTION
The Egress controller now stores information in tags and therefore need to be able to Create and **delete** tags.