### PR TITLE
Admission controller: new policy for pod-managing resources

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -209,16 +209,13 @@ teapot_admission_controller_deployment_default_max_unavailable: "1"
 
 {{if eq .Environment "production"}}
 teapot_admission_controller_validate_application_label: "true"
-teapot_admission_controller_resource_cutoff_timestamp: "2019-07-08T22:00:00Z"
-teapot_admission_controller_resource_validate_redeployments: "true"
+teapot_admission_controller_validate_pod_template_resources: "true"
 {{else if eq .Environment "e2e"}}
 teapot_admission_controller_validate_application_label: "false"
-teapot_admission_controller_resource_cutoff_timestamp: ""
-teapot_admission_controller_resource_validate_redeployments: "false"
+teapot_admission_controller_validate_pod_template_resources: "false"
 {{else}}
 teapot_admission_controller_validate_application_label: "false"
-teapot_admission_controller_resource_cutoff_timestamp: "2019-07-08T22:00:00Z"
-teapot_admission_controller_resource_validate_redeployments: "true"
+teapot_admission_controller_validate_pod_template_resources: "true"
 {{end}}
 
 {{if eq .Environment "e2e"}}

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -172,7 +172,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-51
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-53
           name: admission-controller
           readinessProbe:
             httpGet:
@@ -214,9 +214,8 @@ write_files:
             - --validate-application-label-min-creation-time={{ .Cluster.ConfigItems.teapot_admission_controller_application_min_creation_time }}
             - --application-registry-url=http://127.0.0.1:8285/
 {{- end }}
-            - --resource-cutoff-timestamp={{ .Cluster.ConfigItems.teapot_admission_controller_resource_cutoff_timestamp }}
-{{- if eq .Cluster.ConfigItems.teapot_admission_controller_resource_validate_redeployments "true" }}
-            - --resource-validate-redeployments
+{{- if eq .Cluster.ConfigItems.teapot_admission_controller_validate_pod_template_resources "true" }}
+            - --validate-pod-template-resources
 {{- end }}
             - --deployment-rolling-update-default-max-surge={{ .Cluster.ConfigItems.teapot_admission_controller_deployment_default_max_surge }}
             - --deployment-rolling-update-default-max-unavailable={{ .Cluster.ConfigItems.teapot_admission_controller_deployment_default_max_unavailable }}


### PR DESCRIPTION
* Update admission controller to the latest version:
  * Support for `--resource-cutoff-timestamp`, `--resource-validate-redeployments` removed. Resources are always checked unless `--validate-pod-template-resources` is disabled.
  * Application labels are validated if the application is being redeployed as well, drop support for grandfathering.
* Drop support for `teapot_admission_controller_resource_validate_redeployments` config item, add `teapot_admission_controller_validate_pod_template_resources` instead. The only cluster where this was used was updated.