### PR TITLE
Enable OIDC-based Service Account tokens for Ingress Controller

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -763,6 +763,16 @@ Resources:
     Properties:
       AssumeRolePolicyDocument:
         Statement:
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
+          - Effect: Allow
+            Principal:
+              Federated: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:oidc-provider/{{.Cluster.LocalID}}.{{ .Values.hosted_zone }}"
+            Action:
+              - 'sts:AssumeRoleWithWebIdentity'
+            Condition:
+              StringLike:
+                "{{ .Cluster.LocalID }}.{{ .Values.hosted_zone }}:sub": "system:serviceaccount:kube-system:kube-ingress-aws-controller"
+{{ end }}
           - Action:
               - 'sts:AssumeRole'
             Effect: Allow

--- a/cluster/manifests/ingress-controller/01-rbac.yaml
+++ b/cluster/manifests/ingress-controller/01-rbac.yaml
@@ -3,6 +3,10 @@ kind: ServiceAccount
 metadata:
   name: kube-ingress-aws-controller
   namespace: kube-system
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:role/{{ .Cluster.LocalID }}-app-ingr-ctrl"
+{{ end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole

--- a/cluster/manifests/ingress-controller/aws-iam-role.yaml
+++ b/cluster/manifests/ingress-controller/aws-iam-role.yaml
@@ -1,3 +1,4 @@
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
 apiVersion: zalando.org/v1
 kind: AWSIAMRole
@@ -6,4 +7,5 @@ metadata:
   namespace: kube-system
 spec:
   roleReference: {{.LocalID}}-app-ingr-ctrl
+{{ end }}
 {{ end }}

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -16,9 +16,11 @@ spec:
       labels:
         application: kube-ingress-aws-controller
         version: v0.10.5
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "false"}}
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-ingr-ctrl"
+{{ end }}
 {{ end }}
     spec:
       dnsConfig:
@@ -43,16 +45,20 @@ spec:
           value: "tag:kubernetes.io/cluster/{{ .Cluster.ID }}=owned tag:node.kubernetes.io/role=worker tag:zalando.org/ingress-enabled=true"
         - name: AWS_REGION
           value: {{ .Region }}
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
         # must be set for the AWS SDK/AWS CLI to find the credentials file.
         - name: AWS_SHARED_CREDENTIALS_FILE # used by golang SDK
           value: /meta/aws-iam/credentials.process
 {{ end }}
+{{ end }}
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
         volumeMounts:
         - name: aws-iam-credentials
           mountPath: /meta/aws-iam
           readOnly: true
+{{ end }}
 {{ end }}
         resources:
           limits:
@@ -61,9 +67,11 @@ spec:
           requests:
             cpu: 50m
             memory: 100Mi
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
       volumes:
       - name: aws-iam-credentials
         secret:
           secretName: kube-ingress-aws-controller-aws-iam-credentials
+{{ end }}
 {{ end }}


### PR DESCRIPTION
Tests enabled Service Account credentials on a single service.

Split of https://github.com/zalando-incubator/kubernetes-on-aws/pull/2918