### PR TITLE
Fix the priority class used for autoscaling buffer pods

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -163,3 +163,5 @@ post_apply:
   kind: RoleBinding
 - name: visibility-logging
   kind: PriorityClass
+- name: autoscaling-buffer
+  kind: PriorityClass

--- a/cluster/manifests/kube-cluster-autoscaler/autoscaling-priority-class.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/autoscaling-priority-class.yaml
@@ -1,7 +1,8 @@
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
-  name: autoscaling-buffer
+  name: autoscaling-buffer-nonpreempting
 value: -1000000
 globalDefault: false
 description: "This priority class is used by the autoscalling buffer pods."
+preemptionPolicy: Never

--- a/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment.yaml
@@ -28,7 +28,7 @@ spec:
             value: "1"
       nodeSelector:
         topology.kubernetes.io/zone: "{{$zone}}"
-      priorityClassName: autoscaling-buffer
+      priorityClassName: autoscaling-buffer-nonpreempting
       terminationGracePeriodSeconds: 0
       containers:
       - name: pause


### PR DESCRIPTION
I forgot about it in #3613. :(