### PR TITLE
Add the cluster's VPC ID to the deployment config

### DIFF
--- a/cluster/manifests/infrastructure-configs/deployment-config.yaml
+++ b/cluster/manifests/infrastructure-configs/deployment-config.yaml
@@ -6,6 +6,7 @@ metadata:
 data:
   aws-account-id: "{{accountID .Cluster.InfrastructureAccount}}"
   cluster-alias: "{{.Cluster.Alias}}"
+  cluster-vpc-id: "{{.Cluster.ConfigItems.vpc_id}}"
   scalyr-team-token: "{{.Cluster.ConfigItems.scalyr_team_token}}"
   create-namespaces: "true"
   aws-available: "true"


### PR DESCRIPTION
We can expose it as a predefine variable to simplify CF templates.