### PR TITLE
Improve CRD deletion

### DIFF
--- a/cluster/manifests/roles/poweruser-role.yaml
+++ b/cluster/manifests/roles/poweruser-role.yaml
@@ -92,6 +92,8 @@ rules:
   - customresourcedefinitions
   verbs:
   - create
+  - delete
+  - deletecollection
   - patch
   - update
 - apiGroups:

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -173,7 +173,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-59
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-60
           name: admission-controller
           readinessProbe:
             httpGet:


### PR DESCRIPTION
 * Fix the role cleanup when the CRD is deleted
 * Forbid deleting a CRD unless all resources are gone
 * Allow the users to delete CRDs now that it's safe