### PR TITLE
Allow restoring the legacy node pool label

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -276,3 +276,6 @@ enable_cdp_sa: "false"
 # virtual memory configuration
 vm_dirty_background_bytes: ""
 vm_dirty_bytes: ""
+
+# temporary flag for kubernetes.io/node-pool node label
+legacy_node_pool_label_enabled: "false"

--- a/cluster/node-pools/worker-default/stack.yaml
+++ b/cluster/node-pools/worker-default/stack.yaml
@@ -63,9 +63,11 @@ Resources:
       - Key: k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role
         PropagateAtLaunch: true
         Value: worker
+{{ - if eq .Cluster.ConfigItems.legacy_node_pool_label_enabled "true" }}
       - Key: k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/node-pool
         PropagateAtLaunch: true
         Value: {{ .NodePool.Name }}
+{{ - end }}
       - Key: k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/node-pool
         PropagateAtLaunch: true
         Value: {{ .NodePool.Name }}

--- a/cluster/node-pools/worker-default/userdata.yaml
+++ b/cluster/node-pools/worker-default/userdata.yaml
@@ -5,7 +5,7 @@ write_files:
     path: /etc/kubernetes/secrets.env
     content: |
       NODEPOOL_TAINTS={{if index .NodePool.ConfigItems "taints"}}{{.NodePool.ConfigItems.taints}}{{end}}
-      NODE_LABELS={{ .Values.node_labels }},kubernetes.io/role=worker,node.kubernetes.io/distro=ubuntu{{if index .NodePool.ConfigItems "labels"}},{{.NodePool.ConfigItems.labels}}{{end}}
+      NODE_LABELS={{ .Values.node_labels }},{{if eq .Cluster.ConfigItems.legacy_node_pool_label_enabled "true"}}kubernetes.io/node-pool={{.NodePool.Name}},{{end}}kubernetes.io/role=worker,node.kubernetes.io/distro=ubuntu{{if index .NodePool.ConfigItems "labels"}},{{.NodePool.ConfigItems.labels}}{{end}}
       NODEPOOL_NAME={{ .NodePool.Name }}
       KUBELET_ROLE=worker
       ON_DEMAND_WORKER_REPLACEMENT_STRATEGY={{if eq .Cluster.Environment "production"}}prepare-replacement{{else}}none{{end}}

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -67,9 +67,11 @@ Resources:
       - Key: k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/role
         PropagateAtLaunch: true
         Value: worker
+{{ - if eq .Cluster.ConfigItems.legacy_node_pool_label_enabled "true" }}
       - Key: k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/node-pool
         PropagateAtLaunch: true
         Value: {{ $data.NodePool.Name }}
+{{- end }}
       - Key: k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/node-pool
         PropagateAtLaunch: true
         Value: {{ $data.NodePool.Name }}


### PR DESCRIPTION
Turns out some of the clusters users still rely on it, so we can't just drop it. Additionally, remove the autoscaler template label so it doesn't try to scale up since the nodes won't match anyway.