### PR TITLE
Cut off resources from cadvisor in favour of node-problem-detector

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -79,8 +79,12 @@ image_policy: "dev"
 {{end}}
 
 # cadvisor settings
-cadvisor_cpu: "150m"
-cadvisor_memory: "150Mi"
+cadvisor_cpu: "125m"
+cadvisor_memory: "125Mi"
+
+# node-problem-detector settings
+node_problem_detector_cpu: "25m"
+node_problem_detector_memory: "25Mi"
 
 # node exporter settings
 node_exporter_cpu: "20m"

--- a/cluster/manifests/node-problem-detector/ds-node-problem-detector.yaml
+++ b/cluster/manifests/node-problem-detector/ds-node-problem-detector.yaml
@@ -26,7 +26,7 @@ spec:
         - /node-problem-detector
         args:
         - --config.system-log-monitor=/config/abrt-adaptor.json,/config/docker-monitor-filelog.json,/config/docker-monitor.json,/config/kernel-monitor-filelog.json,/config/kernel-monitor.json,/config/systemd-monitor.json
-        - --config.custom-plugin-monitor=/config/custom-plugin-monitor.json,/config/docker-monitor-counter.json,/config/kernel-monitor-counter.json,/config/network-problem-monitor.json,/config/systemd-monitor-counter.json
+        - --config.custom-plugin-monitor=/config/docker-monitor-counter.json,/config/kernel-monitor-counter.json,/config/network-problem-monitor.json,/config/systemd-monitor-counter.json
         - --config.system-stats-monitor=/config/system-stats-monitor.json
         - --address=0.0.0.0
         - --prometheus-address=0.0.0.0

--- a/cluster/manifests/node-problem-detector/ds-node-problem-detector.yaml
+++ b/cluster/manifests/node-problem-detector/ds-node-problem-detector.yaml
@@ -25,7 +25,7 @@ spec:
         command:
         - /node-problem-detector
         args:
-        - --config.system-log-monitor=/config/abrt-adaptor.json,/config/docker-monitor-filelog.json,/config/docker-monitor.json,/config/kernel-monitor-filelog.json,/config/kernel-monitor.json,/config/systemd-monitor.json
+        - --config.system-log-monitor=/config/abrt-adaptor.json,/config/docker-monitor.json,/config/kernel-monitor-filelog.json,/config/kernel-monitor.json,/config/systemd-monitor.json
         - --config.custom-plugin-monitor=/config/docker-monitor-counter.json,/config/kernel-monitor-counter.json,/config/network-problem-monitor.json,/config/systemd-monitor-counter.json
         - --config.system-stats-monitor=/config/system-stats-monitor.json
         - --address=0.0.0.0

--- a/cluster/manifests/node-problem-detector/ds-node-problem-detector.yaml
+++ b/cluster/manifests/node-problem-detector/ds-node-problem-detector.yaml
@@ -53,7 +53,6 @@ spec:
         volumeMounts:
         - name: log
           mountPath: /var/log
-          readOnly: true
         - name: localtime
           mountPath: /etc/localtime
           readOnly: true

--- a/cluster/manifests/node-problem-detector/ds-node-problem-detector.yaml
+++ b/cluster/manifests/node-problem-detector/ds-node-problem-detector.yaml
@@ -40,11 +40,11 @@ spec:
           timeoutSeconds: 3
         resources:
           requests:
-            cpu: 50m
-            memory: 50Mi
+            cpu: "{{ .ConfigItems.node_problem_detector_cpu }}"
+            memory: "{{ .ConfigItems.node_problem_detector_memory }}"
           limits:
-            cpu: 50m
-            memory: 50Mi
+            cpu: "{{ .ConfigItems.node_problem_detector_cpu }}"
+            memory: "{{ .ConfigItems.node_problem_detector_memory }}"
         env:
         - name: NODE_NAME
           valueFrom:


### PR DESCRIPTION
Follow up to https://github.com/zalando-incubator/kubernetes-on-aws/pull/2377.

Take some resources off `cadvisor` and account them for `node-problem-detector`. This keeps the overall usage of our components like before. We currently reserve more resources than we need for `cadvisor` so it seems safe to keep it from there.

Values for `node-problem-detector` detector are taken from current usage in `dev` channel but probably need to be adjusted for other clusters.