### PR TITLE
Use issuer as defined in tokens for production

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -85,7 +85,7 @@ skipper_ingress_tokeninfo_memory: "512Mi"
 {{if eq .Environment "production"}}
 tokeninfo_url: "https://info.services.auth.zalando.com/oauth2/tokeninfo"
 opendid_provider_cfg_url: "https://planb-provider.greendale-questionmark.zalan.do/.well-known/openid-configuration"
-openid_issuer: "https://planb-provider.greendale-questionmark.zalan.do"
+openid_issuer: "https://identity.zalando.com"
 {{else}}
 tokeninfo_url: "https://sandbox-tokeninfo-bridge.stups.zalan.do/oauth2/tokeninfo"
 opendid_provider_cfg_url: "https://sandbox.identity.zalando.com/.well-known/openid-configuration"


### PR DESCRIPTION
Only the `provider_cfg_url` should be updated. We still have the same issuer as before.

This fixes an issue in the tokeninfo skipper sidecar configuration.