### PR TITLE
Disable downscaling for statefulsets

### DIFF
--- a/cluster/manifests/kube-downscaler/deployment.yaml
+++ b/cluster/manifests/kube-downscaler/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           - --exclude-deployments=kube-downscaler,postgres-operator
           - "--default-uptime={{ .ConfigItems.downscaler_default_uptime }}"
           - "--default-downtime={{ .ConfigItems.downscaler_default_downtime }}"
-          - --include-resources=deployments,statefulsets,stacks
+          - --include-resources=deployments,stacks
           - --deployment-time-annotation=deployment-time
         resources:
           limits:


### PR DESCRIPTION
Many statefulsets are managed by operators and the downscaler is constantly scaling them down while the operators are bringing them up.