### PR TITLE
Make it possible to allow collaborator admin access in pet clusters

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -271,6 +271,13 @@ custom_dns_zone_nameservers: "" # space seperated list of nameserver IP addresse
 # prefix prepended to ownership TXT records for external-dns
 external_dns_ownership_prefix: ""
 
+# special roles for test/pet clusters
+{{if eq .Cluster.Environment "e2e"}}
+collaborator_administrator_access: "true"
+{{else}}
+collaborator_administrator_access: "false"
+{{end}}
+
 # enable legacy serviceaccounts for smooth RBAC migration
 enable_operator_sa: "false"
 enable_default_sa: "false"

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -260,7 +260,7 @@ write_files:
             - --derived-role=CollaboratorManual=Collaborator24x7,Manual
 {{- else if eq .Cluster.Environment "test"}}
             - --role-mapping=CollaboratorPowerUser=cn=Deployer,ou=collaborators,ou=Kubernetes,ou=apps,dc=zalando,dc=net
-{{- else if eq .Cluster.Environment "e2e"}}
+{{- else if eq .Cluster.ConfigItems.collaborator_administrator_access "true"}}
             - --role-mapping=Administrator=cn=Contributor,ou=collaborators,ou=Kubernetes,ou=apps,dc=zalando,dc=net
 {{- end}}
 


### PR DESCRIPTION
Currently we only allow access to e2e clusters, but pet clusters should also work.