### PR TITLE
Update audittrail-adapter to work with v1 audit events instead of v1beta1 [1/2]

### DIFF
--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     application: audittrail-adapter
-    version: master-23
+    version: master-24
 spec:
   selector:
     matchLabels:
@@ -17,7 +17,7 @@ spec:
     metadata:
       labels:
         application: audittrail-adapter
-        version: master-23
+        version: master-24
     spec:
       serviceAccountName: audittrail-adapter
       priorityClassName: system-node-critical
@@ -31,7 +31,7 @@ spec:
       hostNetwork: true
       containers:
       - name: audittrail-adapter
-        image: pierone.stups.zalan.do/teapot/audittrail-adapter:master-23
+        image: pierone.stups.zalan.do/teapot/audittrail-adapter:master-24
         env:
           - name: AWS_REGION
             value: {{.Cluster.Region}}


### PR DESCRIPTION
This updates the audittrail-adapter to internally work with `v1` audit events instead of `v1beta1`.

The purpose of this change is simply to stay up to date.

This is the first out of two steps, in the second step we need to switch the APIserver to send events in `v1` format: https://github.com/zalando-incubator/kubernetes-on-aws/blob/186e218a6b401500629fd9ab214ab0e2823136d1/cluster/node-pools/master-default/userdata.yaml#L128

The adapter can understand the `v1beta1` events from the API server, so it's fine to have different versions during the migration, it just doesn't work the other way around hence this: https://github.com/zalando-incubator/kubernetes-on-aws/pull/2086