### PR TITLE
Git ingress-host-sync access to networking.k8s.io api

### DIFF
--- a/cluster/manifests/roles/ingress-host-sync.yaml
+++ b/cluster/manifests/roles/ingress-host-sync.yaml
@@ -4,7 +4,8 @@ metadata:
   name: ingress-host-sync
 rules:
 - apiGroups:
-  - extensions
+  - extensions # TODO: remove once only networking.k8s.io is in use
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:


### PR DESCRIPTION
Allows the ingress-host-sync job to read ingresses from `networking.k8s.io` this is needed in order to update the job to use the new API.