### PR TITLE
Revert "Revert "RBAC: rollout [2/2]""

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -311,3 +311,8 @@ custom_dns_zone_nameservers: "" # space seperated list of nameserver IP addresse
 
 # prefix prepended to ownership TXT records for external-dns
 external_dns_ownership_prefix: ""
+
+# enable legacy serviceaccounts for smooth RBAC migration
+enable_operator_sa: "false"
+enable_default_sa: "false"
+enable_cdp_sa: "false"

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -22,3 +22,9 @@ post_apply:
 - name: ingress-template-controller
   kind: ClusterRoleBinding
 {{ end }}
+- name: poweruser-new
+  kind: ClusterRoleBinding
+- name: readonly-new
+  kind: ClusterRoleBinding
+- name: zmon-external-new
+  kind: ClusterRoleBinding

--- a/cluster/manifests/roles/poweruser-binding.yaml
+++ b/cluster/manifests/roles/poweruser-binding.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: poweruser-new # TODO: migrate name
+  name: poweruser
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/cluster/manifests/roles/poweruser-role.yaml
+++ b/cluster/manifests/roles/poweruser-role.yaml
@@ -838,3 +838,18 @@ rules:
   - create
   - update
   - patch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/cluster/manifests/roles/readonly-binding.yaml
+++ b/cluster/manifests/roles/readonly-binding.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: readonly-new # TODO: migrate name
+  name: readonly
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/cluster/manifests/roles/zmon-binding.yaml
+++ b/cluster/manifests/roles/zmon-binding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: zmon-external-new
+  name: zmon-external
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -227,7 +227,7 @@ write_files:
             - mountPath: /etc/kubernetes/ssl
               name: ssl-certs-kubernetes
               readOnly: true
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.7.1
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.7.2
           name: webhook
           ports:
           - containerPort: 8081
@@ -282,6 +282,7 @@ write_files:
 {{ if eq .Cluster.ConfigItems.enable_cdp_sa "true"}}
             - --enable-cdp-sa
 {{ end }}
+            - --system-users=zalando-iam:zalando:service:credentials-provider
           env:
             - name: TEAMS_API_URL
               value: https://teams.auth.zalando.com

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -227,7 +227,7 @@ write_files:
             - mountPath: /etc/kubernetes/ssl
               name: ssl-certs-kubernetes
               readOnly: true
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.7.0
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.7.1
           name: webhook
           ports:
           - containerPort: 8081
@@ -272,7 +272,16 @@ write_files:
             - --role-mapping=PowerUser=cn=PowerUser,ou={{.Cluster.ID}},ou=Kubernetes,ou=apps,dc=zalando,dc=net
 {{- end }}
             - --role-mapping=ReadOnly=cn=ReadOnly,ou={{.Cluster.ID}},ou=Kubernetes,ou=apps,dc=zalando,dc=net
-
+            # enable legacy serviceaccounts for smooth RBAC migration
+{{ if eq .Cluster.ConfigItems.enable_operator_sa "true"}}
+            - --enable-operator-sa
+{{ end }}
+{{ if eq .Cluster.ConfigItems.enable_default_sa "true"}}
+            - --enable-default-sa
+{{ end }}
+{{ if eq .Cluster.ConfigItems.enable_cdp_sa "true"}}
+            - --enable-cdp-sa
+{{ end }}
           env:
             - name: TEAMS_API_URL
               value: https://teams.auth.zalando.com

--- a/test/e2e/authorisation_test.go
+++ b/test/e2e/authorisation_test.go
@@ -2686,6 +2686,62 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				}}`,
 				},
 			},
+			{
+				msg: "system user (credentials-provider) should be allowed get secrets in kube-system.",
+				reqBody: `{
+					"apiVersion": "authorization.k8s.io/v1beta1",
+					"kind": "SubjectAccessReview",
+					"spec": {
+					"resourceAttributes": {
+						"namespace": "kube-system",
+						"verb": "get",
+						"group": "",
+						"resource": "secrets"
+					},
+					"user": "zalando-iam:zalando:service:credentials-provider",
+					"group": []
+					}
+				}`,
+				expect: expect{
+					status: http.StatusCreated,
+					body: `{
+						"apiVersion": "authorization.k8s.io/v1beta1",
+						"kind": "SubjectAccessReview",
+						"status": {
+							"allowed": true
+						}
+				}}`,
+				},
+			},
+			{
+				msg: "non system user (cdp-controller) should NOT be allowed get secrets in kube-system.",
+				reqBody: `{
+					"apiVersion": "authorization.k8s.io/v1beta1",
+					"kind": "SubjectAccessReview",
+					"spec": {
+					"resourceAttributes": {
+						"namespace": "kube-system",
+						"verb": "get",
+						"group": "",
+						"resource": "secrets"
+					},
+					"user": "zalando-iam:zalando:service:credprov-cdp-controller-cluster-token",
+					"group": []
+					}
+				}`,
+				expect: expect{
+					status: http.StatusCreated,
+					body: `{
+						"apiVersion": "authorization.k8s.io/v1beta1",
+						"kind": "SubjectAccessReview",
+						"status": {
+							"allowed": false,
+							"denied": true,
+							"reason":"unauthorized access to system namespace by zalando-iam:zalando:service:credprov-cdp-controller-cluster-token/[]"
+						}
+				}}`,
+				},
+			},
 		} {
 
 			By(ti.msg)

--- a/test/e2e/authorisation_test.go
+++ b/test/e2e/authorisation_test.go
@@ -22,7 +22,6 @@ type expect struct {
 const (
 	authzAPIVersion          = "authorization.k8s.io/v1beta1"
 	authorizeMessageKind     = "SubjectAccessReview"
-	administratorGroup       = "Administrator"
 	systemMastersGroup       = "system:masters"
 	operatorGroup            = "Operator"
 	powerUserGroup           = "PowerUser"
@@ -30,7 +29,6 @@ const (
 	manualGroup              = "Manual"
 	controllerGroup          = "ControllerUser"
 	readOnlyGroup            = "ReadOnly"
-	billingGroup             = "Billing"
 	portForwardPodNamePrefix = "port-forward-"
 	systemNamespace          = "kube-system"
 	accessReviewURL          = "/apis/authorization.k8s.io/v1beta1/subjectaccessreviews"
@@ -73,13 +71,13 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"spec": {
 					"resourceAttributes": {
 						"namespace": "teapot",
-						"verb": "GET",
-						"group": "*",
+						"verb": "get",
+						"group": "",
 						"resource": "pods"
 					},
 					"user": "kubelet",
 					"group": [
-						"Administrator"
+						"system:masters"
 					]
 					}
 				}`,
@@ -94,7 +92,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				}}`,
 				},
 			}, {
-				msg: "kube-system default account can update daemonset status",
+				msg: "kube-system daemonset-controller service account can update daemonset status",
 				reqBody: `{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
@@ -107,7 +105,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"subresource": "status"
 					},
 					"user": "system:serviceaccount:kube-system:daemon-set-controller",
-					"group": []
+					"group": ["system:serviceaccounts:kube-system"]
 					}
 				}`,
 				expect: expect{
@@ -134,7 +132,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"subresource": "finalizers"
 					},
 					"user": "system:serviceaccount:kube-system:daemon-set-controller",
-					"group": []
+					"group": ["system:serviceaccounts:kube-system"]
 					}
 				}`,
 				expect: expect{
@@ -148,32 +146,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				}}`,
 				},
 			}, {
-				msg: "kube-system default account can list podtemplates",
-				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"spec": {
-					"resourceAttributes": {
-						"namespace": "kube-system",
-						"verb": "list",
-						"resource": "podtemplates"
-					},
-					"user": "system:serviceaccount:kube-system:default",
-					"group": []
-					}
-				}`,
-				expect: expect{
-					status: http.StatusCreated,
-					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"status": {
-						"allowed": true
-					}
-				}}`,
-				},
-			}, {
-				msg: "default account in default namespace can list statefulsets",
+				msg: "default account in default namespace can not list statefulsets",
 				reqBody: `{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
@@ -193,12 +166,12 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": true
+						"allowed": false
 					}
 				}}`,
 				},
 			}, {
-				msg: "default account in non-default namespace can list statefulsets",
+				msg: "default account in non-default namespace can not list statefulsets",
 				reqBody: `{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
@@ -218,7 +191,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": true
+						"allowed": false
 					}
 				}}`,
 				},
@@ -238,7 +211,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"user": "sszuecs",
 					"group": [
 						"ReadOnly",
-						"Administrator",
+						"system:masters",
 						"system:authenticated"
 					]
 					}
@@ -261,8 +234,8 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"spec": {
 					"resourceAttributes": {
 						"namespace": "teapot",
-						"verb": "GET",
-						"group": "*",
+						"verb": "get",
+						"group": "",
 						"resource": "pods"
 					},
 					"user": "rdifazio",
@@ -291,7 +264,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "teapot",
 						"verb": "list",
-						"group": "*",
+						"group": "",
 						"resource": "pods"
 					},
 					"user": "rdifazio",
@@ -346,7 +319,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"name": "privileged",
 						"namespace": "",
 						"verb": "use",
-						"group": "*",
+						"group": "extensions",
 						"resource": "podsecuritypolicies"
 					},
 					"user": "sszuecs",
@@ -367,36 +340,6 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				}}`, readOnlyGroup),
 				},
 			}, {
-				msg: "ReadOnly role should give port-forward access to the 'port-forward-' pod in kube-system namespace",
-				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-						"spec": {
-						"resourceAttributes": {
-							"name": "port-forward-abc",
-							"namespace": "kube-system",
-							"verb": "create",
-							"group": "*",
-							"resource": "pods",
-							"subresource": "portforward"
-						},
-						"user": "read-only-user",
-						"group": [
-							"%s"
-						]
-					}
-				}`, readOnlyGroup),
-				expect: expect{
-					status: http.StatusCreated,
-					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"status": {
-						"allowed": true
-					}
-				}}`,
-				},
-			}, {
 				msg: "ReadOnly role should not give port-forward access to the 'port-forward-' pod in default namespace",
 				reqBody: fmt.Sprintf(`{
 					"apiVersion": "authorization.k8s.io/v1beta1",
@@ -406,7 +349,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 							"name": "port-forward-abc",
 							"namespace": "default",
 							"verb": "create",
-							"group": "*",
+							"group": "",
 							"resource": "pods",
 							"subresource": "portforward"
 						},
@@ -467,7 +410,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 							"name": "restricted",
 							"namespace": "",
 							"verb": "use",
-							"group": "*",
+							"group": "extensions",
 							"resource": "podsecuritypolicies"
 						},
 						"user": "sszuecs",
@@ -499,7 +442,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"name": "restricted",
 						"namespace": "",
 						"verb": "use",
-						"group": "*",
+						"group": "extensions",
 						"resource": "podsecuritypolicies"
 					},
 					"user": "sszuecs",
@@ -531,7 +474,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"name": "restricted",
 						"namespace": "",
 						"verb": "use",
-						"group": "*",
+						"group": "extensions",
 						"resource": "podsecuritypolicies"
 					},
 					"user": "sszuecs",
@@ -552,38 +495,39 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				},
 			},
 
-			//- poweruser can not use privileged PSP
-			{
-				msg: "access to use privileged PodSecurityPolicy for PowerUser should not be allowed",
-				reqBody: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"spec": {
-					"resourceAttributes": {
-						"name": "privileged",
-						"namespace": "",
-						"verb": "use",
-						"group": "*",
-						"resource": "podsecuritypolicies"
-					},
-					"user": "sszuecs",
-					"group": [
-						"%s"
-					]
-					}
-				}`, powerUserGroup),
-				expect: expect{
-					status: http.StatusCreated,
-					body: fmt.Sprintf(`{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"status": {
-						"allowed": false,
-						"reason":"unauthorized access sszuecs/[%s]"
-					}
-				}}`, powerUserGroup),
-				},
-			},
+			////- poweruser can not use privileged PSP
+			//// TODO: disable privileged PSP access for PowerUsers.
+			//{
+			//	msg: "access to use privileged PodSecurityPolicy for PowerUser should not be allowed",
+			//	reqBody: fmt.Sprintf(`{
+			//		"apiVersion": "authorization.k8s.io/v1beta1",
+			//		"kind": "SubjectAccessReview",
+			//		"spec": {
+			//		"resourceAttributes": {
+			//			"name": "privileged",
+			//			"namespace": "",
+			//			"verb": "use",
+			//			"group": "extensions",
+			//			"resource": "podsecuritypolicies"
+			//		},
+			//		"user": "sszuecs",
+			//		"group": [
+			//			"%s"
+			//		]
+			//		}
+			//	}`, powerUserGroup),
+			//	expect: expect{
+			//		status: http.StatusCreated,
+			//		body: fmt.Sprintf(`{
+			//		"apiVersion": "authorization.k8s.io/v1beta1",
+			//		"kind": "SubjectAccessReview",
+			//		"status": {
+			//			"allowed": false,
+			//			"reason":"unauthorized access sszuecs/[%s]"
+			//		}
+			//	}}`, powerUserGroup),
+			//	},
+			//},
 
 			//- poweruser has read access to kube system
 			{
@@ -594,8 +538,8 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"spec": {
 					"resourceAttributes": {
 						"namespace": "kube-system",
-						"verb": "GET",
-						"group": "*",
+						"verb": "get",
+						"group": "",
 						"resource": "pods"
 					},
 					"user": "rdifazio",
@@ -625,8 +569,8 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"spec": {
 					"resourceAttributes": {
 						"namespace": "kube-system",
-						"verb": "GET",
-						"group": "*",
+						"verb": "get",
+						"group": "",
 						"resource": "secrets"
 					},
 					"user": "sszuecs",
@@ -658,8 +602,8 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"spec": {
 					"resourceAttributes": {
 						"namespace": "teapot",
-						"verb": "GET",
-						"group": "*",
+						"verb": "get",
+						"group": "",
 						"resource": "secrets"
 					},
 					"user": "sszuecs",
@@ -690,8 +634,8 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "teapot",
 						"verb": "create",
-						"group": "*",
-						"resource": "pods"
+						"group": "",
+						"resource": "secrets"
 					},
 					"user": "sszuecs",
 					"group": [
@@ -721,8 +665,9 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"spec": {
 					"resourceAttributes": {
 						"namespace": "teapot",
-						"verb": "proxy",
-						"group": "*"
+						"verb": "create",
+						"group": "",
+						"resource": "pods/proxy"
 					},
 					"user": "sszuecs",
 					"group": [
@@ -751,7 +696,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "teapot",
 						"verb": "create",
-						"group": "*",
+						"group": "",
 						"resource": "daemonsets"
 					},
 					"user": "sszuecs",
@@ -766,9 +711,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": false,
-						"denied": true,
-						"reason":"unauthorized non read access to daemonsets: sszuecs/[PowerUser]"
+						"allowed": false
 					}
 				}}`,
 				},
@@ -783,7 +726,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "teapot",
 						"verb": "update",
-						"group": "*",
+						"group": "apps",
 						"resource": "daemonsets"
 					},
 					"user": "sszuecs",
@@ -798,9 +741,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": false,
-						"denied": true,
-						"reason":"unauthorized non read access to daemonsets: sszuecs/[PowerUser]"
+						"allowed": false
 					}
 				}}`,
 				},
@@ -815,7 +756,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "teapot",
 						"verb": "delete",
-						"group": "*",
+						"group": "apps",
 						"resource": "daemonsets"
 					},
 					"user": "sszuecs",
@@ -830,9 +771,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": false,
-						"denied": true,
-						"reason":"unauthorized non read access to daemonsets: sszuecs/[PowerUser]"
+						"allowed": false
 					}
 				}}`,
 				},
@@ -847,7 +786,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "teapot",
 						"verb": "patch",
-						"group": "*",
+						"group": "apps",
 						"resource": "daemonsets"
 					},
 					"user": "sszuecs",
@@ -862,19 +801,46 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": false,
-						"denied": true,
-						"reason":"unauthorized non read access to daemonsets: sszuecs/[PowerUser]"
+						"allowed": false
 					}
 				}}`,
 				},
 			},
 
-			//- operator is allowed to use privileged PSP
+			// poweruser can't delete metrics (non-resource endpoint)
+			{
+				msg: "PowerUser can't delete metrics (non-resource endpoint access)",
+				reqBody: fmt.Sprintf(`{
+					"apiVersion": "authorization.k8s.io/v1beta1",
+					"kind": "SubjectAccessReview",
+					"spec": {
+						"resourceAttributes": {
+							"verb": "delete",
+							"path": "/metrics"
+						},
+						"user": "sszuecs",
+						"group": [
+							"%s"
+						]
+					}
+				}`, powerUserGroup),
+				expect: expect{
+					status: http.StatusCreated,
+					body: `{
+						"apiVersion": "authorization.k8s.io/v1beta1",
+						"kind": "SubjectAccessReview",
+						"status": {
+							"allowed": false
+						}
+				}}`,
+				},
+			},
+
+			//- operator is not allowed to use privileged PSP
 			// Namespace is currently always empty string, because in Kubernetes PSPs are not namespaced, yet.
 			// Check Kubernetes >= 1.7 if they namespaced it https://github.com/kubernetes/kubernetes/pull/42360
 			{
-				msg: "operator is allowed to use privileged PodSecurityPolicy (for own namespace)",
+				msg: "operator is not allowed to use privileged PodSecurityPolicy (for own namespace)",
 				reqBody: `{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
@@ -883,7 +849,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"name": "privileged",
 						"namespace": "",
 						"verb": "use",
-						"group": "*",
+						"group": "extensions",
 						"resource": "podsecuritypolicies"
 					},
 					"user": "system:serviceaccount:teapot:operator",
@@ -896,15 +862,15 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": true
+						"allowed": false
 					}
 				}}`,
 				},
 			},
 
-			//- operator has read access to own namespace
+			//- operator has no read access to own namespace
 			{
-				msg: "operator has read access to own namespace",
+				msg: "operator has no read access to own namespace",
 				reqBody: `{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
@@ -912,7 +878,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "teapot",
 						"verb": "get",
-						"group": "*",
+						"group": "",
 						"resource": "pods"
 					},
 					"user": "system:serviceaccount:teapot:operator",
@@ -925,15 +891,15 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": true
+						"allowed": false
 					}
 				}}`,
 				},
 			},
 
-			//- operator has write access to own namespace
+			//- operator has no write access to own namespace
 			{
-				msg: "operator has write access to own namespace",
+				msg: "operator has no write access to own namespace",
 				reqBody: `{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
@@ -941,7 +907,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "teapot",
 						"verb": "create",
-						"group": "*",
+						"group": "",
 						"resource": "pods"
 					},
 					"user": "system:serviceaccount:teapot:operator",
@@ -954,14 +920,14 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": true
+						"allowed": false
 					}
 				}}`,
 				},
 			},
-			//- operator has read access to other namespaces
+			//- operator has no read access to other namespaces
 			{
-				msg: "operator has read access to other namespace",
+				msg: "operator has no read access to other namespace",
 				reqBody: `{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
@@ -969,7 +935,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "coffeepot",
 						"verb": "get",
-						"group": "*",
+						"group": "",
 						"resource": "pods"
 					},
 					"user": "system:serviceaccount:teapot:operator",
@@ -982,7 +948,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": true
+						"allowed": false
 					}
 				}}`,
 				},
@@ -998,7 +964,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "coffeepot",
 						"verb": "create",
-						"group": "*",
+						"group": "",
 						"resource": "pods"
 					},
 					"user": "system:serviceaccount:teapot:operator",
@@ -1018,7 +984,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				},
 			},
 
-			//- operator has read access to secrets in own namespace
+			//- operator has no read access to secrets in own namespace
 			{
 				msg: "operator has read access to secrets in own namespace",
 				reqBody: `{
@@ -1028,7 +994,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "teapot",
 						"verb": "get",
-						"group": "*",
+						"group": "",
 						"resource": "secrets"
 					},
 					"user": "system:serviceaccount:teapot:operator",
@@ -1041,7 +1007,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": true
+						"allowed": false
 					}
 				}}`,
 				},
@@ -1057,7 +1023,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "coffeepot",
 						"verb": "get",
-						"group": "*",
+						"group": "",
 						"resource": "secrets"
 					},
 					"user": "system:serviceaccount:teapot:operator",
@@ -1077,63 +1043,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				},
 			},
 
-			//- operator has write access to third party resources in all namespaces
-			{
-				msg: "operator has write access to third party resources in all namespacese",
-				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"spec": {
-					"resourceAttributes": {
-						"namespace": "coffeepot",
-						"verb": "create",
-						"group": "*",
-						"resource": "thirdpartyresources"
-					},
-					"user": "system:serviceaccount:teapot:operator",
-					"group": []
-					}
-				}`,
-				expect: expect{
-					status: http.StatusCreated,
-					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"status": {
-						"allowed": true
-					}
-				}}`,
-				},
-			},
-			//- operator has read access to third party resources in all namespaces
-			{
-				msg: "operator has read access to third party resources in all namespacese",
-				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"spec": {
-					"resourceAttributes": {
-						"namespace": "coffeepot",
-						"verb": "get",
-						"group": "*",
-						"resource": "thirdpartyresources"
-					},
-					"user": "system:serviceaccount:teapot:operator",
-					"group": []
-					}
-				}`,
-				expect: expect{
-					status: http.StatusCreated,
-					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"status": {
-						"allowed": true
-					}
-				}}`,
-				},
-			},
-			//- operator has read access to custom resource definitions (CRD) in all namespaces
+			//- operator has no read access to custom resource definitions (CRD) in all namespaces
 			{
 				msg: "operator has read access to custom resource definitions (CRD) in all namespacese",
 				reqBody: `{
@@ -1143,7 +1053,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "get",
-						"group": "*",
+						"group": "apiextensions.k8s.io",
 						"resource": "customresourcedefinitions"
 					},
 					"user": "system:serviceaccount:teapot:operator",
@@ -1156,12 +1066,12 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": true
+						"allowed": false
 					}
 				}}`,
 				},
 			},
-			//- operator has write access to custom resource definitions (CRD) in all namespaces
+			//- operator has no write access to custom resource definitions (CRD) in all namespaces
 			{
 				msg: "operator has read access to custom resource definitions (CRD) in all namespacese",
 				reqBody: `{
@@ -1171,7 +1081,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "create",
-						"group": "*",
+						"group": "apiextensions.k8s.io",
 						"resource": "customresourcedefinitions"
 					},
 					"user": "system:serviceaccount:teapot:operator",
@@ -1184,12 +1094,12 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": true
+						"allowed": false
 					}
 				}}`,
 				},
 			},
-			//- operator has write access to storageclasses in all namespaces
+			//- operator has no write access to storageclasses in all namespaces
 			{
 				msg: "operator has write access to storageclasses in all namespaces",
 				reqBody: `{
@@ -1198,7 +1108,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"spec": {
 					"resourceAttributes": {
 						"verb": "create",
-						"group": "*",
+						"group": "storage.k8s.io",
 						"resource": "storageclasses"
 					},
 					"user": "system:serviceaccount:teapot:operator",
@@ -1211,12 +1121,12 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": true
+						"allowed": false
 					}
 				}}`,
 				},
 			},
-			//- operator has read access to storageclasses in all namespaces
+			//- operator has no read access to storageclasses in all namespaces
 			{
 				msg: "operator has read access to storageclasses in all namespaces",
 				reqBody: `{
@@ -1225,7 +1135,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"spec": {
 					"resourceAttributes": {
 						"verb": "get",
-						"group": "*",
+						"group": "storage.k8s.io",
 						"resource": "storageclasses"
 					},
 					"user": "system:serviceaccount:teapot:operator",
@@ -1238,12 +1148,12 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": true
+						"allowed": false
 					}
 				}}`,
 				},
 			},
-			//- operator has read access to nodes in global namespace
+			//- operator has no read access to nodes in global namespace
 			{
 				msg: "operator has read access to nodes in global namespace",
 				reqBody: `{
@@ -1252,7 +1162,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"spec": {
 					"resourceAttributes": {
 						"verb": "get",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "system:serviceaccount:teapot:operator",
@@ -1265,12 +1175,12 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": true
+						"allowed": false
 					}
 				}}`,
 				},
 			},
-			//- operator has write access to nodes in global namespace
+			//- operator has no write access to nodes in global namespace
 			{
 				msg: "operator has write access to nodes in global namespace",
 				reqBody: `{
@@ -1279,7 +1189,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"spec": {
 					"resourceAttributes": {
 						"verb": "create",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "system:serviceaccount:teapot:operator",
@@ -1292,7 +1202,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": true
+						"allowed": false
 					}
 				}}`,
 				},
@@ -1307,7 +1217,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "coffeepot",
 						"verb": "get",
-						"group": "*",
+						"group": "",
 						"resource": "secrets"},
 					"user": "mkerk",
 					"group": ["ReadOnly"]
@@ -1336,7 +1246,8 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "coffeepot",
 						"verb": "proxy",
-						"group": "*"
+						"group": "",
+						"resource": "services"
 					},
 					"user": "mkerk",
 					"group": ["ReadOnly"]
@@ -1366,7 +1277,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "coffeepot",
 						"verb": "create",
-						"group": "*",
+						"group": "",
 						"resource": "secrets"
 					},
 					"user": "mkerk",
@@ -1396,7 +1307,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "default",
 						"verb": "delete",
-						"group": "*",
+						"group": "",
 						"resource": "pods"
 					},
 					"user": "rdifazio",
@@ -1428,7 +1339,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "default",
 						"verb": "delete",
-						"group": "*",
+						"group": "",
 						"resource": "pods"
 					},
 					"user": "rdifazio",
@@ -1460,7 +1371,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "kube-system",
 						"verb": "delete",
-						"group": "*",
+						"group": "",
 						"resource": "pods"
 					},
 					"user": "rdifazio",
@@ -1484,9 +1395,9 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				},
 			},
 
-			//- Manual role can delete non-namespaced resources
+			//- Manual role can delete namespaces
 			{
-				msg: "Manual role can delete non-namespaced resources",
+				msg: "Manual role can delete namespaces",
 				reqBody: `{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
@@ -1494,7 +1405,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "delete",
-						"group": "*",
+						"group": "",
 						"resource": "namespaces"
 					},
 					"user": "rdifazio",
@@ -1516,6 +1427,40 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				},
 			},
 
+			//- Manual role can't delete kube-system namespace
+			{
+				msg: "Manual role can't delete kube-system namespace",
+				reqBody: `{
+					"apiVersion": "authorization.k8s.io/v1beta1",
+					"kind": "SubjectAccessReview",
+					"spec": {
+					"resourceAttributes": {
+						"verb": "delete",
+						"group": "",
+						"resource": "namespaces",
+						"name": "kube-system"
+					},
+					"user": "rdifazio",
+					"group": [
+						"ReadOnly",
+						"Manual"
+					]
+					}
+				}`,
+				expect: expect{
+					status: http.StatusCreated,
+					body: `{
+					"apiVersion": "authorization.k8s.io/v1beta1",
+					"kind": "SubjectAccessReview",
+					"status": {
+						"allowed": false,
+						"denied": true,
+						"reason":"unauthorized access rdifazio/[ReadOnly Manual]"
+					}
+				}}`,
+				},
+			},
+
 			//- Manual role can create resources
 			{
 				msg: "Manual role can create resources",
@@ -1526,7 +1471,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "default",
 						"verb": "create",
-						"group": "*",
+						"group": "",
 						"resource": "pods"
 					},
 					"user": "rdifazio",
@@ -1558,7 +1503,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "default",
 						"verb": "get",
-						"group": "*",
+						"group": "",
 						"resource": "pods"
 					},
 					"user": "rdifazio",
@@ -1582,7 +1527,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 
 			//- administrator can use restricted PSP
 			{
-				msg: "access to use PodSecurityPolicy for Administrator should be allowed",
+				msg: "access to use PodSecurityPolicy for Administrator (system:masters) should be allowed",
 				reqBody: fmt.Sprintf(`{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
@@ -1591,7 +1536,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"name": "restricted",
 						"namespace": "",
 						"verb": "use",
-						"group": "*",
+						"group": "extensions",
 						"resource": "podsecuritypolicies"
 					},
 					"user": "sszuecs",
@@ -1599,7 +1544,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"%s"
 					]
 					}
-				}`, administratorGroup),
+				}`, systemMastersGroup),
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
@@ -1614,7 +1559,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 
 			//- administrator can use privileged PSP
 			{
-				msg: "access to use PodSecurityPolicy for Administrator should be allowed",
+				msg: "access to use PodSecurityPolicy for Administrator (system:masters) should be allowed",
 				reqBody: fmt.Sprintf(`{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
@@ -1623,7 +1568,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"name": "privileged",
 						"namespace": "",
 						"verb": "use",
-						"group": "*",
+						"group": "extensions",
 						"resource": "podsecuritypolicies"
 					},
 					"user": "sszuecs",
@@ -1631,7 +1576,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"%s"
 					]
 					}
-				}`, administratorGroup),
+				}`, systemMastersGroup),
 				expect: expect{
 					status: http.StatusCreated,
 					body: `{
@@ -1655,7 +1600,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"name": "privileged",
 						"namespace": "",
 						"verb": "use",
-						"group": "*",
+						"group": "extensions",
 						"resource": "podsecuritypolicies"
 					},
 					"user": "sszuecs",
@@ -1706,20 +1651,20 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 
 			//- administrator has read access to kube system
 			{
-				msg: "Administrator has read access (pods) to kube-system",
+				msg: "Administrator (system:masters) has read access (pods) to kube-system",
 				reqBody: `{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"spec": {
 					"resourceAttributes": {
 						"namespace": "kube-system",
-						"verb": "GET",
-						"group": "*",
+						"verb": "get",
+						"group": "",
 						"resource": "pods"
 					},
 					"user": "rdifazio",
 					"group": [
-						"Administrator"
+						"system:masters"
 					]
 					}
 				}`,
@@ -1736,7 +1681,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			},
 			//- administrator has write access to kube system
 			{
-				msg: "Administrator has write access (pods) to kube-system",
+				msg: "Administrator (system:masters) has write access (pods) to kube-system",
 				reqBody: `{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
@@ -1744,12 +1689,42 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "kube-system",
 						"verb": "create",
-						"group": "*",
+						"group": "",
 						"resource": "pods"
 					},
 					"user": "rdifazio",
 					"group": [
-						"Administrator"
+						"system:masters"
+					]
+					}
+				}`,
+				expect: expect{
+					status: http.StatusCreated,
+					body: `{
+					"apiVersion": "authorization.k8s.io/v1beta1",
+					"kind": "SubjectAccessReview",
+					"status": {
+						"allowed": true
+					}
+				}}`,
+				},
+			},
+			//- administrator can read secrets from kube-system namespaces
+			{
+				msg: "Administrator (system:masters) can read secrets from kube-system namespaces",
+				reqBody: `{
+					"apiVersion": "authorization.k8s.io/v1beta1",
+					"kind": "SubjectAccessReview",
+					"spec": {
+					"resourceAttributes": {
+						"namespace": "kube-system",
+						"verb": "get",
+						"group": "",
+						"resource": "secrets"
+					},
+					"user": "rdifazio",
+					"group": [
+						"system:masters"
 					]
 					}
 				}`,
@@ -1766,7 +1741,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			},
 			//- administrator can read secrets from non kube-system namespaces
 			{
-				msg: "Administrator can read secrets from non kube-system namespaces",
+				msg: "Administrator (system:masters) can read secrets from non kube-system namespaces",
 				reqBody: `{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
@@ -1774,12 +1749,12 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "teapot",
 						"verb": "get",
-						"group": "*",
+						"group": "",
 						"resource": "secrets"
 					},
 					"user": "rdifazio",
 					"group": [
-						"Administrator"
+						"system:masters"
 					]
 					}
 				}`,
@@ -1796,7 +1771,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			},
 			//- administrator has write access to non kube-system namespaces
 			{
-				msg: "Administrator has write access to non kube-system namespaces",
+				msg: "Administrator (system:masters) has write access to non kube-system namespaces",
 				reqBody: `{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
@@ -1804,12 +1779,12 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "teapot",
 						"verb": "create",
-						"group": "*",
+						"group": "",
 						"resource": "pods"
 					},
 					"user": "rdifazio",
 					"group": [
-						"Administrator"
+						"system:masters"
 					]
 					}
 				}`,
@@ -1828,7 +1803,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 
 			//- administrator has proxy right
 			{
-				msg: "Administrator has proxy right",
+				msg: "Administrator (system:masters) has proxy right",
 				reqBody: `{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
@@ -1836,11 +1811,11 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "teapot",
 						"verb": "proxy",
-						"group": "*"
+						"group": ""
 					},
 					"user": "sszuecs",
 					"group": [
-						"Administrator"
+						"system:masters"
 					]
 					}
 				}`,
@@ -1857,7 +1832,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 			},
 			//- administrator can write daemonsets
 			{
-				msg: "Administrator can write daemonsets",
+				msg: "Administrator (system:masters) can write daemonsets",
 				reqBody: `{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
@@ -1865,12 +1840,12 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "teapot",
 						"verb": "create",
-						"group": "*",
+						"group": "apps",
 						"resource": "daemonsets"
 					},
 					"user": "sszuecs",
 					"group": [
-						"Administrator"
+						"system:masters"
 					]
 					}
 				}`,
@@ -1885,250 +1860,6 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				}}`,
 				},
 			},
-			//- Billing role can read nodes
-			{
-				msg: "Billing role can read nodes",
-				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"spec": {
-						"resourceAttributes": {
-							"namespace": "",
-							"verb": "get",
-							"group": "*",
-							"resource": "nodes"
-						},
-						"user": "rdifazio",
-						"group": [
-							"Billing"
-						]
-					}
-				}`,
-				expect: expect{
-					status: http.StatusCreated,
-					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
-						"kind": "SubjectAccessReview",
-						"status": {
-							"allowed": true
-						}
-					}`,
-				},
-			},
-			//- Billing role can read namespaces
-			{
-				msg: "Billing role can read namespaces",
-				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"spec": {
-						"resourceAttributes": {
-							"namespace": "",
-							"verb": "get",
-							"group": "*",
-							"resource": "namespaces"
-						},
-						"user": "rdifazio",
-						"group": [
-							"Billing"
-						]
-					}
-				}`,
-				expect: expect{
-					status: http.StatusCreated,
-					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
-						"kind": "SubjectAccessReview",
-						"status": {
-							"allowed": true
-						}
-					}`,
-				},
-			},
-			//- Billing role can read pods
-			{
-				msg: "Billing role can read pods",
-				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"spec": {
-						"resourceAttributes": {
-							"namespace": "",
-							"verb": "get",
-							"group": "*",
-							"resource": "pods"
-						},
-						"user": "rdifazio",
-						"group": [
-							"Billing"
-						]
-					}
-				}`,
-				expect: expect{
-					status: http.StatusCreated,
-					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
-						"kind": "SubjectAccessReview",
-						"status": {
-							"allowed": true
-						}
-					}`,
-				},
-			},
-			//- Billing role can read services
-			{
-				msg: "Billing role can read services",
-				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"spec": {
-						"resourceAttributes": {
-							"namespace": "",
-							"verb": "get",
-							"group": "*",
-							"resource": "services"
-						},
-						"user": "rdifazio",
-						"group": [
-							"Billing"
-						]
-					}
-				}`,
-				expect: expect{
-					status: http.StatusCreated,
-					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
-						"kind": "SubjectAccessReview",
-						"status": {
-							"allowed": true
-						}
-					}`,
-				},
-			},
-			//- Billing role can proxy to the heapster service
-			{
-				msg: "Billing role can proxy to the heapster service",
-				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"spec": {
-						"resourceAttributes": {
-							"namespace": "kube-system",
-							"verb": "proxy",
-							"group": "*",
-							"resource": "services",
-							"name": "heapster"
-						},
-						"user": "rdifazio",
-						"group": [
-							"Billing"
-						]
-					}
-				}`,
-				expect: expect{
-					status: http.StatusCreated,
-					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"status": {
-						"allowed": true
-					}
-				}}`,
-				},
-			},
-			//- Billing role can't write pods
-			{
-				msg: "Billing role can't write pods",
-				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"spec": {
-						"resourceAttributes": {
-							"namespace": "",
-							"verb": "update",
-							"group": "*",
-							"resource": "pods"
-						},
-						"user": "rdifazio",
-						"group": [
-							"Billing"
-						]
-					}
-				}`,
-				expect: expect{
-					status: http.StatusCreated,
-					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
-						"kind": "SubjectAccessReview",
-						"status": {
-							"allowed": false,
-							"reason": "unauthorized access rdifazio/[Billing]"
-						}
-					}`,
-				},
-			},
-			//- Billing role can't read configmaps
-			{
-				msg: "Billing role can't read configmaps",
-				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"spec": {
-						"resourceAttributes": {
-							"namespace": "",
-							"verb": "get",
-							"group": "*",
-							"resource": "configmaps"
-						},
-						"user": "rdifazio",
-						"group": [
-							"Billing"
-						]
-					}
-				}`,
-				expect: expect{
-					status: http.StatusCreated,
-					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
-						"kind": "SubjectAccessReview",
-						"status": {
-							"allowed": false,
-							"reason": "unauthorized access rdifazio/[Billing]"
-						}
-					}`,
-				},
-			},
-			//- Billing role can't write configmaps
-			{
-				msg: "Billing role can't write configmaps",
-				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"spec": {
-						"resourceAttributes": {
-							"namespace": "",
-							"verb": "update",
-							"group": "*",
-							"resource": "configmaps"
-						},
-						"user": "rdifazio",
-						"group": [
-							"Billing"
-						]
-					}
-				}`,
-				expect: expect{
-					status: http.StatusCreated,
-					body: `{
-						"apiVersion": "authorization.k8s.io/v1beta1",
-						"kind": "SubjectAccessReview",
-						"status": {
-							"allowed": false,
-							"reason": "unauthorized access rdifazio/[Billing]"
-						}
-					}`,
-				},
-			},
 			{
 				msg: "cdp service account can create namespaces",
 				reqBody: `{
@@ -2138,7 +1869,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "create",
-						"group": "*",
+						"group": "",
 						"resource": "namespaces"
 					},
 					"user": "system:serviceaccount:default:cdp",
@@ -2156,38 +1887,8 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				}}`,
 				},
 			},
-			// {
-			// 	// TODO: can be enabled when we have
-			// 	// cdp-controller creating bindings in place
-			// 	msg: "cdp service account can't escalate permissions",
-			// 	reqBody: `{
-			// 		"apiVersion": "authorization.k8s.io/v1beta1",
-			// 		"kind": "SubjectAccessReview",
-			// 		"spec": {
-			// 		"resourceAttributes": {
-			// 			"namespace": "",
-			// 			"verb": "escalate",
-			// 			"group": "*",
-			// 			"resource": "clusterroles"
-			// 		},
-			// 		"user": "system:serviceaccount:default:cdp",
-			// 		"group": []
-			// 		}
-			// 	}`,
-			// 	expect: expect{
-			// 		status: http.StatusCreated,
-			// 		body: `{
-			// 		"apiVersion": "authorization.k8s.io/v1beta1",
-			// 		"kind": "SubjectAccessReview",
-			// 		"status": {
-			// 			"denied": true,
-			// 			"reason": "no one is allowed to escalate"
-			// 		}
-			// 	}}`,
-			// 	},
-			// },
 			{
-				msg: "cdp service account can escalate permissions",
+				msg: "cdp service account can't escalate permissions",
 				reqBody: `{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
@@ -2195,7 +1896,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "escalate",
-						"group": "*",
+						"group": "rbac.authorization.k8s.io",
 						"resource": "clusterroles"
 					},
 					"user": "system:serviceaccount:default:cdp",
@@ -2208,7 +1909,8 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": true
+						"allowed": false,
+						"denied": true
 					}
 				}}`,
 				},
@@ -2222,7 +1924,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				"resourceAttributes": {
 					"namespace": "",
 					"verb": "escalate",
-					"group": "*",
+					"group": "rbac.authorization.k8s.io",
 					"resource": "clusterroles"
 				},
 				"user": "mlarsen",
@@ -2235,8 +1937,8 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				"apiVersion": "authorization.k8s.io/v1beta1",
 				"kind": "SubjectAccessReview",
 				"status": {
-					"denied": true,
-					"reason": "no one is allowed to escalate"
+					"allow": false,
+					"denied": true
 				}
 			}}`,
 				},
@@ -2250,7 +1952,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "create",
-						"group": "*",
+						"group": "",
 						"resource": "namespaces"
 					},
 					"user": "system:serviceaccount:default:operator",
@@ -2282,7 +1984,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"resource": "pods"
 					},
 					"user": "system:serviceaccount:kube-system:daemon-set-controller",
-					"group": []
+					"group": ["system:serviceaccounts:kube-system"]
 					}
 				}`,
 				expect: expect{
@@ -2297,34 +1999,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				},
 			},
 			{
-				msg: "system service account in kube-system namespace can create pods",
-				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"spec": {
-					"resourceAttributes": {
-						"namespace": "kube-system",
-						"verb": "create",
-						"group": "",
-						"resource": "pods"
-					},
-					"user": "system:serviceaccount:kube-system:system",
-					"group": []
-					}
-				}`,
-				expect: expect{
-					status: http.StatusCreated,
-					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"status": {
-						"allowed": true
-					}
-				}}`,
-				},
-			},
-			{
-				msg: "operator service account can access persistent volumes in other namespaces",
+				msg: "operator service account can not access persistent volumes in other namespaces",
 				reqBody: `{
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
@@ -2332,7 +2007,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "get",
-						"group": "*",
+						"group": "",
 						"resource": "persistentvolumes"
 					},
 					"user": "system:serviceaccount:default:operator",
@@ -2345,8 +2020,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"apiVersion": "authorization.k8s.io/v1beta1",
 					"kind": "SubjectAccessReview",
 					"status": {
-						"allowed": true,
-						"reason": ""
+						"allowed": false
 					}
 				}}`,
 				},
@@ -2364,7 +2038,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"resource": "persistentvolumeclaims"
 					},
 					"user": "system:serviceaccount:kube-system:persistent-volume-binder",
-					"group": []
+					"group": ["system:serviceaccounts:kube-system"]
 					}
 				}`,
 				expect: expect{
@@ -2392,7 +2066,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"resource": "persistentvolumes"
 					},
 					"user": "system:serviceaccount:kube-system:persistent-volume-binder",
-					"group": []
+					"group": ["system:serviceaccounts:kube-system"]
 					}
 				}`,
 				expect: expect{
@@ -2420,7 +2094,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"resource": "*/scale"
 					},
 					"user": "system:serviceaccount:kube-system:horizontal-pod-autoscaler",
-					"group": []
+					"group": ["system:serviceaccounts:kube-system"]
 					}
 				}`,
 				expect: expect{
@@ -2448,7 +2122,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"resource": "*/scale"
 					},
 					"user": "system:serviceaccount:kube-system:horizontal-pod-autoscaler",
-					"group": []
+					"group": ["system:serviceaccounts:kube-system"]
 					}
 				}`,
 				expect: expect{
@@ -2475,7 +2149,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"resource": "nodes"
 					},
 					"user": "system:serviceaccount:kube-system:aws-cloud-provider",
-					"group": []
+					"group": ["system:serviceaccounts:kube-system"]
 					}
 				}`,
 				expect: expect{
@@ -2499,7 +2173,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "update",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",
@@ -2514,9 +2188,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
-							"allowed": false,
-							"denied": true,
-							"reason": "unauthorized non read access to nodes: sszuecs/[Emergency]"
+							"allowed": false
 						}
 				}}`,
 				},
@@ -2530,7 +2202,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "update",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",
@@ -2545,9 +2217,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
-							"allowed": false,
-							"denied": true,
-							"reason": "unauthorized non read access to nodes: sszuecs/[Manual]"
+							"allowed": false
 						}
 				}}`,
 				},
@@ -2561,7 +2231,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "update",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",
@@ -2576,9 +2246,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
-							"allowed": false,
-							"denied": true,
-							"reason": "unauthorized non read access to nodes: sszuecs/[PowerUser]"
+							"allowed": false
 						}
 				}}`,
 				},
@@ -2592,7 +2260,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "create",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",
@@ -2607,9 +2275,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
-							"allowed": false,
-							"denied": true,
-							"reason": "unauthorized non read access to nodes: sszuecs/[Emergency]"
+							"allowed": false
 						}
 				}}`,
 				},
@@ -2623,7 +2289,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "create",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",
@@ -2638,9 +2304,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
-							"allowed": false,
-							"denied": true,
-							"reason": "unauthorized non read access to nodes: sszuecs/[Manual]"
+							"allowed": false
 						}
 				}}`,
 				},
@@ -2654,7 +2318,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "create",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",
@@ -2669,9 +2333,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
-							"allowed": false,
-							"denied": true,
-							"reason": "unauthorized non read access to nodes: sszuecs/[PowerUser]"
+							"allowed": false
 						}
 				}}`,
 				},
@@ -2685,7 +2347,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "patch",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",
@@ -2700,9 +2362,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
-							"allowed": false,
-							"denied": true,
-							"reason": "unauthorized non read access to nodes: sszuecs/[Emergency]"
+							"allowed": false
 						}
 				}}`,
 				},
@@ -2716,7 +2376,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "patch",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",
@@ -2731,9 +2391,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
-							"allowed": false,
-							"denied": true,
-							"reason": "unauthorized non read access to nodes: sszuecs/[Manual]"
+							"allowed": false
 						}
 				}}`,
 				},
@@ -2747,7 +2405,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "patch",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",
@@ -2762,9 +2420,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
-							"allowed": false,
-							"denied": true,
-							"reason": "unauthorized non read access to nodes: sszuecs/[PowerUser]"
+							"allowed": false
 						}
 				}}`,
 				},
@@ -2778,7 +2434,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "delete",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",
@@ -2793,9 +2449,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
-							"allowed": false,
-							"denied": true,
-							"reason": "unauthorized non read access to nodes: sszuecs/[Emergency]"
+							"allowed": false
 						}
 				}}`,
 				},
@@ -2809,7 +2463,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "delete",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",
@@ -2824,9 +2478,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
-							"allowed": false,
-							"denied": true,
-							"reason": "unauthorized non read access to nodes: sszuecs/[Manual]"
+							"allowed": false
 						}
 				}}`,
 				},
@@ -2840,7 +2492,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "delete",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",
@@ -2855,9 +2507,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 						"apiVersion": "authorization.k8s.io/v1beta1",
 						"kind": "SubjectAccessReview",
 						"status": {
-							"allowed": false,
-							"denied": true,
-							"reason": "unauthorized non read access to nodes: sszuecs/[PowerUser]"
+							"allowed": false
 						}
 				}}`,
 				},
@@ -2871,7 +2521,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "list",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",
@@ -2900,7 +2550,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "list",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",
@@ -2929,7 +2579,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "list",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",
@@ -2958,7 +2608,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "get",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",
@@ -2987,7 +2637,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "get",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",
@@ -3016,7 +2666,7 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 					"resourceAttributes": {
 						"namespace": "",
 						"verb": "get",
-						"group": "*",
+						"group": "",
 						"resource": "nodes"
 					},
 					"user": "sszuecs",

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -409,7 +410,27 @@ func createServiceAccount(namespace, serviceAccount string) *v1.ServiceAccount {
 		},
 		AutomountServiceAccountToken: &trueValue,
 	}
+}
 
+func createRBACRoleBindingSA(role, namespace, serviceAccount string) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceAccount,
+			Namespace: namespace,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      serviceAccount,
+				Namespace: namespace,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     role,
+		},
+	}
 }
 
 func createNginxPodWithHostNetwork(namespace, serviceAccount string, label map[string]string, port int32) *v1.Pod {


### PR DESCRIPTION
Reverts zalando-incubator/kubernetes-on-aws#2861

Rolls out RBAC again with a way to white list system users such as `zalando-iam:zalando:service:credentials-provider`

First commit is same as #2456, second commit adds the new flag `system-users` which allows the whitelisting.