### PR TITLE
Skipper v0.11.34 to fix default filters from configmap

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.11.33
+    version: v0.11.34
     component: ingress
 spec:
   strategy:
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.11.33
+        version: v0.11.34
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -43,7 +43,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.33
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.34
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -92,7 +92,7 @@ spec:
 {{ end }}
           - "-oauth2-tokeninfo-url={{ .ConfigItems.tokeninfo_url }}"
           - "-histogram-metric-buckets=.0001,.00025,.0005,.00075,.001,.0025,.005,.0075,.01,.025,.05,.075,.1,.2,.3,.4,.5,.75,1,2,3,4,5,7,10,15,20,30,60,120,300,600"
-          - "-opentracing=lightstep component-name=skipper-ingress token=$(LIGHTSTEP_TOKEN) collector=tracing.stups.zalan.do:8444 cmd-line=skipper-ingress max-buffered-spans={{ .ConfigItems.skipper_ingress_tracing_buffer }} tag=application=skipper-ingress tag=account={{ .Cluster.Alias }} tag=cluster={{ .Cluster.Alias }} tag=artifact=registry.opensource.zalan.do/pathfinder/skipper:v0.11.33 grpc-max-msg-size={{ .ConfigItems.skipper_ingress_lightstep_grpc_max_msg_size }} max-period={{ .ConfigItems.skipper_ingress_lightstep_max_period }} min-period={{ .ConfigItems.skipper_ingress_lightstep_min_period }} {{ .Cluster.ConfigItems.skipper_ingress_lightstep_log_events }}"
+          - "-opentracing=lightstep component-name=skipper-ingress token=$(LIGHTSTEP_TOKEN) collector=tracing.stups.zalan.do:8444 cmd-line=skipper-ingress max-buffered-spans={{ .ConfigItems.skipper_ingress_tracing_buffer }} tag=application=skipper-ingress tag=account={{ .Cluster.Alias }} tag=cluster={{ .Cluster.Alias }} tag=artifact=registry.opensource.zalan.do/pathfinder/skipper:v0.11.34 grpc-max-msg-size={{ .ConfigItems.skipper_ingress_lightstep_grpc_max_msg_size }} max-period={{ .ConfigItems.skipper_ingress_lightstep_max_period }} min-period={{ .ConfigItems.skipper_ingress_lightstep_min_period }} {{ .Cluster.ConfigItems.skipper_ingress_lightstep_log_events }}"
           - "-opentracing-excluded-proxy-tags={{ .ConfigItems.skipper_ingress_opentracing_excluded_proxy_tags }}"
           - "-expect-continue-timeout-backend={{ .ConfigItems.skipper_expect_continue_timeout_backend }}"
           - "-keepalive-backend={{ .ConfigItems.skipper_keepalive_backend }}"


### PR DESCRIPTION
Fix to read from configmap (https://github.com/zalando/skipper/pull/1294) --- important for API monitoring default filters (which are currently broken).