### PR TITLE
Enable read auditlog for test with enable_default_sa=true

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -248,6 +248,14 @@ allow_external_service_accounts: "false"
 # issue service account tokens with expiration time.
 rotate_service_account_tokens: "false"
 
+# enable auditlogging for read access such that we can identified clients using
+# the default service account to read from the API server.
+{{ if eq .Cluster.Environment "test" }}
+auditlog_read_access: "true"
+{{ else }}
+auditlog_read_access: "false"
+{{ end }}
+
 # use kube-aws-iam-controller for kube-system components
 kube_aws_iam_controller_kube_system_enable: "true"
 

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -139,6 +139,11 @@ write_files:
           - --audit-log-maxage=0
           - --audit-log-maxbackup=0
           - --audit-policy-file=/etc/kubernetes/config/audit-policy.yaml
+          {{ else if and (eq .Cluster.ConfigItems.enable_default_sa "true") (eq .Cluster.ConfigItems.auditlog_read_access "true") }}
+          - --audit-log-path=/dev/stdout
+          - --audit-log-maxage=0
+          - --audit-log-maxbackup=0
+          - --audit-policy-file=/etc/kubernetes/config/audit-policy-ro.yaml
           {{ end }}
           # enable aggregated apiservers
           - --client-ca-file=/etc/kubernetes/ssl/ca.pem
@@ -744,6 +749,24 @@ write_files:
         - level: Request
           omitStages:
             - "RequestReceived"
+
+{{ if and (eq .Cluster.ConfigItems.enable_default_sa "true") (eq .Cluster.ConfigItems.auditlog_read_access "true") }}
+  - owner: root:root
+    path: /etc/kubernetes/config/audit-policy-ro.yaml
+    content: |
+      apiVersion: audit.k8s.io/v1beta1
+      kind: Policy
+      rules:
+      - level: None
+        verbs: ["create", "update", "patch", "delete", "deletecollection"]
+      - level: None
+        userGroups: ["system:serviceaccounts:kube-system"]
+      - level: Request
+        verbs: ["watch", "list", "get"]
+        userGroups: ["system:serviceaccounts"]
+        omitStages:
+        - "RequestReceived"
+{{ end }}
 
 {{- if eq .Cluster.ConfigItems.support_encryption "true" }}
   - owner: root:root

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -128,7 +128,7 @@ write_files:
           - --service-account-signing-key-file=/etc/kubernetes/ssl/service-account-private-key.pem
           - --service-account-issuer=kubernetes/serviceaccount
           {{- end }}
-          {{ if ne .Cluster.ConfigItems.audittrail_url "" }}
+          {{ if and (ne .Cluster.ConfigItems.audittrail_url "") (ne .Cluster.Environment "e2e") }}
           - --audit-webhook-config-file=/etc/kubernetes/config/audit.yaml
           - --audit-webhook-mode=batch
           - --audit-webhook-version=audit.k8s.io/v1beta1
@@ -143,7 +143,9 @@ write_files:
           - --audit-log-path=/dev/stdout
           - --audit-log-maxage=0
           - --audit-log-maxbackup=0
+          {{ if eq .Cluster.ConfigItems.audittrail_url "" }}
           - --audit-policy-file=/etc/kubernetes/config/audit-policy-ro.yaml
+          {{ end }}
           {{ end }}
           # enable aggregated apiservers
           - --client-ca-file=/etc/kubernetes/ssl/ca.pem
@@ -742,6 +744,16 @@ write_files:
               resources: ["tokenreviews"]
           omitStages:
             - "RequestReceived"
+{{ if and (eq .Cluster.ConfigItems.enable_default_sa "true") (eq .Cluster.ConfigItems.auditlog_read_access "true") }}
+        - level: None
+          verbs: ["watch", "list", "get"]
+          userGroups: ["system:serviceaccounts:kube-system"]
+        - level: Request
+          verbs: ["watch", "list", "get"]
+          userGroups: ["system:serviceaccounts"]
+          omitStages:
+          - "RequestReceived"
+{{ end }}
         # Don't audit read-only events.
         - level: None
           verbs: ["watch", "list", "get"]
@@ -757,8 +769,6 @@ write_files:
       apiVersion: audit.k8s.io/v1beta1
       kind: Policy
       rules:
-      - level: None
-        verbs: ["create", "update", "patch", "delete", "deletecollection"]
       - level: None
         userGroups: ["system:serviceaccounts:kube-system"]
       - level: Request


### PR DESCRIPTION
This achieves the same as #3065 but uses Kubernetes audit logs instead of a proxy.

The purpose of this is to log (to stdout from `kube-apiserver`) all read events from service accounts not in `kube-system` namespace such that we can better identify pods using the `default` service account to read from the API server, something we want to migrate away from.

This logs more events than we need as we can't easily match "`default` service account in ANY namespace" via the audit configuration, but it will only be enabled for clusters where `enable_default_sa=true` and only in `test` as a start to see how much it helps us before we start to add extra logging in production clusters.

The events we will get looks like this:

```
{"kind":"Event","apiVersion":"audit.k8s.io/v1","level":"Request","auditID":"x","stage":"ResponseComplete","requestURI":"/apis","verb":"get","user":{"username":"system:serviceaccount:default:default","uid":"x","groups":["system:serviceaccounts","system:serviceaccounts:default","system:authenticated"]},"sourceIPs":["10.x.x.x"],"userAgent":"curl/7.64.0","responseStatus":{"metadata":{},"code":200},"requestReceivedTimestamp":"x","stageTimestamp":"x","annotations":{"authorization.k8s.io/decision":"allow","authorization.k8s.io/reason":"RBAC: allowed by ClusterRoleBinding \"system:discovery\" of ClusterRole \"system:discovery\" to Group \"system:authenticated\""}}
```