### PR TITLE
Prometheus: only allow access for users/services

### DIFF
--- a/cluster/manifests/prometheus/ingress.yaml
+++ b/cluster/manifests/prometheus/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   annotations:
     zalando.org/skipper-filter: |
-      oauthTokeninfoAnyScope("uid")
+      oauthTokeninfoAnyKV("https://identity.zalando.com/realm", "users", "https://identity.zalando.com/realm", "services")
   labels:
     application: prometheus
 spec:


### PR DESCRIPTION
This isn't handled by tokeninfo, let's be explicit.