### PR TITLE
cdp-controller-rbac: Read+Patch access to StackSet

### DIFF
--- a/cluster/manifests/roles/cdp-controller-rbac.yaml
+++ b/cluster/manifests/roles/cdp-controller-rbac.yaml
@@ -46,6 +46,15 @@ rules:
 - apiGroups:
   - "zalando.org"
   resources:
+  - stacksets
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - "zalando.org"
+  resources:
   - stacks
   verbs:
   - get

--- a/cluster/manifests/roles/cdp-controller-rbac.yaml
+++ b/cluster/manifests/roles/cdp-controller-rbac.yaml
@@ -52,6 +52,7 @@ rules:
   - list
   - watch
   - patch
+  - update
 - apiGroups:
   - "zalando.org"
   resources:


### PR DESCRIPTION
With https://github.com/zalando-incubator/stackset-controller/issues/159, CDP needs to read and change the traffic map on StackSet resources.

CDP needs that access even before the new StackSet format is rolled out, because it is planned to support both formats at the same time during the transition period. See https://github.bus.zalan.do/automata/cdp/pull/1302 for details.