### PR TITLE
Enable cluster autoscaler release 1.18 in tests

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -9,6 +9,9 @@ autoscaling_utilization_threshold: "1.0"
 autoscaling_max_empty_bulk_delete: "25"
 autoscaling_scale_down_unneeded_time: "10m"
 
+# the cluster autoscaler release to use, options are 1_12 and 1_18.
+cluster_autoscaler_release: "1_12"
+
 # defines which expander the autoscaler should use
 cluster_autoscaler_expander: highest-priority
 

--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -5,7 +5,11 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-cluster-autoscaler
+    {{- if eq .Cluster.ConfigItems.cluster_autoscaler_release "1_18" }}
+    version: v1.18.2-internal.11
+    {{- else }}
     version: v1.12.2-internal-2.16
+    {{- end }}
 spec:
   selector:
     matchLabels:
@@ -16,7 +20,11 @@ spec:
     metadata:
       labels:
         application: kube-cluster-autoscaler
+        {{- if eq .Cluster.ConfigItems.cluster_autoscaler_release "1_18" }}
+        version: v1.18.2-internal.11
+        {{- else }}
         version: v1.12.2-internal-2.16
+        {{- end }}
       annotations:
         iam.amazonaws.com/role: "{{ .LocalID }}-app-autoscaler"
         config/pool-sizes: "{{range .NodePools}}{{.Name}}-{{.MinSize}}-{{.MaxSize}} {{end}}"
@@ -33,7 +41,11 @@ spec:
         effect: NoSchedule
       containers:
       - name: cluster-autoscaler
+        {{- if eq .Cluster.ConfigItems.cluster_autoscaler_release "1_18" }}
+        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.18.2-internal.11
+        {{- else }}
         image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.12.2-internal-2.16
+        {{- end }}
         command:
           - ./cluster-autoscaler
           - --v=1

--- a/cluster/manifests/kube-cluster-autoscaler/rbac.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/rbac.yaml
@@ -3,11 +3,15 @@ kind: ServiceAccount
 metadata:
   name: cluster-autoscaler
   namespace: kube-system
+  labels:
+    application: kube-cluster-autoscaler
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cluster-autoscaler
+  labels:
+    application: kube-cluster-autoscaler
 rules:
 - apiGroups: [""]
   resources: ["events", "endpoints"]
@@ -15,6 +19,9 @@ rules:
 - apiGroups: [""]
   resources: ["pods/eviction"]
   verbs: ["create"]
+- apiGroups: [""]
+  resources: ["pods/status"]
+  verbs: ["update"]
 - apiGroups: [""]
   resources: ["endpoints"]
   resourceNames: ["cluster-autoscaler"]
@@ -40,11 +47,18 @@ rules:
   resources: ["statefulsets", "replicasets", "daemonsets"]
   verbs: ["watch", "list", "get"]
 - apiGroups: ["storage.k8s.io"]
-  resources: ["storageclasses"]
+  resources: ["storageclasses", "csinodes"]
   verbs: ["watch", "list", "get"]
 - apiGroups: ["batch", "extensions"]
   resources: ["jobs"]
-  verbs: ["get", "list", "watch"]
+  verbs: ["get", "list", "watch", "patch"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["create"]
+- apiGroups: ["coordination.k8s.io"]
+  resourceNames: ["cluster-autoscaler"]
+  resources: ["leases"]
+  verbs: ["get", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -52,8 +66,7 @@ metadata:
   name: cluster-autoscaler
   namespace: kube-system
   labels:
-    k8s-addon: cluster-autoscaler.addons.k8s.io
-    k8s-app: cluster-autoscaler
+    application: kube-cluster-autoscaler
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
@@ -67,6 +80,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cluster-autoscaler
+  labels:
+    application: kube-cluster-autoscaler
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -81,6 +96,8 @@ kind: RoleBinding
 metadata:
   name: cluster-autoscaler
   namespace: kube-system
+  labels:
+    application: kube-cluster-autoscaler
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -10,6 +10,7 @@ clusters:
   api_server_url: ${API_SERVER_URL}
   channel: ${1}
   config_items:
+    cluster_autoscaler_release: 1_18
     scalyr_access_key: no-key-defined
     scalyr_read_key: no-key-defined
     scalyr_server: no-key-defined


### PR DESCRIPTION
Use the 1.18 release in e2e tests.