### PR TITLE
Revert "Update registry.opensource.zalan.do/teapot/external-dns Docker tag to v0.7.2"

### DIFF
--- a/cluster/manifests/external-dns/01-rbac.yaml
+++ b/cluster/manifests/external-dns/01-rbac.yaml
@@ -20,7 +20,7 @@ metadata:
     application: external-dns
 rules:
 - apiGroups: [""]
-  resources: ["services", "endpoints", "pods", "nodes"]
+  resources: ["services"]
   verbs: ["list"]
 - apiGroups: ["extensions"]
   resources: ["ingresses"]

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: external-dns
-    version: v0.7.2
+    version: v0.7.1
 spec:
   strategy:
     type: Recreate
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: external-dns
-        version: v0.7.2
+        version: v0.7.1
 {{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "false"}}
       annotations:
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.7.2
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.7.1
         args:
         - --source=service
         - --source=ingress


### PR DESCRIPTION
Reverts zalando-incubator/kubernetes-on-aws#3468