### PR TITLE
Enable the EBS CSI driver

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1340,8 +1340,61 @@ Resources:
           PolicyName: root
       RoleName: "{{.Cluster.LocalID}}-kube-metrics-adapter"
     Type: 'AWS::IAM::Role'
-{{ if eq .Cluster.Environment "e2e" }}
-  # This is a hack to easily create an aws iam role and s3 bucket for testing
+
+  EBSCSIControllerIAMRole:
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action:
+              - 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+          - Action:
+              - 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              AWS: !Join
+                - ''
+                - - 'arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/'
+                  - !Ref MasterIAMRole
+          - Action:
+              - 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              AWS: !Join
+                - ''
+                - - 'arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/'
+                  - !Ref WorkerIAMRole
+        Version: 2012-10-17
+      Path: /
+      Policies:
+        - PolicyDocument:
+            Statement:
+              - Effect: Allow # All the policies needed for the EBS CSI driver
+                Action:
+                  - 'ec2:AttachVolume'
+                  - 'ec2:CreateSnapshot'
+                  - 'ec2:CreateTags'
+                  - 'ec2:CreateVolume'
+                  - 'ec2:DeleteSnapshot'
+                  - 'ec2:DeleteTags'
+                  - 'ec2:DeleteVolume'
+                  - 'ec2:DescribeInstances'
+                  - 'ec2:DescribeSnapshots'
+                  - 'ec2:DescribeTags'
+                  - 'ec2:DescribeVolumes'
+                  - 'ec2:DetachVolume'
+                  - 'ec2:ModifyVolume'
+                Resource: '*'
+            Version: 2012-10-17
+          PolicyName: root
+      RoleName: "{{.Cluster.LocalID}}-ebs-csi-controller"
+    Type: 'AWS::IAM::Role'
+
+  {{ if eq .Cluster.Environment "e2e" }}
+# This is a hack to easily create an aws iam role and s3 bucket for testing
   # AWS IAM intergration in e2e tests.
   E2EAWSIAMTestRole:
     Properties:

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -111,6 +111,7 @@ prometheus_mem_min: "2Gi"
 prometheus_cpu_min: "0"
 prometheus_remote_write: "disabled"
 prometheus_tsdb_retention_size: "disabled"
+prometheus_csi_ebs: "true"
 
 metrics_service_cpu: "100m"
 metrics_service_mem: "200Mi"

--- a/cluster/manifests/03-ebs-csi/01-rbac.yaml
+++ b/cluster/manifests/03-ebs-csi/01-rbac.yaml
@@ -1,0 +1,240 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ebs-csi-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ebs-external-attacher
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - csi.storage.k8s.io
+    resources:
+      - csinodeinfos
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - volumeattachments
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ebs-external-provisioner
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - list
+      - watch
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - snapshot.storage.k8s.io
+    resources:
+      - volumesnapshots
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - snapshot.storage.k8s.io
+    resources:
+      - volumesnapshotcontents
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csinodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - watch
+      - list
+      - delete
+      - update
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ebs-csi-attacher-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ebs-external-attacher
+subjects:
+  - kind: ServiceAccount
+    name: ebs-csi-controller
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ebs-csi-provisioner-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ebs-external-provisioner
+subjects:
+  - kind: ServiceAccount
+    name: ebs-csi-controller
+    namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ebs-csi-node
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: ebs-csi-node-privileged-psp
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: privileged-psp
+subjects:
+  - kind: ServiceAccount
+    name: ebs-csi-node
+    namespace: kube-system
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ebs-external-resizer-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - list
+      -  watch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims/status
+    verbs:
+      - update
+      - patch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - list
+      - watch
+      - create
+      - update
+      - patch
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ebs-csi-resizer-binding
+subjects:
+  - kind: ServiceAccount
+    name: ebs-csi-controller
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: ebs-external-resizer-role
+  apiGroup: rbac.authorization.k8s.io

--- a/cluster/manifests/03-ebs-csi/02-csi-driver.yaml
+++ b/cluster/manifests/03-ebs-csi/02-csi-driver.yaml
@@ -1,0 +1,143 @@
+{{- if eq .ConfigItems.prometheus_csi_ebs "true" }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: csi-node-driver
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      application: container-storage-interface
+      component: driver
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        application: container-storage-interface
+        component: driver
+    spec:
+      initContainers:
+        - name: cleanup
+          image: registry.opensource.zalan.do/stups/alpine:3.10.3-5
+          command:
+             - /bin/sh
+          args:
+             - -c
+             - rm -rf /registration/ebs.csi.aws.com-reg.sock /csi/csi.sock
+          resources:
+            requests:
+              cpu: 10m
+              memory: 30Mi
+            limits:
+              cpu: 10m
+              memory: 30Mi
+          volumeMounts:
+            - mountPath: /csi
+              name: plugin-dir
+            - mountPath: /registration
+              name: registration-dir
+      containers:
+        - args:
+            - node
+            - --endpoint=$(CSI_ENDPOINT)
+            - --logtostderr
+            - --v=5
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:/csi/csi.sock
+          image: registry.opensource.zalan.do/teapot/ebs-csi-driver:v0.5.0-master-2
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+          name: ebs-plugin
+          ports:
+            - containerPort: 9808
+              name: healthz
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 20m
+              memory: 50Mi
+            limits:
+              cpu: 20m
+              memory: 50Mi
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /opt/podruntime/kubelet
+              mountPropagation: Bidirectional
+              name: kubelet-dir
+            - mountPath: /csi
+              name: plugin-dir
+            - mountPath: /dev
+              name: device-dir
+        - args:
+            - --csi-address=$(ADDRESS)
+            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+            - --v=5
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /opt/podruntime/kubelet/plugins/ebs.csi.aws.com/csi.sock
+          image: registry.opensource.zalan.do/teapot/csi-node-driver-registrar:v1.1.0-master-1
+
+          name: node-driver-registrar
+          resources:
+            requests:
+              cpu: 20m
+              memory: 50Mi
+            limits:
+              cpu: 20m
+              memory: 50Mi
+          volumeMounts:
+            - mountPath: /csi
+              name: plugin-dir
+            - mountPath: /registration
+              name: registration-dir
+        - args:
+            - --csi-address=/csi/csi.sock
+          image: registry.opensource.zalan.do/teapot/livenessprobe:v1.1.0-master-1
+          name: liveness-probe
+          resources:
+            requests:
+              cpu: 10m
+              memory: 20Mi
+            limits:
+              cpu: 10m
+              memory: 20Mi
+          volumeMounts:
+            - mountPath: /csi
+              name: plugin-dir
+      hostNetwork: true
+      priorityClassName: system-node-critical
+      serviceAccountName: ebs-csi-node
+      tolerations:
+        - operator: Exists
+          effect: NoSchedule
+        - operator: Exists
+          effect: NoExecute
+      volumes:
+        - hostPath:
+            path: /opt/podruntime/kubelet
+            type: Directory
+          name: kubelet-dir
+        - hostPath:
+            path: /opt/podruntime/kubelet/plugins/ebs.csi.aws.com/
+            type: DirectoryOrCreate
+          name: plugin-dir
+        - hostPath:
+            path: /opt/podruntime/kubelet/plugins_registry/
+            type: Directory
+          name: registration-dir
+        - hostPath:
+            path: /dev
+            type: Directory
+          name: device-dir
+{{- end }}

--- a/cluster/manifests/03-ebs-csi/controller-aws-iam-role.yaml
+++ b/cluster/manifests/03-ebs-csi/controller-aws-iam-role.yaml
@@ -1,0 +1,7 @@
+apiVersion: zalando.org/v1
+kind: AWSIAMRole
+metadata:
+  name: ebs-csi-controller-iam-credentials
+  namespace: kube-system
+spec:
+  roleReference: {{ .LocalID}}-ebs-csi-controller

--- a/cluster/manifests/03-ebs-csi/csi-driver.yaml
+++ b/cluster/manifests/03-ebs-csi/csi-driver.yaml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1beta1
+kind: CSIDriver
+metadata:
+  name: ebs.csi.aws.com
+spec:
+  attachRequired: true
+  podInfoOnMount: false

--- a/cluster/manifests/03-ebs-csi/ebs-controller.yaml
+++ b/cluster/manifests/03-ebs-csi/ebs-controller.yaml
@@ -1,0 +1,142 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ebs-csi-controller
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      application: container-storage-interface
+      component: ebs-controller
+  template:
+    metadata:
+      labels:
+        application: container-storage-interface
+        component: ebs-controller
+    spec:
+      containers:
+        - args:
+            - controller
+            - --endpoint=$(CSI_ENDPOINT)
+            - --logtostderr
+            - --v=5
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+          # must be set for the AWS SDK/AWS CLI to find the credentials file.
+            - name: AWS_SHARED_CREDENTIALS_FILE # used by golang SDK
+              value: /meta/aws-iam/credentials.process
+          image: registry.opensource.zalan.do/teapot/ebs-csi-driver:v0.5.0-master-2
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+          name: ebs-plugin
+          ports:
+            - containerPort: 9808
+              name: healthz
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 50m
+              memory: 50Mi
+            limits:
+              cpu: 50m
+              memory: 50Mi
+          volumeMounts:
+            - mountPath: /var/lib/csi/sockets/pluginproxy/
+              name: socket-dir
+            - name: aws-iam-credentials
+              mountPath: /meta/aws-iam
+              readOnly: true
+        - args:
+            - --csi-address=$(ADDRESS)
+            - --v=5
+            - --feature-gates=Topology=true
+            - --enable-leader-election
+            - --leader-election-type=leases
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          image: registry.opensource.zalan.do/teapot/csi-provisioner:v1.3.0-master-2
+          name: csi-provisioner
+          resources:
+            requests:
+              cpu: 50m
+              memory: 50Mi
+            limits:
+              cpu: 50m
+              memory: 50Mi
+          volumeMounts:
+            - mountPath: /var/lib/csi/sockets/pluginproxy/
+              name: socket-dir
+        - args:
+            - --csi-address=$(ADDRESS)
+            - --v=5
+            - --leader-election=true
+            - --leader-election-type=leases
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          image: registry.opensource.zalan.do/teapot/csi-attacher:v1.2.0-master-2
+          name: csi-attacher
+          resources:
+            requests:
+              cpu: 50m
+              memory: 50Mi
+            limits:
+              cpu: 50m
+              memory: 50Mi
+          volumeMounts:
+            - mountPath: /var/lib/csi/sockets/pluginproxy/
+              name: socket-dir
+        - args:
+            - --csi-address=/csi/csi.sock
+          image: registry.opensource.zalan.do/teapot/livenessprobe:v1.1.0-master-2
+          name: liveness-probe
+          resources:
+            requests:
+              cpu: 10m
+              memory: 20Mi
+            limits:
+              cpu: 10m
+              memory: 20Mi
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+        - name: csi-resizer
+          image: registry.opensource.zalan.do/teapot/csi-resizer:v0.3.0-master-3
+          args:
+            - --csi-address=$(ADDRESS)
+            - --v=5
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          resources:
+            requests:
+              cpu: 50m
+              memory: 50Mi
+            limits:
+              cpu: 50m
+              memory: 50Mi
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+      nodeSelector:
+        node.kubernetes.io/role: master
+      priorityClassName: system-cluster-critical
+      serviceAccountName: ebs-csi-controller
+      tolerations:
+        - key: node.kubernetes.io/role
+          value: master
+          effect: NoSchedule
+      volumes:
+        - emptyDir: {}
+          name: socket-dir
+        - name: aws-iam-credentials
+          secret:
+            secretName: ebs-csi-controller-iam-credentials

--- a/cluster/manifests/03-ebs-csi/storageclass.yaml
+++ b/cluster/manifests/03-ebs-csi/storageclass.yaml
@@ -1,0 +1,7 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: ebs
+provisioner: ebs.csi.aws.com
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -37,3 +37,27 @@ post_apply:{{ if and (ne .ConfigItems.teapot_admission_controller_process_resour
   kind: AWSIAMRole
   apiVersion: zalando.org/v1
 {{ end }}
+{{ if ne .ConfigItems.prometheus_csi_ebs "true" }}
+- name: prometheus-csi
+  namespace: kube-system
+  kind: StatefulSet
+- name: prometheus-storage-volume-prometheus-csi-0
+  kind: PersistentVolumeClaim
+  namespace: kube-system
+- name: prometheus-storage-volume-prometheus-csi-1
+  kind: PersistentVolumeClaim
+  namespace: kube-system
+- name: csi-node-driver
+  namespace: kube-system
+  kind: DaemonSet
+{{ else }}
+- name: prometheus
+  namespace: kube-system
+  kind: StatefulSet
+- name: prometheus-storage-volume-prometheus-0
+  kind: PersistentVolumeClaim
+  namespace: kube-system
+- name: prometheus-storage-volume-prometheus-1
+  kind: PersistentVolumeClaim
+  namespace: kube-system
+{{ end }}

--- a/cluster/manifests/prometheus/prometheus-vpa.yaml
+++ b/cluster/manifests/prometheus/prometheus-vpa.yaml
@@ -9,7 +9,11 @@ spec:
   targetRef:
     apiVersion: apps/v1
     kind: StatefulSet
+{{ if ne .ConfigItems.prometheus_csi_ebs "true" }}
     name: prometheus
+{{ else }}
+    name: prometheus-csi
+{{ end }}
   updatePolicy:
     updateMode: Auto
   resourcePolicy:

--- a/cluster/manifests/prometheus/statefulset.yaml
+++ b/cluster/manifests/prometheus/statefulset.yaml
@@ -6,7 +6,11 @@ metadata:
   labels:
     application: prometheus
     version: v2.15.2
+{{- if ne .ConfigItems.prometheus_csi_ebs "true" }}
   name: prometheus
+{{- else }}
+  name: prometheus-csi
+{{- end }}
   namespace: kube-system
 spec:
   replicas: 2
@@ -111,7 +115,11 @@ spec:
   - metadata:
       name: prometheus-storage-volume
     spec:
+{{- if ne .ConfigItems.prometheus_csi_ebs "true" }}
       storageClassName: standard
+{{- else }}
+      storageClassName: ebs
+{{- end }}
       accessModes:
       - "ReadWriteOnce"
       resources:

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -43,6 +43,10 @@ write_files:
 {{- end }}
       featureGates:
         BoundServiceAccountTokenVolume: {{ .Cluster.ConfigItems.rotate_service_account_tokens }}
+        CSINodeInfo: true
+        CSIDriverRegistry: true
+        CSIBlockVolume: true
+        CSIMigration: true
       podPidsLimit: {{ .NodePool.ConfigItems.pod_max_pids }}
       maxPods: {{ nodeCIDRMaxPods (parseInt64 .Cluster.ConfigItems.node_cidr_mask_size) 8 }}
       healthzPort: 10248
@@ -125,7 +129,7 @@ write_files:
           - --authorization-mode=Webhook,RBAC
           - --authorization-webhook-config-file=/etc/kubernetes/config/authz.yaml
           - --admission-control-config-file=/etc/kubernetes/config/image-policy-webhook.yaml
-          - --feature-gates=TTLAfterFinished=true,BoundServiceAccountTokenVolume={{ .Cluster.ConfigItems.rotate_service_account_tokens }},EndpointSlice={{ .Cluster.ConfigItems.enable_endpointslice }},HPAScaleToZero={{ .Cluster.ConfigItems.enable_hpa_scale_to_zero }}
+          - --feature-gates=TTLAfterFinished=true,BoundServiceAccountTokenVolume={{ .Cluster.ConfigItems.rotate_service_account_tokens }},EndpointSlice={{ .Cluster.ConfigItems.enable_endpointslice }},HPAScaleToZero={{ .Cluster.ConfigItems.enable_hpa_scale_to_zero }},CSINodeInfo=true,CSIDriverRegistry=true,CSIBlockVolume=true,VolumeSnapshotDataSource=true,CSIMigration=true
           - --anonymous-auth=false
           - --service-account-key-file=/etc/kubernetes/ssl/service-account-public-key.pem
           {{- if eq .Cluster.ConfigItems.rotate_service_account_tokens "true" }}

--- a/cluster/node-pools/worker-default/userdata.yaml
+++ b/cluster/node-pools/worker-default/userdata.yaml
@@ -53,6 +53,10 @@ write_files:
       cpuCFSQuota: false
       featureGates:
         BoundServiceAccountTokenVolume: {{ .Cluster.ConfigItems.rotate_service_account_tokens }}
+        CSINodeInfo: true
+        CSIDriverRegistry: true
+        CSIBlockVolume: true
+        CSIMigration: true
       podPidsLimit: {{ .NodePool.ConfigItems.pod_max_pids }}
       cpuManagerPolicy: {{ .NodePool.ConfigItems.cpu_manager_policy }}
       maxPods: {{ nodeCIDRMaxPods (parseInt64 .Cluster.ConfigItems.node_cidr_mask_size) 0 }}


### PR DESCRIPTION
This PR adds [CSI components](https://kubernetes-csi.github.io/docs/) for Kubernetes with the [EBS driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver).
 Also changed in this PR is the `prometheus` statefulset. Another statefulset needs to be created because the `persistentVolumeClaims` cannot be modified. Instead a new `statefulset` is created with CSI volumes.