### PR TITLE
allow varying number of skipper redis pods

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -257,7 +257,7 @@ Resources:
           FromPort: 9999
           IpProtocol: tcp
           ToPort: 9999
-{{- if eq .Cluster.ConfigItems.skipper_clusterratelimit "true"}}
+{{- if ne .Cluster.ConfigItems.skipper_redis_replicas "0"}}
         - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
           FromPort: 9990
           IpProtocol: tcp

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -56,12 +56,12 @@ skipper_read_timeout_server: "5m"
 skipper_write_timeout_server: "60s"
 
 # skipper redis settings
+skipper_redis_replicas: 2
 skipper_redis_cpu: "100m"
 skipper_redis_memory: "100Mi"
 
 # skipper api GW features
 enable_apimonitoring: "true"
-skipper_clusterratelimit: "true"
 {{if eq .Environment "production"}}
 enable_skipper_eastwest: "false"
 {{else}}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -89,7 +89,7 @@ spec:
           - "-max-audit-body=0"
 {{ if ne .ConfigItems.skipper_redis_replicas "0" }}
           - "-enable-swarm"
-          - "-swarm-redis-urls={{ indexedList skipper-ingress-redis-$.skipper-ingress-redis.kube-system.svc.cluster.local:6379 .ConfigItems.skipper_redis_replicas }}"
+          - "-swarm-redis-urls={{ indexedListindexedList "skipper-ingress-redis-$.skipper-ingress-redis.kube-system.svc.cluster.local:6379" .ConfigItems.skipper_redis_replicas }}"
 {{ end }}
           - "-oauth2-tokeninfo-url={{ .ConfigItems.tokeninfo_url }}"
           - "-histogram-metric-buckets=.0001,.00025,.0005,.00075,.001,.0025,.005,.0075,.01,.025,.05,.075,.1,.2,.3,.4,.5,.75,1,2,3,4,5,7,10,15,20,30,60,120,300,600"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -87,9 +87,9 @@ spec:
           - "-default-filters-dir=/etc/config/default-filters"
 {{ end }}
           - "-max-audit-body=0"
-{{ if eq .ConfigItems.skipper_clusterratelimit "true"}}
+{{ if ne .ConfigItems.skipper_redis_replicas "0" }}
           - "-enable-swarm"
-          - "-swarm-redis-urls=skipper-ingress-redis-0.skipper-ingress-redis.kube-system.svc.cluster.local:6379,skipper-ingress-redis-1.skipper-ingress-redis.kube-system.svc.cluster.local:6379"
+          - "-swarm-redis-urls={{ indexedList skipper-ingress-redis-$.skipper-ingress-redis.kube-system.svc.cluster.local:6379 .ConfigItems.skipper_redis_replicas }}"
 {{ end }}
           - "-oauth2-tokeninfo-url={{ .ConfigItems.tokeninfo_url }}"
           - "-histogram-metric-buckets=.0001,.00025,.0005,.00075,.001,.0025,.005,.0075,.01,.025,.05,.075,.1,.2,.3,.4,.5,.75,1,2,3,4,5,7,10,15,20,30,60,120,300,600"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -89,7 +89,7 @@ spec:
           - "-max-audit-body=0"
 {{ if ne .ConfigItems.skipper_redis_replicas "0" }}
           - "-enable-swarm"
-          - "-swarm-redis-urls={{ indexedListindexedList "skipper-ingress-redis-$.skipper-ingress-redis.kube-system.svc.cluster.local:6379" .ConfigItems.skipper_redis_replicas }}"
+          - "-swarm-redis-urls={{ indexedList "skipper-ingress-redis-$.skipper-ingress-redis.kube-system.svc.cluster.local:6379" .ConfigItems.skipper_redis_replicas }}"
 {{ end }}
           - "-oauth2-tokeninfo-url={{ .ConfigItems.tokeninfo_url }}"
           - "-histogram-metric-buckets=.0001,.00025,.0005,.00075,.001,.0025,.005,.0075,.01,.025,.05,.075,.1,.2,.3,.4,.5,.75,1,2,3,4,5,7,10,15,20,30,60,120,300,600"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -89,7 +89,7 @@ spec:
           - "-max-audit-body=0"
 {{ if ne .ConfigItems.skipper_redis_replicas "0" }}
           - "-enable-swarm"
-          - "-swarm-redis-urls={{ indexedList "skipper-ingress-redis-$.skipper-ingress-redis.kube-system.svc.cluster.local:6379" .ConfigItems.skipper_redis_replicas }}"
+          - "-swarm-redis-urls={{ indexedList "skipper-ingress-redis-$.skipper-ingress-redis.kube-system.svc.cluster.local:6379" (parseInt64 .ConfigItems.skipper_redis_replicas) }}"
 {{ end }}
           - "-oauth2-tokeninfo-url={{ .ConfigItems.tokeninfo_url }}"
           - "-histogram-metric-buckets=.0001,.00025,.0005,.00075,.001,.0025,.005,.0075,.01,.025,.05,.075,.1,.2,.3,.4,.5,.75,1,2,3,4,5,7,10,15,20,30,60,120,300,600"

--- a/cluster/manifests/skipper/skipper-redis.yaml
+++ b/cluster/manifests/skipper/skipper-redis.yaml
@@ -7,7 +7,7 @@ metadata:
   name: skipper-ingress-redis
   namespace: kube-system
 spec:
-  replicas: {{if eq .ConfigItems.skipper_clusterratelimit "true"}}2{{else}}0{{end}}
+  replicas: {{ .ConfigItems.skipper_redis_replicas }}
   selector:
     matchLabels:
       application: skipper-ingress-redis


### PR DESCRIPTION
allow varying number of skipper redis pods

Relying on: https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/360

Signed-off-by: Arpad Ryszka <arpad.ryszka@gmail.com>