### PR TITLE
Ingress controller: configure deregistration delay

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -15,6 +15,11 @@ cluster_autoscaler_expander: highest-priority
 # ALB config created by kube-aws-ingress-controller
 kube_aws_ingress_controller_ssl_policy: "ELBSecurityPolicy-TLS-1-2-2017-01"
 kube_aws_ingress_controller_idle_timeout: "1m"
+{{if eq .Environment "e2e"}}
+kube_aws_ingress_controller_deregistration_delay_timeout: "1m"
+{{else}}
+kube_aws_ingress_controller_deregistration_delay_timeout: "5m"
+{{end}}
 # allow using NLBs for ingress
 # This opens port 9999 (skipper-ingress) on all worker nodes.
 kube_aws_ingress_controller_nlb_enabled: "false"

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -38,6 +38,7 @@ spec:
         - --stack-termination-protection
         - --ssl-policy={{ .ConfigItems.kube_aws_ingress_controller_ssl_policy }}
         - --idle-connection-timeout={{ .ConfigItems.kube_aws_ingress_controller_idle_timeout }}
+        - --deregistration-delay-timeout={{ .ConfigItems.kube_aws_ingress_controller_deregistration_delay_timeout }}
         {{ if eq .ConfigItems.kube_aws_ingress_controller_nlb_cross_zone "true" }}
         - --nlb-cross-zone
         {{ end }}

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.11.6
+    version: v0.11.7
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.11.6
+        version: v0.11.7
 {{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "false"}}
       annotations:
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: kube-ingress-aws-controller
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.11.6
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.11.7
         args:
         - --stack-termination-protection
         - --ssl-policy={{ .ConfigItems.kube_aws_ingress_controller_ssl_policy }}


### PR DESCRIPTION
 * Update ingress controller to v0.11.7 (support for `--deregistration-delay-timeout`)
 * Make deregistration delay configurable via `kube_aws_ingress_controller_deregistration_delay_timeout`
 * Use a smaller timeout for e2e clusters so we don't have to wait so long for AMI updates