### PR TITLE
Reduce CA log verbosity

### DIFF
--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -37,7 +37,7 @@ spec:
         image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.12.2-internal-2.10
         command:
           - ./cluster-autoscaler
-          - --v=4
+          - --v=1
           - --stderrthreshold=info
           - --scale-down-utilization-threshold={{.Cluster.ConfigItems.autoscaling_utilization_threshold}}
           - --cloud-provider=aws


### PR DESCRIPTION
It logs an insane amount of data, so let's try to reduce it. We can always edit the deployment for investigation.