### PR TITLE
Use NLB by default for new clusters

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -266,7 +266,7 @@ apiserver_proxy: "true"
 #   promoted:    NLB will be fully functional and ELB will be unhooked
 #   exclusive:   NLB will be fully functional and ELB will be removed
 #
-apiserver_nlb: "hooked"
+apiserver_nlb: "exclusive"
 
 # when set to true, service account tokens can be used from outside the cluster
 # requires apiserver_proxy to be set to "true"

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -91,7 +91,7 @@ pipeline:
           image: "registry.opensource.zalan.do/teapot/kubernetes-on-aws-e2e:#{CDP_BUILD_VERSION}"
           env:
           - name: APISERVER_NLB
-            value: active
+            value: exclusive
           resources:
             limits:
               cpu: 500m

--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -15,7 +15,7 @@ CDP_TARGET_COMMIT_ID="${CDP_TARGET_COMMIT_ID:-"dev"}"
 CDP_HEAD_COMMIT_ID="${CDP_HEAD_COMMIT_ID:-"$(git describe --tags --always)"}"
 
 export CLUSTER_ALIAS="${CLUSTER_ALIAS:-"e2e-test"}"
-export APISERVER_NLB="${APISERVER_NLB:-"hooked"}"
+export APISERVER_NLB="${APISERVER_NLB:-"disabled"}"
 # TODO: we need the date in LOCAL_ID because of CDP retriggering
 export LOCAL_ID="${LOCAL_ID:-$(echo "e2e-$CDP_BUILD_VERSION-$(date +'%H%M%S')-$APISERVER_NLB" | cut -c-28)}"
 export API_SERVER_URL="https://${LOCAL_ID}.${HOSTED_ZONE}"


### PR DESCRIPTION
Enable NLB by default for new clusters and control the rollout via cluster-registry config-items per cluster.

This way we avoid running multiple Load balancers for a longer time in case the rollout gets stuck in some channel.