### PR TITLE
Add resourcequota permissions for PowerUser

### DIFF
--- a/cluster/manifests/roles/poweruser-role.yaml
+++ b/cluster/manifests/roles/poweruser-role.yaml
@@ -32,6 +32,7 @@ rules:
   - pods/portforward
   - pods/proxy
   - podtemplates
+  - resourcequotas
   - secrets
   - serviceaccounts
   - services


### PR DESCRIPTION
Allows users to deploy custom `resourcequotas` as a protection for not spawning too many resources in case of configuration errors etc.