### PR TITLE
Updated the webhook with policies for cache

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -78,7 +78,6 @@ image_policy: "trusted"
 {{else}}
 image_policy: "dev"
 {{end}}
-compliance_checker_enabled: "true"
 
 # cadvisor settings
 cadvisor_cpu: "150m"

--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -613,7 +613,7 @@ storage:
                 cpu: 100m
                 memory: 20Mi
 {{ end }}
-          - image: registry.opensource.zalan.do/teapot/image-policy-webhook:{{if eq .Cluster.ConfigItems.compliance_checker_enabled "true"}}master-44{{else}}v0.4.1{{end}}
+          - image: registry.opensource.zalan.do/teapot/image-policy-webhook:0.5.3
             name: image-policy-webhook
             args:
             - --policy={{ .Cluster.ConfigItems.image_policy }}

--- a/cluster/node-pools/master-ubuntu-default/userdata.yaml
+++ b/cluster/node-pools/master-ubuntu-default/userdata.yaml
@@ -350,7 +350,7 @@ write_files:
               cpu: 100m
               memory: 20Mi
 {{ end }}
-        - image: registry.opensource.zalan.do/teapot/image-policy-webhook:{{if eq .Cluster.ConfigItems.compliance_checker_enabled "true"}}master-44{{else}}v0.4.1{{end}}
+        - image: registry.opensource.zalan.do/teapot/image-policy-webhook:0.5.3
           name: image-policy-webhook
           args:
           - --policy={{ .Cluster.ConfigItems.image_policy }}


### PR DESCRIPTION
This version of the webhook trusts cached images in the Ubuntu AMIs.