### PR TITLE
Add support for spot.io Ocean pools

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1033,6 +1033,9 @@ Resources:
           - Action: 'ec2:DescribeInstanceStatus'
             Effect: Allow
             Resource: '*'
+          - Action: 'ec2:TerminateInstances'
+            Effect: Allow
+            Resource: '*'
           - Action: 'autoscaling:DescribeAutoScalingGroups'
             Effect: Allow
             Resource: '*'

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -364,3 +364,14 @@ system_pods_critical: "true"
 {{else}}
 system_pods_critical: "false"
 {{end}}
+
+# spot.io Ocean configuration.
+#
+# Default configuration per ocean, can be configured on individual node pools.
+spotio_ocean_spot_percentage: "100"
+spotio_ocean_fallback_to_ondemand: "true"
+spotio_ocean_utilize_reserved_instances: "false"
+
+# configuration for spot.io controller
+spotio_ocean_controller_cpu: "50m"
+spotio_ocean_controller_memory: "512Mi"

--- a/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: cluster-lifecycle-controller
-    version: master-16
+    version: master-17
 spec:
   replicas: 1
   selector:
@@ -17,7 +17,7 @@ spec:
     metadata:
       labels:
         application: cluster-lifecycle-controller
-        version: master-16
+        version: master-17
     spec:
       dnsConfig:
         options:
@@ -32,7 +32,7 @@ spec:
         operator: Exists
       containers:
       - name: cluster-lifecycle-controller
-        image: registry.opensource.zalan.do/teapot/cluster-lifecycle-controller:master-16
+        image: registry.opensource.zalan.do/teapot/cluster-lifecycle-controller:master-17
         args:
             - --drain-grace-period={{.ConfigItems.drain_grace_period}}
             - --drain-min-pod-lifetime={{.ConfigItems.drain_min_pod_lifetime}}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -211,7 +211,4 @@ spec:
       - effect: NoSchedule
         key: dedicated
         value: skipper-ingress
-{{ else }}
-      nodeSelector:
-        node.kubernetes.io/role: worker
 {{ end }}

--- a/cluster/manifests/spotio-controller/deployment.yaml
+++ b/cluster/manifests/spotio-controller/deployment.yaml
@@ -1,0 +1,86 @@
+{{ if and (index .Cluster.ConfigItems "spotio_account_id") (index .Cluster.ConfigItems "spotio_access_token") }}
+{{ with $data := . }}
+{{ range $nodePool := .Cluster.NodePools }}
+{{ if eq $nodePool.Profile "worker-spotio-ocean" }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: spotinst-kubernetes-cluster-controller-{{ $nodePool.Name }}
+  namespace: kube-system
+  labels:
+    application: spotinst-kubernetes-cluster-controller
+    component: "{{ $nodePool.Name }}"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      application: spotinst-kubernetes-cluster-controller # TODO: this label name is REQUIRED by the controller
+      component: "{{ $nodePool.Name }}"
+  template:
+    metadata:
+      labels:
+        application: spotinst-kubernetes-cluster-controller
+        component: "{{ $nodePool.Name }}"
+      annotations:
+        config/hash: {{"secret.yaml" | manifestHash}}
+    spec:
+      # TODO: run on master?
+      # nodeSelector:
+      #   node.kubernetes.io/role: master
+      containers:
+      - name: controller
+        image: spotinst/kubernetes-cluster-controller:1.0.61 # TODO: setup pipeline
+        env:
+        - name: SPOTINST_TOKEN
+          valueFrom:
+            secretKeyRef:
+              key: spotinst.token
+              name: spotinst-kubernetes-cluster-controller
+        - name: SPOTINST_ACCOUNT
+          value: "{{ $data.ConfigItems.spotio_account_id }}"
+        - name: CLUSTER_IDENTIFIER
+          value: "{{ $data.LocalID }}-{{ $nodePool.Name }}"
+        - name: DISABLE_AUTO_UPDATE
+          value: "true"
+        - name: POD_ID
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.uid
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthcheck
+            port: 4401
+            scheme: HTTP
+          initialDelaySeconds: 300
+          periodSeconds: 20
+          successThreshold: 1
+          timeoutSeconds: 2
+        resources:
+          limits:
+            cpu: "{{ $data.ConfigItems.spotio_ocean_controller_cpu }}"
+            memory: "{{ $data.ConfigItems.spotio_ocean_controller_memory }}"
+          requests:
+            cpu: "{{ $data.ConfigItems.spotio_ocean_controller_cpu }}"
+            memory: "{{ $data.ConfigItems.spotio_ocean_controller_memory }}"
+      serviceAccountName: spotinst-kubernetes-cluster-controller
+      tolerations:
+      - key: node.kubernetes.io/role
+        value: master
+        effect: NoSchedule
+{{ end }}
+{{ end }}
+{{ end }}
+{{ end }}

--- a/cluster/manifests/spotio-controller/rbac.yaml
+++ b/cluster/manifests/spotio-controller/rbac.yaml
@@ -1,0 +1,91 @@
+{{ if and (index .Cluster.ConfigItems "spotio_account_id") (index .Cluster.ConfigItems "spotio_access_token") }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: spotinst-kubernetes-cluster-controller
+  namespace: kube-system
+  labels:
+    application: spotinst-kubernetes-cluster-controller
+---
+# ------------------------------------------------------------------------------
+# Cluster Role
+# ------------------------------------------------------------------------------
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: spotinst-kubernetes-cluster-controller
+  labels:
+    application: spotinst-kubernetes-cluster-controller
+rules:
+  # ----------------------------------------------------------------------------
+  # Required for functional operation (read-only).
+  # ----------------------------------------------------------------------------
+- apiGroups: [""]
+  resources: ["pods", "nodes", "services", "namespaces", "replicationcontrollers", "limitranges", "events", "persistentvolumes", "persistentvolumeclaims"]
+  verbs: ["get", "list"]
+- apiGroups: ["apps"]
+  resources: ["deployments", "daemonsets", "statefulsets", "replicasets"]
+  verbs: ["get","list"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["get", "list"]
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "list"]
+- apiGroups: ["policy"]
+  resources: ["poddisruptionbudgets"]
+  verbs: ["get", "list"]
+- apiGroups: ["metrics.k8s.io"]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+- apiGroups: ["autoscaling"]
+  resources: ["horizontalpodautoscalers"]
+  verbs: ["get", "list"]
+- nonResourceURLs: ["/version/", "/version"]
+  verbs: ["get"]
+  # ----------------------------------------------------------------------------
+  # Required by the draining feature and for functional operation.
+  # ----------------------------------------------------------------------------
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["patch", "update"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["delete"]
+- apiGroups: [""]
+  resources: ["pods/eviction"]
+  verbs: ["create"]
+  # ----------------------------------------------------------------------------
+  # Required by the Spotinst CleanUp feature.
+  # ----------------------------------------------------------------------------
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["delete"]
+  # ----------------------------------------------------------------------------
+  # Required by the Spotinst Apply feature.
+  # ----------------------------------------------------------------------------
+- apiGroups: ["apps"]
+  resources: ["deployments", "daemonsets"]
+  verbs: ["get", "list", "patch","update","create","delete"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "patch", "update", "create", "delete"]
+---
+# ------------------------------------------------------------------------------
+# Cluster Role Binding
+# ------------------------------------------------------------------------------
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: spotinst-kubernetes-cluster-controller
+  labels:
+    application: spotinst-kubernetes-cluster-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: spotinst-kubernetes-cluster-controller
+subjects:
+- kind: ServiceAccount
+  name: spotinst-kubernetes-cluster-controller
+  namespace: kube-system
+{{ end }}

--- a/cluster/manifests/spotio-controller/secret.yaml
+++ b/cluster/manifests/spotio-controller/secret.yaml
@@ -1,0 +1,12 @@
+{{ if and (index .Cluster.ConfigItems "spotio_account_id") (index .Cluster.ConfigItems "spotio_access_token") }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: spotinst-kubernetes-cluster-controller
+  namespace: kube-system
+  labels:
+    application: spotinst-kubernetes-cluster-controller
+type: Opaque
+data:
+  spotinst.token: "{{ .Cluster.ConfigItems.spotio_access_token | base64 }}"
+{{ end }}

--- a/cluster/manifests/spotio-controller/vpa.yaml
+++ b/cluster/manifests/spotio-controller/vpa.yaml
@@ -1,0 +1,22 @@
+{{ if and (index .Cluster.ConfigItems "spotio_account_id") (index .Cluster.ConfigItems "spotio_access_token") }}
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: spotinst-kubernetes-cluster-controller
+  namespace: kube-system
+  labels:
+    application: spotinst-kubernetes-cluster-controller
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: spotinst-kubernetes-cluster-controller
+  updatePolicy:
+    updateMode: Auto
+  resourcePolicy:
+    containerPolicies:
+    - containerName: controller
+      maxAllowed:
+        cpu: 1000m
+        memory: 2Gi
+{{ end }}

--- a/cluster/node-pools/worker-default/userdata.yaml
+++ b/cluster/node-pools/worker-default/userdata.yaml
@@ -5,7 +5,7 @@ write_files:
     path: /etc/kubernetes/secrets.env
     content: |
       NODEPOOL_TAINTS={{if index .NodePool.ConfigItems "taints"}}{{.NodePool.ConfigItems.taints}}{{end}}
-      NODE_LABELS={{ .Values.node_labels }},node.kubernetes.io/distro=ubuntu{{if index .NodePool.ConfigItems "labels"}},{{.NodePool.ConfigItems.labels}}{{end}}
+      NODE_LABELS={{ .Values.node_labels }}{{if eq .NodePool.Profile "worker-spotio-ocean"}},spot.io=true{{end}},node.kubernetes.io/distro=ubuntu{{if index .NodePool.ConfigItems "labels"}},{{.NodePool.ConfigItems.labels}}{{end}}
       NODEPOOL_NAME={{ .NodePool.Name }}
       KUBELET_ROLE=worker
       ON_DEMAND_WORKER_REPLACEMENT_STRATEGY={{ .Cluster.ConfigItems.on_demand_worker_replacement_strategy }}

--- a/cluster/node-pools/worker-spotio-ocean/files.yaml
+++ b/cluster/node-pools/worker-spotio-ocean/files.yaml
@@ -1,0 +1,1 @@
+../worker-default/files.yaml

--- a/cluster/node-pools/worker-spotio-ocean/stack.yaml
+++ b/cluster/node-pools/worker-spotio-ocean/stack.yaml
@@ -1,0 +1,158 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Kubernetes spot.io Ocean node pool stack
+
+Mappings:
+  Images:
+    eu-central-1:
+      MachineImage: "{{ .Cluster.ConfigItems.kuberuntu_image_v1_17 }}"
+
+Resources:
+  AutoScalingInstanceProfile:
+    Properties:
+      Path: /
+      Roles:
+      - !ImportValue "{{ .Cluster.ID }}:worker-iam-role"
+    Type: "AWS::IAM::InstanceProfile"
+  SpotinstOcean:
+    Type: Custom::ocean
+    Properties:
+      ServiceToken: !Sub "arn:aws:lambda:${AWS::Region}:178579023202:function:spotinst-cloudformation"
+      accessToken: "{{ .Cluster.ConfigItems.spotio_access_token }}"
+      accountId: "{{ .Cluster.ConfigItems.spotio_account_id }}"
+      autoTag: true
+      updatePolicy:
+        shouldUpdateTargetCapacity: false
+        shouldRoll: "false" # disable rolling update, this is managed by CLM,CLC
+        rollConfig:
+          roll:
+            batchSizePercentage: "25"
+      # API Docs: https://help.spot.io/spotinst-api/ocean/ocean-cloud-api/ocean-for-aws/create-2/
+      ocean:
+        name: "{{ .Cluster.Alias }}-{{ .NodePool.Name }}"
+        controllerClusterId: "{{ .Cluster.LocalID }}-{{ .NodePool.Name }}"
+        region: !Ref AWS::Region
+        autoScaler:
+          isEnabled: true
+          cooldown: 180 # 3 min. This seems to be the minimum value
+          # maximum resources which can be allocated to the cluster
+          # Use very high values as we have the limit set via the
+          # NodePool.MaxSize
+          resourceLimits:
+            maxMemoryGib: 1500000
+            maxVCpu: 75000
+          down:
+            # evaluationPeriods: 3
+            maxScaleDownPercentage: 100
+          headroom: # disable headroom/preprovisioned instances
+            cpuPerUnit: 0
+            memoryPerUnit: 0
+            numOfUnits: 0
+          isAutoConfig: false
+        capacity:
+          minimum: {{ .NodePool.MinSize }}
+          maximum: {{ .NodePool.MaxSize }}
+          target: 0 # default target (should just be zero)
+        strategy:
+          spotPercentage: {{ .Cluster.ConfigItems.spotio_ocean_spot_percentage }}
+          fallbackToOd: {{ .Cluster.ConfigItems.spotio_ocean_fallback_to_ondemand }}
+          utilizeReservedInstances: {{ .Cluster.ConfigItems.spotio_ocean_utilize_reserved_instances }}
+        compute:
+          subnetIds:
+          {{ with $values := .Values }}
+          {{ range $az := $values.availability_zones }}
+            - "{{ index $values.subnets $az }}"
+          {{ end }}
+          {{ end }}
+          instanceTypes:
+            whitelist:
+            {{ range $type := .NodePool.InstanceTypes }}
+              - "{{ $type }}"
+            {{ end }}
+          launchSpecification:
+            tags:
+            - tagKey: kubernetes.io/cluster/{{ .Cluster.ID }}
+              tagValue: owned
+            # TODO:
+            - tagKey: Name
+              tagValue: "SHOULD NOT SPAWN: {{ .NodePool.Name }} ({{ .Cluster.ID }})"
+            - tagKey: spot.io/type
+              tagValue: "ocean"
+            associatePublicIpAddress: true
+            imageId: !FindInMap
+            - Images
+            - !Ref "AWS::Region"
+            - MachineImage
+            userData: "{{ .UserData }}"
+            securityGroupIds:
+            - !ImportValue "{{ .Cluster.ID }}:worker-security-group"
+            iamInstanceProfile:
+              arn: !GetAtt
+                - AutoScalingInstanceProfile
+                - Arn
+  SpotinstOceanLaunchSpec:
+    Type: Custom::oceanLaunchSpec
+    Properties:
+      ServiceToken: !Sub "arn:aws:lambda:${AWS::Region}:178579023202:function:spotinst-cloudformation"
+      accessToken: "{{ .Cluster.ConfigItems.spotio_access_token }}"
+      accountId: "{{ .Cluster.ConfigItems.spotio_account_id }}"
+      oceanLaunchSpec:
+        oceanId: !Ref SpotinstOcean
+        imageId: !FindInMap
+        - Images
+        - !Ref "AWS::Region"
+        - MachineImage
+        userData: "{{ .UserData }}"
+{{- if index .NodePool.ConfigItems "labels"}}
+        labels:
+        - key: "spot.io"
+          value: "true"
+  {{- range split .NodePool.ConfigItems.labels ","}}
+    {{- $label := split . "="}}
+        - key: {{index $label 0}}
+          value: {{index $label 1}}
+  {{- end}}
+{{end}}
+{{- if index .NodePool.ConfigItems "taints"}}
+        taints:
+  {{- range split .NodePool.ConfigItems.taints ","}}
+    {{- $taint := split . "="}}
+      {{- with $value := index $taint 1 }}
+        {{- $valueEffect := split $value ":" }}
+        - key: {{index $taint 0}}
+          value: {{index $valueEffect 0}}
+          effect: {{index $valueEffect 1}}
+      {{- end}}
+  {{- end}}
+{{end}}
+        tags:
+          - tagKey: kubernetes.io/cluster/{{ .Cluster.ID }}
+            tagValue: owned
+          - tagKey: Name
+            tagValue: "{{ .NodePool.Name }} ({{ .Cluster.ID }})"
+            # TODO: evaluate how much of this we need?
+          - tagKey: node.kubernetes.io/role
+            tagValue: worker
+          - tagKey: node.kubernetes.io/node-pool
+            tagValue: {{ .NodePool.Name }}
+          - tagKey: node.kubernetes.io/node-pool-profile
+            tagValue: {{ .NodePool.Profile }}
+          - tagKey: kubernetes.io/role/node-pool
+            tagValue: "true"
+          # only node pools without taints should be attached to Ingress Load balancer
+{{- if or (not (index .NodePool.ConfigItems "taints")) (eq (index .NodePool.ConfigItems "taints") "dedicated=skipper-ingress:NoSchedule") }}
+          - tagKey: zalando.org/ingress-enabled
+            tagValue: "true"
+{{- end }}
+          - tagKey: spot.io/type
+            tagValue: launchSpec
+          - tagKey: spot.io/ocean-id # used by CLM to lookup information from instance
+            tagValue: !Ref SpotinstOcean
+        autoScale:
+          # disable headroom/preprovisioned instances
+          headrooms: []
+Outputs:
+  OceanId:
+    Description: The spot.io Ocean ID
+    Value: !Ref SpotinstOcean
+    Export:
+      Name: "{{ .Cluster.ID}}:{{ .Cluster.Alias }}-{{ .NodePool.Name }}:spotio-ocean-id"

--- a/cluster/node-pools/worker-spotio-ocean/userdata.yaml
+++ b/cluster/node-pools/worker-spotio-ocean/userdata.yaml
@@ -1,0 +1,1 @@
+../worker-default/userdata.yaml


### PR DESCRIPTION
Related change in CLM: https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/316

This introduces:
* Deployment for the `spotinst/spot.io controller`. Looks for pending pods in the cluster and scales up those that should run on spot.io managed instances
* node pool profile: `worker-spotio-ocean`. Node pool which maps to an ocean. This means we can have `n` oceans per Kubernetes cluster. We deploy one spot.io controller per spot.io node pool. ~This is like a main spot.io pool that defines all the instance types to be available. THERE CAN ONLY BE ON OF THESE POOLS PER CLUSTER (or you need to run multiple controllers as well) Pods can be scheduled here with:~

* ~node pool profile: `worker-spotio`. This can act as secondary node pool with additional labels/taints. E.g. it can be used to isolate workloads on a group of instances. NOTE: You can't specify instance types at this level, the instance types of the `worker-spotio-ocean` pool will be used.~

~I don't know if modelling the node pools in this way really make sense, but was the simplest way to do it in CLM as a first PoC.~

This have a few quirks around the node pool handling which we need to address after the PoC:
1. CLM can't safely cleanup spot.io node pools 
2. If a spot.io node pool is removed the corresponding spotinst-controller deployment is not dropped and has to be done manually.