### PR TITLE
Secrets encryption: increase cache size to 50000

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -758,7 +758,7 @@ write_files:
           - kms:
               name: aws-encryption-provider
               endpoint: unix:///var/run/kmsplugin/socket.sock
-              cachesize: 1000
+              cachesize: 50000
               timeout: 3s
       {{- if eq .Cluster.ConfigItems.enable_encryption "true" }}
           - identity: {}


### PR DESCRIPTION
This pretty much *has* to be greater than the number of secrets we have in the clusters, otherwise performance degrades massively. We'll add monitoring later, for now let's just stop the bleeding. Memory impact is pretty much nil since the cached entries are very small.