### PR TITLE
Easter 2020: configure default downtime

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -127,8 +127,11 @@ kube_state_metrics_mem_max: "1Gi"
 # Kubernetes Downscaler (for non-production clusters)
 {{if eq .Environment "test"}}
 downscaler_default_uptime: "Mon-Fri 07:30-20:30 Europe/Berlin"
+# Easter 2020: Thursday 20:00 CEST to Tuesday 07:00 CEST
+downscaler_default_downtime: "2020-04-09T20:00:00+02:00-2020-04-13T07:00:00+02:00"
 {{else}}
 downscaler_default_uptime: "always"
+downscaler_default_downtime: "never"
 {{end}}
 
 # HPA settings (defaults from https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/)

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -127,9 +127,7 @@ kube_state_metrics_mem_max: "1Gi"
 # Kubernetes Downscaler (for non-production clusters)
 {{if eq .Environment "test"}}
 downscaler_default_uptime: "Mon-Fri 07:30-20:30 Europe/Berlin"
-# Easter 2020: Friday 20:00 CEST to Tuesday 07:00 CEST
-# (Friday is not a public holiday in Ireland)
-downscaler_default_downtime: "2020-04-10T20:00:00+02:00-2020-04-13T07:00:00+02:00"
+downscaler_default_downtime: "never"
 {{else}}
 downscaler_default_uptime: "always"
 downscaler_default_downtime: "never"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -127,8 +127,9 @@ kube_state_metrics_mem_max: "1Gi"
 # Kubernetes Downscaler (for non-production clusters)
 {{if eq .Environment "test"}}
 downscaler_default_uptime: "Mon-Fri 07:30-20:30 Europe/Berlin"
-# Easter 2020: Thursday 20:00 CEST to Tuesday 07:00 CEST
-downscaler_default_downtime: "2020-04-09T20:00:00+02:00-2020-04-13T07:00:00+02:00"
+# Easter 2020: Friday 20:00 CEST to Tuesday 07:00 CEST
+# (Friday is not a public holiday in Ireland)
+downscaler_default_downtime: "2020-04-10T20:00:00+02:00-2020-04-13T07:00:00+02:00"
 {{else}}
 downscaler_default_uptime: "always"
 downscaler_default_downtime: "never"

--- a/cluster/manifests/kube-downscaler/deployment.yaml
+++ b/cluster/manifests/kube-downscaler/deployment.yaml
@@ -33,6 +33,7 @@ spec:
           # do not downscale ourselves, also keep Postgres Operator so excluded DBs can be managed
           - --exclude-deployments=kube-downscaler,postgres-operator
           - "--default-uptime={{ .ConfigItems.downscaler_default_uptime }}"
+          - "--default-downtime={{ .ConfigItems.downscaler_default_downtime }}"
           - --include-resources=deployments,statefulsets,stacks,cronjobs
           - --deployment-time-annotation=deployment-time
         resources:


### PR DESCRIPTION
Scale down test clusters over Easter 2020: Friday 20:00 CEST to Tuesday 07:00 CEST.

Kubernetes Downscaler supports recurring times (like Mon-Fri) and absolute ranges: https://github.com/hjacobs/kube-downscaler/#configuration

When uptime and downtime overlap, the downtime wins (relevant code: https://github.com/hjacobs/kube-downscaler/blob/master/kube_downscaler/scaler.py#L187).

Note that Friday is a public holiday only in Germany and Finland, not Ireland.