### PR TITLE
cdp-controller-rbac: Add permissions for Flagger's metrictemplates

### DIFF
--- a/cluster/manifests/roles/cdp-controller-rbac.yaml
+++ b/cluster/manifests/roles/cdp-controller-rbac.yaml
@@ -93,6 +93,7 @@ rules:
   - "flagger.app"
   resources:
   - canaries
+  - metrictemplates
   verbs:
   - create
   - get


### PR DESCRIPTION
Follow up from https://github.com/zalando-incubator/kubernetes-on-aws/pull/3338

As part of the Gradual Deployments Experiment project we need CDP Controller to manage Flagger's metrictemplates resources as well, for the LightStep integration: [documentation](https://docs.flagger.app/usage/metrics#custom-metrics).