### PR TITLE
bump scalyr-agent image version

### DIFF
--- a/cluster/manifests/logging-agent/daemonset.yaml
+++ b/cluster/manifests/logging-agent/daemonset.yaml
@@ -142,7 +142,7 @@ spec:
 
       - name: scalyr-agent
 
-        image: registry.opensource.zalan.do/eagleeye/scalyr-agent:master-8
+        image: registry.opensource.zalan.do/eagleeye/scalyr-agent:master-9
 
         env:
         # Note: added for scalyr-config-base, but not needed by the scalyr-agent itself.


### PR DESCRIPTION
This adds the python module "yappi" to this docker image.
This is necessary to enable scalyr-agent profiling.