### PR TITLE
Use m5a.large for e2e master nodes

### DIFF
--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -70,7 +70,7 @@ clusters:
   local_id: ${LOCAL_ID}
   node_pools:
   - discount_strategy: none
-    instance_types: ["t3.large"]
+    instance_types: ["m5a.large"]
     name: default-master
     profile: master-default
     min_size: 2


### PR DESCRIPTION
We have observed negative impact when using `t3.large` instances. Switch to `m5a.large` for master nodes when running e2e.