### PR TITLE
kube-janitor v20.4.1

### DIFF
--- a/cluster/manifests/kube-janitor/deployment.yaml
+++ b/cluster/manifests/kube-janitor/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-janitor
-    version: v20.4.0
+    version: v20.4.1
 spec:
   replicas: 1
   selector:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: kube-janitor
-        version: v20.4.0
+        version: v20.4.1
     spec:
       dnsConfig:
         options:
@@ -27,7 +27,7 @@ spec:
       containers:
       - name: janitor
         # see https://github.com/hjacobs/kube-janitor/releases
-        image: registry.opensource.zalan.do/teapot/kube-janitor:20.4.0
+        image: registry.opensource.zalan.do/teapot/kube-janitor:20.4.1
         args:
           # run every minute
           - --interval=60


### PR DESCRIPTION
Kubernetes Janitor [v20.4.1](https://github.com/hjacobs/kube-janitor/releases/tag/20.4.1) fixes an issue with deleting PVCs referenced by Deployments in test clusters.
That being said, most of the cases involve Redis which should be deployed as a StatefulSet instead.
