### PR TITLE
alb support for sslpolicy, dualstack and trigger CF stack updates on start

### DIFF
--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.8.6
+    version: v0.8.10
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.8.6
+        version: v0.8.10
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "false"}}
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: kube-ingress-aws-controller
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.8.6
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.8.10
         args:
         - -stack-termination-protection
         env:


### PR DESCRIPTION
feature: sslpolicy
feature: dualstack support
fix: trigger CF stack update on controller start

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>