### PR TITLE
Update CoreDNS to version 1.6.9

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -197,6 +197,7 @@ dynamodb_service_link_enabled: "false"
 
 cluster_dns: "coredns"
 coredns_log_svc_names: "true"
+coredns_max_upstream_concurrency: 0 #0 means there is not concurrency limits
 
 kuberuntu_image_v1_16: {{ amiID "zalando-ubuntu-kubernetes-production-v1.16.8-master-96" "861068367966" }}
 

--- a/cluster/manifests/coredns-local/configmap-local.yaml
+++ b/cluster/manifests/coredns-local/configmap-local.yaml
@@ -50,7 +50,9 @@ data:
         health :9154 # this is global for all servers
         ready :9155
         prometheus :9153
-        forward . /etc/resolv.conf
+        forward . /etc/resolv.conf {
+          max_concurrent {{ .ConfigItems.coredns_max_upstream_concurrency }}
+        }
         pprof 127.0.0.1:9156
         cache 30
         reload

--- a/cluster/manifests/coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/coredns-local/daemonset-coredns.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: coredns
-    version: v1.6.4
+    version: v1.6.9
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
     component: cluster-dns
@@ -21,7 +21,7 @@ spec:
       labels:
         application: coredns
         instance: node-dns
-        version: v1.6.4
+        version: v1.6.9
         component: cluster-dns
     spec:
       containers:
@@ -96,7 +96,7 @@ spec:
             cpu: {{.Cluster.ConfigItems.dns_dnsmasq_sidecar_cpu}}
             memory: {{.Cluster.ConfigItems.dns_dnsmasq_sidecar_mem}}
       - name: coredns
-        image: registry.opensource.zalan.do/teapot/coredns:1.6.4
+        image: registry.opensource.zalan.do/teapot/coredns:1.6.9
         args: [ "-conf", "/etc/coredns/Corefile" ]
         volumeMounts:
         - name: config-volume

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -58,6 +58,7 @@ clusters:
     aws_pod_identity_webhook_key: ${POD_IDENTITY_WEBHOOK_KEY}
     aws_pod_identity_webhook_cert: ${POD_IDENTITY_WEBHOOK_CERT}
     prometheus_tsdb_retention_size: enabled
+    coredns_max_upsteam_concurrency: 30
   criticality_level: 1
   environment: e2e
   id: ${CLUSTER_ID}


### PR DESCRIPTION
For @szuecs 
Update the CoreDNS version to 1.6.9

This version has the fix for this [issue](https://github.com/coredns/coredns/pull/3640).
This change does not change the current behavior because the default value for concurrency is 0 which means there is no concurrency control. This can be changed by setting the config item `coredns_max_concurrency`.