### PR TITLE
Audittrail bucket: allow access from a central role

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1372,6 +1372,59 @@ Resources:
             Status: Enabled
       VersioningConfiguration:
         Status: Suspended
+  AuditTrailBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref AuditTrailBucket
+      PolicyDocument:
+        Statement:
+          # In-cluster access
+          - Action:
+              - s3:ListBucket
+            Effect: Allow
+            Principal:
+              AWS:
+                - !GetAtt EmergencyAccessServiceIAMRole.Arn
+                - !GetAtt AudittrailAdapterIAMRole.Arn
+            Resource:
+              - !GetAtt AuditTrailBucket.Arn
+
+          - Action:
+              - s3:PutObject
+            Effect: Allow
+            Principal:
+              AWS:
+              - !GetAtt EmergencyAccessServiceIAMRole.Arn
+              - !GetAtt AudittrailAdapterIAMRole.Arn
+            Resource:
+              - !Sub
+                - "${BucketArn}/*"
+                - BucketArn: !GetAtt AuditTrailBucket.Arn
+
+{{- if ne .Cluster.ConfigItems.audittrail_root_account_role "" }}
+          # Central access
+          - Action:
+              - s3:ListBucket
+            Effect: Allow
+            Principal:
+              AWS:
+                - {{.Cluster.ConfigItems.audittrail_root_account_role}}
+            Resource:
+              - !GetAtt AuditTrailBucket.Arn
+
+          - Action:
+              - s3:GetObject
+              - s3:DeleteObject
+            Effect: Allow
+            Principal:
+              AWS:
+                - {{.Cluster.ConfigItems.audittrail_root_account_role}}
+            Resource:
+              - !Sub
+                - "${BucketArn}/*"
+                - BucketArn: !GetAtt AuditTrailBucket.Arn
+{{- end }}
+
   EmergencyAccessServiceIAMRole:
     Properties:
       AssumeRolePolicyDocument:
@@ -1396,17 +1449,18 @@ Resources:
         - PolicyDocument:
             Statement:
               - Action:
-                  - 's3:ListBucket'
+                  - s3:ListBucket
                 Effect: Allow
                 Resource:
-                  - >-
-                    arn:aws:s3:::zalando-audittrail-{{accountID .Cluster.InfrastructureAccount}}-{{.Cluster.LocalID}}
+                  - !GetAtt AuditTrailBucket.Arn
+
               - Action:
-                  - 's3:PutObject'
+                  - s3:PutObject
                 Effect: Allow
                 Resource:
-                  - >-
-                    arn:aws:s3:::zalando-audittrail-{{accountID .Cluster.InfrastructureAccount}}-{{.Cluster.LocalID}}/*
+                  - !Sub
+                    - "${BucketArn}/*"
+                    - BucketArn: !GetAtt AuditTrailBucket.Arn
             Version: 2012-10-17
           PolicyName: root
       RoleName: "{{.Cluster.LocalID}}-emergency-access-service"
@@ -1435,17 +1489,18 @@ Resources:
         - PolicyDocument:
             Statement:
               - Action:
-                  - 's3:ListBucket'
+                  - s3:ListBucket
                 Effect: Allow
                 Resource:
-                  - >-
-                    arn:aws:s3:::zalando-audittrail-{{accountID .Cluster.InfrastructureAccount}}-{{.Cluster.LocalID}}
+                  - !GetAtt AuditTrailBucket.Arn
+
               - Action:
-                  - 's3:PutObject'
+                  - s3:PutObject
                 Effect: Allow
                 Resource:
-                  - >-
-                    arn:aws:s3:::zalando-audittrail-{{accountID .Cluster.InfrastructureAccount}}-{{.Cluster.LocalID}}/*
+                  - !Sub
+                    - "${BucketArn}/*"
+                    - BucketArn: !GetAtt AuditTrailBucket.Arn
             Version: 2012-10-17
           PolicyName: root
       RoleName: "{{.Cluster.LocalID}}-audittrail-adapter"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -285,6 +285,7 @@ audittrail_url: "https://audittrail.cloud.zalando.com"
 {{else}}
 audittrail_url: ""
 {{end}}
+audittrail_root_account_role: ""
 
 # Feature toggle for CustomResourceWebhookConversion (alpha in v1.13)
 # https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definition-versioning/#webhook-conversion

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -15,6 +15,7 @@ clusters:
     zmon_worker_plugin_sql_user:
     zmon_worker_plugin_sql_pass:
     zmon_root_account_role: ${ZMON_ROOT_ACCOUNT_ROLE}
+    audittrail_root_account_role: ${AUDITTRAIL_ROOT_ACCOUNT_ROLE}
     apiserver_etcd_prefix: /registry-${LOCAL_ID}
     apiserver_business_partner_ids: ${APISERVER_BUSINESS_PARTNER_IDS}
     etcd_s3_backup_bucket: zalando-kubernetes-etcd-${AWS_ACCOUNT}-${REGION}


### PR DESCRIPTION
Setup a policy on the audit events bucket. If `audittrail_root_account_role` is set, additionally give access to the bucket to a central role.