### PR TITLE
Keep the system service account for safe RBAC rollout

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -47,9 +47,6 @@ post_apply:
 - name: kubernetes-dashboard
   kind: RoleBinding
   namespace: kube-system
-- name: system
-  namespace: kube-system
-  kind: ServiceAccount
 - name: privileged-psp
   namespace: kube-system
   kind: RoleBinding


### PR DESCRIPTION
Keep the system service account for safe RBAC rollout