### PR TITLE
UX: additionalPrinterColumns for PlatformCredentialsSet

### DIFF
--- a/cluster/manifests/01-platformcredentialsset/customresourcedefinition.yaml
+++ b/cluster/manifests/01-platformcredentialsset/customresourcedefinition.yaml
@@ -16,6 +16,23 @@ spec:
       - pcs
     categories:
       - all
+  additionalPrinterColumns:
+  - JSONPath: .spec.application
+    description: ID of application registered in application registry
+    name: Application
+    type: string
+  - JSONPath: .status.errors
+    description: Errors reported by Credentials Provider
+    name: Errors
+    type: string
+  - JSONPath: .status.problems
+    description: Problems reported by Credentials Provider
+    name: Problems
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age of the PlatformCredentialsSet
+    name: Age
+    type: date
   validation:
     openAPIV3Schema:
       required:

--- a/cluster/manifests/01-platformcredentialsset/customresourcedefinition.yaml
+++ b/cluster/manifests/01-platformcredentialsset/customresourcedefinition.yaml
@@ -21,13 +21,9 @@ spec:
     description: ID of application registered in application registry
     name: Application
     type: string
-  - JSONPath: .status.errors
-    description: Errors reported by Credentials Provider
-    name: Errors
-    type: string
-  - JSONPath: .status.problems
-    description: Problems reported by Credentials Provider
-    name: Problems
+  - JSONPath: .status.processingStatus
+    description: Processing status reported by Credentials Provider
+    name: Status
     type: string
   - JSONPath: .metadata.creationTimestamp
     description: Age of the PlatformCredentialsSet


### PR DESCRIPTION
Adding `additionalPrinterColumns` makes `kubectl` and [kube-web-view](https://codeberg.org/hjacobs/kube-web-view/) much more useful:
![Screenshot_2019-07-29 platformcredentialssets - Kubernetes Web UI(1)](https://user-images.githubusercontent.com/510328/62036308-d927a700-b1f1-11e9-8bd2-76bfde1e29eb.png)

Sadly the CRD JSONPath only supports simple expression, i.e. there is no way to show the number of clients/tokens (would require some `length()` function) or the keys of maps (to list token names or similar). Related K8s issue to support complex stuff in CRD JSONPath: https://github.com/kubernetes/kubernetes/issues/67268