### PR TITLE
Tune prometheus for faster startup

### DIFF
--- a/cluster/manifests/prometheus/statefulset.yaml
+++ b/cluster/manifests/prometheus/statefulset.yaml
@@ -36,6 +36,8 @@ spec:
         - "--config.file=/etc/prometheus/prometheus.yml"
         - "--storage.tsdb.path=/prometheus/"
         - "--storage.tsdb.retention.time=1d"
+        - "--storage.tsdb.wal-compression"
+        - "--storage.tsdb.min-block-duration=30m"
         ports:
         - name: ingress-port
           containerPort: 9090

--- a/cluster/manifests/prometheus/statefulset.yaml
+++ b/cluster/manifests/prometheus/statefulset.yaml
@@ -55,6 +55,9 @@ spec:
             port: 9090
           initialDelaySeconds: 5
           timeoutSeconds: 5
+          # ensure that we have at least a minute of metrics before marking ourselves as ready
+          periodSeconds: 5
+          successThreshold: 14
         volumeMounts:
         - name: prometheus-config-volume
           mountPath: /etc/prometheus
@@ -70,6 +73,7 @@ spec:
       securityContext:
         runAsUser: 65534
         fsGroup: 65534
+      terminationGracePeriodSeconds: 60
   volumeClaimTemplates:
   - metadata:
       name: prometheus-storage-volume


### PR DESCRIPTION
It takes _ages_ for Prometheus to restart, since it doesn't flush anything during shutdown so it has to replay all the WAL files. This is mostly IO bound, so let's try to tune it by enabling WAL compression and reducing the interval from the default hardcoded 2 hours to 30 minutes.