### PR TITLE
Auth webhook: use externally provided roles, add collaborators

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -224,7 +224,7 @@ write_files:
             - mountPath: /etc/kubernetes/ssl
               name: ssl-certs-kubernetes
               readOnly: true
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.5.8
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook-test:pr-118-2
           name: webhook
           ports:
           - containerPort: 8081
@@ -246,11 +246,26 @@ write_files:
               memory: 50Mi
           args:
             - --tokens-file=/etc/kubernetes/config/tokenfile.csv
+
+            # Collaborator roles
+            - --role-mapping=Administrator=cn=Administrator,ou=collaborators,ou=Kubernetes,ou=apps,dc=zalando,dc=net
+            - --role-mapping=ReadOnly=cn=ReadOnly,ou=collaborators,ou=Kubernetes,ou=apps,dc=zalando,dc=net
+{{- if eq .Cluster.Environment "test"}}
+            - --role-mapping=PowerUser=cn=Deployer,ou=collaborators,ou=Kubernetes,ou=apps,dc=zalando,dc=net
+{{- end}}
+
+            # Member roles
+{{- if eq .Cluster.Environment "production"}}
+            - --role-mapping=Manual=cn=Manual,ou={{.Cluster.InfrastructureAccount}}:{{.Cluster.Region}}:{{.Cluster.LocalID}},ou=Kubernetes,ou=apps,dc=zalando,dc=net
+            - --role-mapping=Emergency=cn=Emergency,ou={{.Cluster.InfrastructureAccount}}:{{.Cluster.Region}}:{{.Cluster.LocalID}},ou=Kubernetes,ou=apps,dc=zalando,dc=net
+{{- else }}
+            - --role-mapping=PowerUser=cn=PowerUser,ou={{.Cluster.InfrastructureAccount}}:{{.Cluster.Region}}:{{.Cluster.LocalID}},ou=Kubernetes,ou=apps,dc=zalando,dc=net
+{{- end }}
+            - --role-mapping=ReadOnly=cn=ReadOnly,ou={{.Cluster.InfrastructureAccount}}:{{.Cluster.Region}}:{{.Cluster.LocalID}},ou=Kubernetes,ou=apps,dc=zalando,dc=net
+
           env:
             - name: TEAMS_API_URL
               value: https://teams.auth.zalando.com
-            - name: CLUSTER_ID
-              value: {{if index .Cluster.ConfigItems "webhook_id"}}{{ .Cluster.ConfigItems.webhook_id }}{{else}}{{ .Cluster.ID }}{{end}}
             - name: TOKEN_INTROSPECTION_URL
               value: http://127.0.0.1:{{ if eq .Cluster.Environment "production" }}9021{{else}}9023{{end}}/oauth2/introspect
             - name: USER_GROUPS

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -224,7 +224,7 @@ write_files:
             - mountPath: /etc/kubernetes/ssl
               name: ssl-certs-kubernetes
               readOnly: true
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook-test:pr-118-2
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.6.0
           name: webhook
           ports:
           - containerPort: 8081

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -252,6 +252,8 @@ write_files:
             - --role-mapping=ReadOnly=cn=ReadOnly,ou=collaborators,ou=Kubernetes,ou=apps,dc=zalando,dc=net
 {{- if eq .Cluster.Environment "test"}}
             - --role-mapping=PowerUser=cn=Deployer,ou=collaborators,ou=Kubernetes,ou=apps,dc=zalando,dc=net
+{{- else if eq .Cluster.Environment "e2e"}}
+            - --role-mapping=Administrator=cn=Contributor,ou=collaborators,ou=Kubernetes,ou=apps,dc=zalando,dc=net
 {{- end}}
 
             # Member roles

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -258,12 +258,12 @@ write_files:
 
             # Member roles
 {{- if eq .Cluster.Environment "production"}}
-            - --role-mapping=Manual=cn=Manual,ou={{.Cluster.InfrastructureAccount}}:{{.Cluster.Region}}:{{.Cluster.LocalID}},ou=Kubernetes,ou=apps,dc=zalando,dc=net
-            - --role-mapping=Emergency=cn=Emergency,ou={{.Cluster.InfrastructureAccount}}:{{.Cluster.Region}}:{{.Cluster.LocalID}},ou=Kubernetes,ou=apps,dc=zalando,dc=net
+            - --role-mapping=Manual=cn=Manual,ou={{.Cluster.ID}},ou=Kubernetes,ou=apps,dc=zalando,dc=net
+            - --role-mapping=Emergency=cn=Emergency,ou={{.Cluster.ID}},ou=Kubernetes,ou=apps,dc=zalando,dc=net
 {{- else }}
-            - --role-mapping=PowerUser=cn=PowerUser,ou={{.Cluster.InfrastructureAccount}}:{{.Cluster.Region}}:{{.Cluster.LocalID}},ou=Kubernetes,ou=apps,dc=zalando,dc=net
+            - --role-mapping=PowerUser=cn=PowerUser,ou={{.Cluster.ID}},ou=Kubernetes,ou=apps,dc=zalando,dc=net
 {{- end }}
-            - --role-mapping=ReadOnly=cn=ReadOnly,ou={{.Cluster.InfrastructureAccount}}:{{.Cluster.Region}}:{{.Cluster.LocalID}},ou=Kubernetes,ou=apps,dc=zalando,dc=net
+            - --role-mapping=ReadOnly=cn=ReadOnly,ou={{.Cluster.ID}},ou=Kubernetes,ou=apps,dc=zalando,dc=net
 
           env:
             - name: TEAMS_API_URL

--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -36,6 +36,8 @@ else
     exit 1
 fi
 
+echo "Creating cluster ${CLUSTER_ID}: ${API_SERVER_URL}"
+
 # if E2E_SKIP_CLUSTER_UPDATE is true, don't create a cluster from base first
 if [ "$E2E_SKIP_CLUSTER_UPDATE" != "true" ]; then
     BASE_CFG_PATH="base_config"


### PR DESCRIPTION
Change the webhook to explicitly configure the role mapping, allow collaborator access for test clusters.