### PR TITLE
Add a temporary config item for pinning Skipper to an old version

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -87,6 +87,9 @@ opendid_provider_cfg_url: "https://sandbox.identity.zalando.com/.well-known/open
 openid_issuer: "https://sandbox.identity.zalando.com"
 {{end}}
 
+# temporary config item for one of the clusters
+hack_skipper_pin_0_11_115: "false"
+
 # Image Policy Webhook
 {{if eq .Environment "production"}}
 image_policy: "trusted"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.11.137
+    version: {{if eq .Cluster.ConfigItems.hack_skipper_pin_0_11_115 "true"}}v0.11.115{{else}}v0.11.137{{end}}
     component: ingress
 spec:
   strategy:
@@ -19,7 +19,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.11.137
+        version: {{if eq .Cluster.ConfigItems.hack_skipper_pin_0_11_115 "true"}}v0.11.115{{else}}v0.11.137{{end}}
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -44,7 +44,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.137
+        image: registry.opensource.zalan.do/pathfinder/skipper:{{if eq .Cluster.ConfigItems.hack_skipper_pin_0_11_115 "true"}}v0.11.115{{else}}v0.11.137{{end}}
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -103,13 +103,13 @@ spec:
             tag=application=skipper-ingress
             tag=account={{ .Cluster.Alias }}
             tag=cluster={{ .Cluster.Alias }}
-            tag=artifact=registry.opensource.zalan.do/pathfinder/skipper:v0.11.137
+            tag=artifact=registry.opensource.zalan.do/pathfinder/skipper:{{if eq .Cluster.ConfigItems.hack_skipper_pin_0_11_115 "true"}}v0.11.115{{else}}v0.11.137{{end}}
             grpc-max-msg-size={{ .ConfigItems.skipper_ingress_lightstep_grpc_max_msg_size }}
             max-period={{ .ConfigItems.skipper_ingress_lightstep_max_period }}
             min-period={{ .ConfigItems.skipper_ingress_lightstep_min_period }}
             {{ .Cluster.ConfigItems.skipper_ingress_lightstep_log_events }}
           - "-opentracing-excluded-proxy-tags={{ .ConfigItems.skipper_ingress_opentracing_excluded_proxy_tags }}"
-{{ if eq .ConfigItems.skipper_ingress_opentracing_backend_name_tag "true" }}
+{{ if and (eq .ConfigItems.skipper_ingress_opentracing_backend_name_tag "true") (ne .Cluster.ConfigItems.hack_skipper_pin_0_11_115 "true") }}
           - "-opentracing-backend-name-tag"
 {{ end }}
           - "-expect-continue-timeout-backend={{ .ConfigItems.skipper_expect_continue_timeout_backend }}"

--- a/cluster/node-pools/worker-default/userdata.yaml
+++ b/cluster/node-pools/worker-default/userdata.yaml
@@ -1,4 +1,7 @@
 #cloud-config
+mounts:
+  - [ephemeral0]
+  - [swap]
 
 write_files:
   - owner: root:root


### PR DESCRIPTION
This allows us to at least unblock cluster updates until the corresponding issue is resolved.