### PR TITLE
Adapt problem detector docker paths to ubuntu setup

### DIFF
--- a/cluster/manifests/node-problem-detector/cm-node-problem-detector.yaml
+++ b/cluster/manifests/node-problem-detector/cm-node-problem-detector.yaml
@@ -1,0 +1,62 @@
+{{ if eq .ConfigItems.node_problem_detector_enabled "true" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: node-problem-detector
+  namespace: kube-system
+data:
+  docker-monitor.json: |
+    {
+      "plugin": "journald",
+      "pluginConfig": {
+        "source": "dockerd"
+      },
+      "logPath": "/var/log/journal",
+      "lookback": "5m",
+      "bufferSize": 10,
+      "source": "docker-monitor",
+      "metricsReporting": true,
+      "conditions": [],
+      "rules": [
+        {
+          "type": "temporary",
+          "reason": "CorruptDockerImage",
+          "pattern": "Error trying v2 registry: failed to register layer: rename /opt/podruntime/docker/image/(.+) /opt/podruntime/docker/image/(.+): directory not empty.*"
+        }
+      ]
+    }
+  docker-monitor-counter.json: |
+    {
+      "plugin": "custom",
+      "pluginConfig": {
+        "invoke_interval": "5m",
+        "timeout": "1m",
+        "max_output_length": 80,
+        "concurrency": 1
+      },
+      "source": "docker-monitor",
+      "conditions": [
+        {
+          "type": "CorruptDockerOverlay2",
+          "reason": "NoCorruptDockerOverlay2",
+          "message": "docker overlay2 is functioning properly"
+        }
+      ],
+      "rules": [
+        {
+          "type": "permanent",
+          "condition": "CorruptDockerOverlay2",
+          "reason": "CorruptDockerOverlay2",
+          "path": "/home/kubernetes/bin/log-counter",
+          "args": [
+            "--journald-source=dockerd",
+            "--log-path=/var/log/journal",
+            "--lookback=5m",
+            "--count=10",
+            "--pattern=returned error: readlink /opt/podruntime/docker/overlay2.*: invalid argument.*"
+          ],
+          "timeout": "1m"
+        }
+      ]
+    }
+{{ end }}

--- a/cluster/manifests/node-problem-detector/ds-node-problem-detector.yaml
+++ b/cluster/manifests/node-problem-detector/ds-node-problem-detector.yaml
@@ -7,6 +7,8 @@ metadata:
   labels:
     application: node-problem-detector
     version: v0.7.1
+  annotations:
+    config/hash: {{ "cm-node-problem-detector.yaml" | manifestHash }}
 spec:
   selector:
     matchLabels:

--- a/cluster/manifests/node-problem-detector/ds-node-problem-detector.yaml
+++ b/cluster/manifests/node-problem-detector/ds-node-problem-detector.yaml
@@ -7,8 +7,6 @@ metadata:
   labels:
     application: node-problem-detector
     version: v0.7.1
-  annotations:
-    config/hash: {{ "cm-node-problem-detector.yaml" | manifestHash }}
 spec:
   selector:
     matchLabels:
@@ -18,6 +16,8 @@ spec:
       labels:
         application: node-problem-detector
         version: v0.7.1
+      annotations:
+        config/hash: {{ "cm-node-problem-detector.yaml" | manifestHash }}
     spec:
       serviceAccountName: node-problem-detector
       priorityClassName: system-node-critical

--- a/cluster/manifests/node-problem-detector/ds-node-problem-detector.yaml
+++ b/cluster/manifests/node-problem-detector/ds-node-problem-detector.yaml
@@ -25,8 +25,8 @@ spec:
         command:
         - /node-problem-detector
         args:
-        - --config.system-log-monitor=/config/abrt-adaptor.json,/config/docker-monitor.json,/config/kernel-monitor-filelog.json,/config/kernel-monitor.json,/config/systemd-monitor.json
-        - --config.custom-plugin-monitor=/config/docker-monitor-counter.json,/config/kernel-monitor-counter.json,/config/systemd-monitor-counter.json
+        - --config.system-log-monitor=/config/abrt-adaptor.json,/custom-config/docker-monitor.json,/config/kernel-monitor-filelog.json,/config/kernel-monitor.json,/config/systemd-monitor.json
+        - --config.custom-plugin-monitor=/custom-config/docker-monitor-counter.json,/config/kernel-monitor-counter.json,/config/systemd-monitor-counter.json
         - --config.system-stats-monitor=/config/system-stats-monitor.json
         - --address=0.0.0.0
         - --prometheus-address=0.0.0.0
@@ -51,12 +51,17 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         volumeMounts:
+        - name: custom-config
+          mountPath: /custom-config
         - name: log
           mountPath: /var/log
         - name: localtime
           mountPath: /etc/localtime
           readOnly: true
       volumes:
+      - name: custom-config
+        configMap:
+          name: node-problem-detector
       - name: log
         hostPath:
           path: /var/log


### PR DESCRIPTION
Problem detector default configs use `/var/lib/docker` to detect pattern in logs. This adapts the configs to use our path.