### PR TITLE
Allow customizing etcd_endpoints per node pool

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -110,6 +110,8 @@ write_files:
           - --insecure-bind-address=0.0.0.0
 {{- if eq .Cluster.ConfigItems.etcd_use_proxy "true" }}
           - --etcd-servers=http://127.0.0.1:2379
+{{- else if index .NodePool.ConfigItems.etcd_endpoints }}
+          -- -etcd-servers={{ .NodePool.ConfigItems.etcd_endpoints }}
 {{- else }}
           - --etcd-servers={{ .Cluster.ConfigItems.etcd_endpoints }}
 {{- end }}


### PR DESCRIPTION
etcd apparently doesn't allow having http and https endpoints in the same client. 🤷‍♂️ This allows us to setup a temporary master node pool and then get rid of it after the migration.