### PR TITLE
Fix StackSet/Stack validation for unknown fields

### DIFF
--- a/cluster/manifests/stackset-controller/01-stack-crd.yaml
+++ b/cluster/manifests/stackset-controller/01-stack-crd.yaml
@@ -12,6 +12,7 @@ spec:
     plural: stacks
     categories:
     - all
+  preserveUnknownFields: false
   additionalPrinterColumns:
   - name: Desired
     type: integer

--- a/cluster/manifests/stackset-controller/01-stackset-crd.yaml
+++ b/cluster/manifests/stackset-controller/01-stackset-crd.yaml
@@ -12,6 +12,7 @@ spec:
     plural: stacksets
     categories:
     - all
+  preserveUnknownFields: false
   additionalPrinterColumns:
   - name: Stacks
     type: integer


### PR DESCRIPTION
This fixes the validation of unknown fields such that the most common error by our users is detected!!

The common error is that the indentation is wrong like in this example:

```yaml
apiVersion: zalando.org/v1
kind: StackSet
metadata:
  ...
spec:
  ...
  template:
    spec:
      containers:
      - name: x
      env: # <- this is not correctly indented under the container
      -  name: X
         value: Y
```

Here the wrongly placed `env` would be silently ignored and the users would not understand why it wasn't applied to their containers.

By using `preserveUnknownFields: false` this now becomes an error like this:

```
Invalid value: "The edited file failed validation": ValidationError(StackSet.spec.stackTemplate.spec.podTemplate.spec): unknown field "env" in org.zalando.v1.StackSet.spec.stackTemplate.spec.podTemplate.spec
```

This was introduced with the GA (v1) of CRDs and since we're still on `v1beta1` for StackSet/Stack AND because it defaults to `preserveUnknownFields: true` for `v1beta` CRDs, this was always broken in our setup.

Note: I tried to migrate the CRD to v1, but because of the giant validation schema I think kubectl can't figure out how to create the right patch so it just gets stuck forever on my machine. I think we need to manually drop the schema, update to v1 and add the schema back for it to work. But this can be done later, main thing is to fix the validation