### PR TITLE
Switch APIServer to audit v1 events

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -131,7 +131,7 @@ write_files:
           {{ if and (ne .Cluster.ConfigItems.audittrail_url "") (ne .Cluster.Environment "e2e") }}
           - --audit-webhook-config-file=/etc/kubernetes/config/audit.yaml
           - --audit-webhook-mode=batch
-          - --audit-webhook-version=audit.k8s.io/v1beta1
+          - --audit-webhook-version=audit.k8s.io/v1
           - --audit-policy-file=/etc/kubernetes/config/audit-policy.yaml
           {{ end }}
           {{ if eq .Cluster.Environment "e2e" }}


### PR DESCRIPTION
Depends on https://github.com/zalando-incubator/kubernetes-on-aws/pull/2844 being rolled.