### PR TITLE
Bind Emergency and Manual Groups same as PowerUser

### DIFF
--- a/cluster/manifests/roles/poweruser-binding.yaml
+++ b/cluster/manifests/roles/poweruser-binding.yaml
@@ -10,3 +10,9 @@ subjects:
 - kind: Group
   name: PowerUser
   apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: Manual
+  apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: Emergency
+  apiGroup: rbac.authorization.k8s.io

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -489,7 +489,7 @@ storage:
               - mountPath: /etc/kubernetes/ssl
                 name: ssl-certs-kubernetes
                 readOnly: true
-          - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.5.6
+          - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.5.7
             name: webhook
             ports:
             - containerPort: 8081

--- a/cluster/node-pools/master-ubuntu-default/userdata.yaml
+++ b/cluster/node-pools/master-ubuntu-default/userdata.yaml
@@ -226,7 +226,7 @@ write_files:
             - mountPath: /etc/kubernetes/ssl
               name: ssl-certs-kubernetes
               readOnly: true
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.5.6
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.5.7
           name: webhook
           ports:
           - containerPort: 8081

--- a/test/e2e/authorisation_test.go
+++ b/test/e2e/authorisation_test.go
@@ -2157,6 +2157,34 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				},
 			},
 			{
+				msg: "cdp service account can't escalate permissions",
+				reqBody: `{
+					"apiVersion": "authorization.k8s.io/v1beta1",
+					"kind": "SubjectAccessReview",
+					"spec": {
+					"resourceAttributes": {
+						"namespace": "",
+						"verb": "escalate",
+						"group": "*",
+						"resource": "clusterroles"
+					},
+					"user": "system:serviceaccount:default:cdp",
+					"group": []
+					}
+				}`,
+				expect: expect{
+					status: http.StatusCreated,
+					body: `{
+					"apiVersion": "authorization.k8s.io/v1beta1",
+					"kind": "SubjectAccessReview",
+					"status": {
+						"denied": true,
+						"reason": "no one is allowed to escalate"
+					}
+				}}`,
+				},
+			},
+			{
 				msg: "operator service account cannot create namespaces",
 				reqBody: `{
 					"apiVersion": "authorization.k8s.io/v1beta1",


### PR DESCRIPTION
Binds `Emergency` and `Manual` Groups same way as `PowerUser` since they are defined to have the same permissions.

This is currently done in the auth webhook, but we should migrate to RBAC to fix blacklist/whitelist bugs in the auth webhook.