### PR TITLE
add SCHEDULER_USE_ENV=1 to zmon-scheduler

### DIFF
--- a/cluster/manifests/zmon-scheduler/deployment.yaml
+++ b/cluster/manifests/zmon-scheduler/deployment.yaml
@@ -68,6 +68,9 @@ spec:
             periodSeconds: 60
 
           env:
+            - name: SCHEDULER_USE_ENV
+              value: "1"
+
             - name: LOCAL_ENTITY_ID
               value: kube-cluster[{{ .ID }}]
 


### PR DESCRIPTION
scheduler in k8s should use env for all configs