### PR TITLE
Update ExternalDNS to use pod identity credentials

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -715,6 +715,16 @@ Resources:
     Properties:
       AssumeRolePolicyDocument:
         Statement:
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
+          - Effect: Allow
+            Principal:
+              Federated: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+            Action:
+              - 'sts:AssumeRoleWithWebIdentity'
+            Condition:
+              StringLike:
+                "{{ .Cluster.LocalID }}.{{ .Values.hosted_zone }}:sub": "system:serviceaccount:kube-system:external-dns"
+{{ end }}
           - Action:
               - 'sts:AssumeRole'
             Effect: Allow

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -31,3 +31,9 @@ post_apply:{{ if and (ne .ConfigItems.teapot_admission_controller_process_resour
 - name: leader-locking-efs-provisioner
   namespace: default
   kind: RoleBinding
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true"}}
+- name: external-dns-aws-iam-credentials
+  namespace: kube-system
+  kind: AWSIAMRole
+  apiVersion: zalando.org/v1
+{{ end }}

--- a/cluster/manifests/external-dns/01-rbac.yaml
+++ b/cluster/manifests/external-dns/01-rbac.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: kube-system
   labels:
     application: external-dns
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:role/{{ .LocalID }}-app-external-dns"
+{{ end }}
 ---
 # allows to list services and ingresses
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cluster/manifests/external-dns/aws-iam-role.yaml
+++ b/cluster/manifests/external-dns/aws-iam-role.yaml
@@ -1,3 +1,4 @@
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
 apiVersion: zalando.org/v1
 kind: AWSIAMRole
@@ -6,4 +7,5 @@ metadata:
   namespace: kube-system
 spec:
   roleReference: {{ .LocalID }}-app-external-dns
+{{ end }}
 {{ end }}

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -17,9 +17,11 @@ spec:
       labels:
         application: external-dns
         version: v0.7.0
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "false"}}
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
+{{ end }}
 {{ end }}
     spec:
       dnsConfig:
@@ -41,11 +43,13 @@ spec:
         - --txt-owner-id={{ .Region }}:{{ .LocalID }}
         - --txt-prefix={{ .ConfigItems.external_dns_ownership_prefix }}
         - --aws-batch-change-size=100
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
         env:
         # must be set for the AWS SDK/AWS CLI to find the credentials file.
         - name: AWS_SHARED_CREDENTIALS_FILE # used by golang SDK
           value: /meta/aws-iam/credentials.process
+{{ end }}
 {{ end }}
         resources:
           limits:
@@ -55,11 +59,13 @@ spec:
           httpGet:
             path: /healthz
             port: 7979
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
         volumeMounts:
         - name: aws-iam-credentials
           mountPath: /meta/aws-iam
           readOnly: true
+{{ end }}
 {{ end }}
         securityContext:
           readOnlyRootFilesystem: true
@@ -69,9 +75,11 @@ spec:
             drop: ["ALL"]
       securityContext:
         fsGroup: 65534
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
       volumes:
       - name: aws-iam-credentials
         secret:
           secretName: external-dns-aws-iam-credentials
+{{ end }}
 {{ end }}


### PR DESCRIPTION
This enables ExternalDNS to use the new IAM credentials mechanism.

Looks a bit cumbersome but that's due to the **three** different ways we can get AWS IAM credentials at the moment and I didn't want to change that for now.

Before continuing with the next services I'll intend to reduce it to avoid the many conditionals.