### PR TITLE
cdp-controller-rbac: Add permissions for Flagger canaries

### DIFF
--- a/cluster/manifests/roles/cdp-controller-rbac.yaml
+++ b/cluster/manifests/roles/cdp-controller-rbac.yaml
@@ -82,6 +82,19 @@ rules:
   - list
   - watch
   - create
+- apiGroups:
+  - "flagger.app"
+  resources:
+  - canaries
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+  - deletecollection
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/cluster/manifests/roles/cdp-controller-rbac.yaml
+++ b/cluster/manifests/roles/cdp-controller-rbac.yaml
@@ -21,6 +21,13 @@ rules:
   - ""
   resources:
   - pods/log
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "apps"
+  resources:
   - deployments
   verbs:
   - get

--- a/cluster/manifests/roles/cdp-controller-rbac.yaml
+++ b/cluster/manifests/roles/cdp-controller-rbac.yaml
@@ -93,8 +93,6 @@ rules:
   - watch
   - update
   - patch
-  - delete
-  - deletecollection
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/cluster/manifests/roles/cdp-controller-rbac.yaml
+++ b/cluster/manifests/roles/cdp-controller-rbac.yaml
@@ -21,6 +21,7 @@ rules:
   - ""
   resources:
   - pods/log
+  - deployments
   verbs:
   - get
   - list


### PR DESCRIPTION
As part of the Gradual Deployments Experiment project we need CDP Controller to:

* Manage Flagger canary resources
* List Deployments to configure [Flagger's `targetRef` attribute](https://docs.flagger.app/usage/how-it-works#canary-target)