### PR TITLE
Allow to configure ExternalDNS TXT prefix

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -324,3 +324,6 @@ ssh_vpc_only: "false"
 # configure custom dns zone
 custom_dns_zone: "" # zone name e.g. example.org
 custom_dns_zone_nameservers: "" # space seperated list of nameserver IP addresses
+
+# prefix prepended to ownership TXT records for external-dns
+external_dns_ownership_prefix:

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -326,4 +326,4 @@ custom_dns_zone: "" # zone name e.g. example.org
 custom_dns_zone_nameservers: "" # space seperated list of nameserver IP addresses
 
 # prefix prepended to ownership TXT records for external-dns
-external_dns_ownership_prefix:
+external_dns_ownership_prefix: ""

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -37,6 +37,7 @@ spec:
         - --provider=aws
         - --registry=txt
         - --txt-owner-id={{ .Region }}:{{ .LocalID }}
+        - --txt-prefix={{ .ConfigItems.external_dns_ownership_prefix }}
         - --aws-batch-change-size=100
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
         env:


### PR DESCRIPTION
Allows people to use custom TXT records on the same DNS names as their Ingresses, e.g. for SPF etc.

For example see https://github.com/kubernetes-sigs/external-dns/issues/930#issuecomment-474427868