### PR TITLE
Simplify RBAC definitions for readonly/poweruser

### DIFF
--- a/cluster/manifests/roles/poweruser-role.yaml
+++ b/cluster/manifests/roles/poweruser-role.yaml
@@ -18,22 +18,17 @@ rules:
 - apiGroups:
   - ''
   resources:
-  - bindings
-  - componentstatuses
   - configmaps
   - endpoints
-  - limitranges
   - namespaces
   - namespaces/finalize
   - namespaces/status
-  - nodes/proxy
-  - nodes/status
   - persistentvolumeclaims
   - persistentvolumeclaims/status
   - persistentvolumes
   - persistentvolumes/status
+  - pods
   - pods/attach
-  - pods/binding
   - pods/eviction
   - pods/exec
   - pods/log
@@ -42,8 +37,6 @@ rules:
   - pods/status
   - podtemplates
   - replicationcontrollers/status
-  - resourcequotas
-  - resourcequotas/status
   - secrets
   - serviceaccounts
   - services
@@ -57,22 +50,23 @@ rules:
   - update
 - apiGroups:
   - ''
-  - extensions
   resources:
-  - replicationcontrollers
-  - replicationcontrollers/scale
+  - secrets
   verbs:
   - create
   - delete
   - deletecollection
+  - get
+  - list
   - patch
   - update
+  - watch
 - apiGroups:
   - ''
-  - metrics.k8s.io
+  - extensions
   resources:
-  - nodes
-  - pods
+  - replicationcontrollers
+  - replicationcontrollers/scale
   verbs:
   - create
   - delete
@@ -93,7 +87,6 @@ rules:
 - apiGroups:
   - admissionregistration.k8s.io
   resources:
-  - mutatingwebhookconfigurations
   - validatingwebhookconfigurations
   verbs:
   - create
@@ -113,19 +106,9 @@ rules:
   - patch
   - update
 - apiGroups:
-  - apiregistration.k8s.io
-  resources:
-  - apiservices
-  - apiservices/status
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - patch
-  - update
-- apiGroups:
   - apps
   resources:
+  - controllerrevisions
   - statefulsets
   - statefulsets/scale
   - statefulsets/status
@@ -139,8 +122,6 @@ rules:
   - apps
   - extensions
   resources:
-  - daemonsets
-  - daemonsets/status
   - deployments
   - deployments/rollback
   - deployments/scale
@@ -148,40 +129,6 @@ rules:
   - replicasets
   - replicasets/scale
   - replicasets/status
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - patch
-  - update
-- apiGroups:
-  - apps
-  - metacontroller.k8s.io
-  resources:
-  - controllerrevisions
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - patch
-  - update
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - patch
-  - update
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - localsubjectaccessreviews
-  - selfsubjectaccessreviews
-  - selfsubjectrulesreviews
-  - subjectaccessreviews
   verbs:
   - create
   - delete
@@ -224,28 +171,6 @@ rules:
   - patch
   - update
 - apiGroups:
-  - certificates.k8s.io
-  resources:
-  - certificatesigningrequests
-  - certificatesigningrequests/approval
-  - certificatesigningrequests/status
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - patch
-  - update
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - patch
-  - update
-- apiGroups:
   - extensions
   - networking.k8s.io
   resources:
@@ -259,42 +184,11 @@ rules:
   - patch
   - update
 - apiGroups:
-  - extensions
-  - policy
-  resources:
-  - podsecuritypolicies
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - patch
-  - update
-- apiGroups:
-  - external.metrics.k8s.io
-  resources:
-  - sqs-queue-length
-  - zmon-check
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - patch
-  - update
-- apiGroups:
   - metacontroller.k8s.io
   resources:
   - compositecontrollers
+  - controllerrevisions
   - decoratorcontrollers
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - patch
-  - update
-- apiGroups:
-  - node.k8s.io
-  resources:
-  - runtimeclasses
   verbs:
   - create
   - delete
@@ -338,11 +232,7 @@ rules:
 - apiGroups:
   - storage.k8s.io
   resources:
-  - csidrivers
-  - csinodes
   - storageclasses
-  - volumeattachments
-  - volumeattachments/status
   verbs:
   - create
   - delete

--- a/cluster/manifests/roles/poweruser-role.yaml
+++ b/cluster/manifests/roles/poweruser-role.yaml
@@ -22,26 +22,19 @@ rules:
   - endpoints
   - namespaces
   - namespaces/finalize
-  - namespaces/status
   - persistentvolumeclaims
-  - persistentvolumeclaims/status
   - persistentvolumes
-  - persistentvolumes/status
   - pods
   - pods/attach
   - pods/eviction
   - pods/exec
-  - pods/log
   - pods/portforward
   - pods/proxy
-  - pods/status
   - podtemplates
-  - replicationcontrollers/status
   - secrets
   - serviceaccounts
   - services
   - services/proxy
-  - services/status
   verbs:
   - create
   - delete
@@ -80,8 +73,6 @@ rules:
   - events
   verbs:
   - create
-  - delete
-  - deletecollection
   - patch
   - update
 - apiGroups:
@@ -98,7 +89,6 @@ rules:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
-  - customresourcedefinitions/status
   verbs:
   - create
   - patch
@@ -109,7 +99,6 @@ rules:
   - controllerrevisions
   - statefulsets
   - statefulsets/scale
-  - statefulsets/status
   verbs:
   - create
   - delete
@@ -123,10 +112,8 @@ rules:
   - deployments
   - deployments/rollback
   - deployments/scale
-  - deployments/status
   - replicasets
   - replicasets/scale
-  - replicasets/status
   verbs:
   - create
   - delete
@@ -148,7 +135,6 @@ rules:
   - autoscaling
   resources:
   - horizontalpodautoscalers
-  - horizontalpodautoscalers/status
   verbs:
   - create
   - delete
@@ -159,9 +145,7 @@ rules:
   - batch
   resources:
   - cronjobs
-  - cronjobs/status
   - jobs
-  - jobs/status
   verbs:
   - create
   - delete
@@ -173,7 +157,6 @@ rules:
   - networking.k8s.io
   resources:
   - ingresses
-  - ingresses/status
   - networkpolicies
   verbs:
   - create
@@ -197,7 +180,6 @@ rules:
   - policy
   resources:
   - poddisruptionbudgets
-  - poddisruptionbudgets/status
   verbs:
   - create
   - delete

--- a/cluster/manifests/roles/poweruser-role.yaml
+++ b/cluster/manifests/roles/poweruser-role.yaml
@@ -16,823 +16,85 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-poweruser: "true"
 rules:
 - apiGroups:
-  - ""
+  - ''
   resources:
-  - pods
+  - bindings
+  - componentstatuses
+  - configmaps
+  - endpoints
+  - limitranges
+  - namespaces
+  - namespaces/finalize
+  - namespaces/status
+  - nodes/proxy
+  - nodes/status
+  - persistentvolumeclaims
+  - persistentvolumeclaims/status
+  - persistentvolumes
+  - persistentvolumes/status
   - pods/attach
-  - pods/proxy
+  - pods/binding
+  - pods/eviction
   - pods/exec
+  - pods/log
   - pods/portforward
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-  - deletecollection
-- apiGroups:
-  - ""
-  resources:
-  - replicationcontrollers
-  - replicationcontrollers/scale
+  - pods/proxy
+  - pods/status
+  - podtemplates
+  - replicationcontrollers/status
+  - resourcequotas
+  - resourcequotas/status
+  - secrets
   - serviceaccounts
   - services
   - services/proxy
-  - endpoints
-  - persistentvolumeclaims
-  - configmaps
-  - secrets
+  - services/status
   verbs:
-  - get
-  - list
-  - watch
   - create
-  - update
-  - patch
   - delete
   - deletecollection
+  - patch
+  - update
 - apiGroups:
-  - ""
+  - ''
+  - extensions
   resources:
-  - limitranges
-  - resourcequotas
-  - bindings
-  - pods/status
-  - resourcequotas/status
-  - namespaces/status
-  - replicationcontrollers/status
-  - pods/log
+  - replicationcontrollers
+  - replicationcontrollers/scale
   verbs:
-  - get
-  - list
-  - watch
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
 - apiGroups:
-  - ""
-  - "events.k8s.io"
+  - ''
+  - metrics.k8s.io
+  resources:
+  - nodes
+  - pods
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - ''
+  - events.k8s.io
   resources:
   - events
   verbs:
-    - get
-    - list
-    - watch
-    - create
-    - update
-    - patch
-    - delete
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets
-  verbs:
-  - get
-  - list
-  - watch
   - create
-  - update
-  - patch
   - delete
   - deletecollection
-- apiGroups:
-  - autoscaling
-  resources:
-  - horizontalpodautoscalers
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
   - patch
-  - delete
-  - deletecollection
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  - cronjobs
-  - scheduledjobs
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-  - deletecollection
-- apiGroups:
-  - extensions
-  resources:
-  - jobs
-  - horizontalpodautoscalers
-  - replicationcontrollers/scale
-  - replicasets
-  - replicasets/scale
-  - deployments
-  - deployments/scale
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-  - deletecollection
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - create
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - delete
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - deletecollection
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - patch
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
   - update
 - apiGroups:
-  - apps
+  - admissionregistration.k8s.io
   resources:
-  - deployments
-  verbs:
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - deployments/rollback
-  verbs:
-  - create
-- apiGroups:
-  - apps
-  resources:
-  - deployments/rollback
-  verbs:
-  - delete
-- apiGroups:
-  - apps
-  resources:
-  - deployments/rollback
-  verbs:
-  - deletecollection
-- apiGroups:
-  - apps
-  resources:
-  - deployments/rollback
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - deployments/rollback
-  verbs:
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - deployments/rollback
-  verbs:
-  - patch
-- apiGroups:
-  - apps
-  resources:
-  - deployments/rollback
-  verbs:
-  - update
-- apiGroups:
-  - apps
-  resources:
-  - deployments/rollback
-  verbs:
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - deployments/scale
-  verbs:
-  - create
-- apiGroups:
-  - apps
-  resources:
-  - deployments/scale
-  verbs:
-  - delete
-- apiGroups:
-  - apps
-  resources:
-  - deployments/scale
-  verbs:
-  - deletecollection
-- apiGroups:
-  - apps
-  resources:
-  - deployments/scale
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - deployments/scale
-  verbs:
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - deployments/scale
-  verbs:
-  - patch
-- apiGroups:
-  - apps
-  resources:
-  - deployments/scale
-  verbs:
-  - update
-- apiGroups:
-  - apps
-  resources:
-  - deployments/scale
-  verbs:
-  - watch
-- apiGroups:
-  - extensions
-  resources:
-  - deployments/rollback
-  verbs:
-  - create
-- apiGroups:
-  - extensions
-  resources:
-  - deployments/rollback
-  verbs:
-  - delete
-- apiGroups:
-  - extensions
-  resources:
-  - deployments/rollback
-  verbs:
-  - deletecollection
-- apiGroups:
-  - extensions
-  resources:
-  - deployments/rollback
-  verbs:
-  - get
-- apiGroups:
-  - extensions
-  resources:
-  - deployments/rollback
-  verbs:
-  - list
-- apiGroups:
-  - extensions
-  resources:
-  - deployments/rollback
-  verbs:
-  - patch
-- apiGroups:
-  - extensions
-  resources:
-  - deployments/rollback
-  verbs:
-  - update
-- apiGroups:
-  - extensions
-  resources:
-  - deployments/rollback
-  verbs:
-  - watch
-- apiGroups:
-  - extensions
-  resources:
-  - ingresses
-  verbs:
-  - create
-- apiGroups:
-  - extensions
-  resources:
-  - ingresses
-  verbs:
-  - delete
-- apiGroups:
-  - extensions
-  resources:
-  - ingresses
-  verbs:
-  - deletecollection
-- apiGroups:
-  - extensions
-  resources:
-  - ingresses
-  verbs:
-  - get
-- apiGroups:
-  - extensions
-  resources:
-  - ingresses
-  verbs:
-  - list
-- apiGroups:
-  - extensions
-  resources:
-  - ingresses
-  verbs:
-  - patch
-- apiGroups:
-  - extensions
-  resources:
-  - ingresses
-  verbs:
-  - update
-- apiGroups:
-  - extensions
-  resources:
-  - ingresses
-  verbs:
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  verbs:
-  - create
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  verbs:
-  - delete
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  verbs:
-  - deletecollection
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  verbs:
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  verbs:
-  - patch
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  verbs:
-  - update
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  verbs:
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - replicasets/scale
-  verbs:
-  - create
-- apiGroups:
-  - apps
-  resources:
-  - replicasets/scale
-  verbs:
-  - delete
-- apiGroups:
-  - apps
-  resources:
-  - replicasets/scale
-  verbs:
-  - deletecollection
-- apiGroups:
-  - apps
-  resources:
-  - replicasets/scale
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - replicasets/scale
-  verbs:
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - replicasets/scale
-  verbs:
-  - patch
-- apiGroups:
-  - apps
-  resources:
-  - replicasets/scale
-  verbs:
-  - update
-- apiGroups:
-  - apps
-  resources:
-  - replicasets/scale
-  verbs:
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets/scale
-  verbs:
-  - create
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets/scale
-  verbs:
-  - delete
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets/scale
-  verbs:
-  - deletecollection
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets/scale
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets/scale
-  verbs:
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets/scale
-  verbs:
-  - patch
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets/scale
-  verbs:
-  - update
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets/scale
-  verbs:
-  - watch
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies
-  verbs:
-  - create
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies
-  verbs:
-  - delete
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies
-  verbs:
-  - deletecollection
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies
-  verbs:
-  - get
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies
-  verbs:
-  - list
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies
-  verbs:
-  - patch
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies
-  verbs:
-  - update
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies
-  verbs:
-  - watch
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - create
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - delete
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - deletecollection
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - get
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - list
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - patch
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - update
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - watch
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - networkpolicies
-  verbs:
-  - create
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - networkpolicies
-  verbs:
-  - delete
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - networkpolicies
-  verbs:
-  - deletecollection
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - networkpolicies
-  verbs:
-  - get
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - networkpolicies
-  verbs:
-  - list
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - networkpolicies
-  verbs:
-  - patch
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - networkpolicies
-  verbs:
-  - update
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - networkpolicies
-  verbs:
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - controllerrevisions
-  verbs:
-  - create
-- apiGroups:
-  - apps
-  resources:
-  - controllerrevisions
-  verbs:
-  - delete
-- apiGroups:
-  - apps
-  resources:
-  - controllerrevisions
-  verbs:
-  - deletecollection
-- apiGroups:
-  - apps
-  resources:
-  - controllerrevisions
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - controllerrevisions
-  verbs:
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - controllerrevisions
-  verbs:
-  - patch
-- apiGroups:
-  - apps
-  resources:
-  - controllerrevisions
-  verbs:
-  - update
-- apiGroups:
-  - apps
-  resources:
-  - controllerrevisions
-  verbs:
-  - watch
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - create
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - delete
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - deletecollection
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - patch
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - replicationcontrollers
-  - replicationcontrollers/scale
-  - serviceaccounts
-  - services
-  - endpoints
-  - persistentvolumeclaims
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - autoscaling
-  resources:
-  - horizontalpodautoscalers
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  - cronjobs
-  - scheduledjobs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - extensions
-  resources:
-  - jobs
-  - daemonsets
-  - horizontalpodautoscalers
-  - replicationcontrollers/scale
-  - replicasets
-  - replicasets/scale
-  - deployments
-  - deployments/scale
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - get
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - list
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
   verbs:
   - create
   - delete
@@ -843,65 +105,248 @@ rules:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
+  - customresourcedefinitions/status
   verbs:
-  - get
-  - list
-  - watch
   - create
-  - update
+  - delete
+  - deletecollection
   - patch
+  - update
+- apiGroups:
+  - apiregistration.k8s.io
+  resources:
+  - apiservices
+  - apiservices/status
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  - statefulsets/scale
+  - statefulsets/status
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - apps
+  - extensions
+  resources:
+  - daemonsets
+  - daemonsets/status
+  - deployments
+  - deployments/rollback
+  - deployments/scale
+  - deployments/status
+  - replicasets
+  - replicasets/scale
+  - replicasets/status
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - apps
+  - metacontroller.k8s.io
+  resources:
+  - controllerrevisions
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - localsubjectaccessreviews
+  - selfsubjectaccessreviews
+  - selfsubjectrulesreviews
+  - subjectaccessreviews
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - autoscaling.k8s.io
+  resources:
+  - verticalpodautoscalercheckpoints
+  - verticalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  - horizontalpodautoscalers/status
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - cronjobs/status
+  - jobs
+  - jobs/status
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  - certificatesigningrequests/approval
+  - certificatesigningrequests/status
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - extensions
+  - networking.k8s.io
+  resources:
+  - ingresses
+  - ingresses/status
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - extensions
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - external.metrics.k8s.io
+  resources:
+  - sqs-queue-length
+  - zmon-check
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - metacontroller.k8s.io
+  resources:
+  - compositecontrollers
+  - decoratorcontrollers
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - node.k8s.io
+  resources:
+  - runtimeclasses
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  - poddisruptionbudgets/status
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
-  - roles
-  - rolebindings
-  - clusterroles
   - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  - roles
   verbs:
-  - get
-  - list
-  - watch
   - create
-  - update
-  - patch
   - delete
-- apiGroups:
-  - ""
-  resources:
-  - persistentvolumes
-  verbs:
-  - update
+  - deletecollection
   - patch
+  - update
 - apiGroups:
   - scheduling.k8s.io
   resources:
   - priorityclasses
   verbs:
-  - get
-  - list
-  - watch
   - create
-  - update
-  - patch
   - delete
+  - deletecollection
+  - patch
+  - update
 - apiGroups:
   - storage.k8s.io
   resources:
+  - csidrivers
+  - csinodes
   - storageclasses
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - admissionregistration.k8s.io
-  resources:
-  - validatingwebhookconfigurations
+  - volumeattachments
+  - volumeattachments/status
   verbs:
   - create
-  - update
-  - patch
   - delete
+  - deletecollection
+  - patch
+  - update
+

--- a/cluster/manifests/roles/poweruser-role.yaml
+++ b/cluster/manifests/roles/poweruser-role.yaml
@@ -101,8 +101,6 @@ rules:
   - customresourcedefinitions/status
   verbs:
   - create
-  - delete
-  - deletecollection
   - patch
   - update
 - apiGroups:

--- a/cluster/manifests/roles/readonly-role.yaml
+++ b/cluster/manifests/roles/readonly-role.yaml
@@ -18,305 +18,77 @@ metadata:
   name: readonly-base
 rules:
 - apiGroups:
-  - ""
+  - ''
   resources:
-  - pods
-  - replicationcontrollers
-  - replicationcontrollers/scale
+  - bindings
+  - componentstatuses
+  - configmaps
+  - endpoints
+  - limitranges
+  - namespaces
+  - namespaces/finalize
+  - namespaces/status
+  - nodes/proxy
+  - nodes/status
+  - persistentvolumeclaims
+  - persistentvolumeclaims/status
+  - persistentvolumes
+  - persistentvolumes/status
+  - pods/attach
+  - pods/binding
+  - pods/eviction
+  - pods/exec
+  - pods/log
+  - pods/portforward
+  - pods/proxy
+  - pods/status
+  - podtemplates
+  - replicationcontrollers/status
+  - resourcequotas
+  - resourcequotas/status
+  - secrets
   - serviceaccounts
   - services
-  - endpoints
-  - persistentvolumeclaims
-  - configmaps
+  - services/proxy
+  - services/status
   verbs:
   - get
   - list
   - watch
 - apiGroups:
-  - ""
-  resources:
-  - limitranges
-  - resourcequotas
-  - bindings
-  - events
-  - pods/status
-  - resourcequotas/status
-  - namespaces/status
-  - replicationcontrollers/status
-  - pods/log
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - autoscaling
-  resources:
-  - horizontalpodautoscalers
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  - cronjobs
-  - scheduledjobs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
+  - ''
   - extensions
   resources:
-  - jobs
-  - daemonsets
-  - horizontalpodautoscalers
+  - replicationcontrollers
   - replicationcontrollers/scale
-  - replicasets
-  - replicasets/scale
-  - deployments
-  - deployments/scale
   verbs:
   - get
   - list
   - watch
 - apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - deployments/scale
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - deployments/scale
-  verbs:
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - deployments/scale
-  verbs:
-  - watch
-- apiGroups:
-  - extensions
-  resources:
-  - ingresses
-  verbs:
-  - get
-- apiGroups:
-  - extensions
-  resources:
-  - ingresses
-  verbs:
-  - list
-- apiGroups:
-  - extensions
-  resources:
-  - ingresses
-  verbs:
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - daemonsets
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - daemonsets
-  verbs:
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - daemonsets
-  verbs:
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  verbs:
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  verbs:
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - replicasets/scale
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - replicasets/scale
-  verbs:
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - replicasets/scale
-  verbs:
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets/scale
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets/scale
-  verbs:
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets/scale
-  verbs:
-  - watch
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies
-  verbs:
-  - get
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies
-  verbs:
-  - list
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies
-  verbs:
-  - watch
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - get
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - list
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - watch
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - networkpolicies
-  verbs:
-  - get
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - networkpolicies
-  verbs:
-  - list
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - networkpolicies
-  verbs:
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - controllerrevisions
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - controllerrevisions
-  verbs:
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - controllerrevisions
-  verbs:
-  - watch
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - get
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - list
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - watch
-- apiGroups:
-  - ""
+  - ''
+  - metrics.k8s.io
   resources:
   - nodes
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
   verbs:
   - get
   - list
@@ -325,14 +97,184 @@ rules:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
+  - customresourcedefinitions/status
   verbs:
   - get
   - list
   - watch
 - apiGroups:
-  - ""
+  - apiregistration.k8s.io
   resources:
-  - persistentvolumes
+  - apiservices
+  - apiservices/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  - extensions
+  resources:
+  - daemonsets
+  - daemonsets/status
+  - deployments
+  - deployments/rollback
+  - deployments/scale
+  - deployments/status
+  - replicasets
+  - replicasets/scale
+  - replicasets/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  - statefulsets/scale
+  - statefulsets/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  - metacontroller.k8s.io
+  resources:
+  - controllerrevisions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - localsubjectaccessreviews
+  - selfsubjectaccessreviews
+  - selfsubjectrulesreviews
+  - subjectaccessreviews
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling.k8s.io
+  resources:
+  - verticalpodautoscalercheckpoints
+  - verticalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  - horizontalpodautoscalers/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - cronjobs/status
+  - jobs
+  - jobs/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  - certificatesigningrequests/approval
+  - certificatesigningrequests/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  - networking.k8s.io
+  resources:
+  - ingresses
+  - ingresses/status
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - external.metrics.k8s.io
+  resources:
+  - sqs-queue-length
+  - zmon-check
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - metacontroller.k8s.io
+  resources:
+  - compositecontrollers
+  - decoratorcontrollers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - node.k8s.io
+  resources:
+  - runtimeclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  - poddisruptionbudgets/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  - roles
   verbs:
   - get
   - list
@@ -348,25 +290,13 @@ rules:
 - apiGroups:
   - storage.k8s.io
   resources:
+  - csidrivers
+  - csinodes
   - storageclasses
+  - volumeattachments
+  - volumeattachments/status
   verbs:
   - get
   - list
   - watch
-- apiGroups:
-  - admissionregistration.k8s.io
-  resources:
-  - validatingwebhookconfigurations
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - metrics.k8s.io
-  resources:
-  - pods
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
+

--- a/cluster/manifests/roles/readonly-role.yaml
+++ b/cluster/manifests/roles/readonly-role.yaml
@@ -28,25 +28,20 @@ rules:
   - namespaces
   - namespaces/finalize
   - namespaces/status
+  - nodes
   - nodes/proxy
   - nodes/status
   - persistentvolumeclaims
   - persistentvolumeclaims/status
   - persistentvolumes
   - persistentvolumes/status
-  - pods/attach
-  - pods/binding
-  - pods/eviction
-  - pods/exec
+  - pods
   - pods/log
-  - pods/portforward
-  - pods/proxy
   - pods/status
   - podtemplates
   - replicationcontrollers/status
   - resourcequotas
   - resourcequotas/status
-  - secrets
   - serviceaccounts
   - services
   - services/proxy
@@ -66,7 +61,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - ''
   - metrics.k8s.io
   resources:
   - nodes
@@ -131,37 +125,10 @@ rules:
 - apiGroups:
   - apps
   resources:
+  - controllerrevisions
   - statefulsets
   - statefulsets/scale
   - statefulsets/status
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apps
-  - metacontroller.k8s.io
-  resources:
-  - controllerrevisions
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - localsubjectaccessreviews
-  - selfsubjectaccessreviews
-  - selfsubjectrulesreviews
-  - subjectaccessreviews
   verbs:
   - get
   - list
@@ -196,16 +163,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - certificates.k8s.io
-  resources:
-  - certificatesigningrequests
-  - certificatesigningrequests/approval
-  - certificatesigningrequests/status
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - coordination.k8s.io
   resources:
   - leases
@@ -234,18 +191,10 @@ rules:
   - list
   - watch
 - apiGroups:
-  - external.metrics.k8s.io
-  resources:
-  - sqs-queue-length
-  - zmon-check
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - metacontroller.k8s.io
   resources:
   - compositecontrollers
+  - controllerrevisions
   - decoratorcontrollers
   verbs:
   - get


### PR DESCRIPTION
Regenerate the policies with a helper script and then tune them based on the existing policies and a manual review. Hopefully makes the result more readable.