### PR TITLE
Prometheus: increase readiness delay to 2 minutes

### DIFF
--- a/cluster/manifests/prometheus/statefulset.yaml
+++ b/cluster/manifests/prometheus/statefulset.yaml
@@ -55,9 +55,9 @@ spec:
             port: 9090
           initialDelaySeconds: 5
           timeoutSeconds: 5
-          # ensure that we have at least a minute of metrics before marking ourselves as ready
+          # ensure that we have at least two minutes of metrics before marking ourselves as ready
           periodSeconds: 5
-          successThreshold: 14
+          successThreshold: 26
         volumeMounts:
         - name: prometheus-config-volume
           mountPath: /etc/prometheus


### PR DESCRIPTION
`rate[1m]` might not behave correctly if we only have data for 1 minute, so increase the readiness delay a bit. Let's see if this helps.