### PR TITLE
Update APIServer skipper

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -392,7 +392,7 @@ write_files:
               exec:
                 command: ["/bin/sh", "-c",  " sleep 60"]
         - name: skipper-proxy
-          image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.90
+          image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.141
           args:
           - skipper
           - -access-log-strip-query

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -392,7 +392,7 @@ write_files:
               exec:
                 command: ["/bin/sh", "-c",  " sleep 60"]
         - name: skipper-proxy
-          image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.141
+          image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.117
           args:
           - skipper
           - -access-log-strip-query


### PR DESCRIPTION
Main motivation for updating is to run a version NOT build with Go 1.14 to avoid this issue: https://github.com/golang/go/issues/37436

Similar to #3512 and #3513