### PR TITLE
Use AverageValue for kube-metrics-adapter tests

### DIFF
--- a/test/e2e/kube_metrics_adapter_test.go
+++ b/test/e2e/kube_metrics_adapter_test.go
@@ -339,7 +339,8 @@ func podHPA(deploymentName string, ingressName string, metricTargets map[string]
 					Kind:       "Ingress",
 					Name:       ingressName,
 				},
-				TargetValue: *resource.NewQuantity(target, resource.DecimalSI),
+				TargetValue:  *resource.NewQuantity(target, resource.DecimalSI),
+				AverageValue: resource.NewQuantity(target, resource.DecimalSI),
 			},
 		})
 	}


### PR DESCRIPTION
kube-metrics-adapter supports AverageValue for the skipper based RPS metric since [v0.4.0](https://github.com/zalando-incubator/kube-metrics-adapter/releases/tag/v0.0.4)

Use it in the e2e tests as using TargetValue is not desired: https://github.com/zalando-incubator/kube-metrics-adapter#skipper-collector (not as precise)