### PR TITLE
enable TCP-lifo as default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -57,11 +57,7 @@ enable_skipper_eastwest: "true"
 
 # skipper tcp lifo
 # See: https://opensource.zalando.com/skipper/operation/operation/#tcp-lifo
-{{if eq .Environment "production"}}
-skipper_enable_tcp_queue: "false"
-{{else}}
 skipper_enable_tcp_queue: "true"
-{{end}}
 skipper_expected_bytes_per_request: "51200"
 skipper_max_tcp_listener_concurrency: "-1"
 skipper_max_tcp_listener_queue: "-1"


### PR DESCRIPTION
enable TCP-lifo as default, because it works in all enabled production clusters reliably and we could not see drawbacks

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>