### PR TITLE
Simplify template logic based on config item propagation

### DIFF
--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -269,12 +269,10 @@ storage:
 {{- if not (index .Cluster.ConfigItems "enable_cfs_quota") }}
         cpuCFSQuota: false
 {{- end }}
-{{- $pod_max_pids := .Cluster.ConfigItems.pod_max_pids }}
-{{- if index .NodePool.ConfigItems "pod_max_pids" }}{{ $pod_max_pids = .NodePool.ConfigItems.pod_max_pids }}{{ end }}
-{{- if ne $pod_max_pids "-1" }}
+{{- if ne .NodePool.ConfigItems.pod_max_pids "-1" }}
         featureGates:
           SupportPodPidsLimit: true
-        podPidsLimit: {{ $pod_max_pids }}
+        podPidsLimit: {{ .NodePool.ConfigItems.pod_max_pids }}
 {{- end }}
         maxPods: {{ .Cluster.ConfigItems.node_max_pods }}
         healthzPort: 10248

--- a/cluster/node-pools/master-ubuntu-default/userdata.yaml
+++ b/cluster/node-pools/master-ubuntu-default/userdata.yaml
@@ -54,12 +54,10 @@ write_files:
 {{- if not (index .Cluster.ConfigItems "enable_cfs_quota") }}
       cpuCFSQuota: false
 {{- end }}
-{{- $pod_max_pids := .Cluster.ConfigItems.pod_max_pids }}
-{{- if index .NodePool.ConfigItems "pod_max_pids" }}{{ $pod_max_pids = .NodePool.ConfigItems.pod_max_pids }}{{ end }}
-{{- if ne $pod_max_pids "-1" }}
+{{- if ne .NodePool.ConfigItems.pod_max_pids "-1" }}
       featureGates:
         SupportPodPidsLimit: true
-      podPidsLimit: {{ $pod_max_pids }}
+      podPidsLimit: {{ .NodePool.ConfigItems.pod_max_pids }}
 {{- end }}
       maxPods: {{ .Cluster.ConfigItems.node_max_pods }}
       healthzPort: 10248

--- a/cluster/node-pools/worker-default/userdata.clc.yaml
+++ b/cluster/node-pools/worker-default/userdata.clc.yaml
@@ -302,12 +302,10 @@ storage:
 {{- if not (index .Cluster.ConfigItems "enable_cfs_quota") }}
         cpuCFSQuota: false
 {{- end }}
-{{- $pod_max_pids := .Cluster.ConfigItems.pod_max_pids }}
-{{- if index .NodePool.ConfigItems "pod_max_pids" }}{{ $pod_max_pids = .NodePool.ConfigItems.pod_max_pids }}{{ end }}
-{{- if ne $pod_max_pids "-1" }}
+{{- if ne .NodePool.ConfigItems.pod_max_pids "-1" }}
         featureGates:
           SupportPodPidsLimit: true
-        podPidsLimit: {{ $pod_max_pids }}
+        podPidsLimit: {{ .NodePool.ConfigItems.pod_max_pids }}
 {{- end }}
         maxPods: {{ .Cluster.ConfigItems.node_max_pods }}
         healthzPort: 10248

--- a/cluster/node-pools/worker-ubuntu-default/userdata.yaml
+++ b/cluster/node-pools/worker-ubuntu-default/userdata.yaml
@@ -48,12 +48,10 @@ write_files:
       kind: KubeletConfiguration
       clusterDomain: cluster.local
       cpuCFSQuota: false
-{{- $pod_max_pids := .Cluster.ConfigItems.pod_max_pids }}
-{{- if index .NodePool.ConfigItems "pod_max_pids" }}{{ $pod_max_pids = .NodePool.ConfigItems.pod_max_pids }}{{ end }}
-{{- if ne $pod_max_pids "-1" }}
+{{- if ne .NodePool.ConfigItems.pod_max_pids "-1" }}
       featureGates:
         SupportPodPidsLimit: true
-      podPidsLimit: {{ $pod_max_pids }}
+      podPidsLimit: {{ .NodePool.ConfigItems.pod_max_pids }}
 {{- end }}
       maxPods: {{ .Cluster.ConfigItems.node_max_pods }}
       healthzPort: 10248


### PR DESCRIPTION
Simplifies NodePool config item lookup by using pending CLM feature: https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/153