### PR TITLE
Prometheus: use extractEndpointHosts for etcd addresses

### DIFF
--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -80,14 +80,18 @@ data:
       scheme: http
       dns_sd_configs:
       - names:
-        - "{{ with $hostPort := splitHostPort .ConfigItems.etcd_endpoints }}{{ .Host }}{{ end }}"
+{{ range $host := extractEndpointHosts .Cluster.ConfigItems.etcd_endpoints }}
+        - "{{ $host }}"
+{{ end }}
         type: "A"
         port: 2381
     - job_name: 'etcd-servers-node-metrics'
       scheme: http
       dns_sd_configs:
       - names:
-        - "{{ with $hostPort := splitHostPort .ConfigItems.etcd_endpoints }}{{ .Host }}{{ end }}"
+{{ range $host := extractEndpointHosts .Cluster.ConfigItems.etcd_endpoints }}
+        - "{{ $host }}"
+{{ end }}
         type: "A"
         port: 9100
       metric_relabel_configs:


### PR DESCRIPTION
CLM PR: https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/297
This is needed for the TLS migration.