### PR TITLE
Comment a couple flaky RouteGroup tests

### DIFF
--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -169,9 +169,7 @@ if [ "$e2e" = true ]; then
     mkdir -p junit_reports
     ginkgo -nodes=25 -flakeAttempts=2 \
         -focus="(\[Conformance\]|\[StatefulSetBasic\]|\[Feature:StatefulSet\]\s\[Slow\].*mysql|\[Zalando\])" \
-        -skip="(\[Serial\])" \
-        -skip="(should.resolve.DNS.of.partial.qualified.names.for.the.cluster|should.resolve.DNS.of.partial.qualified.names.for.services|should.be.able.to.change.the.type.from.ExternalName.to.NodePort|should.be.able.to.create.a.functioning.NodePort.service|\[Serial\])" \
-        -skip="(Should create gradual traffic routes|Should create blue-green routes)" \
+        -skip="(should.resolve.DNS.of.partial.qualified.names.for.the.cluster|should.resolve.DNS.of.partial.qualified.names.for.services|should.be.able.to.change.the.type.from.ExternalName.to.NodePort|should.be.able.to.create.a.functioning.NodePort.service|\[Serial\]|Should.create.gradual.traffic.routes|Should.create.blue-green.routes)" \
         "e2e.test" -- -delete-namespace-on-failure=false -non-blocking-taints=node.kubernetes.io/role,nvidia.com/gpu -report-dir=junit_reports
     TEST_RESULT="$?"
 

--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -171,6 +171,7 @@ if [ "$e2e" = true ]; then
         -focus="(\[Conformance\]|\[StatefulSetBasic\]|\[Feature:StatefulSet\]\s\[Slow\].*mysql|\[Zalando\])" \
         -skip="(\[Serial\])" \
         -skip="(should.resolve.DNS.of.partial.qualified.names.for.the.cluster|should.resolve.DNS.of.partial.qualified.names.for.services|should.be.able.to.change.the.type.from.ExternalName.to.NodePort|should.be.able.to.create.a.functioning.NodePort.service|\[Serial\])" \
+        -skip="(Should create gradual traffic routes|Should create blue-green routes)" \
         "e2e.test" -- -delete-namespace-on-failure=false -non-blocking-taints=node.kubernetes.io/role,nvidia.com/gpu -report-dir=junit_reports
     TEST_RESULT="$?"
 


### PR DESCRIPTION
Comment a couple flaky RouteGroup tests. Rename test file so funcs from
e2e_test.go get picked up by IDEs.

Signed-off-by: Muaaz Saleem <muhammad.muaaz.saleem@zalando.de>