### PR TITLE
Enable OIDC-based Service Account tokens for Emergency Access Service

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1485,6 +1485,16 @@ Resources:
     Properties:
       AssumeRolePolicyDocument:
         Statement:
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
+          - Effect: Allow
+            Principal:
+              Federated: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+            Action:
+              - 'sts:AssumeRoleWithWebIdentity'
+            Condition:
+              StringLike:
+                "{{ .Cluster.LocalID }}.{{ .Values.hosted_zone }}:sub": "system:serviceaccount:kube-system:emergency-access-service"
+{{ end }}
           - Action:
               - 'sts:AssumeRole'
             Effect: Allow

--- a/cluster/manifests/emergency-access-service/01-rbac.yaml
+++ b/cluster/manifests/emergency-access-service/01-rbac.yaml
@@ -4,6 +4,10 @@ kind: ServiceAccount
 metadata:
   name: emergency-access-service
   namespace: kube-system
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:role/{{ .LocalID }}-emergency-access-service"
+{{ end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role

--- a/cluster/manifests/emergency-access-service/aws-iam-role.yaml
+++ b/cluster/manifests/emergency-access-service/aws-iam-role.yaml
@@ -1,3 +1,4 @@
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
 apiVersion: zalando.org/v1
 kind: AWSIAMRole
@@ -6,4 +7,5 @@ metadata:
   namespace: kube-system
 spec:
   roleReference: {{.LocalID}}-emergency-access-service
+{{ end }}
 {{ end }}

--- a/cluster/manifests/emergency-access-service/deployment.yaml
+++ b/cluster/manifests/emergency-access-service/deployment.yaml
@@ -20,8 +20,10 @@ spec:
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
           [{"container": "emergency-access-service", "parser": "json-structured-log"}]
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "false"}}
         iam.amazonaws.com/role: {{.LocalID}}-emergency-access-service
+{{ end }}
 {{ end }}
     spec:
       dnsConfig:
@@ -82,10 +84,12 @@ spec:
           value: "8444"
         - name: OPENTRACING_LIGHTSTEP_COMPONENT_NAME
           value: "emergency-access-service"
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
         # must be set for the AWS SDK/AWS CLI to find the credentials file.
         - name: AWS_SHARED_CREDENTIALS_FILE # used by golang SDK
           value: /meta/aws-iam/credentials.process
+{{ end }}
 {{ end }}
         ports:
         - containerPort: 8080
@@ -96,10 +100,12 @@ spec:
         - name: secrets
           mountPath: /meta/secrets
           readOnly: true
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
         - name: aws-iam-credentials
           mountPath: /meta/aws-iam
           readOnly: true
+{{ end }}
 {{ end }}
         livenessProbe:
           httpGet:
@@ -128,9 +134,11 @@ spec:
       - name: secrets
         secret:
           secretName: "emergency-access-service-secrets"
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
       - name: aws-iam-credentials
         secret:
           secretName: emergency-access-service-aws-iam-credentials
+{{ end }}
 {{ end }}
 {{ end }}


### PR DESCRIPTION
Tests enabled Service Account credentials on a single service.

Split of https://github.com/zalando-incubator/kubernetes-on-aws/pull/2918