### PR TITLE
Add lifecycle-status=ready label to spot.io nodes

### DIFF
--- a/cluster/node-pools/worker-spotio-ocean/stack.yaml
+++ b/cluster/node-pools/worker-spotio-ocean/stack.yaml
@@ -106,6 +106,8 @@ Resources:
         labels:
         - key: "spot.io"
           value: "true"
+        - key: "lifecycle-status"
+          value: "ready"
   {{- range split .NodePool.ConfigItems.labels ","}}
     {{- $label := split . "="}}
         - key: {{index $label 0}}


### PR DESCRIPTION
Adds `lifecycle-status=ready` label to the spot.io configuration to indicate to spot.io autoscaler that new nodes will match pods with this label selector.