### PR TITLE
Update kube-ingress-aws-controller to v0.8.14

### DIFF
--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.8.12
+    version: v0.8.14
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.8.12
+        version: v0.8.14
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "false"}}
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: kube-ingress-aws-controller
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.8.12
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.8.14
         args:
         - -stack-termination-protection
         - -ssl-policy={{ .ConfigItems.kube_aws_ingress_controller_ssl_policy }}


### PR DESCRIPTION
* Fixes issues with SSL Policy validation.
* Fixes updates of Target groups on ASGs
* Adds option of http to https redirection (not enabled here, I want to test it in our setup separately).

https://github.com/zalando-incubator/kube-ingress-aws-controller/releases/tag/v0.8.14

https://github.com/zalando-incubator/kube-ingress-aws-controller/releases/tag/v0.8.13