### PR TITLE
Reduce min-memory-request to 25Mi

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -202,6 +202,7 @@ write_files:
             - --address=:8085
             - --tls-cert-file=/etc/kubernetes/ssl/admission-controller.pem
             - --tls-key-file=/etc/kubernetes/ssl/admission-controller-key.pem
+            - --pod-min-memory-request=25Mi
             - --pod-default-cpu-request={{ .Cluster.ConfigItems.teapot_admission_controller_default_cpu_request }}
             - --pod-default-memory-request={{ .Cluster.ConfigItems.teapot_admission_controller_default_memory_request }}
             - --pod-ignore-namespaces={{ .Cluster.ConfigItems.teapot_admission_controller_ignore_namespaces }}


### PR DESCRIPTION
25Mi is still plenty enough to not run into the issue of Docker not being able to start a container.