### PR TITLE
kube-metrics-adapter: Better JSON Path support

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.8
+        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.9
         env:
 {{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}

--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.6
+        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.8
         env:
 {{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "true"}}


### PR DESCRIPTION
Support bracket notation in JSON path: https://github.com/zalando-incubator/kube-metrics-adapter/pull/192

Follow up to #3619 which had a bug

Additionally fixes a bug to properly expose OpenAPI spec and get rid of errors in the apiserver: https://github.com/zalando-incubator/kube-metrics-adapter/pull/164