### PR TITLE
Add a logger for Kubernetes events

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -375,3 +375,6 @@ spotio_ocean_utilize_reserved_instances: "false"
 # configuration for spot.io controller
 spotio_ocean_controller_cpu: "50m"
 spotio_ocean_controller_memory: "512Mi"
+
+# Log Kubernetes events to Scalyr
+kubernetes_event_logger_enabled: "true"

--- a/cluster/manifests/event-logger/01-rbac.yaml
+++ b/cluster/manifests/event-logger/01-rbac.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubernetes-event-logger
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubernetes-event-logger
+rules:
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  resourceNames: ["kubernetes-event-logger"]
+  verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubernetes-event-logger
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubernetes-event-logger
+subjects:
+- kind: ServiceAccount
+  name: kubernetes-event-logger
+  namespace: kube-system

--- a/cluster/manifests/event-logger/service.yaml
+++ b/cluster/manifests/event-logger/service.yaml
@@ -1,0 +1,12 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: kubernetes-event-logger
+  namespace: kube-system
+  labels:
+    application: kubernetes-event-logger
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    application: kubernetes-event-logger

--- a/cluster/manifests/event-logger/statefulset.yaml
+++ b/cluster/manifests/event-logger/statefulset.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: kubernetes-event-logger
+  namespace: kube-system
+  labels:
+    application: kubernetes-event-logger
+    version: master-2
+  annotations:
+    kubernetes-log-watcher/scalyr-parser: '[{"container": "logger", "parser": "json"}]'
+spec:
+  replicas: {{if eq .Cluster.ConfigItems.kubernetes_event_logger_enabled "true"}}1{{else}}0{{end}}
+  selector:
+    matchLabels:
+      application: kubernetes-event-logger
+  serviceName: kubernetes-event-logger
+  template:
+    metadata:
+      labels:
+        application: kubernetes-event-logger
+        version: master-2
+    spec:
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+      serviceAccountName: kubernetes-event-logger
+      containers:
+      - name: logger
+        image: registry.opensource.zalan.do/teapot/event-logger:master-2
+        args:
+            - --snapshot-namespace=kube-system
+            - --snapshot-name=kubernetes-event-logger
+        resources:
+          limits:
+            memory: 100Mi
+          requests:
+            cpu: 10m
+            memory: 100Mi


### PR DESCRIPTION
This can help during incident investigations. There's a feature flag to disable it in case it logs too much.