### PR TITLE
fix: initcontainer cp -a not permitted

### DIFF
--- a/cluster/manifests/prometheus/statefulset.yaml
+++ b/cluster/manifests/prometheus/statefulset.yaml
@@ -39,7 +39,7 @@ spec:
         - /bin/sh
         args:
         - -c
-        - sed s/'@@POD_NAME@@'/${POD_NAME}/g /etc/prometheus/prometheus.yml > /prometheus/prometheus.yaml ; cp -a /etc/prometheus/prometheus.rules.yml /prometheus/prometheus.rules.yaml
+        - sed s/'@@POD_NAME@@'/${POD_NAME}/g /etc/prometheus/prometheus.yml > /prometheus/prometheus.yaml ; cp /etc/prometheus/prometheus.rules.yml /prometheus/prometheus.rules.yaml
         env:
         - name: POD_NAME
           valueFrom:


### PR DESCRIPTION
fix: cp: can't preserve ownership of '/prometheus/prometheus.rules.yaml': Operation not permitted

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>