### PR TITLE
prometheus-node-exporter: enable processes collector

### DIFF
--- a/cluster/manifests/prometheus-node-exporter/daemonset.yaml
+++ b/cluster/manifests/prometheus-node-exporter/daemonset.yaml
@@ -32,6 +32,7 @@ spec:
       - image: registry.opensource.zalan.do/teapot/prometheus-node-exporter:v0.18.1
         args:
           - --collector.textfile.directory=/prometheus-exporter-data
+          - --collector.processes
         name: prometheus-node-exporter
         ports:
         - name: prom-node-exp


### PR DESCRIPTION
This way we can collect the PID usage information.