### PR TITLE
Admission controller: better deployment defaults

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -224,6 +224,8 @@ teapot_admission_controller_process_resources: "true"
 teapot_admission_controller_application_min_creation_time: "2019-06-03T12:00:00Z"
 teapot_admission_controller_ndots: "2"
 teapot_admission_controller_inject_environment_variables: "true"
+teapot_admission_controller_deployment_default_max_surge: "5%"
+teapot_admission_controller_deployment_default_max_unavailable: "1"
 
 {{if eq .Environment "production"}}
 teapot_admission_controller_validate_application_label: "true"

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -172,7 +172,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-40
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-43
           name: admission-controller
           readinessProbe:
             httpGet:
@@ -221,6 +221,8 @@ write_files:
 {{- if eq .Cluster.ConfigItems.teapot_admission_controller_resource_validate_redeployments "true" }}
             - --resource-validate-redeployments
 {{- end }}
+            - --deployment-rolling-update-default-max-surge={{ .Cluster.ConfigItems.teapot_admission_controller_deployment_default_max_surge }}
+            - --deployment-rolling-update-default-max-unavailable={{ .Cluster.ConfigItems.teapot_admission_controller_deployment_default_max_unavailable }}
           ports:
             - containerPort: 8085
           volumeMounts:


### PR DESCRIPTION
 * Update admission controller to `master-43`
 * Set better defaults for rolling update strategy of deployments (1 max unavailable, 5% max surge). Note that max unavailable is a static value since it rounds down, so 1% would be 0 for most of our stuff. Unfortunately, API server applies defaults _before_ passing the request to the admission controller, so 25%/25% set by the users would also be replaced.