### PR TITLE
Remove the runcmd directive

### DIFF
--- a/cluster/node-pools/worker-default/userdata.yaml
+++ b/cluster/node-pools/worker-default/userdata.yaml
@@ -88,11 +88,6 @@ write_files:
           cacheUnauthorizedTTL: "30s"
       readOnlyPort: 10255 # TODO: remove after complete rollout of webhook auth
 
-  - owner: root:root
-    path: /etc/sysctl.d/02-vm-max-mmaps.conf
-    content: |
-      vm.max_map_count=524288
-
 {{- if ( and ( ne .Cluster.ConfigItems.vm_dirty_background_bytes "" ) ( ne .Cluster.ConfigItems.vm_dirty_bytes "" ) )}}
   - owner: root:root
     path: /etc/sysctl.d/03-vm-dirty-ratios.conf
@@ -100,6 +95,3 @@ write_files:
       vm.dirty_background_bytes = {{ .Cluster.ConfigItems.vm_dirty_background_bytes }}
       vm.dirty_bytes = {{ .Cluster.ConfigItems.vm_dirty_bytes }}
 {{- end}}
-
-runcmd:
-- [ "/sbin/sysctl", "--system"]


### PR DESCRIPTION
 Because `cloud-final.service` does not start before `multi-user.target` anything that requires `cloud-final.service` causes a circular dependency in SystemD. More information [here](https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/1623868).
