### PR TITLE
Enable encryption of secrets in etcd by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -310,11 +310,7 @@ enable_hpa_scale_to_zero: "true"
 # enable encryption of secrets in etcd
 # this flag can be switched between true and false
 # to ensure all secrets are encrypted/decrypted all secrets need to be rewritten after masters have been rolled
-{{if eq .Environment "test"}}
 enable_encryption: "true"
-{{else}}
-enable_encryption: "false"
-{{end}}
 
 # default ttl for kube janitor for resources build from PRs in namespaces matching .*-pr-.*
 kube_janitor_default_pr_ttl: "1w"  # 1 week


### PR DESCRIPTION
Let's turn this on so new clusters will have it from the start.