### PR TITLE
problem-detector: Don't match on version label, e2e test

### DIFF
--- a/cluster/manifests/node-problem-detector/ds-node-problem-detector.yaml
+++ b/cluster/manifests/node-problem-detector/ds-node-problem-detector.yaml
@@ -11,7 +11,6 @@ spec:
   selector:
     matchLabels:
       application: node-problem-detector
-      version: v0.7.1
   template:
     metadata:
       labels:

--- a/cluster/manifests/node-problem-detector/svc-node-problem-detector.yaml
+++ b/cluster/manifests/node-problem-detector/svc-node-problem-detector.yaml
@@ -15,7 +15,6 @@ metadata:
 spec:
   selector:
     application: node-problem-detector
-    version: v0.7.0
   type: ClusterIP
   ports:
   - name: metrics

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -51,6 +51,7 @@ clusters:
     skipper_ingress_cpu: 100m
     efs_id: ${EFS_ID}
     webhook_id: ${INFRASTRUCTURE_ACCOUNT}:${REGION}:kube-aws-test
+    node_problem_detector_enabled: true
   criticality_level: 1
   environment: e2e
   id: ${CLUSTER_ID}


### PR DESCRIPTION
uses the correct labels selectors and deploys it during e2e to detect errors with deployment files.