### PR TITLE
Changed Ubuntu AMI to use ID from name and account ID

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -218,7 +218,8 @@ cluster_dns: "coredns"
 coredns_log_svc_names: "true"
 
 coreos_image: "ami-0d1579b60bb706fb7" # Container Linux 2079.6.0 (HVM, eu-central-1)
-kuberuntu_image: "ami-0892b0cf01ee56aa6" # zalando-ubuntu-kubernetes-production-v1.13.7-master-48 (HVM, eu-central-1)
+kuberuntu_image: {{ amiID "zalando-ubuntu-kubernetes-production-v1.13.7-master-48" "861068367966" }}
+
 
 # Feature toggle to allow gradual decommissioning of ingress-template-controller
 enable_ingress_template_controller: "false"


### PR DESCRIPTION
The AMI id is derived from the AMI name and the account owner of the image.