### PR TITLE
CA: allow configuring scale-down settings

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -9,6 +9,8 @@ autoscaling_buffer_pods: "0"
 cluster_autoscaler_cpu: "100m"
 cluster_autoscaler_memory: "300Mi"
 autoscaling_utilization_threshold: "1.0"
+autoscaling_max_empty_bulk_delete: "25"
+autoscaling_scale_down_unneeded_time: "10m"
 
 # defines which expander the autoscaler should use
 cluster_autoscaler_expander: highest-priority

--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -50,7 +50,9 @@ spec:
           - --balance-similar-node-groups
           - --max-node-provision-time=7m
           - --max-nodes-total={{ nodeCIDRMaxNodes (parseInt64 .Cluster.ConfigItems.node_cidr_mask_size) (parseInt64 .Cluster.ConfigItems.reserved_nodes) }}
-          - --scale-down-enabled={{ .ConfigItems.autoscaling_scale_down_enabled }}
+          - --scale-down-enabled={{ .Cluster.ConfigItems.autoscaling_scale_down_enabled }}
+          - --max-empty-bulk-delete={{ .Cluster.ConfigItems.autoscaling_max_empty_bulk_delete }}
+          - --scale-down-unneeded-time={{ .Cluster.ConfigItems.autoscaling_scale_down_unneeded_time }}
           - --scale-down-delay-after-add=-1s
         resources:
           requests:


### PR DESCRIPTION
* Allow configuring `--max-empty-bulk-delete`, `--scale-down-unneeded-time `
* Change the default for `--max-empty-bulk-delete` from 10 to 25