### PR TITLE
Disable cluster downscaling during e2e

### DIFF
--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 set -x
 
+autoscaling_scale_down_enabled="${3:-"false"}"
+
 cat <<EOF
 clusters:
 - alias: ${CLUSTER_ALIAS}
@@ -57,6 +59,7 @@ clusters:
     vm_dirty_background_bytes: 67108864
     prometheus_tsdb_retention_size: enabled
     coredns_max_upsteam_concurrency: 30
+    autoscaling_scale_down_enabled: "${autoscaling_scale_down_enabled}"
   criticality_level: 1
   environment: e2e
   id: ${CLUSTER_ID}


### PR DESCRIPTION
Our e2e tests are quite unstable and one big reason is how the e2e test framework [checks for nodes ready after each test has run](https://github.com/kubernetes/kubernetes/blob/9f2892aab98fe339f3bd70e3c470144299398ace/test/e2e/framework/framework.go#L475).
The intention is that a test should not make a node unready, but in our setup this is not ideal because 
 nodes can go unready e.g. when they're being scaled down.

As a hack we can disable downscaling of the cluster during the e2e run and enable it again after (in case the e2e fail and we want to keep the cluster running but scaled down as much as possible).