### PR TITLE
Only handle CRD v1 in admission-controller

### DIFF
--- a/cluster/manifests/01-admission-control/teapot.yaml
+++ b/cluster/manifests/01-admission-control/teapot.yaml
@@ -110,10 +110,11 @@ webhooks:
       url: "https://localhost:8085/crd"
       caBundle: "{{ .ConfigItems.ca_cert_decompressed }}"
     failurePolicy: Fail
+    matchPolicy: Equivalent
     rules:
       - operations: ["CREATE", "UPDATE", "DELETE"]
         apiGroups: ["apiextensions.k8s.io"]
-        apiVersions: ["v1", "v1beta1"]
+        apiVersions: ["v1"]
         resources: ["customresourcedefinitions"]
   - name: ingress-admitter.teapot.zalan.do
     clientConfig:

--- a/cluster/manifests/admission-control-proxy/daemonset.yaml
+++ b/cluster/manifests/admission-control-proxy/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cluster-autoscaler
-        image: registry.opensource.zalan.do/teapot/admission-controller:master-65
+        image: registry.opensource.zalan.do/teapot/admission-controller:master-69
         command:
           - /registry-proxy
           - --address=127.0.0.1:8285

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -190,7 +190,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-66
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-69
           name: admission-controller
           readinessProbe:
             httpGet:


### PR DESCRIPTION
Updates the admission-controller to only handle CRDs in v1. This ensures that our automatic RBAC rules for CRDs works both with `v1beta1` (as before) and also with `v1`.

Admission controller will only accept CRD of `v1` and any `v1beta1` CRDs will be converted by the APIserver before being sent to the admission controller.

Before it didn't work for `v1` CRDs because the status and scale subresources were not correctly discovered in the admission controller.