### PR TITLE
Drop broken fluentd metrics from etcd servers

### DIFF
--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -90,6 +90,10 @@ data:
         - "{{ with $hostPort := splitHostPort .ConfigItems.etcd_endpoints }}{{ .Host }}{{ end }}"
         type: "A"
         port: 9100
+      metric_relabel_configs:
+       - source_labels: [ __name__ ]
+         regex: 'node_textfile.*'
+         action: drop
     - job_name: 'kubernetes-service-endpoints'
       scheme: http
       kubernetes_sd_configs:


### PR DESCRIPTION
Because of this [bug](https://github.com/prometheus/node_exporter/issues/704) there is a lot of noise generated in the remote write end points.