### PR TITLE
spotio: Configure on-demand ratio per pool

### DIFF
--- a/cluster/node-pools/worker-spotio-ocean/stack.yaml
+++ b/cluster/node-pools/worker-spotio-ocean/stack.yaml
@@ -53,9 +53,9 @@ Resources:
           maximum: {{ .NodePool.MaxSize }}
           target: 0 # default target (should just be zero)
         strategy:
-          spotPercentage: {{ .Cluster.ConfigItems.spotio_ocean_spot_percentage }}
-          fallbackToOd: {{ .Cluster.ConfigItems.spotio_ocean_fallback_to_ondemand }}
-          utilizeReservedInstances: {{ .Cluster.ConfigItems.spotio_ocean_utilize_reserved_instances }}
+          spotPercentage: {{ .NodePool.ConfigItems.spotio_ocean_spot_percentage }}
+          fallbackToOd: {{ .NodePool.ConfigItems.spotio_ocean_fallback_to_ondemand }}
+          utilizeReservedInstances: {{ .NodePool.ConfigItems.spotio_ocean_utilize_reserved_instances }}
         compute:
           subnetIds:
           {{ with $values := .Values }}


### PR DESCRIPTION
Allow configuring on-demand ratio etc. per node pool instead of globally for the cluster.