### PR TITLE
Disable conntrack monitor in NodeProblemDetector

### DIFF
--- a/cluster/manifests/node-problem-detector/ds-node-problem-detector.yaml
+++ b/cluster/manifests/node-problem-detector/ds-node-problem-detector.yaml
@@ -27,7 +27,7 @@ spec:
         - /node-problem-detector
         args:
         - --config.system-log-monitor=/config/abrt-adaptor.json,/config/docker-monitor.json,/config/kernel-monitor-filelog.json,/config/kernel-monitor.json,/config/systemd-monitor.json
-        - --config.custom-plugin-monitor=/config/docker-monitor-counter.json,/config/kernel-monitor-counter.json,/config/network-problem-monitor.json,/config/systemd-monitor-counter.json
+        - --config.custom-plugin-monitor=/config/docker-monitor-counter.json,/config/kernel-monitor-counter.json,/config/systemd-monitor-counter.json
         - --config.system-stats-monitor=/config/system-stats-monitor.json
         - --address=0.0.0.0
         - --prometheus-address=0.0.0.0


### PR DESCRIPTION
The network problem detector currently uses wrong paths in `/proc` for conntrack. Disable it for now.