### PR TITLE
Add per-cluster admin role back

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -258,6 +258,7 @@ write_files:
 {{- end}}
 
             # Member roles
+            - --role-mapping=Administrator=cn=Administrator,ou={{.Cluster.ID}},ou=Kubernetes,ou=apps,dc=zalando,dc=net
 {{- if eq .Cluster.Environment "production"}}
             - --role-mapping=Manual=cn=Manual,ou={{.Cluster.ID}},ou=Kubernetes,ou=apps,dc=zalando,dc=net
             - --role-mapping=Emergency=cn=Emergency,ou={{.Cluster.ID}},ou=Kubernetes,ou=apps,dc=zalando,dc=net


### PR DESCRIPTION
A number of teams are apparently using this. Add back for now, we'll discuss how we want to approach it later.