### PR TITLE
Hack: Opt-in to using rotated service account tokens

### DIFF
--- a/cluster/manifests/external-dns/cm-kube-root-ca.yaml
+++ b/cluster/manifests/external-dns/cm-kube-root-ca.yaml
@@ -1,0 +1,12 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: kube-root-ca.crt
+  namespace: kube-system
+  labels:
+    application: external-dns
+data:
+  ca.crt: |
+    -----BEGIN CERTIFICATE-----
+    ...
+    -----END CERTIFICATE-----

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -53,8 +53,11 @@ spec:
           httpGet:
             path: /healthz
             port: 7979
-{{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
         volumeMounts:
+        - name: kube-api-access
+          mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          readOnly: true
+{{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
         - name: aws-iam-credentials
           mountPath: /meta/aws-iam
           readOnly: true
@@ -67,8 +70,26 @@ spec:
             drop: ["ALL"]
       securityContext:
         fsGroup: 65534
-{{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
       volumes:
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3600
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
+{{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
       - name: aws-iam-credentials
         secret:
           secretName: external-dns-aws-iam-credentials

--- a/cluster/manifests/external-dns/rbac.yaml
+++ b/cluster/manifests/external-dns/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     application: external-dns
+automountServiceAccountToken: false
 ---
 # allows to list services and ingresses
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -122,10 +122,8 @@ write_files:
           - --admission-control-config-file=/etc/kubernetes/config/image-policy-webhook.yaml
           - --feature-gates=TaintNodesByCondition={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},ScheduleDaemonSetPods={{.Cluster.ConfigItems.experimental_schedule_daemonset_pods}},TTLAfterFinished=true,CustomResourceWebhookConversion={{.Cluster.ConfigItems.custom_resource_webhook_conversion}},CustomResourcePublishOpenAPI={{.Cluster.ConfigItems.custom_resource_publish_openapi}},BoundServiceAccountTokenVolume={{ .Cluster.ConfigItems.rotate_service_account_tokens }}
           - --anonymous-auth=false
-          {{- if eq .Cluster.ConfigItems.rotate_service_account_tokens "true" }}
           - --service-account-signing-key-file=/etc/kubernetes/ssl/service-account-private-key.pem
           - --service-account-issuer=kubernetes/serviceaccount
-          {{- end }}
           {{ if ne .Cluster.ConfigItems.audittrail_url "" }}
           - --audit-webhook-config-file=/etc/kubernetes/config/audit.yaml
           - --audit-webhook-mode=batch


### PR DESCRIPTION
This is how one can use rotating service account tokens without enabling it cluster-wide via the feature flag.