### PR TITLE
Update Ubuntu AMI with HWE

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -215,7 +215,7 @@ cluster_dns: "coredns"
 coredns_log_svc_names: "true"
 
 coreos_image: "ami-0d1579b60bb706fb7" # Container Linux 2079.6.0 (HVM, eu-central-1)
-kuberuntu_image: {{ amiID "zalando-ubuntu-kubernetes-production-v1.13.7-master-48" "861068367966" }}
+kuberuntu_image: {{ amiID "zalando-ubuntu-kubernetes-production-v1.13.7-master-49" "861068367966" }}
 
 
 # Feature toggle to allow gradual decommissioning of ingress-template-controller


### PR DESCRIPTION
This AMI has the Ubuntu [Hardware Enablement Stack](https://wiki.ubuntu.com/Kernel/LTSEnablementStack) and therefore has a newer version of the kernel. 