### PR TITLE
Split skipper lightstep config over multiple lines

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -92,7 +92,21 @@ spec:
 {{ end }}
           - "-oauth2-tokeninfo-url={{ .ConfigItems.tokeninfo_url }}"
           - "-histogram-metric-buckets=.0001,.00025,.0005,.00075,.001,.0025,.005,.0075,.01,.025,.05,.075,.1,.2,.3,.4,.5,.75,1,2,3,4,5,7,10,15,20,30,60,120,300,600"
-          - "-opentracing=lightstep component-name=skipper-ingress token=$(LIGHTSTEP_TOKEN) collector=tracing.stups.zalan.do:8444 cmd-line=skipper-ingress max-buffered-spans={{ .ConfigItems.skipper_ingress_tracing_buffer }} tag=application=skipper-ingress tag=account={{ .Cluster.Alias }} tag=cluster={{ .Cluster.Alias }} tag=artifact=registry.opensource.zalan.do/pathfinder/skipper:v0.11.48 grpc-max-msg-size={{ .ConfigItems.skipper_ingress_lightstep_grpc_max_msg_size }} max-period={{ .ConfigItems.skipper_ingress_lightstep_max_period }} min-period={{ .ConfigItems.skipper_ingress_lightstep_min_period }} {{ .Cluster.ConfigItems.skipper_ingress_lightstep_log_events }}"
+          - >-
+            -opentracing=lightstep
+            component-name=skipper-ingress
+            token=$(LIGHTSTEP_TOKEN)
+            collector=tracing.stups.zalan.do:8444
+            cmd-line=skipper-ingress
+            max-buffered-spans={{ .ConfigItems.skipper_ingress_tracing_buffer }}
+            tag=application=skipper-ingress
+            tag=account={{ .Cluster.Alias }}
+            tag=cluster={{ .Cluster.Alias }}
+            tag=artifact=registry.opensource.zalan.do/pathfinder/skipper:v0.11.48
+            grpc-max-msg-size={{ .ConfigItems.skipper_ingress_lightstep_grpc_max_msg_size }}
+            max-period={{ .ConfigItems.skipper_ingress_lightstep_max_period }}
+            min-period={{ .ConfigItems.skipper_ingress_lightstep_min_period }}
+            {{ .Cluster.ConfigItems.skipper_ingress_lightstep_log_events }}
           - "-opentracing-excluded-proxy-tags={{ .ConfigItems.skipper_ingress_opentracing_excluded_proxy_tags }}"
           - "-expect-continue-timeout-backend={{ .ConfigItems.skipper_expect_continue_timeout_backend }}"
           - "-keepalive-backend={{ .ConfigItems.skipper_keepalive_backend }}"


### PR DESCRIPTION
I always found it hard to read this config when it was a single line. Instead split it over multiple lines so it's easier to read and review changes.

This uses the yaml features `>` (replace newline with space) and `-` (drop trailing newline) to make the configuration a valid single line string when passed as a flag to skipper.