### PR TITLE
Drop the textfile collector

### DIFF
--- a/cluster/manifests/node-monitor/daemonset.yaml
+++ b/cluster/manifests/node-monitor/daemonset.yaml
@@ -72,7 +72,6 @@ spec:
               hostPort: 9101
         - image: registry.opensource.zalan.do/teapot/prometheus-node-exporter:v0.18.1
           args:
-            - --collector.textfile.directory=/prometheus-exporter-data
             - --collector.processes
             - --path.procfs=/host/proc
             - --path.sysfs=/host/sys


### PR DESCRIPTION
The directory was dropped since we haven't used it, but I forgot to drop the configuration.