### PR TITLE
Update Kubernetes lifecycle metrics

### DIFF
--- a/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kubernetes-lifecycle-metrics
-    version: master-5
+    version: master-7
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kubernetes-lifecycle-metrics
-        version: master-5
+        version: master-7
       annotations:
         kubernetes-log-watcher/scalyr-parser: '[{"container": "kubernetes-lifecycle-metrics", "parser": "system-json-escaped-json"}]'
     spec:
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: kubernetes-lifecycle-metrics
       containers:
         - name: kubernetes-lifecycle-metrics
-          image: "pierone.stups.zalan.do/teapot/kubernetes-lifecycle-metrics:master-5"
+          image: "pierone.stups.zalan.do/teapot/kubernetes-lifecycle-metrics:master-7"
           ports:
             - containerPort: 9090
           resources:


### PR DESCRIPTION
Update client-go to v0.17.0. This version of client-go refreshes mounted service account tokens before they expire.
