### PR TITLE
change rollingUpdate strategy skipper

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,12 +5,13 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.11.48
+    version: v0.11.66
     component: ingress
 spec:
   strategy:
     rollingUpdate:
-      maxSurge: 0
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       application: skipper-ingress
@@ -18,7 +19,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.11.48
+        version: v0.11.66
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -43,7 +44,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.48
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.66
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -102,7 +103,7 @@ spec:
             tag=application=skipper-ingress
             tag=account={{ .Cluster.Alias }}
             tag=cluster={{ .Cluster.Alias }}
-            tag=artifact=registry.opensource.zalan.do/pathfinder/skipper:v0.11.48
+            tag=artifact=registry.opensource.zalan.do/pathfinder/skipper:v0.11.66
             grpc-max-msg-size={{ .ConfigItems.skipper_ingress_lightstep_grpc_max_msg_size }}
             max-period={{ .ConfigItems.skipper_ingress_lightstep_max_period }}
             min-period={{ .ConfigItems.skipper_ingress_lightstep_min_period }}


### PR DESCRIPTION
- change rollingUpdate strategy to add 1 instead of remove 1
- update skipper: Methods() predicate added, Go1.14 build, redirectTo optional single arg, modRequestHeader() added, origin marker does not pollute routes

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>