### PR TITLE
upgrade Skipper to v0.10.287

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.10.286
+    version: v0.10.287
     component: ingress
 spec:
   strategy:
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.10.286
+        version: v0.10.287
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -42,7 +42,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.286
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.287
         ports:
         - name: ingress-port
           containerPort: 9999

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.10.282
+    version: v0.10.286
     component: ingress
 spec:
   strategy:
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.10.282
+        version: v0.10.286
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -42,7 +42,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.282
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.10.286
         ports:
         - name: ingress-port
           containerPort: 9999


### PR DESCRIPTION
updated the PR to introduce 287 instead of 286, including this way a fix for the route creation time measurement.

- use go 1.13
- remove invalid lifo warnings from logs
- fix route creation time