### PR TITLE
Make stackset-controller use networking API

### DIFF
--- a/cluster/manifests/stackset-controller/deployment.yaml
+++ b/cluster/manifests/stackset-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: stackset-controller
-    version: "v1.2.0"
+    version: "v1.2.1"
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: stackset-controller
-        version: "v1.2.0"
+        version: "v1.2.1"
     spec:
 {{- if eq .Cluster.ConfigItems.system_pods_critical "true" }}
       priorityClassName: system-cluster-critical
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: stackset-controller
       containers:
       - name: stackset-controller
-        image: "registry.opensource.zalan.do/teapot/stackset-controller:v1.2.0"
+        image: "registry.opensource.zalan.do/teapot/stackset-controller:v1.2.1"
         args:
         - "--interval={{ .Cluster.ConfigItems.stackset_controller_sync_interval }}"
         - "--migrate-to=stackset"

--- a/cluster/manifests/stackset-controller/deployment.yaml
+++ b/cluster/manifests/stackset-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: stackset-controller
-    version: "v1.1.31"
+    version: "v1.2.0"
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: stackset-controller
-        version: "v1.1.31"
+        version: "v1.2.0"
     spec:
 {{- if eq .Cluster.ConfigItems.system_pods_critical "true" }}
       priorityClassName: system-cluster-critical
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: stackset-controller
       containers:
       - name: stackset-controller
-        image: "registry.opensource.zalan.do/teapot/stackset-controller:v1.1.31"
+        image: "registry.opensource.zalan.do/teapot/stackset-controller:v1.2.0"
         args:
         - "--interval={{ .Cluster.ConfigItems.stackset_controller_sync_interval }}"
         - "--migrate-to=stackset"

--- a/cluster/manifests/stackset-controller/rbac.yaml
+++ b/cluster/manifests/stackset-controller/rbac.yaml
@@ -37,7 +37,7 @@ rules:
   - patch
   - delete
 - apiGroups:
-  - "extensions"
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:


### PR DESCRIPTION
Updates the stackset-controller to a version that uses `networking.k8s.io/v1beta1` instead of `extensions/v1beta1` for interaction with the Ingress API.