### PR TITLE
update skipper to v0.11.156

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.11.154
+    version: v0.11.156
     component: ingress
 spec:
   strategy:
@@ -19,7 +19,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.11.154
+        version: v0.11.156
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -42,7 +42,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.154
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.156
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -101,7 +101,7 @@ spec:
             tag=application=skipper-ingress
             tag=account={{ .Cluster.Alias }}
             tag=cluster={{ .Cluster.Alias }}
-            tag=artifact=registry.opensource.zalan.do/pathfinder/skipper:v0.11.154
+            tag=artifact=registry.opensource.zalan.do/pathfinder/skipper:v0.11.156
             grpc-max-msg-size={{ .ConfigItems.skipper_ingress_lightstep_grpc_max_msg_size }}
             max-period={{ .ConfigItems.skipper_ingress_lightstep_max_period }}
             min-period={{ .ConfigItems.skipper_ingress_lightstep_min_period }}


### PR DESCRIPTION
- connect tokeninfo tracing with main request span
- hash away redis keys

Signed-off-by: Arpad Ryszka <arpad.ryszka@gmail.com>