### PR TITLE
Collaborators: bind something that actually exists

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -28,3 +28,6 @@ post_apply:
   kind: ClusterRoleBinding
 - name: zmon-external-new
   kind: ClusterRoleBinding
+- name: collaborator
+  namespace: visibility
+  kind: RoleBinding

--- a/cluster/manifests/roles/collaborator-roles.yaml
+++ b/cluster/manifests/roles/collaborator-roles.yaml
@@ -18,12 +18,12 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: collaborator
+  name: collaborator-binding
   namespace: visibility
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: collaborator-visibility
+  kind: Role
+  name: collaborator
 subjects:
 - kind: Group
   name: CollaboratorPowerUser


### PR DESCRIPTION
Collaborators have a normal role, not a ClusterRole. The name is also wrong.