### PR TITLE
Drop the prometheus deletion

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -1,8 +1,5 @@
 # everything defined under here will be deleted before applying the manifests
-pre_apply:
-- name: prometheus
-  namespace: kube-system
-  kind: StatefulSet
+pre_apply: []
 
 # everything defined under here will be deleted after applying the manifests
 post_apply:


### PR DESCRIPTION
We don't want to delete it every time we roll any cluster update. Easier to just delete it manually once to let CLM proceed.