### PR TITLE
Disable kube-downscaler in production clusters by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -137,9 +137,15 @@ kube_state_metrics_mem_max: "1Gi"
 {{if eq .Environment "test"}}
 downscaler_default_uptime: "Mon-Fri 07:30-20:30 Europe/Berlin"
 downscaler_default_downtime: "never"
+downscaler_enabled: "true"
+{{else if eq .Environment "e2e"}}
+downscaler_default_uptime: "always"
+downscaler_default_downtime: "never"
+downscaler_enabled: "true"
 {{else}}
 downscaler_default_uptime: "always"
 downscaler_default_downtime: "never"
+downscaler_enabled: "false"
 {{end}}
 
 # HPA settings (defaults from https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/)

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -124,3 +124,18 @@ post_apply:
 - name: kube-dns-metrics
   namespace: kube-system
   kind: Deployment
+{{ if ne .ConfigItems.downscaler_enabled "true" }}
+- name: kube-downscaler
+  namespace: kube-system
+  kind: Deployment
+- name: kube-downscaler
+  namespace: kube-system
+  kind: ServiceAccount
+- name: kube-downscaler
+  kind: ClusterRole
+- name: kube-downscaler
+  kind: ClusterRoleBinding
+- name: kube-downscaler
+  namespace: kube-system
+  kind: VerticalPodAutoscaler
+{{ end }}

--- a/cluster/manifests/kube-downscaler/deployment.yaml
+++ b/cluster/manifests/kube-downscaler/deployment.yaml
@@ -1,3 +1,4 @@
+{{ if eq .Cluster.ConfigItems.downscaler_enabled "true" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -46,3 +47,4 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 1000
+{{ end }}

--- a/cluster/manifests/kube-downscaler/rbac.yaml
+++ b/cluster/manifests/kube-downscaler/rbac.yaml
@@ -1,3 +1,4 @@
+{{ if eq .Cluster.ConfigItems.downscaler_enabled "true" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -62,3 +63,4 @@ subjects:
 - kind: ServiceAccount
   name: kube-downscaler
   namespace: kube-system
+{{ end }}

--- a/cluster/manifests/kube-downscaler/vpa.yaml
+++ b/cluster/manifests/kube-downscaler/vpa.yaml
@@ -1,3 +1,4 @@
+{{ if eq .Cluster.ConfigItems.downscaler_enabled "true" }}
 apiVersion: autoscaling.k8s.io/v1beta2
 kind: VerticalPodAutoscaler
 metadata:
@@ -18,3 +19,4 @@ spec:
       maxAllowed:
         cpu: 500m
         memory: 2Gi
+{{ end }}


### PR DESCRIPTION
There's no clear ownership of it so we've decided to disable it in production clusters. Some clusters will have it grandfathered in, though, so adding a config item for it. 