### PR TITLE
Set various configurations for virtual memory

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -266,3 +266,7 @@ external_dns_ownership_prefix: ""
 enable_operator_sa: "false"
 enable_default_sa: "false"
 enable_cdp_sa: "false"
+
+# virtual memory configuration
+vm_dirty_background_bytes: ""
+vm_dirty_bytes: ""

--- a/cluster/node-pools/worker-default/userdata.yaml
+++ b/cluster/node-pools/worker-default/userdata.yaml
@@ -87,3 +87,19 @@ write_files:
           cacheAuthorizedTTL: "5m"
           cacheUnauthorizedTTL: "30s"
       readOnlyPort: 10255 # TODO: remove after complete rollout of webhook auth
+
+  - owner: root:root
+    path: /etc/sysctl.d/02-vm-max-mmaps.conf
+    content: |
+      vm.max_map_count=524288
+
+{{- if ( and ( ne .Cluster.ConfigItems.vm_dirty_background_bytes "" ) ( ne .Cluster.ConfigItems.vm_dirty_bytes "" ) )}}
+  - owner: root:root
+    path: /etc/sysctl.d/03-vm-dirty-ratios.conf
+    content: |
+      vm.dirty_background_bytes = {{ .Cluster.ConfigItems.vm_dirty_background_bytes }}
+      vm.dirty_bytes = {{ .Cluster.ConfigItems.vm_dirty_bytes }}
+{{- end}}
+
+runcmd:
+- [ "/sbin/sysctl", "--system"]

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -53,6 +53,8 @@ clusters:
     efs_id: ${EFS_ID}
     webhook_id: ${INFRASTRUCTURE_ACCOUNT}:${REGION}:kube-aws-test
     kube_aws_ingress_controller_nlb_enabled: "true"
+    vm_dirty_bytes: 134217728
+    vm_dirty_background_bytes: 67108864
   criticality_level: 1
   environment: e2e
   id: ${CLUSTER_ID}


### PR DESCRIPTION
When both the config items  `vm_dirty_background_bytes` and `vm_dirty_bytes` are set a `sysctl` override file is created. Also override the maximum number of `mmaps` allowed  by default.
Also based on the information from this [article](https://www.suse.com/support/kb/doc/?id=7000830) it would be safe to increase the allowed number of mmaps for processes. It should not have an impact on the performance of virtual memory nor would it increase resource usage. So we have increased the value to 8x the default value. 