### PR TITLE
Get rid of priorities as much as possible

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -357,3 +357,10 @@ stackset_controller_sync_interval: "10s"
 
 # EBS settings for the root volume
 ebs_root_volume_size: "50"
+
+# Migration off priority classes
+{{if eq .Environment "production"}}
+system_pods_critical: "true"
+{{else}}
+system_pods_critical: "false"
+{{end}}

--- a/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
@@ -22,7 +22,9 @@ spec:
       annotations:
         config/hash: {{"02-secret.yaml" | manifestHash}}
     spec:
+{{- if eq .Cluster.ConfigItems.system_pods_critical "true" }}
       priorityClassName: system-cluster-critical
+{{- end }}
       serviceAccountName: vpa-admission-controller
       containers:
       - name: admission-controller

--- a/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
@@ -21,7 +21,6 @@ spec:
         version: v0.6.1-internal.7
     spec:
       serviceAccountName: vpa-recommender
-      priorityClassName: system-cluster-critical
       containers:
       - name: recommender
         image: registry.opensource.zalan.do/teapot/vpa-recommender:v0.6.1-internal.7

--- a/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
@@ -21,7 +21,6 @@ spec:
         version: v0.6.1-internal.7
     spec:
       serviceAccountName: vpa-updater
-      priorityClassName: system-cluster-critical
       containers:
       - name: updater
         image: registry.opensource.zalan.do/teapot/vpa-updater:v0.6.1-internal.7

--- a/cluster/manifests/02-kube-aws-iam-controller/deployment.yaml
+++ b/cluster/manifests/02-kube-aws-iam-controller/deployment.yaml
@@ -18,7 +18,9 @@ spec:
         version: v0.1.0
     spec:
       serviceAccountName: kube-aws-iam-controller
+{{- if eq .Cluster.ConfigItems.system_pods_critical "true" }}
       priorityClassName: system-cluster-critical
+{{- end }}
       # running with hostNetwork to bypass metadata service block from pod
       # network.
       hostNetwork: true

--- a/cluster/manifests/03-ebs-csi/ebs-controller.yaml
+++ b/cluster/manifests/03-ebs-csi/ebs-controller.yaml
@@ -129,7 +129,6 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
       nodeSelector:
         node.kubernetes.io/role: master
-      priorityClassName: system-cluster-critical
       serviceAccountName: ebs-csi-controller
       tolerations:
         - key: node.kubernetes.io/role

--- a/cluster/manifests/admission-control-proxy/daemonset.yaml
+++ b/cluster/manifests/admission-control-proxy/daemonset.yaml
@@ -21,7 +21,6 @@ spec:
         options:
           - name: ndots
             value: "1"
-      priorityClassName: system-cluster-critical
       serviceAccountName: admission-controller-proxy
       dnsPolicy: Default
       hostNetwork: true

--- a/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
@@ -23,7 +23,6 @@ spec:
         options:
           - name: ndots
             value: "1"
-      priorityClassName: system-cluster-critical
       serviceAccountName: cluster-lifecycle-controller
       tolerations:
       - key: node.kubernetes.io/role

--- a/cluster/manifests/cronjob-fixer/deployment.yaml
+++ b/cluster/manifests/cronjob-fixer/deployment.yaml
@@ -19,7 +19,6 @@ spec:
         options:
           - name: ndots
             value: "1"
-      priorityClassName: system-cluster-critical
       serviceAccountName: cronjob-fixer
       containers:
         - name: cronjob-fixer

--- a/cluster/manifests/dashboard/deployment.yaml
+++ b/cluster/manifests/dashboard/deployment.yaml
@@ -26,7 +26,6 @@ spec:
         options:
           - name: ndots
             value: "1"
-      priorityClassName: system-cluster-critical
       serviceAccountName: kubernetes-dashboard
       containers:
       - name: kubernetes-dashboard

--- a/cluster/manifests/dashboard/scraper.yaml
+++ b/cluster/manifests/dashboard/scraper.yaml
@@ -38,7 +38,6 @@ spec:
         component: metrics-scraper
         version: v1.0.2
     spec:
-      priorityClassName: system-cluster-critical
       serviceAccountName: kubernetes-dashboard
       containers:
       - name: dashboard-metrics-scraper

--- a/cluster/manifests/efs-provisioner/depl-efs-provisioner.yaml
+++ b/cluster/manifests/efs-provisioner/depl-efs-provisioner.yaml
@@ -24,7 +24,6 @@ spec:
           - name: ndots
             value: "1"
       serviceAccountName: efs-provisioner
-      priorityClassName: system-cluster-critical
       containers:
       - name: efs-provisioner
         image: registry.opensource.zalan.do/teapot/efs-provisioner:v2.4.0

--- a/cluster/manifests/emergency-access-service/deployment.yaml
+++ b/cluster/manifests/emergency-access-service/deployment.yaml
@@ -30,7 +30,9 @@ spec:
         options:
           - name: ndots
             value: "1"
+{{- if eq .Cluster.ConfigItems.system_pods_critical "true" }}
       priorityClassName: system-cluster-critical
+{{- end }}
       serviceAccountName: emergency-access-service
       containers:
       - name: apiserver-proxy

--- a/cluster/manifests/etcd-backup/cronjob.yaml
+++ b/cluster/manifests/etcd-backup/cronjob.yaml
@@ -30,7 +30,6 @@ spec:
             options:
               - name: ndots
                 value: "1"
-          priorityClassName: system-cluster-critical
           restartPolicy: Never
           containers:
           - name: etcd-backup

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -28,7 +28,9 @@ spec:
         options:
           - name: ndots
             value: "1"
+{{- if eq .Cluster.ConfigItems.system_pods_critical "true" }}
       priorityClassName: system-cluster-critical
+{{- end }}
       serviceAccountName: external-dns
       containers:
       - name: external-dns

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -27,7 +27,9 @@ spec:
         options:
           - name: ndots
             value: "1"
+{{- if eq .Cluster.ConfigItems.system_pods_critical "true" }}
       priorityClassName: system-cluster-critical
+{{- end }}
       serviceAccountName: kube-ingress-aws-controller
       containers:
       - name: controller

--- a/cluster/manifests/ingress-template-controller/deployment.yaml
+++ b/cluster/manifests/ingress-template-controller/deployment.yaml
@@ -22,7 +22,6 @@ spec:
         options:
           - name: ndots
             value: "1"
-      priorityClassName: system-cluster-critical
       serviceAccountName: ingress-template-controller
       containers:
       - name: ingress-template-controller

--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -25,7 +25,6 @@ spec:
         options:
           - name: ndots
             value: "1"
-      priorityClassName: system-cluster-critical
       serviceAccountName: cluster-autoscaler
       dnsPolicy: Default
       tolerations:

--- a/cluster/manifests/kube-dns-metrics/deployment.yaml
+++ b/cluster/manifests/kube-dns-metrics/deployment.yaml
@@ -21,7 +21,6 @@ spec:
         options:
           - name: ndots
             value: "1"
-      priorityClassName: system-cluster-critical
       containers:
         - image: pierone.stups.zalan.do/teapot/kube-dns-metrics:v1.0.2
           name: kube-dns-metrics

--- a/cluster/manifests/kube-downscaler/deployment.yaml
+++ b/cluster/manifests/kube-downscaler/deployment.yaml
@@ -22,7 +22,6 @@ spec:
           - name: ndots
             value: "1"
       serviceAccountName: kube-downscaler
-      priorityClassName: system-cluster-critical
       containers:
       - name: downscaler
         # see https://github.com/hjacobs/kube-downscaler/releases

--- a/cluster/manifests/kube-janitor/deployment.yaml
+++ b/cluster/manifests/kube-janitor/deployment.yaml
@@ -22,7 +22,6 @@ spec:
         options:
           - name: ndots
             value: "1"
-      priorityClassName: system-cluster-critical
       serviceAccountName: kube-janitor
       containers:
       - name: janitor

--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -25,7 +25,6 @@ spec:
         options:
           - name: ndots
             value: "1"
-      priorityClassName: system-cluster-critical
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter

--- a/cluster/manifests/kube-state-metrics/deployment.yaml
+++ b/cluster/manifests/kube-state-metrics/deployment.yaml
@@ -21,7 +21,6 @@ spec:
         options:
           - name: ndots
             value: "1"
-      priorityClassName: system-cluster-critical
       serviceAccountName: kube-state-metrics
       containers:
       - name: kube-state-metrics

--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -27,7 +27,6 @@ spec:
         options:
           - name: ndots
             value: "1"
-      priorityClassName: system-cluster-critical
       serviceAccountName: kube-static-egress-controller
       containers:
       - name: controller

--- a/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
@@ -23,7 +23,6 @@ spec:
         options:
           - name: ndots
             value: "1"
-      priorityClassName: system-cluster-critical
       serviceAccountName: kubernetes-lifecycle-metrics
       containers:
         - name: kubernetes-lifecycle-metrics

--- a/cluster/manifests/metrics-server/deployment.yaml
+++ b/cluster/manifests/metrics-server/deployment.yaml
@@ -22,7 +22,6 @@ spec:
         options:
           - name: ndots
             value: "1"
-      priorityClassName: system-cluster-critical
       serviceAccountName: metrics-server
       containers:
       - name: metrics-server

--- a/cluster/manifests/pdb-controller/deployment.yaml
+++ b/cluster/manifests/pdb-controller/deployment.yaml
@@ -21,7 +21,6 @@ spec:
         options:
           - name: ndots
             value: "1"
-      priorityClassName: system-cluster-critical
       serviceAccountName: pdb-controller
       containers:
       - name: pdb-controller

--- a/cluster/manifests/prometheus/statefulset.yaml
+++ b/cluster/manifests/prometheus/statefulset.yaml
@@ -32,7 +32,6 @@ spec:
         options:
         - name: ndots
           value: "1"
-      priorityClassName: system-cluster-critical
       initContainers:
       - name: generate-config
         image: registry.opensource.zalan.do/stups/alpine:3.11.6-7

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -36,7 +36,9 @@ spec:
                   values:
                   - skipper-ingress
               topologyKey: kubernetes.io/hostname
+{{- if eq .Cluster.ConfigItems.system_pods_critical "true" }}
       priorityClassName: system-cluster-critical
+{{- end }}
       serviceAccountName: skipper-ingress
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true

--- a/cluster/manifests/skipper/skipper-redis.yaml
+++ b/cluster/manifests/skipper/skipper-redis.yaml
@@ -18,7 +18,9 @@ spec:
         application: skipper-ingress-redis
         version: v4.0.9
     spec:
+{{- if eq .Cluster.ConfigItems.system_pods_critical "true" }}
       priorityClassName: system-cluster-critical
+{{- end }}
       containers:
       - image: registry.opensource.zalan.do/zmon/redis:4.0.9-master-6
         name: skipper-ingress-redis

--- a/cluster/manifests/stackset-controller/deployment.yaml
+++ b/cluster/manifests/stackset-controller/deployment.yaml
@@ -17,7 +17,9 @@ spec:
         application: stackset-controller
         version: "v1.1.23"
     spec:
+{{- if eq .Cluster.ConfigItems.system_pods_critical "true" }}
       priorityClassName: system-cluster-critical
+{{- end }}
       serviceAccountName: stackset-controller
       containers:
       - name: stackset-controller


### PR DESCRIPTION
 * Drop priority classes for things running on master nodes (they should be sized correctly from the beginning)
 * Drop `system-cluster-critical` from most of our components unconditionally
 * Keep `system-cluster-critical` if `system_pods_critical` is set to `true` (default in production clusters) for the following components:
   * emergency access service
   * external-dns
   * kube-ingress-aws-controller
   * skipper + skipper redis
   * stackset-controller
   * VPA admission controller

We'll then slowly disable priorities altogether if it doesn't cause any issues.