### PR TITLE
Allow disabling legacy apiVersions

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -279,3 +279,6 @@ vm_dirty_bytes: ""
 
 # temporary flag for kubernetes.io/node-pool node label
 legacy_node_pool_label_enabled: "false"
+
+# Disable legacy apiVersions which will be gone in Kubernetes v1.16
+disable_legacy_api_versions: "true"

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -110,7 +110,7 @@ write_files:
           - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
           - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
           - --service-account-key-file=/etc/kubernetes/ssl/service-account-public-key.pem
-          - --runtime-config=extensions/v1beta1/networkpolicies=true,batch/v2alpha1=true,policy/v1beta1/podsecuritypolicy=true,imagepolicy.k8s.io/v1alpha1=true,authorization.k8s.io/v1beta1=true,scheduling.k8s.io/v1alpha1=true,admissionregistration.k8s.io/v1beta1=true
+          - --runtime-config=extensions/v1beta1/networkpolicies=true,batch/v2alpha1=true,policy/v1beta1/podsecuritypolicy=true,imagepolicy.k8s.io/v1alpha1=true,authorization.k8s.io/v1beta1=true,scheduling.k8s.io/v1alpha1=true,admissionregistration.k8s.io/v1beta1=true{{ if eq .Cluster.ConfigItems.disable_legacy_api_versions "true" }},extensions/v1beta1/deployments=false,apps/v1beta1=false,apps/v1beta2=false{{ end }}
           - --authentication-token-webhook-config-file=/etc/kubernetes/config/authn.yaml
           - --authentication-token-webhook-cache-ttl=10s
           - --cloud-provider=aws


### PR DESCRIPTION
This adds a config-item `disable_legacy_api_versions` which when set to `true` (default) will disable legacy `apiVersions` like `extensions/v1beta1/deployments`, `apps/v1beta1`, `apps/v1beta2`.

The idea is that we set it manually to `false` in all clusters, and then we can disable once we are sure nothing will break for the users.