### PR TITLE
Enable rotation of service account tokens

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -298,6 +298,8 @@ apiserver_proxy: "true"
 # when set to true, service account tokens can be used from outside the cluster
 # requires apiserver_proxy to be set to "true"
 allow_external_service_accounts: "false"
+# issue service account tokens with expiration time.
+rotate_service_account_tokens: "false"
 
 # use kube-aws-iam-controller for kube-system components
 kube_aws_iam_controller_kube_system_enable: "true"

--- a/cluster/manifests/dashboard/deployment.yaml
+++ b/cluster/manifests/dashboard/deployment.yaml
@@ -47,3 +47,5 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 1000
+      securityContext:
+        fsGroup: 1000

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -65,6 +65,8 @@ spec:
           runAsUser: 65534
           capabilities:
             drop: ["ALL"]
+      securityContext:
+        fsGroup: 65534
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
       volumes:
       - name: aws-iam-credentials

--- a/cluster/manifests/heapster/deployment.yaml
+++ b/cluster/manifests/heapster/deployment.yaml
@@ -24,6 +24,8 @@ spec:
             value: "1"
       priorityClassName: system-cluster-critical
       serviceAccountName: heapster
+      securityContext:
+        fsGroup: 65534
       containers:
         - image: registry.opensource.zalan.do/teapot/heapster:v1.5.4
           name: heapster

--- a/cluster/manifests/kube-proxy/configmap.yaml
+++ b/cluster/manifests/kube-proxy/configmap.yaml
@@ -24,6 +24,7 @@ data:
     enableProfiling: false
     featureGates:
       TaintBasedEvictions: true
+      BoundServiceAccountTokenVolume: true
     healthzBindAddress: 0.0.0.0:10256
     hostnameOverride: ""
     iptables:

--- a/cluster/manifests/kube-proxy/configmap.yaml
+++ b/cluster/manifests/kube-proxy/configmap.yaml
@@ -24,7 +24,7 @@ data:
     enableProfiling: false
     featureGates:
       TaintBasedEvictions: true
-      BoundServiceAccountTokenVolume: true
+      BoundServiceAccountTokenVolume: {{ .Cluster.ConfigItems.rotate_service_account_tokens }}
     healthzBindAddress: 0.0.0.0:10256
     hostnameOverride: ""
     iptables:

--- a/cluster/manifests/kube-state-metrics/deployment.yaml
+++ b/cluster/manifests/kube-state-metrics/deployment.yaml
@@ -47,3 +47,5 @@ spec:
           runAsUser: 65534
           capabilities:
             drop: ["ALL"]
+      securityContext:
+        fsGroup: 65534

--- a/cluster/manifests/psp/pod_security_policy.yaml
+++ b/cluster/manifests/psp/pod_security_policy.yaml
@@ -43,3 +43,4 @@ spec:
   - persistentVolumeClaim
   - downwardAPI
   - configMap
+  - projected

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -177,6 +177,8 @@ spec:
               name: skipper-ingress
               key: lightstep-token
 {{ end }}
+      securityContext:
+        fsGroup: 1000
 {{ if eq .ConfigItems.enable_apimonitoring "true"}}
       volumes:
         - name: filters

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -44,6 +44,7 @@ write_files:
 {{- if ne .NodePool.ConfigItems.pod_max_pids "-1" }}
       featureGates:
         SupportPodPidsLimit: true
+        BoundServiceAccountTokenVolume: true
       podPidsLimit: {{ .NodePool.ConfigItems.pod_max_pids }}
 {{- end }}
       maxPods: {{ nodeCIDRMaxPods (parseInt64 .Cluster.ConfigItems.node_cidr_mask_size) 8 }}
@@ -120,7 +121,7 @@ write_files:
           - --authorization-mode=Webhook,RBAC
           - --authorization-webhook-config-file=/etc/kubernetes/config/authz.yaml
           - --admission-control-config-file=/etc/kubernetes/config/image-policy-webhook.yaml
-          - --feature-gates=TaintNodesByCondition={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},ScheduleDaemonSetPods={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},TTLAfterFinished=true,CustomResourceWebhookConversion={{.Cluster.ConfigItems.custom_resource_webhook_conversion}},CustomResourcePublishOpenAPI={{.Cluster.ConfigItems.custom_resource_publish_openapi}}
+          - --feature-gates=TaintNodesByCondition={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},ScheduleDaemonSetPods={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},TTLAfterFinished=true,CustomResourceWebhookConversion={{.Cluster.ConfigItems.custom_resource_webhook_conversion}},CustomResourcePublishOpenAPI={{.Cluster.ConfigItems.custom_resource_publish_openapi}},BoundServiceAccountTokenVolume=true
           - --anonymous-auth=false
           {{ if ne .Cluster.ConfigItems.audittrail_url "" }}
           - --audit-webhook-config-file=/etc/kubernetes/config/audit.yaml
@@ -147,6 +148,8 @@ write_files:
           - --kubelet-certificate-authority=/etc/kubernetes/ssl/ca.pem
           - --kubelet-client-certificate=/etc/kubernetes/ssl/kubelet-client.pem
           - --kubelet-client-key=/etc/kubernetes/ssl/kubelet-client-key.pem
+          - --service-account-signing-key-file=/etc/kubernetes/ssl/service-account-private-key.pem
+          - --service-account-issuer=kubernetes/serviceaccount
           livenessProbe:
             httpGet:
               host: 127.0.0.1
@@ -487,7 +490,7 @@ write_files:
           - --root-ca-file=/etc/kubernetes/ssl/ca.pem
           - --cloud-provider=aws
           - --cloud-config=/etc/kubernetes/cloud-config.ini
-          - --feature-gates=TaintNodesByCondition={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},ScheduleDaemonSetPods={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},TTLAfterFinished=true
+          - --feature-gates=TaintNodesByCondition={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},ScheduleDaemonSetPods={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},TTLAfterFinished=true,BoundServiceAccountTokenVolume=true
           - --horizontal-pod-autoscaler-use-rest-clients=true
           - --use-service-account-credentials=true
           - --configure-cloud-routes=false
@@ -550,7 +553,7 @@ write_files:
           args:
           - --master=http://127.0.0.1:8080
           - --leader-elect=true
-          - --feature-gates=TaintBasedEvictions=true,TaintNodesByCondition={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},ScheduleDaemonSetPods={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}}
+          - --feature-gates=TaintBasedEvictions=true,TaintNodesByCondition={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},ScheduleDaemonSetPods={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},BoundServiceAccountTokenVolume=true
           env:
           - name: KUBE_MAX_PD_VOLS
             value: "26"

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -41,12 +41,9 @@ write_files:
 {{- if not (index .Cluster.ConfigItems "enable_cfs_quota") }}
       cpuCFSQuota: false
 {{- end }}
-{{- if ne .NodePool.ConfigItems.pod_max_pids "-1" }}
       featureGates:
-        SupportPodPidsLimit: true
-        BoundServiceAccountTokenVolume: true
+        BoundServiceAccountTokenVolume: {{ .Cluster.ConfigItems.rotate_service_account_tokens }}
       podPidsLimit: {{ .NodePool.ConfigItems.pod_max_pids }}
-{{- end }}
       maxPods: {{ nodeCIDRMaxPods (parseInt64 .Cluster.ConfigItems.node_cidr_mask_size) 8 }}
       healthzPort: 10248
       healthzBindAddress: "0.0.0.0"
@@ -121,8 +118,12 @@ write_files:
           - --authorization-mode=Webhook,RBAC
           - --authorization-webhook-config-file=/etc/kubernetes/config/authz.yaml
           - --admission-control-config-file=/etc/kubernetes/config/image-policy-webhook.yaml
-          - --feature-gates=TaintNodesByCondition={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},ScheduleDaemonSetPods={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},TTLAfterFinished=true,CustomResourceWebhookConversion={{.Cluster.ConfigItems.custom_resource_webhook_conversion}},CustomResourcePublishOpenAPI={{.Cluster.ConfigItems.custom_resource_publish_openapi}},BoundServiceAccountTokenVolume=true
+          - --feature-gates=TaintNodesByCondition={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},ScheduleDaemonSetPods={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},TTLAfterFinished=true,CustomResourceWebhookConversion={{.Cluster.ConfigItems.custom_resource_webhook_conversion}},CustomResourcePublishOpenAPI={{.Cluster.ConfigItems.custom_resource_publish_openapi}},BoundServiceAccountTokenVolume={{ .Cluster.ConfigItems.rotate_service_account_tokens }}
           - --anonymous-auth=false
+          {{- if eq .Cluster.ConfigItems.rotate_service_account_tokens "true" }}
+          - --service-account-signing-key-file=/etc/kubernetes/ssl/service-account-private-key.pem
+          - --service-account-issuer=kubernetes/serviceaccount
+          {{- end }}
           {{ if ne .Cluster.ConfigItems.audittrail_url "" }}
           - --audit-webhook-config-file=/etc/kubernetes/config/audit.yaml
           - --audit-webhook-mode=batch
@@ -148,8 +149,6 @@ write_files:
           - --kubelet-certificate-authority=/etc/kubernetes/ssl/ca.pem
           - --kubelet-client-certificate=/etc/kubernetes/ssl/kubelet-client.pem
           - --kubelet-client-key=/etc/kubernetes/ssl/kubelet-client-key.pem
-          - --service-account-signing-key-file=/etc/kubernetes/ssl/service-account-private-key.pem
-          - --service-account-issuer=kubernetes/serviceaccount
           livenessProbe:
             httpGet:
               host: 127.0.0.1
@@ -484,14 +483,13 @@ write_files:
         - name: kube-controller-manager
           image: nonexistent.zalan.do/teapot/kube-controller-manager:fixed
           args:
-          - --controllers=*,-serviceaccount-token
           - --kubeconfig=/etc/kubernetes/controller-kubeconfig
           - --leader-elect=true
           - --service-account-private-key-file=/etc/kubernetes/ssl/service-account-private-key.pem
           - --root-ca-file=/etc/kubernetes/ssl/ca.pem
           - --cloud-provider=aws
           - --cloud-config=/etc/kubernetes/cloud-config.ini
-          - --feature-gates=TaintNodesByCondition={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},ScheduleDaemonSetPods={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},TTLAfterFinished=true,BoundServiceAccountTokenVolume=true
+          - --feature-gates=TaintNodesByCondition={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},ScheduleDaemonSetPods={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},TTLAfterFinished=true,BoundServiceAccountTokenVolume={{ .Cluster.ConfigItems.rotate_service_account_tokens }}
           - --horizontal-pod-autoscaler-use-rest-clients=true
           - --use-service-account-credentials=true
           - --configure-cloud-routes=false
@@ -554,7 +552,7 @@ write_files:
           args:
           - --master=http://127.0.0.1:8080
           - --leader-elect=true
-          - --feature-gates=TaintBasedEvictions=true,TaintNodesByCondition={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},ScheduleDaemonSetPods={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},BoundServiceAccountTokenVolume=true
+          - --feature-gates=TaintBasedEvictions=true,TaintNodesByCondition={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},ScheduleDaemonSetPods={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},BoundServiceAccountTokenVolume={{ .Cluster.ConfigItems.rotate_service_account_tokens }}
           env:
           - name: KUBE_MAX_PD_VOLS
             value: "26"

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -484,6 +484,7 @@ write_files:
         - name: kube-controller-manager
           image: nonexistent.zalan.do/teapot/kube-controller-manager:fixed
           args:
+          - --controllers=*,-serviceaccount-token
           - --kubeconfig=/etc/kubernetes/controller-kubeconfig
           - --leader-elect=true
           - --service-account-private-key-file=/etc/kubernetes/ssl/service-account-private-key.pem

--- a/cluster/node-pools/worker-default/userdata.yaml
+++ b/cluster/node-pools/worker-default/userdata.yaml
@@ -51,12 +51,9 @@ write_files:
       kind: KubeletConfiguration
       clusterDomain: cluster.local
       cpuCFSQuota: false
-{{- if ne .NodePool.ConfigItems.pod_max_pids "-1" }}
       featureGates:
-        SupportPodPidsLimit: true
-        BoundServiceAccountTokenVolume: true
+        BoundServiceAccountTokenVolume: {{ .Cluster.ConfigItems.rotate_service_account_tokens }}
       podPidsLimit: {{ .NodePool.ConfigItems.pod_max_pids }}
-{{- end }}
       cpuManagerPolicy: {{ .NodePool.ConfigItems.cpu_manager_policy }}
       maxPods: {{ nodeCIDRMaxPods (parseInt64 .Cluster.ConfigItems.node_cidr_mask_size) 0 }}
       healthzPort: 10248

--- a/cluster/node-pools/worker-default/userdata.yaml
+++ b/cluster/node-pools/worker-default/userdata.yaml
@@ -52,7 +52,10 @@ write_files:
       clusterDomain: cluster.local
       cpuCFSQuota: false
       featureGates:
+        SupportPodPidsLimit: true
+{{- if eq .Cluster.ConfigItems.rotate_service_account_tokens "true" }}
         BoundServiceAccountTokenVolume: {{ .Cluster.ConfigItems.rotate_service_account_tokens }}
+{{- end }}
       podPidsLimit: {{ .NodePool.ConfigItems.pod_max_pids }}
       cpuManagerPolicy: {{ .NodePool.ConfigItems.cpu_manager_policy }}
       maxPods: {{ nodeCIDRMaxPods (parseInt64 .Cluster.ConfigItems.node_cidr_mask_size) 0 }}

--- a/cluster/node-pools/worker-default/userdata.yaml
+++ b/cluster/node-pools/worker-default/userdata.yaml
@@ -54,6 +54,7 @@ write_files:
 {{- if ne .NodePool.ConfigItems.pod_max_pids "-1" }}
       featureGates:
         SupportPodPidsLimit: true
+        BoundServiceAccountTokenVolume: true
       podPidsLimit: {{ .NodePool.ConfigItems.pod_max_pids }}
 {{- end }}
       cpuManagerPolicy: {{ .NodePool.ConfigItems.cpu_manager_policy }}


### PR DESCRIPTION
Adds timestamps to `ServiceAccountTokens` so that they can be rejected by the API server when they have been expired (via `iat`, `exp` and `nbf` fields). Tokens will also be rejected once the corresponding Pod terminates.

`exp`: expires at
`iat`: issued at
`nbf`: not valid before (equals issued at)

```json
# JWT header
# ...
# JWT payload
{
  "aud": [
    "kubernetes/serviceaccount"
  ],
  "exp": 1578415862,
  "iat": 1578412262,
  "iss": "kubernetes/serviceaccount",
  "kubernetes.io": {
    "namespace": "kapp",
    "pod": {
      "name": "chaoskube-56967cd969-bcmht",
      "uid": "feaf2cc8-ff62-4681-a92a-f25f96a6beff"
    },
    "serviceaccount": {
      "name": "chaoskube",
      "uid": "d1a29604-36f2-4c90-94e8-d7886353e2f9"
    }
  },
  "nbf": 1578412262,
  "sub": "system:serviceaccount:kapp:chaoskube"
}
# JWT signature
# ...
```

Like before Kubernetes injects ServiceAccountToken mounts into the Pod but they look different now.

```yaml
  # PodSpec
  # ...
  # following is injected into each pod
  volumes:
  - name: kube-api-access-7nxqz
    projected:
      defaultMode: 420
      sources:
      - serviceAccountToken:
          expirationSeconds: 3600
          path: token
      - configMap:
          items:
          - key: ca.crt
            path: ca.crt
          name: kube-root-ca.crt
      - downwardAPI:
          items:
          - fieldRef:
              apiVersion: v1
              fieldPath: metadata.namespace
            path: namespace
```

The feature uses `projected` volumes under the hood. With this it's possible to retain the original filesystem structure which is three files that are now gathered from different sources.

```console
ls /var/run/secrets/kubernetes.io/serviceaccount/
ca.crt     namespace  token
```

Instead of a ServiceAccount secret with three entries the following is used:

`namespace`: via downward API
`ca.crt`: a shared configmap containing only the root cert of the cluster
`token`: new volume type `serviceAccountToken` that provides an expiring token

Currently, the "old" secret still exists and contains a non-expiring ServiceAccountToken which still gets accepted by the API server.

The only different for clients is the requirement to reload refreshed tokens from the filesystem before they expire.

Part of: https://github.bus.zalan.do/teapot/issues/issues/1993

Todo:
- [ ] prevent issue of "old" service account secrets (`--controllers` flag on controller manager)
- [ ] test how clients behave when the token gets refreshed (recent `client-go` works fine)
- [ ] cleanup
- [ ] probably: find a way to opt-out individual pods to ease migration efforts
- [ ] optional: open-up external access for service account tokens again

In order for non-root applications to read the credentials you might need to add the following to your pod spec. This requirement might go away in future versions. Also see [here](https://github.com/kubernetes-sigs/external-dns/pull/1185#issuecomment-531678363).

```yaml
      securityContext:
        fsGroup: 65534
```

Original feature issue: https://github.com/kubernetes/kubernetes/issues/70679