### PR TITLE
Test clusters: bind PowerUser role to CollaboratorPowerUser

### DIFF
--- a/cluster/manifests/roles/poweruser-binding.yaml
+++ b/cluster/manifests/roles/poweruser-binding.yaml
@@ -10,6 +10,11 @@ subjects:
 - kind: Group
   name: PowerUser
   apiGroup: rbac.authorization.k8s.io
+{{- if eq .Cluster.Environment "test" }}
+- kind: Group
+  name: CollaboratorPowerUser
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
 - kind: Group
   name: Manual
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
They should automatically get access in test clusters.