### PR TITLE
Give PowerUser/ReadOnly access to persistentvolumes via RBAC

### DIFF
--- a/cluster/manifests/roles/poweruser-role.yaml
+++ b/cluster/manifests/roles/poweruser-role.yaml
@@ -853,3 +853,10 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - update
+  - patch

--- a/cluster/manifests/roles/readonly-role.yaml
+++ b/cluster/manifests/roles/readonly-role.yaml
@@ -329,3 +329,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
Give `PowerUser/ReadOnly` access to persistentvolumes via RBAC.

* Read access should generally be fine.
* Adds write access for `update` and `patch` which are needed by postgres-operator (and thereby must be in the poweruser role for cdp to deploy the operator roles).