### PR TITLE
Add role & binding for ingress-host-sync

### DIFF
--- a/cluster/manifests/roles/ingress-host-sync.yaml
+++ b/cluster/manifests/roles/ingress-host-sync.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ingress-host-sync
+rules:
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ingress-host-sync
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ingress-host-sync
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: zalando-iam:zalando:service:stups_ingress-host-sync


### PR DESCRIPTION
This is needed for the new ZMON entity sync job.