### PR TITLE
Allow deploying Cassandra via CloudFormation

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -581,6 +581,7 @@ Resources:
                   - 'backup-storage:*'
                   - 'backup:*'
                   - 'budgets:ViewBudget'
+                  - 'cassandra:*'
                   - 'ce:*'
                   - 'cloudformation:*'
                   - 'cloudfront:*'


### PR DESCRIPTION
This should allow `cdp-steps` to deploy Managed Cassandra CloudFormation Stacks once it's available.