### PR TITLE
spotinst controller image from Pierone

### DIFF
--- a/cluster/manifests/spotio-controller/deployment.yaml
+++ b/cluster/manifests/spotio-controller/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       #   node.kubernetes.io/role: master
       containers:
       - name: controller
-        image: spotinst/kubernetes-cluster-controller:1.0.61 # TODO: setup pipeline
+        image: pierone.stups.zalan.do/teapot/spotinst-kubernetes-cluster-controller:1.0.61
         env:
         - name: SPOTINST_TOKEN
           valueFrom:


### PR DESCRIPTION
Use spotinst controller image from Pierone so the controller can run in production clusters.