### PR TITLE
etcd-backup: add TLS support

### DIFF
--- a/cluster/manifests/etcd-backup/01-rbac.yaml
+++ b/cluster/manifests/etcd-backup/01-rbac.yaml
@@ -7,3 +7,17 @@ metadata:
   annotations:
     eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:role/{{ .Cluster.LocalID }}-etcd-backup"
 {{ end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: etcd-backup-privileged-psp
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: privileged-psp
+subjects:
+- kind: ServiceAccount
+  name: etcd-backup
+  namespace: kube-system

--- a/cluster/manifests/etcd-backup/aws-iam-role.yaml
+++ b/cluster/manifests/etcd-backup/aws-iam-role.yaml
@@ -1,5 +1,4 @@
-{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
-{{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
+{{ if and (eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false") (eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true") }}
 apiVersion: zalando.org/v1
 kind: AWSIAMRole
 metadata:
@@ -7,5 +6,4 @@ metadata:
   namespace: kube-system
 spec:
   roleReference: {{.LocalID}}-etcd-backup
-{{ end }}
 {{ end }}

--- a/cluster/manifests/etcd-backup/cronjob.yaml
+++ b/cluster/manifests/etcd-backup/cronjob.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: etcd-backup
-    version: "master-9"
+    version: "master-12"
 spec:
   schedule: "*/1 * * * *"
   concurrencyPolicy: Forbid
@@ -14,16 +14,15 @@ spec:
   jobTemplate:
     spec:
       activeDeadlineSeconds: 600
+      backoffLimit: 1
       template:
         metadata:
           labels:
             application: etcd-backup
-            version: "master-9"
-{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
-{{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "false"}}
+            version: "master-12"
+{{ if and (eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "false") (eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false") }}
           annotations:
             iam.amazonaws.com/role: "{{ .LocalID }}-etcd-backup"
-{{ end }}
 {{ end }}
         spec:
           serviceAccountName: etcd-backup
@@ -35,18 +34,28 @@ spec:
           restartPolicy: Never
           containers:
           - name: etcd-backup
-            image: pierone.stups.zalan.do/teapot/etcd-backup:master-11
+            image: pierone.stups.zalan.do/teapot/etcd-backup:master-12
             env:
             - name: ETCD_S3_BACKUP_BUCKET
               value: "{{ .ConfigItems.etcd_s3_backup_bucket }}"
             - name: ETCD_ENDPOINTS
               value: "{{ .ConfigItems.etcd_endpoints }}"
-{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
-{{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
+{{ if and (eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "false") (eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false") }}
             # must be set for the AWS SDK/AWS CLI to find the credentials file.
             - name: AWS_SHARED_CREDENTIALS_FILE # used by golang SDK
               value: /meta/aws-iam/credentials.process
 {{ end }}
+{{ if index .Cluster.ConfigItems "etcd_client_ca_cert" }}
+            - name: ETCD_CA_CERTIFICATE
+              value: /mnt/etcd-ca.pem
+{{ end }}
+{{ if index .Cluster.ConfigItems "etcd_client_apiserver_cert" }}
+            - name: ETCD_CLIENT_CERTIFICATE
+              value: /mnt/etcd-cert.pem
+{{ end }}
+{{ if index .Cluster.ConfigItems "etcd_client_apiserver_key" }}
+            - name: ETCD_CLIENT_KEY
+              value: /mnt/etcd-key.pem
 {{ end }}
             resources:
               limits:
@@ -55,13 +64,26 @@ spec:
               requests:
                 cpu: 50m
                 memory: 384Mi
-{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
-{{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
             volumeMounts:
+{{ if index .Cluster.ConfigItems "etcd_client_ca_cert" }}
+            - name: etcd-ca
+              mountPath: /mnt/etcd-ca.pem
+              readOnly: true
+{{ end }}
+{{ if index .Cluster.ConfigItems "etcd_client_apiserver_cert" }}
+            - name: etcd-cert
+              mountPath: /mnt/etcd-cert.pem
+              readOnly: true
+{{ end }}
+{{ if index .Cluster.ConfigItems "etcd_client_apiserver_key" }}
+            - name: etcd-key
+              mountPath: /mnt/etcd-key.pem
+              readOnly: true
+{{ end }}
+{{ if and (eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "false") (eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false") }}
             - name: aws-iam-credentials
               mountPath: /meta/aws-iam
               readOnly: true
-{{ end }}
 {{ end }}
           tolerations:
           - key: node.kubernetes.io/role
@@ -69,11 +91,27 @@ spec:
             effect: NoSchedule
           nodeSelector:
             node.kubernetes.io/role: master
-{{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
-{{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}
           volumes:
+{{ if index .Cluster.ConfigItems "etcd_client_ca_cert" }}
+          - name: etcd-ca
+            hostPath:
+              path: /etc/kubernetes/ssl/etcd-ca.pem
+              type: File
+{{ end }}
+{{ if index .Cluster.ConfigItems "etcd_client_apiserver_cert" }}
+          - name: etcd-cert
+            hostPath:
+              path: /etc/kubernetes/ssl/etcd-cert.pem
+              type: File
+{{ end }}
+{{ if index .Cluster.ConfigItems "etcd_client_apiserver_key" }}
+          - name: etcd-key
+            hostPath:
+              path: /etc/kubernetes/ssl/etcd-key.pem
+              type: File
+{{ end }}
+{{ if and (eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "false") (eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false") }}
           - name: aws-iam-credentials
             secret:
               secretName: etcd-backup-aws-iam-credentials
-{{ end }}
 {{ end }}


### PR DESCRIPTION
Use the certificates & keys configured for the API server when doing the backups (since we run on the masters anyway).