### PR TITLE
Add missing RBAC permission to kube-state-metrics

### DIFF
--- a/cluster/manifests/kube-state-metrics/rbac.yaml
+++ b/cluster/manifests/kube-state-metrics/rbac.yaml
@@ -78,6 +78,7 @@ rules:
   - autoscaling
   resources:
   - horizontalpodautoscalers
+  - verticalpodautoscalers
   verbs:
   - list
   - watch

--- a/cluster/manifests/kube-state-metrics/rbac.yaml
+++ b/cluster/manifests/kube-state-metrics/rbac.yaml
@@ -78,7 +78,6 @@ rules:
   - autoscaling
   resources:
   - horizontalpodautoscalers
-  - verticalpodautoscalers
   verbs:
   - list
   - watch
@@ -128,6 +127,13 @@ rules:
   - networking.k8s.io
   resources:
   - networkpolicies
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - autoscaling.k8s.io
+  resources:
+  - verticalpodautoscalers
   verbs:
   - list
   - watch


### PR DESCRIPTION
It now looks for VPAs and needs permission.