### PR TITLE
kube-janitor v20.2.0 (--deployment-time-annotation)

### DIFF
--- a/cluster/manifests/kube-janitor/deployment.yaml
+++ b/cluster/manifests/kube-janitor/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-janitor
-    version: v20.1.0
+    version: v20.2.0
 spec:
   replicas: 1
   selector:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: kube-janitor
-        version: v20.1.0
+        version: v20.2.0
     spec:
       dnsConfig:
         options:
@@ -27,7 +27,7 @@ spec:
       containers:
       - name: janitor
         # see https://github.com/hjacobs/kube-janitor/releases
-        image: registry.opensource.zalan.do/teapot/kube-janitor:20.1.0
+        image: registry.opensource.zalan.do/teapot/kube-janitor:20.2.0
         args:
           # run every minute
           - --interval=60

--- a/cluster/manifests/kube-janitor/deployment.yaml
+++ b/cluster/manifests/kube-janitor/deployment.yaml
@@ -34,6 +34,7 @@ spec:
           # do not touch system/infra namespaces
           - --exclude-namespaces=kube-system,visibility
           - --rules-file=/config/rules.yaml
+          - --deployment-time-annotation=deployment-time
         resources:
           limits:
             cpu: 5m


### PR DESCRIPTION
Update Kubernetes Janitor (https://github.com/hjacobs/kube-janitor/releases/tag/20.2.0 implements https://github.com/hjacobs/kube-janitor/pull/55) and configure it to use CDP's `deployment-time` annotation.

How this looks like on resources:

```
apiVersion: batch/v1beta1
kind: CronJob
metadata:
  annotations:
    deployment-time: '2020-02-12T15:23:05Z'
    kubectl.kubernetes.io/last-applied-configuration: '...  '
  creationTimestamp: '2020-02-04T12:57:03Z'
  labels:
    deployment-id: d-dicjy55g655far96z1wu9cy9b
    pipeline-id: l-9qdt4p3c4wgrmirabpfyf5n8i
  name: foobar
```

The `deployment-time` annotation is usually newer than the `creationTimestamp` and overrides the time value for kube-janitor. This keeps resources which are continuously updated (e.g. from PRs being worked on).