### PR TITLE
Fix the master node pool config for e2e

### DIFF
--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -65,11 +65,11 @@ clusters:
   local_id: ${LOCAL_ID}
   node_pools:
   - discount_strategy: none
-    instance_types: ["t2.medium"]
+    instance_types: ["t3.large"]
     name: default-master
     profile: master-default
-    min_size: 1
-    max_size: 2
+    min_size: 2
+    max_size: 3
   - discount_strategy: spot
     instance_types: ["m4.large", "m5.large", "m5.xlarge", "m4.xlarge"]
     name: default-worker-splitaz


### PR DESCRIPTION
Some of our tests flake because we provision just one very small master node. Change the configuration to something more similar to what we have in actual clusters.