### PR TITLE
Add back tokeninfo cpu/memory config items

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -94,6 +94,8 @@ routegroups_validation: "enabled"
 skipper_single_container_enabled: "true"
 
 # tokeninfo
+skipper_ingress_tokeninfo_cpu: "1000m"
+skipper_ingress_tokeninfo_memory: "512Mi"
 {{if eq .Environment "production"}}
 tokeninfo_url: "http://127.0.0.1:9021/oauth2/tokeninfo"
 skipper_local_tokeninfo: "true"


### PR DESCRIPTION
Follow up to #3660 adding back the tokeninfo resource config items which were accidentally dropped, but are still required by the legacy setup.