### PR TITLE
Use cluster-critical-nonpreempting in production clusters

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -395,11 +395,7 @@ ebs_root_volume_size: "50"
 ebs_root_volume_delete_on_termination: "true"
 
 # Priority class used for critical system pods
-{{if eq .Environment "production"}}
-system_priority_class: "system-cluster-critical"
-{{else}}
 system_priority_class: "cluster-critical-nonpreempting"
-{{end}}
 
 # spot.io Ocean configuration.
 #


### PR DESCRIPTION
This shouldn't cause any issues since we're using the highest priority class value anyway, and can help with rapid scale ups of system components.