### PR TITLE
Autoscaling buffers: just use the static sizes

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1,10 +1,7 @@
 # Autoscaling settings
 autoscaling_scale_down_enabled: "true"
-autoscaling_buffer_pools: "default-worker"
-autoscaling_buffer_cpu_scale: "1"
-autoscaling_buffer_memory_scale: "0.85"
-autoscaling_buffer_cpu_reserved: "1250m"
-autoscaling_buffer_memory_reserved: "3Gi"
+autoscaling_buffer_cpu: "2"
+autoscaling_buffer_memory: "10Gi"
 autoscaling_buffer_pods: "0"
 cluster_autoscaler_cpu: "100m"
 cluster_autoscaler_memory: "300Mi"

--- a/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment.yaml
@@ -34,14 +34,12 @@ spec:
       - name: pause
         image: registry.opensource.zalan.do/teapot/pause-amd64:3.1
         resources:
-{{ with $resources := autoscalingBufferSettings $data.Cluster }}
           limits:
-            cpu: {{$resources.CPU}}
-            memory: {{$resources.Memory}}
+            cpu: {{$data.ConfigItems.autoscaling_buffer_cpu}}
+            memory: {{$data.ConfigItems.autoscaling_buffer_memory}}
           requests:
-            cpu: {{$resources.CPU}}
-            memory: {{$resources.Memory}}
-{{ end }}
+            cpu: {{$data.ConfigItems.autoscaling_buffer_cpu}}
+            memory: {{$data.ConfigItems.autoscaling_buffer_memory}}
 ---
 {{ end }}
 {{ end }}


### PR DESCRIPTION
The automagical sizing function needs too many tweaks in our current setup, and we don't even use the buffer pods a lot. Let's just replace the sizes with static ones.