### PR TITLE
Add rbac for scalyr-key-rotation

### DIFF
--- a/cluster/manifests/roles/scalyr-key-rotation-rbac.yaml
+++ b/cluster/manifests/roles/scalyr-key-rotation-rbac.yaml
@@ -1,0 +1,63 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: scalyr-key-rotation
+  namespace: visibility
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  - scalyr-keys
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: scalyr-key-rotation
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  - scalyr-delegation-token
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: scalyr-key-rotation
+  namespace: visibility
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: scalyr-key-rotation
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: zalando-iam:zalando:service:scalyr-key-rotation
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: scalyr-key-rotation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: scalyr-key-rotation
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: zalando-iam:zalando:service:scalyr-key-rotation

--- a/cluster/manifests/roles/scalyr-key-rotation-rbac.yaml
+++ b/cluster/manifests/roles/scalyr-key-rotation-rbac.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: scalyr-key-rotation
   namespace: visibility
@@ -12,13 +12,12 @@ rules:
   - scalyr-keys
   verbs:
   - get
-  - list
   - watch
   - update
   - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: scalyr-key-rotation
 rules:
@@ -30,19 +29,18 @@ rules:
   - scalyr-delegation-token
   verbs:
   - get
-  - list
   - watch
   - update
   - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: scalyr-key-rotation
   namespace: visibility
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: scalyr-key-rotation
 subjects:
 - apiGroup: rbac.authorization.k8s.io
@@ -50,14 +48,14 @@ subjects:
   name: zalando-iam:zalando:service:scalyr-key-rotation
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: scalyr-key-rotation
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: scalyr-key-rotation
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
-  name: zalando-iam:zalando:service:scalyr-key-rotation
+  name: zalando-iam:zalando:service:stups_scalyr-key-rotation


### PR DESCRIPTION
Change to allow the service scalyr-key-rotation access to the two scalyr secrets.
Please check if this makes sense to you with the 4 yaml documents.
Maybe there is a simpler way of doing this?