### PR TITLE
Enable AWS waiter injection in test clusters

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -167,12 +167,15 @@ teapot_admission_controller_deployment_default_max_unavailable: "1"
 {{if eq .Environment "production"}}
 teapot_admission_controller_validate_application_label: "true"
 teapot_admission_controller_validate_pod_template_resources: "true"
+teapot_admission_controller_inject_aws_waiter: "false"
 {{else if eq .Environment "e2e"}}
 teapot_admission_controller_validate_application_label: "false"
 teapot_admission_controller_validate_pod_template_resources: "false"
+teapot_admission_controller_inject_aws_waiter: "true"
 {{else}}
 teapot_admission_controller_validate_application_label: "false"
 teapot_admission_controller_validate_pod_template_resources: "true"
+teapot_admission_controller_inject_aws_waiter: "true"
 {{end}}
 
 {{if eq .Environment "e2e"}}
@@ -183,7 +186,6 @@ teapot_admission_controller_ignore_namespaces: "^kube-system$"
 teapot_admission_controller_crd_ensure_no_resources_on_delete: "true"
 {{end}}
 
-teapot_admission_controller_experimental_inject_aws_waiter: "false"
 
 # etcd cluster
 {{if eq .Environment "production"}}

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -234,7 +234,7 @@ write_files:
 {{- if eq .Cluster.ConfigItems.teapot_admission_controller_crd_ensure_no_resources_on_delete "true" }}
             - --crd-ensure-no-resources-on-delete
 {{- end }}
-{{- if eq .Cluster.ConfigItems.teapot_admission_controller_experimental_inject_aws_waiter "true" }}
+{{- if eq .Cluster.ConfigItems.teapot_admission_controller_inject_aws_waiter "true" }}
             - --pod-aws-credentials-waiter-image=pierone.stups.zalan.do/automata/aws-credentials-waiter:master-4
 {{- end }}
           ports:


### PR DESCRIPTION
 * Rename the config item to `teapot_admission_controller_inject_aws_waiter`
 * Enable by default in test clusters