### PR TITLE
Instruct renovate to also bump the version label

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,9 +2,15 @@
   "gomod": {
     "enabled": false
   },
-  "kubernetes": {
-    "fileMatch": ["cluster/manifests/.+\\.yaml$"]
-  },
+  "regexManagers": [
+    {
+      "fileMatch": ["cluster/manifests/.+\\.yaml$"],
+      "matchStrings": [
+        "version: [\"]?(?<currentValue>.*?)[\"]?\n(?s).*image: [\"]?(?<depName>.*?):.*?[\"]?\n"
+      ],
+      "datasourceTemplate": "docker"
+    }
+  ],
   "schedule": [
     "before 3am on Monday"
   ]


### PR DESCRIPTION
Uses the regexp manager to also bump the version label acordingly.

Tested in another project but here it's trial and error. Needs to be merged to master to see effects.