### PR TITLE
Enable secretsmanager for deployments

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -611,6 +611,7 @@ Resources:
                   - 'route53domains:List*'
                   - 's3:*'
                   - 'sdb:*'
+                  - 'secretsmanager:*'
                   - 'ses:*'
                   - 'sns:*'
                   - 'sqs:*'


### PR DESCRIPTION
The secretsmanager permissions are enabled for `PowerUser` but we forgot to update the permissions here so it's possible to deploy via cloudformation.