### PR TITLE
Prometheus VPA: limit CPU as well

### DIFF
--- a/cluster/manifests/prometheus/prometheus-vpa.yaml
+++ b/cluster/manifests/prometheus/prometheus-vpa.yaml
@@ -18,6 +18,7 @@ spec:
         cpu: {{.ConfigItems.prometheus_cpu_min}}
       maxAllowed:
   {{ with $resources := autoscalingBufferSettings .Cluster }}
-        # Set the max memory to max available on the Node
+        # Set the max CPU and memory to max available on the Node
         memory: {{$resources.Memory}}
+        cpu: {{$resources.CPU}}
   {{ end }}


### PR DESCRIPTION
Otherwise Prometheus can kick out logging-agent pods.