### PR TITLE
Allow cdp service account to escalate

### DIFF
--- a/cluster/node-pools/master-default/userdata.clc.yaml
+++ b/cluster/node-pools/master-default/userdata.clc.yaml
@@ -487,7 +487,7 @@ storage:
               - mountPath: /etc/kubernetes/ssl
                 name: ssl-certs-kubernetes
                 readOnly: true
-          - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.5.7
+          - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.5.8
             name: webhook
             ports:
             - containerPort: 8081

--- a/cluster/node-pools/master-ubuntu-default/userdata.yaml
+++ b/cluster/node-pools/master-ubuntu-default/userdata.yaml
@@ -224,7 +224,7 @@ write_files:
             - mountPath: /etc/kubernetes/ssl
               name: ssl-certs-kubernetes
               readOnly: true
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.5.7
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.5.8
           name: webhook
           ports:
           - containerPort: 8081

--- a/test/e2e/authorisation_test.go
+++ b/test/e2e/authorisation_test.go
@@ -2156,8 +2156,38 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				}}`,
 				},
 			},
+			// {
+			// 	// TODO: can be enabled when we have
+			// 	// cdp-controller creating bindings in place
+			// 	msg: "cdp service account can't escalate permissions",
+			// 	reqBody: `{
+			// 		"apiVersion": "authorization.k8s.io/v1beta1",
+			// 		"kind": "SubjectAccessReview",
+			// 		"spec": {
+			// 		"resourceAttributes": {
+			// 			"namespace": "",
+			// 			"verb": "escalate",
+			// 			"group": "*",
+			// 			"resource": "clusterroles"
+			// 		},
+			// 		"user": "system:serviceaccount:default:cdp",
+			// 		"group": []
+			// 		}
+			// 	}`,
+			// 	expect: expect{
+			// 		status: http.StatusCreated,
+			// 		body: `{
+			// 		"apiVersion": "authorization.k8s.io/v1beta1",
+			// 		"kind": "SubjectAccessReview",
+			// 		"status": {
+			// 			"denied": true,
+			// 			"reason": "no one is allowed to escalate"
+			// 		}
+			// 	}}`,
+			// 	},
+			// },
 			{
-				msg: "cdp service account can't escalate permissions",
+				msg: "cdp service account can escalate permissions",
 				reqBody: `{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
@@ -2178,10 +2208,37 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"denied": true,
-						"reason": "no one is allowed to escalate"
+						"allowed": true
 					}
 				}}`,
+				},
+			},
+			{
+				msg: "PowerUsers can't escalate permissions",
+				reqBody: `{
+				"apiVersion": "authorization.k8s.io/v1beta1",
+				"kind": "SubjectAccessReview",
+				"spec": {
+				"resourceAttributes": {
+					"namespace": "",
+					"verb": "escalate",
+					"group": "*",
+					"resource": "clusterroles"
+				},
+				"user": "mlarsen",
+				"group": ["PowerUser"]
+				}
+			}`,
+				expect: expect{
+					status: http.StatusCreated,
+					body: `{
+				"apiVersion": "authorization.k8s.io/v1beta1",
+				"kind": "SubjectAccessReview",
+				"status": {
+					"denied": true,
+					"reason": "no one is allowed to escalate"
+				}
+			}}`,
 				},
 			},
 			{


### PR DESCRIPTION
Partly "revert" of #2358 to allow only `cdp` service account to `escalate`. This is to prevent breaking deployments which currently creates RBAC roles/bindings.