### PR TITLE
Allow SSH access to master and worker nodes from outside based on config

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -112,7 +112,7 @@ Resources:
           FromPort: -1
           IpProtocol: icmp
           ToPort: -1
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+        - CidrIp: {{ if eq .Cluster.ConfigItems.ssh_vpc_only "true" }}"{{.Values.vpc_ipv4_cidr}}"{{ else }}"0.0.0.0/0"{{ end }}
           FromPort: 22
           IpProtocol: tcp
           ToPort: 22
@@ -311,7 +311,7 @@ Resources:
           FromPort: -1
           IpProtocol: icmp
           ToPort: -1
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+        - CidrIp: {{ if eq .Cluster.ConfigItems.ssh_vpc_only "true" }}"{{.Values.vpc_ipv4_cidr}}"{{ else }}"0.0.0.0/0"{{ end }}
           FromPort: 22
           IpProtocol: tcp
           ToPort: 22

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -259,3 +259,6 @@ allow_external_service_accounts: "false"
 
 # use kube-aws-iam-controller for kube-system components
 kube_aws_iam_controller_kube_system_enable: "true"
+
+# allow ssh access for internal VPC IPs only
+ssh_vpc_only: "false"


### PR DESCRIPTION
Make the SSH IP range in the master and worker security groups a configuration item.