### PR TITLE
Update Prometheus to v2.19.2

### DIFF
--- a/cluster/manifests/prometheus/statefulset.yaml
+++ b/cluster/manifests/prometheus/statefulset.yaml
@@ -5,7 +5,7 @@ metadata:
     pdb-controller.zalando.org/non-ready-ttl: "5m"
   labels:
     application: prometheus
-    version: v2.18.1
+    version: v2.19.2
 {{- if ne .ConfigItems.prometheus_csi_ebs "true" }}
   name: prometheus
 {{- else }}
@@ -23,7 +23,7 @@ spec:
     metadata:
       labels:
         application: prometheus
-        version: v2.18.1
+        version: v2.19.2
       annotations:
         config/hash: {{"configmap.yaml" | manifestHash}}
     spec:
@@ -56,7 +56,7 @@ spec:
           mountPath: /prometheus
       containers:
       - name: prometheus
-        image: registry.opensource.zalan.do/teapot/prometheus:v2.18.1
+        image: registry.opensource.zalan.do/teapot/prometheus:v2.19.2
         args:
         - "--config.file=/prometheus/prometheus.yaml"
         - "--storage.tsdb.path=/prometheus/"


### PR DESCRIPTION
https://github.com/prometheus/prometheus/releases/tag/v2.19.0

Interesting change for us:

```
[FEATURE] TSDB: Memory-map full chunks of Head (in-memory) block from disk. This reduces memory footprint and makes restarts faster. #6679
```