### PR TITLE
Make autoscaler resource usage configurable

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -10,6 +10,8 @@ autoscaling_buffer_pods: "1"
 {{else}}
 autoscaling_buffer_pods: "0"
 {{end}}
+cluster_autoscaler_cpu: "100m"
+cluster_autoscaler_memory: "300Mi"
 
 # ALB config created by kube-aws-ingress-controller
 kube_aws_ingress_controller_ssl_policy: "ELBSecurityPolicy-TLS-1-2-2017-01"

--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -51,11 +51,11 @@ spec:
           - --scale-down-enabled={{ .ConfigItems.autoscaling_scale_down_enabled }}
         resources:
           limits:
-            cpu: 100m
-            memory: 300Mi
+            cpu: {{.Cluster.ConfigItems.cluster_autoscaler_cpu}}
+            memory: {{.Cluster.ConfigItems.cluster_autoscaler_memory}}
           requests:
-            cpu: 100m
-            memory: 300Mi
+            cpu: {{.Cluster.ConfigItems.cluster_autoscaler_cpu}}
+            memory: {{.Cluster.ConfigItems.cluster_autoscaler_memory}}
         env:
           - name: AWS_REGION
             value: {{ .Region }}


### PR DESCRIPTION
Not sure if I'd like VPA to constantly restart it, so let's still run with static resources for now.