### PR TITLE
Revert "Update EC2 AMI to the latest versions"

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -213,8 +213,8 @@ cluster_dns: "coredns"
 coredns_log_svc_names: "true"
 coredns_max_upstream_concurrency: 0 #0 means there is not concurrency limits
 
-kuberuntu_image_v1_17: {{ amiID "zalando-ubuntu-kubernetes-production-v1.17.5-master-103" "861068367966" }}
-kuberuntu_image_v1_18: {{ amiID "zalando-ubuntu-kubernetes-production-v1.18.2-master-103" "861068367966" }}
+kuberuntu_image_v1_16: {{ amiID "zalando-ubuntu-kubernetes-production-v1.16.8-master-96" "861068367966" }}
+kuberuntu_image_v1_17: {{ amiID "zalando-ubuntu-kubernetes-production-v1.17.4-master-98" "861068367966" }}
 
 # Feature toggle to allow gradual decommissioning of ingress-template-controller
 enable_ingress_template_controller: "false"


### PR DESCRIPTION
Reverts zalando-incubator/kubernetes-on-aws#3228

Revert to avoid rolling the nodes right now as we had to do an "emergency" rollout of new certificates for the majority of production clusters.