### PR TITLE
Reduce priority for visibility-zmon

### DIFF
--- a/cluster/manifests/01-visibility/priority.yaml
+++ b/cluster/manifests/01-visibility/priority.yaml
@@ -2,6 +2,6 @@ apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: visibility-zmon
-value: 1000000000
+value: 100000000
 globalDefault: false
 description: "This priority class is used by ZMON components."

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -1,8 +1,5 @@
 # everything defined under here will be deleted before applying the manifests
-pre_apply:
-- name: vpa-admission-controller-new
-  namespace: kube-system
-  kind: Deployment
+pre_apply: []
 
 # everything defined under here will be deleted after applying the manifests
 post_apply:{{ if and (ne .ConfigItems.teapot_admission_controller_process_resources "true") (eq .ConfigItems.enable_ingress_template_controller "true") }} []{{ end }}


### PR DESCRIPTION
Reduces the `visibility-zmon` priority value in order to ensure that the `visibility-logging` priority is higher as it's used for daemonset pods. Before they had the same priority and we could thus risk that zmon components land on a node making it impossible for `logging-agent` to be scheduled.
Since we're not using Priorities lower than this I just dropped a `0` to keep it simple.

Note that the priority will need to be deleted and re-created (as it can't be modified in place). The impact is that pods created with the previous priority will still keep the higher priority, but pods created with the new with get the lower priority value.