### PR TITLE
Enable SSL Policy >= 1.2 for test

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -11,6 +11,9 @@ autoscaling_buffer_pods: "1"
 autoscaling_buffer_pods: "0"
 {{end}}
 
+# ALB config created by kube-aws-ingress-controller
+kube_aws_ingress_controller_ssl_policy: "ELBSecurityPolicy-TLS-1-2-2017-01"
+
 # skipper resource settings
 skipper_limits_mem: "250Mi"
 skipper_requests_cpu: "150m"

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -32,6 +32,7 @@ spec:
         image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.8.10
         args:
         - -stack-termination-protection
+        - -ssl-policy={{ .ConfigItems.kube_aws_ingress_controller_ssl_policy }}
         env:
         - name: AWS_REGION
           value: {{ .Region }}


### PR DESCRIPTION
Follow up to: https://github.com/zalando-incubator/kubernetes-on-aws/pull/2255 which was reverted when we needed users to fix CNAMEs pointing directly to ALB addresses. The CNAMEs are now fixed so we can restart the rollout.

Only enables new SSL policy for test clusters and for new clusters. (existing production clusters have the policy: `ELBSecurityPolicy-2016-08` set in cluster registry config items).