### PR TITLE
Allow EAS to read mounted service account token

### DIFF
--- a/cluster/manifests/emergency-access-service/deployment.yaml
+++ b/cluster/manifests/emergency-access-service/deployment.yaml
@@ -127,6 +127,8 @@ spec:
         securityContext:
           runAsNonRoot: true
           runAsUser: 1000
+      securityContext:
+        fsGroup: 1000
       volumes:
       - name: platform-iam-credentials
         secret:


### PR DESCRIPTION
Hotfix to alpha to allow EAC to read the token.