### PR TITLE
Default storage class: allow volume expansion

### DIFF
--- a/cluster/manifests/storageclass/storageclass.yaml
+++ b/cluster/manifests/storageclass/storageclass.yaml
@@ -10,3 +10,4 @@ provisioner: kubernetes.io/aws-ebs
 parameters:
   type: gp2
   zones: eu-central-1a, eu-central-1b, eu-central-1c
+allowVolumeExpansion: true


### PR DESCRIPTION
This works fine, and can help us recover from incidents.