### PR TITLE
Enable OIDC-based IAM credentials by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -272,7 +272,7 @@ auditlog_read_access: "false"
 {{ end }}
 
 # enable automatic injection of OIDC-based AWS API access
-teapot_admission_controller_service_account_iam: "true"
+teapot_admission_controller_service_account_iam: "false"
 # only configure the userdata part of the OIDC-based AWS API access feature, useful for rolling back
 # has no effect when teapot_admission_controller_service_account_iam is true
 teapot_admission_controller_service_account_iam_userdata: "true"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -272,10 +272,10 @@ auditlog_read_access: "false"
 {{ end }}
 
 # enable automatic injection of OIDC-based AWS API access
-teapot_admission_controller_service_account_iam: "false"
+teapot_admission_controller_service_account_iam: "true"
 # only configure the userdata part of the OIDC-based AWS API access feature, useful for rolling back
 # has no effect when teapot_admission_controller_service_account_iam is true
-teapot_admission_controller_service_account_iam_userdata: "false"
+teapot_admission_controller_service_account_iam_userdata: "true"
 # use kube-aws-iam-controller for kube-system components
 kube_aws_iam_controller_kube_system_enable: "true"
 


### PR DESCRIPTION
This has been enabled in all clusters. In order to e2e test it we need to make it the default here. Note that you can still disable it like before.