### PR TITLE
allow to configure whther to run node-problem-detector

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -79,12 +79,14 @@ image_policy: "dev"
 {{end}}
 
 # cadvisor settings
-cadvisor_cpu: "125m"
-cadvisor_memory: "100Mi"
+cadvisor_cpu: "150m"
+cadvisor_memory: "150Mi"
 
+# whether to deploy node-problem-detector
+node_problem_detector_enabled: "false"
 # node-problem-detector settings
 node_problem_detector_cpu: "25m"
-node_problem_detector_memory: "50Mi"
+node_problem_detector_memory: "75Mi"
 
 # node exporter settings
 node_exporter_cpu: "20m"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -80,11 +80,11 @@ image_policy: "dev"
 
 # cadvisor settings
 cadvisor_cpu: "125m"
-cadvisor_memory: "125Mi"
+cadvisor_memory: "100Mi"
 
 # node-problem-detector settings
 node_problem_detector_cpu: "25m"
-node_problem_detector_memory: "25Mi"
+node_problem_detector_memory: "50Mi"
 
 # node exporter settings
 node_exporter_cpu: "20m"

--- a/cluster/manifests/node-problem-detector/crb-node-problem-detector.yaml
+++ b/cluster/manifests/node-problem-detector/crb-node-problem-detector.yaml
@@ -1,3 +1,4 @@
+{{ if eq .ConfigItems.node_problem_detector_enabled "true" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -10,3 +11,4 @@ subjects:
 - kind: ServiceAccount
   name: node-problem-detector
   namespace: kube-system
+{{ end }}

--- a/cluster/manifests/node-problem-detector/ds-node-problem-detector.yaml
+++ b/cluster/manifests/node-problem-detector/ds-node-problem-detector.yaml
@@ -1,3 +1,4 @@
+{{ if eq .ConfigItems.node_problem_detector_enabled "true" }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -69,3 +70,4 @@ spec:
         effect: NoExecute
       - operator: Exists
         effect: NoSchedule
+{{ end }}

--- a/cluster/manifests/node-problem-detector/rb-node-problem-detector.yaml
+++ b/cluster/manifests/node-problem-detector/rb-node-problem-detector.yaml
@@ -1,3 +1,4 @@
+{{ if eq .ConfigItems.node_problem_detector_enabled "true" }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
@@ -11,3 +12,4 @@ subjects:
 - kind: ServiceAccount
   name: node-problem-detector
   namespace: kube-system
+{{ end }}

--- a/cluster/manifests/node-problem-detector/sa-node-problem-detector.yaml
+++ b/cluster/manifests/node-problem-detector/sa-node-problem-detector.yaml
@@ -1,5 +1,7 @@
+{{ if eq .ConfigItems.node_problem_detector_enabled "true" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: node-problem-detector
   namespace: kube-system
+{{ end }}

--- a/cluster/manifests/node-problem-detector/svc-node-problem-detector.yaml
+++ b/cluster/manifests/node-problem-detector/svc-node-problem-detector.yaml
@@ -1,3 +1,4 @@
+{{ if eq .ConfigItems.node_problem_detector_enabled "true" }}
 kind: Service
 apiVersion: v1
 metadata:
@@ -21,3 +22,4 @@ spec:
     port: 20257
     targetPort: 20257
     protocol: TCP
+{{ end }}


### PR DESCRIPTION
after discussion with @aermakov-zalando 
* reset the default resource requirements for cadvisor
* make problem detector component optional