### PR TITLE
Encrypt secrets in etcd using KMS

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1586,6 +1586,7 @@ Resources:
             Resource: "*"
             Action:
             - "kms:Decrypt"
+{{- if eq .Cluster.ConfigItems.support_encryption "true" }}
   EtcdEncryptionKey:
     Type: "AWS::KMS::Key"
     Properties:
@@ -1612,6 +1613,7 @@ Resources:
             Action:
             - "kms:Encrypt"
             - "kms:Decrypt"
+{{- end }}
   MasterFilesEncryptionKey:
     Type: "AWS::KMS::Key"
     Properties:
@@ -1713,7 +1715,9 @@ Outputs:
     Export:
       Name: '{{ .Cluster.ID}}:master-files-encryption-key'
     Value: !Ref MasterFilesEncryptionKey
+{{- if eq .Cluster.ConfigItems.support_encryption "true" }}
   EtcdEncryptionKey:
     Export:
       Name: '{{ .Cluster.ID}}:etcd-encryption-key'
     Value: !Ref EtcdEncryptionKey
+{{- end }}

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1586,6 +1586,32 @@ Resources:
             Resource: "*"
             Action:
             - "kms:Decrypt"
+  EtcdEncryptionKey:
+    Type: "AWS::KMS::Key"
+    Properties:
+      Description: The KMS key for encryption of secrets in etcd
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: "2012-10-17"
+        Id: "etcd-key-policy"
+        Statement:
+          - Sid: "Enable IAM User Permissions"
+            Effect: "Allow"
+            Principal:
+              AWS: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:root"
+            Action: "kms:*"
+            Resource: "*"
+          - Sid: "Enable master nodes to encrypt and decrypt secrets in etcd"
+            Effect: "Allow"
+            Principal:
+              AWS:
+                - "Fn::GetAtt":
+                  - "MasterIAMRole"
+                  - "Arn"
+            Resource: "*"
+            Action:
+            - "kms:Encrypt"
+            - "kms:Decrypt"
   MasterFilesEncryptionKey:
     Type: "AWS::KMS::Key"
     Properties:
@@ -1687,3 +1713,7 @@ Outputs:
     Export:
       Name: '{{ .Cluster.ID}}:master-files-encryption-key'
     Value: !Ref MasterFilesEncryptionKey
+  EtcdEncryptionKey:
+    Export:
+      Name: '{{ .Cluster.ID}}:etcd-encryption-key'
+    Value: !Ref EtcdEncryptionKey

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -285,5 +285,3 @@ disable_legacy_api_versions: "true"
 
 # enable encryption of secrets in etcd
 enable_encryption: "false"
-# when secrets encryption is enabled, the encryption key to use
-encryption_key:

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -283,5 +283,10 @@ legacy_node_pool_label_enabled: "false"
 # Disable legacy apiVersions which will be gone in Kubernetes v1.16
 disable_legacy_api_versions: "true"
 
-# enable encryption of secrets in etcd
+# setup supporting components to enable encryption
+# this flag must only be switched from true to false when enable_encryption is false and all secrets were decrypted
+support_encryption: "false"
+# enable encryption of secrets in etcd, requires support_encryption: true
+# this flag can be switched between true and false as long as support_encryption is true
+# to ensure all secrets are encrypted/decrypted all secrets need to be rewritten
 enable_encryption: "false"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -282,3 +282,8 @@ legacy_node_pool_label_enabled: "false"
 
 # Disable legacy apiVersions which will be gone in Kubernetes v1.16
 disable_legacy_api_versions: "true"
+
+# enable encryption of secrets in etcd
+enable_encryption: "false"
+# when secrets encryption is enabled, the encryption key to use
+encryption_key:

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -430,7 +430,6 @@ write_files:
             requests:
               cpu: 25m
               memory: 25Mi
-        {{- if index .Values "ClusterStackOutputs" }}
         - name: aws-encryption-provider
           image: registry.opensource.zalan.do/teapot/aws-encryption-provider:master-1
           command:
@@ -453,7 +452,6 @@ write_files:
           volumeMounts:
           - mountPath: /var/run/kmsplugin
             name: var-run-kmsplugin
-        {{- end }}
         volumes:
         - hostPath:
             path: /etc/kubernetes/ssl

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -432,8 +432,7 @@ write_files:
               memory: 25Mi
         {{- if index .Values "ClusterStackOutputs" }}
         - name: aws-encryption-provider
-          image: quay.io/linki/aws-encryption-provider:latest
-          imagePullPolicy: Always
+          image: registry.opensource.zalan.do/teapot/aws-encryption-provider:master-1
           command:
           - /aws-encryption-provider
           - --key=arn:aws:kms:{{ .Cluster.Region }}:{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:key/{{ .Values.ClusterStackOutputs.EtcdEncryptionKey }}

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -103,6 +103,9 @@ write_files:
           - --etcd-prefix={{ .Cluster.ConfigItems.apiserver_etcd_prefix }}
           - --storage-backend=etcd3
           - --storage-media-type=application/vnd.kubernetes.protobuf
+          {{ if eq .Cluster.ConfigItems.enable_encryption "true" }}
+          - --encryption-provider-config=/etc/kubernetes/config/encryption-config.yaml
+          {{ end }}
           - --allow-privileged=true
           - --service-cluster-ip-range=10.3.0.0/16
           - --secure-port=443
@@ -693,3 +696,21 @@ write_files:
         - level: Request
           omitStages:
             - "RequestReceived"
+
+{{ if eq .Cluster.ConfigItems.enable_encryption "true" }}
+  - owner: root:root
+    path: /etc/kubernetes/config/encryption-config.yaml
+    permissions: '0400'
+    content: |
+      apiVersion: apiserver.config.k8s.io/v1
+      kind: EncryptionConfiguration
+      resources:
+        - resources:
+          - secrets
+          providers:
+          - aescbc:
+              keys:
+              - name: key1
+                secret: {{ .Cluster.ConfigItems.encryption_key }}
+          - identity: {}
+{{ end }}

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -430,13 +430,13 @@ write_files:
             requests:
               cpu: 25m
               memory: 25Mi
-        {{- if index .Values "EtcdEncryptionKey" }}
+        {{- if index .Values "ClusterStackOutputs" }}
         - name: aws-encryption-provider
           image: quay.io/linki/aws-encryption-provider:latest
           imagePullPolicy: Always
           command:
           - /aws-encryption-provider
-          - --key=arn:aws:kms:{{ .Cluster.Region }}:{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:key/{{ .Values.EtcdEncryptionKey }}
+          - --key=arn:aws:kms:{{ .Cluster.Region }}:{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:key/{{ .Values.ClusterStackOutputs.EtcdEncryptionKey }}
           - --region={{ .Cluster.Region }}
           - --listen=/var/run/kmsplugin/socket.sock
           - --health-port=:8086

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -103,7 +103,9 @@ write_files:
           - --etcd-prefix={{ .Cluster.ConfigItems.apiserver_etcd_prefix }}
           - --storage-backend=etcd3
           - --storage-media-type=application/vnd.kubernetes.protobuf
+          {{- if eq .Cluster.ConfigItems.support_encryption "true" }}
           - --encryption-provider-config=/etc/kubernetes/config/encryption-config.yaml
+          {{- end }}
           - --allow-privileged=true
           - --service-cluster-ip-range=10.3.0.0/16
           - --secure-port=443
@@ -170,8 +172,10 @@ write_files:
           - mountPath: /etc/kubernetes/config
             name: kubernetes-configs
             readOnly: true
+          {{- if eq .Cluster.ConfigItems.support_encryption "true" }}
           - mountPath: /var/run/kmsplugin
             name: var-run-kmsplugin
+          {{- end }}
           resources:
             requests:
               cpu: 100m
@@ -430,6 +434,7 @@ write_files:
             requests:
               cpu: 25m
               memory: 25Mi
+        {{- if eq .Cluster.ConfigItems.support_encryption "true" }}
         - name: aws-encryption-provider
           image: registry.opensource.zalan.do/teapot/aws-encryption-provider:master-1
           command:
@@ -452,6 +457,7 @@ write_files:
           volumeMounts:
           - mountPath: /var/run/kmsplugin
             name: var-run-kmsplugin
+        {{- end }}
         volumes:
         - hostPath:
             path: /etc/kubernetes/ssl
@@ -462,10 +468,12 @@ write_files:
         - hostPath:
             path: /etc/kubernetes/nginx
           name: config-volume
+        {{- if eq .Cluster.ConfigItems.support_encryption "true" }}
         - name: var-run-kmsplugin
           hostPath:
             path: /var/run/kmsplugin
             type: DirectoryOrCreate
+        {{- end }}
 
   - owner: root:root
     path: /etc/kubernetes/manifests/kube-controller-manager.yaml
@@ -723,6 +731,7 @@ write_files:
           omitStages:
             - "RequestReceived"
 
+{{- if eq .Cluster.ConfigItems.support_encryption "true" }}
   - owner: root:root
     path: /etc/kubernetes/config/encryption-config.yaml
     permissions: '0400'
@@ -744,3 +753,4 @@ write_files:
       {{- if eq .Cluster.ConfigItems.enable_encryption "true" }}
           - identity: {}
       {{- end }}
+{{ end }}

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -103,9 +103,7 @@ write_files:
           - --etcd-prefix={{ .Cluster.ConfigItems.apiserver_etcd_prefix }}
           - --storage-backend=etcd3
           - --storage-media-type=application/vnd.kubernetes.protobuf
-          {{ if eq .Cluster.ConfigItems.enable_encryption "true" }}
           - --encryption-provider-config=/etc/kubernetes/config/encryption-config.yaml
-          {{ end }}
           - --allow-privileged=true
           - --service-cluster-ip-range=10.3.0.0/16
           - --secure-port=443
@@ -172,6 +170,8 @@ write_files:
           - mountPath: /etc/kubernetes/config
             name: kubernetes-configs
             readOnly: true
+          - mountPath: /var/run/kmsplugin
+            name: var-run-kmsplugin
           resources:
             requests:
               cpu: 100m
@@ -430,6 +430,31 @@ write_files:
             requests:
               cpu: 25m
               memory: 25Mi
+        {{- if index .Values "EtcdEncryptionKey" }}
+        - name: aws-encryption-provider
+          image: quay.io/linki/aws-encryption-provider:latest
+          imagePullPolicy: Always
+          command:
+          - /aws-encryption-provider
+          - --key=arn:aws:kms:{{ .Cluster.Region }}:{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:key/{{ .Values.EtcdEncryptionKey }}
+          - --region={{ .Cluster.Region }}
+          - --listen=/var/run/kmsplugin/socket.sock
+          - --health-port=:8086
+          ports:
+          - containerPort: 8086
+            protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8086
+          resources:
+            requests:
+              cpu: 50m
+              memory: 50Mi
+          volumeMounts:
+          - mountPath: /var/run/kmsplugin
+            name: var-run-kmsplugin
+        {{- end }}
         volumes:
         - hostPath:
             path: /etc/kubernetes/ssl
@@ -440,6 +465,10 @@ write_files:
         - hostPath:
             path: /etc/kubernetes/nginx
           name: config-volume
+        - name: var-run-kmsplugin
+          hostPath:
+            path: /var/run/kmsplugin
+            type: DirectoryOrCreate
 
   - owner: root:root
     path: /etc/kubernetes/manifests/kube-controller-manager.yaml
@@ -697,7 +726,6 @@ write_files:
           omitStages:
             - "RequestReceived"
 
-{{ if eq .Cluster.ConfigItems.enable_encryption "true" }}
   - owner: root:root
     path: /etc/kubernetes/config/encryption-config.yaml
     permissions: '0400'
@@ -708,9 +736,14 @@ write_files:
         - resources:
           - secrets
           providers:
-          - aescbc:
-              keys:
-              - name: key1
-                secret: {{ .Cluster.ConfigItems.encryption_key }}
+      {{- if ne .Cluster.ConfigItems.enable_encryption "true" }}
           - identity: {}
-{{ end }}
+      {{- end }}
+          - kms:
+              name: aws-encryption-provider
+              endpoint: unix:///var/run/kmsplugin/socket.sock
+              cachesize: 1000
+              timeout: 3s
+      {{- if eq .Cluster.ConfigItems.enable_encryption "true" }}
+          - identity: {}
+      {{- end }}

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -55,9 +55,7 @@ clusters:
     kube_aws_ingress_controller_nlb_enabled: "true"
     vm_dirty_bytes: 134217728
     vm_dirty_background_bytes: 67108864
-    enable_encryption: true
-    # key used for testing. don't use me for anything
-    encryption_key: Mnz9PR8jacvFAMIhyi0FvlHhg1RBn/0kx2H6NmJc56I=
+    enable_encryption: false
   criticality_level: 1
   environment: e2e
   id: ${CLUSTER_ID}

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -55,6 +55,9 @@ clusters:
     kube_aws_ingress_controller_nlb_enabled: "true"
     vm_dirty_bytes: 134217728
     vm_dirty_background_bytes: 67108864
+    enable_encryption: true
+    # key used for testing. don't use me for anything
+    encryption_key: Mnz9PR8jacvFAMIhyi0FvlHhg1RBn/0kx2H6NmJc56I=
   criticality_level: 1
   environment: e2e
   id: ${CLUSTER_ID}

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -55,7 +55,6 @@ clusters:
     kube_aws_ingress_controller_nlb_enabled: "true"
     vm_dirty_bytes: 134217728
     vm_dirty_background_bytes: 67108864
-    enable_encryption: false
   criticality_level: 1
   environment: e2e
   id: ${CLUSTER_ID}


### PR DESCRIPTION
Use KMS to encrypt secrets in etcd. Follow up of https://github.com/zalando-incubator/kubernetes-on-aws/pull/2595.

It mitigates the effects of unauthorized access to an etcd endpoint by preventing reading clear-text secrets. It doesn't protect against a compromised Kubernetes master because it has access to etcd and is allowed to decrypt with the KMS key.

All providers are used for reading but only the first is used for writing. This way one can seamlessly migrate from non-encrypted to encrypted, encrypted to non-encrypted and from one key to another.

The only thing to do is to swap the order which can be done via the `enable_encryption: true|false` config item. When enabled, secrets get encrypted when they are written, so it's lazy. Same for decryption in case it's turned off later. Both encrypted and non-encrypted secrets can always be read.

To be sure that all secrets are stored encrypted one has to force a rewrite of all secrets after turning the feature on (and waiting for all masters to update) with `kubectl get secrets --all-namespaces -o json | kubectl replace -f -`.

Note that a compromised etcd is quite terrible still. Using secrets encryption prevents an attacker to immediately extract secrets from etcd but it doesn't prevent her from scheduling a pod that mounts the secret and exposes it as part of the scheduled container image.