### PR TITLE
Drop the cadvisor/node-exporter SAs

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -145,10 +145,16 @@ post_apply:
   kind: ClusterRole
 - name: cadvisor
   namespace: kube-system
+  kind: ServiceAccount
+- name: cadvisor
+  namespace: kube-system
   kind: Service
 - name: cadvisor-privileged-psp
   namespace: kube-system
   kind: RoleBinding
+- name: prometheus-node-exporter
+  namespace: kube-system
+  kind: ServiceAccount
 - name: prometheus-node-exporter
   namespace: kube-system
   kind: Service


### PR DESCRIPTION
Revert #3607, to be merged after the other PR is fully rolled out.