### PR TITLE
Update ingress-template-controller to work with v1.18

### DIFF
--- a/cluster/manifests/ingress-template-controller/deployment.yaml
+++ b/cluster/manifests/ingress-template-controller/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: kube-system
   labels:
     application: ingress-template-controller
-    version: master-5
 spec:
   replicas: 1
   selector:
@@ -16,7 +15,6 @@ spec:
     metadata:
       labels:
         application: ingress-template-controller
-        version: master-5
     spec:
       dnsConfig:
         options:
@@ -25,7 +23,7 @@ spec:
       serviceAccountName: ingress-template-controller
       containers:
       - name: ingress-template-controller
-        image: pierone.stups.zalan.do/teapot/ingress-template-controller:master-5
+        image: pierone.stups.zalan.do/teapot/ingress-template-controller:3ec5b3c
         resources:
           limits:
             cpu: 10m


### PR DESCRIPTION
Makes `ingress-template-controller` work with v1.18. Before it would fail on listing services:

```
error msg="v1.ServiceList: Items: []v1.Service: v1.Service: ObjectMeta: v1.ObjectMeta: readObjectFieldAsBytes: expect : after object field, parsing 8739 ...:{},\"k:
```

Since I changed the build the tag ended up being the commit hash. I don't wan't to fix it now as this component is supposed to go away ASAP, this is just to not break it for the two remaining use cases if it's not fixed before v1.18 goes to production.