### PR TITLE
Remove playground default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -154,8 +154,6 @@ kube_state_metrics_mem_max: "1Gi"
 # Kubernetes Downscaler (for non-production clusters)
 {{if eq .Environment "test"}}
 downscaler_default_uptime: "Mon-Fri 07:30-20:30 Europe/Berlin"
-{{else if eq .Environment "playground"}}
-downscaler_default_uptime: "Mon-Fri 07:30-20:30 Europe/Berlin"
 {{else}}
 downscaler_default_uptime: "always"
 {{end}}


### PR DESCRIPTION
We no longer have `playground` as a special environment.