### PR TITLE
Update admission controller, enable validation for redeployments

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -204,14 +204,22 @@ teapot_admission_controller_default_cpu_request: "25m"
 teapot_admission_controller_default_memory_request: "100Mi"
 teapot_admission_controller_process_resources: "true"
 teapot_admission_controller_application_min_creation_time: "2019-06-03T12:00:00Z"
-teapot_admission_controller_resource_cutoff_timestamp: "2019-07-08T22:00:00Z"
 teapot_admission_controller_ndots: "2"
+teapot_admission_controller_inject_environment_variables: "true"
+
 {{if eq .Environment "production"}}
 teapot_admission_controller_validate_application_label: "true"
+teapot_admission_controller_resource_cutoff_timestamp: "2019-07-08T22:00:00Z"
+teapot_admission_controller_resource_validate_redeployments: "false"
+{{else if eq .Environment "e2e"}}
+teapot_admission_controller_validate_application_label: "false"
+teapot_admission_controller_resource_cutoff_timestamp: ""
+teapot_admission_controller_resource_validate_redeployments: "false"
 {{else}}
 teapot_admission_controller_validate_application_label: "false"
+teapot_admission_controller_resource_cutoff_timestamp: "2019-07-08T22:00:00Z"
+teapot_admission_controller_resource_validate_redeployments: "true"
 {{end}}
-teapot_admission_controller_inject_environment_variables: "true"
 
 {{if eq .Environment "e2e"}}
 teapot_admission_controller_ignore_namespaces: "^kube-system|((downward-api|kubectl|projected|statefulset|pod-network)-.*)$"

--- a/cluster/manifests/admission-control/daemonset.yaml
+++ b/cluster/manifests/admission-control/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cluster-autoscaler
-        image: registry.opensource.zalan.do/teapot/admission-controller:master-31
+        image: registry.opensource.zalan.do/teapot/admission-controller:master-35
         command:
           - /registry-proxy
           - --address=127.0.0.1:8285

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -172,7 +172,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-32
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-35
           name: admission-controller
           readinessProbe:
             httpGet:
@@ -218,6 +218,9 @@ write_files:
             - --application-registry-url=http://127.0.0.1:8285/
 {{- end }}
             - --resource-cutoff-timestamp={{ .Cluster.ConfigItems.teapot_admission_controller_resource_cutoff_timestamp }}
+{{- if eq .Cluster.ConfigItems.teapot_admission_controller_resource_validate_redeployments "true" }}
+            - --resource-validate-redeployments
+{{- end }}
           ports:
             - containerPort: 8085
           volumeMounts:


### PR DESCRIPTION
 * Update admission controller to `master-35` (support for validating redeployments, unbind the resource validation from the application label check)
 * Enforce resource validation for test clusters for redeployments