### PR TITLE
Rebuild kube-node-ready with Go 1.15

### DIFF
--- a/cluster/manifests/kube-node-ready/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready/daemonset.yaml
@@ -1,4 +1,4 @@
-{{ $version := "v0.0.4" }}
+{{ $version := "v0.0.4-1" }}
 
 apiVersion: apps/v1
 kind: DaemonSet


### PR DESCRIPTION
We had to rebuild kube-node-ready with a newer go version to fix this bug: https://github.com/golang/go/issues/37436