### PR TITLE
clc: Reduce CPU requests

### DIFF
--- a/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
@@ -46,10 +46,10 @@ spec:
           readOnly: true
         resources:
           limits:
-            cpu: 100m
+            cpu: 15m
             memory: 250Mi
           requests:
-            cpu: 100m
+            cpu: 15m
             memory: 250Mi
         env:
         - name: AWS_REGION


### PR DESCRIPTION
On master nodes we currently request `1777m` CPU for daemonsets, deployments and mirror pods This means we only have `23m` left if running on an instance with `2000m` (`1800m` after kubelet resources) like an `m4.large`. Our `etcd-backup` cronjob requests `100m` (and we don't have metrics for how much it actually uses as it runs for so little time usually).
This has the effect that other things with lower priority e.g. `logging-agent` is kicked out to make room for the `etcd-backup` job.
This happens after #3103 where we enabled daemonset scheduling via the normal scheduler as it now can correctly handle priorities. (I'm not sure what happened before).

In order to continue to use `m4.large` or similar "small" instances for masters we need to reduce the CPU requests. CLC is a good candidate because it requests `100m` but only uses around `10-14m` as max.

Here is a graph showing CLC CPU usage across all clusters for the last 20 days. It has a single spike of `39m` but otherwise uses around `10-14m` as max. Lower the request to `15m` to reduce the requested CPU for master nodes to `1692m` leaving `108m` spare for the `etcd-backup` job.

![image](https://user-images.githubusercontent.com/128566/78536483-34348380-77ee-11ea-91f6-b30c9f2ad4ab.png)

We can ofc. optimize other components as well, but this is the minimum needed along with the v1.17 rollout to avoid `logging-agent` getting kicked out of small master nodes all the time.