### PR TITLE
Fix the scaling_priority and exercise in test

### DIFF
--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -70,7 +70,7 @@ Resources:
       - Key: k8s.io/cluster-autoscaler/node-template/label/zalando.org/scaling-priority
         PropagateAtLaunch: true
 {{- if index $data.NodePool.ConfigItems "scaling_priority" }}
-        Value: "{{ .NodePools.ConfigItems.scaling_priority }}"
+        Value: "{{ $data.NodePool.ConfigItems.scaling_priority }}"
 {{- else if eq $data.NodePool.DiscountStrategy "spot_max_price" }}
         Value: "1000"
 {{- else }}

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -83,6 +83,7 @@ clusters:
     instance_types: ["m4.large", "m5.large", "m5.xlarge", "m4.xlarge"]
     config_items:
       availability_zones: "eu-central-1a"
+      scaling_priority: "-100"
     name: worker-limit-az
     profile: ${WORKER_PROFILE}-splitaz
     min_size: 1
@@ -102,6 +103,7 @@ clusters:
     config_items:
       availability_zones: "eu-central-1a"
       labels: zalando.org/nvidia-gpu=tesla
+      scaling_priority: "-100"
   provider: zalando-aws
   region: ${REGION}
   owner: '${OWNER}'


### PR DESCRIPTION
Uses the correct variable for setting the `scaling_priority`. Adds `scaling_priority` to one of the node pools to verify this configuration can be applied in e2e test.

@linki FYI