### PR TITLE
Set vm dirty bytes by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -278,8 +278,8 @@ enable_default_sa: "false"
 enable_cdp_sa: "false"
 
 # virtual memory configuration
-vm_dirty_background_bytes: ""
-vm_dirty_bytes: ""
+vm_dirty_background_bytes: "67108864"
+vm_dirty_bytes: "134217728"
 
 # Enable FeatureGate EndpointSlice
 enable_endpointslice: "false"


### PR DESCRIPTION
We have enabled it everywhere (except `search`) so let's configure it by default.