### PR TITLE
Bump admission-controller to the latest version

### DIFF
--- a/cluster/manifests/admission-control/daemonset.yaml
+++ b/cluster/manifests/admission-control/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cluster-autoscaler
-        image: registry.opensource.zalan.do/teapot/admission-controller:master-44
+        image: registry.opensource.zalan.do/teapot/admission-controller:master-45
         command:
           - /registry-proxy
           - --address=127.0.0.1:8285

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -172,7 +172,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-44
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-45
           name: admission-controller
           readinessProbe:
             httpGet:


### PR DESCRIPTION
Fixes a bug where an omitted namespace leads to wrong admission