### PR TITLE
skipper: restart when the lightstep token changes

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -23,6 +23,7 @@ spec:
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
           [{"container": "skipper-ingress", "parser": "skipper-access-log"}]
+        config/hash: {{"secret.yaml" | manifestHash}}
     spec:
       affinity:
         podAntiAffinity:


### PR DESCRIPTION
Otherwise we'll have to wait until the next node rotation.