### PR TITLE
Update kube-metrics-adapter to v0.1.5

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/01-rbac.yaml
+++ b/cluster/manifests/kube-metrics-adapter/01-rbac.yaml
@@ -70,6 +70,7 @@ rules:
   - get
 - apiGroups:
   - extensions
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.3
+        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.5
         env:
 {{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}

--- a/test/e2e/kube_metrics_adapter_test.go
+++ b/test/e2e/kube_metrics_adapter_test.go
@@ -78,7 +78,41 @@ var _ = framework.KubeDescribe("[HPA] Horizontal pod autoscaling (scale resource
 			scaledReplicas:  scaledReplicas,
 			deployment:      simplePodDeployment(DeploymentName, int32(initialReplicas)),
 			ingress:         ingress,
-			hpa:             rpsBasedHPA(DeploymentName, ingress.Name, metricTarget),
+			hpa:             rpsBasedHPA(DeploymentName, ingress.Name, "extensions/v1beta1", metricTarget),
+			service:         createServiceTypeClusterIP(DeploymentName, labels, 80, targetPort),
+			auxDeployments: []*appsv1.Deployment{
+				createVegetaDeployment(targetUrl, metricValue),
+			},
+		}
+		tc.Run()
+	})
+
+	// TODO: this is almost identical to the test above, but tests that the
+	// HPA can scale when the referenced ingress uses the networking.k8s.io
+	// apiGroup
+	It("should scale down with Custom Metric of type Object from Skipper (networking.k8s.io) [Ingress] [CustomMetricsAutoscaling] [Zalando]", func() {
+		hostName := fmt.Sprintf("%s-%d.%s", DeploymentName, time.Now().UTC().Unix(), E2EHostedZone())
+
+		initialReplicas := 2
+		scaledReplicas := 1
+		metricValue := 10
+		metricTarget := int64(metricValue) * 2
+		labels := map[string]string{
+			"application": DeploymentName,
+		}
+		port := 80
+		targetPort := 8000
+		targetUrl := hostName + "/metrics"
+		ingress := createIngress(DeploymentName, hostName, f.Namespace.Name, labels, nil, port)
+		tc := CustomMetricTestCase{
+			framework:       f,
+			kubeClient:      cs,
+			jig:             jig,
+			initialReplicas: initialReplicas,
+			scaledReplicas:  scaledReplicas,
+			deployment:      simplePodDeployment(DeploymentName, int32(initialReplicas)),
+			ingress:         ingress,
+			hpa:             rpsBasedHPA(DeploymentName, ingress.Name, "networking.k8s.io/v1beta1", metricTarget),
 			service:         createServiceTypeClusterIP(DeploymentName, labels, 80, targetPort),
 			auxDeployments: []*appsv1.Deployment{
 				createVegetaDeployment(targetUrl, metricValue),
@@ -322,11 +356,11 @@ func podMetricHPA(deploymentName string, metricTargets map[string]int64) *autosc
 	}
 }
 
-func rpsBasedHPA(deploymentName string, ingressName string, metricTarget int64) *autoscaling.HorizontalPodAutoscaler {
-	return podHPA(deploymentName, ingressName, map[string]int64{"requests-per-second": metricTarget})
+func rpsBasedHPA(deploymentName string, ingressName, ingressAPIVersion string, metricTarget int64) *autoscaling.HorizontalPodAutoscaler {
+	return podHPA(deploymentName, ingressName, ingressAPIVersion, map[string]int64{"requests-per-second": metricTarget})
 }
 
-func podHPA(deploymentName string, ingressName string, metricTargets map[string]int64) *autoscaling.HorizontalPodAutoscaler {
+func podHPA(deploymentName string, ingressName, ingressAPIVersion string, metricTargets map[string]int64) *autoscaling.HorizontalPodAutoscaler {
 	var minReplicas int32 = 1
 	metrics := []autoscaling.MetricSpec{}
 	for metric, target := range metricTargets {
@@ -335,7 +369,7 @@ func podHPA(deploymentName string, ingressName string, metricTargets map[string]
 			Object: &autoscaling.ObjectMetricSource{
 				MetricName: metric,
 				Target: autoscaling.CrossVersionObjectReference{
-					APIVersion: "extensions/v1beta1",
+					APIVersion: ingressAPIVersion,
 					Kind:       "Ingress",
 					Name:       ingressName,
 				},


### PR DESCRIPTION
Update the kube-metrics-adapter to v0.1.5

https://github.com/zalando-incubator/kube-metrics-adapter/releases/tag/v0.1.5
https://github.com/zalando-incubator/kube-metrics-adapter/releases/tag/v0.1.4

* Add support for Ingress of API Group networking.k8s.io https://github.com/zalando-incubator/kube-metrics-adapter/pull/156
* Fetch pod metrics in parallel https://github.com/zalando-incubator/kube-metrics-adapter/pull/152
* Add support for custom timeouts https://github.com/zalando-incubator/kube-metrics-adapter/pull/153

Extends the e2e test to cover both ingress of `extensions/v1beta1` and `networking.k8s.io/v1beta1`