### PR TITLE
Small fixes to e2e package

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -215,7 +215,8 @@ Follow up code, that waits for creations to be happen:
   KUBECONFIG=~/.kube/config HOSTED_ZONE=example.org CLUSTER_ALIAS=example \
   S3_AWS_IAM_BUCKET=zalando-e2e-aws-iam-test-12345678912-kube-1 \
   AWS_IAM_ROLE=kube-1-e2e-aws-iam-test \
-  ginkgo -nodes=25 -flakeAttempts=2 -focus="\[Zalando\]" e2e.test
+  ginkgo -nodes=25 -flakeAttempts=2 -focus="\[Zalando\]" \
+  e2e.test -- -non-blocking-taints=node.kubernetes.io/role,nvidia.com/gpu
   ```
 
 * **Why is the go modules such a mess?**

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -76,6 +76,4 @@ replace k8s.io/component-base => ./e2e_modules/kubernetes/staging/src/k8s.io/com
 
 replace k8s.io/cri-api => ./e2e_modules/kubernetes/staging/src/k8s.io/cri-api
 
-replace github.com/szuecs/routegroup-client => github.com/mikkeloscar/routegroup-client v0.17.8-0.20200625082607-0f1ebad84234
-
 go 1.13

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -543,8 +543,6 @@ github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2/go.mod h1:g4cOPx
 github.com/miekg/dns v1.1.3/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.4 h1:rCMZsU2ScVSYcAsOXgmC6+AKOK+6pmQTOcw03nfwYV0=
 github.com/miekg/dns v1.1.4/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
-github.com/mikkeloscar/routegroup-client v0.17.8-0.20200625082607-0f1ebad84234 h1:Bu8zKOSJcqmHEK3twSe2GUz4O7HtvDRj4W/j/2deIgg=
-github.com/mikkeloscar/routegroup-client v0.17.8-0.20200625082607-0f1ebad84234/go.mod h1:iYMMsVp4q60g+s+3H2iuOycHMheBwnr20cPEo6Rjfeg=
 github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989 h1:PS1dLCGtD8bb9RPKJrc8bS7qHL6JnW1CZvwzH9dPoUs=
 github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989/go.mod h1:2eu9pRWp8mo84xCg6KswZ+USQHjwgRhNp06sozOdsTY=
 github.com/mistifyio/go-zfs v2.1.1+incompatible h1:gAMO1HM9xBRONLHHYnu5iFsOJUiJdNZo6oqSENd4eW8=
@@ -744,6 +742,8 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 h1:b6uOv7YOFK0TYG7HtkIgExQo+2RdLuwRft63jn2HWj8=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
+github.com/szuecs/routegroup-client v0.17.8-0.20200717074340-6a596422b948 h1:lxelhK7iTdJj0bsDqyhdmUBACSuCwxugaAAa+JXKcp8=
+github.com/szuecs/routegroup-client v0.17.8-0.20200717074340-6a596422b948/go.mod h1:iYMMsVp4q60g+s+3H2iuOycHMheBwnr20cPEo6Rjfeg=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/thecodeteam/goscaleio v0.1.0 h1:SB5tO98lawC+UK8ds/U2jyfOCH7GTcFztcF5x9gbut4=
 github.com/thecodeteam/goscaleio v0.1.0/go.mod h1:68sdkZAsK8bvEwBlbQnlLS+xU+hvLYM/iQ8KXej1AwM=

--- a/test/e2e/ingress.go
+++ b/test/e2e/ingress.go
@@ -648,8 +648,8 @@ var _____ = framework.KubeDescribe("Ingress tests simple NLB", func() {
 		// err = waitForResponse(addr, "http", waitTime, isRedirect, true)
 		// Expect(err).NotTo(HaveOccurred())
 
-		// ALB ready
-		By("Waiting for ALB to create endpoint " + addr + " and skipper route, to see that our ingress-controller and skipper works")
+		// NLB ready
+		By("Waiting for NLB to create endpoint " + addr + " and skipper route, to see that our ingress-controller and skipper works")
 		err = waitForResponse(addr, "https", waitTime, isNotFound, true)
 		Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
Minor fixes to the e2e package.
* Fix example in e2e
* Use correct name for test
* Don't use a fork of `github.com/szuecs/routegroup-client`