### PR TITLE
Build with Go 1.12

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -6,7 +6,7 @@ pipeline:
   when:
     event: pull_request
   vm: large # speed up building kubernetes/kubernetes
-  overlay: ci/golang
+  overlay: ci/golang-1-12
   cache:
     paths:
     - /go/pkg/mod       # pkg cache for Go modules


### PR DESCRIPTION
Kubernetes test suite doesn't work after compiling with 1.13, fallback to 1.12.