### PR TITLE
Make it possible to configure AMI per Node Pool

### DIFF
--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -7,7 +7,7 @@ Metadata:
 Mappings:
   Images:
     eu-central-1:
-      MachineImage: '{{ .Cluster.ConfigItems.kuberuntu_image_v1_18 }}'
+      MachineImage: '{{ .NodePool.ConfigItems.kuberuntu_image_v1_18 }}'
 
 Resources:
   AutoScalingGroup:

--- a/cluster/node-pools/worker-default/stack.yaml
+++ b/cluster/node-pools/worker-default/stack.yaml
@@ -7,7 +7,7 @@ Metadata:
 Mappings:
   Images:
     eu-central-1:
-      MachineImage: '{{ .Cluster.ConfigItems.kuberuntu_image_v1_18 }}'
+      MachineImage: '{{ .NodePool.ConfigItems.kuberuntu_image_v1_18 }}'
 
 Resources:
   AutoScalingGroup:

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -7,7 +7,7 @@ Metadata:
 Mappings:
   Images:
     eu-central-1:
-      MachineImage: '{{ .Cluster.ConfigItems.kuberuntu_image_v1_18 }}'
+      MachineImage: '{{ .NodePool.ConfigItems.kuberuntu_image_v1_18 }}'
 
 Resources:
 {{ with $data := . }}

--- a/cluster/node-pools/worker-spotio-ocean/stack.yaml
+++ b/cluster/node-pools/worker-spotio-ocean/stack.yaml
@@ -7,7 +7,7 @@ Metadata:
 Mappings:
   Images:
     eu-central-1:
-      MachineImage: "{{ .Cluster.ConfigItems.kuberuntu_image_v1_18 }}"
+      MachineImage: "{{ .NodePool.ConfigItems.kuberuntu_image_v1_18 }}"
 
 Resources:
   AutoScalingInstanceProfile:


### PR DESCRIPTION
Allows specifying the AMI_ID per node pool if desired. Useful to test a new AMI just for a single node pool.