### PR TITLE
Run kube-proxy from a prepulled image

### DIFF
--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-proxy
-    version: v1.14.6
 spec:
   selector:
     matchLabels:
@@ -17,7 +16,6 @@ spec:
       name: kube-proxy
       labels:
         application: kube-proxy
-        version: v1.14.6
       annotations:
         config/hash: {{"configmap.yaml" | manifestHash}}
     spec:
@@ -31,7 +29,7 @@ spec:
       hostNetwork: true
       containers:
       - name: kube-proxy
-        image: registry.opensource.zalan.do/teapot/kube-proxy:v1.14.6
+        image: nonexistent.zalan.do/teapot/kube-proxy:fixed
         args:
         - --hostname-override=$(HOSTNAME_OVERRIDE)
         - --config=/config/kube-proxy.yaml


### PR DESCRIPTION
This allows us to not have to resolve conflicts between major version branches.