### PR TITLE
Switch to conflist cni configuration for flannel

### DIFF
--- a/cluster/manifests/flannel/configmap.yaml
+++ b/cluster/manifests/flannel/configmap.yaml
@@ -8,12 +8,17 @@ metadata:
 data:
   cni-conf.json: |
     {
-        "name": "podnet",
-        "type": "flannel",
-        "delegate": {
+      "name": "podnet",
+      "cniVersion": "0.3.1",
+      "plugins": [
+        {
+          "type": "flannel",
+          "delegate": {
             "isDefaultGateway": true,
             "hairpinMode": true
+          }
         }
+      ]
     }
   net-conf.json: |
     {

--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -35,7 +35,7 @@ spec:
           - name: CNI_CONFIG_SOURCE
             value: /etc/kube-flannel/cni-conf.json
           - name: CNI_CONFIG_TARGET
-            value: /etc/cni/net.d/10-flannel.conf
+            value: /etc/cni/net.d/10-flannel.conflist
         resources:
           requests:
             cpu: 25m


### PR DESCRIPTION
Switches to use the newer `conflist` cni configuration. This is required
because Kubernetes v1.16.0 introduces config validation:
https://github.com/kubernetes/kubernetes/pull/80482 which is no longer
able to validate the old configuration. The behavior is the same with
the new configuration.

The configuration comes from the documented deployment from flannel: https://github.com/coreos/flannel/pull/888. I did not include the portMapping config has we don't have pods with hostports (running in pod network).

Unfortunately this is not really covered by our e2e as it will only apply to new nodes. I have tested this by setting up a new cluster based on this configuration.

Required for #2774 