### PR TITLE
Ensure pre-apply steps are only done for existing clusters

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -1,8 +1,10 @@
 # everything defined under here will be deleted before applying the manifests
 pre_apply:
+{{ if eq .LifecycleStatus "ready" }}
 - name: logging-agent
   kind: DaemonSet
   namespace: {{if eq .ConfigItems.logging_agent_in_visibility "true"}}kube-system{{else}}visibility{{end}}
+{{ end }}
 
 # everything defined under here will be deleted after applying the manifests
 post_apply:


### PR DESCRIPTION
Without this in place CLM will try to delete resources before it has any access rights, because the `ClusterRoleBinding` for CLM has not yet been setup when a new cluster is created.