### PR TITLE
Limit nodes considered for ingress load balancer based on taints [1/2]

### DIFF
--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -38,6 +38,8 @@ spec:
         - --nlb-cross-zone
         {{ end }}
         env:
+        - name: CUSTOM_FILTERS
+          value: "tag:kubernetes.io/cluster/{{ .Cluster.ID }}=owned tag:node.kubernetes.io/role=worker" # TODO: tag:zalando.org/ingress-enabled=true"
         - name: AWS_REGION
           value: {{ .Region }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.9.3
+    version: v0.9.6
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.9.3
+        version: v0.9.6
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "false"}}
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: kube-ingress-aws-controller
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.9.3
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.9.6
         args:
         - --stack-termination-protection
         - --ssl-policy={{ .ConfigItems.kube_aws_ingress_controller_ssl_policy }}

--- a/cluster/node-pools/worker-default/stack.yaml
+++ b/cluster/node-pools/worker-default/stack.yaml
@@ -48,6 +48,12 @@ Resources:
       - Key: node.kubernetes.io/role
         PropagateAtLaunch: true
         Value: worker
+# only node pools without taints should be attached to Ingress Load balancer
+{{- if not (index .NodePool.ConfigItems "taints") }}
+      - Key: zalando.org/ingress-enabled
+        Value: "true"
+        PropagateAtLaunch: true
+{{- end }}
       - Key: k8s.io/cluster-autoscaler/enabled
         PropagateAtLaunch: true
         Value: ''

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -52,6 +52,12 @@ Resources:
       - Key: node.kubernetes.io/role
         PropagateAtLaunch: true
         Value: worker
+# only node pools without taints should be attached to Ingress Load balancer
+{{- if not (index $data.NodePool.ConfigItems "taints") }}
+      - Key: zalando.org/ingress-enabled
+        Value: "true"
+        PropagateAtLaunch: true
+{{- end }}
       - Key: k8s.io/cluster-autoscaler/enabled
         PropagateAtLaunch: true
         Value: ''


### PR DESCRIPTION
This is a proposal for how we can reduce the amount of targets in the ingress load balancers to only the relevant nodes.

Right now the problem is that all nodes are considered as target (but only those running skipper will get traffic) even if the node is a master node or a special node pool which wouldn't be able to run skipper because of `taints`.

The idea is to first only limit the possible targets to worker nodes and then tag all node pools which DON'T have any taints defined to be considered as target. Later we can be more specific and allow certain type of nodes e.g. if we have a dedicated system/skipper node pool in place.

The `tag:zalando.org/ingress-enabled=true` is marked as TODO for now because we need to do the rollout in two steps to be safe.