### PR TITLE
bump kubernetes-log-watcher to version 0.31

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -123,7 +123,7 @@ logging_fluentd_cpu: "100m"
 logging_s3_bucket: "zalando-logging-{{.InfrastructureAccount | getAWSAccountID}}-{{.Region}}"
 logging_agent_in_visibility: "true"
 scalyr_team_token: ""
-logging_agent_version: "v0.30"
+logging_agent_version: "v0.31"
 
 zmon_redis_mem: "1Gi"
 zmon_agent_mem: "500Mi"

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -83,7 +83,7 @@ spec:
           mountPath: /mnt/scalyr-checkpoint
       containers:
       - name: log-watcher
-        image: registry.opensource.zalan.do/logging/kubernetes-log-watcher:0.30
+        image: registry.opensource.zalan.do/logging/kubernetes-log-watcher:0.31
         env:
         - name: CLUSTER_NODE_NAME
           valueFrom:


### PR DESCRIPTION
For details see:
https://github.com/zalando-incubator/kubernetes-log-watcher/commit/f47fa2959df59185352e7d9f6211ef6f883a4e6b

This should lead to less "bytes skipped" for scalyr-agent