### PR TITLE
Switch to capacity-optimized spot

### DIFF
--- a/cluster/node-pools/worker-default/stack.yaml
+++ b/cluster/node-pools/worker-default/stack.yaml
@@ -18,7 +18,7 @@ Resources:
 {{ if gt (len .NodePool.InstanceTypes) 1 }}
       MixedInstancesPolicy:
         InstancesDistribution:
-          OnDemandPercentageAboveBaseCapacity: {{if eq .NodePool.DiscountStrategy "spot_max_price"}}0{{else}}100{{end}}
+          OnDemandPercentageAboveBaseCapacity: {{if or (eq .NodePool.DiscountStrategy "spot") (eq .NodePool.DiscountStrategy "spot_max_price")}}0{{else}}100{{end}}
           SpotInstancePools: {{ len .NodePool.InstanceTypes }}
         LaunchTemplate:
           LaunchTemplateSpecification:
@@ -59,7 +59,7 @@ Resources:
         Value: ready
       - Key: k8s.io/cluster-autoscaler/node-template/label/aws.amazon.com/spot
         PropagateAtLaunch: true
-        Value: {{if eq .NodePool.DiscountStrategy "spot_max_price"}}true{{else}}false{{end}}
+        Value: {{if or (eq .NodePool.DiscountStrategy "spot") (eq .NodePool.DiscountStrategy "spot_max_price")}}true{{else}}false{{end}}
       - Key: k8s.io/cluster-autoscaler/node-template/resources/ephemeral-storage
         PropagateAtLaunch: false
         Value: "30Gi"
@@ -67,7 +67,7 @@ Resources:
         PropagateAtLaunch: true
 {{- if index .NodePool.ConfigItems "scaling_priority" }}
         Value: "{{ .NodePool.ConfigItems.scaling_priority }}"
-{{- else if eq .NodePool.DiscountStrategy "spot_max_price" }}
+{{- else if or (eq .NodePool.DiscountStrategy "spot") (eq .NodePool.DiscountStrategy "spot_max_price") }}
         Value: "1000"
 {{- else }}
         Value: "0"
@@ -117,7 +117,7 @@ Resources:
         - !Ref 'AWS::Region'
         - MachineImage
         InstanceType: "{{ index .NodePool.InstanceTypes 0 }}"
-{{- if and (eq .NodePool.DiscountStrategy "spot_max_price") (eq (len .NodePool.InstanceTypes) 1) }}
+{{- if and (or (eq .NodePool.DiscountStrategy "spot") (eq .NodePool.DiscountStrategy "spot_max_price")) (eq (len .NodePool.InstanceTypes) 1) }}
         InstanceMarketOptions:
           MarketType: spot
 {{ end }}

--- a/cluster/node-pools/worker-default/stack.yaml
+++ b/cluster/node-pools/worker-default/stack.yaml
@@ -19,7 +19,7 @@ Resources:
       MixedInstancesPolicy:
         InstancesDistribution:
           OnDemandPercentageAboveBaseCapacity: {{if or (eq .NodePool.DiscountStrategy "spot") (eq .NodePool.DiscountStrategy "spot_max_price")}}0{{else}}100{{end}}
-          SpotInstancePools: {{ len .NodePool.InstanceTypes }}
+          SpotAllocationStrategy: capacity-optimized
         LaunchTemplate:
           LaunchTemplateSpecification:
             LaunchTemplateId: !Ref LaunchTemplate

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -23,7 +23,7 @@ Resources:
       MixedInstancesPolicy:
         InstancesDistribution:
           OnDemandPercentageAboveBaseCapacity: {{if or (eq $data.NodePool.DiscountStrategy "spot") (eq $data.NodePool.DiscountStrategy "spot_max_price")}}0{{else}}100{{end}}
-          SpotInstancePools: {{ len $data.NodePool.InstanceTypes }}
+          SpotAllocationStrategy: capacity-optimized
         LaunchTemplate:
           LaunchTemplateSpecification:
             LaunchTemplateId: !Ref LaunchTemplate

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -22,7 +22,7 @@ Resources:
 {{ if gt (len $data.NodePool.InstanceTypes) 1 }}
       MixedInstancesPolicy:
         InstancesDistribution:
-          OnDemandPercentageAboveBaseCapacity: {{if eq $data.NodePool.DiscountStrategy "spot_max_price"}}0{{else}}100{{end}}
+          OnDemandPercentageAboveBaseCapacity: {{if or (eq $data.NodePool.DiscountStrategy "spot") (eq $data.NodePool.DiscountStrategy "spot_max_price")}}0{{else}}100{{end}}
           SpotInstancePools: {{ len $data.NodePool.InstanceTypes }}
         LaunchTemplate:
           LaunchTemplateSpecification:
@@ -63,7 +63,7 @@ Resources:
         Value: ready
       - Key: k8s.io/cluster-autoscaler/node-template/label/aws.amazon.com/spot
         PropagateAtLaunch: true
-        Value: {{if eq $data.NodePool.DiscountStrategy "spot_max_price"}}true{{else}}false{{end}}
+        Value: {{if or (eq $data.NodePool.DiscountStrategy "spot") (eq $data.NodePool.DiscountStrategy "spot_max_price")}}true{{else}}false{{end}}
       - Key: k8s.io/cluster-autoscaler/node-template/resources/ephemeral-storage
         PropagateAtLaunch: false
         Value: "30Gi"
@@ -71,7 +71,7 @@ Resources:
         PropagateAtLaunch: true
 {{- if index $data.NodePool.ConfigItems "scaling_priority" }}
         Value: "{{ $data.NodePool.ConfigItems.scaling_priority }}"
-{{- else if eq $data.NodePool.DiscountStrategy "spot_max_price" }}
+{{- else if or (eq $data.NodePool.DiscountStrategy "spot") (eq $data.NodePool.DiscountStrategy "spot_max_price") }}
         Value: "1000"
 {{- else }}
         Value: "0"
@@ -127,7 +127,7 @@ Resources:
         - !Ref 'AWS::Region'
         - MachineImage
         InstanceType: "{{ index .NodePool.InstanceTypes 0 }}"
-{{- if and (eq .NodePool.DiscountStrategy "spot_max_price") (eq (len $data.NodePool.InstanceTypes) 1) }}
+{{- if and (or (eq .NodePool.DiscountStrategy "spot") (eq .NodePool.DiscountStrategy "spot_max_price")) (eq (len $data.NodePool.InstanceTypes) 1) }}
         InstanceMarketOptions:
           MarketType: spot
 {{ end }}

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -65,7 +65,7 @@ clusters:
     profile: ${MASTER_PROFILE}-default
     min_size: 1
     max_size: 2
-  - discount_strategy: spot_max_price
+  - discount_strategy: spot
     instance_types: ["m4.large", "m5.large", "m5.xlarge", "m4.xlarge"]
     name: default-worker-splitaz
     profile: ${WORKER_PROFILE}-splitaz
@@ -73,13 +73,13 @@ clusters:
     max_size: 21
     config_items:
       cpu_manager_policy: static
-  - discount_strategy: spot_max_price
+  - discount_strategy: spot
     instance_types: ["m4.large", "m5.large", "m5.xlarge", "m4.xlarge"]
     name: default-worker
     profile: ${WORKER_PROFILE}-default
     min_size: 1
     max_size: 21
-  - discount_strategy: spot_max_price
+  - discount_strategy: spot
     instance_types: ["m4.large", "m5.large", "m5.xlarge", "m4.xlarge"]
     config_items:
       availability_zones: "eu-central-1a"
@@ -88,13 +88,13 @@ clusters:
     profile: ${WORKER_PROFILE}-splitaz
     min_size: 1
     max_size: 21
-  - discount_strategy: spot_max_price
+  - discount_strategy: spot
     instance_types: ["m5d.large", "m5d.xlarge", "m5d.2xlarge"]
     name: worker-instance-storage
     profile: ${WORKER_PROFILE}-default
     min_size: 1
     max_size: 21
-  - discount_strategy: spot_max_price
+  - discount_strategy: spot
     instance_types: ["p3.2xlarge", "g2.2xlarge", "g3s.xlarge", "g3.4xlarge"]
     name: worker-gpu
     profile: ${WORKER_PROFILE}-default


### PR DESCRIPTION
 * Support both `spot_max_price` and `spot` discount strategies (so we could migrate to the latter)
 * Change spot pools to use the capacity optimized allocation strategy