### PR TITLE
Allow to configure PID limit per node pool

### DIFF
--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -269,10 +269,13 @@ storage:
 {{- if not (index .Cluster.ConfigItems "enable_cfs_quota") }}
         cpuCFSQuota: false
 {{- end }}
+{{- if index .NodePool.ConfigItems "pod_max_pids" }}{{ $pod_max_pids := .NodePool.ConfigItems.pod_max_pids }}{{ else }}{{ $pod_max_pids := .Cluster.ConfigItems.pod_max_pids }}{{ end }}
+{{- if ne $pod_max_pids "-1" }}
         featureGates:
           SupportPodPidsLimit: true
+        podPidsLimit: {{ $pod_max_pids }}
+{{- end }}
         maxPods: {{ .Cluster.ConfigItems.node_max_pods }}
-        podPidsLimit: {{ if index .NodePool.ConfigItems "pod_max_pids" }}{{ .NodePool.ConfigItems.pod_max_pids }}{{ else }}{{ .Cluster.ConfigItems.pod_max_pids }}{{ end }}
         healthzPort: 10248
         healthzBindAddress: "0.0.0.0"
         tlsCertFile: "/etc/kubernetes/ssl/worker.pem"

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -269,7 +269,8 @@ storage:
 {{- if not (index .Cluster.ConfigItems "enable_cfs_quota") }}
         cpuCFSQuota: false
 {{- end }}
-{{- if index .NodePool.ConfigItems "pod_max_pids" }}{{ $pod_max_pids := .NodePool.ConfigItems.pod_max_pids }}{{ else }}{{ $pod_max_pids := .Cluster.ConfigItems.pod_max_pids }}{{ end }}
+{{- $pod_max_pids := .Cluster.ConfigItems.pod_max_pids }}
+{{- if index .NodePool.ConfigItems "pod_max_pids" }}{{ $pod_max_pids = .NodePool.ConfigItems.pod_max_pids }}{{ end }}
 {{- if ne $pod_max_pids "-1" }}
         featureGates:
           SupportPodPidsLimit: true

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -272,7 +272,7 @@ storage:
         featureGates:
           SupportPodPidsLimit: true
         maxPods: {{ .Cluster.ConfigItems.node_max_pods }}
-        podPidsLimit: {{ .Cluster.ConfigItems.pod_max_pids }}
+        podPidsLimit: {{ if index .NodePool.ConfigItems "pod_max_pids" }}{{ .NodePool.ConfigItems.pod_max_pids }}{{ else }}{{ .Cluster.ConfigItems.pod_max_pids }}{{ end }}
         healthzPort: 10248
         healthzBindAddress: "0.0.0.0"
         tlsCertFile: "/etc/kubernetes/ssl/worker.pem"

--- a/cluster/node-pools/master-ubuntu-default/userdata.yaml
+++ b/cluster/node-pools/master-ubuntu-default/userdata.yaml
@@ -54,7 +54,8 @@ write_files:
 {{- if not (index .Cluster.ConfigItems "enable_cfs_quota") }}
       cpuCFSQuota: false
 {{- end }}
-{{- if index .NodePool.ConfigItems "pod_max_pids" }}{{ $pod_max_pids := .NodePool.ConfigItems.pod_max_pids }}{{ else }}{{ $pod_max_pids := .Cluster.ConfigItems.pod_max_pids }}{{ end }}
+{{- $pod_max_pids := .Cluster.ConfigItems.pod_max_pids }}
+{{- if index .NodePool.ConfigItems "pod_max_pids" }}{{ $pod_max_pids = .NodePool.ConfigItems.pod_max_pids }}{{ end }}
 {{- if ne $pod_max_pids "-1" }}
       featureGates:
         SupportPodPidsLimit: true

--- a/cluster/node-pools/master-ubuntu-default/userdata.yaml
+++ b/cluster/node-pools/master-ubuntu-default/userdata.yaml
@@ -54,10 +54,13 @@ write_files:
 {{- if not (index .Cluster.ConfigItems "enable_cfs_quota") }}
       cpuCFSQuota: false
 {{- end }}
+{{- if index .NodePool.ConfigItems "pod_max_pids" }}{{ $pod_max_pids := .NodePool.ConfigItems.pod_max_pids }}{{ else }}{{ $pod_max_pids := .Cluster.ConfigItems.pod_max_pids }}{{ end }}
+{{- if ne $pod_max_pids "-1" }}
       featureGates:
         SupportPodPidsLimit: true
+      podPidsLimit: {{ $pod_max_pids }}
+{{- end }}
       maxPods: {{ .Cluster.ConfigItems.node_max_pods }}
-      podPidsLimit: {{ if index .NodePool.ConfigItems "pod_max_pids" }}{{ .NodePool.ConfigItems.pod_max_pids }}{{ else }}{{ .Cluster.ConfigItems.pod_max_pids }}{{ end }}
       healthzPort: 10248
       healthzBindAddress: "0.0.0.0"
       tlsCertFile: "/etc/kubernetes/ssl/worker.pem"

--- a/cluster/node-pools/master-ubuntu-default/userdata.yaml
+++ b/cluster/node-pools/master-ubuntu-default/userdata.yaml
@@ -57,7 +57,7 @@ write_files:
       featureGates:
         SupportPodPidsLimit: true
       maxPods: {{ .Cluster.ConfigItems.node_max_pods }}
-      podPidsLimit: {{ .Cluster.ConfigItems.pod_max_pids }}
+      podPidsLimit: {{ if index .NodePool.ConfigItems "pod_max_pids" }}{{ .NodePool.ConfigItems.pod_max_pids }}{{ else }}{{ .Cluster.ConfigItems.pod_max_pids }}{{ end }}
       healthzPort: 10248
       healthzBindAddress: "0.0.0.0"
       tlsCertFile: "/etc/kubernetes/ssl/worker.pem"

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -302,10 +302,13 @@ storage:
 {{- if not (index .Cluster.ConfigItems "enable_cfs_quota") }}
         cpuCFSQuota: false
 {{- end }}
+{{- if index .NodePool.ConfigItems "pod_max_pids" }}{{ $pod_max_pids := .NodePool.ConfigItems.pod_max_pids }}{{ else }}{{ $pod_max_pids := .Cluster.ConfigItems.pod_max_pids }}{{ end }}
+{{- if ne $pod_max_pids "-1" }}
         featureGates:
           SupportPodPidsLimit: true
+        podPidsLimit: {{ $pod_max_pids }}
+{{- end }}
         maxPods: {{ .Cluster.ConfigItems.node_max_pods }}
-        podPidsLimit: {{ if index .NodePool.ConfigItems "pod_max_pids" }}{{ .NodePool.ConfigItems.pod_max_pids }}{{ else }}{{ .Cluster.ConfigItems.pod_max_pids }}{{ end }}
         healthzPort: 10248
         healthzBindAddress: "0.0.0.0"
         tlsCertFile: "/etc/kubernetes/ssl/worker.pem"

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -302,7 +302,8 @@ storage:
 {{- if not (index .Cluster.ConfigItems "enable_cfs_quota") }}
         cpuCFSQuota: false
 {{- end }}
-{{- if index .NodePool.ConfigItems "pod_max_pids" }}{{ $pod_max_pids := .NodePool.ConfigItems.pod_max_pids }}{{ else }}{{ $pod_max_pids := .Cluster.ConfigItems.pod_max_pids }}{{ end }}
+{{- $pod_max_pids := .Cluster.ConfigItems.pod_max_pids }}
+{{- if index .NodePool.ConfigItems "pod_max_pids" }}{{ $pod_max_pids = .NodePool.ConfigItems.pod_max_pids }}{{ end }}
 {{- if ne $pod_max_pids "-1" }}
         featureGates:
           SupportPodPidsLimit: true

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -305,7 +305,7 @@ storage:
         featureGates:
           SupportPodPidsLimit: true
         maxPods: {{ .Cluster.ConfigItems.node_max_pods }}
-        podPidsLimit: {{ .Cluster.ConfigItems.pod_max_pids }}
+        podPidsLimit: {{ if index .NodePool.ConfigItems "pod_max_pids" }}{{ .NodePool.ConfigItems.pod_max_pids }}{{ else }}{{ .Cluster.ConfigItems.pod_max_pids }}{{ end }}
         healthzPort: 10248
         healthzBindAddress: "0.0.0.0"
         tlsCertFile: "/etc/kubernetes/ssl/worker.pem"

--- a/cluster/node-pools/worker-ubuntu-default/userdata.yaml
+++ b/cluster/node-pools/worker-ubuntu-default/userdata.yaml
@@ -48,7 +48,8 @@ write_files:
       kind: KubeletConfiguration
       clusterDomain: cluster.local
       cpuCFSQuota: false
-{{- if index .NodePool.ConfigItems "pod_max_pids" }}{{ $pod_max_pids := .NodePool.ConfigItems.pod_max_pids }}{{ else }}{{ $pod_max_pids := .Cluster.ConfigItems.pod_max_pids }}{{ end }}
+{{- $pod_max_pids := .Cluster.ConfigItems.pod_max_pids }}
+{{- if index .NodePool.ConfigItems "pod_max_pids" }}{{ $pod_max_pids = .NodePool.ConfigItems.pod_max_pids }}{{ end }}
 {{- if ne $pod_max_pids "-1" }}
       featureGates:
         SupportPodPidsLimit: true

--- a/cluster/node-pools/worker-ubuntu-default/userdata.yaml
+++ b/cluster/node-pools/worker-ubuntu-default/userdata.yaml
@@ -48,10 +48,13 @@ write_files:
       kind: KubeletConfiguration
       clusterDomain: cluster.local
       cpuCFSQuota: false
+{{- if index .NodePool.ConfigItems "pod_max_pids" }}{{ $pod_max_pids := .NodePool.ConfigItems.pod_max_pids }}{{ else }}{{ $pod_max_pids := .Cluster.ConfigItems.pod_max_pids }}{{ end }}
+{{- if ne $pod_max_pids "-1" }}
       featureGates:
         SupportPodPidsLimit: true
+      podPidsLimit: {{ $pod_max_pids }}
+{{- end }}
       maxPods: {{ .Cluster.ConfigItems.node_max_pods }}
-      podPidsLimit: {{ if index .NodePool.ConfigItems "pod_max_pids" }}{{ .NodePool.ConfigItems.pod_max_pids }}{{ else }}{{ .Cluster.ConfigItems.pod_max_pids }}{{ end }}
       healthzPort: 10248
       healthzBindAddress: "0.0.0.0"
       tlsCertFile: "/etc/kubernetes/ssl/worker.pem"

--- a/cluster/node-pools/worker-ubuntu-default/userdata.yaml
+++ b/cluster/node-pools/worker-ubuntu-default/userdata.yaml
@@ -51,7 +51,7 @@ write_files:
       featureGates:
         SupportPodPidsLimit: true
       maxPods: {{ .Cluster.ConfigItems.node_max_pods }}
-      podPidsLimit: {{ .Cluster.ConfigItems.pod_max_pids }}
+      podPidsLimit: {{ if index .NodePool.ConfigItems "pod_max_pids" }}{{ .NodePool.ConfigItems.pod_max_pids }}{{ else }}{{ .Cluster.ConfigItems.pod_max_pids }}{{ end }}
       healthzPort: 10248
       healthzBindAddress: "0.0.0.0"
       tlsCertFile: "/etc/kubernetes/ssl/worker.pem"


### PR DESCRIPTION
Allows to specify `pod_max_pids` config item on a node pool. If it's not defined on the node pool the cluster-wide `pod_max_pids` config item is used. Defaults to 4096 if not defined in cluster registry.