### PR TITLE
Stackset controller: add a liveness probe

### DIFF
--- a/cluster/manifests/stackset-controller/deployment.yaml
+++ b/cluster/manifests/stackset-controller/deployment.yaml
@@ -35,7 +35,13 @@ spec:
           requests:
             cpu: 10m
             memory: 100Mi
+        livenessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /healthz
+            port: 7979
         readinessProbe:
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 7979


### PR DESCRIPTION
It gets stuck sometimes for an unclear reason. Let's add a liveness probe until the underlying issue is fixed.