### PR TITLE
Grant PowerUser access to manage validatingwebhookconfigurations

### DIFF
--- a/cluster/manifests/roles/poweruser-role.yaml
+++ b/cluster/manifests/roles/poweruser-role.yaml
@@ -896,3 +896,12 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - create
+  - update
+  - patch
+  - delete

--- a/cluster/manifests/roles/readonly-role.yaml
+++ b/cluster/manifests/roles/readonly-role.yaml
@@ -353,3 +353,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
This is needed for users to deploy validating webhooks along with their operator.

Team Fabric currently depends on this.