### PR TITLE
Update node selector for skipper

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -38,7 +38,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: skipper-ingress
       nodeSelector:
-        kubernetes.io/role: worker
+        node.kubernetes.io/role: worker
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       containers:


### PR DESCRIPTION
Update node selector for skipper. The legacy `kubernetes.io/role` selector will not be supported by v1.16, so we need to roll this out before.