### PR TITLE
Allow deploying WAFv2 resources

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -697,6 +697,7 @@ Resources:
                   - 'trustedadvisor:*'
                   - 'waf-regional:*'
                   - 'waf:*'
+                  - 'wafv2:*'
                 Effect: Allow
                 Resource: '*'
             Version: 2012-10-17


### PR DESCRIPTION
Allows deploying `wafv2` resources which we now support in the ingress-controller #3183