### PR TITLE
Update Egress controller

### DIFF
--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-static-egress-controller
-    version: v0.1.13
+    version: v0.2.0
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-static-egress-controller
-        version: v0.1.13
+        version: v0.2.0
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "false"}}
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-static-egress-controller"
@@ -28,7 +28,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-static-egress-controller:v0.1.13
+        image: registry.opensource.zalan.do/teapot/kube-static-egress-controller:v0.2.0
         args:
         - "--provider=aws"
 {{- range $subnet := stupsNATSubnets .Values.vpc_ipv4_cidr }}
@@ -38,6 +38,7 @@ spec:
         - "--aws-az={{ $zone }}"
 {{ end }}
         - "--stack-termination-protection"
+        - "--cluster-id={{ .ID }}"
         env:
         - name: AWS_REGION
           value: eu-central-1


### PR DESCRIPTION
* Feature: CF stack ownership: new stacks are created with a dynamic stack name and you can now run multiple controllers and multiple clusters in the same account
* Fix: overlapping CIDRs are merged

https://github.com/szuecs/kube-static-egress-controller/releases/tag/v0.2.0