### PR TITLE
prometheus: Remove VPA max

### DIFF
--- a/cluster/manifests/prometheus/prometheus-vpa.yaml
+++ b/cluster/manifests/prometheus/prometheus-vpa.yaml
@@ -22,9 +22,3 @@ spec:
       minAllowed:
         memory: {{.ConfigItems.prometheus_mem_min}}
         cpu: {{.ConfigItems.prometheus_cpu_min}}
-      maxAllowed:
-  {{ with $resources := autoscalingBufferSettings .Cluster }}
-        # Set the max CPU and memory to max available on the Node
-        memory: {{$resources.Memory}}
-        cpu: {{$resources.CPU}}
-  {{ end }}


### PR DESCRIPTION
Since we introduced support for fallback node pools we no longer need to limit the max size that can be suggested by the VPA. Instead we can let the VPA suggest as high has it needs and then just add fallback pools (with lower priority) which can be used if Prometheus needs more memory than the default pool provides.

This enables us to not be limited by the size of the default node pool which is currently used for the calculation in the `autoscalingBufferSettings` function.