### PR TITLE
Update kube-state-metrics to v1.9.2

### DIFF
--- a/cluster/manifests/kube-state-metrics/deployment.yaml
+++ b/cluster/manifests/kube-state-metrics/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-state-metrics
-    version: v1.9.1
+    version: v1.9.2
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-state-metrics
-        version: v1.9.1
+        version: v1.9.2
     spec:
       dnsConfig:
         options:
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: kube-state-metrics
       containers:
       - name: kube-state-metrics
-        image: registry.opensource.zalan.do/teapot/kube-state-metrics:v1.9.1
+        image: registry.opensource.zalan.do/teapot/kube-state-metrics:v1.9.2
         ports:
         - containerPort: 8080
           name: http-metrics


### PR DESCRIPTION
Attempt to fix a panic in the previous version