### PR TITLE
Added a feature flag to restrict prometheus TSDB by size

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -107,9 +107,10 @@ scalyr_team_token: ""
 
 prometheus_cpu: "1000m"
 prometheus_mem: "4Gi"
-prometheus_mem_min: "1Gi"
+prometheus_mem_min: "2Gi"
 prometheus_cpu_min: "0"
 prometheus_remote_write: "disabled"
+prometheus_tsdb_retention_size: "disabled"
 
 metrics_service_cpu: "100m"
 metrics_service_mem: "200Mi"

--- a/cluster/manifests/prometheus/statefulset.yaml
+++ b/cluster/manifests/prometheus/statefulset.yaml
@@ -57,7 +57,11 @@ spec:
         args:
         - "--config.file=/prometheus/prometheus.yaml"
         - "--storage.tsdb.path=/prometheus/"
+{{- if ne .ConfigItems.prometheus_tsdb_retention_size "disabled" }}
+        - "--storage.tsdb.retention.size={{ kubernetesSizeToKiloBytes .ConfigItems.prometheus_mem_min 0.6 }}"
+{{- else }}
         - "--storage.tsdb.retention.time=1d"
+{{- end }}
         - "--storage.tsdb.wal-compression"
         - "--storage.tsdb.min-block-duration=30m"
         ports:

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -55,6 +55,7 @@ clusters:
     kube_aws_ingress_controller_nlb_enabled: "true"
     vm_dirty_bytes: 134217728
     vm_dirty_background_bytes: 67108864
+    prometheus_tsdb_retention_size: enabled
   criticality_level: 1
   environment: e2e
   id: ${CLUSTER_ID}


### PR DESCRIPTION
The below image shows the size of the TSDBs across our clusters. The smallest are less than a GB in size and the largest are around 10GBs. By setting the the max size for the TSDB to be `0.8` of the minimum memory for prometheus we can ensure that the TSDB always fits into memory when the container is started. This is important to prevent the constant restarts when the prometheus containers get a very small recommendation from the VPA.

![prometheus_tsdb_sizes](https://user-images.githubusercontent.com/626536/74751332-62292d00-526d-11ea-903e-f0c6a67d429b.png)
