### PR TITLE
Update to metrics-server v0.3.6

### DIFF
--- a/cluster/manifests/metrics-server/deployment.yaml
+++ b/cluster/manifests/metrics-server/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: metrics-server
-    version: v0.3.5
+    version: v0.3.6
 spec:
   replicas: 1
   selector:
@@ -16,7 +16,7 @@ spec:
       name: metrics-server
       labels:
         application: metrics-server
-        version: v0.3.5
+        version: v0.3.6
     spec:
       dnsConfig:
         options:
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: metrics-server
       containers:
       - name: metrics-server
-        image: registry.opensource.zalan.do/teapot/metrics-server:v0.3.5
+        image: registry.opensource.zalan.do/teapot/metrics-server:v0.3.6
         resources:
           limits:
             cpu: "{{.ConfigItems.metrics_service_cpu}}"


### PR DESCRIPTION
https://github.com/kubernetes-incubator/metrics-server/releases/tag/v0.3.6

Adds a fix:

> Don't break metric storage when duplicate pod metrics encountered