### PR TITLE
Update CSI components to latest version

### DIFF
--- a/cluster/manifests/03-ebs-csi/02-csi-driver.yaml
+++ b/cluster/manifests/03-ebs-csi/02-csi-driver.yaml
@@ -86,7 +86,7 @@ spec:
               value: /csi/csi.sock
             - name: DRIVER_REG_SOCK_PATH
               value: /opt/podruntime/kubelet/plugins/ebs.csi.aws.com/csi.sock
-          image: registry.opensource.zalan.do/teapot/csi-node-driver-registrar:v1.1.0-master-1
+          image: registry.opensource.zalan.do/teapot/csi-node-driver-registrar:v1.3.0-master-4
 
           name: node-driver-registrar
           resources:
@@ -103,7 +103,7 @@ spec:
               name: registration-dir
         - args:
             - --csi-address=/csi/csi.sock
-          image: registry.opensource.zalan.do/teapot/livenessprobe:v1.1.0-master-1
+          image: registry.opensource.zalan.do/teapot/livenessprobe:v2.0.0-master-4
           name: liveness-probe
           resources:
             requests:

--- a/cluster/manifests/03-ebs-csi/ebs-controller.yaml
+++ b/cluster/manifests/03-ebs-csi/ebs-controller.yaml
@@ -63,7 +63,7 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          image: registry.opensource.zalan.do/teapot/csi-provisioner:v1.3.0-master-2
+          image: registry.opensource.zalan.do/teapot/csi-provisioner:v1.6.0-master-4
           name: csi-provisioner
           resources:
             requests:
@@ -83,7 +83,7 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          image: registry.opensource.zalan.do/teapot/csi-attacher:v1.2.0-master-2
+          image: registry.opensource.zalan.do/teapot/csi-attacher:v2.2.0-master-4
           name: csi-attacher
           resources:
             requests:
@@ -97,7 +97,7 @@ spec:
               name: socket-dir
         - args:
             - --csi-address=/csi/csi.sock
-          image: registry.opensource.zalan.do/teapot/livenessprobe:v1.1.0-master-2
+          image: registry.opensource.zalan.do/teapot/livenessprobe:v2.0.0-master-4
           name: liveness-probe
           resources:
             requests:
@@ -110,7 +110,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-resizer
-          image: registry.opensource.zalan.do/teapot/csi-resizer:v0.3.0-master-3
+          image: registry.opensource.zalan.do/teapot/csi-resizer:v0.5.0-master-4
           args:
             - --csi-address=$(ADDRESS)
             - --v=5


### PR DESCRIPTION
Update CSI components to latest version.
The CSI components are turned-off by default and there are too many of them to link all the release notes individually.