### PR TITLE
Add default docker capabilities to allow list

### DIFF
--- a/cluster/manifests/psp/pod_security_policy.yaml
+++ b/cluster/manifests/psp/pod_security_policy.yaml
@@ -25,6 +25,21 @@ spec:
     - net.ipv4.tcp_keepalive_probes
   volumes:
   - '*'
+  allowedCapabilities:
+  - AUDIT_WRITE
+  - CHOWN
+  - DAC_OVERRIDE
+  - FOWNER
+  - FSETID
+  - KILL
+  - MKNOD
+  - NET_BIND_SERVICE
+  - NET_RAW
+  - SETFCAP
+  - SETGID
+  - SETPCAP
+  - SETUID
+  - SYS_CHROOT
 ---
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -53,3 +68,18 @@ spec:
   - persistentVolumeClaim
   - projected
   - secret
+  allowedCapabilities:
+  - AUDIT_WRITE
+  - CHOWN
+  - DAC_OVERRIDE
+  - FOWNER
+  - FSETID
+  - KILL
+  - MKNOD
+  - NET_BIND_SERVICE
+  - NET_RAW
+  - SETFCAP
+  - SETGID
+  - SETPCAP
+  - SETUID
+  - SYS_CHROOT


### PR DESCRIPTION
Our PSPs are missing the `allowedCapabilities` field which is equivalent of allowing docker's default capabilities listed here: https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities

However, this approach leads to unnecessary rejections when a container explicitly reduces the set of given permissions, e.g. via: 

```yaml
        securityContext:
          capabilities:
            add:
            - CHOWN
            - FOWNER
            drop:
            - ALL
```

Our current PSPs reject the above setup although it actually reduces the set of capabilities compared to the default, since both mentioned capabilities are part of the default list.

This can be solved by explicitly adding the default capabilities to the PSP's `allowedCapabilities` list. This doesn't increase the set of allowed capabilities and allows to select a subset to reduce the container's permissions.

For reference, check if there's any issues with PSP in the cluster:
```
$ kubectl get events -A | grep "pod security policy"
namespace   12s         Warning   FailedCreate                   statefulset/my-server                           create Pod my-server-3 in StatefulSet my-server failed error: pods "my-server-3" is forbidden: unable to validate against any pod security policy: [spec.initContainers[0].securityContext.capabilities.add: Invalid value: "FOWNER": capability may not be added]
``` 