### PR TITLE
Add possibility to configure NLB for Kubernetes API server

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -48,7 +48,7 @@ Resources:
           Value: owned
       ToPort: 10250
     Type: 'AWS::EC2::SecurityGroupIngress'
-{{- if or (eq .Cluster.ConfigItems.apiserver_active_load_balancer "nlb") (eq .Cluster.ConfigItems.apiserver_provision_nlb "true") }}
+{{- if ne .Cluster.ConfigItems.apiserver_nlb "disabled" }}
   MasterLoadBalancerNLB:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
@@ -106,7 +106,7 @@ Resources:
       Port: 443
       Protocol: TLS
 {{- end }}
-{{- if or (eq .Cluster.ConfigItems.apiserver_active_load_balancer "elb") (eq .Cluster.ConfigItems.apiserver_provision_elb "true") }}
+{{- if ne .Cluster.ConfigItems.apiserver_nlb "exclusive" }}
   MasterLoadBalancer:
     Properties:
       ConnectionDrainingPolicy:
@@ -166,16 +166,7 @@ Resources:
 {{- end }}
   MasterLoadBalancerDNSRecord:
     Properties:
-    {{- if eq .Cluster.ConfigItems.apiserver_active_load_balancer "elb" }}
-      AliasTarget:
-        DNSName: !GetAtt
-          - MasterLoadBalancer
-          - DNSName
-        HostedZoneId: !GetAtt
-          - MasterLoadBalancer
-          - CanonicalHostedZoneNameID
-    {{- end }}
-    {{- if eq .Cluster.ConfigItems.apiserver_active_load_balancer "nlb" }}
+    {{- if or (eq .Cluster.ConfigItems.apiserver_nlb "active") (eq .Cluster.ConfigItems.apiserver_nlb "promoted") (eq .Cluster.ConfigItems.apiserver_nlb "exclusive") }}
       AliasTarget:
         DNSName: !GetAtt
           - MasterLoadBalancerNLB
@@ -183,6 +174,14 @@ Resources:
         HostedZoneId: !GetAtt
           - MasterLoadBalancerNLB
           - CanonicalHostedZoneID
+    {{- else }}
+      AliasTarget:
+        DNSName: !GetAtt
+          - MasterLoadBalancer
+          - DNSName
+        HostedZoneId: !GetAtt
+          - MasterLoadBalancer
+          - CanonicalHostedZoneNameID
     {{- end }}
       HostedZoneName: "{{.Values.hosted_zone}}."
       Name: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}."
@@ -192,7 +191,7 @@ Resources:
     Properties:
       GroupDescription: !Ref 'AWS::StackName'
       SecurityGroupIngress:
-{{- if or (eq .Cluster.ConfigItems.apiserver_active_load_balancer "nlb") (eq .Cluster.ConfigItems.apiserver_provision_nlb "true") }}
+{{- if and (ne .Cluster.ConfigItems.apiserver_nlb "disabled") (ne .Cluster.ConfigItems.apiserver_nlb "provisioned") }}
         - CidrIp: 0.0.0.0/0
           FromPort: {{ if eq .ConfigItems.apiserver_proxy "true" }}8443{{ else }}443{{ end }}
           IpProtocol: tcp
@@ -276,7 +275,7 @@ Resources:
           Value: owned
       ToPort: 8472
     Type: 'AWS::EC2::SecurityGroupIngress'
-{{- if or (eq .Cluster.ConfigItems.apiserver_active_load_balancer "elb") (eq .Cluster.ConfigItems.apiserver_provision_elb "true") }}
+{{- if ne .Cluster.ConfigItems.apiserver_nlb "exclusive" }}
   MasterSecurityGroupIngressFromLoadBalancer:
     Properties:
       FromPort: {{ if eq .ConfigItems.apiserver_proxy "true" }}8443{{ else }}443{{ end }}
@@ -1991,13 +1990,13 @@ Outputs:
       Name: '{{ .Cluster.ID}}:master-files-encryption-key'
     Value: !Ref MasterFilesEncryptionKey
 {{- if ne .Cluster.ConfigItems.delete_vpc_resources "true" }}
-{{- if or (eq .Cluster.ConfigItems.apiserver_active_load_balancer "elb") (eq .Cluster.ConfigItems.apiserver_provision_elb "true") }}
+{{- if ne .Cluster.ConfigItems.apiserver_nlb "exclusive" }}
   MasterLoadBalancer:
     Export:
       Name: '{{.Cluster.ID}}:master-load-balancer'
     Value: !Ref MasterLoadBalancer
 {{- end }}
-{{- if or (eq .Cluster.ConfigItems.apiserver_active_load_balancer "nlb") (eq .Cluster.ConfigItems.apiserver_provision_nlb "true") }}
+{{- if ne .Cluster.ConfigItems.apiserver_nlb "disabled" }}
   MasterLoadBalancerNLBTargetGroup:
     Export:
       Name: '{{.Cluster.ID}}:master-load-balancer-nlb-target-group'

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -164,7 +164,7 @@ Resources:
       VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
     Type: 'AWS::EC2::SecurityGroup'
 {{- end }}
-  MasterLoadBalancerDNSRecord:
+  MasterLoadBalancerVersionDomain:
     Properties:
     {{- if or (eq .Cluster.ConfigItems.apiserver_nlb "active") (eq .Cluster.ConfigItems.apiserver_nlb "promoted") (eq .Cluster.ConfigItems.apiserver_nlb "exclusive") }}
       AliasTarget:

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -105,23 +105,6 @@ Resources:
       LoadBalancerArn: !Ref MasterLoadBalancerNLB
       Port: 443
       Protocol: TLS
-  MasterLoadBalancerNLBDNSName:
-    Type: AWS::Route53::RecordSet
-    Properties:
-      AliasTarget:
-        DNSName: !GetAtt
-          - MasterLoadBalancerNLB
-          - DNSName
-        HostedZoneId: !GetAtt
-          - MasterLoadBalancerNLB
-          - CanonicalHostedZoneID
-      HostedZoneName: "{{.Values.hosted_zone}}."
-    {{- if eq .Cluster.ConfigItems.apiserver_active_load_balancer "nlb" }}
-      Name: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}."
-    {{- else }}
-      Name: "{{.Cluster.LocalID}}-nlb.{{.Values.hosted_zone}}."
-    {{- end }}
-      Type: A
 {{- end }}
 {{- if or (eq .Cluster.ConfigItems.apiserver_active_load_balancer "elb") (eq .Cluster.ConfigItems.apiserver_provision_elb "true") }}
   MasterLoadBalancer:
@@ -180,8 +163,10 @@ Resources:
           Value: owned
       VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
     Type: 'AWS::EC2::SecurityGroup'
-  MasterLoadBalancerVersionDomain:
+{{- end }}
+  MasterLoadBalancerDNSRecord:
     Properties:
+    {{- if eq .Cluster.ConfigItems.apiserver_active_load_balancer "elb" }}
       AliasTarget:
         DNSName: !GetAtt
           - MasterLoadBalancer
@@ -189,15 +174,20 @@ Resources:
         HostedZoneId: !GetAtt
           - MasterLoadBalancer
           - CanonicalHostedZoneNameID
-      HostedZoneName: "{{.Values.hosted_zone}}."
-    {{- if eq .Cluster.ConfigItems.apiserver_active_load_balancer "elb" }}
-      Name: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}."
-    {{- else }}
-      Name: "{{.Cluster.LocalID}}-elb.{{.Values.hosted_zone}}."
     {{- end }}
+    {{- if eq .Cluster.ConfigItems.apiserver_active_load_balancer "nlb" }}
+      AliasTarget:
+        DNSName: !GetAtt
+          - MasterLoadBalancerNLB
+          - DNSName
+        HostedZoneId: !GetAtt
+          - MasterLoadBalancerNLB
+          - CanonicalHostedZoneID
+    {{- end }}
+      HostedZoneName: "{{.Values.hosted_zone}}."
+      Name: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}."
       Type: A
     Type: 'AWS::Route53::RecordSet'
-{{- end }}
   MasterSecurityGroup:
     Properties:
       GroupDescription: !Ref 'AWS::StackName'

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -48,6 +48,82 @@ Resources:
           Value: owned
       ToPort: 10250
     Type: 'AWS::EC2::SecurityGroupIngress'
+{{- if or (eq .Cluster.ConfigItems.apiserver_active_load_balancer "nlb") (eq .Cluster.ConfigItems.apiserver_provision_nlb "true") }}
+  MasterLoadBalancerNLB:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: "{{.Cluster.LocalID}}-nlb"
+      LoadBalancerAttributes:
+        - Key: load_balancing.cross_zone.enabled
+          Value: true
+      Scheme: internet-facing
+      Subnets:
+  {{ with $values := .Values }}
+  {{ range $az := $values.availability_zones }}
+        - "{{ index $values.subnets $az }}"
+  {{ end }}
+  {{ end }}
+      Tags:
+        - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
+          Value: owned
+        - Key: "application"
+          Value: kube-apiserver
+        - Key: "component"
+          Value: "kube-apiserver"
+      Type: network
+  MasterLoadBalancerNLBTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckIntervalSeconds: 10
+      HealthCheckPath: /healthz
+      HealthCheckPort: 8080
+      HealthCheckProtocol: HTTP
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 2
+      Name: "{{.Cluster.LocalID}}-nlb"
+      Port: {{ if eq .ConfigItems.apiserver_proxy "true" }}8443{{ else }}443{{ end }}
+      Protocol: TLS
+      Tags:
+        - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
+          Value: owned
+        - Key: "application"
+          Value: kube-apiserver
+        - Key: "component"
+          Value: "kube-apiserver"
+      VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
+      TargetGroupAttributes:
+        - Key: deregistration_delay.timeout_seconds
+          Value: 60
+  MasterLoadBalancerNLBListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      Certificates:
+        - CertificateArn: "{{.Values.load_balancer_certificate}}"
+      DefaultActions:
+      - Type: forward
+        TargetGroupArn: !Ref MasterLoadBalancerNLBTargetGroup
+      LoadBalancerArn: !Ref MasterLoadBalancerNLB
+      Port: 443
+      Protocol: TLS
+  MasterLoadBalancerNLBDNSName:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      AliasTarget:
+        DNSName: !GetAtt
+          - MasterLoadBalancerNLB
+          - DNSName
+        HostedZoneId: !GetAtt
+          - MasterLoadBalancerNLB
+          - CanonicalHostedZoneID
+      HostedZoneName: "{{.Values.hosted_zone}}."
+    {{- if eq .Cluster.ConfigItems.apiserver_active_load_balancer "nlb" }}
+      Name: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}."
+    {{- else }}
+      Name: "{{.Cluster.LocalID}}-nlb.{{.Values.hosted_zone}}."
+    {{- end }}
+      Type: A
+{{- end }}
+{{- if or (eq .Cluster.ConfigItems.apiserver_active_load_balancer "elb") (eq .Cluster.ConfigItems.apiserver_provision_elb "true") }}
   MasterLoadBalancer:
     Properties:
       ConnectionDrainingPolicy:
@@ -114,13 +190,28 @@ Resources:
           - MasterLoadBalancer
           - CanonicalHostedZoneNameID
       HostedZoneName: "{{.Values.hosted_zone}}."
+    {{- if eq .Cluster.ConfigItems.apiserver_active_load_balancer "elb" }}
       Name: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}."
+    {{- else }}
+      Name: "{{.Cluster.LocalID}}-elb.{{.Values.hosted_zone}}."
+    {{- end }}
       Type: A
     Type: 'AWS::Route53::RecordSet'
+{{- end }}
   MasterSecurityGroup:
     Properties:
       GroupDescription: !Ref 'AWS::StackName'
       SecurityGroupIngress:
+{{- if or (eq .Cluster.ConfigItems.apiserver_active_load_balancer "nlb") (eq .Cluster.ConfigItems.apiserver_provision_nlb "true") }}
+        - CidrIp: 0.0.0.0/0
+          FromPort: {{ if eq .ConfigItems.apiserver_proxy "true" }}8443{{ else }}443{{ end }}
+          IpProtocol: tcp
+          ToPort: {{ if eq .ConfigItems.apiserver_proxy "true" }}8443{{ else }}443{{ end }}
+        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+          FromPort: 8080
+          IpProtocol: tcp
+          ToPort: 8080
+{{- end }}
         - CidrIp: 0.0.0.0/0
           FromPort: -1
           IpProtocol: icmp
@@ -195,6 +286,7 @@ Resources:
           Value: owned
       ToPort: 8472
     Type: 'AWS::EC2::SecurityGroupIngress'
+{{- if or (eq .Cluster.ConfigItems.apiserver_active_load_balancer "elb") (eq .Cluster.ConfigItems.apiserver_provision_elb "true") }}
   MasterSecurityGroupIngressFromLoadBalancer:
     Properties:
       FromPort: {{ if eq .ConfigItems.apiserver_proxy "true" }}8443{{ else }}443{{ end }}
@@ -217,6 +309,7 @@ Resources:
           Value: owned
       ToPort: 8080
     Type: 'AWS::EC2::SecurityGroupIngress'
+{{- end }}
   MasterSecurityGroupIngressFromMaster:
     Properties:
       FromPort: 443
@@ -1908,10 +2001,18 @@ Outputs:
       Name: '{{ .Cluster.ID}}:master-files-encryption-key'
     Value: !Ref MasterFilesEncryptionKey
 {{- if ne .Cluster.ConfigItems.delete_vpc_resources "true" }}
+{{- if or (eq .Cluster.ConfigItems.apiserver_active_load_balancer "elb") (eq .Cluster.ConfigItems.apiserver_provision_elb "true") }}
   MasterLoadBalancer:
     Export:
       Name: '{{.Cluster.ID}}:master-load-balancer'
     Value: !Ref MasterLoadBalancer
+{{- end }}
+{{- if or (eq .Cluster.ConfigItems.apiserver_active_load_balancer "nlb") (eq .Cluster.ConfigItems.apiserver_provision_nlb "true") }}
+  MasterLoadBalancerNLBTargetGroup:
+    Export:
+      Name: '{{.Cluster.ID}}:master-load-balancer-nlb-target-group'
+    Value: !Ref MasterLoadBalancerNLBTargetGroup
+{{- end }}
   MasterSecurityGroup:
     Export:
       Name: '{{.Cluster.ID}}:master-security-group'

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -256,6 +256,24 @@ serialize_image_pulls: "false"
 
 # when set to true, routes external traffic to the apiserver through a skipper sidecar
 apiserver_proxy: "true"
+
+# when set to true provisions an ELB for the apiserver
+apiserver_provision_elb: "true"
+# when set to true attaches master nodes to the apiserver ELB
+#   note: true does not imply `apiserver_provision_elb: true` for the sake of rolling back
+apiserver_attach_to_elb: "true"
+
+# when set to true provisions an NLB for the apiserver
+apiserver_provision_nlb: "true"
+# when set to true attaches master nodes to the apiserver NLB
+#   note: true does not imply `apiserver_provision_nlb: true` for the sake of rolling back
+apiserver_attach_to_nlb: "true"
+
+# defines which load balancer should be used for the main domain, options: [elb, nlb]
+#   if set to elb implies `apiserver_provision_elb: true` and `apiserver_attach_to_elb: true`
+#   if set to nlb implies `apiserver_provision_nlb: true` and `apiserver_attach_to_nlb: true`
+apiserver_active_load_balancer: "elb"
+
 # when set to true, service account tokens can be used from outside the cluster
 # requires apiserver_proxy to be set to "true"
 allow_external_service_accounts: "false"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -257,22 +257,16 @@ serialize_image_pulls: "false"
 # when set to true, routes external traffic to the apiserver through a skipper sidecar
 apiserver_proxy: "true"
 
-# when set to true provisions an ELB for the apiserver
-apiserver_provision_elb: "true"
-# when set to true attaches master nodes to the apiserver ELB
-#   note: true does not imply `apiserver_provision_elb: true` for the sake of rolling back
-apiserver_attach_to_elb: "true"
-
-# when set to true provisions an NLB for the apiserver
-apiserver_provision_nlb: "true"
-# when set to true attaches master nodes to the apiserver NLB
-#   note: true does not imply `apiserver_provision_nlb: true` for the sake of rolling back
-apiserver_attach_to_nlb: "true"
-
-# defines which load balancer should be used for the main domain, options: [elb, nlb]
-#   if set to elb implies `apiserver_provision_elb: true` and `apiserver_attach_to_elb: true`
-#   if set to nlb implies `apiserver_provision_nlb: true` and `apiserver_attach_to_nlb: true`
-apiserver_active_load_balancer: "elb"
+# defines the rollout status of the NLB for the API server. The options are:
+#
+#   disabled:    no NLB will be provisioned
+#   provisioned: NLB will be provisioned but not hooked up to the ASG
+#   hooked:      NLB will be provisioned and hooked up to the ASG but DNS still points to the ELB
+#   active:      NLB will be fully functional and DNS points to the NLB
+#   promoted:    NLB will be fully functional and ELB will be unhooked
+#   exclusive:   NLB will be fully functional and ELB will be removed
+#
+apiserver_nlb: "disabled"
 
 # when set to true, service account tokens can be used from outside the cluster
 # requires apiserver_proxy to be set to "true"

--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -18,8 +18,10 @@ Resources:
       LaunchTemplate:
         LaunchTemplateId: !Ref LaunchTemplate
         Version: !GetAtt LaunchTemplate.LatestVersionNumber
+{{- if or (eq .Cluster.ConfigItems.apiserver_active_load_balancer "elb") (eq .Cluster.ConfigItems.apiserver_attach_to_elb "true") }}
       LoadBalancerNames:
       - !ImportValue '{{ .Cluster.ID }}:master-load-balancer'
+{{- end }}
       MinSize: '{{ .NodePool.MinSize }}'
       MaxSize: '{{ .NodePool.MaxSize }}'
       Tags:
@@ -38,6 +40,10 @@ Resources:
         - "{{ index $values.subnets $az }}"
 {{ end }}
 {{ end }}
+{{- if or (eq .Cluster.ConfigItems.apiserver_active_load_balancer "nlb") (eq .Cluster.ConfigItems.apiserver_attach_to_nlb "true") }}
+      TargetGroupARNs:
+      - !ImportValue '{{ .Cluster.ID }}:master-load-balancer-nlb-target-group'
+{{- end }}
     Type: 'AWS::AutoScaling::AutoScalingGroup'
   LaunchTemplate:
     Properties:

--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -18,7 +18,7 @@ Resources:
       LaunchTemplate:
         LaunchTemplateId: !Ref LaunchTemplate
         Version: !GetAtt LaunchTemplate.LatestVersionNumber
-{{- if or (eq .Cluster.ConfigItems.apiserver_active_load_balancer "elb") (eq .Cluster.ConfigItems.apiserver_attach_to_elb "true") }}
+{{- if and (ne .Cluster.ConfigItems.apiserver_nlb "promoted") (ne .Cluster.ConfigItems.apiserver_nlb "exclusive") }}
       LoadBalancerNames:
       - !ImportValue '{{ .Cluster.ID }}:master-load-balancer'
 {{- end }}
@@ -40,7 +40,7 @@ Resources:
         - "{{ index $values.subnets $az }}"
 {{ end }}
 {{ end }}
-{{- if or (eq .Cluster.ConfigItems.apiserver_active_load_balancer "nlb") (eq .Cluster.ConfigItems.apiserver_attach_to_nlb "true") }}
+{{- if and (ne .Cluster.ConfigItems.apiserver_nlb "disabled") (ne .Cluster.ConfigItems.apiserver_nlb "provisioned") }}
       TargetGroupARNs:
       - !ImportValue '{{ .Cluster.ID }}:master-load-balancer-nlb-target-group'
 {{- end }}


### PR DESCRIPTION
Prepares for replacing ELB with NLB. Doesn't create NLB yet.

Config Items:
```markdown
# defines the rollout status of the NLB for the API server. The options are:
#
#   disabled:    no NLB will be provisioned
#   provisioned: NLB will be provisioned but not hooked up to the ASG
#   hooked:      NLB will be provisioned and hooked up to the ASG but DNS still points to the ELB
#   active:      NLB will be fully functional and DNS points to the NLB
#   promoted:    NLB will be fully functional and ELB will be unhooked
#   exclusive:   NLB will be fully functional and ELB will be removed
#
apiserver_nlb: "disabled"
```

It's safe to go through the stages one-by-one in both directions.