### PR TITLE
Allow dropping labels from kube-state-metrics scrapes

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -113,6 +113,11 @@ prometheus_remote_write: "disabled"
 prometheus_tsdb_retention_size: "disabled"
 prometheus_csi_ebs: "false"
 
+# regex defining labels to be dropped when scraping from kube-state-metrics
+# Simple workaround for: https://github.com/kubernetes/kube-state-metrics/issues/1115
+# TODO: remove when kube-state-metrics is fixed
+prometheus_kube_state_metrics_drop_labels: ""
+
 metrics_service_cpu: "100m"
 metrics_service_mem: "200Mi"
 metrics_service_mem_max: "1Gi"

--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -76,6 +76,10 @@ data:
         target_label: node_name
       - action: labeldrop
         regex: "^(pod|node|container)$"
+{{ if ne .Cluster.ConfigItems.prometheus_kube_state_metrics_drop_labels "" }}
+      - regex: '{{ .Cluster.ConfigItems.prometheus_kube_state_metrics_drop_labels }}'
+        action: labeldrop
+{{ end }}
     - job_name: 'etcd-servers'
       scheme: http
       dns_sd_configs:
@@ -106,7 +110,7 @@ data:
       # Look for the Prometheus annotations and scrape based on those
       - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_endpoints_name, __meta_kubernetes_service_annotation_prometheus_io_scrape]
         action: keep
-        regex: ^(kube-system;.*?|default;stackset-controller);true$
+        regex: ^(kube-system;.*?);true$
       - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
         action: replace
         target_label: __scheme__


### PR DESCRIPTION
* This is a quick fix to allow excluding labels per cluster for the kube-state-metrics scrape which otherwise could prevent Prometheus >2.16.0 from scraping anything from `kube-state-metrics`: https://github.com/kubernetes/kube-state-metrics/issues/1115 The idea is that this will not happen often but if it does we can easily exclude some labels. We have monitoring in place to alert us if Prometheus fails to scrape targets.
* Drops scraping stackset-controller from `default` namespace as it has been moved to `kube-system`.