### PR TITLE
Always run CLC

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -193,9 +193,6 @@ drain_force_evict_interval: "5m"
 node_update_prepare_replacement_node: "false" # don't wait for a replacement instance for on-demand pools in test clusters
 {{end}}
 
-# Temporary feature toggles for the cluster lifecycle controller
-experimental_cluster_lifecycle_controller: "false"
-
 # Teapot admission controller
 teapot_admission_controller_default_cpu_request: "25m"
 teapot_admission_controller_default_memory_request: "100Mi"

--- a/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     application: cluster-lifecycle-controller
     version: master-8
 spec:
-  replicas: {{if eq .ConfigItems.experimental_cluster_lifecycle_controller "true"}}1{{else}}0{{end}}
+  replicas: 1
   selector:
     matchLabels:
       application: cluster-lifecycle-controller


### PR DESCRIPTION
`rolling` strategy will be dropped from CLM at some point, so CLC always needs to run.