### PR TITLE
OpenAPI v2 Publishing for CRD's

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -254,6 +254,10 @@ audit_pod_events: "true"
 # https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definition-versioning/#webhook-conversion
 custom_resource_webhook_conversion: "false"
 
+# Feature toggle for CustomResourcePublishOpenAPI (alpha in v1.14)
+# https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#publish-validation-schema-in-openapi-v2
+custom_resource_publish_openapi: "false"
+
 # CIDR configuration for nodes and pods
 # Changing this will change the number of nodes and pods we can schedule in the
 # cluster

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -256,7 +256,7 @@ custom_resource_webhook_conversion: "false"
 
 # Feature toggle for CustomResourcePublishOpenAPI (alpha in v1.14)
 # https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#publish-validation-schema-in-openapi-v2
-custom_resource_publish_openapi: "false"
+custom_resource_publish_openapi: "true"
 
 # CIDR configuration for nodes and pods
 # Changing this will change the number of nodes and pods we can schedule in the

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -120,7 +120,7 @@ write_files:
           - --authorization-mode=Webhook,RBAC
           - --authorization-webhook-config-file=/etc/kubernetes/config/authz.yaml
           - --admission-control-config-file=/etc/kubernetes/config/image-policy-webhook.yaml
-          - --feature-gates=TaintNodesByCondition={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},ScheduleDaemonSetPods={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},TTLAfterFinished=true,CustomResourceWebhookConversion={{.Cluster.ConfigItems.custom_resource_webhook_conversion}}
+          - --feature-gates=TaintNodesByCondition={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},ScheduleDaemonSetPods={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},TTLAfterFinished=true,CustomResourceWebhookConversion={{.Cluster.ConfigItems.custom_resource_webhook_conversion}},CustomResourcePublishOpenAPI={{.Cluster.ConfigItems.custom_resource_publish_openapi}}
           - --anonymous-auth=false
           {{ if or (eq .Cluster.Environment "production") (index .Cluster.ConfigItems "audittrail_url") }}
           - --audit-webhook-config-file=/etc/kubernetes/config/audit.yaml

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -46,6 +46,7 @@ clusters:
     zmon_scheduler_replicas: '0'
     zmon_worker_replicas: '0'
     node_pool_feature_enabled: "true"
+    custom_resource_publish_openapi: "true"
     enable_rbac: "true"
     dynamodb_service_link_enabled: "false"
     skipper_ingress_cpu: 100m

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -46,7 +46,6 @@ clusters:
     zmon_scheduler_replicas: '0'
     zmon_worker_replicas: '0'
     node_pool_feature_enabled: "true"
-    custom_resource_publish_openapi: "true"
     enable_rbac: "true"
     dynamodb_service_link_enabled: "false"
     skipper_ingress_cpu: 100m


### PR DESCRIPTION
Enable CustomResourcePublishOpenAPI to use `kubectl explain` on CRD's.

https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#publish-validation-schema-in-openapi-v2