### PR TITLE
Allow static cpu manager policy to be enabled on nodepools

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -255,6 +255,9 @@ node_cidr_mask_size: "24" # Default: 24
 # maximum number of PIDs allowed to be allocated per pod
 pod_max_pids: "4096"
 
+# the cpu management policy which should be used by the kubelet
+cpu_manager_policy: "none"
+
 # when set to true, routes external traffic to the apiserver through a skipper sidecar
 apiserver_proxy: "true"
 # when set to true, service account tokens can be used from outside the cluster

--- a/cluster/node-pools/worker-ubuntu-default/userdata.yaml
+++ b/cluster/node-pools/worker-ubuntu-default/userdata.yaml
@@ -53,6 +53,7 @@ write_files:
         SupportPodPidsLimit: true
       podPidsLimit: {{ .NodePool.ConfigItems.pod_max_pids }}
 {{- end }}
+      cpuManagerPolicy: {{ .NodePool.ConfigItems.cpu_manager_policy }}
       maxPods: {{ .Cluster.ConfigItems.node_max_pods }}
       healthzPort: 10248
       healthzBindAddress: "0.0.0.0"

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -69,6 +69,8 @@ clusters:
     profile: ${WORKER_PROFILE}-splitaz
     min_size: 3
     max_size: 21
+    config_items:
+      cpu_manager_policy: static
   - discount_strategy: spot_max_price
     instance_types: ["m4.large", "m5.large", "m5.xlarge", "m4.xlarge"]
     name: default-worker


### PR DESCRIPTION
The `static` CPU management policies allow entire CPUs to be allocated to pods which might be useful for workloads which benefit from CPU affinity. The `static` policy is only enabled when the config item is present and static to the value `static`.