### PR TITLE
enable route lifo metrics

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -76,6 +76,7 @@ spec:
           - "-lb-healthcheck-interval=3s"
           - "-metrics-flavour=prometheus"
           - "-enable-connection-metrics"
+          - "-enable-route-lifo-metrics"
 {{ if eq .ConfigItems.enable_apimonitoring "true"}}
           - "-enable-api-usage-monitoring"
           - "-api-usage-monitoring-realm-keys=https://identity.zalando.com/realm"


### PR DESCRIPTION
This enables metrics for the lifo queues per route. This means that we would have 2 additional metrics for each route, which can blow up the number of prometheus metrics. The reason why we need this change is that we need the queue size from the lifo as an input for scaling the cluster, since it can prevent the scaling based on the memory in extreme cases.

Signed-off-by: Arpad Ryszka <arpad.ryszka@gmail.com>