### PR TITLE
enable compression by default on the ingress level

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -31,7 +31,7 @@ skipper_ingress_tracing_buffer: "8192"
 enable_dedicate_nodepool_skipper: "false"
 
 # skipper default filters
-skipper_default_filters: 'enableAccessLog(4,5) -> lifo(2000,20000,"3s")'
+skipper_default_filters: 'enableAccessLog(4,5) -> lifo(2000,20000,"3s") -> compress()'
 
 # skipper backend timeout defaults
 skipper_expect_continue_timeout_backend: "30s"


### PR DESCRIPTION
Enable compression by default on the ingress level.

This filter only compresses the responses when the client explicitly indicated in the request that it's ok, with the Accept-Encoding header. It doesn't compress already compressed responses, either. This means that it should be safe from functional perspective. Regarding the performance perspective: from earlier experience, we can assume that the positive impact on the traffic for the shared service landscape will be way bigger than the additional CPU usage in Skipper due to the compression.

Signed-off-by: Arpad Ryszka <arpad.ryszka@gmail.com>