### PR TITLE
Allow audittrail adapter to read mounted token

### DIFF
--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -65,6 +65,8 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 1000
+      securityContext:
+        fsGroup: 1000
       volumes:
       - name: platform-iam-credentials
         secret:


### PR DESCRIPTION
Permissions of the filesystem didn't grant access to the service account token.