### PR TITLE
Disable CustomResourcePublishOpenAPI by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -256,7 +256,7 @@ custom_resource_webhook_conversion: "false"
 
 # Feature toggle for CustomResourcePublishOpenAPI (alpha in v1.14)
 # https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#publish-validation-schema-in-openapi-v2
-custom_resource_publish_openapi: "true"
+custom_resource_publish_openapi: "false"
 
 # CIDR configuration for nodes and pods
 # Changing this will change the number of nodes and pods we can schedule in the


### PR DESCRIPTION
Currenlty breaks our CRD's:

```
platformcredentialssets.zalando.org "test-credentials" was not valid:
* : Invalid value: "The edited file failed validation": ValidationError(PlatformCredentialsSet): unknown field "status" in org.zalando.v1.PlatformCredentialsSet
```