### PR TITLE
Updated image with support for RAID0 for local storage instances

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -227,7 +227,7 @@ dynamodb_service_link_enabled: "false"
 cluster_dns: "coredns"
 coredns_log_svc_names: "true"
 
-kuberuntu_image_v1_14: {{ amiID "zalando-ubuntu-kubernetes-production-v1.14.6-master-61" "861068367966" }}
+kuberuntu_image_v1_14: {{ amiID "zalando-ubuntu-kubernetes-production-v1.14.6-master-69" "861068367966" }}
 
 # Feature toggle to allow gradual decommissioning of ingress-template-controller
 enable_ingress_template_controller: "false"


### PR DESCRIPTION
This image has the following changes:

- Remove `motd` and other nonessential packages
- Remove the bind mount for `/var/lib/docker`
- Add support for RAID0 for instances with multiple local storage disks
- Fixed spot termination handler.