### PR TITLE
Allow CLM to keep managing this key

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1597,6 +1597,12 @@ Resources:
         Version: "2012-10-17"
         Id: "etcd-key-policy"
         Statement:
+          - Sid: "Allow CLM to manage this key"
+            Effect: "Allow"
+            Principal:
+              AWS: "arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/cluster-lifecycle-manager-entrypoint"
+            Action: "kms:*"
+            Resource: "*"
           - Sid: "Allow Administrator to manage and use this key"
             Effect: "Allow"
             Principal:


### PR DESCRIPTION
I accidentally dropped permission to this key for CLM in https://github.com/zalando-incubator/kubernetes-on-aws/pull/2980. It needs it though.