### PR TITLE
remove resource quota on visibility namespace

### DIFF
--- a/cluster/manifests/01-visibility/quota.yaml
+++ b/cluster/manifests/01-visibility/quota.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: ResourceQuota
-metadata:
-  name: compute-resources
-  namespace: visibility
-spec:
-  hard:
-    pods: "500"

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -9,6 +9,9 @@ post_apply:
 - name: compute-resources
   namespace: kube-system
   kind: ResourceQuota
+- name: compute-resources
+  namespace: visibility
+  kind: ResourceQuota
 {{ if eq .ConfigItems.teapot_admission_controller_process_resources "true" }}
 - name: limits
   namespace: default


### PR DESCRIPTION
We removed quotas for `default` and `kube-system`, but forgot `visibility`. We're running into this limit now.

/cc @hjacobs 