### PR TITLE
Update StackSet controller: Scaling behavior

### DIFF
--- a/cluster/manifests/stackset-controller/01-stack-crd.yaml
+++ b/cluster/manifests/stackset-controller/01-stack-crd.yaml
@@ -74,6 +74,121 @@ spec:
             autoscaler:
               description: Autoscaler is the autoscaling definition for a stack
               properties:
+                behavior:
+                  description: behavior configures the scaling behavior of the target
+                    in both Up and Down directions (scaleUp and scaleDown fields respectively).
+                    If not set, the default HPAScalingRules for scale up and scale
+                    down are used.
+                  properties:
+                    scaleDown:
+                      description: scaleDown is scaling policy for scaling Down. If
+                        not set, the default value is to allow to scale down to minReplicas
+                        pods, with a 300 second stabilization window (i.e., the highest
+                        recommendation for the last 300sec is used).
+                      properties:
+                        policies:
+                          description: policies is a list of potential scaling polices
+                            which can be used during scaling. At least one policy
+                            must be specified, otherwise the HPAScalingRules will
+                            be discarded as invalid
+                          items:
+                            description: HPAScalingPolicy is a single policy which
+                              must hold true for a specified past interval.
+                            properties:
+                              periodSeconds:
+                                description: PeriodSeconds specifies the window of
+                                  time for which the policy should hold true. PeriodSeconds
+                                  must be greater than zero and less than or equal
+                                  to 1800 (30 min).
+                                format: int32
+                                type: integer
+                              type:
+                                description: Type is used to specify the scaling policy.
+                                type: string
+                              value:
+                                description: Value contains the amount of change which
+                                  is permitted by the policy. It must be greater than
+                                  zero
+                                format: int32
+                                type: integer
+                            required:
+                            - periodSeconds
+                            - type
+                            - value
+                            type: object
+                          type: array
+                        selectPolicy:
+                          description: selectPolicy is used to specify which policy
+                            should be used. If not set, the default value MaxPolicySelect
+                            is used.
+                          type: string
+                        stabilizationWindowSeconds:
+                          description: 'StabilizationWindowSeconds is the number of
+                            seconds for which past recommendations should be considered
+                            while scaling up or scaling down. StabilizationWindowSeconds
+                            must be greater than or equal to zero and less than or
+                            equal to 3600 (one hour). If not set, use the default
+                            values: - For scale up: 0 (i.e. no stabilization is done).
+                            - For scale down: 300 (i.e. the stabilization window is
+                            300 seconds long).'
+                          format: int32
+                          type: integer
+                      type: object
+                    scaleUp:
+                      description: 'scaleUp is scaling policy for scaling Up. If not
+                        set, the default value is the higher of:   * increase no more
+                        than 4 pods per 60 seconds   * double the number of pods per
+                        60 seconds No stabilization is used.'
+                      properties:
+                        policies:
+                          description: policies is a list of potential scaling polices
+                            which can be used during scaling. At least one policy
+                            must be specified, otherwise the HPAScalingRules will
+                            be discarded as invalid
+                          items:
+                            description: HPAScalingPolicy is a single policy which
+                              must hold true for a specified past interval.
+                            properties:
+                              periodSeconds:
+                                description: PeriodSeconds specifies the window of
+                                  time for which the policy should hold true. PeriodSeconds
+                                  must be greater than zero and less than or equal
+                                  to 1800 (30 min).
+                                format: int32
+                                type: integer
+                              type:
+                                description: Type is used to specify the scaling policy.
+                                type: string
+                              value:
+                                description: Value contains the amount of change which
+                                  is permitted by the policy. It must be greater than
+                                  zero
+                                format: int32
+                                type: integer
+                            required:
+                            - periodSeconds
+                            - type
+                            - value
+                            type: object
+                          type: array
+                        selectPolicy:
+                          description: selectPolicy is used to specify which policy
+                            should be used. If not set, the default value MaxPolicySelect
+                            is used.
+                          type: string
+                        stabilizationWindowSeconds:
+                          description: 'StabilizationWindowSeconds is the number of
+                            seconds for which past recommendations should be considered
+                            while scaling up or scaling down. StabilizationWindowSeconds
+                            must be greater than or equal to zero and less than or
+                            equal to 3600 (one hour). If not set, use the default
+                            values: - For scale up: 0 (i.e. no stabilization is done).
+                            - For scale down: 300 (i.e. the stabilization window is
+                            300 seconds long).'
+                          format: int32
+                          type: integer
+                      type: object
+                  type: object
                 maxReplicas:
                   description: maxReplicas is the upper limit for the number of replicas
                     to which the autoscaler can scale up. It cannot be less that minReplicas.
@@ -143,6 +258,121 @@ spec:
               description: HorizontalPodAutoscaler is the Autoscaling configuration
                 of a Stack. If defined an HPA will be created for the Stack.
               properties:
+                behavior:
+                  description: behavior configures the scaling behavior of the target
+                    in both Up and Down directions (scaleUp and scaleDown fields respectively).
+                    If not set, the default HPAScalingRules for scale up and scale
+                    down are used.
+                  properties:
+                    scaleDown:
+                      description: scaleDown is scaling policy for scaling Down. If
+                        not set, the default value is to allow to scale down to minReplicas
+                        pods, with a 300 second stabilization window (i.e., the highest
+                        recommendation for the last 300sec is used).
+                      properties:
+                        policies:
+                          description: policies is a list of potential scaling polices
+                            which can be used during scaling. At least one policy
+                            must be specified, otherwise the HPAScalingRules will
+                            be discarded as invalid
+                          items:
+                            description: HPAScalingPolicy is a single policy which
+                              must hold true for a specified past interval.
+                            properties:
+                              periodSeconds:
+                                description: PeriodSeconds specifies the window of
+                                  time for which the policy should hold true. PeriodSeconds
+                                  must be greater than zero and less than or equal
+                                  to 1800 (30 min).
+                                format: int32
+                                type: integer
+                              type:
+                                description: Type is used to specify the scaling policy.
+                                type: string
+                              value:
+                                description: Value contains the amount of change which
+                                  is permitted by the policy. It must be greater than
+                                  zero
+                                format: int32
+                                type: integer
+                            required:
+                            - periodSeconds
+                            - type
+                            - value
+                            type: object
+                          type: array
+                        selectPolicy:
+                          description: selectPolicy is used to specify which policy
+                            should be used. If not set, the default value MaxPolicySelect
+                            is used.
+                          type: string
+                        stabilizationWindowSeconds:
+                          description: 'StabilizationWindowSeconds is the number of
+                            seconds for which past recommendations should be considered
+                            while scaling up or scaling down. StabilizationWindowSeconds
+                            must be greater than or equal to zero and less than or
+                            equal to 3600 (one hour). If not set, use the default
+                            values: - For scale up: 0 (i.e. no stabilization is done).
+                            - For scale down: 300 (i.e. the stabilization window is
+                            300 seconds long).'
+                          format: int32
+                          type: integer
+                      type: object
+                    scaleUp:
+                      description: 'scaleUp is scaling policy for scaling Up. If not
+                        set, the default value is the higher of:   * increase no more
+                        than 4 pods per 60 seconds   * double the number of pods per
+                        60 seconds No stabilization is used.'
+                      properties:
+                        policies:
+                          description: policies is a list of potential scaling polices
+                            which can be used during scaling. At least one policy
+                            must be specified, otherwise the HPAScalingRules will
+                            be discarded as invalid
+                          items:
+                            description: HPAScalingPolicy is a single policy which
+                              must hold true for a specified past interval.
+                            properties:
+                              periodSeconds:
+                                description: PeriodSeconds specifies the window of
+                                  time for which the policy should hold true. PeriodSeconds
+                                  must be greater than zero and less than or equal
+                                  to 1800 (30 min).
+                                format: int32
+                                type: integer
+                              type:
+                                description: Type is used to specify the scaling policy.
+                                type: string
+                              value:
+                                description: Value contains the amount of change which
+                                  is permitted by the policy. It must be greater than
+                                  zero
+                                format: int32
+                                type: integer
+                            required:
+                            - periodSeconds
+                            - type
+                            - value
+                            type: object
+                          type: array
+                        selectPolicy:
+                          description: selectPolicy is used to specify which policy
+                            should be used. If not set, the default value MaxPolicySelect
+                            is used.
+                          type: string
+                        stabilizationWindowSeconds:
+                          description: 'StabilizationWindowSeconds is the number of
+                            seconds for which past recommendations should be considered
+                            while scaling up or scaling down. StabilizationWindowSeconds
+                            must be greater than or equal to zero and less than or
+                            equal to 3600 (one hour). If not set, use the default
+                            values: - For scale up: 0 (i.e. no stabilization is done).
+                            - For scale down: 300 (i.e. the stabilization window is
+                            300 seconds long).'
+                          format: int32
+                          type: integer
+                      type: object
+                  type: object
                 maxReplicas:
                   description: maxReplicas is the upper limit for the number of replicas
                     to which the autoscaler can scale up. It cannot be less that minReplicas.

--- a/cluster/manifests/stackset-controller/01-stackset-crd.yaml
+++ b/cluster/manifests/stackset-controller/01-stackset-crd.yaml
@@ -119,6 +119,129 @@ spec:
                       description: Autoscaler is the autoscaling definition for a
                         stack
                       properties:
+                        behavior:
+                          description: behavior configures the scaling behavior of
+                            the target in both Up and Down directions (scaleUp and
+                            scaleDown fields respectively). If not set, the default
+                            HPAScalingRules for scale up and scale down are used.
+                          properties:
+                            scaleDown:
+                              description: scaleDown is scaling policy for scaling
+                                Down. If not set, the default value is to allow to
+                                scale down to minReplicas pods, with a 300 second
+                                stabilization window (i.e., the highest recommendation
+                                for the last 300sec is used).
+                              properties:
+                                policies:
+                                  description: policies is a list of potential scaling
+                                    polices which can be used during scaling. At least
+                                    one policy must be specified, otherwise the HPAScalingRules
+                                    will be discarded as invalid
+                                  items:
+                                    description: HPAScalingPolicy is a single policy
+                                      which must hold true for a specified past interval.
+                                    properties:
+                                      periodSeconds:
+                                        description: PeriodSeconds specifies the window
+                                          of time for which the policy should hold
+                                          true. PeriodSeconds must be greater than
+                                          zero and less than or equal to 1800 (30
+                                          min).
+                                        format: int32
+                                        type: integer
+                                      type:
+                                        description: Type is used to specify the scaling
+                                          policy.
+                                        type: string
+                                      value:
+                                        description: Value contains the amount of
+                                          change which is permitted by the policy.
+                                          It must be greater than zero
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - periodSeconds
+                                    - type
+                                    - value
+                                    type: object
+                                  type: array
+                                selectPolicy:
+                                  description: selectPolicy is used to specify which
+                                    policy should be used. If not set, the default
+                                    value MaxPolicySelect is used.
+                                  type: string
+                                stabilizationWindowSeconds:
+                                  description: 'StabilizationWindowSeconds is the
+                                    number of seconds for which past recommendations
+                                    should be considered while scaling up or scaling
+                                    down. StabilizationWindowSeconds must be greater
+                                    than or equal to zero and less than or equal to
+                                    3600 (one hour). If not set, use the default values:
+                                    - For scale up: 0 (i.e. no stabilization is done).
+                                    - For scale down: 300 (i.e. the stabilization
+                                    window is 300 seconds long).'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            scaleUp:
+                              description: 'scaleUp is scaling policy for scaling
+                                Up. If not set, the default value is the higher of:   *
+                                increase no more than 4 pods per 60 seconds   * double
+                                the number of pods per 60 seconds No stabilization
+                                is used.'
+                              properties:
+                                policies:
+                                  description: policies is a list of potential scaling
+                                    polices which can be used during scaling. At least
+                                    one policy must be specified, otherwise the HPAScalingRules
+                                    will be discarded as invalid
+                                  items:
+                                    description: HPAScalingPolicy is a single policy
+                                      which must hold true for a specified past interval.
+                                    properties:
+                                      periodSeconds:
+                                        description: PeriodSeconds specifies the window
+                                          of time for which the policy should hold
+                                          true. PeriodSeconds must be greater than
+                                          zero and less than or equal to 1800 (30
+                                          min).
+                                        format: int32
+                                        type: integer
+                                      type:
+                                        description: Type is used to specify the scaling
+                                          policy.
+                                        type: string
+                                      value:
+                                        description: Value contains the amount of
+                                          change which is permitted by the policy.
+                                          It must be greater than zero
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - periodSeconds
+                                    - type
+                                    - value
+                                    type: object
+                                  type: array
+                                selectPolicy:
+                                  description: selectPolicy is used to specify which
+                                    policy should be used. If not set, the default
+                                    value MaxPolicySelect is used.
+                                  type: string
+                                stabilizationWindowSeconds:
+                                  description: 'StabilizationWindowSeconds is the
+                                    number of seconds for which past recommendations
+                                    should be considered while scaling up or scaling
+                                    down. StabilizationWindowSeconds must be greater
+                                    than or equal to zero and less than or equal to
+                                    3600 (one hour). If not set, use the default values:
+                                    - For scale up: 0 (i.e. no stabilization is done).
+                                    - For scale down: 300 (i.e. the stabilization
+                                    window is 300 seconds long).'
+                                  format: int32
+                                  type: integer
+                              type: object
+                          type: object
                         maxReplicas:
                           description: maxReplicas is the upper limit for the number
                             of replicas to which the autoscaler can scale up. It cannot
@@ -191,6 +314,129 @@ spec:
                       description: HorizontalPodAutoscaler is the Autoscaling configuration
                         of a Stack. If defined an HPA will be created for the Stack.
                       properties:
+                        behavior:
+                          description: behavior configures the scaling behavior of
+                            the target in both Up and Down directions (scaleUp and
+                            scaleDown fields respectively). If not set, the default
+                            HPAScalingRules for scale up and scale down are used.
+                          properties:
+                            scaleDown:
+                              description: scaleDown is scaling policy for scaling
+                                Down. If not set, the default value is to allow to
+                                scale down to minReplicas pods, with a 300 second
+                                stabilization window (i.e., the highest recommendation
+                                for the last 300sec is used).
+                              properties:
+                                policies:
+                                  description: policies is a list of potential scaling
+                                    polices which can be used during scaling. At least
+                                    one policy must be specified, otherwise the HPAScalingRules
+                                    will be discarded as invalid
+                                  items:
+                                    description: HPAScalingPolicy is a single policy
+                                      which must hold true for a specified past interval.
+                                    properties:
+                                      periodSeconds:
+                                        description: PeriodSeconds specifies the window
+                                          of time for which the policy should hold
+                                          true. PeriodSeconds must be greater than
+                                          zero and less than or equal to 1800 (30
+                                          min).
+                                        format: int32
+                                        type: integer
+                                      type:
+                                        description: Type is used to specify the scaling
+                                          policy.
+                                        type: string
+                                      value:
+                                        description: Value contains the amount of
+                                          change which is permitted by the policy.
+                                          It must be greater than zero
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - periodSeconds
+                                    - type
+                                    - value
+                                    type: object
+                                  type: array
+                                selectPolicy:
+                                  description: selectPolicy is used to specify which
+                                    policy should be used. If not set, the default
+                                    value MaxPolicySelect is used.
+                                  type: string
+                                stabilizationWindowSeconds:
+                                  description: 'StabilizationWindowSeconds is the
+                                    number of seconds for which past recommendations
+                                    should be considered while scaling up or scaling
+                                    down. StabilizationWindowSeconds must be greater
+                                    than or equal to zero and less than or equal to
+                                    3600 (one hour). If not set, use the default values:
+                                    - For scale up: 0 (i.e. no stabilization is done).
+                                    - For scale down: 300 (i.e. the stabilization
+                                    window is 300 seconds long).'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            scaleUp:
+                              description: 'scaleUp is scaling policy for scaling
+                                Up. If not set, the default value is the higher of:   *
+                                increase no more than 4 pods per 60 seconds   * double
+                                the number of pods per 60 seconds No stabilization
+                                is used.'
+                              properties:
+                                policies:
+                                  description: policies is a list of potential scaling
+                                    polices which can be used during scaling. At least
+                                    one policy must be specified, otherwise the HPAScalingRules
+                                    will be discarded as invalid
+                                  items:
+                                    description: HPAScalingPolicy is a single policy
+                                      which must hold true for a specified past interval.
+                                    properties:
+                                      periodSeconds:
+                                        description: PeriodSeconds specifies the window
+                                          of time for which the policy should hold
+                                          true. PeriodSeconds must be greater than
+                                          zero and less than or equal to 1800 (30
+                                          min).
+                                        format: int32
+                                        type: integer
+                                      type:
+                                        description: Type is used to specify the scaling
+                                          policy.
+                                        type: string
+                                      value:
+                                        description: Value contains the amount of
+                                          change which is permitted by the policy.
+                                          It must be greater than zero
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - periodSeconds
+                                    - type
+                                    - value
+                                    type: object
+                                  type: array
+                                selectPolicy:
+                                  description: selectPolicy is used to specify which
+                                    policy should be used. If not set, the default
+                                    value MaxPolicySelect is used.
+                                  type: string
+                                stabilizationWindowSeconds:
+                                  description: 'StabilizationWindowSeconds is the
+                                    number of seconds for which past recommendations
+                                    should be considered while scaling up or scaling
+                                    down. StabilizationWindowSeconds must be greater
+                                    than or equal to zero and less than or equal to
+                                    3600 (one hour). If not set, use the default values:
+                                    - For scale up: 0 (i.e. no stabilization is done).
+                                    - For scale down: 300 (i.e. the stabilization
+                                    window is 300 seconds long).'
+                                  format: int32
+                                  type: integer
+                              type: object
+                          type: object
                         maxReplicas:
                           description: maxReplicas is the upper limit for the number
                             of replicas to which the autoscaler can scale up. It cannot

--- a/cluster/manifests/stackset-controller/deployment.yaml
+++ b/cluster/manifests/stackset-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: stackset-controller
-    version: "v1.3.1"
+    version: "v1.3.2"
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: stackset-controller
-        version: "v1.3.1"
+        version: "v1.3.2"
     spec:
 {{- if eq .Cluster.ConfigItems.system_pods_critical "true" }}
       priorityClassName: system-cluster-critical
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: stackset-controller
       containers:
       - name: stackset-controller
-        image: "registry.opensource.zalan.do/teapot/stackset-controller:v1.3.1"
+        image: "registry.opensource.zalan.do/teapot/stackset-controller:v1.3.2"
         args:
         - "--interval={{ .Cluster.ConfigItems.stackset_controller_sync_interval }}"
         env:

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/szuecs/routegroup-client v0.17.8-0.20200717074340-6a596422b948
 	github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc // indirect
 	github.com/zalando-incubator/kube-aws-iam-controller v0.1.2
-	github.com/zalando-incubator/stackset-controller v1.3.1
+	github.com/zalando-incubator/stackset-controller v1.3.2
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	k8s.io/api v0.18.8
 	k8s.io/apimachinery v0.18.8

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -751,8 +751,8 @@ github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1/go.mod h1:QcJo0QPSf
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/zalando-incubator/kube-aws-iam-controller v0.1.2 h1:uEXMHnd7wuXk3gAZ8iiOnL9XVUqA1iuDQzQFsa3ywA4=
 github.com/zalando-incubator/kube-aws-iam-controller v0.1.2/go.mod h1:7RQdyNqtYaKEWVavXUFlrE8A+QsGe/hkBba2RyG5V4o=
-github.com/zalando-incubator/stackset-controller v1.3.1 h1:pl34cDhbXfaLS2iFnRa7ZzBj5gkmfZufy81su3Tul/E=
-github.com/zalando-incubator/stackset-controller v1.3.1/go.mod h1:kDbSjJaBy5Uk3ryrrIEx26pNoXMppvsa3eYZXrnQIZc=
+github.com/zalando-incubator/stackset-controller v1.3.2 h1:RKe1hJMySH+pCZIbac38QbBgV54W29m5PkuimoLtuGA=
+github.com/zalando-incubator/stackset-controller v1.3.2/go.mod h1:kDbSjJaBy5Uk3ryrrIEx26pNoXMppvsa3eYZXrnQIZc=
 go.etcd.io/bbolt v1.3.3 h1:MUGmc65QhB3pIlaQ5bB4LwqSj6GIonVJXpZiaKNyaKk=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738 h1:VcrIfasaLFkyjk6KNlXQSzO+B0fZcnECiDrKJsfxka0=


### PR DESCRIPTION
Adds support for [Scaling behavior](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-configurable-scaling-behavior)

Ref: https://github.com/zalando-incubator/stackset-controller/pull/239