### PR TITLE
Default stackset_validation_enabled to false

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -376,4 +376,4 @@ spotio_ocean_controller_memory: "512Mi"
 kubernetes_event_logger_enabled: "true"
 
 # enable/disable stackset validation (preserveUnknownFields)
-stackset_validation_enabled: "true"
+stackset_validation_enabled: "false"


### PR DESCRIPTION
It cannot work in its current form, because we don't define a schema for the status field. Disable by default until we have that.