### PR TITLE
Prevent kube-node-ready from running on spot.io nodes

### DIFF
--- a/cluster/manifests/kube-node-ready/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready/daemonset.yaml
@@ -26,6 +26,13 @@ spec:
 {{ end }}
 {{ end }}
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: spot.io
+                operator: DoesNotExist
       serviceAccountName: kube-node-ready
       dnsConfig:
         options:


### PR DESCRIPTION
`kube-node-ready` can't run on spot.io nodes because it triggeres ASG events which are not relevant for spot.io as they are managed EC2 instances without an ASG.