### PR TITLE
Make it possible to configure one custom DNS zone

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -317,3 +317,7 @@ kube_aws_iam_controller_kube_system_enable: "true"
 
 # allow ssh access for internal VPC IPs only
 ssh_vpc_only: "false"
+
+# configure custom dns zone
+custom_dns_zone: "" # zone name e.g. example.org
+custom_dns_zone_nameservers: "" # space seperated list of nameserver IP addresses

--- a/cluster/manifests/coredns-local/configmap-local.yaml
+++ b/cluster/manifests/coredns-local/configmap-local.yaml
@@ -7,6 +7,16 @@ metadata:
     application: coredns
 data:
   Corefile: |
+{{ if and (ne .ConfigItems.custom_dns_zone "") (ne .ConfigItems.custom_dns_zone_nameservers "") }}
+    {{ .ConfigItems.custom_dns_zone }}:9254 {
+        errors
+        forward . {{ .ConfigItems.custom_dns_zone_nameservers }}
+        prometheus :9153
+        ready :9155
+        cache 30
+    }
+{{ end }}
+
 {{ if eq .ConfigItems.enable_skipper_eastwest "true"}}
     ingress.cluster.local:9254 {
         template IN A {


### PR DESCRIPTION
This is a simple way to allow an additional custom nameserver to be configured in CoreDNS. The use case right now is to enable DC DNS in certain DC connected clusters.