### PR TITLE
Update Emergency Access Service to Go 1.15

### DIFF
--- a/cluster/manifests/emergency-access-service/deployment.yaml
+++ b/cluster/manifests/emergency-access-service/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     application: emergency-access-service
-    version: master-73
+    version: master-74
 spec:
   replicas: 1
   selector:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: emergency-access-service
-        version: master-73
+        version: master-74
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
           [{"container": "emergency-access-service", "parser": "json-structured-log"}]
@@ -50,7 +50,7 @@ spec:
             cpu: 25m
             memory: 25Mi
       - name: emergency-access-service
-        image: "pierone.stups.zalan.do/teapot/emergency-access-service:master-73"
+        image: "pierone.stups.zalan.do/teapot/emergency-access-service:master-74"
         args:
         - --insecure-http
         - --community={{ .Owner }}


### PR DESCRIPTION
We had to rebuild with a newer go version to fix this bug: https://github.com/golang/go/issues/37436

Similar to: https://github.com/zalando-incubator/kubernetes-on-aws/pull/3512