### PR TITLE
RBAC: rollout [2/2]

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -313,6 +313,6 @@ custom_dns_zone_nameservers: "" # space seperated list of nameserver IP addresse
 external_dns_ownership_prefix: ""
 
 # enable legacy serviceaccounts for smooth RBAC migration
-enable_operator_sa: "true"
-enable_default_sa: "true"
-enable_cdp_sa: "true"
+enable_operator_sa: "false"
+enable_default_sa: "false"
+enable_cdp_sa: "false"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -311,3 +311,8 @@ custom_dns_zone_nameservers: "" # space seperated list of nameserver IP addresse
 
 # prefix prepended to ownership TXT records for external-dns
 external_dns_ownership_prefix: ""
+
+# enable legacy serviceaccounts for smooth RBAC migration
+enable_operator_sa: "true"
+enable_default_sa: "true"
+enable_cdp_sa: "true"

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -22,3 +22,9 @@ post_apply:
 - name: ingress-template-controller
   kind: ClusterRoleBinding
 {{ end }}
+- name: poweruser-new
+  kind: ClusterRoleBinding
+- name: readonly-new
+  kind: ClusterRoleBinding
+- name: zmon-external-new
+  kind: ClusterRoleBinding

--- a/cluster/manifests/roles/poweruser-binding.yaml
+++ b/cluster/manifests/roles/poweruser-binding.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: poweruser-new # TODO: migrate name
+  name: poweruser
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/cluster/manifests/roles/poweruser-role.yaml
+++ b/cluster/manifests/roles/poweruser-role.yaml
@@ -838,3 +838,18 @@ rules:
   - create
   - update
   - patch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/cluster/manifests/roles/readonly-binding.yaml
+++ b/cluster/manifests/roles/readonly-binding.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: readonly-new # TODO: migrate name
+  name: readonly
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/cluster/manifests/roles/zmon-binding.yaml
+++ b/cluster/manifests/roles/zmon-binding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: zmon-external-new
+  name: zmon-external
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -226,7 +226,7 @@ write_files:
             - mountPath: /etc/kubernetes/ssl
               name: ssl-certs-kubernetes
               readOnly: true
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook-test:pr-119-20
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook-test:pr-119-21
           name: webhook
           ports:
           - containerPort: 8081

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -226,7 +226,7 @@ write_files:
             - mountPath: /etc/kubernetes/ssl
               name: ssl-certs-kubernetes
               readOnly: true
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook-test:pr-119-11
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook-test:pr-119-16
           name: webhook
           ports:
           - containerPort: 8081

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -226,7 +226,7 @@ write_files:
             - mountPath: /etc/kubernetes/ssl
               name: ssl-certs-kubernetes
               readOnly: true
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.7.0
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook-test:pr-119-9
           name: webhook
           ports:
           - containerPort: 8081
@@ -271,7 +271,16 @@ write_files:
             - --role-mapping=PowerUser=cn=PowerUser,ou={{.Cluster.ID}},ou=Kubernetes,ou=apps,dc=zalando,dc=net
 {{- end }}
             - --role-mapping=ReadOnly=cn=ReadOnly,ou={{.Cluster.ID}},ou=Kubernetes,ou=apps,dc=zalando,dc=net
-
+            # enable legacy serviceaccounts for smooth RBAC migration
+{{ if eq .Cluster.ConfigItems.enable_operator_sa "true"}}
+            - --enable-operator-sa
+{{ end }}
+{{ if eq .Cluster.ConfigItems.enable_default_sa "true"}}
+            - --enable-default-sa
+{{ end }}
+{{ if eq .Cluster.ConfigItems.enable_cdp_sa "true"}}
+            - --enable-cdp-sa
+{{ end }}
           env:
             - name: TEAMS_API_URL
               value: https://teams.auth.zalando.com

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -226,7 +226,7 @@ write_files:
             - mountPath: /etc/kubernetes/ssl
               name: ssl-certs-kubernetes
               readOnly: true
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook-test:pr-119-9
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook-test:pr-119-11
           name: webhook
           ports:
           - containerPort: 8081

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -226,7 +226,7 @@ write_files:
             - mountPath: /etc/kubernetes/ssl
               name: ssl-certs-kubernetes
               readOnly: true
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook-test:pr-119-16
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook-test:pr-119-18
           name: webhook
           ports:
           - containerPort: 8081

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -226,7 +226,7 @@ write_files:
             - mountPath: /etc/kubernetes/ssl
               name: ssl-certs-kubernetes
               readOnly: true
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook-test:pr-119-21
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.7.1
           name: webhook
           ports:
           - containerPort: 8081

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -226,7 +226,7 @@ write_files:
             - mountPath: /etc/kubernetes/ssl
               name: ssl-certs-kubernetes
               readOnly: true
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook-test:pr-119-19
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook-test:pr-119-20
           name: webhook
           ports:
           - containerPort: 8081

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -226,7 +226,7 @@ write_files:
             - mountPath: /etc/kubernetes/ssl
               name: ssl-certs-kubernetes
               readOnly: true
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook-test:pr-119-18
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook-test:pr-119-19
           name: webhook
           ports:
           - containerPort: 8081

--- a/test/e2e/authorisation_test.go
+++ b/test/e2e/authorisation_test.go
@@ -520,38 +520,39 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				},
 			},
 
-			//- poweruser can not use privileged PSP
-			{
-				msg: "access to use privileged PodSecurityPolicy for PowerUser should not be allowed",
-				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"spec": {
-					"resourceAttributes": {
-						"name": "privileged",
-						"namespace": "",
-						"verb": "use",
-						"group": "extensions",
-						"resource": "podsecuritypolicies"
-					},
-					"user": "sszuecs",
-					"group": [
-						"%s"
-					]
-					}
-				}`, powerUserGroup),
-				expect: expect{
-					status: http.StatusCreated,
-					body: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"status": {
-						"allowed": false,
-						"reason":"unauthorized access sszuecs/[%s]"
-					}
-				}}`, powerUserGroup),
-				},
-			},
+			////- poweruser can not use privileged PSP
+			//// TODO: disable privileged PSP access for PowerUsers.
+			//{
+			//	msg: "access to use privileged PodSecurityPolicy for PowerUser should not be allowed",
+			//	reqBody: fmt.Sprintf(`{
+			//		"apiVersion": "authorization.k8s.io/v1beta1",
+			//		"kind": "SubjectAccessReview",
+			//		"spec": {
+			//		"resourceAttributes": {
+			//			"name": "privileged",
+			//			"namespace": "",
+			//			"verb": "use",
+			//			"group": "extensions",
+			//			"resource": "podsecuritypolicies"
+			//		},
+			//		"user": "sszuecs",
+			//		"group": [
+			//			"%s"
+			//		]
+			//		}
+			//	}`, powerUserGroup),
+			//	expect: expect{
+			//		status: http.StatusCreated,
+			//		body: fmt.Sprintf(`{
+			//		"apiVersion": "authorization.k8s.io/v1beta1",
+			//		"kind": "SubjectAccessReview",
+			//		"status": {
+			//			"allowed": false,
+			//			"reason":"unauthorized access sszuecs/[%s]"
+			//		}
+			//	}}`, powerUserGroup),
+			//	},
+			//},
 
 			//- poweruser has read access to kube system
 			{

--- a/test/e2e/authorisation_test.go
+++ b/test/e2e/authorisation_test.go
@@ -1953,7 +1953,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"resource": "pods"
 					},
 					"user": "system:serviceaccount:kube-system:daemon-set-controller",
-					"group": []
+					"group": ["system:serviceaccounts:kube-system"]
 					}
 				}`,
 				expect: expect{

--- a/test/e2e/authorisation_test.go
+++ b/test/e2e/authorisation_test.go
@@ -1705,6 +1705,36 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				}}`,
 				},
 			},
+			//- administrator can read secrets from kube-system namespaces
+			{
+				msg: "Administrator (system:masters) can read secrets from kube-system namespaces",
+				reqBody: `{
+					"apiVersion": "authorization.k8s.io/v1beta1",
+					"kind": "SubjectAccessReview",
+					"spec": {
+					"resourceAttributes": {
+						"namespace": "kube-system",
+						"verb": "get",
+						"group": "",
+						"resource": "secrets"
+					},
+					"user": "rdifazio",
+					"group": [
+						"system:masters"
+					]
+					}
+				}`,
+				expect: expect{
+					status: http.StatusCreated,
+					body: `{
+					"apiVersion": "authorization.k8s.io/v1beta1",
+					"kind": "SubjectAccessReview",
+					"status": {
+						"allowed": true
+					}
+				}}`,
+				},
+			},
 			//- administrator can read secrets from non kube-system namespaces
 			{
 				msg: "Administrator (system:masters) can read secrets from non kube-system namespaces",

--- a/test/e2e/authorisation_test.go
+++ b/test/e2e/authorisation_test.go
@@ -105,7 +105,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"subresource": "status"
 					},
 					"user": "system:serviceaccount:kube-system:daemon-set-controller",
-					"group": ["system:serviceaccount:kube-system"]
+					"group": ["system:serviceaccounts:kube-system"]
 					}
 				}`,
 				expect: expect{
@@ -132,7 +132,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"subresource": "finalizers"
 					},
 					"user": "system:serviceaccount:kube-system:daemon-set-controller",
-					"group": ["system:serviceaccount:kube-system"]
+					"group": ["system:serviceaccounts:kube-system"]
 					}
 				}`,
 				expect: expect{
@@ -157,7 +157,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"resource": "podtemplates"
 					},
 					"user": "system:serviceaccount:kube-system:default",
-					"group": ["system:serviceaccount:kube-system"]
+					"group": ["system:serviceaccounts:kube-system"]
 					}
 				}`,
 				expect: expect{

--- a/test/e2e/authorisation_test.go
+++ b/test/e2e/authorisation_test.go
@@ -22,7 +22,6 @@ type expect struct {
 const (
 	authzAPIVersion          = "authorization.k8s.io/v1beta1"
 	authorizeMessageKind     = "SubjectAccessReview"
-	administratorGroup       = "Administrator"
 	systemMastersGroup       = "system:masters"
 	operatorGroup            = "Operator"
 	powerUserGroup           = "PowerUser"
@@ -30,7 +29,6 @@ const (
 	manualGroup              = "Manual"
 	controllerGroup          = "ControllerUser"
 	readOnlyGroup            = "ReadOnly"
-	billingGroup             = "Billing"
 	portForwardPodNamePrefix = "port-forward-"
 	systemNamespace          = "kube-system"
 	accessReviewURL          = "/apis/authorization.k8s.io/v1beta1/subjectaccessreviews"
@@ -73,13 +71,13 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"spec": {
 					"resourceAttributes": {
 						"namespace": "teapot",
-						"verb": "GET",
-						"group": "*",
+						"verb": "get",
+						"group": "",
 						"resource": "pods"
 					},
 					"user": "kubelet",
 					"group": [
-						"Administrator"
+						"system:masters"
 					]
 					}
 				}`,
@@ -238,7 +236,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"user": "sszuecs",
 					"group": [
 						"ReadOnly",
-						"Administrator",
+						"system:masters",
 						"system:authenticated"
 					]
 					}
@@ -261,8 +259,8 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"spec": {
 					"resourceAttributes": {
 						"namespace": "teapot",
-						"verb": "GET",
-						"group": "*",
+						"verb": "get",
+						"group": "",
 						"resource": "pods"
 					},
 					"user": "rdifazio",
@@ -291,7 +289,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "teapot",
 						"verb": "list",
-						"group": "*",
+						"group": "",
 						"resource": "pods"
 					},
 					"user": "rdifazio",
@@ -346,7 +344,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"name": "privileged",
 						"namespace": "",
 						"verb": "use",
-						"group": "*",
+						"group": "extensions",
 						"resource": "podsecuritypolicies"
 					},
 					"user": "sszuecs",
@@ -367,36 +365,6 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				}}`, readOnlyGroup),
 				},
 			}, {
-				msg: "ReadOnly role should give port-forward access to the 'port-forward-' pod in kube-system namespace",
-				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-						"spec": {
-						"resourceAttributes": {
-							"name": "port-forward-abc",
-							"namespace": "kube-system",
-							"verb": "create",
-							"group": "*",
-							"resource": "pods",
-							"subresource": "portforward"
-						},
-						"user": "read-only-user",
-						"group": [
-							"%s"
-						]
-					}
-				}`, readOnlyGroup),
-				expect: expect{
-					status: http.StatusCreated,
-					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"status": {
-						"allowed": true
-					}
-				}}`,
-				},
-			}, {
 				msg: "ReadOnly role should not give port-forward access to the 'port-forward-' pod in default namespace",
 				reqBody: fmt.Sprintf(`{
 					"apiVersion": "authorization.k8s.io/v1beta1",
@@ -406,7 +374,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 							"name": "port-forward-abc",
 							"namespace": "default",
 							"verb": "create",
-							"group": "*",
+							"group": "",
 							"resource": "pods",
 							"subresource": "portforward"
 						},
@@ -467,7 +435,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 							"name": "restricted",
 							"namespace": "",
 							"verb": "use",
-							"group": "*",
+							"group": "extensions",
 							"resource": "podsecuritypolicies"
 						},
 						"user": "sszuecs",
@@ -499,7 +467,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"name": "restricted",
 						"namespace": "",
 						"verb": "use",
-						"group": "*",
+						"group": "extensions",
 						"resource": "podsecuritypolicies"
 					},
 					"user": "sszuecs",
@@ -531,7 +499,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"name": "restricted",
 						"namespace": "",
 						"verb": "use",
-						"group": "*",
+						"group": "extensions",
 						"resource": "podsecuritypolicies"
 					},
 					"user": "sszuecs",
@@ -563,7 +531,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"name": "privileged",
 						"namespace": "",
 						"verb": "use",
-						"group": "*",
+						"group": "extensions",
 						"resource": "podsecuritypolicies"
 					},
 					"user": "sszuecs",
@@ -594,8 +562,8 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"spec": {
 					"resourceAttributes": {
 						"namespace": "kube-system",
-						"verb": "GET",
-						"group": "*",
+						"verb": "get",
+						"group": "",
 						"resource": "pods"
 					},
 					"user": "rdifazio",
@@ -625,8 +593,8 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"spec": {
 					"resourceAttributes": {
 						"namespace": "kube-system",
-						"verb": "GET",
-						"group": "*",
+						"verb": "get",
+						"group": "",
 						"resource": "secrets"
 					},
 					"user": "sszuecs",
@@ -658,8 +626,8 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"spec": {
 					"resourceAttributes": {
 						"namespace": "teapot",
-						"verb": "GET",
-						"group": "*",
+						"verb": "get",
+						"group": "",
 						"resource": "secrets"
 					},
 					"user": "sszuecs",
@@ -690,8 +658,8 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "teapot",
 						"verb": "create",
-						"group": "*",
-						"resource": "pods"
+						"group": "",
+						"resource": "secrets"
 					},
 					"user": "sszuecs",
 					"group": [
@@ -721,8 +689,9 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"spec": {
 					"resourceAttributes": {
 						"namespace": "teapot",
-						"verb": "proxy",
-						"group": "*"
+						"verb": "create",
+						"group": "",
+						"resource": "pods/proxy"
 					},
 					"user": "sszuecs",
 					"group": [
@@ -751,7 +720,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "teapot",
 						"verb": "create",
-						"group": "*",
+						"group": "",
 						"resource": "daemonsets"
 					},
 					"user": "sszuecs",
@@ -766,9 +735,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": false,
-						"denied": true,
-						"reason":"unauthorized non read access to daemonsets: sszuecs/[PowerUser]"
+						"allowed": false
 					}
 				}}`,
 				},
@@ -783,7 +750,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "teapot",
 						"verb": "update",
-						"group": "*",
+						"group": "apps",
 						"resource": "daemonsets"
 					},
 					"user": "sszuecs",
@@ -798,9 +765,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": false,
-						"denied": true,
-						"reason":"unauthorized non read access to daemonsets: sszuecs/[PowerUser]"
+						"allowed": false
 					}
 				}}`,
 				},
@@ -815,7 +780,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "teapot",
 						"verb": "delete",
-						"group": "*",
+						"group": "apps",
 						"resource": "daemonsets"
 					},
 					"user": "sszuecs",
@@ -830,9 +795,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": false,
-						"denied": true,
-						"reason":"unauthorized non read access to daemonsets: sszuecs/[PowerUser]"
+						"allowed": false
 					}
 				}}`,
 				},
@@ -847,7 +810,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "teapot",
 						"verb": "patch",
-						"group": "*",
+						"group": "apps",
 						"resource": "daemonsets"
 					},
 					"user": "sszuecs",
@@ -862,9 +825,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": false,
-						"denied": true,
-						"reason":"unauthorized non read access to daemonsets: sszuecs/[PowerUser]"
+						"allowed": false
 					}
 				}}`,
 				},
@@ -883,7 +844,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"name": "privileged",
 						"namespace": "",
 						"verb": "use",
-						"group": "*",
+						"group": "extensions",
 						"resource": "podsecuritypolicies"
 					},
 					"user": "system:serviceaccount:teapot:operator",
@@ -912,7 +873,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "teapot",
 						"verb": "get",
-						"group": "*",
+						"group": "",
 						"resource": "pods"
 					},
 					"user": "system:serviceaccount:teapot:operator",
@@ -941,7 +902,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "teapot",
 						"verb": "create",
-						"group": "*",
+						"group": "",
 						"resource": "pods"
 					},
 					"user": "system:serviceaccount:teapot:operator",
@@ -969,7 +930,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "coffeepot",
 						"verb": "get",
-						"group": "*",
+						"group": "",
 						"resource": "pods"
 					},
 					"user": "system:serviceaccount:teapot:operator",
@@ -998,7 +959,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "coffeepot",
 						"verb": "create",
-						"group": "*",
+						"group": "",
 						"resource": "pods"
 					},
 					"user": "system:serviceaccount:teapot:operator",
@@ -1028,7 +989,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "teapot",
 						"verb": "get",
-						"group": "*",
+						"group": "",
 						"resource": "secrets"
 					},
 					"user": "system:serviceaccount:teapot:operator",
@@ -1057,7 +1018,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "coffeepot",
 						"verb": "get",
-						"group": "*",
+						"group": "",
 						"resource": "secrets"
 					},
 					"user": "system:serviceaccount:teapot:operator",
@@ -1077,62 +1038,6 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				},
 			},
 
-			//- operator has write access to third party resources in all namespaces
-			{
-				msg: "operator has write access to third party resources in all namespacese",
-				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"spec": {
-					"resourceAttributes": {
-						"namespace": "coffeepot",
-						"verb": "create",
-						"group": "*",
-						"resource": "thirdpartyresources"
-					},
-					"user": "system:serviceaccount:teapot:operator",
-					"group": []
-					}
-				}`,
-				expect: expect{
-					status: http.StatusCreated,
-					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"status": {
-						"allowed": true
-					}
-				}}`,
-				},
-			},
-			//- operator has read access to third party resources in all namespaces
-			{
-				msg: "operator has read access to third party resources in all namespacese",
-				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"spec": {
-					"resourceAttributes": {
-						"namespace": "coffeepot",
-						"verb": "get",
-						"group": "*",
-						"resource": "thirdpartyresources"
-					},
-					"user": "system:serviceaccount:teapot:operator",
-					"group": []
-					}
-				}`,
-				expect: expect{
-					status: http.StatusCreated,
-					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"status": {
-						"allowed": true
-					}
-				}}`,
-				},
-			},
 			//- operator has read access to custom resource definitions (CRD) in all namespaces
 			{
 				msg: "operator has read access to custom resource definitions (CRD) in all namespacese",
@@ -1143,7 +1048,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "get",
-						"group": "*",
+						"group": "apiextensions.k8s.io",
 						"resource": "customresourcedefinitions"
 					},
 					"user": "system:serviceaccount:teapot:operator",
@@ -1171,7 +1076,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "create",
-						"group": "*",
+						"group": "apiextensions.k8s.io",
 						"resource": "customresourcedefinitions"
 					},
 					"user": "system:serviceaccount:teapot:operator",
@@ -1198,7 +1103,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"spec": {
 					"resourceAttributes": {
 						"verb": "create",
-						"group": "*",
+						"group": "storage.k8s.io",
 						"resource": "storageclasses"
 					},
 					"user": "system:serviceaccount:teapot:operator",
@@ -1225,7 +1130,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"spec": {
 					"resourceAttributes": {
 						"verb": "get",
-						"group": "*",
+						"group": "storage.k8s.io",
 						"resource": "storageclasses"
 					},
 					"user": "system:serviceaccount:teapot:operator",
@@ -1252,7 +1157,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"spec": {
 					"resourceAttributes": {
 						"verb": "get",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "system:serviceaccount:teapot:operator",
@@ -1279,7 +1184,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"spec": {
 					"resourceAttributes": {
 						"verb": "create",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "system:serviceaccount:teapot:operator",
@@ -1307,7 +1212,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "coffeepot",
 						"verb": "get",
-						"group": "*",
+						"group": "",
 						"resource": "secrets"},
 					"user": "mkerk",
 					"group": ["ReadOnly"]
@@ -1336,7 +1241,8 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "coffeepot",
 						"verb": "proxy",
-						"group": "*"
+						"group": "",
+						"resource": "services"
 					},
 					"user": "mkerk",
 					"group": ["ReadOnly"]
@@ -1366,7 +1272,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "coffeepot",
 						"verb": "create",
-						"group": "*",
+						"group": "",
 						"resource": "secrets"
 					},
 					"user": "mkerk",
@@ -1396,7 +1302,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "default",
 						"verb": "delete",
-						"group": "*",
+						"group": "",
 						"resource": "pods"
 					},
 					"user": "rdifazio",
@@ -1428,7 +1334,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "default",
 						"verb": "delete",
-						"group": "*",
+						"group": "",
 						"resource": "pods"
 					},
 					"user": "rdifazio",
@@ -1460,7 +1366,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "kube-system",
 						"verb": "delete",
-						"group": "*",
+						"group": "",
 						"resource": "pods"
 					},
 					"user": "rdifazio",
@@ -1484,9 +1390,9 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				},
 			},
 
-			//- Manual role can delete non-namespaced resources
+			//- Manual role can delete namespaces
 			{
-				msg: "Manual role can delete non-namespaced resources",
+				msg: "Manual role can delete namespaces",
 				reqBody: `{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
@@ -1494,7 +1400,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "delete",
-						"group": "*",
+						"group": "",
 						"resource": "namespaces"
 					},
 					"user": "rdifazio",
@@ -1516,6 +1422,40 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				},
 			},
 
+			//- Manual role can't delete kube-system namespace
+			{
+				msg: "Manual role can't delete kube-system namespace",
+				reqBody: `{
+					"apiVersion": "authorization.k8s.io/v1beta1",
+					"kind": "SubjectAccessReview",
+					"spec": {
+					"resourceAttributes": {
+						"verb": "delete",
+						"group": "",
+						"resource": "namespaces",
+						"name": "kube-system"
+					},
+					"user": "rdifazio",
+					"group": [
+						"ReadOnly",
+						"Manual"
+					]
+					}
+				}`,
+				expect: expect{
+					status: http.StatusCreated,
+					body: `{
+					"apiVersion": "authorization.k8s.io/v1beta1",
+					"kind": "SubjectAccessReview",
+					"status": {
+						"allowed": false,
+						"denied": true,
+						"reason":"unauthorized access rdifazio/[ReadOnly Manual]"
+					}
+				}}`,
+				},
+			},
+
 			//- Manual role can create resources
 			{
 				msg: "Manual role can create resources",
@@ -1526,7 +1466,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "default",
 						"verb": "create",
-						"group": "*",
+						"group": "",
 						"resource": "pods"
 					},
 					"user": "rdifazio",
@@ -1558,7 +1498,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "default",
 						"verb": "get",
-						"group": "*",
+						"group": "",
 						"resource": "pods"
 					},
 					"user": "rdifazio",
@@ -1582,7 +1522,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 
 			//- administrator can use restricted PSP
 			{
-				msg: "access to use PodSecurityPolicy for Administrator should be allowed",
+				msg: "access to use PodSecurityPolicy for Administrator (system:masters) should be allowed",
 				reqBody: fmt.Sprintf(`{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
@@ -1591,7 +1531,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"name": "restricted",
 						"namespace": "",
 						"verb": "use",
-						"group": "*",
+						"group": "extensions",
 						"resource": "podsecuritypolicies"
 					},
 					"user": "sszuecs",
@@ -1599,7 +1539,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"%s"
 					]
 					}
-				}`, administratorGroup),
+				}`, systemMastersGroup),
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
@@ -1614,7 +1554,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 
 			//- administrator can use privileged PSP
 			{
-				msg: "access to use PodSecurityPolicy for Administrator should be allowed",
+				msg: "access to use PodSecurityPolicy for Administrator (system:masters) should be allowed",
 				reqBody: fmt.Sprintf(`{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
@@ -1623,7 +1563,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"name": "privileged",
 						"namespace": "",
 						"verb": "use",
-						"group": "*",
+						"group": "extensions",
 						"resource": "podsecuritypolicies"
 					},
 					"user": "sszuecs",
@@ -1631,7 +1571,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"%s"
 					]
 					}
-				}`, administratorGroup),
+				}`, systemMastersGroup),
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
@@ -1655,7 +1595,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"name": "privileged",
 						"namespace": "",
 						"verb": "use",
-						"group": "*",
+						"group": "extensions",
 						"resource": "podsecuritypolicies"
 					},
 					"user": "sszuecs",
@@ -1706,20 +1646,20 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 
 			//- administrator has read access to kube system
 			{
-				msg: "Administrator has read access (pods) to kube-system",
+				msg: "Administrator (system:masters) has read access (pods) to kube-system",
 				reqBody: `{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
 						"namespace": "kube-system",
-						"verb": "GET",
-						"group": "*",
+						"verb": "get",
+						"group": "",
 						"resource": "pods"
 					},
 					"user": "rdifazio",
 					"group": [
-						"Administrator"
+						"system:masters"
 					]
 					}
 				}`,
@@ -1736,7 +1676,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			},
 			//- administrator has write access to kube system
 			{
-				msg: "Administrator has write access (pods) to kube-system",
+				msg: "Administrator (system:masters) has write access (pods) to kube-system",
 				reqBody: `{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
@@ -1744,12 +1684,12 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "kube-system",
 						"verb": "create",
-						"group": "*",
+						"group": "",
 						"resource": "pods"
 					},
 					"user": "rdifazio",
 					"group": [
-						"Administrator"
+						"system:masters"
 					]
 					}
 				}`,
@@ -1766,7 +1706,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			},
 			//- administrator can read secrets from non kube-system namespaces
 			{
-				msg: "Administrator can read secrets from non kube-system namespaces",
+				msg: "Administrator (system:masters) can read secrets from non kube-system namespaces",
 				reqBody: `{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
@@ -1774,12 +1714,12 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "teapot",
 						"verb": "get",
-						"group": "*",
+						"group": "",
 						"resource": "secrets"
 					},
 					"user": "rdifazio",
 					"group": [
-						"Administrator"
+						"system:masters"
 					]
 					}
 				}`,
@@ -1796,7 +1736,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			},
 			//- administrator has write access to non kube-system namespaces
 			{
-				msg: "Administrator has write access to non kube-system namespaces",
+				msg: "Administrator (system:masters) has write access to non kube-system namespaces",
 				reqBody: `{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
@@ -1804,12 +1744,12 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "teapot",
 						"verb": "create",
-						"group": "*",
+						"group": "",
 						"resource": "pods"
 					},
 					"user": "rdifazio",
 					"group": [
-						"Administrator"
+						"system:masters"
 					]
 					}
 				}`,
@@ -1828,7 +1768,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 
 			//- administrator has proxy right
 			{
-				msg: "Administrator has proxy right",
+				msg: "Administrator (system:masters) has proxy right",
 				reqBody: `{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
@@ -1836,11 +1776,11 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "teapot",
 						"verb": "proxy",
-						"group": "*"
+						"group": ""
 					},
 					"user": "sszuecs",
 					"group": [
-						"Administrator"
+						"system:masters"
 					]
 					}
 				}`,
@@ -1857,7 +1797,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			},
 			//- administrator can write daemonsets
 			{
-				msg: "Administrator can write daemonsets",
+				msg: "Administrator (system:masters) can write daemonsets",
 				reqBody: `{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
@@ -1865,12 +1805,12 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "teapot",
 						"verb": "create",
-						"group": "*",
+						"group": "apps",
 						"resource": "daemonsets"
 					},
 					"user": "sszuecs",
 					"group": [
-						"Administrator"
+						"system:masters"
 					]
 					}
 				}`,
@@ -1885,250 +1825,6 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				}}`,
 				},
 			},
-			//- Billing role can read nodes
-			{
-				msg: "Billing role can read nodes",
-				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"spec": {
-						"resourceAttributes": {
-							"namespace": "",
-							"verb": "get",
-							"group": "*",
-							"resource": "nodes"
-						},
-						"user": "rdifazio",
-						"group": [
-							"Billing"
-						]
-					}
-				}`,
-				expect: expect{
-					status: http.StatusCreated,
-					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
-						"kind": "SubjectAccessReview",
-						"status": {
-							"allowed": true
-						}
-					}`,
-				},
-			},
-			//- Billing role can read namespaces
-			{
-				msg: "Billing role can read namespaces",
-				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"spec": {
-						"resourceAttributes": {
-							"namespace": "",
-							"verb": "get",
-							"group": "*",
-							"resource": "namespaces"
-						},
-						"user": "rdifazio",
-						"group": [
-							"Billing"
-						]
-					}
-				}`,
-				expect: expect{
-					status: http.StatusCreated,
-					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
-						"kind": "SubjectAccessReview",
-						"status": {
-							"allowed": true
-						}
-					}`,
-				},
-			},
-			//- Billing role can read pods
-			{
-				msg: "Billing role can read pods",
-				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"spec": {
-						"resourceAttributes": {
-							"namespace": "",
-							"verb": "get",
-							"group": "*",
-							"resource": "pods"
-						},
-						"user": "rdifazio",
-						"group": [
-							"Billing"
-						]
-					}
-				}`,
-				expect: expect{
-					status: http.StatusCreated,
-					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
-						"kind": "SubjectAccessReview",
-						"status": {
-							"allowed": true
-						}
-					}`,
-				},
-			},
-			//- Billing role can read services
-			{
-				msg: "Billing role can read services",
-				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"spec": {
-						"resourceAttributes": {
-							"namespace": "",
-							"verb": "get",
-							"group": "*",
-							"resource": "services"
-						},
-						"user": "rdifazio",
-						"group": [
-							"Billing"
-						]
-					}
-				}`,
-				expect: expect{
-					status: http.StatusCreated,
-					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
-						"kind": "SubjectAccessReview",
-						"status": {
-							"allowed": true
-						}
-					}`,
-				},
-			},
-			//- Billing role can proxy to the heapster service
-			{
-				msg: "Billing role can proxy to the heapster service",
-				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"spec": {
-						"resourceAttributes": {
-							"namespace": "kube-system",
-							"verb": "proxy",
-							"group": "*",
-							"resource": "services",
-							"name": "heapster"
-						},
-						"user": "rdifazio",
-						"group": [
-							"Billing"
-						]
-					}
-				}`,
-				expect: expect{
-					status: http.StatusCreated,
-					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"status": {
-						"allowed": true
-					}
-				}}`,
-				},
-			},
-			//- Billing role can't write pods
-			{
-				msg: "Billing role can't write pods",
-				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"spec": {
-						"resourceAttributes": {
-							"namespace": "",
-							"verb": "update",
-							"group": "*",
-							"resource": "pods"
-						},
-						"user": "rdifazio",
-						"group": [
-							"Billing"
-						]
-					}
-				}`,
-				expect: expect{
-					status: http.StatusCreated,
-					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
-						"kind": "SubjectAccessReview",
-						"status": {
-							"allowed": false,
-							"reason": "unauthorized access rdifazio/[Billing]"
-						}
-					}`,
-				},
-			},
-			//- Billing role can't read configmaps
-			{
-				msg: "Billing role can't read configmaps",
-				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"spec": {
-						"resourceAttributes": {
-							"namespace": "",
-							"verb": "get",
-							"group": "*",
-							"resource": "configmaps"
-						},
-						"user": "rdifazio",
-						"group": [
-							"Billing"
-						]
-					}
-				}`,
-				expect: expect{
-					status: http.StatusCreated,
-					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
-						"kind": "SubjectAccessReview",
-						"status": {
-							"allowed": false,
-							"reason": "unauthorized access rdifazio/[Billing]"
-						}
-					}`,
-				},
-			},
-			//- Billing role can't write configmaps
-			{
-				msg: "Billing role can't write configmaps",
-				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"spec": {
-						"resourceAttributes": {
-							"namespace": "",
-							"verb": "update",
-							"group": "*",
-							"resource": "configmaps"
-						},
-						"user": "rdifazio",
-						"group": [
-							"Billing"
-						]
-					}
-				}`,
-				expect: expect{
-					status: http.StatusCreated,
-					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
-						"kind": "SubjectAccessReview",
-						"status": {
-							"allowed": false,
-							"reason": "unauthorized access rdifazio/[Billing]"
-						}
-					}`,
-				},
-			},
 			{
 				msg: "cdp service account can create namespaces",
 				reqBody: `{
@@ -2138,7 +1834,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "create",
-						"group": "*",
+						"group": "",
 						"resource": "namespaces"
 					},
 					"user": "system:serviceaccount:default:cdp",
@@ -2156,38 +1852,8 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				}}`,
 				},
 			},
-			// {
-			// 	// TODO: can be enabled when we have
-			// 	// cdp-controller creating bindings in place
-			// 	msg: "cdp service account can't escalate permissions",
-			// 	reqBody: `{
-			// 		"apiVersion": "authorization.k8s.io/v1beta1",
-			// 		"kind": "SubjectAccessReview",
-			// 		"spec": {
-			// 		"resourceAttributes": {
-			// 			"namespace": "",
-			// 			"verb": "escalate",
-			// 			"group": "*",
-			// 			"resource": "clusterroles"
-			// 		},
-			// 		"user": "system:serviceaccount:default:cdp",
-			// 		"group": []
-			// 		}
-			// 	}`,
-			// 	expect: expect{
-			// 		status: http.StatusCreated,
-			// 		body: `{
-			// 		"apiVersion": "authorization.k8s.io/v1beta1",
-			// 		"kind": "SubjectAccessReview",
-			// 		"status": {
-			// 			"denied": true,
-			// 			"reason": "no one is allowed to escalate"
-			// 		}
-			// 	}}`,
-			// 	},
-			// },
 			{
-				msg: "cdp service account can escalate permissions",
+				msg: "cdp service account can't escalate permissions",
 				reqBody: `{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
@@ -2195,7 +1861,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "escalate",
-						"group": "*",
+						"group": "rbac.authorization.k8s.io",
 						"resource": "clusterroles"
 					},
 					"user": "system:serviceaccount:default:cdp",
@@ -2208,7 +1874,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": true
+						"allowed": false
 					}
 				}}`,
 				},
@@ -2222,7 +1888,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				"resourceAttributes": {
 					"namespace": "",
 					"verb": "escalate",
-					"group": "*",
+					"group": "rbac.authorization.k8s.io",
 					"resource": "clusterroles"
 				},
 				"user": "mlarsen",
@@ -2235,8 +1901,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				"apiVersion": "authorization.k8s.io/v1beta1",
 				"kind": "SubjectAccessReview",
 				"status": {
-					"denied": true,
-					"reason": "no one is allowed to escalate"
+					"allow": false
 				}
 			}}`,
 				},
@@ -2250,7 +1915,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "create",
-						"group": "*",
+						"group": "",
 						"resource": "namespaces"
 					},
 					"user": "system:serviceaccount:default:operator",
@@ -2297,33 +1962,6 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				},
 			},
 			{
-				msg: "system service account in kube-system namespace can create pods",
-				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"spec": {
-					"resourceAttributes": {
-						"namespace": "kube-system",
-						"verb": "create",
-						"group": "",
-						"resource": "pods"
-					},
-					"user": "system:serviceaccount:kube-system:system",
-					"group": []
-					}
-				}`,
-				expect: expect{
-					status: http.StatusCreated,
-					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"status": {
-						"allowed": true
-					}
-				}}`,
-				},
-			},
-			{
 				msg: "operator service account can access persistent volumes in other namespaces",
 				reqBody: `{
 					"apiVersion": "authorization.k8s.io/v1beta1",
@@ -2332,7 +1970,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "get",
-						"group": "*",
+						"group": "",
 						"resource": "persistentvolumes"
 					},
 					"user": "system:serviceaccount:default:operator",
@@ -2499,7 +2137,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "update",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",
@@ -2514,9 +2152,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
-							"allowed": false,
-							"denied": true,
-							"reason": "unauthorized non read access to nodes: sszuecs/[Emergency]"
+							"allowed": false
 						}
 				}}`,
 				},
@@ -2530,7 +2166,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "update",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",
@@ -2545,9 +2181,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
-							"allowed": false,
-							"denied": true,
-							"reason": "unauthorized non read access to nodes: sszuecs/[Manual]"
+							"allowed": false
 						}
 				}}`,
 				},
@@ -2561,7 +2195,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "update",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",
@@ -2576,9 +2210,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
-							"allowed": false,
-							"denied": true,
-							"reason": "unauthorized non read access to nodes: sszuecs/[PowerUser]"
+							"allowed": false
 						}
 				}}`,
 				},
@@ -2592,7 +2224,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "create",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",
@@ -2607,9 +2239,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
-							"allowed": false,
-							"denied": true,
-							"reason": "unauthorized non read access to nodes: sszuecs/[Emergency]"
+							"allowed": false
 						}
 				}}`,
 				},
@@ -2623,7 +2253,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "create",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",
@@ -2638,9 +2268,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
-							"allowed": false,
-							"denied": true,
-							"reason": "unauthorized non read access to nodes: sszuecs/[Manual]"
+							"allowed": false
 						}
 				}}`,
 				},
@@ -2654,7 +2282,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "create",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",
@@ -2669,9 +2297,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
-							"allowed": false,
-							"denied": true,
-							"reason": "unauthorized non read access to nodes: sszuecs/[PowerUser]"
+							"allowed": false
 						}
 				}}`,
 				},
@@ -2685,7 +2311,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "patch",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",
@@ -2700,9 +2326,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
-							"allowed": false,
-							"denied": true,
-							"reason": "unauthorized non read access to nodes: sszuecs/[Emergency]"
+							"allowed": false
 						}
 				}}`,
 				},
@@ -2716,7 +2340,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "patch",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",
@@ -2731,9 +2355,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
-							"allowed": false,
-							"denied": true,
-							"reason": "unauthorized non read access to nodes: sszuecs/[Manual]"
+							"allowed": false
 						}
 				}}`,
 				},
@@ -2747,7 +2369,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "patch",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",
@@ -2762,9 +2384,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
-							"allowed": false,
-							"denied": true,
-							"reason": "unauthorized non read access to nodes: sszuecs/[PowerUser]"
+							"allowed": false
 						}
 				}}`,
 				},
@@ -2778,7 +2398,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "delete",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",
@@ -2793,9 +2413,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
-							"allowed": false,
-							"denied": true,
-							"reason": "unauthorized non read access to nodes: sszuecs/[Emergency]"
+							"allowed": false
 						}
 				}}`,
 				},
@@ -2809,7 +2427,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "delete",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",
@@ -2824,9 +2442,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
-							"allowed": false,
-							"denied": true,
-							"reason": "unauthorized non read access to nodes: sszuecs/[Manual]"
+							"allowed": false
 						}
 				}}`,
 				},
@@ -2840,7 +2456,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "delete",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",
@@ -2855,9 +2471,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
-							"allowed": false,
-							"denied": true,
-							"reason": "unauthorized non read access to nodes: sszuecs/[PowerUser]"
+							"allowed": false
 						}
 				}}`,
 				},
@@ -2871,7 +2485,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "list",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",
@@ -2900,7 +2514,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "list",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",
@@ -2929,7 +2543,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "list",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",
@@ -2958,7 +2572,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "get",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",
@@ -2987,7 +2601,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "get",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",
@@ -3016,7 +2630,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "get",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",

--- a/test/e2e/authorisation_test.go
+++ b/test/e2e/authorisation_test.go
@@ -105,7 +105,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"subresource": "status"
 					},
 					"user": "system:serviceaccount:kube-system:daemon-set-controller",
-					"group": []
+					"group": ["system:serviceaccount:kube-system"]
 					}
 				}`,
 				expect: expect{
@@ -132,7 +132,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"subresource": "finalizers"
 					},
 					"user": "system:serviceaccount:kube-system:daemon-set-controller",
-					"group": []
+					"group": ["system:serviceaccount:kube-system"]
 					}
 				}`,
 				expect: expect{
@@ -157,7 +157,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"resource": "podtemplates"
 					},
 					"user": "system:serviceaccount:kube-system:default",
-					"group": []
+					"group": ["system:serviceaccount:kube-system"]
 					}
 				}`,
 				expect: expect{

--- a/test/e2e/authorisation_test.go
+++ b/test/e2e/authorisation_test.go
@@ -2008,7 +2008,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"resource": "persistentvolumeclaims"
 					},
 					"user": "system:serviceaccount:kube-system:persistent-volume-binder",
-					"group": []
+					"group": ["system:serviceaccounts:kube-system"]
 					}
 				}`,
 				expect: expect{
@@ -2036,7 +2036,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"resource": "persistentvolumes"
 					},
 					"user": "system:serviceaccount:kube-system:persistent-volume-binder",
-					"group": []
+					"group": ["system:serviceaccounts:kube-system"]
 					}
 				}`,
 				expect: expect{
@@ -2064,7 +2064,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"resource": "*/scale"
 					},
 					"user": "system:serviceaccount:kube-system:horizontal-pod-autoscaler",
-					"group": []
+					"group": ["system:serviceaccounts:kube-system"]
 					}
 				}`,
 				expect: expect{
@@ -2092,7 +2092,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"resource": "*/scale"
 					},
 					"user": "system:serviceaccount:kube-system:horizontal-pod-autoscaler",
-					"group": []
+					"group": ["system:serviceaccounts:kube-system"]
 					}
 				}`,
 				expect: expect{
@@ -2119,7 +2119,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"resource": "nodes"
 					},
 					"user": "system:serviceaccount:kube-system:aws-cloud-provider",
-					"group": []
+					"group": ["system:serviceaccounts:kube-system"]
 					}
 				}`,
 				expect: expect{

--- a/test/e2e/authorisation_test.go
+++ b/test/e2e/authorisation_test.go
@@ -146,31 +146,6 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				}}`,
 				},
 			}, {
-				msg: "kube-system default account can list podtemplates",
-				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"spec": {
-					"resourceAttributes": {
-						"namespace": "kube-system",
-						"verb": "list",
-						"resource": "podtemplates"
-					},
-					"user": "system:serviceaccount:kube-system:default",
-					"group": ["system:serviceaccounts:kube-system"]
-					}
-				}`,
-				expect: expect{
-					status: http.StatusCreated,
-					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"status": {
-						"allowed": true
-					}
-				}}`,
-				},
-			}, {
 				msg: "default account in default namespace can list statefulsets",
 				reqBody: `{
 					"apiVersion": "authorization.k8s.io/v1beta1",

--- a/test/e2e/authorisation_test.go
+++ b/test/e2e/authorisation_test.go
@@ -807,6 +807,35 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				},
 			},
 
+			// poweruser can't delete metrics (non-resource endpoint)
+			{
+				msg: "PowerUser can't delete metrics (non-resource endpoint access)",
+				reqBody: fmt.Sprintf(`{
+					"apiVersion": "authorization.k8s.io/v1",
+					"kind": "SubjectAccessReview",
+					"spec": {
+						"resourceAttributes": {
+							"verb": "delete",
+							"path": "/metrics"
+						},
+						"user": "sszuecs",
+						"group": [
+							"%s"
+						]
+					}
+				}`, powerUserGroup),
+				expect: expect{
+					status: http.StatusCreated,
+					body: `{
+						"apiVersion": "authorization.k8s.io/v1",
+						"kind": "SubjectAccessReview",
+						"status": {
+							"allowed": false
+						}
+				}}`,
+				},
+			},
+
 			//- operator is allowed to use privileged PSP
 			// Namespace is currently always empty string, because in Kubernetes PSPs are not namespaced, yet.
 			// Check Kubernetes >= 1.7 if they namespaced it https://github.com/kubernetes/kubernetes/pull/42360

--- a/test/e2e/authorisation_test.go
+++ b/test/e2e/authorisation_test.go
@@ -146,7 +146,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				}}`,
 				},
 			}, {
-				msg: "default account in default namespace can list statefulsets",
+				msg: "default account in default namespace can not list statefulsets",
 				reqBody: `{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
@@ -166,12 +166,12 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": true
+						"allowed": false
 					}
 				}}`,
 				},
 			}, {
-				msg: "default account in non-default namespace can list statefulsets",
+				msg: "default account in non-default namespace can not list statefulsets",
 				reqBody: `{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
@@ -191,7 +191,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": true
+						"allowed": false
 					}
 				}}`,
 				},
@@ -836,11 +836,11 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				},
 			},
 
-			//- operator is allowed to use privileged PSP
+			//- operator is not allowed to use privileged PSP
 			// Namespace is currently always empty string, because in Kubernetes PSPs are not namespaced, yet.
 			// Check Kubernetes >= 1.7 if they namespaced it https://github.com/kubernetes/kubernetes/pull/42360
 			{
-				msg: "operator is allowed to use privileged PodSecurityPolicy (for own namespace)",
+				msg: "operator is not allowed to use privileged PodSecurityPolicy (for own namespace)",
 				reqBody: `{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
@@ -862,15 +862,15 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": true
+						"allowed": false
 					}
 				}}`,
 				},
 			},
 
-			//- operator has read access to own namespace
+			//- operator has no read access to own namespace
 			{
-				msg: "operator has read access to own namespace",
+				msg: "operator has no read access to own namespace",
 				reqBody: `{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
@@ -891,15 +891,15 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": true
+						"allowed": false
 					}
 				}}`,
 				},
 			},
 
-			//- operator has write access to own namespace
+			//- operator has no write access to own namespace
 			{
-				msg: "operator has write access to own namespace",
+				msg: "operator has no write access to own namespace",
 				reqBody: `{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
@@ -920,14 +920,14 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": true
+						"allowed": false
 					}
 				}}`,
 				},
 			},
-			//- operator has read access to other namespaces
+			//- operator has no read access to other namespaces
 			{
-				msg: "operator has read access to other namespace",
+				msg: "operator has no read access to other namespace",
 				reqBody: `{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
@@ -948,7 +948,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": true
+						"allowed": false
 					}
 				}}`,
 				},
@@ -984,7 +984,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				},
 			},
 
-			//- operator has read access to secrets in own namespace
+			//- operator has no read access to secrets in own namespace
 			{
 				msg: "operator has read access to secrets in own namespace",
 				reqBody: `{
@@ -1007,7 +1007,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": true
+						"allowed": false
 					}
 				}}`,
 				},
@@ -1043,7 +1043,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				},
 			},
 
-			//- operator has read access to custom resource definitions (CRD) in all namespaces
+			//- operator has no read access to custom resource definitions (CRD) in all namespaces
 			{
 				msg: "operator has read access to custom resource definitions (CRD) in all namespacese",
 				reqBody: `{
@@ -1066,12 +1066,12 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": true
+						"allowed": false
 					}
 				}}`,
 				},
 			},
-			//- operator has write access to custom resource definitions (CRD) in all namespaces
+			//- operator has no write access to custom resource definitions (CRD) in all namespaces
 			{
 				msg: "operator has read access to custom resource definitions (CRD) in all namespacese",
 				reqBody: `{
@@ -1094,12 +1094,12 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": true
+						"allowed": false
 					}
 				}}`,
 				},
 			},
-			//- operator has write access to storageclasses in all namespaces
+			//- operator has no write access to storageclasses in all namespaces
 			{
 				msg: "operator has write access to storageclasses in all namespaces",
 				reqBody: `{
@@ -1121,12 +1121,12 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": true
+						"allowed": false
 					}
 				}}`,
 				},
 			},
-			//- operator has read access to storageclasses in all namespaces
+			//- operator has no read access to storageclasses in all namespaces
 			{
 				msg: "operator has read access to storageclasses in all namespaces",
 				reqBody: `{
@@ -1148,12 +1148,12 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": true
+						"allowed": false
 					}
 				}}`,
 				},
 			},
-			//- operator has read access to nodes in global namespace
+			//- operator has no read access to nodes in global namespace
 			{
 				msg: "operator has read access to nodes in global namespace",
 				reqBody: `{
@@ -1175,12 +1175,12 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": true
+						"allowed": false
 					}
 				}}`,
 				},
 			},
-			//- operator has write access to nodes in global namespace
+			//- operator has no write access to nodes in global namespace
 			{
 				msg: "operator has write access to nodes in global namespace",
 				reqBody: `{
@@ -1202,7 +1202,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": true
+						"allowed": false
 					}
 				}}`,
 				},
@@ -1997,7 +1997,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				},
 			},
 			{
-				msg: "operator service account can access persistent volumes in other namespaces",
+				msg: "operator service account can not access persistent volumes in other namespaces",
 				reqBody: `{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
@@ -2018,8 +2018,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": true,
-						"reason": ""
+						"allowed": false
 					}
 				}}`,
 				},

--- a/test/e2e/authorisation_test.go
+++ b/test/e2e/authorisation_test.go
@@ -20,7 +20,7 @@ type expect struct {
 }
 
 const (
-	authzAPIVersion          = "authorization.k8s.io/v1"
+	authzAPIVersion          = "authorization.k8s.io/v1beta1"
 	authorizeMessageKind     = "SubjectAccessReview"
 	systemMastersGroup       = "system:masters"
 	operatorGroup            = "Operator"
@@ -31,7 +31,7 @@ const (
 	readOnlyGroup            = "ReadOnly"
 	portForwardPodNamePrefix = "port-forward-"
 	systemNamespace          = "kube-system"
-	accessReviewURL          = "/apis/authorization.k8s.io/v1/subjectaccessreviews"
+	accessReviewURL          = "/apis/authorization.k8s.io/v1beta1/subjectaccessreviews"
 )
 
 type authorizationResponseStatus struct {
@@ -66,7 +66,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "kubelet authorized",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -84,7 +84,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -92,9 +92,9 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				}}`,
 				},
 			}, {
-				msg: "kube-system default account can update daemonset status",
+				msg: "kube-system daemonset-controller service account can update daemonset status",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -111,7 +111,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -121,7 +121,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			}, {
 				msg: "kube-system default account can update daemonset finalizers",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -138,7 +138,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -148,7 +148,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			}, {
 				msg: "default account in default namespace can list statefulsets",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -163,7 +163,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -173,7 +173,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			}, {
 				msg: "default account in non-default namespace can list statefulsets",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -188,7 +188,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -198,7 +198,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			}, {
 				msg: "User in admin group can patch daemonsets",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -219,7 +219,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -229,7 +229,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			}, {
 				msg: "non-authorized group",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -247,7 +247,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false,
@@ -258,7 +258,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			}, {
 				msg: "resource list authorized with ReadOnly group",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -276,7 +276,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -286,7 +286,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			}, {
 				msg: "access to non-resource path with ReadOnly group",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"nonResourceAttributes": {
@@ -302,7 +302,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -312,7 +312,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			}, {
 				msg: "access to use PodSecurityPolicy for ReadOnly should not be allowed",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -331,7 +331,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false,
@@ -342,7 +342,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			}, {
 				msg: "ReadOnly role should not give port-forward access to the 'port-forward-' pod in default namespace",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 						"resourceAttributes": {
@@ -362,7 +362,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false
@@ -372,7 +372,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			}, {
 				msg: "ReadOnly role should give read access to nodes",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 						"resourceAttributes": {
@@ -390,7 +390,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1",
+						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": true
@@ -403,7 +403,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "access to use restricted PodSecurityPolicy for PowerUser should be allowed",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 						"resourceAttributes": {
@@ -422,7 +422,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1",
+						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": true
@@ -435,7 +435,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "access to use restricted PodSecurityPolicy for Emergency should be allowed",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -454,7 +454,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1",
+						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": true
@@ -467,7 +467,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "access to use restricted PodSecurityPolicy for Manual role should be allowed",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -486,7 +486,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1",
+						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": true
@@ -500,7 +500,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			//{
 			//	msg: "access to use privileged PodSecurityPolicy for PowerUser should not be allowed",
 			//	reqBody: fmt.Sprintf(`{
-			//		"apiVersion": "authorization.k8s.io/v1",
+			//		"apiVersion": "authorization.k8s.io/v1beta1",
 			//		"kind": "SubjectAccessReview",
 			//		"spec": {
 			//		"resourceAttributes": {
@@ -519,7 +519,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			//	expect: expect{
 			//		status: http.StatusCreated,
 			//		body: fmt.Sprintf(`{
-			//		"apiVersion": "authorization.k8s.io/v1",
+			//		"apiVersion": "authorization.k8s.io/v1beta1",
 			//		"kind": "SubjectAccessReview",
 			//		"status": {
 			//			"allowed": false,
@@ -533,7 +533,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "PowerUser has read access (pods) to kube-system",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -551,7 +551,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -564,7 +564,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "PowerUser has no read access to kube-system secrets",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -582,7 +582,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false,
@@ -597,7 +597,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "PowerUser has read access to non kube-system secrets",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -615,7 +615,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -628,7 +628,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "PowerUser has write access to non kube-system secrets",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -646,7 +646,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -660,7 +660,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "PowerUser has proxy right",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -678,7 +678,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -690,7 +690,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "PowerUser has no create access to daemonsets",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -708,7 +708,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false
@@ -720,7 +720,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "PowerUser has no update access to daemonsets",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -738,7 +738,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false
@@ -750,7 +750,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "PowerUser has no delete access to daemonsets",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -768,7 +768,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false
@@ -780,7 +780,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "PowerUser has no patch access to daemonsets",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -798,7 +798,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false
@@ -811,7 +811,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "PowerUser can't delete metrics (non-resource endpoint access)",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 						"resourceAttributes": {
@@ -827,7 +827,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1",
+						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": false
@@ -842,7 +842,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "operator is allowed to use privileged PodSecurityPolicy (for own namespace)",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -859,7 +859,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -872,7 +872,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "operator has read access to own namespace",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -888,7 +888,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -901,7 +901,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "operator has write access to own namespace",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -917,7 +917,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -929,7 +929,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "operator has read access to other namespace",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -945,7 +945,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -958,7 +958,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "operator has no write access to other namespace",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -974,7 +974,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false,
@@ -988,7 +988,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "operator has read access to secrets in own namespace",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1004,7 +1004,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1017,7 +1017,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "operator is not allowed to read secrets in other namespaces",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1033,7 +1033,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false,
@@ -1047,7 +1047,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "operator has read access to custom resource definitions (CRD) in all namespacese",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1063,7 +1063,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1075,7 +1075,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "operator has read access to custom resource definitions (CRD) in all namespacese",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1091,7 +1091,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1103,7 +1103,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "operator has write access to storageclasses in all namespaces",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1118,7 +1118,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1130,7 +1130,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "operator has read access to storageclasses in all namespaces",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1145,7 +1145,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1157,7 +1157,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "operator has read access to nodes in global namespace",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1172,7 +1172,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1184,7 +1184,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "operator has write access to nodes in global namespace",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1199,7 +1199,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1211,7 +1211,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "readonly is not allowed to read secrets all namespaces",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1226,7 +1226,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false,
@@ -1240,7 +1240,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "readonly is not allowed to use proxy",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1256,7 +1256,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false,
@@ -1271,7 +1271,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "readonly has no write access to any resource",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1287,7 +1287,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false,
@@ -1301,7 +1301,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "ReadOnly role cannot delete resources",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1319,7 +1319,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false,
@@ -1333,7 +1333,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "Manual role can delete resources in all namespaces except kube-system",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1352,7 +1352,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1365,7 +1365,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "Manual role cannot delete resources in kube-sytem namespace",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1384,7 +1384,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false,
@@ -1399,7 +1399,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "Manual role can delete namespaces",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1418,7 +1418,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1431,7 +1431,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "Manual role can't delete kube-system namespace",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1450,7 +1450,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false,
@@ -1465,7 +1465,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "Manual role can create resources",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1484,7 +1484,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1497,7 +1497,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "Manual role doesn't affect funtionality of other roles.",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1516,7 +1516,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1529,7 +1529,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "access to use PodSecurityPolicy for Administrator (system:masters) should be allowed",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1548,7 +1548,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1561,7 +1561,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "access to use PodSecurityPolicy for Administrator (system:masters) should be allowed",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1580,7 +1580,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1593,7 +1593,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "access to use PodSecurityPolicy for system:masters should be allowed",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1612,7 +1612,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1625,7 +1625,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "controller manager can list podsecurity policies",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1640,7 +1640,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1653,7 +1653,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "Administrator (system:masters) has read access (pods) to kube-system",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1671,7 +1671,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1683,7 +1683,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "Administrator (system:masters) has write access (pods) to kube-system",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1701,7 +1701,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1713,7 +1713,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "Administrator (system:masters) can read secrets from kube-system namespaces",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1731,7 +1731,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1743,7 +1743,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "Administrator (system:masters) can read secrets from non kube-system namespaces",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1761,7 +1761,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1773,7 +1773,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "Administrator (system:masters) has write access to non kube-system namespaces",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1791,7 +1791,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1805,7 +1805,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "Administrator (system:masters) has proxy right",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1822,7 +1822,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1834,7 +1834,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "Administrator (system:masters) can write daemonsets",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1852,7 +1852,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1863,7 +1863,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "cdp service account can create namespaces",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1879,7 +1879,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1890,7 +1890,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "cdp service account can't escalate permissions",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1906,34 +1906,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
-					"kind": "SubjectAccessReview",
-					"status": {
-						"allowed": false
-					}
-				}}`,
-				},
-			},
-			{
-				msg: "cdp service account can't bind clusterroles",
-				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
-					"kind": "SubjectAccessReview",
-					"spec": {
-					"resourceAttributes": {
-						"namespace": "",
-						"verb": "bind",
-						"group": "rbac.authorization.k8s.io",
-						"resource": "clusterroles"
-					},
-					"user": "system:serviceaccount:default:cdp",
-					"group": []
-					}
-				}`,
-				expect: expect{
-					status: http.StatusCreated,
-					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false
@@ -1944,7 +1917,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "PowerUsers can't escalate permissions",
 				reqBody: `{
-				"apiVersion": "authorization.k8s.io/v1",
+				"apiVersion": "authorization.k8s.io/v1beta1",
 				"kind": "SubjectAccessReview",
 				"spec": {
 				"resourceAttributes": {
@@ -1960,7 +1933,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-				"apiVersion": "authorization.k8s.io/v1",
+				"apiVersion": "authorization.k8s.io/v1beta1",
 				"kind": "SubjectAccessReview",
 				"status": {
 					"allow": false
@@ -1971,7 +1944,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "operator service account cannot create namespaces",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1987,7 +1960,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false,
@@ -1999,7 +1972,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "controller manager service account can create pods",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2015,7 +1988,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -2026,7 +1999,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "operator service account can access persistent volumes in other namespaces",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2042,7 +2015,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true,
@@ -2054,7 +2027,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "persistent volume binder service account can update kube system persistentVolumeClaims",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2070,7 +2043,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true,
@@ -2082,7 +2055,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "persistent volume binder service account can create kube system persistentVolumes",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2098,7 +2071,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true,
@@ -2110,7 +2083,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "horizontal pod autoscaler service account can update kube system autoscalers",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2126,7 +2099,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true,
@@ -2138,7 +2111,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "horizontal pod autoscaler service account can update any autoscaler",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2154,7 +2127,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true,
@@ -2166,7 +2139,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "aws-cloud-provider service account can access patch nodes",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2181,7 +2154,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true,
@@ -2193,7 +2166,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "emergency user should not have update access to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2211,7 +2184,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1",
+						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": false
@@ -2222,7 +2195,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "manual user should not have non update to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2240,7 +2213,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1",
+						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": false
@@ -2251,7 +2224,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "power user should not have update access to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2269,7 +2242,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1",
+						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": false
@@ -2280,7 +2253,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "emergency user should not have create access to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2298,7 +2271,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1",
+						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": false
@@ -2309,7 +2282,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "manual user should not have create access to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2327,7 +2300,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1",
+						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": false
@@ -2338,7 +2311,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "power user should not have create access to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2356,7 +2329,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1",
+						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": false
@@ -2367,7 +2340,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "emergency user should not have patch access to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2385,7 +2358,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1",
+						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": false
@@ -2396,7 +2369,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "manual user should not have patch access to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2414,7 +2387,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1",
+						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": false
@@ -2425,7 +2398,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "power user should not have patch access to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2443,7 +2416,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1",
+						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": false
@@ -2454,7 +2427,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "emergency user should not have delete access to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2472,7 +2445,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1",
+						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": false
@@ -2483,7 +2456,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "manual user should not have delete access to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2501,7 +2474,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1",
+						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": false
@@ -2512,7 +2485,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "power user should not have delete access to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2530,7 +2503,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1",
+						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": false
@@ -2541,7 +2514,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "power user should be allowed list access to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2559,7 +2532,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1",
+						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": true
@@ -2570,7 +2543,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "emergency user should be allowed list access to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2588,7 +2561,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1",
+						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": true
@@ -2599,7 +2572,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "manual user should be allowed list access to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2617,7 +2590,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1",
+						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": true
@@ -2628,7 +2601,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "power user should be allowed read access to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2646,7 +2619,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1",
+						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": true
@@ -2657,7 +2630,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "emergency user should be allowed read access to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2675,7 +2648,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1",
+						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": true
@@ -2686,7 +2659,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "manual user should be allowed read access to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1",
+					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2704,7 +2677,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1",
+						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": true

--- a/test/e2e/authorisation_test.go
+++ b/test/e2e/authorisation_test.go
@@ -1915,6 +1915,33 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				},
 			},
 			{
+				msg: "cdp service account can't bind clusterroles",
+				reqBody: `{
+					"apiVersion": "authorization.k8s.io/v1",
+					"kind": "SubjectAccessReview",
+					"spec": {
+					"resourceAttributes": {
+						"namespace": "",
+						"verb": "bind",
+						"group": "rbac.authorization.k8s.io",
+						"resource": "clusterroles"
+					},
+					"user": "system:serviceaccount:default:cdp",
+					"group": []
+					}
+				}`,
+				expect: expect{
+					status: http.StatusCreated,
+					body: `{
+					"apiVersion": "authorization.k8s.io/v1",
+					"kind": "SubjectAccessReview",
+					"status": {
+						"allowed": false
+					}
+				}}`,
+				},
+			},
+			{
 				msg: "PowerUsers can't escalate permissions",
 				reqBody: `{
 				"apiVersion": "authorization.k8s.io/v1",

--- a/test/e2e/authorisation_test.go
+++ b/test/e2e/authorisation_test.go
@@ -20,7 +20,7 @@ type expect struct {
 }
 
 const (
-	authzAPIVersion          = "authorization.k8s.io/v1beta1"
+	authzAPIVersion          = "authorization.k8s.io/v1"
 	authorizeMessageKind     = "SubjectAccessReview"
 	systemMastersGroup       = "system:masters"
 	operatorGroup            = "Operator"
@@ -31,7 +31,7 @@ const (
 	readOnlyGroup            = "ReadOnly"
 	portForwardPodNamePrefix = "port-forward-"
 	systemNamespace          = "kube-system"
-	accessReviewURL          = "/apis/authorization.k8s.io/v1beta1/subjectaccessreviews"
+	accessReviewURL          = "/apis/authorization.k8s.io/v1/subjectaccessreviews"
 )
 
 type authorizationResponseStatus struct {
@@ -66,7 +66,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "kubelet authorized",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -84,7 +84,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -94,7 +94,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			}, {
 				msg: "kube-system default account can update daemonset status",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -111,7 +111,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -121,7 +121,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			}, {
 				msg: "kube-system default account can update daemonset finalizers",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -138,7 +138,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -148,7 +148,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			}, {
 				msg: "default account in default namespace can list statefulsets",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -163,7 +163,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -173,7 +173,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			}, {
 				msg: "default account in non-default namespace can list statefulsets",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -188,7 +188,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -198,7 +198,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			}, {
 				msg: "User in admin group can patch daemonsets",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -219,7 +219,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -229,7 +229,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			}, {
 				msg: "non-authorized group",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -247,7 +247,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false,
@@ -258,7 +258,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			}, {
 				msg: "resource list authorized with ReadOnly group",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -276,7 +276,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -286,7 +286,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			}, {
 				msg: "access to non-resource path with ReadOnly group",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"nonResourceAttributes": {
@@ -302,7 +302,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -312,7 +312,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			}, {
 				msg: "access to use PodSecurityPolicy for ReadOnly should not be allowed",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -331,7 +331,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false,
@@ -342,7 +342,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			}, {
 				msg: "ReadOnly role should not give port-forward access to the 'port-forward-' pod in default namespace",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 						"resourceAttributes": {
@@ -362,7 +362,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false
@@ -372,7 +372,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			}, {
 				msg: "ReadOnly role should give read access to nodes",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 						"resourceAttributes": {
@@ -390,7 +390,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
+						"apiVersion": "authorization.k8s.io/v1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": true
@@ -403,7 +403,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "access to use restricted PodSecurityPolicy for PowerUser should be allowed",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 						"resourceAttributes": {
@@ -422,7 +422,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
+						"apiVersion": "authorization.k8s.io/v1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": true
@@ -435,7 +435,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "access to use restricted PodSecurityPolicy for Emergency should be allowed",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -454,7 +454,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
+						"apiVersion": "authorization.k8s.io/v1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": true
@@ -467,7 +467,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "access to use restricted PodSecurityPolicy for Manual role should be allowed",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -486,7 +486,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
+						"apiVersion": "authorization.k8s.io/v1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": true
@@ -500,7 +500,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			//{
 			//	msg: "access to use privileged PodSecurityPolicy for PowerUser should not be allowed",
 			//	reqBody: fmt.Sprintf(`{
-			//		"apiVersion": "authorization.k8s.io/v1beta1",
+			//		"apiVersion": "authorization.k8s.io/v1",
 			//		"kind": "SubjectAccessReview",
 			//		"spec": {
 			//		"resourceAttributes": {
@@ -519,7 +519,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			//	expect: expect{
 			//		status: http.StatusCreated,
 			//		body: fmt.Sprintf(`{
-			//		"apiVersion": "authorization.k8s.io/v1beta1",
+			//		"apiVersion": "authorization.k8s.io/v1",
 			//		"kind": "SubjectAccessReview",
 			//		"status": {
 			//			"allowed": false,
@@ -533,7 +533,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "PowerUser has read access (pods) to kube-system",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -551,7 +551,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -564,7 +564,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "PowerUser has no read access to kube-system secrets",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -582,7 +582,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false,
@@ -597,7 +597,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "PowerUser has read access to non kube-system secrets",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -615,7 +615,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -628,7 +628,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "PowerUser has write access to non kube-system secrets",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -646,7 +646,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -660,7 +660,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "PowerUser has proxy right",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -678,7 +678,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -690,7 +690,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "PowerUser has no create access to daemonsets",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -708,7 +708,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false
@@ -720,7 +720,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "PowerUser has no update access to daemonsets",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -738,7 +738,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false
@@ -750,7 +750,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "PowerUser has no delete access to daemonsets",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -768,7 +768,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false
@@ -780,7 +780,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "PowerUser has no patch access to daemonsets",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -798,7 +798,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false
@@ -813,7 +813,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "operator is allowed to use privileged PodSecurityPolicy (for own namespace)",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -830,7 +830,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -843,7 +843,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "operator has read access to own namespace",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -859,7 +859,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -872,7 +872,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "operator has write access to own namespace",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -888,7 +888,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -900,7 +900,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "operator has read access to other namespace",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -916,7 +916,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -929,7 +929,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "operator has no write access to other namespace",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -945,7 +945,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false,
@@ -959,7 +959,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "operator has read access to secrets in own namespace",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -975,7 +975,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -988,7 +988,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "operator is not allowed to read secrets in other namespaces",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1004,7 +1004,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false,
@@ -1018,7 +1018,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "operator has read access to custom resource definitions (CRD) in all namespacese",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1034,7 +1034,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1046,7 +1046,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "operator has read access to custom resource definitions (CRD) in all namespacese",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1062,7 +1062,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1074,7 +1074,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "operator has write access to storageclasses in all namespaces",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1089,7 +1089,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1101,7 +1101,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "operator has read access to storageclasses in all namespaces",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1116,7 +1116,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1128,7 +1128,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "operator has read access to nodes in global namespace",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1143,7 +1143,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1155,7 +1155,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "operator has write access to nodes in global namespace",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1170,7 +1170,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1182,7 +1182,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "readonly is not allowed to read secrets all namespaces",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1197,7 +1197,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false,
@@ -1211,7 +1211,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "readonly is not allowed to use proxy",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1227,7 +1227,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false,
@@ -1242,7 +1242,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "readonly has no write access to any resource",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1258,7 +1258,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false,
@@ -1272,7 +1272,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "ReadOnly role cannot delete resources",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1290,7 +1290,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false,
@@ -1304,7 +1304,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "Manual role can delete resources in all namespaces except kube-system",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1323,7 +1323,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1336,7 +1336,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "Manual role cannot delete resources in kube-sytem namespace",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1355,7 +1355,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false,
@@ -1370,7 +1370,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "Manual role can delete namespaces",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1389,7 +1389,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1402,7 +1402,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "Manual role can't delete kube-system namespace",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1421,7 +1421,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false,
@@ -1436,7 +1436,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "Manual role can create resources",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1455,7 +1455,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1468,7 +1468,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "Manual role doesn't affect funtionality of other roles.",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1487,7 +1487,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1500,7 +1500,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "access to use PodSecurityPolicy for Administrator (system:masters) should be allowed",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1519,7 +1519,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1532,7 +1532,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "access to use PodSecurityPolicy for Administrator (system:masters) should be allowed",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1551,7 +1551,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1564,7 +1564,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "access to use PodSecurityPolicy for system:masters should be allowed",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1583,7 +1583,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1596,7 +1596,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "controller manager can list podsecurity policies",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1611,7 +1611,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1624,7 +1624,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "Administrator (system:masters) has read access (pods) to kube-system",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1642,7 +1642,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1654,7 +1654,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "Administrator (system:masters) has write access (pods) to kube-system",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1672,7 +1672,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1684,7 +1684,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "Administrator (system:masters) can read secrets from kube-system namespaces",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1702,7 +1702,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1714,7 +1714,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "Administrator (system:masters) can read secrets from non kube-system namespaces",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1732,7 +1732,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1744,7 +1744,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "Administrator (system:masters) has write access to non kube-system namespaces",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1762,7 +1762,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1776,7 +1776,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "Administrator (system:masters) has proxy right",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1793,7 +1793,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1805,7 +1805,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "Administrator (system:masters) can write daemonsets",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1823,7 +1823,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1834,7 +1834,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "cdp service account can create namespaces",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1850,7 +1850,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1861,7 +1861,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "cdp service account can't escalate permissions",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1877,7 +1877,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false
@@ -1888,7 +1888,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "PowerUsers can't escalate permissions",
 				reqBody: `{
-				"apiVersion": "authorization.k8s.io/v1beta1",
+				"apiVersion": "authorization.k8s.io/v1",
 				"kind": "SubjectAccessReview",
 				"spec": {
 				"resourceAttributes": {
@@ -1904,7 +1904,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-				"apiVersion": "authorization.k8s.io/v1beta1",
+				"apiVersion": "authorization.k8s.io/v1",
 				"kind": "SubjectAccessReview",
 				"status": {
 					"allow": false
@@ -1915,7 +1915,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "operator service account cannot create namespaces",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1931,7 +1931,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": false,
@@ -1943,7 +1943,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "controller manager service account can create pods",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1959,7 +1959,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true
@@ -1970,7 +1970,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "operator service account can access persistent volumes in other namespaces",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -1986,7 +1986,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true,
@@ -1998,7 +1998,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "persistent volume binder service account can update kube system persistentVolumeClaims",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2014,7 +2014,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true,
@@ -2026,7 +2026,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "persistent volume binder service account can create kube system persistentVolumes",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2042,7 +2042,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true,
@@ -2054,7 +2054,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "horizontal pod autoscaler service account can update kube system autoscalers",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2070,7 +2070,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true,
@@ -2082,7 +2082,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "horizontal pod autoscaler service account can update any autoscaler",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2098,7 +2098,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true,
@@ -2110,7 +2110,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "aws-cloud-provider service account can access patch nodes",
 				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2125,7 +2125,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"status": {
 						"allowed": true,
@@ -2137,7 +2137,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "emergency user should not have update access to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2155,7 +2155,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
+						"apiVersion": "authorization.k8s.io/v1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": false
@@ -2166,7 +2166,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "manual user should not have non update to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2184,7 +2184,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
+						"apiVersion": "authorization.k8s.io/v1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": false
@@ -2195,7 +2195,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "power user should not have update access to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2213,7 +2213,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
+						"apiVersion": "authorization.k8s.io/v1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": false
@@ -2224,7 +2224,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "emergency user should not have create access to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2242,7 +2242,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
+						"apiVersion": "authorization.k8s.io/v1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": false
@@ -2253,7 +2253,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "manual user should not have create access to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2271,7 +2271,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
+						"apiVersion": "authorization.k8s.io/v1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": false
@@ -2282,7 +2282,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "power user should not have create access to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2300,7 +2300,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
+						"apiVersion": "authorization.k8s.io/v1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": false
@@ -2311,7 +2311,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "emergency user should not have patch access to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2329,7 +2329,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
+						"apiVersion": "authorization.k8s.io/v1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": false
@@ -2340,7 +2340,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "manual user should not have patch access to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2358,7 +2358,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
+						"apiVersion": "authorization.k8s.io/v1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": false
@@ -2369,7 +2369,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "power user should not have patch access to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2387,7 +2387,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
+						"apiVersion": "authorization.k8s.io/v1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": false
@@ -2398,7 +2398,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "emergency user should not have delete access to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2416,7 +2416,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
+						"apiVersion": "authorization.k8s.io/v1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": false
@@ -2427,7 +2427,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "manual user should not have delete access to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2445,7 +2445,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
+						"apiVersion": "authorization.k8s.io/v1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": false
@@ -2456,7 +2456,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "power user should not have delete access to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2474,7 +2474,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
+						"apiVersion": "authorization.k8s.io/v1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": false
@@ -2485,7 +2485,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "power user should be allowed list access to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2503,7 +2503,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
+						"apiVersion": "authorization.k8s.io/v1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": true
@@ -2514,7 +2514,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "emergency user should be allowed list access to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2532,7 +2532,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
+						"apiVersion": "authorization.k8s.io/v1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": true
@@ -2543,7 +2543,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "manual user should be allowed list access to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2561,7 +2561,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
+						"apiVersion": "authorization.k8s.io/v1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": true
@@ -2572,7 +2572,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "power user should be allowed read access to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2590,7 +2590,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
+						"apiVersion": "authorization.k8s.io/v1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": true
@@ -2601,7 +2601,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "emergency user should be allowed read access to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2619,7 +2619,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
+						"apiVersion": "authorization.k8s.io/v1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": true
@@ -2630,7 +2630,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			{
 				msg: "manual user should be allowed read access to node resources.",
 				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1beta1",
+					"apiVersion": "authorization.k8s.io/v1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
@@ -2648,7 +2648,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
+						"apiVersion": "authorization.k8s.io/v1",
 						"kind": "SubjectAccessReview",
 						"status": {
 							"allowed": true

--- a/test/e2e/authorisation_test.go
+++ b/test/e2e/authorisation_test.go
@@ -1909,7 +1909,8 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": false
+						"allowed": false,
+						"denied": true
 					}
 				}}`,
 				},
@@ -1936,7 +1937,8 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				"apiVersion": "authorization.k8s.io/v1beta1",
 				"kind": "SubjectAccessReview",
 				"status": {
-					"allow": false
+					"allow": false,
+					"denied": true
 				}
 			}}`,
 				},

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -409,7 +410,27 @@ func createServiceAccount(namespace, serviceAccount string) *v1.ServiceAccount {
 		},
 		AutomountServiceAccountToken: &trueValue,
 	}
+}
 
+func createRBACRoleBindingSA(role, namespace, serviceAccount string) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceAccount,
+			Namespace: namespace,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      serviceAccount,
+				Namespace: namespace,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     role,
+		},
+	}
 }
 
 func createNginxPodWithHostNetwork(namespace, serviceAccount string, label map[string]string, port int32) *v1.Pod {


### PR DESCRIPTION
This is the first step to remove all explicit allows from the authorization webhook.

The goal is to only use the webhook for explicit denies in cases where we can't express this via RBAC e.g.:
> give read access to all secrets except in kube-system namepase

Before the webhook had a mix of allow and deny rules which made it sometime overlap with the corresponding RBAC rules defined in kubernetes-on-aws. This is both confusing and dangerous because it makes it easy to change something in one place and not the other.
Now the webhook will only do explicit denies e.g. by blocking any access to secrets in kube-system e.g. for `PowerUser` role. everything else is passed through to RBAC and either explicitly whitelisted via the RBAC role+binding or just not allowed if RBAC doesn't allow it.

~Note that `cdp` service account, `operator` serviceaccount and `default` serviceaccount still has explicit allow rules implemented in the webhook. This is because we can't express those rules in RBAC e.g. give read access to `default` serviceaccount for all namespaces.
We should fix those remaining cases by migrating users away from these special "legacy" serviceaccounts, but this is a bigger task not directly part of this PR but part of the RBAC epic.~

Depends on: https://github.com/zalando-incubator/kubernetes-on-aws/pull/2507

## TODO

* [x] Update webhook image
* [x] Update legacy SA config items for all clusters!