### PR TITLE
Update AMI to update containerd to v1.13.7

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -254,7 +254,7 @@ cluster_dns: "coredns"
 coredns_log_svc_names: "true"
 coredns_max_upstream_concurrency: 0 #0 means there is not concurrency limits
 
-kuberuntu_image_v1_18: {{ amiID "zalando-ubuntu-kubernetes-production-v1.18.9-master-126" "861068367966" }}
+kuberuntu_image_v1_18: {{ amiID "zalando-ubuntu-kubernetes-production-v1.18.9-master-127" "861068367966" }}
 
 # Feature toggle for auditing events
 audit_pod_events: "true"


### PR DESCRIPTION
* containerd updated `1.2.13-2` -> `v1.13.7-1` (addresses `CVE-2020-15157` https://twitter.com/containerd/status/1315741286792482816)
* docker-ce updated `5:19.03.12~3-0~ubuntu-focal` -> `5:19.03.13~3-0~ubuntu-focal`