### PR TITLE
deployment-config: add cloudformation-available

### DIFF
--- a/cluster/manifests/infrastructure-configs/configmap.yaml
+++ b/cluster/manifests/infrastructure-configs/configmap.yaml
@@ -8,3 +8,4 @@ data:
   scalyr-team-token: "{{.Cluster.ConfigItems.scalyr_team_token}}"
   create-namespaces: "true"
   aws-available: "true"
+  cloudformation-available: "true"


### PR DESCRIPTION
DC clusters support secret encryption, only CF is unavailable.