### PR TITLE
Added VPA for kube-janitor only for non-prod clusters

### DIFF
--- a/cluster/manifests/kube-janitor/vpa.yaml
+++ b/cluster/manifests/kube-janitor/vpa.yaml
@@ -1,3 +1,4 @@
+{{ if ne .Environment "production" }}
 apiVersion: autoscaling.k8s.io/v1beta2
 kind: VerticalPodAutoscaler
 metadata:
@@ -15,3 +16,4 @@ spec:
     - containerName: janitor
       maxAllowed:
         memory: 750Mi
+{{ end }}


### PR DESCRIPTION
`kube-janitor` only runs in non-production clusters.