### PR TITLE
routegroup e2e tests

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -25,10 +25,10 @@ examples of how to write the tests or checkout the files already defined e.g.
 
   ```bash
   KUBECONFIG=~/.kube/config HOSTED_ZONE=example.org CLUSTER_ALIAS=example \
-    ginkgo -nodes=25 -flakeAttempts=2 \
+    ginkgo -nodes=1 -flakeAttempts=2 \
     -focus="(\[Conformance\]|\[StatefulSetBasic\]|\[Feature:StatefulSet\]\s\[Slow\].*mysql|\[Zalando\])" \
     -skip="(\[Serial\])" \
-    "e2e.test" -- -delete-namespace-on-failure=false
+    "e2e.test" -- -delete-namespace-on-failure=false -non-blocking-taints=node.kubernetes.io/role
   ```
 
   Where `~/.kube/config` is pointing to the cluster you want to run the tests

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -15,11 +15,12 @@ require (
 	github.com/onsi/gomega v1.7.0
 	github.com/opencontainers/runtime-spec v1.0.1 // indirect
 	github.com/pquerna/ffjson v0.0.0-20181028064349-e517b90714f7 // indirect
+	github.com/szuecs/routegroup-client v0.17.7
 	github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc // indirect
 	github.com/zalando-incubator/kube-aws-iam-controller v0.1.1
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	k8s.io/api v0.0.0
-	k8s.io/apimachinery v0.0.0
+	k8s.io/apimachinery v0.17.6
 	k8s.io/apiserver v0.0.0
 	k8s.io/client-go v10.0.0+incompatible
 	k8s.io/kubernetes v1.17.4

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -191,6 +191,7 @@ github.com/go-critic/go-critic v0.3.5-0.20190526074819-1df300866540/go.mod h1:+s
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-lintpack/lintpack v0.5.2/go.mod h1:NwZuYi2nUHho8XEIZ6SIxihrnPoqBTDqfpXvXAN0sXM=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
+github.com/go-logr/logr v0.1.0 h1:M1Tv3VzNlEHg6uyACnRdtrploV2P7wZqH8BoQMtz0cg=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-ole/go-ole v1.2.1/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=
 github.com/go-openapi/analysis v0.0.0-20180825180245-b006789cd277/go.mod h1:k70tL6pCuVxPJOHXQ+wIac1FUrvNkHolPie/cLEU6hI=
@@ -650,6 +651,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 h1:b6uOv7YOFK0TYG7HtkIgExQo+2RdLuwRft63jn2HWj8=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
+github.com/szuecs/routegroup-client v0.17.7 h1:kwFU9/r4yiWnk+DKox367EO25JsKfdFdJMREduWWKgs=
+github.com/szuecs/routegroup-client v0.17.7/go.mod h1:lHgfovfWP6h6zQoWjVmhUWYrSa62yXstI3uCtgTdTuk=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/thecodeteam/goscaleio v0.1.0 h1:SB5tO98lawC+UK8ds/U2jyfOCH7GTcFztcF5x9gbut4=
 github.com/thecodeteam/goscaleio v0.1.0/go.mod h1:68sdkZAsK8bvEwBlbQnlLS+xU+hvLYM/iQ8KXej1AwM=
@@ -754,6 +757,8 @@ golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9 h1:rjwSpXsdiK0dV8/Naq3kAw9ymfAeJIyd0upUIElB+lI=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200528225125-3c3fba18258b h1:IYiJPiJfzktmDAO1HQiwjMjwjlYKHAL7KzeD544RJPs=
+golang.org/x/net v0.0.0-20200528225125-3c3fba18258b/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a h1:tImsplftrFpALCYumobsd0K86vlAs/eXGFms2txfJfA=
@@ -796,6 +801,9 @@ golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a h1:aYOabOQFp6Vj6W1F80affTUvO
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456 h1:ng0gs1AKnRRuEMZoTLLlbOd+C17zUDepwGQBb/n+JVg=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200523222454-059865788121 h1:rITEj+UZHYC927n8GT97eC3zrpzXdb/voyeOuVKS46o=
+golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915090833-1cbadb444a80/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
@@ -892,6 +900,8 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gotest.tools v2.1.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=

--- a/test/e2e/ingress.go
+++ b/test/e2e/ingress.go
@@ -65,14 +65,14 @@ var _ = framework.KubeDescribe("Ingress ALB creation", func() {
 
 		// POD
 		By("Creating a POD with prefix " + nameprefix + " in namespace " + ns)
-		pod := createNginxPod(nameprefix, ns, labels, targetPort)
+		route := fmt.Sprintf(`* -> inlineContent("%s") -> <shunt>`, "OK")
+		pod := createSkipperPod(nameprefix, ns, route, labels, targetPort)
 		defer func() {
 			By("deleting the pod")
 			defer GinkgoRecover()
 			err2 := cs.CoreV1().Pods(ns).Delete(pod.Name, metav1.NewDeleteOptions(0))
 			Expect(err2).NotTo(HaveOccurred())
 		}()
-
 		_, err = cs.CoreV1().Pods(ns).Create(pod)
 		Expect(err).NotTo(HaveOccurred())
 		framework.ExpectNoError(f.WaitForPodRunning(pod.Name))
@@ -441,6 +441,7 @@ var ___ = framework.KubeDescribe("Ingress tests paths", func() {
 		By(fmt.Sprintf("Testing for ingress %s/%s we want to get a 200 for path %s", ingressUpdate.Namespace, ingressUpdate.Name, bepath))
 		beurl := "https://" + hostName + bepath
 		bereq, err := http.NewRequest("GET", beurl, nil)
+		Expect(err).NotTo(HaveOccurred())
 		resp, err = getAndWaitResponse(rt, bereq, 10*time.Second, http.StatusOK)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -452,6 +453,7 @@ var ___ = framework.KubeDescribe("Ingress tests paths", func() {
 		bepath2 := "/bar"
 		beurl2 := "https://" + hostName + bepath2
 		bereq2, err := http.NewRequest("GET", beurl2, nil)
+		Expect(err).NotTo(HaveOccurred())
 		By(fmt.Sprintf("Testing for ingress %s/%s we want to get a 404 for path %s", ingressUpdate.Namespace, ingressUpdate.Name, bepath2))
 		resp, err = getAndWaitResponse(rt, bereq2, 10*time.Second, http.StatusNotFound)
 		Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/ingress.go
+++ b/test/e2e/ingress.go
@@ -139,13 +139,6 @@ var __ = framework.KubeDescribe("Ingress tests simple", func() {
 		By("Creating a deployment with " + serviceName + " in namespace " + ns)
 		depl := createSkipperBackendDeployment(serviceName, ns, route, labels, int32(targetPort), replicas)
 		_, err := cs.AppsV1().Deployments(ns).Create(depl)
-		//deployment, err := cs.AppsV1().Deployments(ns).Create(depl)
-		// defer func() {
-		// 	By("deleting the deployment")
-		// 	defer GinkgoRecover()
-		// 	err2 := cs.AppsV1().Deployments(ns).Delete(deployment.Name, metav1.NewDeleteOptions(0))
-		// 	Expect(err2).NotTo(HaveOccurred())
-		// }()
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Creating service " + serviceName + " in namespace " + ns)
@@ -347,24 +340,10 @@ var ___ = framework.KubeDescribe("Ingress tests paths", func() {
 		By("Creating a deployment with " + serviceName + " in namespace " + ns)
 		depl := createSkipperBackendDeployment(serviceName, ns, route, labels, int32(targetPort), replicas)
 		_, err := cs.AppsV1().Deployments(ns).Create(depl)
-		//deployment, err := cs.AppsV1().Deployments(ns).Create(depl)
-		// defer func() {
-		// 	By("deleting the deployment")
-		// 	defer GinkgoRecover()
-		// 	err2 := cs.AppsV1().Deployments(ns).Delete(deployment.Name, metav1.NewDeleteOptions(0))
-		// 	Expect(err2).NotTo(HaveOccurred())
-		// }()
 		Expect(err).NotTo(HaveOccurred())
 		By("Creating a 2nd deployment with " + serviceName2 + " in namespace " + ns)
 		depl2 := createSkipperBackendDeployment(serviceName2, ns, route2, labels2, int32(targetPort), replicas)
 		_, err = cs.AppsV1().Deployments(ns).Create(depl2)
-		//deployment2, err := cs.AppsV1().Deployments(ns).Create(depl2)
-		// defer func() {
-		// 	By("deleting the deployment")
-		// 	defer GinkgoRecover()
-		// 	err2 := cs.AppsV1().Deployments(ns).Delete(deployment2.Name, metav1.NewDeleteOptions(0))
-		// 	Expect(err2).NotTo(HaveOccurred())
-		// }()
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Creating service " + serviceName + " in namespace " + ns)
@@ -515,13 +494,6 @@ var ____ = framework.KubeDescribe("Ingress tests custom routes", func() {
 		By("Creating a deployment with " + serviceName + " in namespace " + ns)
 		depl := createSkipperBackendDeployment(serviceName, ns, route, labels, int32(targetPort), replicas)
 		_, err := cs.AppsV1().Deployments(ns).Create(depl)
-		//deployment, err := cs.AppsV1().Deployments(ns).Create(depl)
-		// defer func() {
-		// 	By("deleting the deployment")
-		// 	defer GinkgoRecover()
-		// 	err2 := cs.AppsV1().Deployments(ns).Delete(deployment.Name, metav1.NewDeleteOptions(0))
-		// 	Expect(err2).NotTo(HaveOccurred())
-		// }()
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Creating service " + serviceName + " in namespace " + ns)

--- a/test/e2e/routegroup.go
+++ b/test/e2e/routegroup.go
@@ -1,0 +1,679 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	rgclient "github.com/szuecs/routegroup-client"
+	rgv1 "github.com/szuecs/routegroup-client/apis/zalando.org/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+var _ = framework.KubeDescribe("RouteGroup ALB creation", func() {
+	f := framework.NewDefaultFramework("routegroup")
+	var (
+		cs rgclient.Interface
+	)
+	BeforeEach(func() {
+		By("Creating an rgclient Clientset")
+		config, err := framework.LoadConfig()
+		Expect(err).NotTo(HaveOccurred())
+		config.QPS = f.Options.ClientQPS
+		config.Burst = f.Options.ClientBurst
+		if f.Options.GroupVersion != nil {
+			config.GroupVersion = f.Options.GroupVersion
+		}
+		cs, err = rgclient.NewClientset(config)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("Should create valid https and http ALB endpoint [RouteGroup] [Zalando]", func() {
+		var resp *http.Response
+		serviceName := "rg-test"
+		nameprefix := serviceName + "-"
+		ns := f.Namespace.Name
+		hostName := fmt.Sprintf("%s-%d.%s", serviceName, time.Now().UTC().Unix(), E2EHostedZone())
+		labels := map[string]string{
+			"app": serviceName,
+		}
+		port := 83
+		targetPort := 80
+
+		// SVC
+		By("Creating service " + serviceName + " in namespace " + ns)
+		service := createServiceTypeClusterIP(serviceName, labels, port, targetPort)
+		_, err := cs.CoreV1().Services(ns).Create(service)
+		Expect(err).NotTo(HaveOccurred())
+
+		// POD
+		By("Creating a POD with prefix " + nameprefix + " in namespace " + ns)
+		expectedResponse := "OK RG1"
+		pod := createSkipperPod(nameprefix, ns, fmt.Sprintf(`r0: * -> inlineContent("%s") -> <shunt>`, expectedResponse), labels, targetPort)
+
+		_, err = cs.CoreV1().Pods(ns).Create(pod)
+		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(f.WaitForPodRunning(pod.Name))
+
+		// RouteGroup
+		By("Creating a routegroup with name " + serviceName + " in namespace " + ns + " with hostname " + hostName)
+		rg := createRouteGroup(serviceName, hostName, ns, labels, nil, port, rgv1.RouteGroupRouteSpec{
+			PathSubtree: "/",
+		})
+		rgCreate, err := cs.ZalandoV1().RouteGroups(ns).Create(rg)
+		Expect(err).NotTo(HaveOccurred())
+		addr, err := waitForRouteGroup(cs, rgCreate.Name, rgCreate.Namespace, 10*time.Minute)
+		Expect(err).NotTo(HaveOccurred())
+		rgGot, err := cs.ZalandoV1().RouteGroups(ns).Get(rg.Name, metav1.GetOptions{ResourceVersion: "0"})
+		Expect(err).NotTo(HaveOccurred())
+		By(fmt.Sprintf("ALB endpoint from routegroup status: %s", rgGot.Status.LoadBalancer.RouteGroup[0].Hostname))
+
+		//  skipper http -> https redirect
+		By("Waiting for skipper route to default redirect from http to https, to see that our routegroup-controller and skipper works")
+		err = waitForResponse(addr, "http", 10*time.Minute, isRedirect, true)
+		Expect(err).NotTo(HaveOccurred())
+
+		// ALB ready
+		By("Waiting for ALB to create endpoint " + addr + " and skipper route, to see that our routegroup-controller and skipper works")
+		err = waitForResponse(addr, "https", 10*time.Minute, isNotFound, true)
+		Expect(err).NotTo(HaveOccurred())
+
+		// DNS ready
+		By("Waiting for DNS to see that external-dns and skipper route to service and pod works")
+		err = waitForResponse(hostName, "https", 10*time.Minute, isSuccess, false)
+		Expect(err).NotTo(HaveOccurred())
+
+		// response is from our backend
+		By("checking the response body we know, if we got the response from our backend")
+		req, err := http.NewRequest("GET", "https://"+hostName+"/", nil)
+		Expect(err).NotTo(HaveOccurred())
+		resp, err = waitForResponseReturnResponse(req, 10*time.Minute, isSuccess, false)
+		Expect(err).NotTo(HaveOccurred())
+		s, err := getBody(resp)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(s).To(Equal(expectedResponse))
+	})
+
+	It("Should create a route with predicates [RouteGroup] [Zalando]", func() {
+		var resp *http.Response
+		serviceName := "rg-test-pred"
+		nameprefix := serviceName + "-"
+		ns := f.Namespace.Name
+		hostName := fmt.Sprintf("%s-%d.%s", serviceName, time.Now().UTC().Unix(), E2EHostedZone())
+		labels := map[string]string{
+			"app": serviceName,
+		}
+		port := 83
+		targetPort := 80
+
+		// SVC
+		By("Creating service " + serviceName + " in namespace " + ns)
+		service := createServiceTypeClusterIP(serviceName, labels, port, targetPort)
+		_, err := cs.CoreV1().Services(ns).Create(service)
+		Expect(err).NotTo(HaveOccurred())
+
+		// POD
+		By("Creating a POD with prefix " + nameprefix + " in namespace " + ns)
+		expectedResponse := "OK RG predicate"
+		pod := createSkipperPod(
+			nameprefix,
+			ns,
+			fmt.Sprintf(`rHealth: Path("/") -> inlineContent("OK") -> <shunt>;
+rBackend: Path("/backend") -> inlineContent("%s") -> <shunt>;`,
+				expectedResponse),
+			labels,
+			targetPort)
+
+		_, err = cs.CoreV1().Pods(ns).Create(pod)
+		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(f.WaitForPodRunning(pod.Name))
+
+		// RouteGroup
+		By("Creating a routegroup with name " + serviceName + " in namespace " + ns + " with hostname " + hostName)
+		rg := createRouteGroup(serviceName, hostName, ns, labels, nil, port, rgv1.RouteGroupRouteSpec{
+			PathSubtree: "/backend",
+			Methods:     []string{"GET"},
+			Predicates:  []string{`Header("Foo", "bar")`},
+		})
+		rgCreate, err := cs.ZalandoV1().RouteGroups(ns).Create(rg)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = waitForRouteGroup(cs, rgCreate.Name, rgCreate.Namespace, 10*time.Minute)
+		Expect(err).NotTo(HaveOccurred())
+		rgGot, err := cs.ZalandoV1().RouteGroups(ns).Get(rg.Name, metav1.GetOptions{ResourceVersion: "0"})
+		Expect(err).NotTo(HaveOccurred())
+		By(fmt.Sprintf("ALB endpoint from routegroup status: %s", rgGot.Status.LoadBalancer.RouteGroup[0].Hostname))
+
+		// DNS ready
+		By("Waiting for ALB, DNS and skipper route to service and pod works")
+		err = waitForResponse(hostName, "https", 10*time.Minute, isNotFound, false)
+		Expect(err).NotTo(HaveOccurred())
+
+		// checking backend route with predicates
+		By("checking the response for a request to /backend we know if we got the correct route")
+		err = waitForResponse("https://"+hostName+"/backend", "https", 10*time.Minute, isNotFound, false)
+		Expect(err).NotTo(HaveOccurred())
+		By("checking the response for a request with headers to /backend we know if we got the correct route")
+		req, err := http.NewRequest("GET", "https://"+hostName+"/backend", nil)
+		Expect(err).NotTo(HaveOccurred())
+		req.Header.Set("Foo", "bar")
+		resp, err = waitForResponseReturnResponse(req, 10*time.Minute, isSuccess, false)
+		Expect(err).NotTo(HaveOccurred())
+		s, err := getBody(resp)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(s).To(Equal(expectedResponse))
+	})
+
+	It("Should create routes with filters, predicates and shunt backend [SANDOR] [RouteGroup] [Zalando]", func() {
+		var resp *http.Response
+		serviceName := "rg-test-fp"
+		nameprefix := serviceName + "-"
+		ns := f.Namespace.Name
+		hostName := fmt.Sprintf("%s-%d.%s", serviceName, time.Now().UTC().Unix(), E2EHostedZone())
+		labels := map[string]string{
+			"app": serviceName,
+		}
+		port := 83
+		targetPort := 80
+
+		// SVC
+		By("Creating service " + serviceName + " in namespace " + ns)
+		service := createServiceTypeClusterIP(serviceName, labels, port, targetPort)
+		_, err := cs.CoreV1().Services(ns).Create(service)
+		Expect(err).NotTo(HaveOccurred())
+
+		// POD
+		By("Creating a POD with prefix " + nameprefix + " in namespace " + ns)
+		expectedResponse := "OK RG fp"
+		pod := createSkipperPod(
+			nameprefix,
+			ns,
+			fmt.Sprintf(`rHealth: Path("/") -> inlineContent("OK") -> <shunt>;
+rBackend: Path("/backend") -> inlineContent("%s") -> <shunt>;
+rBackend2: Path("/no-match") -> inlineContent("NOT OK") -> <shunt>;
+rBackend3: Path("/multi-methods") -> inlineContent("OK") -> <shunt>;
+rBackend4: Path("/router-response") -> inlineContent("NOT OK") -> <shunt>;
+`, expectedResponse),
+			labels,
+			targetPort)
+
+		_, err = cs.CoreV1().Pods(ns).Create(pod)
+		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(f.WaitForPodRunning(pod.Name))
+
+		// RouteGroup
+		By("Creating a routegroup with name " + serviceName + " in namespace " + ns + " with hostname " + hostName)
+		rg := createRouteGroup(serviceName, hostName, ns, labels, nil, port, rgv1.RouteGroupRouteSpec{
+			PathSubtree: "/backend",
+			Methods:     []string{"GET"},
+			Predicates: []string{
+				`Header("Foo", "bar")`,
+			},
+			Filters: []string{
+				`status(201)`,
+			},
+		}, rgv1.RouteGroupRouteSpec{
+			PathSubtree: "/no-match1",
+			Predicates:  []string{`Method("HEAD")`},
+		}, rgv1.RouteGroupRouteSpec{
+			PathSubtree: "/no-match2",
+			Methods:     []string{"HEAD"},
+		}, rgv1.RouteGroupRouteSpec{
+			PathSubtree: "/multi-methods",
+			Methods:     []string{"GET", "HEAD"},
+		}, rgv1.RouteGroupRouteSpec{
+			PathSubtree: "/router-response",
+			Filters: []string{
+				`status(418) -> inlineContent("I am a teapot")`,
+			},
+			Backends: []rgv1.RouteGroupBackendReference{
+				{
+					BackendName: "router",
+					Weight:      1,
+				},
+			},
+		})
+		rgCreate, err := cs.ZalandoV1().RouteGroups(ns).Create(rg)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = waitForRouteGroup(cs, rgCreate.Name, rgCreate.Namespace, 10*time.Minute)
+		Expect(err).NotTo(HaveOccurred())
+		rgGot, err := cs.ZalandoV1().RouteGroups(ns).Get(rg.Name, metav1.GetOptions{ResourceVersion: "0"})
+		Expect(err).NotTo(HaveOccurred())
+		By(fmt.Sprintf("ALB endpoint from routegroup status: %s", rgGot.Status.LoadBalancer.RouteGroup[0].Hostname))
+
+		// DNS ready
+		By("Waiting for ALB, DNS and skipper route to service and pod works")
+		err = waitForResponse(hostName+"/", "https", 10*time.Minute, isNotFound, false)
+		Expect(err).NotTo(HaveOccurred())
+
+		// response for / is from our backend
+		By("checking the response code of a request without required request header, we can check if predicate match works correctly")
+		req, err := http.NewRequest("GET", "https://"+hostName+"/backend", nil)
+		resp, err = waitForResponseReturnResponse(req, 10*time.Minute, isNotFound, false)
+		Expect(err).NotTo(HaveOccurred())
+		resp.Body.Close()
+
+		// checking backend route with predicates and filters
+		By("checking the response status code for a request to /backend without correct headers we should get 404")
+		err = waitForResponse("https://"+hostName+"/backend", "https", 10*time.Minute, isNotFound, false)
+		By("checking the response for a request to /backend with the right header we know if we got the correct route")
+		req, err = http.NewRequest("GET", "https://"+hostName+"/backend", nil)
+		Expect(err).NotTo(HaveOccurred())
+		req.Header.Set("Foo", "bar")
+		resp, err = waitForResponseReturnResponse(req, 10*time.Minute, func(code int) bool {
+			return code == http.StatusCreated
+		}, false)
+		Expect(err).NotTo(HaveOccurred())
+		s, err := getBody(resp)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(s).To(Equal(expectedResponse))
+
+		By("checking /no-match1 unexpected method should lead to 404")
+		err = waitForResponse("https://"+hostName+"/no-match1", "https", 10*time.Minute, isNotFound, false)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("checking /no-match2 unexpected predicate should lead to 404")
+		err = waitForResponse("https://"+hostName+"/no-match2", "https", 10*time.Minute, isNotFound, false)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("checking /multi-methods matches correctly")
+		req, err = http.NewRequest("GET", "https://"+hostName+"/multi-methods", nil)
+		Expect(err).NotTo(HaveOccurred())
+		resp, err = waitForResponseReturnResponse(req, 10*time.Minute, isSuccess, false)
+		Expect(err).NotTo(HaveOccurred())
+		resp.Body.Close()
+		req, err = http.NewRequest("HEAD", "https://"+hostName+"/multi-methods", nil)
+		Expect(err).NotTo(HaveOccurred())
+		resp, err = waitForResponseReturnResponse(req, 10*time.Minute, isSuccess, false)
+		Expect(err).NotTo(HaveOccurred())
+		resp.Body.Close()
+
+		By("checking /router-response matches correctly and response with shunted route")
+		err = waitForResponse("https://"+hostName+"/router-response", "https", 10*time.Minute, func(code int) bool {
+			return code == http.StatusTeapot
+		}, false)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("Should create blue-green routes [RouteGroup] [Zalando]", func() {
+		var resp *http.Response
+		serviceName := "rg-test-fp"
+		nameprefix := serviceName + "-"
+		ns := f.Namespace.Name
+		hostName := fmt.Sprintf("%s-%d.%s", serviceName, time.Now().UTC().Unix(), E2EHostedZone())
+		labels := map[string]string{
+			"app": serviceName,
+		}
+		port := 83
+		targetPort := 80
+
+		// SVC
+		By("Creating service " + serviceName + " in namespace " + ns)
+		service := createServiceTypeClusterIP(serviceName, labels, port, targetPort)
+		_, err := cs.CoreV1().Services(ns).Create(service)
+		Expect(err).NotTo(HaveOccurred())
+
+		// POD
+		By("Creating a POD with prefix " + nameprefix + " in namespace " + ns)
+		expectedResponse := "OK RG fp"
+		pod := createSkipperPod(
+			nameprefix,
+			ns,
+			fmt.Sprintf(`rHealth: Path("/") -> inlineContent("OK") -> <shunt>;
+rBackend: Path("/backend") -> inlineContent("%s") -> <shunt>;`,
+				expectedResponse),
+			labels,
+			targetPort)
+
+		_, err = cs.CoreV1().Pods(ns).Create(pod)
+		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(f.WaitForPodRunning(pod.Name))
+
+		// RouteGroup
+		By("Creating a routegroup with name " + serviceName + " in namespace " + ns + " with hostname " + hostName)
+		rg := createRouteGroup(serviceName, hostName, ns, labels, nil, port, rgv1.RouteGroupRouteSpec{
+			PathSubtree: "/",
+		}, rgv1.RouteGroupRouteSpec{
+			PathSubtree: "/blue-green",
+			Filters: []string{
+				`status(201) -> inlineContent("blue")`,
+			},
+			Backends: []rgv1.RouteGroupBackendReference{
+				{
+					BackendName: "router",
+					Weight:      1,
+				},
+			},
+		}, rgv1.RouteGroupRouteSpec{
+			PathSubtree: "/blue-green",
+			Predicates: []string{
+				`Traffic(0.5)`,
+			},
+			Filters: []string{
+				`status(202) -> inlineContent("green")`,
+			},
+			Backends: []rgv1.RouteGroupBackendReference{
+				{
+					BackendName: "router",
+					Weight:      1,
+				},
+			},
+		})
+		rgCreate, err := cs.ZalandoV1().RouteGroups(ns).Create(rg)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = waitForRouteGroup(cs, rgCreate.Name, rgCreate.Namespace, 10*time.Minute)
+		Expect(err).NotTo(HaveOccurred())
+		rgGot, err := cs.ZalandoV1().RouteGroups(ns).Get(rg.Name, metav1.GetOptions{ResourceVersion: "0"})
+		Expect(err).NotTo(HaveOccurred())
+		By(fmt.Sprintf("ALB endpoint from routegroup status: %s", rgGot.Status.LoadBalancer.RouteGroup[0].Hostname))
+
+		// DNS ready
+		By("Waiting for ALB, DNS and skipper route to service and pod works")
+		err = waitForResponse(hostName, "https", 10*time.Minute, isSuccess, false)
+		Expect(err).NotTo(HaveOccurred())
+
+		// response for / is from our backend
+		By("checking the response body we know, if we got the response from our backend")
+		req, err := http.NewRequest("GET", "https://"+hostName+"/", nil)
+		Expect(err).NotTo(HaveOccurred())
+		resp, err = waitForResponseReturnResponse(req, 10*time.Minute, func(code int) bool {
+			return code == 200
+		}, false)
+		Expect(err).NotTo(HaveOccurred())
+		s, err := getBody(resp)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(s).To(Equal("OK"))
+
+		// checking blue-green routes are ~50/50 match
+		By("checking the response for a request to /blue-green we know if we got the correct route")
+		req, err = http.NewRequest("GET", "https://"+hostName+"/blue-green", nil)
+		Expect(err).NotTo(HaveOccurred())
+		resp, err = waitForResponseReturnResponse(req, 10*time.Minute, func(code int) bool {
+			return code > 200 && code < 203
+		}, false)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Or(Equal(201), Equal(202)))
+		resp.Body.Close()
+
+		cnt := map[int]int{
+			201: 0,
+			202: 0,
+		}
+		for i := 0; i < 100; i++ {
+			resp, err = waitForResponseReturnResponse(req, 10*time.Minute, func(code int) bool {
+				return code > 200 && code < 203
+			}, false)
+			Expect(err).NotTo(HaveOccurred())
+			resp.Body.Close()
+			cnt[resp.StatusCode]++
+		}
+		res201 := cnt[201] > 40 && cnt[201] < 60
+		res202 := cnt[202] > 40 && cnt[202] < 60
+		Expect(res201).To(BeTrue())
+		Expect(res202).To(BeTrue())
+	})
+
+	It("Should create gradual traffic routes [RouteGroup] [Zalando]", func() {
+		var resp *http.Response
+		serviceName := "rg-blue"
+		serviceName2 := "rg-green"
+		nameprefix := serviceName + "-"
+		nameprefix2 := serviceName2 + "-"
+		ns := f.Namespace.Name
+		hostName := fmt.Sprintf("%s-%d.%s", serviceName, time.Now().UTC().Unix(), E2EHostedZone())
+		labels := map[string]string{
+			"app": serviceName,
+		}
+		labels2 := map[string]string{
+			"app": serviceName2,
+		}
+		port := 83
+		targetPort := 80
+
+		// SVC
+		By("Creating service " + serviceName + " in namespace " + ns)
+		service := createServiceTypeClusterIP(serviceName, labels, port, targetPort)
+		By("Creating service2 " + serviceName2 + " in namespace " + ns)
+		service2 := createServiceTypeClusterIP(serviceName2, labels2, port, targetPort)
+		_, err := cs.CoreV1().Services(ns).Create(service)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = cs.CoreV1().Services(ns).Create(service2)
+		Expect(err).NotTo(HaveOccurred())
+
+		// POD
+		By("Creating 2 PODs with prefix " + nameprefix + " and " + nameprefix + " in namespace " + ns)
+		expectedResponse := "blue"
+		pod := createSkipperPod(
+			nameprefix,
+			ns,
+			fmt.Sprintf(`rHealth: Path("/") -> inlineContent("OK") -> <shunt>;
+rBackend: Path("/blue-green") -> status(201) -> inlineContent("%s") -> <shunt>;`,
+				expectedResponse),
+			labels,
+			targetPort)
+
+		expectedResponse2 := "green"
+		pod2 := createSkipperPod(
+			nameprefix2,
+			ns,
+			fmt.Sprintf(`rHealth: Path("/") -> inlineContent("OK") -> <shunt>;
+rBackend: Path("/blue-green") -> status(202) -> inlineContent("%s") -> <shunt>;`,
+				expectedResponse2),
+			labels2,
+			targetPort)
+
+		_, err = cs.CoreV1().Pods(ns).Create(pod)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = cs.CoreV1().Pods(ns).Create(pod2)
+		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(f.WaitForPodRunning(pod.Name))
+		framework.ExpectNoError(f.WaitForPodRunning(pod2.Name))
+
+		// RouteGroup
+		By("Creating a routegroup with name " + serviceName + "-" + serviceName2 + " in namespace " + ns + " with hostname " + hostName)
+		rg := createRouteGroupWithBackends(serviceName+"-"+serviceName2, hostName, ns, labels, nil, port,
+			[]rgv1.RouteGroupBackend{
+				{
+					Name:        expectedResponse,
+					Type:        "service",
+					ServiceName: serviceName,
+					ServicePort: port,
+				},
+				{
+					Name:        expectedResponse2,
+					Type:        "service",
+					ServiceName: serviceName2,
+					ServicePort: port,
+				},
+				{
+					Name: "router",
+					Type: "shunt",
+				},
+			}, rgv1.RouteGroupRouteSpec{
+				Path: "/",
+				Backends: []rgv1.RouteGroupBackendReference{
+					{
+						BackendName: "router",
+					},
+				},
+				Filters: []string{
+					"status(200)",
+					`inlineContent("OK")`,
+				},
+			}, rgv1.RouteGroupRouteSpec{
+				PathSubtree: "/blue-green",
+				Backends: []rgv1.RouteGroupBackendReference{
+					{
+						BackendName: expectedResponse,
+						Weight:      80,
+					},
+					{
+						BackendName: expectedResponse2,
+						Weight:      20,
+					},
+				},
+			})
+		rgCreate, err := cs.ZalandoV1().RouteGroups(ns).Create(rg)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = waitForRouteGroup(cs, rgCreate.Name, rgCreate.Namespace, 10*time.Minute)
+		Expect(err).NotTo(HaveOccurred())
+		rgGot, err := cs.ZalandoV1().RouteGroups(ns).Get(rg.Name, metav1.GetOptions{ResourceVersion: "0"})
+		Expect(err).NotTo(HaveOccurred())
+		By(fmt.Sprintf("ALB endpoint from routegroup status: %s", rgGot.Status.LoadBalancer.RouteGroup[0].Hostname))
+
+		// DNS and backend to /blue-green ready
+		By("Waiting for ALB, DNS and skipper route to service and pod works")
+		req, err := http.NewRequest("GET", "https://"+hostName+"/blue-green", nil)
+		Expect(err).NotTo(HaveOccurred())
+		resp, err = waitForResponseReturnResponse(req, 10*time.Minute, func(code int) bool {
+			return code > 200 && code < 203
+		}, false)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Or(Equal(201), Equal(202)))
+		s, err := getBody(resp)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(s).To(Or(Equal("blue"), Equal("green")))
+
+		// checking blue-green routes are ~80/20 match
+		By("checking the response for a request to /blue-green we know if we got the correct weights for our backends")
+		req, err = http.NewRequest("GET", "https://"+hostName+"/blue-green", nil)
+		Expect(err).NotTo(HaveOccurred())
+		cnt := map[int]int{
+			201: 0,
+			202: 0,
+		}
+		for i := 0; i < 100; i++ {
+			resp, err = waitForResponseReturnResponse(req, 10*time.Minute, func(code int) bool {
+				return code > 200 && code < 203
+			}, false)
+			Expect(err).NotTo(HaveOccurred())
+			resp.Body.Close()
+			cnt[resp.StatusCode]++
+		}
+		// +/- 5 for 80/20
+		res201 := cnt[201] > 75 && cnt[201] < 85
+		res202 := cnt[202] > 15 && cnt[202] < 25
+		Expect(res201).To(BeTrue())
+		Expect(res202).To(BeTrue())
+	})
+
+	It("Should create NLB routegroup [RouteGroup] [Zalando]", func() {
+		serviceName := "rg-test-nlb"
+		nameprefix := serviceName + "-"
+		ns := f.Namespace.Name
+		hostName := fmt.Sprintf("%s-%d.%s", serviceName, time.Now().UTC().Unix(), E2EHostedZone())
+		labels := map[string]string{
+			"app": serviceName,
+		}
+		annotations := map[string]string{
+			"zalando.org/aws-load-balancer-type": "nlb",
+		}
+		port := 83
+		targetPort := 80
+		// SVC
+		By("Creating service " + serviceName + " in namespace " + ns)
+		service := createServiceTypeClusterIP(serviceName, labels, port, targetPort)
+		_, err := cs.CoreV1().Services(ns).Create(service)
+		Expect(err).NotTo(HaveOccurred())
+
+		// POD
+		By("Creating a POD with prefix " + nameprefix + " in namespace " + ns)
+		pod := createSkipperPod(
+			nameprefix,
+			ns,
+			`rHealth: Path("/") -> inlineContent("OK") -> <shunt>`,
+			labels,
+			targetPort)
+
+		_, err = cs.CoreV1().Pods(ns).Create(pod)
+		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(f.WaitForPodRunning(pod.Name))
+
+		// RouteGroup
+		By("Creating a routegroup with name " + serviceName + " in namespace " + ns + " with hostname " + hostName)
+		rg := createRouteGroup(serviceName, hostName, ns, labels, annotations, port, rgv1.RouteGroupRouteSpec{
+			PathSubtree: "/",
+		})
+		rgCreate, err := cs.ZalandoV1().RouteGroups(ns).Create(rg)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = waitForRouteGroup(cs, rgCreate.Name, rgCreate.Namespace, 10*time.Minute)
+		Expect(err).NotTo(HaveOccurred())
+		rgGot, err := cs.ZalandoV1().RouteGroups(ns).Get(rg.Name, metav1.GetOptions{ResourceVersion: "0"})
+		Expect(err).NotTo(HaveOccurred())
+		By(fmt.Sprintf("NLB endpoint from routegroup status: %s", rgGot.Status.LoadBalancer.RouteGroup[0].Hostname))
+
+		// DNS ready
+		By("Waiting for NLB, DNS and skipper route to service and pod works")
+		err = waitForResponse(hostName, "https", 10*time.Minute, isSuccess, false)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("Should create ALB routegroup with 2 hostnames [RouteGroup] [Zalando]", func() {
+		serviceName := "rg-test-2hosts"
+		nameprefix := serviceName + "-"
+		ns := f.Namespace.Name
+		hostName := fmt.Sprintf("%s-%d.%s", serviceName, time.Now().UTC().Unix(), E2EHostedZone())
+		hostName2 := fmt.Sprintf("%s-2-%d.%s", serviceName, time.Now().UTC().Unix(), E2EHostedZone())
+		labels := map[string]string{
+			"app": serviceName,
+		}
+		port := 83
+		targetPort := 80
+		// SVC
+		By("Creating service " + serviceName + " in namespace " + ns)
+		service := createServiceTypeClusterIP(serviceName, labels, port, targetPort)
+		_, err := cs.CoreV1().Services(ns).Create(service)
+		Expect(err).NotTo(HaveOccurred())
+
+		// POD
+		By("Creating a POD with prefix " + nameprefix + " in namespace " + ns)
+		pod := createSkipperPod(
+			nameprefix,
+			ns,
+			`rHealth: Path("/") -> inlineContent("OK") -> <shunt>`,
+			labels,
+			targetPort)
+
+		_, err = cs.CoreV1().Pods(ns).Create(pod)
+		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(f.WaitForPodRunning(pod.Name))
+
+		// RouteGroup
+		By("Creating a routegroup with name " + serviceName + " in namespace " + ns + " with hostname " + hostName)
+		rg := createRouteGroup(serviceName, hostName, ns, labels, nil, port, rgv1.RouteGroupRouteSpec{
+			PathSubtree: "/",
+		})
+		rg.Spec.Hosts = append(rg.Spec.Hosts, hostName2) // add second hostname
+		rgCreate, err := cs.ZalandoV1().RouteGroups(ns).Create(rg)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = waitForRouteGroup(cs, rgCreate.Name, rgCreate.Namespace, 10*time.Minute)
+		Expect(err).NotTo(HaveOccurred())
+		rgGot, err := cs.ZalandoV1().RouteGroups(ns).Get(rg.Name, metav1.GetOptions{ResourceVersion: "0"})
+		Expect(err).NotTo(HaveOccurred())
+		By(fmt.Sprintf("ALB endpoint from routegroup status: %s", rgGot.Status.LoadBalancer.RouteGroup[0].Hostname))
+
+		// DNS ready for both endpoints
+		By("Waiting for ALB, DNS and skipper route to service and pod works")
+		err = waitForResponse(hostName, "https", 10*time.Minute, isSuccess, false)
+		Expect(err).NotTo(HaveOccurred())
+		err = waitForResponse(hostName2, "https", 10*time.Minute, isSuccess, false)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+})


### PR DESCRIPTION
- cleanup using nginx in all ingress tests as backends, because faster pull and maybe safe costs, because of dockerhub pull to p1
- added routegroup tests for:
    - ALB + externals-dns + skipper route
    - NLB + externals-dns + skipper route
    - predicates route match
    - methods route match
    - multiple hostnames
    - shunt backend
    - blue-green traffic switching
    - gradual traffic switching with weighted routes

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>