### PR TITLE
kube-metrics-adapter: Update to v0.1.0

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.0.4
+        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.0
         {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
         env:
         # must be set for the AWS SDK/AWS CLI to find the credentials file.


### PR DESCRIPTION
Use `autoscaling/v2beta2` api by default.

https://github.com/zalando-incubator/kube-metrics-adapter/releases/tag/v0.1.0
https://github.com/zalando-incubator/kube-metrics-adapter/releases/tag/v0.0.5