### PR TITLE
Updated the Ubuntu Image to use persistent paths for S3 downloads

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -217,7 +217,7 @@ cluster_dns: "coredns"
 coredns_log_svc_names: "true"
 
 coreos_image: "ami-0d1579b60bb706fb7" # Container Linux 2079.6.0 (HVM, eu-central-1)
-kuberuntu_image: {{ amiID "zalando-ubuntu-kubernetes-production-v1.14.6-master-56" "861068367966" }}
+kuberuntu_image: {{ amiID "zalando-ubuntu-kubernetes-production-v1.14.6-master-57" "861068367966" }}
 
 # Feature toggle to allow gradual decommissioning of ingress-template-controller
 enable_ingress_template_controller: "false"

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -22,7 +22,7 @@ write_files:
       KUBELET_ROLE=master
 
   - owner: root:root
-    path: /var/run/s3-certs.env
+    path: /etc/kuberuntu/s3-certs.env
     content: |
       S3_CERTS_BUCKET={{ .S3GeneratedFilesPath }}
       AWS_DEFAULT_REGION={{ .Cluster.Region }}

--- a/cluster/node-pools/worker-ubuntu-default/userdata.yaml
+++ b/cluster/node-pools/worker-ubuntu-default/userdata.yaml
@@ -15,7 +15,7 @@ write_files:
       KUBELET_ROLE=worker
 
   - owner: root:root
-    path: /var/run/s3-certs.env
+    path: /etc/kuberuntu/s3-certs.env
     content: |
       S3_CERTS_BUCKET={{ .S3GeneratedFilesPath }}
       AWS_DEFAULT_REGION={{ .Cluster.Region }}


### PR DESCRIPTION
The configuration to download files from s3 should be persisted across reboots. The `/var/run/` directory is temporary and it's contents are lost after a reboot.