### PR TITLE
Bumping up the CoreDNS version to v1.6.4

### DIFF
--- a/cluster/manifests/coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/coredns-local/daemonset-coredns.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: coredns
-    version: v1.4.0
+    version: v1.6.4
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
     component: cluster-dns
@@ -21,7 +21,7 @@ spec:
       labels:
         application: coredns
         instance: node-dns
-        version: v1.4.0
+        version: v1.6.4
         component: cluster-dns
     spec:
       containers:
@@ -92,7 +92,7 @@ spec:
             cpu: 10m
             memory: 45Mi
       - name: coredns
-        image: registry.opensource.zalan.do/teapot/coredns:1.4.0
+        image: registry.opensource.zalan.do/teapot/coredns:1.6.4
         args: [ "-conf", "/etc/coredns/Corefile" ]
         volumeMounts:
         - name: config-volume

--- a/cluster/manifests/coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/coredns-local/daemonset-coredns.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: dnsmasq
-        image: registry.opensource.zalan.do/teapot/k8s-dns-dnsmasq-nanny-amd64:1.14.10
+        image: registry.opensource.zalan.do/teapot/k8s-dns-dnsmasq-nanny-amd64:1.15.7
         securityContext:
           privileged: true
         livenessProbe:
@@ -66,7 +66,7 @@ spec:
             cpu: 100m
             memory: 50Mi
       - name: sidecar
-        image: registry.opensource.zalan.do/teapot/k8s-dns-sidecar-amd64:1.14.10
+        image: registry.opensource.zalan.do/teapot/k8s-dns-sidecar-amd64:1.15.7
         securityContext:
           privileged: true
         livenessProbe:


### PR DESCRIPTION
We currently running v1.4.0. This has several major fixes and improvements
including one of our issue which was addressed to CoreDNS in v1.5.0 a while ago:

https://github.com/coredns/coredns/issues/2593

We missed some releases 🙂 

https://coredns.io/2019/09/27/coredns-1.6.4-release/
https://coredns.io/2019/08/31/coredns-1.6.3-release/
https://coredns.io/2019/08/13/coredns-1.6.2-release/
https://coredns.io/2019/08/02/coredns-1.6.1-release/
https://coredns.io/2019/07/28/coredns-1.6.0-release/
https://coredns.io/2019/07/03/coredns-1.5.2-release/
https://coredns.io/2019/06/26/coredns-1.5.1-release/
https://coredns.io/2019/04/06/coredns-1.5.0-release/

This also bumps up the dnsmasq to the latest version 1.15.7 (currently 1.14.0)