### PR TITLE
Drop support for etcd_use_proxy

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -355,9 +355,6 @@ on_demand_worker_replacement_strategy: none
 # SpotAllocationStrategy for pools
 spot_allocation_strategy: "capacity-optimized"
 
-# Temporary config items for etcd TLS migration
-etcd_use_proxy: "true"
-
 # Stackset controller
 stackset_controller_sync_interval: "10s"
 

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -111,13 +111,7 @@ write_files:
           - --apiserver-count={{ .Values.apiserver_count }}
           - --bind-address=0.0.0.0
           - --insecure-bind-address=0.0.0.0
-{{- if eq .Cluster.ConfigItems.etcd_use_proxy "true" }}
-          - --etcd-servers=http://127.0.0.1:2379
-{{- else if index .NodePool.ConfigItems.etcd_endpoints }}
           - --etcd-servers={{ .NodePool.ConfigItems.etcd_endpoints }}
-{{- else }}
-          - --etcd-servers={{ .Cluster.ConfigItems.etcd_endpoints }}
-{{- end }}
 {{- if index .Cluster.ConfigItems "etcd_client_ca_cert" }}
           - --etcd-cafile=/etc/kubernetes/ssl/etcd-ca.pem
 {{- end }}
@@ -472,22 +466,6 @@ write_files:
           - mountPath: /var/www/openid-configuration
             name: openid-configuration
             readOnly: true
-{{- end }}
-{{- if eq .Cluster.ConfigItems.etcd_use_proxy "true" }}
-        - name: etcd-proxy
-          image: registry.opensource.zalan.do/teapot/etcd-proxy:master-5
-          args:
-          - {{ .Cluster.ConfigItems.etcd_endpoints }}
-          ports:
-          - containerPort: 2379
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c",  " sleep 60"]
-          resources:
-            requests:
-              cpu: 25m
-              memory: 25Mi
 {{- end }}
         - name: aws-encryption-provider
           image: registry.opensource.zalan.do/teapot/aws-encryption-provider:master-1

--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -20,7 +20,7 @@ export APISERVER_NLB="${APISERVER_NLB:-"disabled"}"
 export LOCAL_ID="${LOCAL_ID:-$(echo "e2e-$CDP_BUILD_VERSION-$(date +'%H%M%S')-$APISERVER_NLB" | cut -c-28)}"
 export API_SERVER_URL="https://${LOCAL_ID}.${HOSTED_ZONE}"
 export INFRASTRUCTURE_ACCOUNT="aws:${AWS_ACCOUNT}"
-export ETCD_ENDPOINTS="${ETCD_ENDPOINTS:-"etcd-server.etcd.${HOSTED_ZONE}:2379"}"
+export ETCD_ENDPOINTS="${ETCD_ENDPOINTS:-"http://etcd-server.etcd.${HOSTED_ZONE}:2379"}"
 export CLUSTER_ID="${INFRASTRUCTURE_ACCOUNT}:${REGION}:${LOCAL_ID}"
 export WORKER_SHARED_SECRET="${WORKER_SHARED_SECRET:-"$(pwgen 30 -n1)"}"
 


### PR DESCRIPTION
We want to get rid of it anyway, and it just complicates the configuration. Let's update the clusters instead.