### PR TITLE
Use linux-aws kernel, increase arp cache threshold

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -219,7 +219,7 @@ cluster_dns: "coredns"
 coredns_log_svc_names: "true"
 
 coreos_image: "ami-0d1579b60bb706fb7" # Container Linux 2079.6.0 (HVM, eu-central-1)
-kuberuntu_image: {{ amiID "zalando-ubuntu-kubernetes-production-v1.14.6-master-54" "861068367966" }}
+kuberuntu_image: {{ amiID "zalando-ubuntu-kubernetes-production-v1.14.6-master-56" "861068367966" }}
 
 # Feature toggle to allow gradual decommissioning of ingress-template-controller
 enable_ingress_template_controller: "false"


### PR DESCRIPTION
Reverts the Ubuntu AMI to use `linux-aws` (default) kernel. Increases the arp cache thresholds:

```
net.ipv4.neigh.default.gc_thresh1 = 1024
net.ipv4.neigh.default.gc_thresh2 = 4096
net.ipv4.neigh.default.gc_thresh3 = 16384
```

This is done to avoid arp_cache overflows as seen with previous AMI.