### PR TITLE
Always evict on OOMs, even if the pod is not old enough

### DIFF
--- a/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
@@ -30,6 +30,8 @@ spec:
           - --v=4
           - --stderrthreshold=info
           - --min-replicas=1
+          - --pod-lifetime-update-threshold=12h
+          - --evict-after-oom-threshold=12h
         resources:
           limits:
             cpu: 200m


### PR DESCRIPTION
Currently, if the pod fails after `--evict-after-oom-threshold` (10 minutes) but before `--pod-lifetime-update-threshold`, it'll just keep running. There's no point in this, because we'd rather fix the pod instead.