### PR TITLE
Delete the LimitRange in the cron namespace

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -23,6 +23,9 @@ post_apply:
 - name: limits
   namespace: default
   kind: LimitRange
+- name: limits
+  namespace: cron
+  kind: LimitRange
 {{ end }}
 {{ if ne .ConfigItems.enable_ingress_template_controller "true" }}
 - name: ingresstemplates.zalando.org


### PR DESCRIPTION
I somehow didn't notice it, so now we have a lot of useless LimitRange objects.