### PR TITLE
Register Pod Identity Webhook with API server

### DIFF
--- a/cluster/manifests/03-aws-pod-identity-webhook/mutatingwebhook.yaml
+++ b/cluster/manifests/03-aws-pod-identity-webhook/mutatingwebhook.yaml
@@ -1,0 +1,18 @@
+{{- if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: pod-identity-webhook
+  namespace: kube-system
+webhooks:
+  - name: pod-identity-webhook.amazonaws.com
+    failurePolicy: Ignore
+    clientConfig:
+      url: "https://localhost:8087/mutate"
+      caBundle: {{ .ConfigItems.ca_cert_decompressed }}
+    rules:
+      - operations: [ "CREATE" ]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods"]
+{{- end }}


### PR DESCRIPTION
This is just to avoid conflicts in the individual PRs and for easier rollout.