### PR TITLE
Inject parent-resource-hash labels in pods

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -175,6 +175,7 @@ teapot_admission_controller_inject_environment_variables: "true"
 teapot_admission_controller_deployment_default_max_surge: "5%"
 teapot_admission_controller_deployment_default_max_unavailable: "1"
 teapot_admission_controller_inject_aws_waiter: "true"
+teapot_admission_controller_parent_resource_hash: "true"
 
 ## Defaults are set per-cluster
 teapot_admission_controller_check_daemonset_resources: "true"

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -215,7 +215,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-72
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-73
           name: admission-controller
           readinessProbe:
             httpGet:
@@ -268,6 +268,9 @@ write_files:
 {{- end }}
 {{- if eq .Cluster.ConfigItems.teapot_admission_controller_inject_aws_waiter "true" }}
             - --pod-aws-credentials-waiter-image=pierone.stups.zalan.do/automata/aws-credentials-waiter:master-7
+{{- end }}
+{{- if eq .Cluster.ConfigItems.teapot_admission_controller_parent_resource_hash "true" }}
+            - --pod-enable-parent-resource-hash
 {{- end }}
 {{- if or (eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true") (eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam_userdata "true") }}
             - --service-account-iam


### PR DESCRIPTION
Updates the admission-controller to a version which supports injecting `parent-resource-hash` labels into pods owned by `StatefulSet` or `Deployment`.

These labels will be used to create non-overlapping PDBs in the pdb-controller.