### PR TITLE
Don't drop the cadvisor/node-exporter PRs

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -145,16 +145,10 @@ post_apply:
   kind: ClusterRole
 - name: cadvisor
   namespace: kube-system
-  kind: ServiceAccount
-- name: cadvisor
-  namespace: kube-system
   kind: Service
 - name: cadvisor-privileged-psp
   namespace: kube-system
   kind: RoleBinding
-- name: prometheus-node-exporter
-  namespace: kube-system
-  kind: ServiceAccount
 - name: prometheus-node-exporter
   namespace: kube-system
   kind: Service


### PR DESCRIPTION
This will be done in a separate PR afterwards, to avoid flaky E2E runs.