### PR TITLE
Only target node pools where skipper can run (v2)

### DIFF
--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -40,7 +40,7 @@ spec:
         {{ end }}
         env:
         - name: CUSTOM_FILTERS
-          value: "tag:kubernetes.io/cluster/{{ .Cluster.ID }}=owned tag:node.kubernetes.io/role=worker" # TODO: tag:zalando.org/ingress-enabled=true"
+          value: "tag:kubernetes.io/cluster/{{ .Cluster.ID }}=owned tag:node.kubernetes.io/role=worker tag:zalando.org/ingress-enabled=true"
         - name: AWS_REGION
           value: {{ .Region }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}

--- a/cluster/node-pools/worker-default/stack.yaml
+++ b/cluster/node-pools/worker-default/stack.yaml
@@ -46,7 +46,7 @@ Resources:
         PropagateAtLaunch: true
         Value: worker
 # only node pools without taints should be attached to Ingress Load balancer
-{{- if not (index .NodePool.ConfigItems "taints") }}
+{{- if or (not (index .NodePool.ConfigItems "taints")) (eq (index .NodePool.ConfigItems "taints") "dedicated=skipper-ingress:NoSchedule") }}
       - Key: zalando.org/ingress-enabled
         Value: "true"
         PropagateAtLaunch: true

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -50,7 +50,7 @@ Resources:
         PropagateAtLaunch: true
         Value: worker
 # only node pools without taints should be attached to Ingress Load balancer
-{{- if not (index $data.NodePool.ConfigItems "taints") }}
+{{- if or (not (index $data.NodePool.ConfigItems "taints")) (eq (index $data.NodePool.ConfigItems "taints") "dedicated=skipper-ingress:NoSchedule") }}
       - Key: zalando.org/ingress-enabled
         Value: "true"
         PropagateAtLaunch: true


### PR DESCRIPTION
This introduces an alternative and simpler solution to https://github.com/zalando-incubator/kubernetes-on-aws/pull/3036

This enables only putting node pools as Ingress LB target if skipper can actually run on the node pool. The motivation for this is that AWS does "connection draining" on nodes that are part of an Autoscaling Group which is a target of a Load Balancer, even if the node was never actually a healthy target that got any traffic.
The impact of this "connection draining" is that node decommissioning takes ~10 min. longer than it has to.

## How it works

1. All node pools without taint (such that skipper couldn't run) gets a tag `zalando.org/ingress-enabled=true`
2. Node pools with taint: `dedicated=skipper-ingress:NoSchedule` also gets the tag `zalando.org/ingress-enabled=true`.
2. The ingress-controller uses this tag as a filter to only consider node pools to be attached in the Load Balancers.

Unlike https://github.com/zalando-incubator/kubernetes-on-aws/pull/3036 it doesn't try to be smart about clusters where skipper is configured to run on a dedicated node pool.
If skipper is configured to run on a dedicated node pool then the ingress-controller will attach both instances from node pools without any taints (even if skipper is not running there) and nodes with the skipper taint.
This avoids a complicated strategy for switching to and from dedicated node pool for skipper while still avoiding to put all custom node pool instances in the LB.