### PR TITLE
kube-downscaler: add VPA

### DIFF
--- a/cluster/manifests/kube-downscaler/vpa.yaml
+++ b/cluster/manifests/kube-downscaler/vpa.yaml
@@ -1,0 +1,20 @@
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: kube-downscaler
+  namespace: kube-system
+  labels:
+    application: kube-downscaler
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: kube-downscaler
+  updatePolicy:
+    updateMode: Auto
+  resourcePolicy:
+    containerPolicies:
+    - containerName: downscaler
+      maxAllowed:
+        cpu: 500m
+        memory: 2Gi


### PR DESCRIPTION
It scales with the number of resources, and we don't want to babysit it.