### PR TITLE
Bugfix: Rename scalyr-region environment variable

### DIFF
--- a/cluster/manifests/zmon-worker/deployment.yaml
+++ b/cluster/manifests/zmon-worker/deployment.yaml
@@ -66,7 +66,7 @@ spec:
             periodSeconds: 60
 
           env:
-            - name: WORKER_SCALYR_REGION
+            - name: WORKER_PLUGIN_SCALYR_SCALYR_REGION
               value: {{.ConfigItems.zmon_scalyr_region}}
             - name: WORKER_ZMON_QUEUES
               value: zmon:queue:default/{{.ConfigItems.zmon_worker_count}}


### PR DESCRIPTION
Similar to WORKER_PLUGIN_SCALYR_READ_KEY in line 75
Please review @astarnell @vetinari 