### PR TITLE
Update CLC

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -791,6 +791,54 @@ Resources:
           PolicyName: root
       RoleName: "{{.Cluster.LocalID}}-app-ingr-ctrl"
     Type: 'AWS::IAM::Role'
+  ClusterLifecycleControllerIAMRole:
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Action:
+          - 'sts:AssumeRole'
+          Effect: Allow
+          Principal:
+            Service:
+            - ec2.amazonaws.com
+        - Action:
+          - 'sts:AssumeRole'
+          Effect: Allow
+          Principal:
+            AWS: !Join
+              - ''
+              - - 'arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/'
+                - !Ref WorkerIAMRole
+        Version: 2012-10-17
+      Path: /
+      Policies:
+      - PolicyDocument:
+          Statement:
+          - Action: 'ec2:DescribeInstanceStatus'
+            Effect: Allow
+            Resource: '*'
+          - Action: 'autoscaling:DescribeAutoScalingGroups'
+            Effect: Allow
+            Resource: '*'
+          - Action: 'autoscaling:DescribeAutoScalingInstances'
+            Effect: Allow
+            Resource: '*'
+          - Action: 'autoscaling:DescribeLoadBalancers'
+            Effect: Allow
+            Resource: '*'
+          - Action: 'autoscaling:SetDesiredCapacity'
+            Effect: Allow
+            Resource: '*'
+          - Action: 'elasticloadbalancing:DescribeInstanceHealth'
+            Effect: Allow
+            Resource: '*'
+          - Action: 'autoscaling:TerminateInstanceInAutoScalingGroup'
+            Effect: Allow
+            Resource: '*'
+          Version: 2012-10-17
+        PolicyName: root
+      RoleName: "{{.Cluster.LocalID}}-cluster-lifecycle-controller"
+    Type: 'AWS::IAM::Role'
   KubeReadyIAMRole:
     Properties:
       AssumeRolePolicyDocument:

--- a/cluster/manifests/cluster-lifecycle-controller/aws-iam-role.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/aws-iam-role.yaml
@@ -1,0 +1,7 @@
+apiVersion: zalando.org/v1
+kind: AWSIAMRole
+metadata:
+  name: cluster-lifecycle-controller-aws-iam-credentials
+  namespace: kube-system
+spec:
+  roleReference: {{.LocalID}}-cluster-lifecycle-controller

--- a/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: cluster-lifecycle-controller
-    version: master-8
+    version: master-11
 spec:
   replicas: 1
   selector:
@@ -17,7 +17,7 @@ spec:
     metadata:
       labels:
         application: cluster-lifecycle-controller
-        version: master-8
+        version: master-11
     spec:
       dnsConfig:
         options:
@@ -32,7 +32,7 @@ spec:
         operator: Exists
       containers:
       - name: cluster-lifecycle-controller
-        image: registry.opensource.zalan.do/teapot/cluster-lifecycle-controller:master-10
+        image: registry.opensource.zalan.do/teapot/cluster-lifecycle-controller:master-11
         args:
             - --drain-grace-period={{.ConfigItems.drain_grace_period}}
             - --drain-min-pod-lifetime={{.ConfigItems.drain_min_pod_lifetime}}

--- a/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
@@ -19,10 +19,12 @@ spec:
         application: cluster-lifecycle-controller
         version: master-8
     spec:
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
       priorityClassName: system-cluster-critical
       serviceAccountName: cluster-lifecycle-controller
-      dnsPolicy: Default
-      hostNetwork: true
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule

--- a/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         version: master-8
     spec:
       priorityClassName: system-cluster-critical
-      serviceAccountName: system
+      serviceAccountName: cluster-lifecycle-controller
       dnsPolicy: Default
       hostNetwork: true
       tolerations:

--- a/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
@@ -32,13 +32,17 @@ spec:
         operator: Exists
       containers:
       - name: cluster-lifecycle-controller
-        image: registry.opensource.zalan.do/teapot/cluster-lifecycle-controller:master-8
+        image: registry.opensource.zalan.do/teapot/cluster-lifecycle-controller:master-10
         args:
             - --drain-grace-period={{.ConfigItems.drain_grace_period}}
             - --drain-min-pod-lifetime={{.ConfigItems.drain_min_pod_lifetime}}
             - --drain-min-healthy-sibling-lifetime={{.ConfigItems.drain_min_healthy_sibling_lifetime}}
             - --drain-min-unhealthy-sibling-lifetime={{.ConfigItems.drain_min_unhealthy_sibling_lifetime}}
             - --drain-force-evict-interval={{.ConfigItems.drain_force_evict_interval}}
+        volumeMounts:
+        - name: aws-iam-credentials
+          mountPath: /meta/aws-iam
+          readOnly: true
         resources:
           limits:
             cpu: 100m
@@ -47,7 +51,14 @@ spec:
             cpu: 100m
             memory: 250Mi
         env:
-          - name: AWS_REGION
-            value: {{ .Region }}
+        - name: AWS_REGION
+          value: {{ .Region }}
+        # must be set for the AWS SDK/AWS CLI to find the credentials file.
+        - name: AWS_SHARED_CREDENTIALS_FILE # used by golang SDK
+          value: /meta/aws-iam/credentials.process
+      volumes:
+      - name: aws-iam-credentials
+        secret:
+          secretName: cluster-lifecycle-controller-aws-iam-credentials
       nodeSelector:
         node-role.kubernetes.io/master: ""

--- a/cluster/manifests/cluster-lifecycle-controller/rbac.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/rbac.yaml
@@ -11,10 +11,13 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["pods", "nodes"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  verbs: ["get", "list", "watch", "patch", "delete"]
 - apiGroups: [""]
   resources: ["pods/eviction"]
   verbs: ["create"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch", "update", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/cluster/manifests/cluster-lifecycle-controller/rbac.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/rbac.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster-lifecycle-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-lifecycle-controller
+rules:
+- apiGroups: [""]
+  resources: ["pods", "nodes"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["pods/eviction"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-lifecycle-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-lifecycle-controller
+subjects:
+- kind: ServiceAccount
+  name: cluster-lifecycle-controller
+  namespace: kube-system


### PR DESCRIPTION
Cherry-pick #2524 to alpha so we could roll out the cluster updates without waiting for TCP timeout to kick in. Other changes picked up as well so we don't get merge conflicts later.