### PR TITLE
Update flannel to v0.11.0

### DIFF
--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: flannel
-    version: v0.10.0-8
+    version: v0.11.0-10
 spec:
   updateStrategy:
     type: OnDelete
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: flannel
-        version: v0.10.0-8
+        version: v0.11.0-10
     spec:
       priorityClassName: system-node-critical
       serviceAccountName: system
@@ -58,7 +58,7 @@ spec:
             cpu: 25m
             memory: 25Mi
       - name: kube-flannel
-        image: registry.opensource.zalan.do/teapot/flannel:v0.10.0-8
+        image: registry.opensource.zalan.do/teapot/flannel:v0.11.0-10
         command:
         - /opt/bin/flanneld
         args:


### PR DESCRIPTION
[Release notes](https://github.com/coreos/flannel/releases/tag/v0.11.0) and new flags:
```console
  -iptables-forward-rules
    	add default accept rules to FORWARD chain in iptables (default true)
  -iptables-resync int
    	resync period for iptables rules, in seconds (default 5)
```
Both defaults match the current behaviour.

Setting `iptables-resync` to a higher value than 5 seconds can help with iptables lock contention that can be seen in the logs of `flannel` and `kube-proxy` as:
```console
E0909 10:04:04.243614       1 iptables.go:97] Failed to ensure iptables rules: Error checking rule existence: failed to check rule existence: running [/sbin/iptables -t nat -C POSTROUTING ! -s 10.2.0.0/16 -d 10.2.0.0/16 -j MASQUERADE --wait]: exit status 4: iptables: Resource temporarily unavailable.
```

> --iptables-resync=5: resync period for iptables rules, in seconds. Defaults to 5 seconds, if you see a large amount of contention for the iptables lock increasing this will probably help.

From https://github.com/coreos/flannel/pull/935:
> On a larger cluster with many services we found 5 seconds to be too aggressive and created too much iptables lock contention causing kube-proxy to fail to sync it's tables.