### PR TITLE
Only test Ubuntu based clusters

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -17,48 +17,7 @@ pipeline:
     cmd: |
       VERSION="$CDP_BUILD_VERSION" make -C test/e2e build.push
 
-- id: e2e-tests-coreos
-  depends_on:
-  - build
-  when:
-    event: pull_request
-  type: process
-  desc: "Kubernetes e2e tests"
-  target: stups-test
-  process: microservice_standard_test
-  config:
-    apply_manifests:
-      env:
-      - name: DEPLOYMENT_PATH
-        value: test/e2e
-    end2end_tests:
-      metadata:
-        name: e2e
-        annotations:
-          iam.amazonaws.com/role: arn:aws:iam::925511348110:role/cluster-e2e-test
-        labels:
-          application: teapot-kubernetes-e2e
-      spec:
-        restartPolicy: Never
-        initContainers:
-        - name: aws-credentials-waiter
-          image: pierone.stups.zalan.do/automata/aws-credentials-waiter:master-2
-          args: ["300"]
-        containers:
-        - name: e2e
-          image: "registry.opensource.zalan.do/teapot/kubernetes-on-aws-e2e:#{CDP_BUILD_VERSION}"
-          env:
-          - name: E2E_NODE_OS
-            value: coreos
-          resources:
-            limits:
-              cpu: 500m
-              memory: 5Gi
-            requests:
-              cpu: 500m
-              memory: 5Gi
-
-- id: e2e-tests-ubuntu
+- id: e2e-tests
   when:
     event: pull_request
   depends_on:


### PR DESCRIPTION
We no longer want to maintain CoreOS based clusters. They can be dropped from the tests.