### PR TITLE
Enable deployments of Managed kafka service from AWS

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -603,6 +603,7 @@ Resources:
                   - 'kms:*'
                   - 'logs:*'
                   - 'machinelearning:*'
+                  - 'kafka:*'
                   - 'rds:*'
                   - 'redshift:*'
                   - 'rekognition:*'


### PR DESCRIPTION
The service was approved and can now be enabled to allow deployments via
cloudformation.