### PR TITLE
Change default replacement strategy for all pools to none

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -326,11 +326,7 @@ kube_janitor_default_unused_pvc_ttl: "forever"
 # necessary to change the VPC subnet of a cluster
 delete_vpc_resources: "false"
 # replacement strategy used for default on-demand worker pool
-{{if eq .Environment "production"}}
-on_demand_worker_replacement_strategy: prepare-replacement
-{{else}}
 on_demand_worker_replacement_strategy: none
-{{end}}
 
 
 # Temporary config items for etcd TLS migration


### PR DESCRIPTION
The current replacement strategy prevents spinning up spot replacement nodes for on-demand nodes during cluster updates. That means that pods are rarely moved away from on-demand nodes.

Now that we're using spot in production this setting allows replacement nodes to be spot during update which should increase the share of spot nodes in production. We use this setting in test clusters for the same reason as described here: https://github.bus.zalan.do/teapot/issues/issues/2198