### PR TITLE
v0.11.10, add tcp lifo flags for skipper, add default config values

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -55,7 +55,12 @@ enable_skipper_eastwest: "true"
 {{end}}
 
 # skipper tcp lifo
+# See: https://opensource.zalando.com/skipper/operation/operation/#tcp-lifo
+{{if eq .Environment "production"}}
+skipper_enable_tcp_queue: "false"
+{{else}}
 skipper_enable_tcp_queue: "true"
+{{end}}
 skipper_expected_bytes_per_request: "51200"
 skipper_max_tcp_listener_concurrency: "-1"
 skipper_max_tcp_listener_queue: "-1"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -54,6 +54,12 @@ enable_skipper_eastwest: "false"
 enable_skipper_eastwest: "true"
 {{end}}
 
+# skipper tcp lifo
+skipper_enable_tcp_queue: "true"
+skipper_expected_bytes_per_request: "51200"
+skipper_max_tcp_listener_concurrency: "-1"
+skipper_max_tcp_listener_queue: "-1"
+
 # opentracing
 skipper_ingress_opentracing_excluded_proxy_tags: "skipper.route"
 # lightstep

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.11.5
+    version: v0.11.10
     component: ingress
 spec:
   strategy:
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.11.5
+        version: v0.11.10
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -43,7 +43,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.5
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.10
         ports:
         - name: ingress-port
           containerPort: 9999

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -106,6 +106,12 @@ spec:
           - "-write-timeout-server={{ .ConfigItems.skipper_write_timeout_server }}"
           - '-default-filters-prepend={{ .ConfigItems.skipper_default_filters }}'
           - "-route-creation-metrics"
+{{ if eq .ConfigItems.skipper_enable_tcp_queue "true" }}
+          - "-enable-tcp-queue"
+          - "-expected-bytes-per-request={{ .ConfigItems.skipper_expected_bytes_per_request }}"
+          - "-max-tcp-listener-concurrency={{ .ConfigItems.skipper_max_tcp_listener_concurrency }}"
+          - "-max-tcp-listener-queue={{ .ConfigItems.skipper_max_tcp_listener_queue }}"
+{{ end }}
         resources:
           limits:
             cpu: "{{ .ConfigItems.skipper_ingress_cpu }}"


### PR DESCRIPTION
tcp lifo default behavior:
- expected request 50k
- use available memory defined for the cgroup

Signed-off-by: Arpad Ryszka <arpad.ryszka@gmail.com>