### PR TITLE
Another RBAC fix

### DIFF
--- a/cluster/manifests/emergency-access-service/rbac.yaml
+++ b/cluster/manifests/emergency-access-service/rbac.yaml
@@ -14,7 +14,10 @@ rules:
 - apiGroups: [""]
   resources: ["configmaps"]
   resourceNames: ["emergency-access-service"]
-  verbs: ["get", "list", "create", "update", "patch"]
+  verbs: ["get", "update", "patch"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["list", "create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding


### PR DESCRIPTION
RBAC: list/create can't be used with `resourceNames`.