### PR TITLE
Add support for internal skipper API Server proxy

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -248,6 +248,10 @@ allow_external_service_accounts: "false"
 # issue service account tokens with expiration time.
 rotate_service_account_tokens: "false"
 
+# when set to true the internal endpoint 10.3.0.1 is proxied through a skipper
+# sidecar to log usage of default service account
+apiserver_internal_proxy: "false"
+
 # use kube-aws-iam-controller for kube-system components
 kube_aws_iam_controller_kube_system_enable: "true"
 

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -110,7 +110,7 @@ write_files:
           {{- end }}
           - --allow-privileged=true
           - --service-cluster-ip-range=10.3.0.0/16
-          - --secure-port=443
+          - --secure-port={{ if eq .Cluster.ConfigItems.apiserver_internal_proxy "true" }}6443{{else}}443{{end}}
           - --enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota,StorageObjectInUseProtection,PodSecurityPolicy,ImagePolicyWebhook,Priority,ExtendedResourceToleration
           - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
           - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
@@ -162,8 +162,8 @@ write_files:
             initialDelaySeconds: 120
             timeoutSeconds: 15
           ports:
-          - containerPort: 443
-            hostPort: 443
+          - containerPort: {{ if eq .Cluster.ConfigItems.apiserver_internal_proxy "true" }}6443{{else}}443{{end}}
+            hostPort: {{ if eq .Cluster.ConfigItems.apiserver_internal_proxy "true" }}6443{{else}}443{{end}}
             name: https
           - containerPort: 8080
             hostPort: 8080
@@ -433,6 +433,51 @@ write_files:
           - mountPath: /etc/kubernetes/ssl
             name: ssl-certs-kubernetes
             readOnly: true
+{{ if eq .Cluster.ConfigItems.apiserver_internal_proxy "true" }}
+        - name: skipper-proxy-internal
+          image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.35
+          args:
+          - skipper
+          - -access-log-strip-query
+          - -address=:443
+          - -support-listener=:9912
+          - -tls-cert=/etc/kubernetes/ssl/apiserver.pem
+          - -tls-key=/etc/kubernetes/ssl/apiserver-key.pem
+          - -insecure
+          - -experimental-upgrade
+          - -runtime-metrics
+          - -enable-connection-metrics
+          - -enable-prometheus-metrics
+          - -write-timeout-server=60m
+          - -inline-routes
+          - |
+            s: JWTPayloadAllKV("kubernetes.io/serviceaccount/service-account.name", "default")
+              -> enableAccessLog()
+              -> "https://127.0.0.1:6443";
+            h: Path("/kube-system/healthz")
+              -> setPath("/healthz")
+              -> disableAccessLog()
+              -> "http://127.0.0.1:8080";
+            all: *
+              -> disableAccessLog()
+              -> "https://127.0.0.1:6443";
+          ports:
+          - containerPort: 443
+          readinessProbe:
+            httpGet:
+              scheme: HTTPS
+              path: /kube-system/healthz
+              port: 443
+            timeoutSeconds: 5
+          resources:
+            requests:
+              cpu: 100m
+              memory: 250Mi
+          volumeMounts:
+          - mountPath: /etc/kubernetes/ssl
+            name: ssl-certs-kubernetes
+            readOnly: true
+{{ end }}
         - name: etcd-proxy
           image: registry.opensource.zalan.do/teapot/etcd-proxy:master-5
           args:

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -56,6 +56,7 @@ clusters:
     vm_dirty_bytes: 134217728
     vm_dirty_background_bytes: 67108864
     prometheus_tsdb_retention_size: enabled
+    apiserver_internal_proxy: "true"
   criticality_level: 1
   environment: e2e
   id: ${CLUSTER_ID}


### PR DESCRIPTION
This adds an internal skipper proxy in front of the API Server (`10.3.0.1`) when the flag `apiserver_internal_proxy` is `true` (default `false`).

The purpose is to route all traffic going to `10.3.0.1` through this proxy in clusters where the `default` service account is being used to read from the APIServer and log any requests from pods with the default service account, such that we can track the source IP and identify the application which needs to be updated.

Unfortunately this only shows the node where the pod is running as the source IP so we still can't 100% identify which pod is the source. But it should help us get a better understanding than simply knowing the `default` service account is being used which is all the visibility we currently have.

Since we never ran with a skipper in front of `10.3.0.1` the intention is to ONLY enable this in test clusters where we see the `default` service account being used and verify that this does not cause issues for other workloads before we decide if it should be enabled for production clusters as well.
This proxy should be completely removed once we have migrated away from legacy service accounts.