### PR TITLE
Making vpa cpu and mem configurable

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -132,6 +132,9 @@ journald_reader_memory: "75Mi"
 logging_s3_bucket: "zalando-logging-{{.InfrastructureAccount | getAWSAccountID}}-{{.Region}}"
 scalyr_team_token: ""
 
+vpa_cpu: "200m"
+vpa_mem: "500Mi"
+
 prometheus_cpu: "1000m"
 prometheus_mem: "4Gi"
 prometheus_mem_min: "2Gi"

--- a/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
@@ -38,11 +38,11 @@ spec:
               fieldPath: metadata.namespace
         resources:
           limits:
-            cpu: 200m
-            memory: 500Mi
+            cpu: {{.Cluster.ConfigItems.vpa_cpu}}
+            memory: {{.Cluster.ConfigItems.vpa_mem}}
           requests:
-            cpu: 200m
-            memory: 500Mi
+            cpu: {{.Cluster.ConfigItems.vpa_cpu}}
+            memory: {{.Cluster.ConfigItems.vpa_mem}}
         ports:
         - containerPort: 8000
       volumes:

--- a/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
@@ -33,10 +33,10 @@ spec:
         - "/recommender"
         resources:
           limits:
-            cpu: 200m
-            memory: 500Mi
+            cpu: {{.Cluster.ConfigItems.vpa_cpu}}
+            memory: {{.Cluster.ConfigItems.vpa_mem}}
           requests:
-            cpu: 200m
-            memory: 500Mi
+            cpu: {{.Cluster.ConfigItems.vpa_cpu}}
+            memory: {{.Cluster.ConfigItems.vpa_mem}}
         ports:
         - containerPort: 8080

--- a/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
@@ -34,10 +34,10 @@ spec:
           - --evict-after-oom-threshold=12h
         resources:
           limits:
-            cpu: 200m
-            memory: 500Mi
+            cpu: {{.Cluster.ConfigItems.vpa_cpu}}
+            memory: {{.Cluster.ConfigItems.vpa_mem}}
           requests:
-            cpu: 200m
-            memory: 500Mi
+            cpu: {{.Cluster.ConfigItems.vpa_cpu}}
+            memory: {{.Cluster.ConfigItems.vpa_mem}}
         ports:
         - containerPort: 8080


### PR DESCRIPTION
For now all three components can use the same amounts.

Signed-off-by: Muaaz Saleem <muhammad.muaaz.saleem@zalando.de>

Using fully qualified config item qualifiers

Signed-off-by: Muaaz Saleem <muhammad.muaaz.saleem@zalando.de>

Fixing typo

Signed-off-by: Muaaz Saleem <muhammad.muaaz.saleem@zalando.de>