### PR TITLE
Add the journald log reader

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -119,6 +119,15 @@ cadvisor_memory: "150Mi"
 node_exporter_cpu: "20m"
 node_exporter_memory: "75Mi"
 
+# journald reader settings
+{{if eq .Environment "e2e"}}
+journald_reader_enabled: "true"
+{{else}}
+journald_reader_enabled: "false"
+{{end}}
+journald_reader_cpu: "1m"
+journald_reader_memory: "75Mi"
+
 # Logging settings
 logging_s3_bucket: "zalando-logging-{{.InfrastructureAccount | getAWSAccountID}}-{{.Region}}"
 scalyr_team_token: ""

--- a/cluster/manifests/node-monitor/daemonset.yaml
+++ b/cluster/manifests/node-monitor/daemonset.yaml
@@ -15,6 +15,8 @@ spec:
     metadata:
       labels:
         application: node-monitor
+      annotations:
+        kubernetes-log-watcher/scalyr-parser: '[{"container": "journald-reader", "parser": "journald"}]'
     spec:
       hostNetwork: true
       hostPID: true
@@ -95,6 +97,24 @@ spec:
             - name: rootfs
               mountPath: /host
               readOnly: true
+{{- if eq .Cluster.ConfigItems.journald_reader_enabled "true" }}
+        - image: registry.opensource.zalan.do/logging/journald-reader:master-2
+          name: journald-reader
+          resources:
+            requests:
+              cpu: {{.Cluster.ConfigItems.journald_reader_cpu}}
+              memory: {{.Cluster.ConfigItems.journald_reader_memory}}
+              ephemeral-storage: 256Mi
+            limits:
+              cpu: {{.Cluster.ConfigItems.journald_reader_cpu}}
+              memory: {{.Cluster.ConfigItems.journald_reader_memory}}
+          volumeMounts:
+            - mountPath: /var/log/journal
+              name: journald-logs
+              readOnly: true
+            - mountPath: /cursorfiles
+              name: journald-reader-state
+{{- end }}
       automountServiceAccountToken: false
       terminationGracePeriodSeconds: 30
       volumes:
@@ -113,6 +133,15 @@ spec:
         - name: kmsg
           hostPath:
             path: /dev/kmsg
+{{- if eq .Cluster.ConfigItems.journald_reader_enabled "true" }}
+        - name: journald-logs
+          hostPath:
+            path: /var/log/journal
+        - name: journald-reader-state
+          hostPath:
+            path: /var/run/journald-reader
+            type: DirectoryOrCreate
+{{- end }}
       tolerations:
         - operator: Exists
           effect: NoSchedule


### PR DESCRIPTION
Builds on #3604.

Adds a container to the `node-monitor` that tails the node's journal. Currently not enabled by default, we'll test it in a couple clusters first.