### PR TITLE
Use parallel management policy for prometheus

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -1,5 +1,8 @@
 # everything defined under here will be deleted before applying the manifests
-pre_apply: []
+pre_apply:
+- name: prometheus
+  namespace: kube-system
+  kind: StatefulSet
 
 # everything defined under here will be deleted after applying the manifests
 post_apply:

--- a/cluster/manifests/prometheus/statefulset.yaml
+++ b/cluster/manifests/prometheus/statefulset.yaml
@@ -10,6 +10,7 @@ metadata:
   namespace: kube-system
 spec:
   replicas: 2
+  podManagementPolicy: Parallel
   selector:
     matchLabels:
       application: prometheus


### PR DESCRIPTION
Currently our two Prometheus replicas use the `OrderedReady` management strategy. This leads to `prometheus-1` not being started if `prometheus-0` isn't ready. Since there's no dependency between the two it's perfectly fine to use the parallel strategy which starts both instances at the same time.