### PR TITLE
Update ExternalDNS to v0.5.17

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: external-dns
-    version: v0.5.16
+    version: v0.5.17
 spec:
   strategy:
     type: Recreate
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: external-dns
-        version: v0.5.16
+        version: v0.5.17
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "false"}}
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: pierone.stups.zalan.do/teapot/external-dns:v0.5.16
+        image: pierone.stups.zalan.do/teapot/external-dns:v0.5.17
         args:
         - --source=service
         - --source=ingress


### PR DESCRIPTION
Changelog: https://github.com/kubernetes-incubator/external-dns/releases/tag/v0.5.17

* Should avoid excessive rate limits by re-introducing the `aws-retries` flag (set it back to `3`, see https://github.com/kubernetes-incubator/external-dns/pull/1158)