### PR TITLE
Enable OIDC-based Service Account tokens for KubeNodeReady

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -895,6 +895,16 @@ Resources:
     Properties:
       AssumeRolePolicyDocument:
         Statement:
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
+          - Effect: Allow
+            Principal:
+              Federated: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+            Action:
+              - 'sts:AssumeRoleWithWebIdentity'
+            Condition:
+              StringLike:
+                "{{ .Cluster.LocalID }}.{{ .Values.hosted_zone }}:sub": "system:serviceaccount:kube-system:kube-node-ready"
+{{ end }}
           - Action:
               - 'sts:AssumeRole'
             Effect: Allow

--- a/cluster/manifests/kube-node-ready/01-rbac.yaml
+++ b/cluster/manifests/kube-node-ready/01-rbac.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-node-ready
+  namespace: kube-system
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:role/{{ .Cluster.LocalID }}-kube-node-ready"
+{{ end }}

--- a/cluster/manifests/kube-node-ready/aws-iam-role.yaml
+++ b/cluster/manifests/kube-node-ready/aws-iam-role.yaml
@@ -1,3 +1,4 @@
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
 apiVersion: zalando.org/v1
 kind: AWSIAMRole
@@ -6,4 +7,5 @@ metadata:
   namespace: kube-system
 spec:
   roleReference: {{.LocalID}}-kube-node-ready
+{{ end }}
 {{ end }}

--- a/cluster/manifests/kube-node-ready/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready/daemonset.yaml
@@ -1,4 +1,4 @@
-{{ $version := "v0.0.3" }}
+{{ $version := "v0.0.4" }}
 
 apiVersion: apps/v1
 kind: DaemonSet
@@ -19,11 +19,14 @@ spec:
       labels:
         application: kube-node-ready
         version: {{$version}}
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "false"}}
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-kube-node-ready"
 {{ end }}
+{{ end }}
     spec:
+      serviceAccountName: kube-node-ready
       dnsConfig:
         options:
           - name: ndots
@@ -39,11 +42,13 @@ spec:
         image: registry.opensource.zalan.do/teapot/kube-node-ready:{{$version}}
         args:
         - --lifecycle-hook=kube-node-ready-lifecycle-hook
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
         env:
         # must be set for the AWS SDK/AWS CLI to find the credentials file.
         - name: AWS_SHARED_CREDENTIALS_FILE # used by golang SDK
           value: /meta/aws-iam/credentials.process
+{{ end }}
 {{ end }}
         resources:
           requests:
@@ -53,11 +58,13 @@ spec:
           limits:
             cpu: 1m
             memory: 50Mi
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
         volumeMounts:
         - name: aws-iam-credentials
           mountPath: /meta/aws-iam
           readOnly: true
+{{ end }}
 {{ end }}
         readinessProbe:
           httpGet:
@@ -69,9 +76,13 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 1000
+      securityContext:
+        fsGroup: 65534
+{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
       volumes:
       - name: aws-iam-credentials
         secret:
           secretName: kube-node-ready-aws-iam-credentials
+{{ end }}
 {{ end }}


### PR DESCRIPTION
Tests enabled Service Account credentials on a single service.

Split of https://github.com/zalando-incubator/kubernetes-on-aws/pull/2918