### PR TITLE
Revert "Set maximum number of bytes streamed to the client"

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -357,6 +357,3 @@ stackset_controller_sync_interval: "10s"
 
 # EBS settings for the root volume
 ebs_root_volume_size: "50"
-
-# maximum number of bytes streamed per second, e.g. for port-forward.
-max_streaming_bytes_per_second: 1000000000 # 1 GB/s

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -188,7 +188,6 @@ write_files:
           - --kubelet-client-certificate=/etc/kubernetes/ssl/kubelet-client.pem
           - --kubelet-client-key=/etc/kubernetes/ssl/kubelet-client-key.pem
           - --shutdown-delay-duration=60s
-          - --max-connection-bytes-per-sec={{ .Cluster.ConfigItems.max_streaming_bytes_per_second }}
           livenessProbe:
             httpGet:
               host: 127.0.0.1


### PR DESCRIPTION
Since the original PR hasn't made it do `alpha` yet and NLB support is already in `dev` there's no need to have this quick fix in place.

It might still be a good idea but for now I can't estimate all the implications and it's safer to just leave it unchanged.

