### PR TITLE
kube-resource-report reads VPAs

### DIFF
--- a/cluster/manifests/roles/kube-resource-report-rbac.yaml
+++ b/cluster/manifests/roles/kube-resource-report-rbac.yaml
@@ -17,6 +17,18 @@ rules:
   verbs:
   - get
   - list
+# allow reading VPAs to get resource recommendations
+- apiGroups: ["autoscaling.k8s.io"]
+  resources: ["verticalpodautoscalers"]
+  verbs:
+  - get
+  - list
+# allow reading Deployments and StatefulSets to get matching Pods for VPAs
+- apiGroups: ["apps"]
+  resources: ["deployments", "statefulsets"]
+  verbs:
+  - get
+  - list
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
Kubernetes Resource Report v20.4.1 (already deployed) now reads VPAs to get resource recommendations: https://github.com/hjacobs/kube-resource-report/pull/143

Add RBAC permissions to read VPAs and Deployments/StatefulSets (to get matching Pods).