### PR TITLE
RBAC: allow events.k8s.io for events

### DIFF
--- a/cluster/manifests/roles/poweruser-role.yaml
+++ b/cluster/manifests/roles/poweruser-role.yaml
@@ -70,6 +70,7 @@ rules:
   - watch
 - apiGroups:
   - ""
+  - "events.k8s.io"
   resources:
   - events
   verbs:


### PR DESCRIPTION
There's a new API group for events apparently.