### PR TITLE
Update kube-metrics-adapter

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.0.2
+        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.0.3
         {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
         env:
         # must be set for the AWS SDK/AWS CLI to find the credentials file.


### PR DESCRIPTION
Changes:
 * Return an error for `request-per-second` metric without a backend name for ingresses that use traffic switching.