### PR TITLE
[hotfix beta] Rebuild kube-node-ready with Go 1.15

### DIFF
--- a/cluster/manifests/kube-node-ready/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready/daemonset.yaml
@@ -1,4 +1,4 @@
-{{ $version := "v0.0.4" }}
+{{ $version := "v0.0.4-1" }}
 
 apiVersion: apps/v1
 kind: DaemonSet


### PR DESCRIPTION
Part of Kubernetes v1.18, but it's required to be rolled out before the Kubernetes v1.18 update.