### PR TITLE
New directories for docker/kubelet

### DIFF
--- a/cluster/manifests/cadvisor/daemonset.yaml
+++ b/cluster/manifests/cadvisor/daemonset.yaml
@@ -59,7 +59,7 @@ spec:
           mountPath: /sys
           readOnly: true
         - name: docker
-          mountPath: /var/lib/docker
+          mountPath: /opt/podruntime/docker
           readOnly: true
         - name: kmsg
           mountPath: /dev/kmsg
@@ -82,7 +82,7 @@ spec:
           path: /sys
       - name: docker
         hostPath:
-          path: /var/lib/docker
+          path: /opt/podruntime/docker
       - name: kmsg
         hostPath:
           path: /dev/kmsg

--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -231,7 +231,7 @@ spec:
       volumes:
       - name: containerlogs
         hostPath:
-          path: /var/lib/docker/containers
+          path: /opt/podruntime/docker/containers
 
       - name: journal
         hostPath:

--- a/cluster/manifests/prometheus-node-exporter/daemonset.yaml
+++ b/cluster/manifests/prometheus-node-exporter/daemonset.yaml
@@ -36,7 +36,7 @@ spec:
           - --path.procfs=/host/proc
           - --path.sysfs=/host/sys
           - --path.rootfs=/host
-          - --collector.filesystem.ignored-mount-points=^/(dev|proc|run|sys|host|var/lib/lxcfs|var/lib/docker/.+|var/lib/kubelet/.+)($|/)
+          - --collector.filesystem.ignored-mount-points=^/(dev|proc|run|sys|host|var/lib/lxcfs|opt/podruntime/docker/.+|opt/podruntime/kubelet/.+)($|/)
         name: prometheus-node-exporter
         ports:
         - name: prom-node-exp


### PR DESCRIPTION
Right now they use the bind mount, but we'd like to get rid of it.