### PR TITLE
PDB controller: add a VPA

### DIFF
--- a/cluster/manifests/pdb-controller/vpa.yaml
+++ b/cluster/manifests/pdb-controller/vpa.yaml
@@ -1,0 +1,17 @@
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: pdb-controller
+  namespace: kube-system
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: pdb-controller
+  updatePolicy:
+    updateMode: Auto
+  resourcePolicy:
+    containerPolicies:
+    - containerName: pdb-controller
+      maxAllowed:
+        memory: 1Gi


### PR DESCRIPTION
This prevents crashes when there are too many deployments/statefulsets/etc.