### PR TITLE
Update skipper to v0.10.271

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.10.241
+    version: v0.10.271
     component: ingress
 spec:
   strategy:
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.10.241
+        version: v0.10.271
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -42,7 +42,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.241
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.271
         ports:
         - name: ingress-port
           containerPort: 9999


### PR DESCRIPTION
Mainly for the `JWTPayloadAllKVRegexp` filter, but we'll pick up all other changes as well.