### PR TITLE
Revert "Update auth webhook to v0.6.2"

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -237,7 +237,7 @@ write_files:
             - mountPath: /etc/kubernetes/ssl
               name: ssl-certs-kubernetes
               readOnly: true
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.6.2
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.6.1
           name: webhook
           ports:
           - containerPort: 8081


### PR DESCRIPTION
This breaks a few normal deployments that are running in `visibility`. Reverting temporarily until they're moved out.