### PR TITLE
Make experimental autoscaler version configurable

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -14,6 +14,7 @@ cluster_autoscaler_cpu: "100m"
 cluster_autoscaler_memory: "300Mi"
 
 experimental_autoscaler_1_14: "false"
+experimental_autoscaler_1_14_version: v1.14.5-internal.10
 
 # ALB config created by kube-aws-ingress-controller
 kube_aws_ingress_controller_ssl_policy: "ELBSecurityPolicy-TLS-1-2-2017-01"

--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cluster-autoscaler
-        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:{{if eq .Cluster.ConfigItems.experimental_autoscaler_1_14 "true" }}v1.14.5-internal.10{{else}}v1.12.2-internal.4{{end}}
+        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:{{if eq .Cluster.ConfigItems.experimental_autoscaler_1_14 "true" }}{{ .Cluster.ConfigItems.experimental_autoscaler_1_14_version }}{{else}}v1.12.2-internal.4{{end}}
         command:
           - ./cluster-autoscaler
           - --v=4


### PR DESCRIPTION
Makes the experimental autoscaler version configurable. I believe we'll need change this more often in the coming weeks.