### PR TITLE
Taint GPU node pool in e2e

### DIFF
--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -109,6 +109,7 @@ clusters:
     config_items:
       availability_zones: "eu-central-1a"
       labels: zalando.org/nvidia-gpu=tesla
+      taints: nvidia.com/gpu=present:NoSchedule
       scaling_priority: "-100"
   provider: zalando-aws
   region: ${REGION}


### PR DESCRIPTION
When not tainted the kube-ingress-aws-controller thinks that it can attach load balancers to this pool. However since it's GPU it doesn't make sense and does not work:

```
UpdateTargetGroupsAndAutoScalingGroups() failed to attach target groups to ASG 'nodepool-worker-gpu-aws-xxxx10-eu-central-1-e2e-pr-3362-1-094448-active-AutoScalingGroup-M0C2L83G1EDX': ValidationError: The specified instance type g2.2xlarge is not supported by Network Load Balancers\n\tstatus code: 400, request id: x"
```