### PR TITLE
Drop node admitter

### DIFF
--- a/cluster/manifests/admission-control/teapot.yaml
+++ b/cluster/manifests/admission-control/teapot.yaml
@@ -37,16 +37,6 @@ webhooks:
         apiGroups: ["storage.k8s.io"]
         apiVersions: ["v1", "v1beta1"]
         resources: ["storageclasses"]
-  - name: node-admitter.teapot.zalan.do
-    clientConfig:
-      url: "https://localhost:8085/node"
-      caBundle: "{{ .ConfigItems.ca_cert_decompressed }}"
-    failurePolicy: Fail
-    rules:
-      - operations: [ "CREATE" ]
-        apiGroups: [""]
-        apiVersions: ["v1"]
-        resources: ["nodes"]
   - name: cronjob-admitter.teapot.zalan.do
     clientConfig:
       url: "https://localhost:8085/cronjob"


### PR DESCRIPTION
It was added to work around a bug in Kubernetes that's been fixed a long time ago, let's just drop it.