### PR TITLE
Make it possible to disable stackset validation

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -368,3 +368,6 @@ spotio_ocean_controller_memory: "512Mi"
 
 # Log Kubernetes events to Scalyr
 kubernetes_event_logger_enabled: "true"
+
+# enable/disable stackset validation (preserveUnknownFields)
+stackset_validation_enabled: "true"

--- a/cluster/manifests/stackset-controller/01-stack-crd.yaml
+++ b/cluster/manifests/stackset-controller/01-stack-crd.yaml
@@ -12,7 +12,7 @@ spec:
     plural: stacks
     categories:
     - all
-  preserveUnknownFields: false
+  preserveUnknownFields: {{ if eq .Cluster.ConfigItems.stackset_validation_enabled "true" }}false{{ else }}true{{ end }}
   additionalPrinterColumns:
   - name: Desired
     type: integer

--- a/cluster/manifests/stackset-controller/01-stackset-crd.yaml
+++ b/cluster/manifests/stackset-controller/01-stackset-crd.yaml
@@ -12,7 +12,7 @@ spec:
     plural: stacksets
     categories:
     - all
-  preserveUnknownFields: false
+  preserveUnknownFields: {{ if eq .Cluster.ConfigItems.stackset_validation_enabled "true" }}false{{ else }}true{{ end }}
   additionalPrinterColumns:
   - name: Stacks
     type: integer


### PR DESCRIPTION
This is causing more problems than expected for some users, so make it possible to disable per cluster.