### PR TITLE
Allow VPA to delete pods

### DIFF
--- a/cluster/manifests/01-vertical-pod-autoscaler/rbac.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/rbac.yaml
@@ -106,6 +106,12 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - pods
+    verbs:
+      - delete
+  - apiGroups:
+      - ""
+    resources:
       - pods/eviction
     verbs:
       - create


### PR DESCRIPTION
It now deletes pods when they OOM crash, so it must have the permission to do that.