### PR TITLE
Test clusters: add rules for StackSets and CronJobs without application label

### DIFF
--- a/cluster/manifests/kube-janitor/rules-config.yaml
+++ b/cluster/manifests/kube-janitor/rules-config.yaml
@@ -21,8 +21,8 @@ data:
         # remove StackSets without a pod label "application"
         resources:
           - stacksets
-        # see http://jmespath.org/specification.html
-        jmespath: "!(spec.stackTemplate.spec.podTemplate.metadata.labels.application) && metadata.creationTimestamp > '2019-04-15'"
+        # StackSet propagates top-level labels to pods, so check podTemplate and StackSet itself
+        jmespath: "!(spec.stackTemplate.spec.podTemplate.metadata.labels.application) && !(metadata.labels.application) && metadata.creationTimestamp > '2019-04-15'"
         ttl: 7d
       - id: require-application-label-cronjobs
         # remove CronJobs without a pod label "application"

--- a/cluster/manifests/kube-janitor/rules-config.yaml
+++ b/cluster/manifests/kube-janitor/rules-config.yaml
@@ -17,6 +17,20 @@ data:
         # see http://jmespath.org/specification.html
         jmespath: "!(spec.template.metadata.labels.application) && metadata.creationTimestamp > '2019-04-15'"
         ttl: 7d
+      - id: require-application-label-stacksets
+        # remove StackSets without a pod label "application"
+        resources:
+          - stacksets
+        # see http://jmespath.org/specification.html
+        jmespath: "!spec.stackTemplate.spec.podTemplate.metadata.labels.application"
+        ttl: 7d
+      - id: require-application-label-cronjobs
+        # remove CronJobs without a pod label "application"
+        resources:
+          - cronjobs
+        # see http://jmespath.org/specification.html
+        jmespath: "!spec.jobTemplate.spec.template.metadata.labels.application"
+        ttl: 7d
       - id: temporary-cdp-namespaces
         # delete all temporary e2e namespaces (created by CDP) with a name starting with "d-*"
         resources:
@@ -27,11 +41,11 @@ data:
         ttl: 24h
       - id: cleanup-resources-from-pull-requests
         # Delete all resources in namespaces matching .*-pr-.* after configured period:
-        # This allows to put resources build from pull requests into a 
-        # namespace like my-project-pr-123 . They won't mess up the cluster 
+        # This allows to put resources build from pull requests into a
+        # namespace like my-project-pr-123 . They won't mess up the cluster
         # anymore, see #2930.
         resources:
-          - namespaces  
+          - namespaces
         jmespath: "contains(metadata.name, '-pr-')"
         ttl: "{{ .Cluster.ConfigItems.kube_janitor_default_pr_ttl }}"
 {{ end }}

--- a/cluster/manifests/kube-janitor/rules-config.yaml
+++ b/cluster/manifests/kube-janitor/rules-config.yaml
@@ -22,14 +22,14 @@ data:
         resources:
           - stacksets
         # see http://jmespath.org/specification.html
-        jmespath: "!spec.stackTemplate.spec.podTemplate.metadata.labels.application"
+        jmespath: "!(spec.stackTemplate.spec.podTemplate.metadata.labels.application) && metadata.creationTimestamp > '2019-04-15'"
         ttl: 7d
       - id: require-application-label-cronjobs
         # remove CronJobs without a pod label "application"
         resources:
           - cronjobs
         # see http://jmespath.org/specification.html
-        jmespath: "!spec.jobTemplate.spec.template.metadata.labels.application"
+        jmespath: "!(spec.jobTemplate.spec.template.metadata.labels.application) && metadata.creationTimestamp > '2019-04-15'"
         ttl: 7d
       - id: temporary-cdp-namespaces
         # delete all temporary e2e namespaces (created by CDP) with a name starting with "d-*"


### PR DESCRIPTION
`kube-janitor` was only deleting Deployments and StatefulSets without the `application` label after 7 days. Do the same for StackSets and CronJobs. I consider this a bug fix and not a new feature.
Note that the 7 days are counted from the last deployment time (CDP `deployment-time` annotation), i.e. some resources without the `application` might never get deleted as long as they are deployed every week.