### PR TITLE
Update ingress-controller to use networking.k8s.io

### DIFF
--- a/cluster/manifests/ingress-controller/01-rbac.yaml
+++ b/cluster/manifests/ingress-controller/01-rbac.yaml
@@ -14,7 +14,7 @@ metadata:
   name: kube-ingress-aws-controller
 rules:
 - apiGroups:
-  - extensions
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:
@@ -22,7 +22,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - extensions
+  - networking.k8s.io
   resources:
   - ingresses/status
   verbs:

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.10.13
+    version: v0.11.0
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.10.13
+        version: v0.11.0
 {{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "false"}}
       annotations:
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: kube-ingress-aws-controller
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.10.13
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.11.0
         args:
         - --stack-termination-protection
         - --ssl-policy={{ .ConfigItems.kube_aws_ingress_controller_ssl_policy }}


### PR DESCRIPTION
Updates the ingress-controller to use the newer `networking.k8s.io/v1beta1` instead of `extensions/v1beta1` for listing ingresses: https://github.com/zalando-incubator/kube-ingress-aws-controller/pull/354