### PR TITLE
ExternalDNS: allow to configure excluded domains

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -297,6 +297,8 @@ custom_dns_zone_nameservers: "" # space seperated list of nameserver IP addresse
 
 # prefix prepended to ownership TXT records for external-dns
 external_dns_ownership_prefix: ""
+# domains that should be ignored by ExternalDNS
+external_dns_excluded_domains: cluster.local
 
 # DNS container resources
 dns_dnsmasq_cpu: "100m"

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -39,7 +39,9 @@ spec:
         - --source=service
         - --source=ingress
         - --source=skipper-routegroup
-        - --exclude-domains=cluster.local
+{{- range split .ConfigItems.external_dns_excluded_domains "," }}
+        - --exclude-domains={{ . }}
+{{- end }}
         - --provider=aws
         - --registry=txt
         - --txt-owner-id={{ .Region }}:{{ .LocalID }}


### PR DESCRIPTION
Can be used to excluded more than just **cluster.local** via:

`external_dns_excluded_domains: cluster.local,myotherdomain.com`

Defaults to **cluster.local**.