### PR TITLE
Webhook drop non resource urls

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -239,7 +239,7 @@ write_files:
             - mountPath: /etc/kubernetes/ssl
               name: ssl-certs-kubernetes
               readOnly: true
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.7.6
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.7.7
           name: webhook
           ports:
           - containerPort: 8081

--- a/test/e2e/authorisation_test.go
+++ b/test/e2e/authorisation_test.go
@@ -284,32 +284,6 @@ var _ = framework.KubeDescribe("Authorization tests", func() {
 				}}`,
 				},
 			}, {
-				msg: "access to non-resource path with ReadOnly group",
-				reqBody: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"spec": {
-					"nonResourceAttributes": {
-						"path": "/apis",
-						"verb": "get"
-					},
-					"user": "mlarsen",
-					"group": [
-						"ReadOnly"
-					]
-					}
-				}`,
-				expect: expect{
-					status: http.StatusCreated,
-					body: `{
-					"apiVersion": "authorization.k8s.io/v1beta1",
-					"kind": "SubjectAccessReview",
-					"status": {
-						"allowed": true
-					}
-				}}`,
-				},
-			}, {
 				msg: "access to use PodSecurityPolicy for ReadOnly should not be allowed",
 				reqBody: fmt.Sprintf(`{
 					"apiVersion": "authorization.k8s.io/v1beta1",


### PR DESCRIPTION
Updates the webhook to drop support for allowing non-resource URLs. Instead those will be handled by RBAC which correctly blocks non GET requests to the non-resource URLs.
Before we allowed e.g. POST to `/api` which would trigger non valid audit events.