### PR TITLE
Allow scaling out e2e master pool for rolling update

### DIFF
--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -62,7 +62,7 @@ clusters:
     name: default-master
     profile: ${MASTER_PROFILE}-default
     min_size: 1
-    max_size: 1
+    max_size: 2
   - discount_strategy: spot_max_price
     instance_types: ["m4.large", "m5.large", "m5.xlarge", "m4.xlarge"]
     name: default-worker-splitaz


### PR DESCRIPTION
For e2e we need to let CLC scale out the master pool otherwise it just cordons the node, kicks itself out and then gets into pending state :)

```
time="2019-09-12T20:53:18Z" level=warning msg="Can't create a replacement node because the ASG is at maximum capacity. Proceeding anyway." node=ip-172-31-12-115.eu-central-1.compute.internal pool=default-master
time="2019-09-12T20:53:18Z" level=info msg="Draining node" node=ip-172-31-12-115.eu-central-1.compute.internal pool=default-master
time="2019-09-12T20:53:19Z" level=info msg="Evicting pod" node=ip-172-31-12-115.eu-central-1.compute.internal ns=kube-system pod=etcd-backup-1568319780-j62wp pool=default-master
time="2019-09-12T20:53:19Z" level=info msg="Evicting pod" node=ip-172-31-12-115.eu-central-1.compute.internal ns=kube-system pod=kube-aws-iam-controller-8c79fdc7c-lbktv pool=default-master
time="2019-09-12T20:53:19Z" level=info msg="Evicting pod" node=ip-172-31-12-115.eu-central-1.compute.internal ns=kube-system pod=cluster-lifecycle-controller-6778d9c867-sn8vn pool=default-master
- cluster-lifecycle-controller-6778d9c867-sn8vn
```

Follow up to #2511