### PR TITLE
keeping the sidecars alive with apiserver

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -465,6 +465,7 @@ write_files:
           - -enable-connection-metrics
           - -enable-prometheus-metrics
           - -write-timeout-server=60m
+          - -wait-for-healthcheck-interval=60s
           - -inline-routes
           - |
             s: JWTPayloadAllKV("iss", "kubernetes/serviceaccount")
@@ -489,10 +490,6 @@ write_files:
               -> "https://127.0.0.1:443";
           ports:
           - containerPort: 8443
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c",  " sleep 60"]
           readinessProbe:
             httpGet:
               scheme: HTTPS

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -286,6 +286,10 @@ write_files:
           name: webhook
           ports:
           - containerPort: 8081
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c",  " sleep 60"]
           livenessProbe:
             httpGet:
               path: /healthcheck

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -218,6 +218,10 @@ write_files:
               memory: 200Mi
         - image: registry.opensource.zalan.do/teapot/admission-controller:master-73
           name: admission-controller
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c",  " sleep 60"]
           readinessProbe:
             httpGet:
               scheme: HTTPS
@@ -360,6 +364,10 @@ write_files:
           name: tokeninfo
           ports:
             - containerPort: 9021
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c",  " sleep 60"]
           livenessProbe:
             httpGet:
               path: /health
@@ -386,6 +394,10 @@ write_files:
           image: registry.opensource.zalan.do/foundation/platform-iam-tokeninfo:2fca26c
           ports:
           - containerPort: 9022
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c",  " sleep 60"]
           livenessProbe:
             httpGet:
               path: /health
@@ -469,6 +481,10 @@ write_files:
               -> "https://127.0.0.1:443";
           ports:
           - containerPort: 8443
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c",  " sleep 60"]
           readinessProbe:
             httpGet:
               scheme: HTTPS
@@ -499,6 +515,10 @@ write_files:
           - {{ .Cluster.ConfigItems.etcd_endpoints }}
           ports:
           - containerPort: 2379
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c",  " sleep 60"]
           resources:
             requests:
               cpu: 25m
@@ -515,6 +535,10 @@ write_files:
           ports:
           - containerPort: 8086
             protocol: TCP
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c",  " sleep 60"]
           readinessProbe:
             httpGet:
               path: /healthz

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -431,6 +431,10 @@ write_files:
           - --failure-policy=fail
           ports:
           - containerPort: 8083
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c",  " sleep 60"]
         - name: nginx
           image: registry.opensource.zalan.do/teapot/nginx:1.12.1
           ports:

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -435,6 +435,10 @@ write_files:
           image: registry.opensource.zalan.do/teapot/nginx:1.12.1
           ports:
           - containerPort: 8082
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c",  " sleep 60"]
           resources:
             requests:
               cpu: 5m


### PR DESCRIPTION
The api server may depend on other sidecars in unexpected ways, so keeping
them all alive.

This is a follow up to  https://github.com/zalando-incubator/kubernetes-on-aws/pull/3045 & https://github.com/zalando-incubator/kubernetes-on-aws/pull/2972

Signed-off-by: Muaaz Saleem <muhammad.muaaz.saleem@zalando.de>