### PR TITLE
PCS schema: define the schema for tokens

### DIFF
--- a/cluster/manifests/01-platformcredentialsset/customresourcedefinition.yaml
+++ b/cluster/manifests/01-platformcredentialsset/customresourcedefinition.yaml
@@ -65,6 +65,13 @@ spec:
               type: object
               additionalProperties:
                 type: object
+                nullable: true
+                properties:
+                  privileges:
+                    type: array
+                    nullable: true
+                    items:
+                      type: string
             token_version:
               type: string
               enum:


### PR DESCRIPTION
We can use `nullable: true` now, which means we can define the schema for the tokens.