### PR TITLE
Application tag on Kubernetes resources (etcd/master-lb)

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -73,6 +73,10 @@ Resources:
       Tags:
         - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
           Value: owned
+        - Key: "application"
+          Value: kube-apiserver
+        - Key: "component"
+          Value: "kube-apiserver"
     Type: 'AWS::ElasticLoadBalancing::LoadBalancer'
   MasterLoadBalancerSecurityGroup:
     Properties:

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1419,6 +1419,11 @@ Resources:
             Status: Enabled
       VersioningConfiguration:
         Status: Suspended
+      Tags:
+      - Key: application
+        Value: audittrail-adapter
+      - Key: component
+        Value: resend
   AuditTrailBucketPolicy:
     Type: AWS::S3::BucketPolicy
     Properties:


### PR DESCRIPTION
This adds `application` and `component` tags to a few AWS resources like:
* ~etcd instances~
* ~etcd s3 bucket~
* Master Load balancer
* Audittrail s3 bucket (`audittrail-adapter`)

~For etcd I used a new application name `kubernetes-etcd`. We have an internal discussion about putting everything under application `kubernetes` (or similar) but it's a bigger effort, so will start with a dedicated application id.~ Done in https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/283

The motivation for this PR is to increase our ability to group costs by application/component and make it simpler to determine "infrastructure" vs. user application costs.