### PR TITLE
Allow PowerUsers to deploy LimitRanges

### DIFF
--- a/cluster/manifests/roles/poweruser-role.yaml
+++ b/cluster/manifests/roles/poweruser-role.yaml
@@ -20,6 +20,7 @@ rules:
   resources:
   - configmaps
   - endpoints
+  - limitranges
   - namespaces
   - namespaces/finalize
   - persistentvolumeclaims


### PR DESCRIPTION
These are used by a couple of teams to provide better defaults for their pods (apparently the operator they use makes it very hard to customise the defaults). Let's allow for them now.