### PR TITLE
Update admission controller

### DIFF
--- a/cluster/manifests/admission-control/daemonset.yaml
+++ b/cluster/manifests/admission-control/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cluster-autoscaler
-        image: registry.opensource.zalan.do/teapot/admission-controller:master-35
+        image: registry.opensource.zalan.do/teapot/admission-controller:master-37
         command:
           - /registry-proxy
           - --address=127.0.0.1:8285

--- a/cluster/manifests/admission-control/teapot.yaml
+++ b/cluster/manifests/admission-control/teapot.yaml
@@ -107,3 +107,13 @@ webhooks:
         apiGroups: ["apiextensions.k8s.io"]
         apiVersions: ["v1", "v1beta1"]
         resources: ["customresourcedefinitions"]
+  - name: ingress-admitter.teapot.zalan.do
+    clientConfig:
+      url: "https://localhost:8085/ingress"
+      caBundle: "{{ .ConfigItems.ca_cert_decompressed }}"
+    failurePolicy: Fail
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["extensions", "networking.k8s.io"]
+        apiVersions: ["v1beta1"]
+        resources: ["ingresses"]

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -172,7 +172,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-35
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-37
           name: admission-controller
           readinessProbe:
             httpGet:


### PR DESCRIPTION
Changes:
 * Ingresses: prevent outdated clients from attempting to switch traffic using Ingresses that are not authoritative anymore