### PR TITLE
Kubernetes Janitor v19.8.0

### DIFF
--- a/cluster/manifests/kube-janitor/deployment.yaml
+++ b/cluster/manifests/kube-janitor/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-janitor
-    version: v0.7
+    version: v19.8.0
 spec:
   replicas: 1
   selector:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: kube-janitor
-        version: v0.7
+        version: v19.8.0
     spec:
       dnsConfig:
         options:
@@ -27,7 +27,7 @@ spec:
       containers:
       - name: janitor
         # see https://github.com/hjacobs/kube-janitor/releases
-        image: registry.opensource.zalan.do/teapot/kube-janitor:0.7
+        image: registry.opensource.zalan.do/teapot/kube-janitor:19.8.0
         args:
           # run every minute
           - --interval=60


### PR DESCRIPTION
This includes a new feature by @antban to allow `forever` as TTL value: https://github.com/hjacobs/kube-janitor/releases/tag/19.8.0

