### PR TITLE
Allow to specify per-pod pid limit

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -248,6 +248,9 @@ node_max_pods: "110" # Default: 110
 # flag passed to controller-manager
 node_cidr_mask_size: "24" # Default: 24
 
+# maximum number of PIDs allowed to be allocated per pod
+pod_max_pids: "4096"
+
 # when set to true, routes external traffic to the apiserver through a skipper sidecar
 apiserver_proxy: "true"
 # when set to true, service account tokens can be used from outside the cluster

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -269,7 +269,10 @@ storage:
 {{- if not (index .Cluster.ConfigItems "enable_cfs_quota") }}
         cpuCFSQuota: false
 {{- end }}
+        featureGates:
+          SupportPodPidsLimit: true
         maxPods: {{ .Cluster.ConfigItems.node_max_pods }}
+        podPidsLimit: {{ .Cluster.ConfigItems.pod_max_pids }}
         healthzPort: 10248
         healthzBindAddress: "0.0.0.0"
         tlsCertFile: "/etc/kubernetes/ssl/worker.pem"

--- a/cluster/node-pools/master-ubuntu-default/userdata.yaml
+++ b/cluster/node-pools/master-ubuntu-default/userdata.yaml
@@ -54,7 +54,10 @@ write_files:
 {{- if not (index .Cluster.ConfigItems "enable_cfs_quota") }}
       cpuCFSQuota: false
 {{- end }}
+      featureGates:
+        SupportPodPidsLimit: true
       maxPods: {{ .Cluster.ConfigItems.node_max_pods }}
+      podPidsLimit: {{ .Cluster.ConfigItems.pod_max_pids }}
       healthzPort: 10248
       healthzBindAddress: "0.0.0.0"
       tlsCertFile: "/etc/kubernetes/ssl/worker.pem"

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -302,7 +302,10 @@ storage:
 {{- if not (index .Cluster.ConfigItems "enable_cfs_quota") }}
         cpuCFSQuota: false
 {{- end }}
+        featureGates:
+          SupportPodPidsLimit: true
         maxPods: {{ .Cluster.ConfigItems.node_max_pods }}
+        podPidsLimit: {{ .Cluster.ConfigItems.pod_max_pids }}
         healthzPort: 10248
         healthzBindAddress: "0.0.0.0"
         tlsCertFile: "/etc/kubernetes/ssl/worker.pem"

--- a/cluster/node-pools/worker-ubuntu-default/userdata.yaml
+++ b/cluster/node-pools/worker-ubuntu-default/userdata.yaml
@@ -48,7 +48,10 @@ write_files:
       kind: KubeletConfiguration
       clusterDomain: cluster.local
       cpuCFSQuota: false
+      featureGates:
+        SupportPodPidsLimit: true
       maxPods: {{ .Cluster.ConfigItems.node_max_pods }}
+      podPidsLimit: {{ .Cluster.ConfigItems.pod_max_pids }}
       healthzPort: 10248
       healthzBindAddress: "0.0.0.0"
       tlsCertFile: "/etc/kubernetes/ssl/worker.pem"


### PR DESCRIPTION
Enable PID limit enforcement and introduce a config item to specify that limit per pod. Currently Kubernetes doesn't enforce any limit which corresponds to setting the config item to "-1".

The limit of 4096 has been chosen to roughly match the internally proposed "Something like 5k would probably be a good initial estimate".

Merging this PR enforces the limit.

The FeatureGate is enabled by default in Kubernetes 1.14 and can be dropped from the config then.