### PR TITLE
Change master nodeSelector to new value

### DIFF
--- a/cluster/manifests/02-kube-aws-iam-controller/deployment.yaml
+++ b/cluster/manifests/02-kube-aws-iam-controller/deployment.yaml
@@ -38,5 +38,8 @@ spec:
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
+      - key: node.kubernetes.io/role
+        value: master
+        effect: NoSchedule
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node.kubernetes.io/role: master

--- a/cluster/manifests/admission-control/daemonset.yaml
+++ b/cluster/manifests/admission-control/daemonset.yaml
@@ -28,6 +28,9 @@ spec:
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
+      - key: node.kubernetes.io/role
+        value: master
+        effect: NoSchedule
       containers:
       - name: cluster-autoscaler
         image: registry.opensource.zalan.do/teapot/admission-controller:master-45
@@ -48,7 +51,7 @@ spec:
             mountPath: /meta/credentials
             readOnly: true
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node.kubernetes.io/role: master
       volumes:
         - name: credentials
           secret:

--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -21,13 +21,8 @@ spec:
     spec:
       serviceAccountName: audittrail-adapter
       priorityClassName: system-node-critical
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
+      nodeSelector:
+        node.kubernetes.io/role: master
       tolerations:
       - operator: Exists
         effect: NoSchedule

--- a/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
@@ -28,6 +28,9 @@ spec:
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
+      - key: node.kubernetes.io/role
+        value: master
+        effect: NoSchedule
       - key: node.kubernetes.io/not-ready
         operator: Exists
       containers:
@@ -61,4 +64,4 @@ spec:
         secret:
           secretName: cluster-lifecycle-controller-aws-iam-credentials
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node.kubernetes.io/role: master

--- a/cluster/manifests/etcd-backup/cronjob.yaml
+++ b/cluster/manifests/etcd-backup/cronjob.yaml
@@ -59,8 +59,11 @@ spec:
           tolerations:
           - key: node-role.kubernetes.io/master
             effect: NoSchedule
+          - key: node.kubernetes.io/role
+            value: master
+            effect: NoSchedule
           nodeSelector:
-            node-role.kubernetes.io/master: ""
+            node.kubernetes.io/role: master
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
           volumes:
           - name: aws-iam-credentials

--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -31,6 +31,9 @@ spec:
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
+      - key: node.kubernetes.io/role
+        value: master
+        effect: NoSchedule
       containers:
       - name: cluster-autoscaler
         image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.12.2-internal-2.5
@@ -60,4 +63,4 @@ spec:
           - name: KUBE_MAX_PD_VOLS
             value: "26"
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node.kubernetes.io/role: master


### PR DESCRIPTION
Use `node.kubernetes.io/role=master` as nodeSelector since `node-role.kubernetes/master` won't be supported in v1.16.
Add a matching taint to align and migrate the naming with v1.16 rollout.

Required before #2774 