### PR TITLE
Etcd: client TLS support

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -9,6 +9,14 @@ Resources:
       SourceSecurityGroupId: !Ref MasterSecurityGroup
       ToPort: 2379
     Type: 'AWS::EC2::SecurityGroupIngress'
+  EtcdSecurityGroupTLSIngressFromMaster:
+    Properties:
+      FromPort: 2479
+      GroupId: !ImportValue 'etcd-cluster-etcd:security-group-id'
+      IpProtocol: tcp
+      SourceSecurityGroupId: !Ref MasterSecurityGroup
+      ToPort: 2479
+    Type: 'AWS::EC2::SecurityGroupIngress'
   IngressLoadBalancerSecurityGroup:
     Properties:
       GroupDescription: !Ref 'AWS::StackName'

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -328,3 +328,7 @@ on_demand_worker_replacement_strategy: prepare-replacement
 {{else}}
 on_demand_worker_replacement_strategy: none
 {{end}}
+
+
+# Temporary config items for etcd TLS migration
+etcd_use_proxy: "true"

--- a/cluster/etcd-cluster.yaml
+++ b/cluster/etcd-cluster.yaml
@@ -19,12 +19,17 @@ SenzaComponents:
     TaupageConfig:
       ports:
         2379: 2379
+        2479: 2479
         2380: 2380
         2381: 2381
       runtime: Docker
-      source: registry.opensource.zalan.do/acid/etcd-cluster:3.4.2-p23
+      source: '{{Arguments.EtcdImage}}'
       environment:
         HOSTED_ZONE: '{{Arguments.HostedZone}}'
+        CLIENT_TRUSTED_CA: '{{Arguments.ClientCACertificate}}'
+        CLIENT_CERT: '{{Arguments.ClientCertificate}}'
+        CLIENT_KEY: '{{Arguments.ClientKey}}'
+        CLIENT_TLS_ENABLED: '{{Arguments.ClientTLSEnabled}}'
       scalyr_account_key: '{{Arguments.ScalyrAccountKey}}'
       mounts:
         /home/etcd:
@@ -63,6 +68,21 @@ SenzaInfo:
       Description: Scalyr account key
   - VpcID:
       Description: VpcID to use for the security groups being setup.
+  - EtcdImage:
+      Description: Docker image for the etcd instances.
+      Default: "registry.opensource.zalan.do/acid/etcd-cluster:3.4.2-p23"
+  - ClientCACertificate:
+      Description: "CA certificate for client-side TLS (empty for no TLS support)"
+      Default: ""
+  - ClientKey:
+      Description: "Key for client-side TLS (empty for no TLS support)"
+      Default: ""
+  - ClientCertificate:
+      Description: "Certificate for client-side TLS (empty for no TLS support)"
+      Default: ""
+  - ClientTLSEnabled:
+      Description: "Whether to enable client-side TLS"
+      Default: "false"
   StackName: etcd-cluster
 
 Outputs:

--- a/cluster/node-pools/master-default/files.yaml
+++ b/cluster/node-pools/master-default/files.yaml
@@ -54,6 +54,24 @@ files:
     data: "{{ .Cluster.ConfigItems.service_account_private_key | base64Decode | publicKey | base64 }}"
     permissions: 0400
     encrypted: false
+{{- if index .Cluster.ConfigItems "etcd_client_ca_cert" }}
+  - path: /etc/kubernetes/ssl/etcd-ca.pem
+    data: "{{ .Cluster.ConfigItems.etcd_client_ca_cert }}"
+    permissions: 0400
+    encrypted: false
+{{- end }}
+{{- if index .Cluster.ConfigItems "etcd_client_apiserver_cert" }}
+  - path: /etc/kubernetes/ssl/etcd-cert.pem
+    data: "{{ .Cluster.ConfigItems.etcd_client_apiserver_cert }}"
+    permissions: 0400
+    encrypted: false
+{{- end }}
+{{- if index .Cluster.ConfigItems "etcd_client_apiserver_key" }}
+  - path: /etc/kubernetes/ssl/etcd-key.pem
+    data: "{{ .Cluster.ConfigItems.etcd_client_apiserver_key }}"
+    permissions: 0400
+    encrypted: true
+{{- end }}
 {{- if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
   - path: /var/www/openid-configuration/openid-configuration
     data: "{{ generateOIDCDiscoveryDocument .Cluster.APIServerURL | base64 }}"

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -101,7 +101,20 @@ write_files:
           - --apiserver-count={{ .Values.apiserver_count }}
           - --bind-address=0.0.0.0
           - --insecure-bind-address=0.0.0.0
+{{- if eq .Cluster.ConfigItems.etcd_use_proxy "true" }}
           - --etcd-servers=http://127.0.0.1:2379
+{{- else }}
+          - --etcd-servers={{ .Cluster.ConfigItems.etcd_endpoints }}
+{{- end }}
+{{- if index .Cluster.ConfigItems "etcd_client_ca_cert" }}
+          - --etcd-cafile=/etcd/kubernetes/ssl/etcd-ca.pem
+{{- end }}
+{{- if index .Cluster.ConfigItems "etcd_client_apiserver_cert" }}
+          - --etcd-certfile=/etcd/kubernetes/ssl/etcd-cert.pem
+{{- end }}
+{{- if index .Cluster.ConfigItems "etcd_client_apiserver_key" }}
+          - --etcd-keyfile=/etcd/kubernetes/ssl/etcd-key.pem
+{{- end }}
           - --etcd-prefix={{ .Cluster.ConfigItems.apiserver_etcd_prefix }}
           - --storage-backend=etcd3
           - --storage-media-type=application/vnd.kubernetes.protobuf
@@ -462,6 +475,7 @@ write_files:
             name: openid-configuration
             readOnly: true
 {{- end }}
+{{- if eq .Cluster.ConfigItems.etcd_use_proxy "true" }}
         - name: etcd-proxy
           image: registry.opensource.zalan.do/teapot/etcd-proxy:master-5
           args:
@@ -472,6 +486,7 @@ write_files:
             requests:
               cpu: 25m
               memory: 25Mi
+{{- end }}
         {{- if eq .Cluster.ConfigItems.support_encryption "true" }}
         - name: aws-encryption-provider
           image: registry.opensource.zalan.do/teapot/aws-encryption-provider:master-1


### PR DESCRIPTION
Kubernetes changes:
 * Add support for `etcd_use_proxy` config item (true by default) that disables the etcd proxy. **Important**: `etcd_endpoints` needs to be changed to a proper URL if this flag is disabled.
 * API server: handle `etcd_client_ca_cert`, `etcd_client_apiserver_cert` and `etcd_client_apiserver_key`.

etcd stack changes:
 * Add configuration settings for client TLS, allow parameterising the image. Related CLM PR [here](https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/292).