### PR TITLE
kube-downscaler v20.3.1: downscale StatefulSets, Stacks with HPA

### DIFF
--- a/cluster/manifests/kube-downscaler/deployment.yaml
+++ b/cluster/manifests/kube-downscaler/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-downscaler
-    version: v0.18
+    version: v20.3.1
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-downscaler
-        version: v0.18
+        version: v20.3.1
     spec:
       dnsConfig:
         options:
@@ -26,13 +26,14 @@ spec:
       containers:
       - name: downscaler
         # see https://github.com/hjacobs/kube-downscaler/releases
-        image: registry.opensource.zalan.do/teapot/kube-downscaler:0.18
+        image: registry.opensource.zalan.do/teapot/kube-downscaler:20.3.1
         args:
           - --interval=30
           - --exclude-namespaces=kube-system,visibility
-          - --exclude-deployments=kube-downscaler,downscaler,postgres-operator
+          - --exclude-deployments=kube-downscaler
           - "--default-uptime={{ .ConfigItems.downscaler_default_uptime }}"
-          - --include-resources=stacks,deployments
+          - --include-resources=deployments,statefulsets,stacks,cronjobs
+          - --deployment-time-annotation=deployment-time
         resources:
           limits:
             cpu: 5m

--- a/cluster/manifests/kube-downscaler/deployment.yaml
+++ b/cluster/manifests/kube-downscaler/deployment.yaml
@@ -30,7 +30,8 @@ spec:
         args:
           - --interval=30
           - --exclude-namespaces=kube-system,visibility
-          - --exclude-deployments=kube-downscaler
+          # do not downscale ourselves, also keep Postgres Operator so excluded DBs can be managed
+          - --exclude-deployments=kube-downscaler,postgres-operator
           - "--default-uptime={{ .ConfigItems.downscaler_default_uptime }}"
           - --include-resources=deployments,statefulsets,stacks,cronjobs
           - --deployment-time-annotation=deployment-time

--- a/cluster/manifests/kube-downscaler/rbac.yaml
+++ b/cluster/manifests/kube-downscaler/rbac.yaml
@@ -19,11 +19,20 @@ rules:
   - watch
   - list
 - apiGroups:
-  - extensions
   - apps
   resources:
   - deployments
   - statefulsets
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+  - patch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
   verbs:
   - get
   - watch
@@ -36,18 +45,10 @@ rules:
   - stacks
   verbs:
   - get
-  - list
   - watch
+  - list
   - update
   - patch
-- apiGroups:
-  - zalando.org
-  resources:
-  - stacksets
-  verbs:
-  - get
-  - list
-  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
New upstream version v20.3.1: https://github.com/hjacobs/kube-downscaler/releases/tag/20.3.1

* scale down Stacks with HPA (new feature in v20.3.1: https://github.com/hjacobs/kube-downscaler/pull/93)
* also downscale StatefulSets
* suspend CronJobs (https://github.com/hjacobs/kube-downscaler/issues/78)
* configure CDP's `deployment-time` annotation (https://github.com/hjacobs/kube-downscaler/issues/87)

This reduces the number of worker nodes in some test clusters during off-hours dramatically (e.g. from 13 to 6).