### PR TITLE
Update IAM role used for e2e

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -35,7 +35,7 @@ pipeline:
       metadata:
         name: e2e
         annotations:
-          iam.amazonaws.com/role: arn:aws:iam::925511348110:role/cluster-e2e-test
+          iam.amazonaws.com/role: arn:aws:iam::925511348110:role/cluster-lifecycle-manager-entrypoint
         labels:
           application: teapot-kubernetes-e2e
       spec:

--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -54,7 +54,6 @@ if [ "$E2E_SKIP_CLUSTER_UPDATE" != "true" ]; then
     clm provision \
         --token="${WORKER_SHARED_SECRET}" \
         --directory="$(pwd)/$BASE_CFG_PATH" \
-        --assumed-role=cluster-lifecycle-manager-entrypoint \
         --debug \
         --registry=base_cluster.yaml
 fi
@@ -65,7 +64,6 @@ fi
 clm provision \
     --token="${WORKER_SHARED_SECRET}" \
     --directory="$(pwd)/../.." \
-    --assumed-role=cluster-lifecycle-manager-entrypoint \
     --debug \
     --registry=head_cluster.yaml
 


### PR DESCRIPTION
Changes the IAM role used by our e2e test to a role that is allowed to delete the `EtcdEncryption` KMS key. Without this the e2e test fails to clean up e2e clusters completely.