### PR TITLE
Give kube-cost-allocator watch access for pods/nodes

### DIFF
--- a/cluster/manifests/roles/kube-cost-allocator.yaml
+++ b/cluster/manifests/roles/kube-cost-allocator.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-cost-allocator-collector
+  labels:
+    application: kube-cost-allocator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-cost-allocator-collector
+  labels:
+    application: kube-cost-allocator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-cost-allocator-collector
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: zalando-iam:zalando:service:stups_kube-cost-allocator


### PR DESCRIPTION
As part of the Cloud Cost Efficiency initiative for doing better per application reporting we have built a small tool that watches for pods/nodes in all clusters and records their start and end time in order to later calculate their usage hours and thus cost.

For this we need read permissions in all clusters.