### PR TITLE
Allow preserving the root volume after termination

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -367,6 +367,7 @@ stackset_controller_mem_max: "1Gi"
 
 # EBS settings for the root volume
 ebs_root_volume_size: "50"
+ebs_root_volume_delete_on_termination: "true"
 
 # Migration off priority classes
 {{if eq .Environment "production"}}

--- a/cluster/node-pools/worker-default/stack.yaml
+++ b/cluster/node-pools/worker-default/stack.yaml
@@ -120,7 +120,7 @@ Resources:
         BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
-            DeleteOnTermination: true
+            DeleteOnTermination: {{.NodePool.ConfigItems.ebs_root_volume_delete_on_termination}}
             VolumeSize: {{.NodePool.ConfigItems.ebs_root_volume_size}}
 {{ end }}
         NetworkInterfaces:

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -130,7 +130,7 @@ Resources:
         BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
-            DeleteOnTermination: true
+            DeleteOnTermination: {{$data.NodePool.ConfigItems.ebs_root_volume_delete_on_termination}}
             VolumeSize: {{$data.NodePool.ConfigItems.ebs_root_volume_size}}
 {{ end }}
         NetworkInterfaces:


### PR DESCRIPTION
This way we can at least look at the logs to see what went wrong. Note: spot.io pools won't support this for now, this will be added in a separate PR.