### PR TITLE
Add 'PowerUser' binding for cdp service account

### DIFF
--- a/cluster/manifests/roles/cdp-deployer-binding.yaml
+++ b/cluster/manifests/roles/cdp-deployer-binding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cdp-deployer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edit
+subjects:
+- kind: ServiceAccount
+  name: cdp
+  namespace: default


### PR DESCRIPTION
Adds a role binding to give `cdp` service account of the default namespace `PowerUser` permissions. These permissions are used by cdp deployment pods.

We roll this out via kubernetes-on-aws because we only need the binding for the `cdp` service account in the `default` namespace and because having it here (instead of created by cdp-controller) means the `cdp-controller` can run with fewer permissions (it can escalate permissions by creating pods, but this may change in the future if cdp deployments are implemented differently).