### PR TITLE
Add aws-account-id, worker-role-arn to deployment-config

### DIFF
--- a/cluster/manifests/infrastructure-configs/deployment-config.yaml
+++ b/cluster/manifests/infrastructure-configs/deployment-config.yaml
@@ -4,7 +4,9 @@ metadata:
   name: deployment-config
   namespace: kube-system
 data:
+  aws-account-id: "{{accountID .Cluster.InfrastructureAccount}}"
   cluster-alias: "{{.Cluster.Alias}}"
   scalyr-team-token: "{{.Cluster.ConfigItems.scalyr_team_token}}"
   create-namespaces: "true"
   aws-available: "true"
+  worker-role-arn: "arn:aws:iam::{{accountID .Cluster.InfrastructureAccount}}:role/{{.Cluster.LocalID}}-worker"


### PR DESCRIPTION
This will allow our deployment step to pick it up automatically so the users don't need to configure it every time.