### PR TITLE
DaemonSet pods: add an ephemeral-storage request

### DIFF
--- a/cluster/manifests/cadvisor/daemonset.yaml
+++ b/cluster/manifests/cadvisor/daemonset.yaml
@@ -40,10 +40,11 @@ spec:
         - --store_container_labels=false
         - --whitelisted_container_labels=io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace,io.kubernetes.pod.uid,application
         resources:
-          limits:
+          requests:
             cpu: "{{ .ConfigItems.cadvisor_cpu }}"
             memory: "{{ .ConfigItems.cadvisor_memory }}"
-          requests:
+            ephemeral-storage: 256Mi
+          limits:
             cpu: "{{ .ConfigItems.cadvisor_cpu }}"
             memory: "{{ .ConfigItems.cadvisor_memory }}"
         securityContext:

--- a/cluster/manifests/coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/coredns-local/daemonset-coredns.yaml
@@ -62,6 +62,8 @@ spec:
           name: dns-tcp
           protocol: TCP
         resources:
+          requests:
+            ephemeral-storage: 256Mi
           limits:
             cpu: 100m
             memory: 50Mi
@@ -88,6 +90,8 @@ spec:
           name: metrics
           protocol: TCP
         resources:
+          requests:
+            ephemeral-storage: 256Mi
           limits:
             cpu: 10m
             memory: 45Mi
@@ -123,6 +127,8 @@ spec:
           successThreshold: 1
           failureThreshold: 3
         resources:
+          requests:
+            ephemeral-storage: 256Mi
           limits:
             cpu: 50m
             memory: 100Mi

--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -40,6 +40,7 @@ spec:
           requests:
             cpu: 25m
             memory: 50Mi
+            ephemeral-storage: 256Mi
           limits:
             cpu: 25m
             memory: 50Mi
@@ -54,6 +55,7 @@ spec:
           requests:
             cpu: 25m
             memory: 25Mi
+            ephemeral-storage: 256Mi
           limits:
             cpu: 25m
             memory: 25Mi
@@ -79,10 +81,11 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         resources:
-          limits:
+          requests:
             cpu: 25m
             memory: 100Mi
-          requests:
+            ephemeral-storage: 256Mi
+          limits:
             cpu: 25m
             memory: 100Mi
         securityContext:
@@ -103,6 +106,7 @@ spec:
           requests:
             cpu: 1m
             memory: 25Mi
+            ephemeral-storage: 256Mi
           limits:
             cpu: 1m
             memory: 25Mi

--- a/cluster/manifests/kube-node-ready/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready/daemonset.yaml
@@ -46,10 +46,11 @@ spec:
           value: /meta/aws-iam/credentials.process
 {{ end }}
         resources:
-          limits:
+          requests:
             cpu: 1m
             memory: 50Mi
-          requests:
+            ephemeral-storage: 256Mi
+          limits:
             cpu: 1m
             memory: 50Mi
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -45,6 +45,7 @@ spec:
           requests:
             cpu: 50m
             memory: 200Mi
+            ephemeral-storage: 256Mi
           limits:
             cpu: 50m
             memory: 200Mi

--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -56,9 +56,10 @@ spec:
             port: 8181
           timeoutSeconds: 3
         resources:
-          limits:
+          requests:
             cpu: 25m
             memory: 100Mi
-          requests:
+            ephemeral-storage: 256Mi
+          limits:
             cpu: 25m
             memory: 100Mi

--- a/cluster/manifests/prometheus-node-exporter/daemonset.yaml
+++ b/cluster/manifests/prometheus-node-exporter/daemonset.yaml
@@ -43,10 +43,11 @@ spec:
           containerPort: 9100
           hostPort: 9100
         resources:
-          limits:
+          requests:
             cpu: {{.Cluster.ConfigItems.node_exporter_cpu}}
             memory: {{.Cluster.ConfigItems.node_exporter_memory}}
-          requests:
+            ephemeral-storage: 256Mi
+          limits:
             cpu: {{.Cluster.ConfigItems.node_exporter_cpu}}
             memory: {{.Cluster.ConfigItems.node_exporter_memory}}
         securityContext:
@@ -62,10 +63,11 @@ spec:
       - image: registry.opensource.zalan.do/teapot/prometheus-node-exporter-txt-exporter:v0.0.4
         name: prometheus-node-exporter-conntrack-exporter
         resources:
-          limits:
+          requests:
             cpu: 10m
             memory: 100Mi
-          requests:
+            ephemeral-storage: 256Mi
+          limits:
             cpu: 10m
             memory: 100Mi
         securityContext:


### PR DESCRIPTION
Kubernetes will still try to evict daemonset pods even though they're critical. Let's give them ephemeral storage that they'll never consume to prevent that.