### PR TITLE
Revert "Update prometheus to v2.14.0"

### DIFF
--- a/cluster/manifests/prometheus/statefulset.yaml
+++ b/cluster/manifests/prometheus/statefulset.yaml
@@ -5,7 +5,7 @@ metadata:
     pdb-controller.zalando.org/non-ready-ttl: "5m"
   labels:
     application: prometheus
-    version: v2.14.0
+    version: v2.13.1
   name: prometheus
   namespace: kube-system
 spec:
@@ -19,7 +19,7 @@ spec:
     metadata:
       labels:
         application: prometheus
-        version: v2.14.0
+        version: v2.13.1
       annotations:
         config/hash: {{"configmap.yaml" | manifestHash}}
     spec:
@@ -31,7 +31,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
       - name: prometheus
-        image: registry.opensource.zalan.do/teapot/prometheus:v2.14.0
+        image: registry.opensource.zalan.do/teapot/prometheus:v2.13.1
         args:
         - "--config.file=/etc/prometheus/prometheus.yml"
         - "--storage.tsdb.path=/prometheus/"


### PR DESCRIPTION
Reverts zalando-incubator/kubernetes-on-aws#2678

Reverting to avoid rolling out a new Prometheus version just before Cyberweek.