### PR TITLE
Add remote write to prometheus with config item

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -152,6 +152,7 @@ prometheus_cpu: "1000m"
 prometheus_mem: "4Gi"
 prometheus_mem_min: "1Gi"
 prometheus_cpu_min: "0"
+prometheus_remote_write: "disabled"
 
 metrics_service_cpu: "100m"
 metrics_service_mem: "200Mi"

--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -10,7 +10,8 @@ data:
     global:
       scrape_interval: 15s
       external_labels:
-        monitor: 'skipper-ingress'
+        prometheus_replica: @@POD_NAME@@
+        cluster: {{ .Cluster.Alias }}
     scrape_configs:
     # scrape from kube-apiserver pods
     - job_name: 'kubernetes-apiservers'
@@ -172,3 +173,8 @@ data:
        - source_labels: [ __name__ ]
          regex: 'reflector.*'
          action: drop
+{{- if ne .ConfigItems.prometheus_remote_write "disabled" }}
+    remote_write:
+    - url: {{ .ConfigItems.prometheus_remote_write }}
+      bearer_token_file: /meta/credentials/remote-write
+{{- end }}

--- a/cluster/manifests/prometheus/credentialset.yaml
+++ b/cluster/manifests/prometheus/credentialset.yaml
@@ -1,0 +1,10 @@
+apiVersion: zalando.org/v1
+kind: PlatformCredentialsSet
+metadata:
+  name: prometheus-credentials
+  namespace: kube-system
+spec:
+  application: prometheus
+  token_version: v2
+  tokens:
+    remote-write: {}

--- a/cluster/manifests/prometheus/statefulset.yaml
+++ b/cluster/manifests/prometheus/statefulset.yaml
@@ -29,11 +29,29 @@ spec:
         - name: ndots
           value: "1"
       priorityClassName: system-cluster-critical
+      initContainers:
+      - name: generate-config
+        image: registry.opensource.zalan.do/stups/alpine:3.10.3-5
+        command:
+        - /bin/sh
+        args:
+        - -c
+        - sed s/'@@POD_NAME@@'/${POD_NAME}/g /etc/prometheus/prometheus.yml > /prometheus/prometheus.yaml
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        volumeMounts:
+        - name: prometheus-config-volume
+          mountPath: /etc/prometheus
+        - name: prometheus-storage-volume
+          mountPath: /prometheus
       containers:
       - name: prometheus
         image: registry.opensource.zalan.do/teapot/prometheus:v2.14.0
         args:
-        - "--config.file=/etc/prometheus/prometheus.yml"
+        - "--config.file=/prometheus/prometheus.yaml"
         - "--storage.tsdb.path=/prometheus/"
         - "--storage.tsdb.retention.time=1d"
         - "--storage.tsdb.wal-compression"
@@ -59,10 +77,12 @@ spec:
           periodSeconds: 5
           successThreshold: 26
         volumeMounts:
-        - name: prometheus-config-volume
-          mountPath: /etc/prometheus
         - name: prometheus-storage-volume
           mountPath: /prometheus
+{{- if ne .ConfigItems.prometheus_remote_write "disabled" }}
+        - name: prometheus-credentials
+          mountPath: /meta/credentials
+{{- end }}
         securityContext:
           allowPrivilegeEscalation: false
       volumes:
@@ -70,6 +90,11 @@ spec:
         configMap:
           defaultMode: 420
           name: prometheus-conf
+{{- if ne .ConfigItems.prometheus_remote_write "disabled" }}
+      - name: prometheus-credentials
+        secret:
+          secretName: prometheus-credentials
+{{- end }}
       securityContext:
         runAsUser: 65534
         fsGroup: 65534


### PR DESCRIPTION
The `prometheus_remote_write` config item will allow prometheus to push metrics data to a central location.