### PR TITLE
Default PSP: allow NFS volumes

### DIFF
--- a/cluster/manifests/psp/pod_security_policy.yaml
+++ b/cluster/manifests/psp/pod_security_policy.yaml
@@ -45,10 +45,11 @@ spec:
     - net.ipv4.tcp_keepalive_intvl
     - net.ipv4.tcp_keepalive_probes
   volumes:
-  - emptyDir
   - awsElasticBlockStore
-  - secret
-  - persistentVolumeClaim
-  - downwardAPI
   - configMap
+  - downwardAPI
+  - emptyDir
+  - nfs
+  - persistentVolumeClaim
   - projected
+  - secret


### PR DESCRIPTION
This was requested by some of the users, and there doesn't seem to be any security impact.