### PR TITLE
Test NLB setup alongside default setup

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -91,7 +91,7 @@ pipeline:
           image: "registry.opensource.zalan.do/teapot/kubernetes-on-aws-e2e:#{CDP_BUILD_VERSION}"
           env:
           - name: APISERVER_NLB
-            value: hooked
+            value: active
           resources:
             limits:
               cpu: 500m

--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -15,7 +15,7 @@ CDP_TARGET_COMMIT_ID="${CDP_TARGET_COMMIT_ID:-"dev"}"
 CDP_HEAD_COMMIT_ID="${CDP_HEAD_COMMIT_ID:-"$(git describe --tags --always)"}"
 
 export CLUSTER_ALIAS="${CLUSTER_ALIAS:-"e2e-test"}"
-export APISERVER_NLB="${APISERVER_NLB:-"disabled"}"
+export APISERVER_NLB="${APISERVER_NLB:-"hooked"}"
 # TODO: we need the date in LOCAL_ID because of CDP retriggering
 export LOCAL_ID="${LOCAL_ID:-$(echo "e2e-$CDP_BUILD_VERSION-$(date +'%H%M%S')-$APISERVER_NLB" | cut -c-28)}"
 export API_SERVER_URL="https://${LOCAL_ID}.${HOSTED_ZONE}"


### PR DESCRIPTION
Makes sure to test the current state as well as enables testing for active NLB. Split in separate PRs to ensure that clusters correctly go through the upgrade path.