### PR TITLE
Update VPA admission controller to have explicit timeouts

### DIFF
--- a/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: vpa-admission-controller
-    version: v0.6.1-internal.4
+    version: v0.6.1-internal.6
     component: vpa
 spec:
   replicas: 1
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: vpa-admission-controller
-        version: v0.6.1-internal.4
+        version: v0.6.1-internal.6
         component: vpa
       annotations:
         config/hash: {{"02-secret.yaml" | manifestHash}}
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: vpa-admission-controller
       containers:
       - name: admission-controller
-        image: registry.opensource.zalan.do/teapot/vpa-admission-controller:v0.6.1-internal.4
+        image: registry.opensource.zalan.do/teapot/vpa-admission-controller:v0.6.1-internal.6
         volumeMounts:
           - name: tls-certs
             mountPath: "/etc/tls-certs"


### PR DESCRIPTION
Add an explicit timeout during the webhook registration. Upstream [PR](https://github.com/zalando-incubator/autoscaler/pull/26).