### PR TITLE
Use node-problem-detector image containing lsblk

### DIFF
--- a/cluster/manifests/node-problem-detector/ds-node-problem-detector.yaml
+++ b/cluster/manifests/node-problem-detector/ds-node-problem-detector.yaml
@@ -21,7 +21,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
       - name: node-problem-detector
-        image: registry.opensource.zalan.do/teapot/node-problem-detector:v0.7.0
+        image: registry.opensource.zalan.do/teapot/node-problem-detector:v0.7.0-1
         command:
         - /node-problem-detector
         args:


### PR DESCRIPTION
Follow up to https://github.com/zalando-incubator/kubernetes-on-aws/pull/2458

This image contains `lsblk` which enables the disk stats monitor.