### PR TITLE
logging-agent: support new node configuration [1/2]

### DIFF
--- a/cluster/manifests/logging-agent/daemonset-legacy.yaml
+++ b/cluster/manifests/logging-agent/daemonset-legacy.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: logging-agent
+  name: logging-agent-legacy
   namespace: visibility
   labels:
     cluster_environment: "{{ .Environment }}"
@@ -37,7 +37,7 @@ spec:
             nodeSelectorTerms:
               - matchExpressions:
                   - key: podruntime
-                    operator: In
+                    operator: NotIn
                     values:
                       - relocated
       tolerations:
@@ -240,7 +240,7 @@ spec:
       volumes:
       - name: containerlogs
         hostPath:
-          path: /opt/podruntime/docker/containers
+          path: /var/lib/docker/containers
 
       - name: journal
         hostPath:


### PR DESCRIPTION
In the new AMI, Docker root directory was moved to a different location. This needs to be merged before we rotate the nodes so the logging agent will work for both node types. I've created a separate daemonset for old nodes, which we can drop after the migration is complete.