### PR TITLE
Update clc to support new node-pool node label

### DIFF
--- a/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: cluster-lifecycle-controller
-    version: master-13
+    version: master-14
 spec:
   replicas: 1
   selector:
@@ -17,7 +17,7 @@ spec:
     metadata:
       labels:
         application: cluster-lifecycle-controller
-        version: master-13
+        version: master-14
     spec:
       dnsConfig:
         options:
@@ -35,7 +35,7 @@ spec:
         operator: Exists
       containers:
       - name: cluster-lifecycle-controller
-        image: registry.opensource.zalan.do/teapot/cluster-lifecycle-controller:master-13
+        image: registry.opensource.zalan.do/teapot/cluster-lifecycle-controller:master-14
         args:
             - --drain-grace-period={{.ConfigItems.drain_grace_period}}
             - --drain-min-pod-lifetime={{.ConfigItems.drain_min_pod_lifetime}}


### PR DESCRIPTION
CLC now looks for node label `node.kubernetes.io/node-pool` instead of `kubernetes.io/node-pool`.

Required for #2774 