### PR TITLE
Drop aws-node-decommissioner AWSIAMRole resource

### DIFF
--- a/cluster/manifests/aws-node-decommissioner/aws-iam-role.yaml
+++ b/cluster/manifests/aws-node-decommissioner/aws-iam-role.yaml
@@ -1,7 +1,0 @@
-apiVersion: zalando.org/v1
-kind: AWSIAMRole
-metadata:
-  name: aws-node-decommissioner-aws-iam-credentials
-  namespace: "kube-system"
-spec:
-  roleReference: {{.LocalID}}-aws-node-decommissioner


### PR DESCRIPTION
It's configured to use the EKS IAM style configuration so the `AWSIAMRole` resource is not needed and didn't work anyway.