### PR TITLE
Make it possible to disable preemption as much as possible

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -220,12 +220,15 @@ teapot_admission_controller_daemonset_reserved_memory: "64Gi"
 {{if eq .Environment "production"}}
 teapot_admission_controller_validate_application_label: "true"
 teapot_admission_controller_validate_pod_template_resources: "true"
+teapot_admission_controller_preemption_enabled: "true"
 {{else if eq .Environment "e2e"}}
 teapot_admission_controller_validate_application_label: "false"
 teapot_admission_controller_validate_pod_template_resources: "false"
+teapot_admission_controller_preemption_enabled: "true"
 {{else}}
 teapot_admission_controller_validate_application_label: "false"
 teapot_admission_controller_validate_pod_template_resources: "true"
+teapot_admission_controller_preemption_enabled: "true"
 {{end}}
 
 {{if eq .Environment "e2e"}}

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -394,11 +394,11 @@ stackset_controller_mem_max: "1Gi"
 ebs_root_volume_size: "50"
 ebs_root_volume_delete_on_termination: "true"
 
-# Migration off priority classes
+# Priority class used for critical system pods
 {{if eq .Environment "production"}}
-system_pods_critical: "true"
+system_priority_class: "system-cluster-critical"
 {{else}}
-system_pods_critical: "false"
+system_priority_class: "cluster-critical-nonpreempting"
 {{end}}
 
 # spot.io Ocean configuration.

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -228,7 +228,7 @@ teapot_admission_controller_preemption_enabled: "true"
 {{else}}
 teapot_admission_controller_validate_application_label: "false"
 teapot_admission_controller_validate_pod_template_resources: "true"
-teapot_admission_controller_preemption_enabled: "true"
+teapot_admission_controller_preemption_enabled: "false"
 {{end}}
 
 {{if eq .Environment "e2e"}}

--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -39,3 +39,5 @@ data:
   deployment.default.rolling-update-max-unavailable: "{{ .Cluster.ConfigItems.teapot_admission_controller_deployment_default_max_unavailable }}"
 
   crd.resource-delete-protection.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_crd_ensure_no_resources_on_delete }}"
+
+  priorityclass.preemption.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_preemption_enabled }}"

--- a/cluster/manifests/01-admission-control/teapot.yaml
+++ b/cluster/manifests/01-admission-control/teapot.yaml
@@ -186,3 +186,16 @@ webhooks:
         apiVersions: ["v1"]
         resources: ["daemonsets"]
 {{- end }}
+  - name: priorityclass-admitter.teapot.zalan.do
+    clientConfig:
+      url: "https://localhost:8085/priorityclass"
+      caBundle: "{{ .ConfigItems.ca_cert_decompressed }}"
+    admissionReviewVersions: ["v1beta1"]
+    failurePolicy: Fail
+    sideEffects: "NoneOnDryRun"
+    matchPolicy: Equivalent
+    rules:
+      - operations: [ "CREATE", "UPDATE" ]
+        apiGroups: ["scheduling.k8s.io"]
+        apiVersions: ["v1"]
+        resources: ["priorityclasses"]

--- a/cluster/manifests/01-priorityclasses/cluster-critical-nonpreempting.yaml
+++ b/cluster/manifests/01-priorityclasses/cluster-critical-nonpreempting.yaml
@@ -1,0 +1,6 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: cluster-critical-nonpreempting
+value: 1000000000
+preemptionPolicy: Never

--- a/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
@@ -22,9 +22,7 @@ spec:
       annotations:
         config/hash: {{"02-secret.yaml" | manifestHash}}
     spec:
-{{- if eq .Cluster.ConfigItems.system_pods_critical "true" }}
-      priorityClassName: system-cluster-critical
-{{- end }}
+      priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       serviceAccountName: vpa-admission-controller
       containers:
       - name: admission-controller

--- a/cluster/manifests/01-visibility/priority-logging.yaml
+++ b/cluster/manifests/01-visibility/priority-logging.yaml
@@ -1,7 +1,0 @@
-apiVersion: scheduling.k8s.io/v1
-kind: PriorityClass
-metadata:
-  name: visibility-logging
-value: 1000000000
-globalDefault: false
-description: "This priority class is used by logging-agent components."

--- a/cluster/manifests/01-visibility/priority.yaml
+++ b/cluster/manifests/01-visibility/priority.yaml
@@ -1,7 +1,0 @@
-apiVersion: scheduling.k8s.io/v1
-kind: PriorityClass
-metadata:
-  name: visibility-zmon
-value: 100000000
-globalDefault: false
-description: "This priority class is used by ZMON components."

--- a/cluster/manifests/02-kube-aws-iam-controller/deployment.yaml
+++ b/cluster/manifests/02-kube-aws-iam-controller/deployment.yaml
@@ -18,9 +18,7 @@ spec:
         version: v0.1.2
     spec:
       serviceAccountName: kube-aws-iam-controller
-{{- if eq .Cluster.ConfigItems.system_pods_critical "true" }}
-      priorityClassName: system-cluster-critical
-{{- end }}
+      priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       # running with hostNetwork to bypass metadata service block from pod
       # network.
       hostNetwork: true

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -161,3 +161,5 @@ post_apply:
 - name: prometheus-node-exporter-privileged-psp
   namespace: kube-system
   kind: RoleBinding
+- name: visibility-logging
+  kind: PriorityClass

--- a/cluster/manifests/emergency-access-service/deployment.yaml
+++ b/cluster/manifests/emergency-access-service/deployment.yaml
@@ -30,9 +30,7 @@ spec:
         options:
           - name: ndots
             value: "1"
-{{- if eq .Cluster.ConfigItems.system_pods_critical "true" }}
-      priorityClassName: system-cluster-critical
-{{- end }}
+      priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       serviceAccountName: emergency-access-service
       containers:
       - name: apiserver-proxy

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -28,9 +28,7 @@ spec:
         options:
           - name: ndots
             value: "1"
-{{- if eq .Cluster.ConfigItems.system_pods_critical "true" }}
-      priorityClassName: system-cluster-critical
-{{- end }}
+      priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       serviceAccountName: external-dns
       containers:
       - name: external-dns

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -27,9 +27,7 @@ spec:
         options:
           - name: ndots
             value: "1"
-{{- if eq .Cluster.ConfigItems.system_pods_critical "true" }}
-      priorityClassName: system-cluster-critical
-{{- end }}
+      priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       serviceAccountName: kube-ingress-aws-controller
       containers:
       - name: controller

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -36,9 +36,7 @@ spec:
                   values:
                   - skipper-ingress
               topologyKey: kubernetes.io/hostname
-{{- if eq .Cluster.ConfigItems.system_pods_critical "true" }}
-      priorityClassName: system-cluster-critical
-{{- end }}
+      priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       serviceAccountName: skipper-ingress
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true

--- a/cluster/manifests/skipper/skipper-redis.yaml
+++ b/cluster/manifests/skipper/skipper-redis.yaml
@@ -18,9 +18,7 @@ spec:
         application: skipper-ingress-redis
         version: v4.0.9
     spec:
-{{- if eq .Cluster.ConfigItems.system_pods_critical "true" }}
-      priorityClassName: system-cluster-critical
-{{- end }}
+      priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       containers:
       - image: registry.opensource.zalan.do/zmon/redis:4.0.9-master-6
         name: skipper-ingress-redis

--- a/cluster/manifests/stackset-controller/deployment.yaml
+++ b/cluster/manifests/stackset-controller/deployment.yaml
@@ -17,9 +17,7 @@ spec:
         application: stackset-controller
         version: "v1.3.6"
     spec:
-{{- if eq .Cluster.ConfigItems.system_pods_critical "true" }}
-      priorityClassName: system-cluster-critical
-{{- end }}
+      priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       serviceAccountName: stackset-controller
       containers:
       - name: stackset-controller

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -211,7 +211,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-76
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-78
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
* Update admission controller to support enforcing preemptionPolicy Never
* Drop the `visibility-logging` priority class since it's not needed anymore
* Remove the manifest for the `visibility-zmon` priority class, it'll be moved into the internal repo
* Add a priority class with the highest value but preemptionPolicy set to Never, for use by system components
* Drop the `system_pods_critical` config item. Instead, add `system_priority_class` which is set to `system-cluster-critical` in production clusters and `cluster-critical-nonpreempting` in test ones for now