### PR TITLE
Drop nginx ReadOnly proxy from apiserver

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -138,10 +138,6 @@ Resources:
           IpProtocol: tcp
           ToPort: 22
         - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 8082
-          IpProtocol: tcp
-          ToPort: 8082
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
           FromPort: 8085
           IpProtocol: tcp
           ToPort: 8085

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -389,21 +389,6 @@ write_files:
             preStop:
               exec:
                 command: ["/bin/sh", "-c",  " sleep 60"]
-        - name: nginx
-          image: registry.opensource.zalan.do/teapot/nginx:1.12.1
-          ports:
-          - containerPort: 8082
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c",  " sleep 60"]
-          resources:
-            requests:
-              cpu: 5m
-              memory: 50Mi
-          volumeMounts:
-          - name: config-volume
-            mountPath: /etc/nginx
         - name: skipper-proxy
           image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.90
           args:
@@ -500,9 +485,6 @@ write_files:
         - hostPath:
             path: /etc/kubernetes/config
           name: kubernetes-configs
-        - hostPath:
-            path: /etc/kubernetes/nginx
-          name: config-volume
         {{- if or (eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true") (eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam_userdata "true") }}
         - hostPath:
             path: /var/www/openid-configuration


### PR DESCRIPTION
We no longer have any zmon checks depending on the nginx ReadOnly proxy. Now all access to the api server is handled via RBAC roles for ZMON.

Therefore we can get rid of the nginx container and the ports that were opened for it!