### PR TITLE
Make node_exporter resources configurable

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -82,6 +82,10 @@ image_policy: "dev"
 cadvisor_cpu: "150m"
 cadvisor_memory: "150Mi"
 
+# node exporter settings
+node_exporter_cpu: "20m"
+node_exporter_memory: "75Mi"
+
 # Monitoring settings
 {{if eq .Environment "e2e"}}
 logging_agent_enabled: "false"

--- a/cluster/manifests/prometheus-node-exporter/daemonset.yaml
+++ b/cluster/manifests/prometheus-node-exporter/daemonset.yaml
@@ -40,11 +40,11 @@ spec:
           hostPort: 9100
         resources:
           limits:
-            cpu: 20m
-            memory: 75Mi
+            cpu: {{.Cluster.ConfigItems.node_exporter_cpu}}
+            memory: {{.Cluster.ConfigItems.node_exporter_memory}}
           requests:
-            cpu: 20m
-            memory: 75Mi
+            cpu: {{.Cluster.ConfigItems.node_exporter_cpu}}
+            memory: {{.Cluster.ConfigItems.node_exporter_memory}}
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
We don't want to use VPA for daemonsets, so we have to do it like this. :(