### PR TITLE
Treat scraper as component of dashboard

### DIFF
--- a/cluster/manifests/dashboard/deployment.yaml
+++ b/cluster/manifests/dashboard/deployment.yaml
@@ -1,10 +1,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: kubernetes-dashboard
+  name: kubernetes-dashboard-new # TODO drop -new suffix once migrated
   namespace: kube-system
   labels:
     application: kubernetes-dashboard
+    component: dashboard
     version: v2.0.0-rc2
     kubernetes.io/cluster-service: "true"
 spec:
@@ -12,10 +13,12 @@ spec:
   selector:
     matchLabels:
       application: kubernetes-dashboard
+      component: dashboard
   template:
     metadata:
       labels:
         application: kubernetes-dashboard
+        component: dashboard
         version: v2.0.0-rc2
         kubernetes.io/cluster-service: "true"
     spec:
@@ -75,6 +78,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kubernetes-dashboard
+    component: dashboard
 type: Opaque
 
 ---
@@ -86,6 +90,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kubernetes-dashboard
+    component: dashboard
 type: Opaque
 data:
   csrf: ""
@@ -99,6 +104,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kubernetes-dashboard
+    component: dashboard
 type: Opaque
 
 ---
@@ -110,3 +116,4 @@ metadata:
   namespace: kube-system
   labels:
     application: kubernetes-dashboard
+    component: dashboard

--- a/cluster/manifests/dashboard/rbac.yaml
+++ b/cluster/manifests/dashboard/rbac.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kubernetes-dashboard
+    component: dashboard
 
 ---
 
@@ -15,6 +16,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kubernetes-dashboard
+    component: dashboard
 rules:
 # Allow Dashboard to get, update and delete Dashboard exclusive secrets.
 - apiGroups: [""]
@@ -44,6 +46,7 @@ metadata:
   name: kubernetes-dashboard
   labels:
     application: kubernetes-dashboard
+    component: dashboard
 rules:
 # Allow Metrics Scraper to get metrics from the Metrics server
 - apiGroups: ["metrics.k8s.io"]
@@ -59,6 +62,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kubernetes-dashboard
+    component: dashboard
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -76,6 +80,7 @@ metadata:
   name: kubernetes-dashboard-internal
   labels:
     application: kubernetes-dashboard
+    component: dashboard
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -93,6 +98,7 @@ metadata:
   name: kubernetes-dashboard-readonly
   labels:
     application: kubernetes-dashboard
+    component: dashboard
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/cluster/manifests/dashboard/scraper.yaml
+++ b/cluster/manifests/dashboard/scraper.yaml
@@ -4,10 +4,12 @@ metadata:
   name: dashboard-metrics-scraper
   namespace: kube-system
   labels:
-    application: dashboard-metrics-scraper
+    application: kubernetes-dashboard
+    component: metrics-scraper
 spec:
   selector:
-    application: dashboard-metrics-scraper
+    application: kubernetes-dashboard
+    component: metrics-scraper
   ports:
   - port: 8000
     targetPort: 8000
@@ -17,20 +19,23 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: dashboard-metrics-scraper
+  name: dashboard-metrics-scraper-new # TODO drop -new suffix once migrated
   namespace: kube-system
   labels:
-    application: dashboard-metrics-scraper
+    application: kubernetes-dashboard
+    component: metrics-scraper
     version: v1.0.2
 spec:
   replicas: 1
   selector:
     matchLabels:
-      application: dashboard-metrics-scraper
+      application: kubernetes-dashboard
+      component: metrics-scraper
   template:
     metadata:
       labels:
-        application: dashboard-metrics-scraper
+        application: kubernetes-dashboard
+        component: metrics-scraper
         version: v1.0.2
     spec:
       priorityClassName: system-cluster-critical

--- a/cluster/manifests/dashboard/service.yaml
+++ b/cluster/manifests/dashboard/service.yaml
@@ -5,10 +5,12 @@ metadata:
   namespace: kube-system
   labels:
     application: kubernetes-dashboard
+    component: dashboard
     kubernetes.io/cluster-service: "true"
 spec:
   selector:
     application: kubernetes-dashboard
+    component: dashboard
   ports:
   - port: 80
     targetPort: 9090

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -9,6 +9,12 @@ pre_apply:
 - name: stackset-controller
   namespace: default
   kind: ServiceAccount
+- name: kubernetes-dashboard
+  namespace: kube-system
+  kind: Deployment
+- name: dashboard-metrics-scraper
+  namespace: kube-system
+  kind: Deployment
 
 # everything defined under here will be deleted after applying the manifests
 post_apply:


### PR DESCRIPTION
To lower the number of applications we have we can define the `metrics-scraper` as simply a component of the `kubernetes-dashboard`.

~This change will cause a conflict on apply because of the `matchLabels` change, but I will just fix it manually.~ Renamed the deployments so this doesn't happen.