### PR TITLE
fast-forward all RBAC changes

### DIFF
--- a/cluster/manifests/roles/collaborator-roles.yaml
+++ b/cluster/manifests/roles/collaborator-roles.yaml
@@ -5,11 +5,10 @@ metadata:
   namespace: visibility
 rules:
 - apiGroups:
-  - ""
+  - apps
+  - extensions
   resources:
   - daemonsets
-  resourceNames:
-  - logging-agent
   verbs:
   - create
   - update
@@ -19,12 +18,12 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: collaborator
+  name: collaborator-binding
   namespace: visibility
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: collaborator-visibility
+  kind: Role
+  name: collaborator
 subjects:
 - kind: Group
   name: CollaboratorPowerUser

--- a/cluster/manifests/roles/poweruser-binding.yaml
+++ b/cluster/manifests/roles/poweruser-binding.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: poweruser-new # TODO: migrate name
+  name: poweruser
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -10,6 +10,11 @@ subjects:
 - kind: Group
   name: PowerUser
   apiGroup: rbac.authorization.k8s.io
+{{- if eq .Cluster.Environment "test" }}
+- kind: Group
+  name: CollaboratorPowerUser
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
 - kind: Group
   name: Manual
   apiGroup: rbac.authorization.k8s.io

--- a/cluster/manifests/roles/poweruser-role.yaml
+++ b/cluster/manifests/roles/poweruser-role.yaml
@@ -16,823 +16,69 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-poweruser: "true"
 rules:
 - apiGroups:
-  - ""
+  - ''
   resources:
+  - configmaps
+  - endpoints
+  - namespaces
+  - namespaces/finalize
+  - persistentvolumeclaims
+  - persistentvolumes
   - pods
   - pods/attach
-  - pods/proxy
+  - pods/eviction
   - pods/exec
   - pods/portforward
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-  - deletecollection
-- apiGroups:
-  - ""
-  resources:
-  - replicationcontrollers
-  - replicationcontrollers/scale
+  - pods/proxy
+  - podtemplates
+  - secrets
   - serviceaccounts
   - services
   - services/proxy
-  - endpoints
-  - persistentvolumeclaims
-  - configmaps
-  - secrets
   verbs:
-  - get
-  - list
-  - watch
   - create
-  - update
-  - patch
   - delete
   - deletecollection
+  - patch
+  - update
 - apiGroups:
-  - ""
+  - ''
   resources:
-  - limitranges
-  - resourcequotas
-  - bindings
-  - pods/status
-  - resourcequotas/status
-  - namespaces/status
-  - replicationcontrollers/status
-  - pods/log
+  - secrets
   verbs:
+  - create
+  - delete
+  - deletecollection
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
-  - ""
-  - "events.k8s.io"
+  - ''
+  - extensions
+  resources:
+  - replicationcontrollers
+  - replicationcontrollers/scale
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - ''
+  - events.k8s.io
   resources:
   - events
   verbs:
-    - get
-    - list
-    - watch
-    - create
-    - update
-    - patch
-    - delete
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets
-  verbs:
-  - get
-  - list
-  - watch
   - create
-  - update
   - patch
-  - delete
-  - deletecollection
-- apiGroups:
-  - autoscaling
-  resources:
-  - horizontalpodautoscalers
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-  - deletecollection
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  - cronjobs
-  - scheduledjobs
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-  - deletecollection
-- apiGroups:
-  - extensions
-  resources:
-  - jobs
-  - horizontalpodautoscalers
-  - replicationcontrollers/scale
-  - replicasets
-  - replicasets/scale
-  - deployments
-  - deployments/scale
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-  - deletecollection
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - create
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - delete
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - deletecollection
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - patch
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
   - update
 - apiGroups:
-  - apps
+  - admissionregistration.k8s.io
   resources:
-  - deployments
-  verbs:
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - deployments/rollback
-  verbs:
-  - create
-- apiGroups:
-  - apps
-  resources:
-  - deployments/rollback
-  verbs:
-  - delete
-- apiGroups:
-  - apps
-  resources:
-  - deployments/rollback
-  verbs:
-  - deletecollection
-- apiGroups:
-  - apps
-  resources:
-  - deployments/rollback
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - deployments/rollback
-  verbs:
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - deployments/rollback
-  verbs:
-  - patch
-- apiGroups:
-  - apps
-  resources:
-  - deployments/rollback
-  verbs:
-  - update
-- apiGroups:
-  - apps
-  resources:
-  - deployments/rollback
-  verbs:
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - deployments/scale
-  verbs:
-  - create
-- apiGroups:
-  - apps
-  resources:
-  - deployments/scale
-  verbs:
-  - delete
-- apiGroups:
-  - apps
-  resources:
-  - deployments/scale
-  verbs:
-  - deletecollection
-- apiGroups:
-  - apps
-  resources:
-  - deployments/scale
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - deployments/scale
-  verbs:
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - deployments/scale
-  verbs:
-  - patch
-- apiGroups:
-  - apps
-  resources:
-  - deployments/scale
-  verbs:
-  - update
-- apiGroups:
-  - apps
-  resources:
-  - deployments/scale
-  verbs:
-  - watch
-- apiGroups:
-  - extensions
-  resources:
-  - deployments/rollback
-  verbs:
-  - create
-- apiGroups:
-  - extensions
-  resources:
-  - deployments/rollback
-  verbs:
-  - delete
-- apiGroups:
-  - extensions
-  resources:
-  - deployments/rollback
-  verbs:
-  - deletecollection
-- apiGroups:
-  - extensions
-  resources:
-  - deployments/rollback
-  verbs:
-  - get
-- apiGroups:
-  - extensions
-  resources:
-  - deployments/rollback
-  verbs:
-  - list
-- apiGroups:
-  - extensions
-  resources:
-  - deployments/rollback
-  verbs:
-  - patch
-- apiGroups:
-  - extensions
-  resources:
-  - deployments/rollback
-  verbs:
-  - update
-- apiGroups:
-  - extensions
-  resources:
-  - deployments/rollback
-  verbs:
-  - watch
-- apiGroups:
-  - extensions
-  resources:
-  - ingresses
-  verbs:
-  - create
-- apiGroups:
-  - extensions
-  resources:
-  - ingresses
-  verbs:
-  - delete
-- apiGroups:
-  - extensions
-  resources:
-  - ingresses
-  verbs:
-  - deletecollection
-- apiGroups:
-  - extensions
-  resources:
-  - ingresses
-  verbs:
-  - get
-- apiGroups:
-  - extensions
-  resources:
-  - ingresses
-  verbs:
-  - list
-- apiGroups:
-  - extensions
-  resources:
-  - ingresses
-  verbs:
-  - patch
-- apiGroups:
-  - extensions
-  resources:
-  - ingresses
-  verbs:
-  - update
-- apiGroups:
-  - extensions
-  resources:
-  - ingresses
-  verbs:
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  verbs:
-  - create
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  verbs:
-  - delete
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  verbs:
-  - deletecollection
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  verbs:
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  verbs:
-  - patch
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  verbs:
-  - update
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  verbs:
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - replicasets/scale
-  verbs:
-  - create
-- apiGroups:
-  - apps
-  resources:
-  - replicasets/scale
-  verbs:
-  - delete
-- apiGroups:
-  - apps
-  resources:
-  - replicasets/scale
-  verbs:
-  - deletecollection
-- apiGroups:
-  - apps
-  resources:
-  - replicasets/scale
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - replicasets/scale
-  verbs:
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - replicasets/scale
-  verbs:
-  - patch
-- apiGroups:
-  - apps
-  resources:
-  - replicasets/scale
-  verbs:
-  - update
-- apiGroups:
-  - apps
-  resources:
-  - replicasets/scale
-  verbs:
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets/scale
-  verbs:
-  - create
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets/scale
-  verbs:
-  - delete
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets/scale
-  verbs:
-  - deletecollection
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets/scale
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets/scale
-  verbs:
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets/scale
-  verbs:
-  - patch
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets/scale
-  verbs:
-  - update
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets/scale
-  verbs:
-  - watch
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies
-  verbs:
-  - create
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies
-  verbs:
-  - delete
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies
-  verbs:
-  - deletecollection
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies
-  verbs:
-  - get
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies
-  verbs:
-  - list
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies
-  verbs:
-  - patch
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies
-  verbs:
-  - update
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies
-  verbs:
-  - watch
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - create
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - delete
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - deletecollection
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - get
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - list
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - patch
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - update
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - watch
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - networkpolicies
-  verbs:
-  - create
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - networkpolicies
-  verbs:
-  - delete
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - networkpolicies
-  verbs:
-  - deletecollection
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - networkpolicies
-  verbs:
-  - get
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - networkpolicies
-  verbs:
-  - list
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - networkpolicies
-  verbs:
-  - patch
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - networkpolicies
-  verbs:
-  - update
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - networkpolicies
-  verbs:
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - controllerrevisions
-  verbs:
-  - create
-- apiGroups:
-  - apps
-  resources:
-  - controllerrevisions
-  verbs:
-  - delete
-- apiGroups:
-  - apps
-  resources:
-  - controllerrevisions
-  verbs:
-  - deletecollection
-- apiGroups:
-  - apps
-  resources:
-  - controllerrevisions
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - controllerrevisions
-  verbs:
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - controllerrevisions
-  verbs:
-  - patch
-- apiGroups:
-  - apps
-  resources:
-  - controllerrevisions
-  verbs:
-  - update
-- apiGroups:
-  - apps
-  resources:
-  - controllerrevisions
-  verbs:
-  - watch
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - create
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - delete
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - deletecollection
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - patch
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - replicationcontrollers
-  - replicationcontrollers/scale
-  - serviceaccounts
-  - services
-  - endpoints
-  - persistentvolumeclaims
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - autoscaling
-  resources:
-  - horizontalpodautoscalers
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  - cronjobs
-  - scheduledjobs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - extensions
-  resources:
-  - jobs
-  - daemonsets
-  - horizontalpodautoscalers
-  - replicationcontrollers/scale
-  - replicasets
-  - replicasets/scale
-  - deployments
-  - deployments/scale
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - get
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - list
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
+  - validatingwebhookconfigurations
   verbs:
   - create
   - delete
@@ -844,43 +90,133 @@ rules:
   resources:
   - customresourcedefinitions
   verbs:
-  - get
-  - list
-  - watch
   - create
-  - update
   - patch
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - controllerrevisions
+  - statefulsets
+  - statefulsets/scale
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - apps
+  - extensions
+  resources:
+  - deployments
+  - deployments/rollback
+  - deployments/scale
+  - replicasets
+  - replicasets/scale
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - autoscaling.k8s.io
+  resources:
+  - verticalpodautoscalercheckpoints
+  - verticalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - extensions
+  - networking.k8s.io
+  resources:
+  - ingresses
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - metacontroller.k8s.io
+  resources:
+  - compositecontrollers
+  - controllerrevisions
+  - decoratorcontrollers
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
-  - roles
-  - rolebindings
-  - clusterroles
   - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  - roles
   verbs:
-  - get
-  - list
-  - watch
   - create
-  - update
-  - patch
   - delete
-- apiGroups:
-  - ""
-  resources:
-  - persistentvolumes
-  verbs:
-  - update
+  - deletecollection
   - patch
+  - update
 - apiGroups:
   - scheduling.k8s.io
   resources:
   - priorityclasses
   verbs:
-  - get
-  - list
-  - watch
   - create
-  - update
-  - patch
   - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+

--- a/cluster/manifests/roles/readonly-binding.yaml
+++ b/cluster/manifests/roles/readonly-binding.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: readonly-new # TODO: migrate name
+  name: readonly
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/cluster/manifests/roles/readonly-role.yaml
+++ b/cluster/manifests/roles/readonly-role.yaml
@@ -18,305 +18,71 @@ metadata:
   name: readonly-base
 rules:
 - apiGroups:
-  - ""
+  - ''
   resources:
+  - bindings
+  - componentstatuses
+  - configmaps
+  - endpoints
+  - limitranges
+  - namespaces
+  - namespaces/finalize
+  - namespaces/status
+  - nodes
+  - nodes/proxy
+  - nodes/status
+  - persistentvolumeclaims
+  - persistentvolumeclaims/status
+  - persistentvolumes
+  - persistentvolumes/status
   - pods
-  - replicationcontrollers
-  - replicationcontrollers/scale
+  - pods/log
+  - pods/status
+  - podtemplates
+  - replicationcontrollers/status
+  - resourcequotas
+  - resourcequotas/status
   - serviceaccounts
   - services
-  - endpoints
-  - persistentvolumeclaims
-  - configmaps
+  - services/proxy
+  - services/status
   verbs:
   - get
   - list
   - watch
 - apiGroups:
-  - ""
-  resources:
-  - limitranges
-  - resourcequotas
-  - bindings
-  - events
-  - pods/status
-  - resourcequotas/status
-  - namespaces/status
-  - replicationcontrollers/status
-  - pods/log
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - autoscaling
-  resources:
-  - horizontalpodautoscalers
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  - cronjobs
-  - scheduledjobs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
+  - ''
   - extensions
   resources:
-  - jobs
-  - daemonsets
-  - horizontalpodautoscalers
+  - replicationcontrollers
   - replicationcontrollers/scale
-  - replicasets
-  - replicasets/scale
-  - deployments
-  - deployments/scale
   verbs:
   - get
   - list
   - watch
 - apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - deployments/scale
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - deployments/scale
-  verbs:
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - deployments/scale
-  verbs:
-  - watch
-- apiGroups:
-  - extensions
-  resources:
-  - ingresses
-  verbs:
-  - get
-- apiGroups:
-  - extensions
-  resources:
-  - ingresses
-  verbs:
-  - list
-- apiGroups:
-  - extensions
-  resources:
-  - ingresses
-  verbs:
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - daemonsets
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - daemonsets
-  verbs:
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - daemonsets
-  verbs:
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  verbs:
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  verbs:
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - replicasets/scale
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - replicasets/scale
-  verbs:
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - replicasets/scale
-  verbs:
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets/scale
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets/scale
-  verbs:
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets/scale
-  verbs:
-  - watch
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies
-  verbs:
-  - get
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies
-  verbs:
-  - list
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies
-  verbs:
-  - watch
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - get
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - list
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - watch
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - networkpolicies
-  verbs:
-  - get
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - networkpolicies
-  verbs:
-  - list
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - networkpolicies
-  verbs:
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - controllerrevisions
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - controllerrevisions
-  verbs:
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - controllerrevisions
-  verbs:
-  - watch
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - get
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - list
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - watch
-- apiGroups:
-  - ""
+  - metrics.k8s.io
   resources:
   - nodes
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
   verbs:
   - get
   - list
@@ -325,14 +91,139 @@ rules:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
+  - customresourcedefinitions/status
   verbs:
   - get
   - list
   - watch
 - apiGroups:
-  - ""
+  - apiregistration.k8s.io
   resources:
-  - persistentvolumes
+  - apiservices
+  - apiservices/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  - extensions
+  resources:
+  - daemonsets
+  - daemonsets/status
+  - deployments
+  - deployments/rollback
+  - deployments/scale
+  - deployments/status
+  - replicasets
+  - replicasets/scale
+  - replicasets/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - controllerrevisions
+  - statefulsets
+  - statefulsets/scale
+  - statefulsets/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling.k8s.io
+  resources:
+  - verticalpodautoscalercheckpoints
+  - verticalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  - horizontalpodautoscalers/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - cronjobs/status
+  - jobs
+  - jobs/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  - networking.k8s.io
+  resources:
+  - ingresses
+  - ingresses/status
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - metacontroller.k8s.io
+  resources:
+  - compositecontrollers
+  - controllerrevisions
+  - decoratorcontrollers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - node.k8s.io
+  resources:
+  - runtimeclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  - poddisruptionbudgets/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  - roles
   verbs:
   - get
   - list
@@ -345,3 +236,16 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csidrivers
+  - csinodes
+  - storageclasses
+  - volumeattachments
+  - volumeattachments/status
+  verbs:
+  - get
+  - list
+  - watch
+

--- a/cluster/manifests/roles/zmon-binding.yaml
+++ b/cluster/manifests/roles/zmon-binding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: zmon-external-new
+  name: zmon-external
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
Fast forward all RBAC changes from `beta` to ensure they are ready in `stable` when we update the authnz webhook in the next `beta-to-stable` merge.