### PR TITLE
kube-metrics-adapter: increase max memory

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/vpa.yaml
+++ b/cluster/manifests/kube-metrics-adapter/vpa.yaml
@@ -14,4 +14,4 @@ spec:
     containerPolicies:
     - containerName: kube-metrics-adapter
       maxAllowed:
-        memory: 200Mi
+        memory: 1Gi


### PR DESCRIPTION
`200Mi` is way too low in some clusters.