### PR TITLE
kubelet: drop readOnlyPort

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -72,7 +72,6 @@ write_files:
         webhook:
           cacheAuthorizedTTL: "5m"
           cacheUnauthorizedTTL: "30s"
-      readOnlyPort: 10255 # TODO: remove after complete rollout of webhook auth
 
   - owner: root:root
     path: /etc/kubernetes/manifests/kube-apiserver.yaml

--- a/cluster/node-pools/worker-default/userdata.yaml
+++ b/cluster/node-pools/worker-default/userdata.yaml
@@ -86,7 +86,6 @@ write_files:
         webhook:
           cacheAuthorizedTTL: "5m"
           cacheUnauthorizedTTL: "30s"
-      readOnlyPort: 10255 # TODO: remove after complete rollout of webhook auth
 
   - owner: root:root
     path: /etc/sysctl.d/02-vm-max-mmaps.conf


### PR DESCRIPTION
We forgot to drop this, and it's not used anymore.