### PR TITLE
Collect vertical pod autoscaler object metrics

### DIFF
--- a/cluster/manifests/kube-state-metrics/deployment.yaml
+++ b/cluster/manifests/kube-state-metrics/deployment.yaml
@@ -26,6 +26,8 @@ spec:
       containers:
       - name: kube-state-metrics
         image: registry.opensource.zalan.do/teapot/kube-state-metrics:v1.9.3
+        args:
+        - --collectors=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments,verticalpodautoscalers
         ports:
         - containerPort: 8080
           name: http-metrics


### PR DESCRIPTION
`kube-state-metrics` supports VPA object metrics as well but it is not enabled by default.