### PR TITLE
[1/2] CDP controller role: allow the use of v2 tokens

### DIFF
--- a/cluster/manifests/roles/cdp-controller-rbac.yaml
+++ b/cluster/manifests/roles/cdp-controller-rbac.yaml
@@ -94,3 +94,6 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
   name: zalando-iam:zalando:service:credprov-cdp-controller-cluster-token
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: zalando-iam:zalando:service:stups_cdp-controller


### PR DESCRIPTION
Let's get rid of V1 tokens, especially for things that have access to all clusters. It looks like CDP controller is the only remaining app.