### PR TITLE
Revert "Change default replacement strategy for all pools to none"

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -327,7 +327,11 @@ kube_janitor_default_unused_pvc_ttl: "forever"
 # necessary to change the VPC subnet of a cluster
 delete_vpc_resources: "false"
 # replacement strategy used for default on-demand worker pool
+{{if eq .Environment "production"}}
+on_demand_worker_replacement_strategy: prepare-replacement
+{{else}}
 on_demand_worker_replacement_strategy: none
+{{end}}
 
 # SpotAllocationStrategy for pools
 spot_allocation_strategy: "capacity-optimized"


### PR DESCRIPTION
Reverts zalando-incubator/kubernetes-on-aws#3217

Revert to avoid rolling the nodes right now as we had to do an "emergency" rollout of new certificates for the majority of production clusters.