### PR TITLE
Use aws-credentials-waiter from OS Registry

### DIFF
--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -18,7 +18,7 @@ data:
   pod.service-account-iam.enable: "true"
 {{- end }}
 {{- if eq .Cluster.ConfigItems.teapot_admission_controller_inject_aws_waiter "true" }}
-  pod.aws-waiter.image: "pierone.stups.zalan.do/automata/aws-credentials-waiter:master-9"
+  pod.aws-waiter.image: "registry.opensource.zalan.do/automata/aws-credentials-waiter:master-10"
 {{- end }}
   pod.env-inject.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_inject_environment_variables }}"
   pod.env-inject.variable._PLATFORM_ACCOUNT: "{{ .Cluster.Alias }}"


### PR DESCRIPTION
Using aws-credentials-waiter from the internal Pierone prevents restoring it in case of an outage, because it makes it dependent on itself.