### PR TITLE
Ingress LB: Only target node pools where skipper can run

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -29,6 +29,9 @@ skipper_ingress_cpu: "1000m"
 skipper_ingress_memory: "1Gi"
 skipper_ingress_tracing_buffer: "8192"
 enable_dedicate_nodepool_skipper: "false"
+# This setting should only be enabled after `enable_dedicate_nodepool_skipper`
+# has been enabled and is successfully switched
+disable_default_nodepool_lb_attach: "false"
 
 # skipper default filters
 skipper_default_filters: 'enableAccessLog(4,5) -> lifo(2000,20000,"3s")'

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -39,7 +39,7 @@ spec:
         {{ end }}
         env:
         - name: CUSTOM_FILTERS
-          value: "tag:kubernetes.io/cluster/{{ .Cluster.ID }}=owned tag:node.kubernetes.io/role=worker" # TODO: tag:zalando.org/ingress-enabled=true"
+          value: "tag:kubernetes.io/cluster/{{ .Cluster.ID }}=owned tag:node.kubernetes.io/role=worker tag:zalando.org/ingress-enabled=true"
         - name: AWS_REGION
           value: {{ .Region }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -50,7 +50,20 @@ Resources:
         PropagateAtLaunch: true
         Value: worker
 # only node pools without taints should be attached to Ingress Load balancer
-{{- if not (index $data.NodePool.ConfigItems "taints") }}
+#
+# This is a complicated way of allowing the following logic:
+# For any nodepool without taints make it a target of Ingress LBs, except when:
+# 1. skipper nodepool support is enabled AND non tainted nodes as target has
+# been *disabled*.
+# 2. or if skipper nodepool support is not enabled.
+#
+# When skipper node pool support is enabled, we only put the skipper nodes as
+# targets in the LBs.
+{{- if and (not (index $data.NodePool.ConfigItems "taints")) (or (and (eq .Cluster.ConfigItems.enable_dedicate_nodepool_skipper "true") (ne .Cluster.ConfigItems.disable_default_nodepool_lb_attach "true")) (ne .Cluster.ConfigItems.enable_dedicate_nodepool_skipper "true")) }}
+      - Key: zalando.org/ingress-enabled
+        Value: "true"
+        PropagateAtLaunch: true
+{{- else if and (or (eq .Cluster.ConfigItems.enable_dedicate_nodepool_skipper "true") (ne .Cluster.ConfigItems.disable_default_nodepool_lb_attach "true")) (eq (index $data.NodePool.ConfigItems "taints") "dedicated=skipper-ingress:NoSchedule") }}
       - Key: zalando.org/ingress-enabled
         Value: "true"
         PropagateAtLaunch: true


### PR DESCRIPTION
This enables only putting node pools as Ingress LB target if skipper can actually run on the node pool. The motivation for this is that AWS does "connection draining" on nodes that are part of an Autoscaling Group which is a target of a Load Balancer, even if the node was never actually a healthy target that got any traffic.
The impact of this "connection draining" is that node decommissioning takes ~10 min. longer than it has to.

## How it works

1. All node pools without taint (such that skipper couldn't run) gets a tag `zalando.org/ingress-enabled=true`
2. The ingress-controller uses this tag as a filter to only consider node pools to be attached in the Load Balancers.

With support for dedicated skipper node pool, this setup becomes a bit more complicated as we have to be careful to have the right node pools in the Load Balancer at the right time when we enable/disable dedicated skipper node pool.

To enable a safe configuration I introduced a config item: `disable_default_nodepool_lb_attach=true|false`.
The idea is that if you want to enable dedicated skipper node pool support for a cluster you do the following:

1. Add node pool with `taints=dedicated=skipper-ingress:NoSchedule`
2. Move skipper to dedicated nodes: set `disable_default_nodepool_lb_attach=true`
3. IMPORTANT: Wait for all skippers to be running on the dedicated node pool
4. Remove normal node pools from LB target: set `disable_default_nodepool_lb_attach=true`

And if you want to roll back to non dedicated node pool for skipper, it's the reverse order:

1. Add normal node pools as LB targets: set `disable_default_nodepool_lb_attach=false`
2. WAIT to ensure the change is applied, you should see the "unhealthy" targets in the LBs.
3. Move skipper to non-dedicated nodes: set `disable_default_nodepool_lb_attach=false`
4. Optional: remove the node pool with `taints=dedicated=skipper-ingress:NoSchedule`