### PR TITLE
Update API Server skipper proxy

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -392,7 +392,7 @@ write_files:
               exec:
                 command: ["/bin/sh", "-c",  " sleep 60"]
         - name: skipper-proxy
-          image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.117
+          image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.150
           args:
           - skipper
           - -access-log-strip-query


### PR DESCRIPTION
In #3516 we updated to the latest working skipper version at the time. Later versions had a bug: https://github.com/zalando/skipper/issues/1508 which has now been fixed so we can upgrade to the latest version.