### PR TITLE
Don't mount host certs. Certs are available in the containers

### DIFF
--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -51,9 +51,6 @@ spec:
             cpu: 50m
             memory: 200Mi
         volumeMounts:
-        - name: ssl-certs
-          mountPath: /etc/ssl/certs
-          readOnly: true
         - name: kubeconfig
           mountPath: /etc/kubernetes/kubeconfig
           readOnly: true
@@ -64,9 +61,6 @@ spec:
           mountPath: /config
           readOnly: true
       volumes:
-      - name: ssl-certs
-        hostPath:
-          path: /usr/share/ca-certificates
       - name: kubeconfig
         hostPath:
           path: /etc/kubernetes/kubeconfig

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -436,9 +436,6 @@ storage:
             - mountPath: /etc/kubernetes/ssl
               name: ssl-certs-kubernetes
               readOnly: true
-            - mountPath: /etc/ssl/certs
-              name: ssl-certs-host
-              readOnly: true
             - mountPath: /etc/kubernetes/config
               name: kubernetes-configs
               readOnly: true
@@ -694,9 +691,6 @@ storage:
               path: /etc/kubernetes/config
             name: kubernetes-configs
           - hostPath:
-              path: /usr/share/ca-certificates
-            name: ssl-certs-host
-          - hostPath:
               path: /etc/kubernetes/nginx
             name: config-volume
 
@@ -757,9 +751,6 @@ storage:
             - mountPath: /etc/kubernetes/ssl
               name: ssl-certs-kubernetes
               readOnly: true
-            - mountPath: /etc/ssl/certs
-              name: ssl-certs-host
-              readOnly: true
             - mountPath: /etc/kubernetes
               name: kubeconfig
               readOnly: true
@@ -771,9 +762,6 @@ storage:
           - hostPath:
               path: /etc/kubernetes
             name: kubeconfig
-          - hostPath:
-              path: /usr/share/ca-certificates
-            name: ssl-certs-host
 
   - filesystem: root
     path: /etc/kubernetes/manifests/kube-scheduler.yaml

--- a/cluster/node-pools/master-ubuntu-default/userdata.yaml
+++ b/cluster/node-pools/master-ubuntu-default/userdata.yaml
@@ -173,9 +173,6 @@ write_files:
           - mountPath: /etc/kubernetes/ssl
             name: ssl-certs-kubernetes
             readOnly: true
-          - mountPath: /etc/ssl/certs
-            name: ssl-certs-host
-            readOnly: true
           - mountPath: /etc/kubernetes/config
             name: kubernetes-configs
             readOnly: true
@@ -431,9 +428,6 @@ write_files:
             path: /etc/kubernetes/config
           name: kubernetes-configs
         - hostPath:
-            path: /usr/share/ca-certificates
-          name: ssl-certs-host
-        - hostPath:
             path: /etc/kubernetes/nginx
           name: config-volume
 
@@ -491,9 +485,6 @@ write_files:
           - mountPath: /etc/kubernetes/ssl
             name: ssl-certs-kubernetes
             readOnly: true
-          - mountPath: /etc/ssl/certs
-            name: ssl-certs-host
-            readOnly: true
           - mountPath: /etc/kubernetes
             name: kubeconfig
             readOnly: true
@@ -505,9 +496,6 @@ write_files:
         - hostPath:
             path: /etc/kubernetes
           name: kubeconfig
-        - hostPath:
-            path: /usr/share/ca-certificates
-          name: ssl-certs-host
 
   - owner: root:root
     path: /etc/kubernetes/manifests/kube-scheduler.yaml


### PR DESCRIPTION
This avoids mounting certs from the host which is not needed since the certs are already in the containers. 

Mounting the certs has the downside that the host certs must be in a special location, which is not always the same from system to system. In Ubuntu nodes we do a hack to move the certs to the expected location but this then breaks the assumptions about where certs are on the ubuntu node for other components (I was playing around with [ec2-instance-connect](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-connect-set-up.html) which didn't work because of this).

Once this is rolled out we can drop the special relocation of certs in the Ubuntu AMI.