### PR TITLE
Fix RouteGroup CRD schema validation

### DIFF
--- a/cluster/manifests/skipper/crd.yaml
+++ b/cluster/manifests/skipper/crd.yaml
@@ -29,11 +29,13 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
           required:
           - backends
           - routes
+          type: object
           properties:
             hosts:
               type: array
@@ -43,6 +45,7 @@ spec:
               type: array
               minLength: 1
               items:
+                type: object
                 required:
                 - type
                 - name
@@ -78,6 +81,7 @@ spec:
             defaultBackends:
               type: array
               items:
+                type: object
                 properties:
                   backendName:
                     type: string
@@ -88,6 +92,7 @@ spec:
               type: array
               minLength: 1
               items:
+                type: object
                 properties:
                   path:
                     type: string
@@ -98,6 +103,7 @@ spec:
                   backends:
                     type: array
                     items:
+                      type: object
                       properties:
                         backendName:
                           type: string


### PR DESCRIPTION
Fixes the routegroup schema validation so it will correct be applied.

Before it failed silently with this status on the CRD:

```
  - lastTransitionTime: "2020-02-03T14:25:24Z"
    message: '[spec.validation.openAPIV3Schema.properties[spec].properties[backends].items.type:
      Required value: must not be empty for specified array items, spec.validation.openAPIV3Schema.properties[spec].properties[defaultBackends].items.type:
      Required value: must not be empty for specified array items, spec.validation.openAPIV3Schema.properties[spec].properties[routes].items.properties[backends].items.type:
      Required value: must not be empty for specified array items, spec.validation.openAPIV3Schema.properties[spec].properties[routes].items.type:
      Required value: must not be empty for specified array items, spec.validation.openAPIV3Schema.properties[spec].type:
      Required value: must not be empty for specified object fields, spec.validation.openAPIV3Schema.type:
      Required value: must not be empty at the root]'
    reason: Violations
    status: "True"
    type: NonStructuralSchema
```

An invalid RouteGroups were not blocked. Now it correctly blocks for the know cases:

```
kubectl apply -f test_rg.yaml 
The RouteGroup "mlarsen-rg-test" is invalid: spec.routes.backends: Invalid value: "string": spec.routes.backends in body must be of type object: "string"
```