### PR TITLE
Adding roles for status subresource for all 3 Fabric operators.

### DIFF
--- a/cluster/manifests/roles/fabric-roles.yaml
+++ b/cluster/manifests/roles/fabric-roles.yaml
@@ -9,6 +9,7 @@ rules:
   - zalando.org
   resources:
   - fabricgateways
+  - fabricgateways/status
   verbs:
   - create
   - update
@@ -27,6 +28,7 @@ rules:
   - zalando.org
   resources:
   - fabricgateways
+  - fabricgateways/status
   verbs:
   - get
   - list
@@ -43,6 +45,7 @@ rules:
   - zalando.org
   resources:
   - fabriceventstreams
+  - fabriceventstreams/status
   verbs:
   - create
   - update
@@ -61,6 +64,7 @@ rules:
   - zalando.org
   resources:
   - fabriceventstreams
+  - fabriceventstreams/status
   verbs:
   - get
   - list
@@ -77,6 +81,7 @@ rules:
   - zalando.org
   resources:
   - servicelevelobjectives
+  - servicelevelobjectives/status
   verbs:
   - create
   - update
@@ -95,6 +100,7 @@ rules:
   - zalando.org
   resources:
   - servicelevelobjectives
+  - servicelevelobjectives/status
   verbs:
   - get
   - list


### PR DESCRIPTION
These are also required as metacontoller updates the status subresources directly for each of the 3 operators.