### PR TITLE
Node exporter should read node stats from mounted host paths

### DIFF
--- a/cluster/manifests/prometheus-node-exporter/daemonset.yaml
+++ b/cluster/manifests/prometheus-node-exporter/daemonset.yaml
@@ -33,6 +33,8 @@ spec:
         args:
           - --collector.textfile.directory=/prometheus-exporter-data
           - --collector.processes
+          - --path.procfs=/host/proc
+          - --path.sysfs=/host/sys
         name: prometheus-node-exporter
         ports:
         - name: prom-node-exp
@@ -51,6 +53,12 @@ spec:
         - name: prometheus-node-exporter-volume
           mountPath: /prometheus-exporter-data
           readOnly: false
+        - name: sys
+          mountPath: /host/sys
+          readOnly: true
+        - name: proc
+          mountPath: /host/proc
+          readOnly: true
       {{- if index .ConfigItems "enable_conntrack_log" }}
       - image: registry.opensource.zalan.do/teapot/prometheus-node-exporter-txt-exporter:v0.0.4
         name: prometheus-node-exporter-conntrack-exporter
@@ -74,3 +82,9 @@ spec:
         - name: prometheus-node-exporter-volume
           emptyDir:
             medium: Memory
+        - name: sys
+          hostPath:
+            path: /sys
+        - name: proc
+          hostPath:
+            path: /proc


### PR DESCRIPTION
Currently node exporter is not reading the node information correctly from the `sysfs` and `procfs` correctly. Mounting them from the host will expose correct metrics.