### PR TITLE
Update custom metrics adapter to v0.1.1

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.0
+        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.1
         {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
         env:
         # must be set for the AWS SDK/AWS CLI to find the credentials file.


### PR DESCRIPTION
This contains a fix for leaking memory when scraping pod metrics. Release notes are [here](https://github.com/zalando-incubator/kube-metrics-adapter/releases/tag/v0.1.1).