### PR TITLE
Enable users to do kubectl top pod/node

### DIFF
--- a/cluster/manifests/roles/readonly-role.yaml
+++ b/cluster/manifests/roles/readonly-role.yaml
@@ -361,3 +361,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
This was missed in the RBAC migration.

`kubectl top pod` requires these read permissions.