### PR TITLE
CA: parameterize the version temporarily

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -13,6 +13,9 @@ autoscaling_buffer_pods: "0"
 cluster_autoscaler_cpu: "100m"
 cluster_autoscaler_memory: "300Mi"
 
+# Temporarily moved to a config item so we could test the new version
+cluster_autoscaler_version: "v1.12.2-internal.4"
+
 # ALB config created by kube-aws-ingress-controller
 kube_aws_ingress_controller_ssl_policy: "ELBSecurityPolicy-TLS-1-2-2017-01"
 kube_aws_ingress_controller_idle_timeout: "1m"

--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-cluster-autoscaler
-    version: v1.12.2-internal.4
+    version: {{.Cluster.ConfigItems.cluster_autoscaler_version}}
 spec:
   selector:
     matchLabels:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: kube-cluster-autoscaler
-        version: v1.12.2-internal.4
+        version: {{.Cluster.ConfigItems.cluster_autoscaler_version}}
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-autoscaler"
         config/pool-sizes: "{{range .NodePools}}{{.Name}}-{{.MinSize}}-{{.MaxSize}} {{end}}"
@@ -33,7 +33,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cluster-autoscaler
-        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.12.2-internal.4
+        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:{{.Cluster.ConfigItems.cluster_autoscaler_version}}
         command:
           - ./cluster-autoscaler
           - --v=4


### PR DESCRIPTION
This will make it easier to test the new version. I'll make it static again after we're comfortable enough.