### PR TITLE
external-dns: ignore cluster.local domain

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -35,6 +35,7 @@ spec:
         - --source=service
         - --source=ingress
         - --source=skipper-routegroup
+        - --exclude-domains=cluster.local
         - --provider=aws
         - --registry=txt
         - --txt-owner-id={{ .Region }}:{{ .LocalID }}


### PR DESCRIPTION
ignore cluster.local domain to allow ingress with public and internal record

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>