### PR TITLE
Enable OIDC-based Service Account tokens for Kube Metrics Adapter

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1313,6 +1313,16 @@ Resources:
     Properties:
       AssumeRolePolicyDocument:
         Statement:
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
+          - Effect: Allow
+            Principal:
+              Federated: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+            Action:
+              - 'sts:AssumeRoleWithWebIdentity'
+            Condition:
+              StringLike:
+                "{{ .Cluster.LocalID }}.{{ .Values.hosted_zone }}:sub": "system:serviceaccount:kube-system:custom-metrics-apiserver"
+{{ end }}
           - Action:
               - 'sts:AssumeRole'
             Effect: Allow

--- a/cluster/manifests/kube-metrics-adapter/01-rbac.yaml
+++ b/cluster/manifests/kube-metrics-adapter/01-rbac.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 metadata:
   name: custom-metrics-apiserver
   namespace: kube-system
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:role/{{ .Cluster.LocalID }}-kube-metrics-adapter"
+{{ end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/cluster/manifests/kube-metrics-adapter/aws-iam-role.yaml
+++ b/cluster/manifests/kube-metrics-adapter/aws-iam-role.yaml
@@ -1,3 +1,4 @@
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
 apiVersion: zalando.org/v1
 kind: AWSIAMRole
@@ -6,4 +7,5 @@ metadata:
   namespace: kube-system
 spec:
   roleReference: {{ .LocalID}}-kube-metrics-adapter
+{{ end }}
 {{ end }}

--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -12,10 +12,12 @@ spec:
       application: kube-metrics-adapter
   template:
     metadata:
-      {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "false"}}
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
+{{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "false"}}
       annotations:
         iam.amazonaws.com/role: {{ .LocalID}}-kube-metrics-adapter
-      {{ end }}
+{{ end }}
+{{ end }}
       labels:
         application: kube-metrics-adapter
     spec:
@@ -28,12 +30,16 @@ spec:
       containers:
       - name: kube-metrics-adapter
         image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.1
-        {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
         env:
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
+{{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
         # must be set for the AWS SDK/AWS CLI to find the credentials file.
         - name: AWS_SHARED_CREDENTIALS_FILE # used by golang SDK
           value: /meta/aws-iam/credentials.process
-        {{ end }}
+{{ end }}
+{{ end }}
+        - name: AWS_REGION
+          value: {{ .Region }}
         args:
         - --prometheus-server=http://prometheus.kube-system.svc.cluster.local
         - --skipper-ingress-metrics
@@ -45,11 +51,13 @@ spec:
         - --zmon-kariosdb-endpoint=https://data-service.zmon.zalan.do/kairosdb-proxy
         {{ end }}
         volumeMounts:
-        {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
+{{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
         - name: aws-iam-credentials
           mountPath: /meta/aws-iam
           readOnly: true
-        {{ end }}
+{{ end }}
+{{ end }}
         {{ if eq .Environment "production" }}
         - name: credentials
           mountPath: /meta/credentials
@@ -63,11 +71,13 @@ spec:
             cpu: 10m
             memory: 100Mi
       volumes:
-      {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
+{{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
       - name: aws-iam-credentials
         secret:
           secretName: kube-metrics-adapter-aws-iam-credentials
-      {{ end }}
+{{ end }}
+{{ end }}
       {{ if eq .Environment "production" }}
       - name: credentials
         secret:

--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.1
+        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.3
         env:
 {{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}


### PR DESCRIPTION
Tests enabled Service Account credentials on a single service.

Split of https://github.com/zalando-incubator/kubernetes-on-aws/pull/2918