### PR TITLE
Update `kubernetes-log-watcher`

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -148,7 +148,7 @@ logging_fluentd_cpu: "100m"
 logging_s3_bucket: "zalando-logging-{{.InfrastructureAccount | getAWSAccountID}}-{{.Region}}"
 scalyr_team_token: ""
 logging_agent_version: "v0.36"
-logging_watcher_version: "master-66"
+logging_watcher_version: "master-67"
 logging_scalyr_enable_profiling: "false"
 
 zmon_redis_mem: "1Gi"


### PR DESCRIPTION
Handles when `scalyr_sampling_rules` is set to `None` (https://github.com/zalando-incubator/kubernetes-log-watcher/pull/105)