### PR TITLE
Enable Service Link for Service Quotas to increase AWS limits

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1365,6 +1365,11 @@ Resources:
       Description: "AWS service role for application autoscaling DynamoDB"
     Type: "AWS::IAM::ServiceLinkedRole"
 {{- end }}
+  ServiceLinkedRoleServiceQuotas:
+    Properties:
+      AWSServiceName: "servicequotas.amazonaws.com"
+      Description: "AWS service role for Service Quotas"
+    Type: "AWS::IAM::ServiceLinkedRole"
   RemoteFilesEncryptionKey:
     Type: "AWS::KMS::Key"
     Properties:


### PR DESCRIPTION
Allows Service Quotas to create support cases on your behalf