### PR TITLE
HPA: make downscale stabilization configurable

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -150,6 +150,7 @@ horizontal_pod_autoscaler_downscale_delay: "5m0s"
 horizontal_pod_autoscaler_sync_period: "30s"
 horizontal_pod_autoscaler_tolerance: "0.1"
 horizontal_pod_autoscaler_upscale_delay: "3m0s"
+horizontal_pod_downscale_stabilization: "5m0s"
 
 # Cluster update settings
 {{if eq .Environment "production"}}

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -553,6 +553,7 @@ write_files:
           - --horizontal-pod-autoscaler-sync-period={{ .Cluster.ConfigItems.horizontal_pod_autoscaler_sync_period }}
           - --horizontal-pod-autoscaler-tolerance={{ .Cluster.ConfigItems.horizontal_pod_autoscaler_tolerance }}
           - --horizontal-pod-autoscaler-upscale-delay={{ .Cluster.ConfigItems.horizontal_pod_autoscaler_upscale_delay }}
+          - --horizontal-pod-autoscaler-downscale-stabilization={{ .Cluster.ConfigItems.horizontal_pod_downscale_stabilization }}
           {{ if eq .Cluster.ConfigItems.enable_endpointslice "true" }}
           - --controllers=endpointslice
           {{ end }}


### PR DESCRIPTION
This could be useful in a couple of clusters, and until 1.18 we can't customize it per-HPA.