### PR TITLE
Test clusters: pull images in parallel

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -249,6 +249,12 @@ cpu_manager_policy: "none"
 # enable CSIMigration feature flag
 enable_csi_migration: "false"
 
+{{ if eq .Environment "production" }}
+serialize_image_pulls: "true"
+{{ else }}
+serialize_image_pulls: "false"
+{{ end }}
+
 # when set to true, routes external traffic to the apiserver through a skipper sidecar
 apiserver_proxy: "true"
 # when set to true, service account tokens can be used from outside the cluster

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -48,6 +48,9 @@ write_files:
         CSIMigration: {{ .Cluster.ConfigItems.enable_csi_migration }}
       podPidsLimit: {{ .NodePool.ConfigItems.pod_max_pids }}
       maxPods: {{ nodeCIDRMaxPods (parseInt64 .Cluster.ConfigItems.node_cidr_mask_size) 8 }}
+{{- if ne .Cluster.ConfigItems.serialize_image_pulls "true" }}
+      serializeImagePulls: false
+{{- end }}
       healthzPort: 10248
       healthzBindAddress: "0.0.0.0"
       tlsCertFile: "/etc/kubernetes/ssl/worker.pem"

--- a/cluster/node-pools/worker-default/userdata.yaml
+++ b/cluster/node-pools/worker-default/userdata.yaml
@@ -59,6 +59,9 @@ write_files:
       podPidsLimit: {{ .NodePool.ConfigItems.pod_max_pids }}
       cpuManagerPolicy: {{ .NodePool.ConfigItems.cpu_manager_policy }}
       maxPods: {{ nodeCIDRMaxPods (parseInt64 .Cluster.ConfigItems.node_cidr_mask_size) 0 }}
+{{- if ne .Cluster.ConfigItems.serialize_image_pulls "true" }}
+      serializeImagePulls: false
+{{- end }}
       healthzPort: 10248
       healthzBindAddress: "0.0.0.0"
       tlsCertFile: "/etc/kubernetes/ssl/worker.pem"


### PR DESCRIPTION
This was only disabled by default due to a bug in an ancient Docker version, so let's enable it to improve the node startup time.

Some [documentation](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubelet/config/v1beta1/types.go#L540).