### PR TITLE
autoscaling_utilization_threshold: default to 1.0

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -8,6 +8,7 @@ autoscaling_buffer_memory_reserved: "3Gi"
 autoscaling_buffer_pods: "0"
 cluster_autoscaler_cpu: "100m"
 cluster_autoscaler_memory: "300Mi"
+autoscaling_utilization_threshold: "1.0"
 
 # defines which expander the autoscaler should use
 cluster_autoscaler_expander: highest-priority

--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -39,7 +39,7 @@ spec:
           - ./cluster-autoscaler
           - --v=4
           - --stderrthreshold=info
-          - --scale-down-utilization-threshold={{if index .ConfigItems "autoscaling_utilization_threshold"}}{{.ConfigItems.autoscaling_utilization_threshold}}{{else}}0.75{{end}}
+          - --scale-down-utilization-threshold={{.Cluster.ConfigItems.autoscaling_utilization_threshold}}
           - --cloud-provider=aws
           - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,zalando.de/cluster-local-id/{{ .LocalID }}
           - --expendable-pods-priority-cutoff=-1000000


### PR DESCRIPTION
We've been running with 1.0 instead of 0.75 for a couple of weeks already with no downsides, let's change the default.