### PR TITLE
Enable OIDC-based Service Account tokens for Audittrail Adapter

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1525,6 +1525,16 @@ Resources:
     Properties:
       AssumeRolePolicyDocument:
         Statement:
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
+          - Effect: Allow
+            Principal:
+              Federated: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+            Action:
+              - 'sts:AssumeRoleWithWebIdentity'
+            Condition:
+              StringLike:
+                "{{ .Cluster.LocalID }}.{{ .Values.hosted_zone }}:sub": "system:serviceaccount:kube-system:audittrail-adapter"
+{{ end }}
           - Action:
               - 'sts:AssumeRole'
             Effect: Allow

--- a/cluster/manifests/audittrail-adapter/01-rbac.yaml
+++ b/cluster/manifests/audittrail-adapter/01-rbac.yaml
@@ -4,6 +4,10 @@ kind: ServiceAccount
 metadata:
   name: audittrail-adapter
   namespace: kube-system
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:role/{{ .LocalID }}-audittrail-adapter"
+{{ end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding

--- a/cluster/manifests/audittrail-adapter/aws-iam-role.yaml
+++ b/cluster/manifests/audittrail-adapter/aws-iam-role.yaml
@@ -1,7 +1,9 @@
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 apiVersion: zalando.org/v1
 kind: AWSIAMRole
 metadata:
   name: audittrail-adapter-aws-iam-credentials
   namespace: kube-system
 spec:
-  roleReference: {{.LocalID}}-audittrail-adapter
+  roleReference: {{ .LocalID }}-audittrail-adapter
+{{ end }}

--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -35,8 +35,10 @@ spec:
         env:
           - name: AWS_REGION
             value: {{.Cluster.Region}}
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
           - name: AWS_SHARED_CREDENTIALS_FILE
             value: /meta/aws-iam/credentials.process
+{{ end }}
         args:
         - --cluster-id={{ .ID }}
         - --audittrail-url={{.Cluster.ConfigItems.audittrail_url}}
@@ -47,9 +49,11 @@ spec:
         - name: platform-iam-credentials
           mountPath: /meta/credentials
           readOnly: true
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
         - name: aws-iam-credentials
           mountPath: /meta/aws-iam
           readOnly: true
+{{ end }}
         resources:
           limits:
             cpu: 50m
@@ -65,7 +69,9 @@ spec:
       - name: platform-iam-credentials
         secret:
           secretName: audittrail-adapter
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
       - name: aws-iam-credentials
         secret:
           secretName: audittrail-adapter-aws-iam-credentials
+{{ end }}
 {{ end }}


### PR DESCRIPTION
Tests enabled Service Account credentials on a single service.

Split of https://github.com/zalando-incubator/kubernetes-on-aws/pull/2918