### PR TITLE
Give collaborators access to nodes and daemonsets

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -225,7 +225,7 @@ write_files:
             - mountPath: /etc/kubernetes/ssl
               name: ssl-certs-kubernetes
               readOnly: true
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.6.0
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.6.1
           name: webhook
           ports:
           - containerPort: 8081
@@ -251,8 +251,12 @@ write_files:
             # Collaborator roles
             - --role-mapping=Administrator=cn=Administrator,ou=collaborators,ou=Kubernetes,ou=apps,dc=zalando,dc=net
             - --role-mapping=ReadOnly=cn=ReadOnly,ou=collaborators,ou=Kubernetes,ou=apps,dc=zalando,dc=net
-{{- if eq .Cluster.Environment "test"}}
-            - --role-mapping=PowerUser=cn=Deployer,ou=collaborators,ou=Kubernetes,ou=apps,dc=zalando,dc=net
+{{- if eq .Cluster.Environment "production"}}
+            - --role-mapping=Collaborator24x7=cn=24x7 Emergency,ou=collaborators,ou=Kubernetes,ou=apps,dc=zalando,dc=net
+            - --derived-role=CollaboratorEmergency=Collaborator24x7,Emergency
+            - --derived-role=CollaboratorManual=Collaborator24x7,Manual
+{{- else if eq .Cluster.Environment "test"}}
+            - --role-mapping=CollaboratorPowerUser=cn=Deployer,ou=collaborators,ou=Kubernetes,ou=apps,dc=zalando,dc=net
 {{- else if eq .Cluster.Environment "e2e"}}
             - --role-mapping=Administrator=cn=Contributor,ou=collaborators,ou=Kubernetes,ou=apps,dc=zalando,dc=net
 {{- end}}


### PR DESCRIPTION
Production: require both global 24x7 Emergency and per-cluster Emergency/Manual. Test: just require global Deployer.