### PR TITLE
Update to v0.0.13: Fix Kind/APIVersion

### DIFF
--- a/cluster/manifests/pdb-controller/deployment.yaml
+++ b/cluster/manifests/pdb-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: pdb-controller
-    version: v0.0.12
+    version: v0.0.13
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: pdb-controller
-        version: v0.0.12
+        version: v0.0.13
     spec:
       dnsConfig:
         options:
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: pdb-controller
       containers:
       - name: pdb-controller
-        image: registry.opensource.zalan.do/teapot/pdb-controller:v0.0.12
+        image: registry.opensource.zalan.do/teapot/pdb-controller:v0.0.13
         args:
         - --debug
         {{ if or (index .ConfigItems "pdb_non_ready_ttl") (eq .Environment "test") }}


### PR DESCRIPTION
Hotfix to `stable`. Want to have this in stable before Kubernetes v1.16 rollout to avoid extra long rollout because of broken PDBs.

Ref: https://github.com/mikkeloscar/pdb-controller/pull/35
