### PR TITLE
Update to new GA topology labels

### DIFF
--- a/cluster/manifests/admission-control-proxy/daemonset.yaml
+++ b/cluster/manifests/admission-control-proxy/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cluster-autoscaler
-        image: registry.opensource.zalan.do/teapot/admission-controller:master-69
+        image: registry.opensource.zalan.do/teapot/admission-controller:master-71
         command:
           - /registry-proxy
           - --address=127.0.0.1:8285

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -210,7 +210,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-70
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-71
           name: admission-controller
           readinessProbe:
             httpGet:

--- a/test/e2e/admission_controller.go
+++ b/test/e2e/admission_controller.go
@@ -83,8 +83,8 @@ var _ = framework.KubeDescribe("Admission controller tests", func() {
 		// Check the injected node zone
 		node, err := cs.CoreV1().Nodes().Get(pod.Spec.NodeName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
-		nodeZone := node.Labels["failure-domain.beta.kubernetes.io/zone"]
-		Expect(pod.Annotations).To(HaveKeyWithValue("failure-domain.beta.kubernetes.io/zone", nodeZone))
+		nodeZone := node.Labels["topology.kubernetes.io/zone"]
+		Expect(pod.Annotations).To(HaveKeyWithValue("topology.kubernetes.io/zone", nodeZone))
 
 		envarValues, err := fetchEnvarValues(cs, ns, pod.Name)
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Updates the topology labels from `failure-domain.beta.kubernetes.io/zone` -> `topology.kubernetes.io/zone` in admission-controller, which is the new name GA in Kubernetes v1.17