### PR TITLE
Duplicate role temporarily instead of deleting early

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -1,10 +1,10 @@
 # everything defined under here will be deleted before applying the manifests
-pre_apply:
-- name: kube-state-metrics
-  kind: ClusterRoleBinding
+pre_apply: []
 
 # everything defined under here will be deleted after applying the manifests
 post_apply:
+- name: kube-state-metrics
+  kind: ClusterRoleBinding
 - name: node-problem-detector
   namespace: kube-system
   kind: ConfigMap

--- a/cluster/manifests/kube-state-metrics/rbac.yaml
+++ b/cluster/manifests/kube-state-metrics/rbac.yaml
@@ -9,7 +9,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kube-state-metrics
+  name: kube-state-metrics-temp
   labels:
     application: kube-state-metrics
 roleRef:


### PR DESCRIPTION
This should ease the rollout to beta and stable.

Cleanup tasks at any point in the future:
- [ ] `post-apply` remove ClusterRole `kube-state-metrics-temp`
- [ ] rename `kube-state-metrics-temp` back to `kube-state-metrics`