### PR TITLE
Allow autoscaling-plans for deployment role

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -570,6 +570,7 @@ Resources:
                   - 'apigateway:*'
                   - 'automation:*'
                   - 'autoscaling:*'
+                  - 'autoscaling-plans:*'
                   - 'application-autoscaling:*'
                   - 'aws-marketplace:View*'
                   - 'aws-portal:View*'


### PR DESCRIPTION
Allow autoscaling-plans for deployment role. Allows deploying those plans via cloudformation.