### PR TITLE
Allow tcp_keepalive sysctls

### DIFF
--- a/cluster/manifests/psp/pod_security_policy.yaml
+++ b/cluster/manifests/psp/pod_security_policy.yaml
@@ -19,6 +19,10 @@ spec:
     rule: RunAsAny
   supplementalGroups:
     rule: RunAsAny
+  allowedUnsafeSysctls:
+    - net.ipv4.tcp_keepalive_time
+    - net.ipv4.tcp_keepalive_intvl
+    - net.ipv4.tcp_keepalive_probes
   volumes:
   - '*'
 ---
@@ -36,6 +40,10 @@ spec:
     rule: RunAsAny
   supplementalGroups:
     rule: RunAsAny
+  allowedUnsafeSysctls:
+    - net.ipv4.tcp_keepalive_time
+    - net.ipv4.tcp_keepalive_intvl
+    - net.ipv4.tcp_keepalive_probes
   volumes:
   - emptyDir
   - awsElasticBlockStore

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -59,6 +59,10 @@ write_files:
       kubeReserved:
         cpu: "100m"
         memory: "282Mi"
+      allowedUnsafeSysctls:
+        - net.ipv4.tcp_keepalive_time
+        - net.ipv4.tcp_keepalive_intvl
+        - net.ipv4.tcp_keepalive_probes
       authentication:
         anonymous:
           enabled: true

--- a/cluster/node-pools/worker-default/userdata.yaml
+++ b/cluster/node-pools/worker-default/userdata.yaml
@@ -70,6 +70,10 @@ write_files:
       kubeReserved:
         cpu: "100m"
         memory: "282Mi"
+      allowedUnsafeSysctls:
+        - net.ipv4.tcp_keepalive_time
+        - net.ipv4.tcp_keepalive_intvl
+        - net.ipv4.tcp_keepalive_probes
       authentication:
         anonymous:
           enabled: false


### PR DESCRIPTION
These are fairly benign so there's no reason to not allow customising them. We also want to inject better defaults via the admission controller, but we need to update kubelets/PSPs first.