### PR TITLE
Make e2e tests build with go1.13

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -6,7 +6,7 @@ pipeline:
   when:
     event: pull_request
   vm: large # speed up building kubernetes/kubernetes
-  overlay: ci/golang-1-12
+  overlay: ci/golang
   cache:
     paths:
     - /go/pkg/mod       # pkg cache for Go modules

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -49,7 +49,7 @@ import (
 
 var viperConfig = flag.String("viper-config", "", "The name of a viper config file (https://github.com/spf13/viper#what-is-viper). All e2e command line parameters can also be configured in such a file. May contain a path and may or may not contain the file suffix. The default is to look for an optional file with `e2e` as base name. If a file is specified explicitly, it must be present.")
 
-func init() {
+func TestE2E(t *testing.T) {
 	// Register framework flags, then handle flags and Viper config.
 	framework.HandleFlags()
 	if err := viperconfig.ViperizeFlags(*viperConfig, ""); err != nil {
@@ -72,9 +72,7 @@ func init() {
 		Asset:      generated.Asset,
 		AssetNames: generated.AssetNames,
 	})
-}
 
-func TestE2E(t *testing.T) {
 	e2e.RunE2ETests(t)
 }
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -49,7 +49,7 @@ import (
 
 var viperConfig = flag.String("viper-config", "", "The name of a viper config file (https://github.com/spf13/viper#what-is-viper). All e2e command line parameters can also be configured in such a file. May contain a path and may or may not contain the file suffix. The default is to look for an optional file with `e2e` as base name. If a file is specified explicitly, it must be present.")
 
-func TestE2E(t *testing.T) {
+func TestMain(m *testing.M) {
 	// Register framework flags, then handle flags and Viper config.
 	framework.HandleFlags()
 	if err := viperconfig.ViperizeFlags(*viperConfig, ""); err != nil {
@@ -72,7 +72,10 @@ func TestE2E(t *testing.T) {
 		Asset:      generated.Asset,
 		AssetNames: generated.AssetNames,
 	})
+	os.Exit(m.Run())
+}
 
+func TestE2E(t *testing.T) {
 	e2e.RunE2ETests(t)
 }
 

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -185,3 +185,5 @@ replace k8s.io/sample-cli-plugin => ../e2e_modules/kubernetes/staging/src/k8s.io
 replace k8s.io/sample-controller => ../e2e_modules/kubernetes/staging/src/k8s.io/sample-controller
 
 replace k8s.io/metrics => ../e2e_modules/kubernetes/staging/src/k8s.io/metrics
+
+go 1.13


### PR DESCRIPTION
Moves the flag handling away from `init()` such that the e2e tests can build with go1.13. It's annoying to build locally if it only works with go1.12 :)