### PR TITLE
Add a cluster-local file to the secrets

### DIFF
--- a/cluster/node-pools/master-default/files.yaml
+++ b/cluster/node-pools/master-default/files.yaml
@@ -1,4 +1,7 @@
 files:
+  - path: /etc/kubernetes/.local-id
+    data: "{{ .Cluster.LocalID | base64 }}"
+    permissions: 0400
   - path: /etc/kubernetes/ssl/worker.pem
     data: "{{ .Cluster.ConfigItems.worker_cert }}"
     permissions: 0400

--- a/cluster/node-pools/worker-default/files.yaml
+++ b/cluster/node-pools/worker-default/files.yaml
@@ -1,4 +1,7 @@
 files:
+  - path: /etc/kubernetes/.local-id
+    data: "{{ .Cluster.LocalID | base64 }}"
+    permissions: 0400
   - path: /etc/kubernetes/ssl/worker.pem
     data: {{ .Cluster.ConfigItems.worker_cert }}
     permissions: 0400


### PR DESCRIPTION
Our e2e clusters run with the same set of certificates, so the generated 'secrets' file is the same for all of them. However, they're encrypted with a per-run KMS key, so it's possible that an e2e will fail because its secrets are reencrypted with a key from a different run. Add a dummy file with the cluster's local ID to prevent this as a quick hack.