### PR TITLE
vpa-updater: fix argument passing

### DIFF
--- a/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
@@ -24,8 +24,9 @@ spec:
       containers:
       - name: updater
         image: registry.opensource.zalan.do/teapot/vpa-updater:patched-0.5.1-master-15
-        args:
+        command:
           - ./updater
+        args:
           - --v=4
           - --stderrthreshold=info
           - --min-replicas=1


### PR DESCRIPTION
We need to provide both `command` and `args`, otherwise the defaults from the Docker image override everything.