### PR TITLE
auth-webhook: log default sa reads

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -239,7 +239,7 @@ write_files:
             - mountPath: /etc/kubernetes/ssl
               name: ssl-certs-kubernetes
               readOnly: true
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.7.7
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.7.8
           name: webhook
           ports:
           - containerPort: 8081


### PR DESCRIPTION
Updates the auth webhook to log whenever a default service account is reading from the APIserver. This change is made in order to discover all clusters where the default service account is used for reading from the Kubernetes API which is something we want to prevent in the future. 