### PR TITLE
cloud-init: disable the default ephemeral0 mount

### DIFF
--- a/cluster/node-pools/worker-default/userdata.yaml
+++ b/cluster/node-pools/worker-default/userdata.yaml
@@ -1,4 +1,7 @@
 #cloud-config
+mounts:
+  - [ephemeral0]
+  - [swap]
 
 write_files:
   - owner: root:root


### PR DESCRIPTION
Docs [here](https://cloudinit.readthedocs.io/en/latest/topics/examples.html#adjust-mount-points-mounted). No idea how this even worked before.