### PR TITLE
use zmon-worker in version v209-py2eol-45-g10d91c6

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -146,7 +146,7 @@ zmon_worker_cpu: "750m"
 zmon_worker_count: "16"
 {{end}}
 zmon_scalyr_region: "eu"
-zmon_worker_version: "v209-py2eol-44-g6f3a030-v251-py2eol"
+zmon_worker_version: "v209-py2eol-45-g10d91c6"
 zmon_agent_version: "0.4-19-ga12da10-zv5"
 logging_watcher_mem: "200Mi"
 logging_scalyr_mem: "175Mi"


### PR DESCRIPTION
This ships the feature in zmon-worker to query scalyr with absolute timestamps
https://github.com/zalando-zmon/zmon-worker/pull/418