### PR TITLE
Add a VPA for ingress-template-controller

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -45,6 +45,9 @@ post_apply:
   kind: ClusterRole
 - name: ingress-template-controller
   kind: ClusterRoleBinding
+- name: ingress-template-controller
+  namespace: kube-system
+  kind: VerticalPodAutoscaler
 {{ end }}
 - name: leader-locking-efs-provisioner
   namespace: default

--- a/cluster/manifests/ingress-template-controller/vpa.yaml
+++ b/cluster/manifests/ingress-template-controller/vpa.yaml
@@ -1,0 +1,19 @@
+{{ if eq .ConfigItems.enable_ingress_template_controller "true"}}
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: ingress-template-controller
+  namespace: kube-system
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: ingress-template-controller
+  updatePolicy:
+    updateMode: Auto
+  resourcePolicy:
+    containerPolicies:
+    - containerName: ingress-template-controller
+      maxAllowed:
+        memory: 1Gi
+{{ end }}


### PR DESCRIPTION
It's crashing in some of the clusters, and we apparently have no VPA defined.