### PR TITLE
kube-janitor v20.4.0

### DIFF
--- a/cluster/manifests/kube-janitor/deployment.yaml
+++ b/cluster/manifests/kube-janitor/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-janitor
-    version: v20.3.2
+    version: v20.4.0
 spec:
   replicas: 1
   selector:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: kube-janitor
-        version: v20.3.2
+        version: v20.4.0
     spec:
       dnsConfig:
         options:
@@ -27,7 +27,7 @@ spec:
       containers:
       - name: janitor
         # see https://github.com/hjacobs/kube-janitor/releases
-        image: registry.opensource.zalan.do/teapot/kube-janitor:20.3.2
+        image: registry.opensource.zalan.do/teapot/kube-janitor:20.4.0
         args:
           # run every minute
           - --interval=60


### PR DESCRIPTION
[v20.4.0](https://github.com/hjacobs/kube-janitor/releases/tag/20.4.0) fixes a bug with CRDs in non-preferred API version (`FabricEventStream`): https://github.com/hjacobs/kube-janitor/issues/61

/cc @herojan