### PR TITLE
Provision and attach API server NLB by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -266,7 +266,7 @@ apiserver_proxy: "true"
 #   promoted:    NLB will be fully functional and ELB will be unhooked
 #   exclusive:   NLB will be fully functional and ELB will be removed
 #
-apiserver_nlb: "disabled"
+apiserver_nlb: "hooked"
 
 # when set to true, service account tokens can be used from outside the cluster
 # requires apiserver_proxy to be set to "true"


### PR DESCRIPTION
Setup API server NLB by default. Don't switch DNS yet.

This intermediate step is needed to avoid downtime by not switching DNS at the same time.

- [x] Merge after https://github.com/zalando-incubator/kubernetes-on-aws/pull/3348