### PR TITLE
Updated Ubuntu AMI with fixes

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -212,7 +212,7 @@ cluster_dns: "coredns"
 coredns_log_svc_names: "true"
 
 coreos_image: "ami-0d1579b60bb706fb7" # Container Linux 2079.6.0 (HVM, eu-central-1)
-kuberuntu_image: "ami-03b8e632206a4e665" # Kuberuntu (dev) (HVM, eu-central-1)
+kuberuntu_image: "ami-06e3bcc8ee7d981fe" # Kuberuntu (dev) (HVM, eu-central-1)
 
 # Feature toggle to allow gradual decommissioning of ingress-template-controller
 enable_ingress_template_controller: "false"


### PR DESCRIPTION
This AMI contains a fix for a regression in the boot time for instances with local storage.