### PR TITLE
Admission: add support for aws-credentials-waiter injection

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -183,6 +183,8 @@ teapot_admission_controller_ignore_namespaces: "^kube-system$"
 teapot_admission_controller_crd_ensure_no_resources_on_delete: "true"
 {{end}}
 
+teapot_admission_controller_experimental_inject_aws_waiter: "false"
+
 # etcd cluster
 {{if eq .Environment "production"}}
 etcd_instance_count: "5"

--- a/cluster/manifests/admission-control-proxy/daemonset.yaml
+++ b/cluster/manifests/admission-control-proxy/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cluster-autoscaler
-        image: registry.opensource.zalan.do/teapot/admission-controller:master-63
+        image: registry.opensource.zalan.do/teapot/admission-controller:master-65
         command:
           - /registry-proxy
           - --address=127.0.0.1:8285

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -182,7 +182,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-63
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-65
           name: admission-controller
           readinessProbe:
             httpGet:
@@ -232,6 +232,9 @@ write_files:
             - --deployment-rolling-update-default-max-unavailable={{ .Cluster.ConfigItems.teapot_admission_controller_deployment_default_max_unavailable }}
 {{- if eq .Cluster.ConfigItems.teapot_admission_controller_crd_ensure_no_resources_on_delete "true" }}
             - --crd-ensure-no-resources-on-delete
+{{- end }}
+{{- if eq .Cluster.ConfigItems.teapot_admission_controller_experimental_inject_aws_waiter "true" }}
+            - --pod-aws-credentials-waiter-image=pierone.stups.zalan.do/automata/aws-credentials-waiter:master-4
 {{- end }}
           ports:
             - containerPort: 8085


### PR DESCRIPTION
If `teapot_admission_controller_experimental_inject_aws_waiter` is set to `true`, automatically inject the AWS credentials waiter initContainer to pods that need it. Will test in a couple of clusters and then enable unconditionally.