### PR TITLE
Update admission-controller (crd admitter)

### DIFF
--- a/cluster/manifests/admission-control/daemonset.yaml
+++ b/cluster/manifests/admission-control/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cluster-autoscaler
-        image: registry.opensource.zalan.do/teapot/admission-controller:master-45
+        image: registry.opensource.zalan.do/teapot/admission-controller:master-54
         command:
           - /registry-proxy
           - --address=127.0.0.1:8285

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -172,7 +172,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-53
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-54
           name: admission-controller
           readinessProbe:
             httpGet:


### PR DESCRIPTION
Will update RBAC rules for CRD resources to include `deletecollection` for poweruser role.