### PR TITLE
Enable parallel pulls by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -251,11 +251,8 @@ cpu_manager_policy: "none"
 # enable CSIMigration feature flag
 enable_csi_migration: "false"
 
-{{ if eq .Environment "production" }}
-serialize_image_pulls: "true"
-{{ else }}
+# pull images in parallel
 serialize_image_pulls: "false"
-{{ end }}
 
 # when set to true, routes external traffic to the apiserver through a skipper sidecar
 apiserver_proxy: "true"


### PR DESCRIPTION
No issues in test clusters.