### PR TITLE
Update aws-node-decommissioner to use correct apiserver url

### DIFF
--- a/cluster/manifests/aws-node-decommissioner/cronjob.yaml
+++ b/cluster/manifests/aws-node-decommissioner/cronjob.yaml
@@ -25,7 +25,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: aws-node-decommissioner
-            image: registry.opensource.zalan.do/teapot/aws-node-decommissioner:master-75e9979d
+            image: registry.opensource.zalan.do/teapot/aws-node-decommissioner:master-a0e6fd3d
             args:
               - --debug
             resources:


### PR DESCRIPTION
```
time="2020-07-28T09:35:09Z" level=debug msg="Requesting nodes from http://localhost:8001"
time="2020-07-28T09:35:09Z" level=fatal msg="error: Get \"http://localhost:8001/api/v1/nodes\": dial tcp 127.0.0.1:8001: connect: connection refused"
````

Fixed in https://gitlab.com/gargravarr/aws-node-decommissioner/-/merge_requests/7