### PR TITLE
pdb-controller: Fix non-ready-ttl handling

### DIFF
--- a/cluster/manifests/pdb-controller/deployment.yaml
+++ b/cluster/manifests/pdb-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: pdb-controller
-    version: v0.0.9
+    version: v0.0.10
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: pdb-controller
-        version: v0.0.9
+        version: v0.0.10
     spec:
       dnsConfig:
         options:
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: pdb-controller
       containers:
       - name: pdb-controller
-        image: registry.opensource.zalan.do/teapot/pdb-controller:v0.0.9
+        image: registry.opensource.zalan.do/teapot/pdb-controller:v0.0.10
         args:
         - --debug
         {{ if or (index .ConfigItems "pdb_non_ready_ttl") (eq .Environment "test") }}


### PR DESCRIPTION
Fixes a bug such that the controller will correctly drop PDBs for statefulsets when non-ready-ttl is reached.

https://github.com/mikkeloscar/pdb-controller/pull/28