### PR TITLE
Enable OIDC-based Service Account tokens for Cluster Lifecycle Controller

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -847,6 +847,16 @@ Resources:
     Properties:
       AssumeRolePolicyDocument:
         Statement:
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
+        - Effect: Allow
+          Principal:
+            Federated: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+          Action:
+            - 'sts:AssumeRoleWithWebIdentity'
+          Condition:
+            StringLike:
+              "{{ .Cluster.LocalID }}.{{ .Values.hosted_zone }}:sub": "system:serviceaccount:kube-system:cluster-lifecycle-controller"
+{{ end }}
         - Action:
           - 'sts:AssumeRole'
           Effect: Allow

--- a/cluster/manifests/cluster-lifecycle-controller/01-rbac.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/01-rbac.yaml
@@ -3,6 +3,10 @@ kind: ServiceAccount
 metadata:
   name: cluster-lifecycle-controller
   namespace: kube-system
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:role/{{ .LocalID }}-cluster-lifecycle-controller"
+{{ end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/cluster/manifests/cluster-lifecycle-controller/aws-iam-role.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/aws-iam-role.yaml
@@ -1,7 +1,9 @@
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 apiVersion: zalando.org/v1
 kind: AWSIAMRole
 metadata:
   name: cluster-lifecycle-controller-aws-iam-credentials
   namespace: kube-system
 spec:
-  roleReference: {{.LocalID}}-cluster-lifecycle-controller
+  roleReference: {{ .LocalID }}-cluster-lifecycle-controller
+{{ end }}

--- a/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
@@ -40,10 +40,12 @@ spec:
             - --drain-min-healthy-sibling-lifetime={{.ConfigItems.drain_min_healthy_sibling_lifetime}}
             - --drain-min-unhealthy-sibling-lifetime={{.ConfigItems.drain_min_unhealthy_sibling_lifetime}}
             - --drain-force-evict-interval={{.ConfigItems.drain_force_evict_interval}}
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
         volumeMounts:
         - name: aws-iam-credentials
           mountPath: /meta/aws-iam
           readOnly: true
+{{ end }}
         resources:
           limits:
             cpu: 15m
@@ -54,12 +56,16 @@ spec:
         env:
         - name: AWS_REGION
           value: {{ .Region }}
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
         # must be set for the AWS SDK/AWS CLI to find the credentials file.
         - name: AWS_SHARED_CREDENTIALS_FILE # used by golang SDK
           value: /meta/aws-iam/credentials.process
+{{ end }}
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
       volumes:
       - name: aws-iam-credentials
         secret:
           secretName: cluster-lifecycle-controller-aws-iam-credentials
+{{ end }}
       nodeSelector:
         node.kubernetes.io/role: master


### PR DESCRIPTION
Tests enabled Service Account credentials on a single service.

Split of https://github.com/zalando-incubator/kubernetes-on-aws/pull/2918