### PR TITLE
Enable OIDC-based IAM credentials by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -271,7 +271,7 @@ auditlog_read_access: "false"
 {{ end }}
 
 # enable automatic injection of OIDC-based AWS API access
-teapot_admission_controller_service_account_iam: "false"
+teapot_admission_controller_service_account_iam: "true"
 # only configure the userdata part of the OIDC-based AWS API access feature, useful for rolling back
 # has no effect when teapot_admission_controller_service_account_iam is true
 teapot_admission_controller_service_account_iam_userdata: "true"


### PR DESCRIPTION
This is the second part of the split of https://github.com/zalando-incubator/kubernetes-on-aws/pull/3262/commits which didn't pass e2e together.