### PR TITLE
Proxy plugin was dropped in a previous release from CoreDNS

### DIFF
--- a/cluster/manifests/coredns-local/configmap-local.yaml
+++ b/cluster/manifests/coredns-local/configmap-local.yaml
@@ -26,7 +26,7 @@ data:
         log svc.svc.cluster.local.
 {{ end }}
         prometheus :9153
-        proxy . /etc/resolv.conf
+        forward . /etc/resolv.conf
         pprof 127.0.0.1:9155
         cache 30
         reload


### PR DESCRIPTION
Instead we need to proceed with the forward plugin