### PR TITLE
Add HPA admitter

### DIFF
--- a/cluster/manifests/01-admission-control/daemonset.yaml
+++ b/cluster/manifests/01-admission-control/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cluster-autoscaler
-        image: registry.opensource.zalan.do/teapot/admission-controller:master-54
+        image: registry.opensource.zalan.do/teapot/admission-controller:master-57
         command:
           - /registry-proxy
           - --address=127.0.0.1:8285

--- a/cluster/manifests/01-admission-control/teapot.yaml
+++ b/cluster/manifests/01-admission-control/teapot.yaml
@@ -137,3 +137,15 @@ webhooks:
         apiGroups: ["zalando.org"]
         apiVersions: ["v1"]
         resources: ["stacks"]
+  - name: hpa-admitter.teapot.zalan.do
+    clientConfig:
+      url: "https://localhost:8085/hpa"
+      caBundle: "{{ .ConfigItems.ca_cert_decompressed }}"
+    failurePolicy: Fail
+    sideEffects: "NoneOnDryRun"
+    matchPolicy: Equivalent
+    rules:
+      - operations: [ "CREATE", "UPDATE" ]
+        apiGroups: ["autoscaling"]
+        apiVersions: ["v2beta2"]
+        resources: ["horizontalpodautoscalers"]

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -173,7 +173,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-56
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-57
           name: admission-controller
           readinessProbe:
             httpGet:


### PR DESCRIPTION
This adds an HPA admitter which enforces that HPAs targeting `Deployment` or `StatefulSet` resources always use the `apps/v1` `apiVersion` in the `scaleTargetRef` definition. This is needed because it's possible to deploy an HPA targeting e.g. `extensions/v1beta1` in Kubernetes v1.16, but this does not work as `extensions/v1beta1` has been disabled for `Deployments` and `StatefulSets` in Kubernetes v1.16.