### PR TITLE
Add renovate bot to bump image versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,5 @@
+{
+  "kubernetes": {
+    "fileMatch": ["cluster/manifests/.+\\.yaml$"]
+  }
+}


### PR DESCRIPTION
We got the Renovate bot enabled on our repo. Let's quickly try it out and see if it's useful.

Docs: https://docs.renovatebot.com/modules/manager/kubernetes/