### PR TITLE
cadvisor: explicitly publish Kubelet metrics

### DIFF
--- a/cluster/manifests/cadvisor/daemonset.yaml
+++ b/cluster/manifests/cadvisor/daemonset.yaml
@@ -36,6 +36,7 @@ spec:
         - --event_storage_age_limit=default=0
         - --disable_metrics=sched,percpu,tcp,udp
         - --docker_only
+        - --raw_cgroup_prefix_whitelist=/system.slice/kubelet.service
         - --store_container_labels=false
         - --whitelisted_container_labels=io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace,io.kubernetes.pod.uid,application
         resources:


### PR DESCRIPTION
v0.33.0 doesn't publish these by default if `--docker-only` is enabled.