### PR TITLE
Fix duplicate keys in manifest YAMLs

### DIFF
--- a/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
@@ -7,7 +7,6 @@ metadata:
     application: vertical-pod-autoscaler
     component: updater
     version: v0.6.1-internal.7
-    component: vpa
 spec:
   replicas: 1
   selector:

--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -7,8 +7,6 @@ metadata:
     application: kube2iam
     version: 0.10.7
 spec:
-  updateStrategy:
-    type: OnDelete
   selector:
     matchLabels:
       application: kube2iam


### PR DESCRIPTION
We've got a bunch of issues that we never noticed. https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/272 uses more strict validation, so let's fix these before applying.