### PR TITLE
Make node updates faster

### DIFF
--- a/cluster/manifests/e2e-resources/pool-reserve.yaml
+++ b/cluster/manifests/e2e-resources/pool-reserve.yaml
@@ -1,5 +1,5 @@
 {{ if eq .Environment "e2e" }}
-{{ range $pool := split "default-worker-splitaz,default-worker,worker-instance-storage" "," }}
+{{ range $pool := split "default-worker-splitaz,default-worker,worker-limit-az,worker-instance-storage" "," }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/cluster/manifests/e2e-resources/pool-reserve.yaml
+++ b/cluster/manifests/e2e-resources/pool-reserve.yaml
@@ -1,0 +1,38 @@
+{{ if eq .Environment "e2e" }}
+{{ range $pool := split "default-worker-splitaz,default-worker,worker-instance-storage" "," }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pool-reserve-{{$pool}}
+  labels:
+    application: pool-reserve
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      application: pool-reserve
+      pool: "{{$pool}}"
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        application: pool-reserve
+        pool: "{{$pool}}"
+    spec:
+      nodeSelector:
+        node.kubernetes.io/node-pool: "{{$pool}}"
+      terminationGracePeriodSeconds: 0
+      containers:
+      - name: pause
+        image: registry.opensource.zalan.do/teapot/pause-amd64:3.2
+        resources:
+          limits:
+            cpu: 1m
+            memory: 50Mi
+          requests:
+            cpu: 1m
+            memory: 50Mi
+---
+{{ end }}
+{{ end }}

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -90,6 +90,15 @@ clusters:
     min_size: 0
     max_size: 21
   - discount_strategy: spot
+    instance_types: ["m4.large", "m5.large", "m5.xlarge", "m4.xlarge"]
+    config_items:
+      availability_zones: "eu-central-1a"
+      scaling_priority: "-100"
+    name: worker-limit-az
+    profile: worker-splitaz
+    min_size: 0
+    max_size: 21
+  - discount_strategy: spot
     instance_types: ["m5d.large", "m5d.xlarge", "m5d.2xlarge"]
     name: worker-instance-storage
     profile: worker-default

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -73,8 +73,8 @@ clusters:
     instance_types: ["m5a.large"]
     name: default-master
     profile: master-default
-    min_size: 2
-    max_size: 3
+    min_size: 1
+    max_size: 2
   - discount_strategy: spot
     instance_types: ["m4.large", "m5.large", "m5.xlarge", "m4.xlarge"]
     name: default-worker-splitaz

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -79,7 +79,7 @@ clusters:
     instance_types: ["m4.large", "m5.large", "m5.xlarge", "m4.xlarge"]
     name: default-worker-splitaz
     profile: worker-splitaz
-    min_size: 3
+    min_size: 0
     max_size: 21
     config_items:
       cpu_manager_policy: static
@@ -87,22 +87,13 @@ clusters:
     instance_types: ["m4.large", "m5.large", "m5.xlarge", "m4.xlarge"]
     name: default-worker
     profile: worker-default
-    min_size: 1
-    max_size: 21
-  - discount_strategy: spot
-    instance_types: ["m4.large", "m5.large", "m5.xlarge", "m4.xlarge"]
-    config_items:
-      availability_zones: "eu-central-1a"
-      scaling_priority: "-100"
-    name: worker-limit-az
-    profile: worker-splitaz
-    min_size: 1
+    min_size: 0
     max_size: 21
   - discount_strategy: spot
     instance_types: ["m5d.large", "m5d.xlarge", "m5d.2xlarge"]
     name: worker-instance-storage
     profile: worker-default
-    min_size: 1
+    min_size: 0
     max_size: 21
   - discount_strategy: spot
     instance_types: ["p3.2xlarge", "g2.2xlarge", "g3s.xlarge", "g3.4xlarge"]

--- a/test/e2e/infra.go
+++ b/test/e2e/infra.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -11,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/framework/deployment"
 )
 
 var _ = framework.KubeDescribe("Infrastructure tests", func() {
@@ -26,6 +28,17 @@ var _ = framework.KubeDescribe("Infrastructure tests", func() {
 			pods, err := podsForApplication(cs, application)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(filterMirrorPods(pods)).NotTo(BeEmpty())
+		}
+	})
+
+	It("All node pools should be able to run pods [Zalando]", func() {
+		// When modifying this list, don't forget to modify cluster/manifests/e2e-resources/pool-reserve.yaml
+		for _, pool := range []string{"default-worker-splitaz", "default-worker", "worker-instance-storage"} {
+			deploy, err := cs.AppsV1().Deployments("default").Get(context.Background(), fmt.Sprintf("pool-reserve-%s", pool), metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = deployment.WaitForDeploymentComplete(cs, deploy)
+			Expect(err).NotTo(HaveOccurred())
 		}
 	})
 

--- a/test/e2e/infra.go
+++ b/test/e2e/infra.go
@@ -33,7 +33,7 @@ var _ = framework.KubeDescribe("Infrastructure tests", func() {
 
 	It("All node pools should be able to run pods [Zalando]", func() {
 		// When modifying this list, don't forget to modify cluster/manifests/e2e-resources/pool-reserve.yaml
-		for _, pool := range []string{"default-worker-splitaz", "default-worker", "worker-instance-storage"} {
+		for _, pool := range []string{"default-worker-splitaz", "default-worker", "worker-limit-az", "worker-instance-storage"} {
 			deploy, err := cs.AppsV1().Deployments("default").Get(context.Background(), fmt.Sprintf("pool-reserve-%s", pool), metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
Having minimum sizes set for multiple node pools means that cluster rotations take a lot of time (almost 2 hours recently). We also don't use this in any of the clusters, so this PR changes the setup a bit.

 * Drop `min_size` to 0 for all node pools.
 * Change back to 1 master node since we use an instance type that should handle this now.
 * Create a marker deployment for every node pool we want to check and explicitly test that these are healthy after an update. This way we can be sure that a pool configuration works, but we can use the usual "drain and let the autoscaler deal with it" approach for the actual upgrade.