### PR TITLE
Wait for the pre-stop hook in --shutdown-delay-duration

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -93,6 +93,7 @@ write_files:
           value: master
           effect: NoSchedule
         hostNetwork: true
+        terminationGracePeriodSeconds: 80
         containers:
         - name: kube-apiserver
           image: nonexistent.zalan.do/teapot/kube-apiserver:fixed


### PR DESCRIPTION
While --shutdown-delay-duration implements a pre-stop hook, it
seems it doesn't actually implement `terminationGracePeriodSeconds`.
This results in the pod being terminated despite the pre-stop hook.

The need for setting `terminationGracePeriodSeconds` in addition to
a preStop hook is documented here:
https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution

Signed-off-by: Muaaz Saleem <muhammad.muaaz.saleem@zalando.de>