### PR TITLE
Removed stack weights to determine traffic in kube-metrics-adapter

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -40,7 +40,6 @@ spec:
         - --aws-external-metrics
         - --aws-region=eu-central-1
         - --aws-region=eu-west-1
-        - --skipper-backends-annotation=zalando.org/stack-traffic-weights
         - --skipper-backends-annotation=zalando.org/backend-weights
         {{ if eq .Environment "production" }}
         - --zmon-kariosdb-endpoint=https://data-service.zmon.zalan.do/kairosdb-proxy


### PR DESCRIPTION
Using the `stackset-weight` to determine the traffic on an ingress causes the calculated RPS to be higher than it actually is. 