### PR TITLE
add new filters and predicates, allow timeouts and ratelimit shunt routes

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.10.273
+    version: v0.10.281
     component: ingress
 spec:
   strategy:
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.10.273
+        version: v0.10.281
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -42,7 +42,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.273
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.281
         ports:
         - name: ingress-port
           containerPort: 9999


### PR DESCRIPTION
Allow monitor route creation time, allow ratelimiting for shunt routes, add tracingBaggageToTag filter, add JWTPayloadAllKVRegexp and JWTPayloadAnyKVRegexp predicates, support timeouts for auth filters, add application tag to apimonitoring filters

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>