### PR TITLE
set minimum memory for metrics components

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -129,6 +129,10 @@ kube_aws_iam_controller_mem_max: "1Gi"
 kube_state_metrics_cpu: "100m"
 kube_state_metrics_mem: "200Mi"
 kube_state_metrics_mem_max: "1Gi"
+kube_state_metrics_mem_min: "120Mi"
+
+kubernetes_lifecycle_metrics_mem_max: "1Gi"
+kubernetes_lifecycle_metrics_mem_min: "120Mi"
 
 # Kubernetes Downscaler (for non-production clusters)
 {{if eq .Environment "test"}}

--- a/cluster/manifests/kube-state-metrics/vpa.yaml
+++ b/cluster/manifests/kube-state-metrics/vpa.yaml
@@ -17,3 +17,5 @@ spec:
     - containerName: kube-state-metrics
       maxAllowed:
         memory: {{.ConfigItems.kube_state_metrics_mem_max}}
+      minAllowed:
+        memory: {{.ConfigItems.kube_state_metrics_mem_min}}

--- a/cluster/manifests/kubernetes-lifecycle-metrics/vpa.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/vpa.yaml
@@ -16,4 +16,6 @@ spec:
     containerPolicies:
     - containerName: kubernetes-lifecycle-metrics
       maxAllowed:
-        memory: 1Gi
+        memory: {{.ConfigItems.kubernetes_lifecycle_metrics_mem_max}}
+      minAllowed:
+        memory: {{.ConfigItems.kubernetes_lifecycle_metrics_mem_min}}


### PR DESCRIPTION
setting minimum memory for the referenced components, as the VPA cannot follow the requirements during starting them up and causing crash loops

Signed-off-by: Arpad Ryszka <arpad.ryszka@gmail.com>