### PR TITLE
Support etcd secrets encryption by default

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1761,7 +1761,6 @@ Resources:
             Resource: "*"
             Action:
             - "kms:Decrypt"
-{{- if eq .Cluster.ConfigItems.support_encryption "true" }}
   EtcdEncryptionKey:
     Type: "AWS::KMS::Key"
     Properties:
@@ -1794,7 +1793,6 @@ Resources:
             Action:
             - "kms:Encrypt"
             - "kms:Decrypt"
-{{- end }}
   MasterFilesEncryptionKey:
     Type: "AWS::KMS::Key"
     Properties:
@@ -1898,9 +1896,7 @@ Outputs:
       Name: '{{.Cluster.ID}}:worker-security-group'
     Value: !Ref WorkerSecurityGroup
 {{- end }}
-{{- if eq .Cluster.ConfigItems.support_encryption "true" }}
   EtcdEncryptionKey:
     Export:
       Name: '{{ .Cluster.ID}}:etcd-encryption-key'
     Value: !Ref EtcdEncryptionKey
-{{- end }}

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -308,16 +308,9 @@ enable_endpointslice: "false"
 # Enable FeatureGate HPAScaleToZero
 enable_hpa_scale_to_zero: "true"
 
-# setup supporting components to enable encryption
-# this flag must only be switched from true to false when enable_encryption is false and all secrets were decrypted
-{{if eq .Environment "test"}}
-support_encryption: "true"
-{{else}}
-support_encryption: "false"
-{{end}}
-# enable encryption of secrets in etcd, requires support_encryption: true
-# this flag can be switched between true and false as long as support_encryption is true
-# to ensure all secrets are encrypted/decrypted all secrets need to be rewritten
+# enable encryption of secrets in etcd
+# this flag can be switched between true and false
+# to ensure all secrets are encrypted/decrypted all secrets need to be rewritten after masters have been rolled
 {{if eq .Environment "test"}}
 enable_encryption: "true"
 {{else}}

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -125,9 +125,7 @@ write_files:
           - --etcd-prefix={{ .Cluster.ConfigItems.apiserver_etcd_prefix }}
           - --storage-backend=etcd3
           - --storage-media-type=application/vnd.kubernetes.protobuf
-          {{- if eq .Cluster.ConfigItems.support_encryption "true" }}
           - --encryption-provider-config=/etc/kubernetes/config/encryption-config.yaml
-          {{- end }}
           - --allow-privileged=true
           - --service-cluster-ip-range=10.3.0.0/16
           - --secure-port=443
@@ -206,10 +204,8 @@ write_files:
           - mountPath: /etc/kubernetes/config
             name: kubernetes-configs
             readOnly: true
-          {{- if eq .Cluster.ConfigItems.support_encryption "true" }}
           - mountPath: /var/run/kmsplugin
             name: var-run-kmsplugin
-          {{- end }}
           resources:
             requests:
               cpu: 100m
@@ -494,7 +490,6 @@ write_files:
               cpu: 25m
               memory: 25Mi
 {{- end }}
-        {{- if eq .Cluster.ConfigItems.support_encryption "true" }}
         - name: aws-encryption-provider
           image: registry.opensource.zalan.do/teapot/aws-encryption-provider:master-1
           command:
@@ -517,7 +512,6 @@ write_files:
           volumeMounts:
           - mountPath: /var/run/kmsplugin
             name: var-run-kmsplugin
-        {{- end }}
         volumes:
         - hostPath:
             path: /etc/kubernetes/ssl
@@ -533,12 +527,10 @@ write_files:
             path: /var/www/openid-configuration
           name: openid-configuration
         {{- end }}
-        {{- if eq .Cluster.ConfigItems.support_encryption "true" }}
         - name: var-run-kmsplugin
           hostPath:
             path: /var/run/kmsplugin
             type: DirectoryOrCreate
-        {{- end }}
 
   - owner: root:root
     path: /etc/kubernetes/manifests/kube-controller-manager.yaml
@@ -827,7 +819,6 @@ write_files:
         - "RequestReceived"
 {{ end }}
 
-{{- if eq .Cluster.ConfigItems.support_encryption "true" }}
   - owner: root:root
     path: /etc/kubernetes/config/encryption-config.yaml
     permissions: '0400'
@@ -849,4 +840,3 @@ write_files:
       {{- if eq .Cluster.ConfigItems.enable_encryption "true" }}
           - identity: {}
       {{- end }}
-{{ end }}


### PR DESCRIPTION
This enables the encryption provider sidecar by default for all environments. It also prevents people from accidentally removing support for encryption while still having encrypted secrets in etcd.

This will be a noop for dev, alpha, beta but will trigger a rolling update for stable. Changing the default is preferred because it allows us to combine the rolling of masters with other userdata changes.