### PR TITLE
kube-janitor v20.1.0 (fixes CRD deletion)

### DIFF
--- a/cluster/manifests/kube-janitor/deployment.yaml
+++ b/cluster/manifests/kube-janitor/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-janitor
-    version: v19.8.0
+    version: v20.1.0
 spec:
   replicas: 1
   selector:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: kube-janitor
-        version: v19.8.0
+        version: v20.1.0
     spec:
       dnsConfig:
         options:
@@ -27,7 +27,7 @@ spec:
       containers:
       - name: janitor
         # see https://github.com/hjacobs/kube-janitor/releases
-        image: registry.opensource.zalan.do/teapot/kube-janitor:19.8.0
+        image: registry.opensource.zalan.do/teapot/kube-janitor:20.1.0
         args:
           # run every minute
           - --interval=60


### PR DESCRIPTION
fix deletion of CRD objects (e.g. PlatformCredentialsSet), see https://github.com/hjacobs/kube-janitor/releases/tag/20.1.0 (https://github.com/hjacobs/kube-janitor/issues/47)