### PR TITLE
Prometheus: fix the QoS class

### DIFF
--- a/cluster/manifests/prometheus/statefulset.yaml
+++ b/cluster/manifests/prometheus/statefulset.yaml
@@ -42,6 +42,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        resources:
+          limits:
+            cpu: 1m
+            memory: 128Mi
         volumeMounts:
         - name: prometheus-config-volume
           mountPath: /etc/prometheus


### PR DESCRIPTION
Init container was missing the resources, so the whole pod was downgraded to `Burstable`.