### PR TITLE
Use the correct numbers for ephemeral storage in template nodes

### DIFF
--- a/cluster/node-pools/worker-default/stack.yaml
+++ b/cluster/node-pools/worker-default/stack.yaml
@@ -77,6 +77,7 @@ Resources:
         Value: {{if .NodePool.IsSpot }}true{{else}}false{{end}}
       - Key: k8s.io/cluster-autoscaler/node-template/resources/ephemeral-storage
         PropagateAtLaunch: false
+        # 40Gi for EBS storage or 95% of instance storage
         Value: "$data.NodePool.AvailableStorage 42949672960 0.95"
       - Key: k8s.io/cluster-autoscaler/node-template/label/zalando.org/scaling-priority
         PropagateAtLaunch: true

--- a/cluster/node-pools/worker-default/stack.yaml
+++ b/cluster/node-pools/worker-default/stack.yaml
@@ -18,7 +18,7 @@ Resources:
 {{ if gt (len .NodePool.InstanceTypes) 1 }}
       MixedInstancesPolicy:
         InstancesDistribution:
-          OnDemandPercentageAboveBaseCapacity: {{if or (eq .NodePool.DiscountStrategy "spot") (eq .NodePool.DiscountStrategy "spot_max_price")}}0{{else}}100{{end}}
+          OnDemandPercentageAboveBaseCapacity: {{if .NodePool.IsSpot }}0{{else}}100{{end}}
           SpotAllocationStrategy: capacity-optimized
         LaunchTemplate:
           LaunchTemplateSpecification:
@@ -74,7 +74,7 @@ Resources:
         Value: ready
       - Key: k8s.io/cluster-autoscaler/node-template/label/aws.amazon.com/spot
         PropagateAtLaunch: true
-        Value: {{if or (eq .NodePool.DiscountStrategy "spot") (eq .NodePool.DiscountStrategy "spot_max_price")}}true{{else}}false{{end}}
+        Value: {{if .NodePool.IsSpot }}true{{else}}false{{end}}
       - Key: k8s.io/cluster-autoscaler/node-template/resources/ephemeral-storage
         PropagateAtLaunch: false
         Value: "$data.NodePool.AvailableStorage 42949672960 0.95"
@@ -82,7 +82,7 @@ Resources:
         PropagateAtLaunch: true
 {{- if index .NodePool.ConfigItems "scaling_priority" }}
         Value: "{{ .NodePool.ConfigItems.scaling_priority }}"
-{{- else if or (eq .NodePool.DiscountStrategy "spot") (eq .NodePool.DiscountStrategy "spot_max_price") }}
+{{- else if .NodePool.IsSpot  }}
         Value: "1000"
 {{- else }}
         Value: "0"
@@ -132,7 +132,7 @@ Resources:
         - !Ref 'AWS::Region'
         - MachineImage
         InstanceType: "{{ index .NodePool.InstanceTypes 0 }}"
-{{- if and (or (eq .NodePool.DiscountStrategy "spot") (eq .NodePool.DiscountStrategy "spot_max_price")) (eq (len .NodePool.InstanceTypes) 1) }}
+{{- if and .NodePool.IsSpot (eq (len .NodePool.InstanceTypes) 1) }}
         InstanceMarketOptions:
           MarketType: spot
 {{ end }}

--- a/cluster/node-pools/worker-default/stack.yaml
+++ b/cluster/node-pools/worker-default/stack.yaml
@@ -77,7 +77,7 @@ Resources:
         Value: {{if or (eq .NodePool.DiscountStrategy "spot") (eq .NodePool.DiscountStrategy "spot_max_price")}}true{{else}}false{{end}}
       - Key: k8s.io/cluster-autoscaler/node-template/resources/ephemeral-storage
         PropagateAtLaunch: false
-        Value: "30Gi"
+        Value: "$data.NodePool.AvailableStorage 42949672960 0.95"
       - Key: k8s.io/cluster-autoscaler/node-template/label/zalando.org/scaling-priority
         PropagateAtLaunch: true
 {{- if index .NodePool.ConfigItems "scaling_priority" }}

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -81,7 +81,7 @@ Resources:
         Value: {{if or (eq $data.NodePool.DiscountStrategy "spot") (eq $data.NodePool.DiscountStrategy "spot_max_price")}}true{{else}}false{{end}}
       - Key: k8s.io/cluster-autoscaler/node-template/resources/ephemeral-storage
         PropagateAtLaunch: false
-        Value: "30Gi"
+        Value: "{{ $data.NodePool.AvailableStorage 42949672960 0.95 }}"
       - Key: k8s.io/cluster-autoscaler/node-template/label/zalando.org/scaling-priority
         PropagateAtLaunch: true
 {{- if index $data.NodePool.ConfigItems "scaling_priority" }}

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -22,7 +22,7 @@ Resources:
 {{ if gt (len $data.NodePool.InstanceTypes) 1 }}
       MixedInstancesPolicy:
         InstancesDistribution:
-          OnDemandPercentageAboveBaseCapacity: {{if or (eq $data.NodePool.DiscountStrategy "spot") (eq $data.NodePool.DiscountStrategy "spot_max_price")}}0{{else}}100{{end}}
+          OnDemandPercentageAboveBaseCapacity: {{if $data.NodePool.IsSpot }}0{{else}}100{{end}}
           SpotAllocationStrategy: capacity-optimized
         LaunchTemplate:
           LaunchTemplateSpecification:
@@ -78,7 +78,7 @@ Resources:
         Value: ready
       - Key: k8s.io/cluster-autoscaler/node-template/label/aws.amazon.com/spot
         PropagateAtLaunch: true
-        Value: {{if or (eq $data.NodePool.DiscountStrategy "spot") (eq $data.NodePool.DiscountStrategy "spot_max_price")}}true{{else}}false{{end}}
+        Value: {{if $data.NodePool.IsSpot }}true{{else}}false{{end}}
       - Key: k8s.io/cluster-autoscaler/node-template/resources/ephemeral-storage
         PropagateAtLaunch: false
         Value: "{{ $data.NodePool.AvailableStorage 42949672960 0.95 }}"
@@ -86,7 +86,7 @@ Resources:
         PropagateAtLaunch: true
 {{- if index $data.NodePool.ConfigItems "scaling_priority" }}
         Value: "{{ $data.NodePool.ConfigItems.scaling_priority }}"
-{{- else if or (eq $data.NodePool.DiscountStrategy "spot") (eq $data.NodePool.DiscountStrategy "spot_max_price") }}
+{{- else if $data.NodePool.IsSpot }}
         Value: "1000"
 {{- else }}
         Value: "0"
@@ -142,7 +142,7 @@ Resources:
         - !Ref 'AWS::Region'
         - MachineImage
         InstanceType: "{{ index .NodePool.InstanceTypes 0 }}"
-{{- if and (or (eq .NodePool.DiscountStrategy "spot") (eq .NodePool.DiscountStrategy "spot_max_price")) (eq (len $data.NodePool.InstanceTypes) 1) }}
+{{- if and $data.NodePool.IsSpot (eq (len $data.NodePool.InstanceTypes) 1) }}
         InstanceMarketOptions:
           MarketType: spot
 {{ end }}

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -81,6 +81,7 @@ Resources:
         Value: {{if $data.NodePool.IsSpot }}true{{else}}false{{end}}
       - Key: k8s.io/cluster-autoscaler/node-template/resources/ephemeral-storage
         PropagateAtLaunch: false
+        # 40Gi for EBS storage or 95% of instance storage
         Value: "{{ $data.NodePool.AvailableStorage 42949672960 0.95 }}"
       - Key: k8s.io/cluster-autoscaler/node-template/label/zalando.org/scaling-priority
         PropagateAtLaunch: true


### PR DESCRIPTION
Instead of just hardcoding 30Gi for `ephemeral-storage`, use a reasonable estimate based on the instance types used in the pool. Related CLM change: https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/231.

Additionally, simplify the templates by using `IsSpot()` function instead of duplicating the logic.