### PR TITLE
admission-controller: drop the arguments migrated to dynamic config

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -238,8 +238,6 @@ write_files:
             - --tls-cert-file=/etc/kubernetes/ssl/admission-controller.pem
             - --tls-key-file=/etc/kubernetes/ssl/admission-controller-key.pem
 {{- if eq .Cluster.ConfigItems.teapot_admission_controller_validate_application_label "true" }}
-            - --validate-application-label
-            - --validate-application-label-min-creation-time={{ .Cluster.ConfigItems.teapot_admission_controller_application_min_creation_time }}
             - --application-registry-url=http://127.0.0.1:8285/
 {{- end }}
           ports:


### PR DESCRIPTION
I forgot to remove them in #3369. :(