### PR TITLE
Define VPA as single app with components

### DIFF
--- a/cluster/manifests/01-vertical-pod-autoscaler/02-secret.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/02-secret.yaml
@@ -4,8 +4,8 @@ metadata:
   name: vpa-tls-certs
   namespace: kube-system
   labels:
-    application: vpa-admission-controller
-    component: vpa
+    application: vertical-pod-autoscaler
+    component: admission-controller
 type: Opaque
 data:
   caKey.pem: ""

--- a/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
@@ -1,23 +1,24 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: vpa-admission-controller
+  name: vpa-admission-controller-new # TODO: drop new later
   namespace: kube-system
   labels:
-    application: vpa-admission-controller
+    application: vertical-pod-autoscaler
+    component: admission-controller
     version: v0.6.1-internal.6
-    component: vpa
 spec:
   replicas: 1
   selector:
     matchLabels:
-      application: vpa-admission-controller
+      application: vertical-pod-autoscaler
+      component: admission-controller
   template:
     metadata:
       labels:
-        application: vpa-admission-controller
+        application: vertical-pod-autoscaler
+        component: admission-controller
         version: v0.6.1-internal.6
-        component: vpa
       annotations:
         config/hash: {{"02-secret.yaml" | manifestHash}}
     spec:

--- a/cluster/manifests/01-vertical-pod-autoscaler/rbac.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/rbac.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: system:metrics-reader
+  labels:
+    application: vertical-pod-autoscaler
 rules:
   - apiGroups:
       - "metrics.k8s.io"
@@ -16,6 +18,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: system:vpa-actor
+  labels:
+    application: vertical-pod-autoscaler
 rules:
   - apiGroups:
       - ""
@@ -61,6 +65,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: system:vpa-checkpoint-actor
+  labels:
+    application: vertical-pod-autoscaler
 rules:
   - apiGroups:
       - "poc.autoscaling.k8s.io"
@@ -96,6 +102,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: system:evictioner
+  labels:
+    application: vertical-pod-autoscaler
 rules:
   - apiGroups:
       - "extensions"
@@ -120,6 +128,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: system:metrics-reader
+  labels:
+    application: vertical-pod-autoscaler
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -133,6 +143,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: system:vpa-actor
+  labels:
+    application: vertical-pod-autoscaler
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -149,6 +161,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: system:vpa-checkpoint-actor
+  labels:
+    application: vertical-pod-autoscaler
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -162,6 +176,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: system:vpa-target-reader
+  labels:
+    application: vertical-pod-autoscaler
 rules:
   - apiGroups:
       - ""
@@ -196,6 +212,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: system:vpa-target-reader-binding
+  labels:
+    application: vertical-pod-autoscaler
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -215,6 +233,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: system:vpa-evictionter-binding
+  labels:
+    application: vertical-pod-autoscaler
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -229,23 +249,35 @@ kind: ServiceAccount
 metadata:
   name: vpa-recommender
   namespace: kube-system
+  labels:
+    application: vertical-pod-autoscaler
+    component: recommender
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: vpa-updater
   namespace: kube-system
+  labels:
+    application: vertical-pod-autoscaler
+    component: updater
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: vpa-admission-controller
   namespace: kube-system
+  labels:
+    application: vertical-pod-autoscaler
+    component: admission-controller
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: system:admission-controller
+  labels:
+    application: vertical-pod-autoscaler
+    component: admission-controller
 rules:
   - apiGroups:
       - ""
@@ -288,6 +320,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: system:admission-controller
+  labels:
+    application: vertical-pod-autoscaler
+    component: admission-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
@@ -4,20 +4,21 @@ metadata:
   name: vpa-recommender
   namespace: kube-system
   labels:
-    application: vpa-recommender
+    application: vertical-pod-autoscaler
+    component: recommender
     version: v0.6.1-internal.5
-    component: vpa
 spec:
   replicas: 1
   selector:
     matchLabels:
-      application: vpa-recommender
+      application: vertical-pod-autoscaler
+      component: recommender
   template:
     metadata:
       labels:
-        application: vpa-recommender
+        application: vertical-pod-autoscaler
+        component: recommender
         version: v0.6.1-internal.5
-        component: vpa
     spec:
       serviceAccountName: vpa-recommender
       priorityClassName: system-cluster-critical

--- a/cluster/manifests/01-vertical-pod-autoscaler/service.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/service.yaml
@@ -4,12 +4,13 @@ metadata:
   name: vpa-webhook
   namespace: kube-system
   labels:
-    application: vpa-admission-controller
+    application: vertical-pod-autoscaler
+    component: admission-controller
     version: master
-    component: vpa
 spec:
   selector:
-    application: vpa-admission-controller
+    application: vertical-pod-autoscaler
+    component: admission-controller
   ports:
     - port: 443
       targetPort: 8000

--- a/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
@@ -4,20 +4,22 @@ metadata:
   name: vpa-updater
   namespace: kube-system
   labels:
-    application: vpa-updater
+    application: vertical-pod-autoscaler
+    component: updater
     version: v0.6.1-internal.4
     component: vpa
 spec:
   replicas: 1
   selector:
     matchLabels:
-      application: vpa-updater
+      application: vertical-pod-autoscaler
+      component: updater
   template:
     metadata:
       labels:
-        application: vpa-updater
+        application: vertical-pod-autoscaler
+        component: updater
         version: v0.6.1-internal.4
-        component: vpa
     spec:
       serviceAccountName: vpa-updater
       priorityClassName: system-cluster-critical

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -1,5 +1,14 @@
 # everything defined under here will be deleted before applying the manifests
-pre_apply: []
+pre_apply:
+- name: vpa-recommender
+  namespace: kube-system
+  kind: Deployment
+- name: vpa-updater
+  namespace: kube-system
+  kind: Deployment
+- name: vpa-admission-controller
+  namespace: kube-system
+  kind: Deployment
 
 # everything defined under here will be deleted after applying the manifests
 post_apply:


### PR DESCRIPTION
We labelled the vpa "backwards" when we introduced it. This means we have 3 apps defined in our application registry, when we only need one.

Change all components to have ~`application: vpa`~ `application: vertical-pod-autoscaler` and a custom `component` label.

To roll this out in a "safe" way I added pre-apply delete for all components. For `updater` and `recommender` this is ok to happen all the time, for admission-controller I renamed it to have `-new` suffix which I will rename later with another PR once this is all rolled out.