### PR TITLE
Update CA to v1.12.2-internal.3

### DIFF
--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-cluster-autoscaler
-    version: v1.12.2-internal63
+    version: v1.12.2-internal.3
 spec:
   selector:
     matchLabels:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: kube-cluster-autoscaler
-        version: v1.12.2-internal63
+        version: v1.12.2-internal.3
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-autoscaler"
         config/pool-sizes: "{{range .NodePools}}{{.Name}}-{{.MinSize}}-{{.MaxSize}} {{end}}"
@@ -33,7 +33,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cluster-autoscaler
-        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.12.2-internal63
+        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.12.2-internal.3
         command:
           - ./cluster-autoscaler
           - --v=4


### PR DESCRIPTION
Changes:
 * Update AWS instance types (https://github.com/zalando-incubator/autoscaler/pull/3)

Build number went down because we moved to a new repo.