### PR TITLE
Drop limits in cluster autoscaler

### DIFF
--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -57,9 +57,6 @@ spec:
           - --max-node-provision-time=10m
 {{- end }}
         resources:
-          limits:
-            cpu: {{.Cluster.ConfigItems.cluster_autoscaler_cpu}}
-            memory: {{.Cluster.ConfigItems.cluster_autoscaler_memory}}
           requests:
             cpu: {{.Cluster.ConfigItems.cluster_autoscaler_cpu}}
             memory: {{.Cluster.ConfigItems.cluster_autoscaler_memory}}


### PR DESCRIPTION
Drop limits in cluster autoscaler to prevent OOMkill in big clusters.

We decided to not run with limits at it's on the master nodes which we control and we don't see spikes/leaks in the cluster-autoscaler.