### PR TITLE
Add InfrastructureComponent=true tags to CF stacks

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1,5 +1,8 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: Kubernetes cluster
+Metadata:
+  Tags:
+    InfrastructureComponent: "true"
 Resources:
 {{ if ne .Cluster.ConfigItems.delete_vpc_resources "true" }}
   EtcdSecurityGroupIngressFromMaster:
@@ -184,8 +187,6 @@ Resources:
       Tags:
         - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
           Value: owned
-        - Key: InfrastructureComponent
-          Value: true
       VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
     Type: 'AWS::EC2::SecurityGroup'
   MasterSecurityGroupIngressFromFlannelToMaster:
@@ -303,8 +304,6 @@ Resources:
           IpProtocol: udp
           ToPort: 53
       Tags:
-        - Key: InfrastructureComponent
-          Value: true
         - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
           Value: owned
       VpcId: "{{.Cluster.ConfigItems.vpc_id}}"

--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -1,5 +1,8 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: Kubernetes default master node pool
+Metadata:
+  Tags:
+    InfrastructureComponent: "true"
 
 Mappings:
   Images:

--- a/cluster/node-pools/worker-default/stack.yaml
+++ b/cluster/node-pools/worker-default/stack.yaml
@@ -1,5 +1,8 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: Kubernetes default worker node pool
+Metadata:
+  Tags:
+    InfrastructureComponent: "true"
 
 Mappings:
   Images:

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -1,5 +1,8 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: Kubernetes default worker node pool
+Metadata:
+  Tags:
+    InfrastructureComponent: "true"
 
 Mappings:
   Images:

--- a/cluster/node-pools/worker-spotio-ocean/stack.yaml
+++ b/cluster/node-pools/worker-spotio-ocean/stack.yaml
@@ -1,5 +1,8 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: Kubernetes spot.io Ocean node pool stack
+Metadata:
+  Tags:
+    InfrastructureComponent: "true"
 
 Mappings:
   Images:


### PR DESCRIPTION
Depends on https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/357 to take effect.

This adds `InfrastructureComponent=true` tags on the CF stacks such that we can condition those resources in IAM role e.g. to not let normal users touch the stacks with such a tag.