### PR TITLE
Update kube-ingress-aws-controller to v0.9.0 (NLB support)

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -323,7 +323,7 @@ Resources:
           ToPort: {{ $element.ToPort }}
 {{- end }}
 {{- end }}
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+        - CidrIp: {{ if eq .Cluster.ConfigItems.kube_aws_ingress_controller_nlb_enabled "true" }}"0.0.0.0/0"{{else}}"{{.Values.vpc_ipv4_cidr}}"{{end}}
           FromPort: 9999
           IpProtocol: tcp
           ToPort: 9999

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -19,6 +19,10 @@ cluster_autoscaler_expander: highest-priority
 # ALB config created by kube-aws-ingress-controller
 kube_aws_ingress_controller_ssl_policy: "ELBSecurityPolicy-TLS-1-2-2017-01"
 kube_aws_ingress_controller_idle_timeout: "1m"
+# allow using NLBs for ingress
+# This opens port 9999 (skipper-ingress) on all worker nodes.
+kube_aws_ingress_controller_nlb_enabled: "false"
+kube_aws_ingress_controller_nlb_cross_zone: "true"
 
 # skipper ingress settings
 skipper_ingress_target_average_utilization_cpu: "70"

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.8.14
+    version: v0.9.3
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.8.14
+        version: v0.9.3
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "false"}}
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
@@ -29,11 +29,14 @@ spec:
       serviceAccountName: kube-ingress-aws-controller
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.8.14
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.9.3
         args:
-        - -stack-termination-protection
-        - -ssl-policy={{ .ConfigItems.kube_aws_ingress_controller_ssl_policy }}
-        - -idle-connection-timeout={{ .ConfigItems.kube_aws_ingress_controller_idle_timeout }}
+        - --stack-termination-protection
+        - --ssl-policy={{ .ConfigItems.kube_aws_ingress_controller_ssl_policy }}
+        - --idle-connection-timeout={{ .ConfigItems.kube_aws_ingress_controller_idle_timeout }}
+        {{ if eq .ConfigItems.kube_aws_ingress_controller_nlb_cross_zone "true" }}
+        - --nlb-cross-zone
+        {{ end }}
         env:
         - name: AWS_REGION
           value: {{ .Region }}

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -52,6 +52,7 @@ clusters:
     efs_id: ${EFS_ID}
     webhook_id: ${INFRASTRUCTURE_ACCOUNT}:${REGION}:kube-aws-test
     node_problem_detector_enabled: true
+    kube_aws_ingress_controller_nlb_enabled: "true"
   criticality_level: 1
   environment: e2e
   id: ${CLUSTER_ID}

--- a/test/e2e/kube_metrics_adapter_test.go
+++ b/test/e2e/kube_metrics_adapter_test.go
@@ -69,7 +69,7 @@ var _ = framework.KubeDescribe("[HPA] Horizontal pod autoscaling (scale resource
 		port := 80
 		targetPort := 8000
 		targetUrl := hostName + "/metrics"
-		ingress := createIngress(DeploymentName, hostName, f.Namespace.Name, labels, port)
+		ingress := createIngress(DeploymentName, hostName, f.Namespace.Name, labels, nil, port)
 		tc := CustomMetricTestCase{
 			framework:       f,
 			kubeClient:      cs,

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -30,12 +30,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 )
 
-func createIngress(name, hostname, namespace string, label map[string]string, port int) *v1beta1.Ingress {
+func createIngress(name, hostname, namespace string, labels, annotations map[string]string, port int) *v1beta1.Ingress {
 	return &v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name + string(uuid.NewUUID()),
-			Namespace: namespace,
-			Labels:    label,
+			Name:        name + string(uuid.NewUUID()),
+			Namespace:   namespace,
+			Labels:      labels,
+			Annotations: annotations,
 		},
 		Spec: v1beta1.IngressSpec{
 			Rules: []v1beta1.IngressRule{


### PR DESCRIPTION
This updates the `kube-ingress-aws-controller` to `v0.9.0` which has support for NLBs

https://github.com/zalando-incubator/kube-ingress-aws-controller/releases/tag/v0.9.0

**NLB Support is disabled by default for our clusters with this change!!** This just enables us to test it in an easy way.

TBD after Cyberweek