### PR TITLE
Allow customizing root volume size

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -349,3 +349,6 @@ etcd_use_proxy: "true"
 
 # Stackset controller
 stackset_controller_sync_interval: "10s"
+
+# EBS settings for the root volume
+ebs_root_volume_size: "50"

--- a/cluster/node-pools/worker-default/stack.yaml
+++ b/cluster/node-pools/worker-default/stack.yaml
@@ -113,6 +113,13 @@ Resources:
     Properties:
       LaunchTemplateName: '{{.Cluster.LocalID}}-{{ .NodePool.Name }}'
       LaunchTemplateData:
+{{ if ne .NodePool.ConfigItems.ebs_root_volume_size "50" }}
+        BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            DeleteOnTermination: true
+            VolumeSize: {{.NodePool.ConfigItems.ebs_root_volume_size}}
+{{ end }}
         NetworkInterfaces:
         - DeviceIndex: 0
           AssociatePublicIpAddress: true

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -123,6 +123,13 @@ Resources:
     Properties:
       LaunchTemplateName: '{{ $data.Cluster.LocalID }}-{{ $data.NodePool.Name }}'
       LaunchTemplateData:
+{{ if ne $data.NodePool.ConfigItems.ebs_root_volume_size "50" }}
+        BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            DeleteOnTermination: true
+            VolumeSize: {{$data.NodePool.ConfigItems.ebs_root_volume_size}}
+{{ end }}
         NetworkInterfaces:
         - DeviceIndex: 0
           AssociatePublicIpAddress: true


### PR DESCRIPTION
Some of our clusters have lots of small pods with big images, so the AMI default doesn't work.