### PR TITLE
Mark skipper-redis pods as unevictable by CA

### DIFF
--- a/cluster/manifests/skipper/skipper-redis.yaml
+++ b/cluster/manifests/skipper/skipper-redis.yaml
@@ -17,6 +17,8 @@ spec:
       labels:
         application: skipper-ingress-redis
         version: v4.0.9
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
     spec:
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       containers:


### PR DESCRIPTION
This should prevent it from being moved around, creating issues.