### PR TITLE
[WIP] Encrypt secrets in etcd using KMS

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -106,6 +106,9 @@ write_files:
           - --etcd-prefix={{ .Cluster.ConfigItems.apiserver_etcd_prefix }}
           - --storage-backend=etcd3
           - --storage-media-type=application/vnd.kubernetes.protobuf
+          {{ if eq .Cluster.ConfigItems.enable_encryption "true" }}
+          - --encryption-provider-config=/etc/kubernetes/config/encryption-config.yaml
+          {{ end }}
           - --allow-privileged=true
           - --service-cluster-ip-range=10.3.0.0/16
           - --secure-port=443
@@ -711,3 +714,21 @@ write_files:
         - level: Request
           omitStages:
             - "RequestReceived"
+
+{{ if eq .Cluster.ConfigItems.enable_encryption "true" }}
+  - owner: root:root
+    path: /etc/kubernetes/config/encryption-config.yaml
+    permissions: '0400'
+    content: |
+      apiVersion: apiserver.config.k8s.io/v1
+      kind: EncryptionConfiguration
+      resources:
+        - resources:
+          - secrets
+          providers:
+          - aescbc:
+              keys:
+              - name: key1
+                secret: {{ .Cluster.ConfigItems.encryption_key }}
+          - identity: {}
+{{ end }}

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -52,6 +52,9 @@ clusters:
     efs_id: ${EFS_ID}
     webhook_id: ${INFRASTRUCTURE_ACCOUNT}:${REGION}:kube-aws-test
     node_problem_detector_enabled: true
+    enable_encryption: true
+    # key used for testing. don't use me for anything
+    encryption_key: Mnz9PR8jacvFAMIhyi0FvlHhg1RBn/0kx2H6NmJc56I=
   criticality_level: 1
   environment: e2e
   id: ${CLUSTER_ID}


### PR DESCRIPTION
**work in progress, e2e test run**

Pass a simple encryption configuration to apiserver where the encryption key is stored in cluster registry.

This protects against an attacker that gained access to an etcd instance to read all data. It doesn't protect against a compromised Kubernetes master. ~~A fully fledged solution would be to [integrate with AWS KMS](https://kubernetes.io/docs/tasks/administer-cluster/kms-provider/), e.g. https://github.com/kubernetes-sigs/aws-encryption-provider~~

AWS KMS based encryption has been added to this PR.