### PR TITLE
Enable OIDC-based Service Account tokens for Etcd Backup

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1011,6 +1011,16 @@ Resources:
     Properties:
       AssumeRolePolicyDocument:
         Statement:
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
+          - Effect: Allow
+            Principal:
+              Federated: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+            Action:
+              - 'sts:AssumeRoleWithWebIdentity'
+            Condition:
+              StringLike:
+                "{{ .Cluster.LocalID }}.{{ .Values.hosted_zone }}:sub": "system:serviceaccount:kube-system:etcd-backup"
+{{ end }}
           - Action:
               - 'sts:AssumeRole'
             Effect: Allow

--- a/cluster/manifests/etcd-backup/01-rbac.yaml
+++ b/cluster/manifests/etcd-backup/01-rbac.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: etcd-backup
+  namespace: kube-system
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:role/{{ .Cluster.LocalID }}-etcd-backup"
+{{ end }}

--- a/cluster/manifests/etcd-backup/aws-iam-role.yaml
+++ b/cluster/manifests/etcd-backup/aws-iam-role.yaml
@@ -1,3 +1,4 @@
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
 apiVersion: zalando.org/v1
 kind: AWSIAMRole
@@ -6,4 +7,5 @@ metadata:
   namespace: kube-system
 spec:
   roleReference: {{.LocalID}}-etcd-backup
+{{ end }}
 {{ end }}

--- a/cluster/manifests/etcd-backup/cronjob.yaml
+++ b/cluster/manifests/etcd-backup/cronjob.yaml
@@ -19,11 +19,14 @@ spec:
           labels:
             application: etcd-backup
             version: "master-9"
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "false"}}
           annotations:
             iam.amazonaws.com/role: "{{ .LocalID }}-etcd-backup"
 {{ end }}
+{{ end }}
         spec:
+          serviceAccountName: etcd-backup
           dnsConfig:
             options:
               - name: ndots
@@ -32,16 +35,18 @@ spec:
           restartPolicy: Never
           containers:
           - name: etcd-backup
-            image: pierone.stups.zalan.do/teapot/etcd-backup:master-9
+            image: pierone.stups.zalan.do/teapot/etcd-backup:master-11
             env:
             - name: ETCD_S3_BACKUP_BUCKET
               value: "{{ .ConfigItems.etcd_s3_backup_bucket }}"
             - name: ETCD_ENDPOINTS
               value: "{{ .ConfigItems.etcd_endpoints }}"
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
             # must be set for the AWS SDK/AWS CLI to find the credentials file.
             - name: AWS_SHARED_CREDENTIALS_FILE # used by golang SDK
               value: /meta/aws-iam/credentials.process
+{{ end }}
 {{ end }}
             resources:
               limits:
@@ -50,11 +55,13 @@ spec:
               requests:
                 cpu: 100m
                 memory: 384Mi
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
             volumeMounts:
             - name: aws-iam-credentials
               mountPath: /meta/aws-iam
               readOnly: true
+{{ end }}
 {{ end }}
           tolerations:
           - key: node.kubernetes.io/role
@@ -62,9 +69,11 @@ spec:
             effect: NoSchedule
           nodeSelector:
             node.kubernetes.io/role: master
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
           volumes:
           - name: aws-iam-credentials
             secret:
               secretName: etcd-backup-aws-iam-credentials
+{{ end }}
 {{ end }}


### PR DESCRIPTION
Tests enabled Service Account credentials on a single service.

Split of https://github.com/zalando-incubator/kubernetes-on-aws/pull/2918