### PR TITLE
E2E: don't run on Spot

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -39,6 +39,8 @@ pipeline:
         labels:
           application: teapot-kubernetes-e2e
       spec:
+        nodeSelector:
+          aws.amazon.com/spot: "false"
         restartPolicy: Never
         initContainers:
         - name: aws-credentials-waiter


### PR DESCRIPTION
They take up to an hour, and we don't want them aborted halfway due to AWS taking an instance back.