### PR TITLE
Fix RBAC for dashboard/admission controller proxy

### DIFF
--- a/cluster/manifests/admission-control/daemonset.yaml
+++ b/cluster/manifests/admission-control/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
           - name: ndots
             value: "1"
       priorityClassName: system-cluster-critical
-      serviceAccountName: admission-controller
+      serviceAccountName: admission-controller-proxy
       dnsPolicy: Default
       hostNetwork: true
       tolerations:

--- a/cluster/manifests/admission-control/rbac.yaml
+++ b/cluster/manifests/admission-control/rbac.yaml
@@ -2,28 +2,20 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: admission-controller
+  name: admission-controller-proxy
   namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: RoleBinding
 metadata:
-  name: admission-controller
-rules:
-- apiGroups: ["*"]
-  resources: ["*"]
-  verbs: ["get"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: admission-controller
+  name: admission-controller-proxy-privileged-psp
+  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: admission-controller
+  name: privileged-psp
 subjects:
 - kind: ServiceAccount
-  name: admission-controller
+  name: admission-controller-proxy
   namespace: kube-system
 {{ end }}

--- a/cluster/manifests/dashboard/rbac.yaml
+++ b/cluster/manifests/dashboard/rbac.yaml
@@ -7,7 +7,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
-  name: audittrail-adapter-privileged-psp
+  name: kubernetes-dashboard
   namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -34,3 +34,10 @@ post_apply:
 - name: nvidia-driver-installer
   namespace: kube-system
   kind: DaemonSet
+- name: admission-controller
+  namespace: kube-system
+  kind: ServiceAccount
+- name: admission-controller
+  kind: ClusterRole
+- name: admission-controller
+  kind: ClusterRoleBinding


### PR DESCRIPTION
* dashboard: don't overwrite audittrail adapter's role definitions
* admission-controller: the daemonset is only for the oauth injecting proxy, which doesn't access any Kubernetes APIs (but needs to be able to use host networking). drop the cluster role for it and replace with a binding for the privileged PSP role.