### PR TITLE
Set maximum number of bytes streamed to the client

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -352,3 +352,6 @@ stackset_controller_sync_interval: "10s"
 
 # EBS settings for the root volume
 ebs_root_volume_size: "50"
+
+# maximum number of bytes streamed per second, e.g. for port-forward.
+max_streaming_bytes_per_second: 1000000000 # 1 GB/s

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -188,6 +188,7 @@ write_files:
           - --kubelet-client-certificate=/etc/kubernetes/ssl/kubelet-client.pem
           - --kubelet-client-key=/etc/kubernetes/ssl/kubelet-client-key.pem
           - --shutdown-delay-duration=60s
+          - --max-connection-bytes-per-sec={{ .Cluster.ConfigItems.max_streaming_bytes_per_second }}
           livenessProbe:
             httpGet:
               host: 127.0.0.1


### PR DESCRIPTION
This limits the number of bytes streamed by the API server for streaming connections, e.g. port-foward and most-likely others but I didn't check thoroughly.

The default is 0 which doesn't throttle the connection at all. Setting the flag to something higher triggers an entirely different branch of the code [here](https://github.com/kubernetes/kubernetes/blob/v1.17.4/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go#L350-L354) which means that setting the value to something unreasonably high is not necessarily the same as not setting it at all.

This should fix https://github.bus.zalan.do/teapot/issues/issues/2575. More details there.