### PR TITLE
Revert "Update kube-ingress-aws-controller to v0.9.0 (NLB support)"

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -323,7 +323,7 @@ Resources:
           ToPort: {{ $element.ToPort }}
 {{- end }}
 {{- end }}
-        - CidrIp: {{ if eq .Cluster.ConfigItems.kube_aws_ingress_controller_nlb_enabled "true" }}"0.0.0.0/0"{{else}}"{{.Values.vpc_ipv4_cidr}}"{{end}}
+        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
           FromPort: 9999
           IpProtocol: tcp
           ToPort: 9999

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -19,10 +19,6 @@ cluster_autoscaler_expander: highest-priority
 # ALB config created by kube-aws-ingress-controller
 kube_aws_ingress_controller_ssl_policy: "ELBSecurityPolicy-TLS-1-2-2017-01"
 kube_aws_ingress_controller_idle_timeout: "1m"
-# allow using NLBs for ingress
-# This opens port 9999 (skipper-ingress) on all worker nodes.
-kube_aws_ingress_controller_nlb_enabled: "false"
-kube_aws_ingress_controller_nlb_cross_zone: "true"
 
 # skipper ingress settings
 skipper_ingress_target_average_utilization_cpu: "70"

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.9.3
+    version: v0.8.14
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.9.3
+        version: v0.8.14
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "false"}}
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
@@ -29,14 +29,11 @@ spec:
       serviceAccountName: kube-ingress-aws-controller
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.9.3
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.8.14
         args:
-        - --stack-termination-protection
-        - --ssl-policy={{ .ConfigItems.kube_aws_ingress_controller_ssl_policy }}
-        - --idle-connection-timeout={{ .ConfigItems.kube_aws_ingress_controller_idle_timeout }}
-        {{ if eq .ConfigItems.kube_aws_ingress_controller_nlb_cross_zone "true" }}
-        - --nlb-cross-zone
-        {{ end }}
+        - -stack-termination-protection
+        - -ssl-policy={{ .ConfigItems.kube_aws_ingress_controller_ssl_policy }}
+        - -idle-connection-timeout={{ .ConfigItems.kube_aws_ingress_controller_idle_timeout }}
         env:
         - name: AWS_REGION
           value: {{ .Region }}

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -52,7 +52,6 @@ clusters:
     efs_id: ${EFS_ID}
     webhook_id: ${INFRASTRUCTURE_ACCOUNT}:${REGION}:kube-aws-test
     node_problem_detector_enabled: true
-    kube_aws_ingress_controller_nlb_enabled: "true"
   criticality_level: 1
   environment: e2e
   id: ${CLUSTER_ID}

--- a/test/e2e/ingress.go
+++ b/test/e2e/ingress.go
@@ -79,7 +79,7 @@ var _ = framework.KubeDescribe("Ingress ALB creation", func() {
 
 		// Ingress
 		By("Creating an ingress with name " + serviceName + " in namespace " + ns + " with hostname " + hostName)
-		ing := createIngress(serviceName, hostName, ns, labels, nil, port)
+		ing := createIngress(serviceName, hostName, ns, labels, port)
 		defer func() {
 			By("deleting the ingress")
 			defer GinkgoRecover()
@@ -153,7 +153,7 @@ var __ = framework.KubeDescribe("Ingress tests simple", func() {
 		_, err = cs.CoreV1().Services(ns).Create(service)
 		Expect(err).NotTo(HaveOccurred())
 
-		ing := createIngress(serviceName, hostName, ns, labels, nil, port)
+		ing := createIngress(serviceName, hostName, ns, labels, port)
 		ingressCreate, err := cs.NetworkingV1beta1().Ingresses(ns).Create(ing)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -378,7 +378,7 @@ var ___ = framework.KubeDescribe("Ingress tests paths", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Creating ingress " + serviceName + " in namespace " + ns + "with hostname " + hostName)
-		ing := createIngress(serviceName, hostName, ns, labels, nil, port)
+		ing := createIngress(serviceName, hostName, ns, labels, port)
 		ingressCreate, err := cs.NetworkingV1beta1().Ingresses(ns).Create(ing)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -528,7 +528,7 @@ var ____ = framework.KubeDescribe("Ingress tests custom routes", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Creating ingress " + serviceName + " in namespace " + ns + "with hostname " + hostName)
-		ing := createIngress(serviceName, hostName, ns, labels, nil, port)
+		ing := createIngress(serviceName, hostName, ns, labels, port)
 		ingressCreate, err := cs.NetworkingV1beta1().Ingresses(ns).Create(ing)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -605,86 +605,6 @@ var ____ = framework.KubeDescribe("Ingress tests custom routes", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 		s, err = getBody(resp)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(s).To(Equal(backendContent))
-	})
-})
-
-var _____ = framework.KubeDescribe("Ingress tests simple NLB", func() {
-	f := framework.NewDefaultFramework("skipper-ingress-simple-nlb")
-	var (
-		cs  kubernetes.Interface
-		jig *ingress.TestJig
-	)
-
-	It("Should create simple NLB ingress [Ingress] [Zalando]", func() {
-		jig = ingress.NewIngressTestJig(f.ClientSet)
-		cs = f.ClientSet
-		serviceName := "skipper-ingress-test"
-		ns := f.Namespace.Name
-		hostName := fmt.Sprintf("%s-%d.%s", serviceName, time.Now().UTC().Unix(), E2EHostedZone())
-		labels := map[string]string{
-			"app": serviceName,
-		}
-		annotations := map[string]string{
-			"zalando.org/aws-load-balancer-type": "nlb",
-		}
-		port := 8080
-		replicas := int32(3)
-		targetPort := 9090
-		backendContent := "mytest"
-		route := fmt.Sprintf(`* -> inlineContent("%s") -> <shunt>`, backendContent)
-		waitTime := 10 * time.Minute
-
-		// CREATE setup
-		// backend deployment
-		By("Creating a deployment with " + serviceName + " in namespace " + ns)
-		depl := createSkipperBackendDeployment(serviceName, ns, route, labels, int32(targetPort), replicas)
-		_, err := cs.AppsV1().Deployments(ns).Create(depl)
-		Expect(err).NotTo(HaveOccurred())
-
-		By("Creating service " + serviceName + " in namespace " + ns)
-		service := createServiceTypeClusterIP(serviceName, labels, port, targetPort)
-		_, err = cs.CoreV1().Services(ns).Create(service)
-		Expect(err).NotTo(HaveOccurred())
-
-		ing := createIngress(serviceName, hostName, ns, labels, annotations, port)
-		ingressCreate, err := cs.NetworkingV1beta1().Ingresses(ns).Create(ing)
-		Expect(err).NotTo(HaveOccurred())
-
-		addr, err := jig.WaitForIngressAddress(cs, ns, ingressCreate.Name, waitTime)
-		Expect(err).NotTo(HaveOccurred())
-
-		_, err = cs.NetworkingV1beta1().Ingresses(ns).Get(ing.Name, metav1.GetOptions{ResourceVersion: "0"})
-		Expect(err).NotTo(HaveOccurred())
-
-		// //  skipper http -> https redirect
-		// By("Waiting for skipper route to default redirect from http to https, to see that our ingress-controller and skipper works")
-		// err = waitForResponse(addr, "http", waitTime, isRedirect, true)
-		// Expect(err).NotTo(HaveOccurred())
-
-		// ALB ready
-		By("Waiting for ALB to create endpoint " + addr + " and skipper route, to see that our ingress-controller and skipper works")
-		err = waitForResponse(addr, "https", waitTime, isNotFound, true)
-		Expect(err).NotTo(HaveOccurred())
-
-		// DNS ready
-		By("Waiting for DNS to see that external-dns and skipper route to service and pod works")
-		err = waitForResponse(hostName, "https", waitTime, isSuccess, false)
-		Expect(err).NotTo(HaveOccurred())
-
-		// Test that we get content from the default ingress
-		By("By checking the content of the reply we see that the ingress stack works")
-		rt, quit := createHTTPRoundTripper()
-		defer func() {
-			quit <- struct{}{}
-		}()
-		url := "https://" + hostName + "/"
-		req, err := http.NewRequest("GET", url, nil)
-		Expect(err).NotTo(HaveOccurred())
-		resp, err := rt.RoundTrip(req)
-		Expect(err).NotTo(HaveOccurred())
-		s, err := getBody(resp)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(s).To(Equal(backendContent))
 	})

--- a/test/e2e/kube_metrics_adapter_test.go
+++ b/test/e2e/kube_metrics_adapter_test.go
@@ -69,7 +69,7 @@ var _ = framework.KubeDescribe("[HPA] Horizontal pod autoscaling (scale resource
 		port := 80
 		targetPort := 8000
 		targetUrl := hostName + "/metrics"
-		ingress := createIngress(DeploymentName, hostName, f.Namespace.Name, labels, nil, port)
+		ingress := createIngress(DeploymentName, hostName, f.Namespace.Name, labels, port)
 		tc := CustomMetricTestCase{
 			framework:       f,
 			kubeClient:      cs,

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -30,13 +30,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 )
 
-func createIngress(name, hostname, namespace string, labels, annotations map[string]string, port int) *v1beta1.Ingress {
+func createIngress(name, hostname, namespace string, label map[string]string, port int) *v1beta1.Ingress {
 	return &v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        name + string(uuid.NewUUID()),
-			Namespace:   namespace,
-			Labels:      labels,
-			Annotations: annotations,
+			Name:      name + string(uuid.NewUUID()),
+			Namespace: namespace,
+			Labels:    label,
 		},
 		Spec: v1beta1.IngressSpec{
 			Rules: []v1beta1.IngressRule{


### PR DESCRIPTION
Reverts zalando-incubator/kubernetes-on-aws#2650

Reverting to avoid rolling out a new Ingress controller version just before Cyberweek.