### PR TITLE
Disable go modules updating in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,7 @@
 {
+  "gomod": {
+    "enabled": false
+  },
   "kubernetes": {
     "fileMatch": ["cluster/manifests/.+\\.yaml$"]
   }


### PR DESCRIPTION
These modules are for e2e tests only.

Ref: https://github.com/zalando-incubator/kubernetes-on-aws/pull/3313#issuecomment-641854543