### PR TITLE
Use our own etcd image by default

### DIFF
--- a/cluster/etcd-cluster.yaml
+++ b/cluster/etcd-cluster.yaml
@@ -70,7 +70,7 @@ SenzaInfo:
       Description: VpcID to use for the security groups being setup.
   - EtcdImage:
       Description: Docker image for the etcd instances.
-      Default: "registry.opensource.zalan.do/acid/etcd-cluster:3.4.2-p23"
+      Default: "registry.opensource.zalan.do/teapot/etcd-cluster:3.4.2-master-4"
   - ClientCACertificate:
       Description: "CA certificate for client-side TLS (empty for no TLS support)"
       Default: ""


### PR DESCRIPTION
No issues so far, let's make sure it's used in new clusters.