### PR TITLE
Update Skipper openid configuration

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -79,11 +79,11 @@ skipper_ingress_tokeninfo_cpu: "1000m"
 skipper_ingress_tokeninfo_memory: "512Mi"
 {{if eq .Environment "production"}}
 tokeninfo_url: "https://info.services.auth.zalando.com/oauth2/tokeninfo"
-opendid_provider_cfg_url: "https://planb-provider.greendale-questionmark.zalan.do/.well-known/openid-configuration"
+openid_provider_cfg_url: "https://planb-provider.greendale-questionmark.zalan.do/.well-known/openid-configuration"
 openid_issuer: "https://identity.zalando.com"
 {{else}}
 tokeninfo_url: "https://sandbox-tokeninfo-bridge.stups.zalan.do/oauth2/tokeninfo"
-opendid_provider_cfg_url: "https://sandbox.identity.zalando.com/.well-known/openid-configuration"
+openid_provider_cfg_url: "https://sandbox.identity.zalando.com/.well-known/openid-configuration"
 openid_issuer: "https://sandbox.identity.zalando.com"
 {{end}}
 

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -79,7 +79,7 @@ skipper_ingress_tokeninfo_cpu: "1000m"
 skipper_ingress_tokeninfo_memory: "512Mi"
 {{if eq .Environment "production"}}
 tokeninfo_url: "https://info.services.auth.zalando.com/oauth2/tokeninfo"
-openid_provider_cfg_url: "https://planb-provider.greendale-questionmark.zalan.do/.well-known/openid-configuration"
+openid_provider_cfg_url: "https://identity.zalando.com/.well-known/openid-configuration"
 openid_issuer: "https://identity.zalando.com"
 {{else}}
 tokeninfo_url: "https://sandbox-tokeninfo-bridge.stups.zalan.do/oauth2/tokeninfo"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -185,7 +185,7 @@ spec:
         - name: BUSINESS_PARTNERS
           value: 810d1d00-4312-43e5-bd31-d8373fdd24c7=com.zalando zalando-legacy=legacy
         - name: OPENID_PROVIDER_CONFIGURATION_URL
-          value: "{{ .ConfigItems.opendid_provider_cfg_url }}"
+          value: "{{ .ConfigItems.openid_provider_cfg_url }}"
         - name: ISSUER
           value: "{{ .ConfigItems.openid_issuer }}"
         - name: ENABLE_OPENTRACING


### PR DESCRIPTION
We're still using an old URL for PF IAM in production, update to use the new one.