### PR TITLE
Rename kuberuntu_image var to prevent merge conflicts

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -221,7 +221,7 @@ dynamodb_service_link_enabled: "false"
 cluster_dns: "coredns"
 coredns_log_svc_names: "true"
 
-kuberuntu_image: {{ amiID "zalando-ubuntu-kubernetes-production-v1.14.6-master-57" "861068367966" }}
+kuberuntu_image_v1_14: {{ amiID "zalando-ubuntu-kubernetes-production-v1.14.6-master-57" "861068367966" }}
 
 # Feature toggle to allow gradual decommissioning of ingress-template-controller
 enable_ingress_template_controller: "false"

--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -4,7 +4,7 @@ Description: Kubernetes default master node pool
 Mappings:
   Images:
     eu-central-1:
-      MachineImage: '{{ .Cluster.ConfigItems.kuberuntu_image }}'
+      MachineImage: '{{ .Cluster.ConfigItems.kuberuntu_image_v1_14 }}'
 
 Resources:
   AutoScalingGroup:

--- a/cluster/node-pools/worker-default/stack.yaml
+++ b/cluster/node-pools/worker-default/stack.yaml
@@ -4,7 +4,7 @@ Description: Kubernetes default worker node pool
 Mappings:
   Images:
     eu-central-1:
-      MachineImage: '{{ .Cluster.ConfigItems.kuberuntu_image }}'
+      MachineImage: '{{ .Cluster.ConfigItems.kuberuntu_image_v1_14 }}'
 
 Resources:
   AutoScalingGroup:

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -4,7 +4,7 @@ Description: Kubernetes default worker node pool
 Mappings:
   Images:
     eu-central-1:
-      MachineImage: '{{ .Cluster.ConfigItems.kuberuntu_image }}'
+      MachineImage: '{{ .Cluster.ConfigItems.kuberuntu_image_v1_14 }}'
 
 Resources:
 {{ with $data := . }}


### PR DESCRIPTION
This just renamed the `kuberuntu_image` variable such that when we prepare for version upgrades we have less change of merge conflicts in case were we update both the AMI for version upgrade in a new branch and also update the AMI for fixes to the old version.

Ref: https://github.com/zalando-incubator/kubernetes-on-aws/pull/2483#issuecomment-527829603