### PR TITLE
PCS: Add schema validation for status

### DIFF
--- a/cluster/manifests/01-platformcredentialsset/customresourcedefinition.yaml
+++ b/cluster/manifests/01-platformcredentialsset/customresourcedefinition.yaml
@@ -82,5 +82,34 @@ spec:
                 enum:
                   - v1
                   - v2
+          status:
+            type: object
+            properties:
+              observedGeneration:
+                type: integer
+              clients:
+                type: object
+                additionalProperties:
+                  type: object
+              errors:
+                type: array
+                items:
+                  type: string
+              problems:
+                type: array
+                items:
+                  type: string
+              processingStatus:
+                type: string
+                enum:
+                - Succeeded
+                - Failed
+              tokens:
+                type: object
+                additionalProperties:
+                  type: object
+                  properties:
+                    expiration:
+                      type: string
     subresources:
       status: {}


### PR DESCRIPTION
This adds status validation for the `PlatformCredentialsSets` CRD. Without this the status is not returned when reading a resource from the API which results in errors for e.g. our deployment system where the status is expected.

This issue is only observed in clusters created AFTER Kubernetes v1.16 was merged, but it is unclear why it happens as there are no errors logged in the APIServer or anywhere else.

~Additionally it removes `nullable: true` as this is not supported and results in the following error in APIServer logs:~

```
'ERROR $root.definitions.org.zalando.v1.PlatformCredentialsSet.properties.spec.properties.tokens.additionalProperties.schema.properties.privileges has invalid property: nullable'
```