### PR TITLE
kube-downscaler v20.4.1: support downscaler/exclude-until

### DIFF
--- a/cluster/manifests/kube-downscaler/deployment.yaml
+++ b/cluster/manifests/kube-downscaler/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-downscaler
-    version: v20.3.1
+    version: v20.4.1
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-downscaler
-        version: v20.3.1
+        version: v20.4.1
     spec:
       dnsConfig:
         options:
@@ -26,7 +26,7 @@ spec:
       containers:
       - name: downscaler
         # see https://github.com/hjacobs/kube-downscaler/releases
-        image: registry.opensource.zalan.do/teapot/kube-downscaler:20.3.1
+        image: registry.opensource.zalan.do/teapot/kube-downscaler:20.4.1
         args:
           - --interval=30
           - --exclude-namespaces=kube-system,visibility


### PR DESCRIPTION
Just a small follow-up to #3095: [version 20.4.1](https://github.com/hjacobs/kube-downscaler/releases/tag/20.4.1) supports the new `downscaler/exclude-until` annotation to allow temporary exclusions (e.g. until end of the week): https://github.com/hjacobs/kube-downscaler/issues/94

Background: I observed that developers add `downscaler/exclude: true` and never remove it again, in most cases a temporary exclusion ("prevent downscaling until next Friday") is better, so nobody has to forget to remove the exclusion again.

I will update our internal Zalando cloud docs accordingly to recommend `downscaler/exclude-until: 2020-04-10T18:00` over `downscaler/exclude: true`.