### PR TITLE
Disable profiling on Kubernetes components by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -388,3 +388,6 @@ kubernetes_event_logger_enabled: "true"
 
 # enable/disable stackset validation (preserveUnknownFields)
 stackset_validation_enabled: "true"
+
+# Enable/Disable profiling for Kubernetes components
+enable_control_plane_profiling: "false"

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -183,6 +183,7 @@ write_files:
           - --kubelet-client-certificate=/etc/kubernetes/ssl/kubelet-client.pem
           - --kubelet-client-key=/etc/kubernetes/ssl/kubelet-client-key.pem
           - --shutdown-delay-duration=60s
+          - --profiling={{ .Cluster.ConfigItems.enable_control_plane_profiling }}
           livenessProbe:
             httpGet:
               host: 127.0.0.1
@@ -541,6 +542,7 @@ write_files:
           {{ if eq .Cluster.ConfigItems.enable_endpointslice "true" }}
           - --controllers=endpointslice
           {{ end }}
+          - --profiling={{ .Cluster.ConfigItems.enable_control_plane_profiling }}
           resources:
             requests:
               cpu: 100m
@@ -592,6 +594,7 @@ write_files:
           - --master=http://127.0.0.1:8080
           - --leader-elect=true
           - --feature-gates=BoundServiceAccountTokenVolume={{ .Cluster.ConfigItems.rotate_service_account_tokens }},NonPreemptingPriority=true,EvenPodsSpread={{ .Cluster.ConfigItems.enable_even_pods_spread }}
+          - --profiling={{ .Cluster.ConfigItems.enable_control_plane_profiling }}
           env:
           - name: KUBE_MAX_PD_VOLS
             value: "26"


### PR DESCRIPTION
Disable profiling by default and make it configurable via config item.

This will disable the `host:port/debug/pprof/` endpoint on `kube-apiserver`, `kube-controller-manager`, `kube-scheduler` ~and disable all debug endpoints on `kubelet`.~ Not disabled on `kubelet` because the [debug endpoint](https://github.com/kubernetes/kubernetes/blob/v1.18.8/staging/src/k8s.io/kubelet/config/v1beta1/types.go#L249-L256) is also serving log and exec access as well as profiling.