### PR TITLE
Make flannel resources configurable

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -123,6 +123,10 @@ node_exporter_memory: "75Mi"
 kube_proxy_cpu: "50m"
 kube_proxy_memory: "200Mi"
 
+# flannel settings
+flannel_cpu: "25m"
+flannel_memory: "100Mi"
+
 # journald reader settings
 {{if eq .Environment "production"}}
 journald_reader_enabled: "false"

--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -82,12 +82,12 @@ spec:
               fieldPath: metadata.namespace
         resources:
           requests:
-            cpu: 25m
-            memory: 100Mi
+            cpu: "{{ .Cluster.ConfigItems.flannel_cpu }}"
+            memory: "{{ .Cluster.ConfigItems.flannel_memory }}"
             ephemeral-storage: 256Mi
           limits:
-            cpu: 25m
-            memory: 100Mi
+            cpu: "{{ .Cluster.ConfigItems.flannel_cpu }}"
+            memory: "{{ .Cluster.ConfigItems.flannel_memory }}"
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
Allows setting higher memory/cpu for flannel if needed. This is needed in clusters with a lot of pods because of the huge iptables table that is needed to have all the kube-proxy routing.