### PR TITLE
Shutdown masters more gracefully

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -152,6 +152,7 @@ write_files:
           - --kubelet-certificate-authority=/etc/kubernetes/ssl/ca.pem
           - --kubelet-client-certificate=/etc/kubernetes/ssl/kubelet-client.pem
           - --kubelet-client-key=/etc/kubernetes/ssl/kubelet-client-key.pem
+          - --shutdown-delay-duration=60s
           livenessProbe:
             httpGet:
               host: 127.0.0.1


### PR DESCRIPTION
### Wait to serve current requests before terminating api-server

To avoid spiking error rates for clients, take api-server out of
the kubernetes.default endpoint and then wait while the current
requests are being served

ref: https://github.com/kubernetes/kubernetes/pull/74416

Signed-off-by: Muaaz Saleem <muhammad.muaaz.saleem@zalando.de>