### PR TITLE
Ubuntu nodes: drop the extra volume

### DIFF
--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -54,12 +54,6 @@ Resources:
           AssociatePublicIpAddress: true
           Groups:
           - !ImportValue '{{ .Cluster.ID }}:master-security-group'
-        BlockDeviceMappings:
-        - DeviceName: /dev/xvda
-          Ebs:
-            DeleteOnTermination: true
-            VolumeSize: 20
-            VolumeType: standard
         EbsOptimized: false
         IamInstanceProfile:
           Name: !Ref AutoScalingInstanceProfile

--- a/cluster/node-pools/worker-default/stack.yaml
+++ b/cluster/node-pools/worker-default/stack.yaml
@@ -100,11 +100,6 @@ Resources:
           AssociatePublicIpAddress: true
           Groups:
           - !ImportValue '{{ .Cluster.ID }}:worker-security-group'
-        BlockDeviceMappings:
-        - DeviceName: /dev/xvda
-          Ebs:
-            VolumeSize: 50
-            VolumeType: standard
         EbsOptimized: false
         IamInstanceProfile:
           Name: !Ref AutoScalingInstanceProfile

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -111,12 +111,6 @@ Resources:
           AssociatePublicIpAddress: true
           Groups:
           - !ImportValue '{{ .Cluster.ID }}:worker-security-group'
-        BlockDeviceMappings:
-        - DeviceName: /dev/xvda
-          Ebs:
-            DeleteOnTermination: true
-            VolumeSize: 50
-            VolumeType: standard
         EbsOptimized: false
         IamInstanceProfile:
           Name: !Ref AutoScalingInstanceProfile


### PR DESCRIPTION
This causes a creation of an extra EBS volume for every node which is completely unused.