### PR TITLE
multiple bf releavant skipper-ingress fixes 

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.11.166
+    version: v0.11.174
     component: ingress
 spec:
   strategy:
@@ -20,7 +20,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.11.166
+        version: v0.11.174
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -43,7 +43,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/teapot/skipper:v0.11.166-2
+        image: registry.opensource.zalan.do/teapot/skipper:v0.11.174-13
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -119,7 +119,7 @@ spec:
             tag=application=skipper-ingress
             tag=account={{ .Cluster.Alias }}
             tag=cluster={{ .Cluster.Alias }}
-            tag=artifact=registry.opensource.zalan.do/teapot/skipper:v0.11.166
+            tag=artifact=registry.opensource.zalan.do/teapot/skipper:v0.11.174
             grpc-max-msg-size={{ .ConfigItems.skipper_ingress_lightstep_grpc_max_msg_size }}
             max-period={{ .ConfigItems.skipper_ingress_lightstep_max_period }}
             min-period={{ .ConfigItems.skipper_ingress_lightstep_min_period }}


### PR DESCRIPTION
fix: shunt fallback route if no endpoints
fix: smoother fade-in when all endpoints are fading in
feature: better tracing in proxy span write request, write request headers, time to first byte from response
fix: error response content-length for requests with Transfer-Encoding: chunked
fix: flush stream to client in error paths

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>