### PR TITLE
Allow CDP to list Stacks & to create GradualStacks

### DIFF
--- a/cluster/manifests/roles/cdp-controller-rbac.yaml
+++ b/cluster/manifests/roles/cdp-controller-rbac.yaml
@@ -46,6 +46,13 @@ rules:
 - apiGroups:
   - "zalando.org"
   resources:
+  - stacks
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - "zalando.org"
+  resources:
   - gradualdeployments
   verbs:
   - get

--- a/cluster/manifests/roles/cdp-controller-rbac.yaml
+++ b/cluster/manifests/roles/cdp-controller-rbac.yaml
@@ -70,6 +70,7 @@ rules:
   - get
   - list
   - watch
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding


### PR DESCRIPTION
CDP needs to know which stacks exist for a given StackSet, so that it can decide what stack is the blue stack of a gradual deployment.

See https://github.bus.zalan.do/automata/issues/issues/2629 for more details.