### PR TITLE
Update zmon-agent to 0.4-13-zv5

### DIFF
--- a/cluster/manifests/zmon-agent/deployment.yaml
+++ b/cluster/manifests/zmon-agent/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: "visibility"
   labels:
     application: "zmon-agent"
-    version: "0.4-2-zv5"
+    version: "0.4-13-zv5"
 spec:
   replicas: {{.ConfigItems.zmon_agent_replicas}}
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: "zmon-agent"
-        version: "0.4-2-zv5"
+        version: "0.4-13-zv5"
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-zmon"
     spec:
@@ -47,7 +47,7 @@ spec:
             readOnly: false
       containers:
         - name: zmon-agent
-          image: "pierone.stups.zalan.do/zmon/zmon-agent-core:0.4-11-gf8f2ced-zv5"
+          image: "pierone.stups.zalan.do/zmon/zmon-agent-core:0.4-13-g4dfea18-zv5"
           resources:
             limits:
               cpu: {{.ConfigItems.zmon_agent_cpu}}


### PR DESCRIPTION
The latest version of `zmon-agent` [collects additional NodeConditions](https://github.com/zalando-zmon/zmon-agent-core/pull/107/files).

/cc @vetinari 