### PR TITLE
Enable check_daemonset_resources by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -168,7 +168,8 @@ teapot_admission_controller_deployment_default_max_surge: "5%"
 teapot_admission_controller_deployment_default_max_unavailable: "1"
 teapot_admission_controller_inject_aws_waiter: "true"
 
-## TODO update defaults
+## Defaults are set per-cluster
+teapot_admission_controller_check_daemonset_resources: "true"
 teapot_admission_controller_daemonset_reserved_cpu: "8"
 teapot_admission_controller_daemonset_reserved_memory: "64Gi"
 
@@ -186,11 +187,9 @@ teapot_admission_controller_validate_pod_template_resources: "true"
 {{if eq .Environment "e2e"}}
 teapot_admission_controller_ignore_namespaces: "^kube-system|((downward-api|kubectl|projected|statefulset|pod-network|scope-selectors|resourcequota)-.*)$"
 teapot_admission_controller_crd_ensure_no_resources_on_delete: "false"
-teapot_admission_controller_check_daemonset_resources: "true"
 {{else}}
 teapot_admission_controller_ignore_namespaces: "^kube-system$"
 teapot_admission_controller_crd_ensure_no_resources_on_delete: "true"
-teapot_admission_controller_check_daemonset_resources: "false"
 {{end}}
 
 


### PR DESCRIPTION
It worked fine in the test clusters, let's roll it out everywhere.