### PR TITLE
Fix condition for enabling aws-iam controller for etcd-backup

### DIFF
--- a/cluster/manifests/etcd-backup/cronjob.yaml
+++ b/cluster/manifests/etcd-backup/cronjob.yaml
@@ -40,7 +40,7 @@ spec:
               value: "{{ .ConfigItems.etcd_s3_backup_bucket }}"
             - name: ETCD_ENDPOINTS
               value: "{{ .ConfigItems.etcd_endpoints }}"
-{{ if and (eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "false") (eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false") }}
+{{ if and (eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true") (eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false") }}
             # must be set for the AWS SDK/AWS CLI to find the credentials file.
             - name: AWS_SHARED_CREDENTIALS_FILE # used by golang SDK
               value: /meta/aws-iam/credentials.process
@@ -80,7 +80,7 @@ spec:
               mountPath: /mnt/etcd-key.pem
               readOnly: true
 {{ end }}
-{{ if and (eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "false") (eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false") }}
+{{ if and (eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true") (eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false") }}
             - name: aws-iam-credentials
               mountPath: /meta/aws-iam
               readOnly: true
@@ -110,7 +110,7 @@ spec:
               path: /etc/kubernetes/ssl/etcd-key.pem
               type: File
 {{ end }}
-{{ if and (eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "false") (eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false") }}
+{{ if and (eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true") (eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false") }}
           - name: aws-iam-credentials
             secret:
               secretName: etcd-backup-aws-iam-credentials


### PR DESCRIPTION
We probably won't need to roll back in the long run but the logic was wrong so `etcd-backup` didn't work when `teapot_admission_controller_service_account_iam=false` and `kube_aws_iam_controller_kube_system_enable=true`