### PR TITLE
Add config item to separate OIDC IAM changes in userdata

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -256,6 +256,9 @@ auditlog_read_access: "false"
 
 # enable automatic injection of OIDC-based AWS API access
 teapot_admission_controller_service_account_iam: "false"
+# only configure the userdata part of the OIDC-based AWS API access feature, useful for rolling back
+# has no effect when teapot_admission_controller_service_account_iam is true
+teapot_admission_controller_service_account_iam_userdata: "false"
 # use kube-aws-iam-controller for kube-system components
 kube_aws_iam_controller_kube_system_enable: "true"
 

--- a/cluster/node-pools/master-default/files.yaml
+++ b/cluster/node-pools/master-default/files.yaml
@@ -72,7 +72,7 @@ files:
     permissions: 0400
     encrypted: true
 {{- end }}
-{{- if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
+{{- if or (eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true") (eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam_userdata "true") }}
   - path: /var/www/openid-configuration/openid-configuration
     data: "{{ generateOIDCDiscoveryDocument .Cluster.APIServerURL | base64 }}"
     permissions: 0644

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -148,7 +148,7 @@ write_files:
           - --service-account-signing-key-file=/etc/kubernetes/ssl/service-account-private-key.pem
           - --service-account-issuer=kubernetes/serviceaccount
           {{- end }}
-          {{- if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
+          {{- if or (eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true") (eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam_userdata "true") }}
           - --service-account-signing-key-file=/etc/kubernetes/ssl/service-account-private-key.pem
           - --service-account-issuer={{ .Cluster.APIServerURL }}
           {{- end }}
@@ -268,7 +268,7 @@ write_files:
 {{- if eq .Cluster.ConfigItems.teapot_admission_controller_inject_aws_waiter "true" }}
             - --pod-aws-credentials-waiter-image=pierone.stups.zalan.do/automata/aws-credentials-waiter:master-7
 {{- end }}
-{{- if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
+{{- if or (eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true") (eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam_userdata "true") }}
             - --service-account-iam
 {{- end }}
           ports:
@@ -444,7 +444,7 @@ write_files:
               -> setPath("/healthz")
               -> disableAccessLog()
               -> "http://127.0.0.1:8080";
-          {{- if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
+          {{- if or (eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true") (eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam_userdata "true") }}
             o: Path("/.well-known/openid-configuration")
               -> setResponseHeader("Content-Type", "application/json")
               -> static("/.well-known/", "/var/www/openid-configuration/")
@@ -477,7 +477,7 @@ write_files:
           - mountPath: /etc/kubernetes/ssl
             name: ssl-certs-kubernetes
             readOnly: true
-{{- if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
+{{- if or (eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true") (eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam_userdata "true") }}
           - mountPath: /var/www/openid-configuration
             name: openid-configuration
             readOnly: true
@@ -528,7 +528,7 @@ write_files:
         - hostPath:
             path: /etc/kubernetes/nginx
           name: config-volume
-        {{- if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
+        {{- if or (eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true") (eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam_userdata "true") }}
         - hostPath:
             path: /var/www/openid-configuration
           name: openid-configuration


### PR DESCRIPTION
This allows to separately control the userdata part of the OIDC IAM rollout.

The current setup doesn't allow for a quick rollback in case enabling the feature leads to problems. The rollback might get stuck because new deployments won't get credentials from the old masters, especially for components that are involved in the rollback itself, such as CLC.

This adds a new temporary config item that allows to separately control the userdata changes which allows a quick manifest-only rollback in case it's needed.