### PR TITLE
Improve CoreDNS configuration

### DIFF
--- a/cluster/manifests/coredns-local/configmap-local.yaml
+++ b/cluster/manifests/coredns-local/configmap-local.yaml
@@ -7,27 +7,41 @@ metadata:
     application: coredns
 data:
   Corefile: |
-    .:9254 {
-        errors
-        health :9154
-        kubernetes cluster.local in-addr.arpa ip6.arpa {
-            pods insecure
-            upstream
-            fallthrough in-addr.arpa ip6.arpa
-        }
 {{ if eq .ConfigItems.enable_skipper_eastwest "true"}}
-        template IN A ingress.cluster.local  {
+    ingress.cluster.local:9254 {
+        template IN A {
             match "^.*[.]ingress[.]cluster[.]local"
             answer "{{"{{"}} .Name {{"}}"}} 60 IN A 10.3.99.99"
             fallthrough
         }
+        prometheus :9153
+        ready :9155
+    }
 {{ end }}
+
+    # 10.2.0.0/16, 10.3.0.0/16 defines that this server is authority for revese
+    # lookups for these ranges.
+    cluster.local:9254 10.2.0.0/16:9254 10.3.0.0/16:9254 {
+        errors
+        kubernetes {
+            pods insecure
+            upstream
+        }
+        cache 30
 {{ if eq .ConfigItems.coredns_log_svc_names "true"}}
         log svc.svc.cluster.local.
 {{ end }}
         prometheus :9153
+        ready :9155
+    }
+
+    .:9254 {
+        errors
+        health :9154 # this is global for all servers
+        ready :9155
+        prometheus :9153
         forward . /etc/resolv.conf
-        pprof 127.0.0.1:9155
+        pprof 127.0.0.1:9156
         cache 30
         reload
     }

--- a/cluster/manifests/coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/coredns-local/daemonset-coredns.yaml
@@ -115,8 +115,8 @@ spec:
           failureThreshold: 5
         readinessProbe:
           httpGet:
-            path: /health
-            port: 9154
+            path: /ready
+            port: 9155
             scheme: HTTP
           initialDelaySeconds: 10
           timeoutSeconds: 3


### PR DESCRIPTION
**THIS IS WIP - needs testing**

This introduces improvements to the CoreDNS configuration as suggested
in https://github.com/coredns/coredns/issues/2593#issuecomment-466888239
The change is to use multiple server directives to avoid expensive
lookup from Kubernetes plugin in terms of reverse DNS lookup or
expensive regex matching for `ingress.cluster.local` names.

* Use the `ready` plugin for readinessProbe
  https://github.com/coredns/coredns/tree/master/plugin/ready
* Enable splitting metrics by zone to see difference between internal and external names

![image](https://user-images.githubusercontent.com/128566/69801212-08b5e280-11d7-11ea-9b51-bedadd002ae0.png)

