### PR TITLE
etcd-backup: run with a 10 minute timeout

### DIFF
--- a/cluster/manifests/etcd-backup/cronjob.yaml
+++ b/cluster/manifests/etcd-backup/cronjob.yaml
@@ -9,9 +9,11 @@ metadata:
 spec:
   schedule: "*/1 * * * *"
   concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 5
   failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
+      activeDeadlineSeconds: 600
       template:
         metadata:
           labels:


### PR DESCRIPTION
It gets stuck sometimes (missing timeouts?), leading to issues with rescheduling due to the stupid limit in the cronjob controller.