### PR TITLE
kube-janitor: delete unused PVCs (opt-in per cluster)

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -316,3 +316,5 @@ enable_encryption: "false"
 
 # default ttl for kube janitor for resources build from PRs in namespaces matching .*-pr-.*
 kube_janitor_default_pr_ttl: "1w"  # 1 week
+# opt-in deletion of unused PVCs
+kube_janitor_default_unused_pvc_ttl: "forever"

--- a/cluster/manifests/kube-janitor/deployment.yaml
+++ b/cluster/manifests/kube-janitor/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-janitor
-    version: v20.3.1
+    version: v20.3.2
 spec:
   replicas: 1
   selector:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: kube-janitor
-        version: v20.3.1
+        version: v20.3.2
     spec:
       dnsConfig:
         options:
@@ -27,7 +27,7 @@ spec:
       containers:
       - name: janitor
         # see https://github.com/hjacobs/kube-janitor/releases
-        image: registry.opensource.zalan.do/teapot/kube-janitor:20.3.1
+        image: registry.opensource.zalan.do/teapot/kube-janitor:20.3.2
         args:
           # run every minute
           - --interval=60

--- a/cluster/manifests/kube-janitor/deployment.yaml
+++ b/cluster/manifests/kube-janitor/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-janitor
-    version: v20.2.0
+    version: v20.3.1
 spec:
   replicas: 1
   selector:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: kube-janitor
-        version: v20.2.0
+        version: v20.3.1
     spec:
       dnsConfig:
         options:
@@ -27,7 +27,7 @@ spec:
       containers:
       - name: janitor
         # see https://github.com/hjacobs/kube-janitor/releases
-        image: registry.opensource.zalan.do/teapot/kube-janitor:20.2.0
+        image: registry.opensource.zalan.do/teapot/kube-janitor:20.3.1
         args:
           # run every minute
           - --interval=60

--- a/cluster/manifests/kube-janitor/rules-config.yaml
+++ b/cluster/manifests/kube-janitor/rules-config.yaml
@@ -40,5 +40,5 @@ data:
         resources:
           - persistentvolumeclaims
         jmespath: "_context.pvc_is_not_mounted && _context.pvc_is_not_referenced"
-        ttl: 24h
+        ttl: "{{ .Cluster.ConfigItems.kube_janitor_default_unused_pvc_ttl }}"
 {{ end }}

--- a/cluster/manifests/kube-janitor/rules-config.yaml
+++ b/cluster/manifests/kube-janitor/rules-config.yaml
@@ -27,11 +27,18 @@ data:
         ttl: 24h
       - id: cleanup-resources-from-pull-requests
         # Delete all resources in namespaces matching .*-pr-.* after configured period:
-        # This allows to put resources build from pull requests into a 
-        # namespace like my-project-pr-123 . They won't mess up the cluster 
+        # This allows to put resources build from pull requests into a
+        # namespace like my-project-pr-123 . They won't mess up the cluster
         # anymore, see #2930.
         resources:
-          - namespaces  
+          - namespaces
         jmespath: "contains(metadata.name, '-pr-')"
         ttl: "{{ .Cluster.ConfigItems.kube_janitor_default_pr_ttl }}"
+      - id: cleanup-unused-pvcs
+        # Delete all unused PersistentVolumeClaims (PVCs) and their EBS volumes
+        # to save costs ($0.119/GiB per month)
+        resources:
+          - persistentvolumeclaims
+        jmespath: "_context.pvc_is_not_mounted && _context.pvc_is_not_referenced"
+        ttl: 24h
 {{ end }}


### PR DESCRIPTION
AWS EBS volumes of unused PersistentVolumeClaims (PVCs) cost money ($0.119/GiB per month).
Deleting a StatefulSet will not delete the PVCs. Clean them up via kube-janitor (https://github.com/hjacobs/kube-janitor/issues/62).

This will only delete PVCs which are not mounted and not referenced by any StatefulSet (volumeClaimTemplates).

NOTE: this will only be active in non-production clusters as `kube-janitor` is only deployed there.