### PR TITLE
1.7.0 removed a deprecated and already ignored option

### DIFF
--- a/cluster/manifests/coredns-local/configmap-local.yaml
+++ b/cluster/manifests/coredns-local/configmap-local.yaml
@@ -44,7 +44,6 @@ data:
         errors
         kubernetes {
             pods insecure
-            upstream
         }
         cache 30
 {{ if eq .ConfigItems.coredns_log_svc_names "true"}}


### PR DESCRIPTION
https://coredns.io/2020/06/15/coredns-1.7.0-release/ removed a deprecated and already ignored option in kubernetes plugin "upstream"
this blocks https://github.com/zalando-incubator/kubernetes-on-aws/pull/3363


Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>