### PR TITLE
Update VPA components

### DIFF
--- a/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: vpa-admission-controller
-    version: v0.6.1-internal.2
+    version: v0.6.1-internal.4
     component: vpa
 spec:
   replicas: 1
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: vpa-admission-controller
-        version: v0.6.1-internal.2
+        version: v0.6.1-internal.4
         component: vpa
       annotations:
         config/hash: {{"secret.yaml" | manifestHash}}
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: vpa-admission-controller
       containers:
       - name: admission-controller
-        image: registry.opensource.zalan.do/teapot/vpa-admission-controller:v0.6.1-internal.2
+        image: registry.opensource.zalan.do/teapot/vpa-admission-controller:v0.6.1-internal.4
         volumeMounts:
           - name: tls-certs
             mountPath: "/etc/tls-certs"

--- a/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: vpa-recommender
-    version: v0.6.1-internal.2
+    version: v0.6.1-internal.4
     component: vpa
 spec:
   replicas: 1
@@ -16,14 +16,14 @@ spec:
     metadata:
       labels:
         application: vpa-recommender
-        version: v0.6.1-internal.2
+        version: v0.6.1-internal.4
         component: vpa
     spec:
       serviceAccountName: vpa-recommender
       priorityClassName: system-cluster-critical
       containers:
       - name: recommender
-        image: registry.opensource.zalan.do/teapot/vpa-recommender:v0.6.1-internal.2
+        image: registry.opensource.zalan.do/teapot/vpa-recommender:v0.6.1-internal.4
         args:
         - --stderrthreshold=info
         - --v=5

--- a/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: vpa-updater
-    version: v0.6.1-internal.2
+    version: v0.6.1-internal.4
     component: vpa
 spec:
   replicas: 1
@@ -16,14 +16,14 @@ spec:
     metadata:
       labels:
         application: vpa-updater
-        version: v0.6.1-internal.2
+        version: v0.6.1-internal.4
         component: vpa
     spec:
       serviceAccountName: vpa-updater
       priorityClassName: system-cluster-critical
       containers:
       - name: updater
-        image: registry.opensource.zalan.do/teapot/vpa-updater:v0.6.1-internal.2
+        image: registry.opensource.zalan.do/teapot/vpa-updater:v0.6.1-internal.4
         command:
           - ./updater
         args:


### PR DESCRIPTION
This version of the VPA has the following changes:
- fixes the broken logging in the recommender
- the updater deletes pods which are being _OOMKilled_ when the recommendation can change.