### PR TITLE
Hotfix new skipper-ingress to stable

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -93,12 +93,12 @@ routegroups_validation: "enabled"
 # tokeninfo
 {{if eq .Environment "production"}}
 tokeninfo_url: "http://127.0.0.1:9021/oauth2/tokeninfo"
-local_tokeninfo: "true"
+skipper_local_tokeninfo: "true"
 {{else}}
 tokeninfo_url: "http://127.0.0.1:9000/oauth2/tokeninfo"
-local_tokeninfo: "true"
-local_sandbox_tokeninfo: "true"
-local_sandbox_bridge: "true"
+skipper_local_tokeninfo: "true"
+skipper_local_sandbox_tokeninfo: "true"
+skipper_local_sandbox_bridge: "true"
 {{end}}
 
 # Image Policy Webhook

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -97,6 +97,7 @@ skipper_single_container_enabled: "true"
 {{if eq .Environment "production"}}
 tokeninfo_url: "http://127.0.0.1:9021/oauth2/tokeninfo"
 skipper_local_tokeninfo: "true"
+skipper_local_sandbox_bridge: "false"             # TODO(sszuecs): delete CR entries
 {{else}}
 tokeninfo_url: "http://127.0.0.1:9000/oauth2/tokeninfo"
 skipper_local_tokeninfo: "true"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -61,7 +61,7 @@ skipper_redis_cpu: "100m"
 skipper_redis_memory: "100Mi"
 
 # skipper api GW features
-enable_apimonitoring: "true"
+enable_apimonitoring: "true"                       # TODO(sszuecs): cleanup candidate to reduce amount of branches in deployment
 {{if eq .Environment "production"}}
 enable_skipper_eastwest: "false"
 {{else}}
@@ -70,7 +70,7 @@ enable_skipper_eastwest: "true"
 
 # skipper tcp lifo
 # See: https://opensource.zalando.com/skipper/operation/operation/#tcp-lifo
-skipper_enable_tcp_queue: "true"
+skipper_enable_tcp_queue: "true"                    # TODO(sszuecs): cleanup candidate to reduce amount of branches in deployment
 skipper_expected_bytes_per_request: "51200"
 skipper_max_tcp_listener_concurrency: "-1"
 skipper_max_tcp_listener_queue: "-1"
@@ -90,18 +90,15 @@ lightstep_token: ""
 # can be one of disabled|provisioned|enabled
 routegroups_validation: "enabled"
 
-
 # tokeninfo
-skipper_ingress_tokeninfo_cpu: "1000m"
-skipper_ingress_tokeninfo_memory: "512Mi"
 {{if eq .Environment "production"}}
-tokeninfo_url: "https://info.services.auth.zalando.com/oauth2/tokeninfo"
-openid_provider_cfg_url: "https://identity.zalando.com/.well-known/openid-configuration"
-openid_issuer: "https://identity.zalando.com"
+tokeninfo_url: "http://127.0.0.1:9021/oauth2/tokeninfo"
+local_tokeninfo: "true"
 {{else}}
-tokeninfo_url: "https://sandbox-tokeninfo-bridge.stups.zalan.do/oauth2/tokeninfo"
-openid_provider_cfg_url: "https://sandbox.identity.zalando.com/.well-known/openid-configuration"
-openid_issuer: "https://sandbox.identity.zalando.com"
+tokeninfo_url: "http://127.0.0.1:9000/oauth2/tokeninfo"
+local_tokeninfo: "true"
+local_sandbox_tokeninfo: "true"
+local_sandbox_bridge: "true"
 {{end}}
 
 # Image Policy Webhook

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -85,6 +85,7 @@ skipper_ingress_lightstep_max_period: "2500ms"
 # set to "log-events" to enable
 skipper_ingress_lightstep_log_events: ""
 lightstep_token: ""
+tracing_collector_host: "tracing.stups.zalan.do"
 
 # disabled|provisioned|enabled routegroup validation ( skipper webhook )
 # can be one of disabled|provisioned|enabled

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -90,6 +90,9 @@ lightstep_token: ""
 # can be one of disabled|provisioned|enabled
 routegroups_validation: "enabled"
 
+# migrate from multi container to single container multi process skipper-ingress
+skipper_single_container_enabled: "true"
+
 # tokeninfo
 {{if eq .Environment "production"}}
 tokeninfo_url: "http://127.0.0.1:9021/oauth2/tokeninfo"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -97,6 +97,7 @@ skipper_single_container_enabled: "true"
 {{if eq .Environment "production"}}
 tokeninfo_url: "http://127.0.0.1:9021/oauth2/tokeninfo"
 skipper_local_tokeninfo: "true"
+skipper_local_sandbox_tokeninfo: "false"          # TODO(sszuecs): delete CR entries
 skipper_local_sandbox_bridge: "false"             # TODO(sszuecs): delete CR entries
 {{else}}
 tokeninfo_url: "http://127.0.0.1:9000/oauth2/tokeninfo"

--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -25,8 +25,8 @@ data:
   pod.env-inject.variable._PLATFORM_CLUSTER_ID: "{{ .Cluster.ID }}"
   pod.env-inject.variable._PLATFORM_OPENTRACING_TAG_ACCOUNT: "{{ .Cluster.Alias }}"
   pod.env-inject.variable._PLATFORM_OPENTRACING_LIGHTSTEP_COLLECTOR_PORT: "8443"
-  pod.env-inject.variable._PLATFORM_OPENTRACING_LIGHTSTEP_COLLECTOR_HOST: "tracing.stups.zalan.do"
-  pod.env-inject.variable._PLATFORM_OPENTRACING_LIGHTSTEP_ACCESS_TOKEN: "{{ .ConfigItems.lightstep_token }}"
+  pod.env-inject.variable._PLATFORM_OPENTRACING_LIGHTSTEP_COLLECTOR_HOST: "{{ .Cluster.ConfigItems.tracing_collector_host }}"
+  pod.env-inject.variable._PLATFORM_OPENTRACING_LIGHTSTEP_ACCESS_TOKEN: "{{ .Cluster.ConfigItems.lightstep_token }}"
 {{- if eq .Cluster.Environment "e2e" }}
   pod.env-inject.variable._PLATFORM_E2E: "injected"
 {{- end }}

--- a/cluster/manifests/emergency-access-service/deployment.yaml
+++ b/cluster/manifests/emergency-access-service/deployment.yaml
@@ -79,7 +79,7 @@ spec:
               name: "emergency-access-service-secrets"
               key: opentracing-lightstep-access-token
         - name: OPENTRACING_LIGHTSTEP_COLLECTOR_HOST
-          value: "tracing.stups.zalan.do"
+          value: "{{ .Cluster.ConfigItems.tracing_collector_host }}"
         - name: OPENTRACING_LIGHTSTEP_COLLECTOR_PORT
           value: "8444"
         - name: OPENTRACING_LIGHTSTEP_COMPONENT_NAME

--- a/cluster/manifests/skipper/configmap-sandbox-tokeninfo-bridge.yaml
+++ b/cluster/manifests/skipper/configmap-sandbox-tokeninfo-bridge.yaml
@@ -1,0 +1,32 @@
+{{ if eq .ConfigItems.enable_tokeninfo_bridge "true"}}
+apiVersion: v1
+data:
+  tokeninfo-bridge.eskip: |
+    health: Path("/healthz") -> inlineContent("ok") -> <shunt>;
+
+    q2h: Path("/oauth2/tokeninfo") && QueryParam("access_token") ->
+         queryToHeader("access_token", "Authorization", "Bearer %s") ->
+         dropQuery("access_token") ->
+         <loopback>;
+
+    production: Path("/oauth2/tokeninfo") && JWTPayloadAllKV("iss", "https://identity.zalando.com") && JWTPayloadAnyKVRegexp("https://identity.zalando.com/realm", "^users$", "azp", "^stups_", "azp", "test|staging|integration|release") ->
+                "http://localhost:9021/oauth2/tokeninfo";
+
+    production_invalid: Path("/oauth2/tokeninfo") && JWTPayloadAllKV("iss", "https://identity.zalando.com") ->
+                enableAccessLog() -> unverifiedAuditLog("azp") -> "https://info.services.auth.zalando.com/oauth2/tokeninfo";
+
+    sandbox: Path("/oauth2/tokeninfo") && JWTPayloadAllKV("iss", "https://sandbox.identity.zalando.com") ->
+             "http://localhost:9121/oauth2/tokeninfo";
+
+    fallback: Path("/oauth2/tokeninfo") ->
+              status(401) ->
+              setResponseHeader("Content-Type", "application/json;charset=UTF-8") ->
+              inlineContent("{\"error\":\"invalid_token\",\"error_description\":\"Access Token not valid\"}") ->
+              <shunt>;
+kind: ConfigMap
+metadata:
+  labels:
+    application: sandbox-tokeninfo-bridge
+  name: sandbox-tokeninfo-bridge-conf
+  namespace: kube-system
+{{ end }}

--- a/cluster/manifests/skipper/configmap-sandbox-tokeninfo-bridge.yaml
+++ b/cluster/manifests/skipper/configmap-sandbox-tokeninfo-bridge.yaml
@@ -1,4 +1,4 @@
-{{ if eq .ConfigItems.local_sandbox_bridge "true"}}
+{{ if eq .ConfigItems.skipper_local_sandbox_bridge "true"}}
 apiVersion: v1
 data:
   tokeninfo-bridge.eskip: |

--- a/cluster/manifests/skipper/configmap-sandbox-tokeninfo-bridge.yaml
+++ b/cluster/manifests/skipper/configmap-sandbox-tokeninfo-bridge.yaml
@@ -1,4 +1,4 @@
-{{ if eq .ConfigItems.enable_tokeninfo_bridge "true"}}
+{{ if eq .ConfigItems.local_sandbox_bridge "true"}}
 apiVersion: v1
 data:
   tokeninfo-bridge.eskip: |

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -53,7 +53,7 @@ spec:
             secretKeyRef:
               name: skipper-ingress
               key: lightstep-token
-{{ if eq .ConfigItems.local_tokeninfo "true" }}
+{{ if eq .ConfigItems.skipper_local_tokeninfo "true" }}
         - name: LOCAL_TOKENINFO
           value: "true"
         - name: ENABLE_OPENTRACING
@@ -66,7 +66,7 @@ spec:
               name: skipper-ingress
               key: lightstep-token
 {{ end }}
-{{ if eq .ConfigItems.local_sandbox_tokeninfo "true" }}
+{{ if eq .ConfigItems.skipper_local_sandbox_tokeninfo "true" }}
         - name: LOCAL_TOKENINFO_SANDBOX
           value: "true"
 {{ end }}
@@ -146,13 +146,13 @@ spec:
           - "-max-tcp-listener-queue={{ .ConfigItems.skipper_max_tcp_listener_queue }}"
 {{ end }}
           - "-oauth2-tokeninfo-url={{ .ConfigItems.tokeninfo_url }}"
-{{ if and (and (eq .ConfigItems.local_sandbox_tokeninfo "true") (eq .ConfigItems.local_tokeninfo "true")) (eq .ConfigItems.local_sandbox_bridge "true") }}
+{{ if and (and (eq .ConfigItems.skipper_local_sandbox_tokeninfo "true") (eq .ConfigItems.skipper_local_tokeninfo "true")) (eq .ConfigItems.skipper_local_sandbox_bridge "true") }}
           - "-status-checks=http://127.0.0.1:9021/health,http://127.0.0.1:9121/health,http://127.0.0.1:9000/healthz"
-{{ else if and (eq .ConfigItems.local_sandbox_tokeninfo "true") (eq .ConfigItems.local_tokeninfo "true") }}
+{{ else if and (eq .ConfigItems.skipper_local_sandbox_tokeninfo "true") (eq .ConfigItems.skipper_local_tokeninfo "true") }}
           - "-status-checks=http://127.0.0.1:9021/health,http://127.0.0.1:9121/health"
-{{ else if eq .ConfigItems.local_sandbox_tokeninfo "true" }}
+{{ else if eq .ConfigItems.skipper_local_sandbox_tokeninfo "true" }}
           - "-status-checks=http://127.0.0.1:9121/health"
-{{ else if eq .ConfigItems.local_tokeninfo "true" }}
+{{ else if eq .ConfigItems.skipper_local_tokeninfo "true" }}
           - "-status-checks=http://127.0.0.1:9021/health"
 {{ end }}
         resources:
@@ -168,7 +168,7 @@ spec:
             port: 9999
           initialDelaySeconds: 60
           timeoutSeconds: 5
-{{ if eq .ConfigItems.local_tokeninfo "true"}}
+{{ if eq .ConfigItems.skipper_local_tokeninfo "true"}}
         livenessProbe:
           httpGet:
             path: /health
@@ -185,13 +185,13 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 1000
-{{ if and (eq .ConfigItems.local_sandbox_bridge "true") (eq .ConfigItems.enable_apimonitoring "true")}}
+{{ if and (eq .ConfigItems.skipper_local_sandbox_bridge "true") (eq .ConfigItems.enable_apimonitoring "true")}}
         volumeMounts:
           - name: routes
             mountPath: /etc/routes
           - name: filters
             mountPath: /etc/config/default-filters
-{{ else if eq .ConfigItems.local_sandbox_bridge "true"}}
+{{ else if eq .ConfigItems.skipper_local_sandbox_bridge "true"}}
         volumeMounts:
           - name: routes
             mountPath: /etc/routes
@@ -202,7 +202,7 @@ spec:
 {{ end }}
       securityContext:
         fsGroup: 1000
-{{ if and (eq .ConfigItems.local_sandbox_bridge "true") (eq .ConfigItems.enable_apimonitoring "true")}}
+{{ if and (eq .ConfigItems.skipper_local_sandbox_bridge "true") (eq .ConfigItems.enable_apimonitoring "true")}}
       volumes:
         - name: filters
           configMap:

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -42,7 +42,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/teapot/skipper:v0.11.166
+        image: registry.opensource.zalan.do/teapot/skipper:v0.11.166-2
         ports:
         - name: ingress-port
           containerPort: 9999

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -113,7 +113,7 @@ spec:
             -opentracing=lightstep
             component-name=skipper-ingress
             token=$(LIGHTSTEP_TOKEN)
-            collector=tracing.stups.zalan.do:8444
+            collector={{ .Cluster.ConfigItems.tracing_collector_host }}:8444
             cmd-line=skipper-ingress
             max-buffered-spans={{ .ConfigItems.skipper_ingress_tracing_buffer }}
             tag=application=skipper-ingress

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.11.166
+    version: v0.11.174
     component: ingress
 spec:
   strategy:
@@ -20,7 +20,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.11.166
+        version: v0.11.174
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -43,7 +43,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/teapot/skipper:v0.11.166-2
+        image: registry.opensource.zalan.do/teapot/skipper:v0.11.174-13
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -119,7 +119,7 @@ spec:
             tag=application=skipper-ingress
             tag=account={{ .Cluster.Alias }}
             tag=cluster={{ .Cluster.Alias }}
-            tag=artifact=registry.opensource.zalan.do/teapot/skipper:v0.11.166
+            tag=artifact=registry.opensource.zalan.do/teapot/skipper:v0.11.174
             grpc-max-msg-size={{ .ConfigItems.skipper_ingress_lightstep_grpc_max_msg_size }}
             max-period={{ .ConfigItems.skipper_ingress_lightstep_max_period }}
             min-period={{ .ConfigItems.skipper_ingress_lightstep_min_period }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.11.174
+    version: v0.11.175
     component: ingress
 spec:
   strategy:
@@ -20,7 +20,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.11.174
+        version: v0.11.175
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -43,7 +43,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/teapot/skipper:v0.11.174-13
+        image: registry.opensource.zalan.do/teapot/skipper:v0.11.175-15
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -119,7 +119,7 @@ spec:
             tag=application=skipper-ingress
             tag=account={{ .Cluster.Alias }}
             tag=cluster={{ .Cluster.Alias }}
-            tag=artifact=registry.opensource.zalan.do/teapot/skipper:v0.11.174
+            tag=artifact=registry.opensource.zalan.do/teapot/skipper:v0.11.175
             grpc-max-msg-size={{ .ConfigItems.skipper_ingress_lightstep_grpc_max_msg_size }}
             max-period={{ .ConfigItems.skipper_ingress_lightstep_max_period }}
             min-period={{ .ConfigItems.skipper_ingress_lightstep_min_period }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.11.156
+    version: v0.11.166
     component: ingress
 spec:
   strategy:
@@ -19,7 +19,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.11.156
+        version: v0.11.166
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -42,7 +42,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.156
+        image: registry.opensource.zalan.do/teapot/skipper:v0.11.166
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -53,7 +53,25 @@ spec:
             secretKeyRef:
               name: skipper-ingress
               key: lightstep-token
+{{ if eq .ConfigItems.local_tokeninfo "true" }}
+        - name: LOCAL_TOKENINFO
+          value: "true"
+        - name: ENABLE_OPENTRACING
+          value: "true"
+        - name: OPENTRACING_LIGHTSTEP_COMPONENT_NAME
+          value: "tokeninfo-skipper-ingress"
+        - name: OPENTRACING_LIGHTSTEP_ACCESS_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: skipper-ingress
+              key: lightstep-token
+{{ end }}
+{{ if eq .ConfigItems.local_sandbox_tokeninfo "true" }}
+        - name: LOCAL_TOKENINFO_SANDBOX
+          value: "true"
+{{ end }}
         args:
+          - "run.sh"
           - "skipper"
           - "-kubernetes"
           - "-kubernetes-in-cluster"
@@ -89,7 +107,6 @@ spec:
           - "-enable-swarm"
           - "-swarm-redis-urls={{ indexedList "skipper-ingress-redis-$.skipper-ingress-redis.kube-system.svc.cluster.local:6379" (parseInt64 .ConfigItems.skipper_redis_replicas) }}"
 {{ end }}
-          - "-oauth2-tokeninfo-url={{ .ConfigItems.tokeninfo_url }}"
           - "-histogram-metric-buckets=.0001,.00025,.0005,.00075,.001,.0025,.005,.0075,.01,.025,.05,.075,.1,.2,.3,.4,.5,.75,1,2,3,4,5,7,10,15,20,30,60,120,300,600"
           - >-
             -opentracing=lightstep
@@ -101,7 +118,7 @@ spec:
             tag=application=skipper-ingress
             tag=account={{ .Cluster.Alias }}
             tag=cluster={{ .Cluster.Alias }}
-            tag=artifact=registry.opensource.zalan.do/pathfinder/skipper:v0.11.156
+            tag=artifact=registry.opensource.zalan.do/teapot/skipper:v0.11.166
             grpc-max-msg-size={{ .ConfigItems.skipper_ingress_lightstep_grpc_max_msg_size }}
             max-period={{ .ConfigItems.skipper_ingress_lightstep_max_period }}
             min-period={{ .ConfigItems.skipper_ingress_lightstep_min_period }}
@@ -128,7 +145,14 @@ spec:
           - "-max-tcp-listener-concurrency={{ .ConfigItems.skipper_max_tcp_listener_concurrency }}"
           - "-max-tcp-listener-queue={{ .ConfigItems.skipper_max_tcp_listener_queue }}"
 {{ end }}
-{{ if eq .ConfigItems.tokeninfo_url "http://127.0.0.1:9021/oauth2/tokeninfo" }}
+          - "-oauth2-tokeninfo-url={{ .ConfigItems.tokeninfo_url }}"
+{{ if and (and (eq .ConfigItems.local_sandbox_tokeninfo "true") (eq .ConfigItems.local_tokeninfo "true")) (eq .ConfigItems.local_sandbox_bridge "true") }}
+          - "-status-checks=http://127.0.0.1:9021/health,http://127.0.0.1:9121/health,http://127.0.0.1:9000/healthz"
+{{ elif and (eq .ConfigItems.local_sandbox_tokeninfo "true") (eq .ConfigItems.local_tokeninfo "true") }}
+          - "-status-checks=http://127.0.0.1:9021/health,http://127.0.0.1:9121/health"
+{{ elif eq .ConfigItems.local_sandbox_tokeninfo "true" }}
+          - "-status-checks=http://127.0.0.1:9121/health"
+{{ elif eq .ConfigItems.local_tokeninfo "true" }}
           - "-status-checks=http://127.0.0.1:9021/health"
 {{ end }}
         resources:
@@ -144,61 +168,50 @@ spec:
             port: 9999
           initialDelaySeconds: 60
           timeoutSeconds: 5
+{{ if eq .ConfigItems.local_tokeninfo "true"}}
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 9021
+            host: 127.0.0.1
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+{{ end }}
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 1000
-{{ if eq .ConfigItems.enable_apimonitoring "true"}}
+{{ if and (eq .ConfigItems.local_sandbox_bridge "true") (eq .ConfigItems.enable_apimonitoring "true")}}
+        volumeMounts:
+          - name: routes
+            mountPath: /etc/routes
+          - name: filters
+            mountPath: /etc/config/default-filters
+{{ elif eq .ConfigItems.local_sandbox_bridge "true"}}
+        volumeMounts:
+          - name: routes
+            mountPath: /etc/routes
+{{ elif eq .ConfigItems.enable_apimonitoring "true"}}
         volumeMounts:
           - name: filters
             mountPath: /etc/config/default-filters
 {{ end }}
-{{ if eq .ConfigItems.tokeninfo_url "http://127.0.0.1:9021/oauth2/tokeninfo" }}
-      - name: tokeninfo
-        image: registry.opensource.zalan.do/foundation/platform-iam-tokeninfo:master-1
-        ports:
-        - containerPort: 9021
-        readinessProbe:
-          httpGet:
-            path: /health
-            port: 9021
-          periodSeconds: 3
-          failureThreshold: 2
-        lifecycle:
-          preStop:
-            exec:
-              command: ["sleep","45"]
-        resources:
-          limits:
-            cpu: "{{ .ConfigItems.skipper_ingress_tokeninfo_cpu }}"
-            memory: "{{ .ConfigItems.skipper_ingress_tokeninfo_memory }}"
-          requests:
-            cpu: "{{ .ConfigItems.skipper_ingress_tokeninfo_cpu }}"
-            memory: "{{ .ConfigItems.skipper_ingress_tokeninfo_memory }}"
-        securityContext:
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          runAsUser: 1000
-        env:
-        - name: BUSINESS_PARTNERS
-          value: 810d1d00-4312-43e5-bd31-d8373fdd24c7=com.zalando zalando-legacy=legacy
-        - name: OPENID_PROVIDER_CONFIGURATION_URL
-          value: "{{ .ConfigItems.openid_provider_cfg_url }}"
-        - name: ISSUER
-          value: "{{ .ConfigItems.openid_issuer }}"
-        - name: ENABLE_OPENTRACING
-          value: "true"
-        - name: OPENTRACING_LIGHTSTEP_COMPONENT_NAME
-          value: "tokeninfo-skipper-ingress"
-        - name: OPENTRACING_LIGHTSTEP_ACCESS_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: skipper-ingress
-              key: lightstep-token
-{{ end }}
       securityContext:
         fsGroup: 1000
-{{ if eq .ConfigItems.enable_apimonitoring "true"}}
+{{ if and (eq .ConfigItems.local_sandbox_bridge "true") (eq .ConfigItems.enable_apimonitoring "true")}}
+      volumes:
+        - name: filters
+          configMap:
+            name: skipper-default-filters
+            optional: true
+        - name: routes
+          configMap:
+            name: sandbox-tokeninfo-bridge-conf
+{{ elif eq .ConfigItems.enable_apimonitoring "true"}}
       volumes:
         - name: filters
           configMap:

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -148,11 +148,11 @@ spec:
           - "-oauth2-tokeninfo-url={{ .ConfigItems.tokeninfo_url }}"
 {{ if and (and (eq .ConfigItems.local_sandbox_tokeninfo "true") (eq .ConfigItems.local_tokeninfo "true")) (eq .ConfigItems.local_sandbox_bridge "true") }}
           - "-status-checks=http://127.0.0.1:9021/health,http://127.0.0.1:9121/health,http://127.0.0.1:9000/healthz"
-{{ elif and (eq .ConfigItems.local_sandbox_tokeninfo "true") (eq .ConfigItems.local_tokeninfo "true") }}
+{{ else if and (eq .ConfigItems.local_sandbox_tokeninfo "true") (eq .ConfigItems.local_tokeninfo "true") }}
           - "-status-checks=http://127.0.0.1:9021/health,http://127.0.0.1:9121/health"
-{{ elif eq .ConfigItems.local_sandbox_tokeninfo "true" }}
+{{ else if eq .ConfigItems.local_sandbox_tokeninfo "true" }}
           - "-status-checks=http://127.0.0.1:9121/health"
-{{ elif eq .ConfigItems.local_tokeninfo "true" }}
+{{ else if eq .ConfigItems.local_tokeninfo "true" }}
           - "-status-checks=http://127.0.0.1:9021/health"
 {{ end }}
         resources:
@@ -191,11 +191,11 @@ spec:
             mountPath: /etc/routes
           - name: filters
             mountPath: /etc/config/default-filters
-{{ elif eq .ConfigItems.local_sandbox_bridge "true"}}
+{{ else if eq .ConfigItems.local_sandbox_bridge "true"}}
         volumeMounts:
           - name: routes
             mountPath: /etc/routes
-{{ elif eq .ConfigItems.enable_apimonitoring "true"}}
+{{ else if eq .ConfigItems.enable_apimonitoring "true"}}
         volumeMounts:
           - name: filters
             mountPath: /etc/config/default-filters
@@ -211,7 +211,7 @@ spec:
         - name: routes
           configMap:
             name: sandbox-tokeninfo-bridge-conf
-{{ elif eq .ConfigItems.enable_apimonitoring "true"}}
+{{ else if eq .ConfigItems.enable_apimonitoring "true"}}
       volumes:
         - name: filters
           configMap:

--- a/cluster/manifests/skipper/old_deployment.yaml
+++ b/cluster/manifests/skipper/old_deployment.yaml
@@ -96,7 +96,7 @@ spec:
             -opentracing=lightstep
             component-name=skipper-ingress
             token=$(LIGHTSTEP_TOKEN)
-            collector=tracing.stups.zalan.do:8444
+            collector={{ .Cluster.ConfigItems.tracing_collector_host }}:8444
             cmd-line=skipper-ingress
             max-buffered-spans={{ .ConfigItems.skipper_ingress_tracing_buffer }}
             tag=application=skipper-ingress

--- a/cluster/manifests/skipper/old_deployment.yaml
+++ b/cluster/manifests/skipper/old_deployment.yaml
@@ -1,4 +1,4 @@
-{{ if eq .ConfigItems.skipper_single_container_enabled "true"}}
+{{ if eq .ConfigItems.skipper_single_container_enabled "false"}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.11.166
+    version: v0.11.156
     component: ingress
 spec:
   strategy:
@@ -20,7 +20,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.11.166
+        version: v0.11.156
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -43,7 +43,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/teapot/skipper:v0.11.166-2
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.156
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -54,25 +54,7 @@ spec:
             secretKeyRef:
               name: skipper-ingress
               key: lightstep-token
-{{ if eq .ConfigItems.skipper_local_tokeninfo "true" }}
-        - name: LOCAL_TOKENINFO
-          value: "true"
-        - name: ENABLE_OPENTRACING
-          value: "true"
-        - name: OPENTRACING_LIGHTSTEP_COMPONENT_NAME
-          value: "tokeninfo-skipper-ingress"
-        - name: OPENTRACING_LIGHTSTEP_ACCESS_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: skipper-ingress
-              key: lightstep-token
-{{ end }}
-{{ if eq .ConfigItems.skipper_local_sandbox_tokeninfo "true" }}
-        - name: LOCAL_TOKENINFO_SANDBOX
-          value: "true"
-{{ end }}
         args:
-          - "run.sh"
           - "skipper"
           - "-kubernetes"
           - "-kubernetes-in-cluster"
@@ -108,6 +90,7 @@ spec:
           - "-enable-swarm"
           - "-swarm-redis-urls={{ indexedList "skipper-ingress-redis-$.skipper-ingress-redis.kube-system.svc.cluster.local:6379" (parseInt64 .ConfigItems.skipper_redis_replicas) }}"
 {{ end }}
+          - "-oauth2-tokeninfo-url={{ .ConfigItems.tokeninfo_url }}"
           - "-histogram-metric-buckets=.0001,.00025,.0005,.00075,.001,.0025,.005,.0075,.01,.025,.05,.075,.1,.2,.3,.4,.5,.75,1,2,3,4,5,7,10,15,20,30,60,120,300,600"
           - >-
             -opentracing=lightstep
@@ -119,7 +102,7 @@ spec:
             tag=application=skipper-ingress
             tag=account={{ .Cluster.Alias }}
             tag=cluster={{ .Cluster.Alias }}
-            tag=artifact=registry.opensource.zalan.do/teapot/skipper:v0.11.166
+            tag=artifact=registry.opensource.zalan.do/pathfinder/skipper:v0.11.156
             grpc-max-msg-size={{ .ConfigItems.skipper_ingress_lightstep_grpc_max_msg_size }}
             max-period={{ .ConfigItems.skipper_ingress_lightstep_max_period }}
             min-period={{ .ConfigItems.skipper_ingress_lightstep_min_period }}
@@ -146,14 +129,7 @@ spec:
           - "-max-tcp-listener-concurrency={{ .ConfigItems.skipper_max_tcp_listener_concurrency }}"
           - "-max-tcp-listener-queue={{ .ConfigItems.skipper_max_tcp_listener_queue }}"
 {{ end }}
-          - "-oauth2-tokeninfo-url={{ .ConfigItems.tokeninfo_url }}"
-{{ if and (and (eq .ConfigItems.skipper_local_sandbox_tokeninfo "true") (eq .ConfigItems.skipper_local_tokeninfo "true")) (eq .ConfigItems.skipper_local_sandbox_bridge "true") }}
-          - "-status-checks=http://127.0.0.1:9021/health,http://127.0.0.1:9121/health,http://127.0.0.1:9000/healthz"
-{{ else if and (eq .ConfigItems.skipper_local_sandbox_tokeninfo "true") (eq .ConfigItems.skipper_local_tokeninfo "true") }}
-          - "-status-checks=http://127.0.0.1:9021/health,http://127.0.0.1:9121/health"
-{{ else if eq .ConfigItems.skipper_local_sandbox_tokeninfo "true" }}
-          - "-status-checks=http://127.0.0.1:9121/health"
-{{ else if eq .ConfigItems.skipper_local_tokeninfo "true" }}
+{{ if eq .ConfigItems.tokeninfo_url "http://127.0.0.1:9021/oauth2/tokeninfo" }}
           - "-status-checks=http://127.0.0.1:9021/health"
 {{ end }}
         resources:
@@ -169,50 +145,61 @@ spec:
             port: 9999
           initialDelaySeconds: 60
           timeoutSeconds: 5
-{{ if eq .ConfigItems.skipper_local_tokeninfo "true"}}
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: 9021
-            host: 127.0.0.1
-            scheme: HTTP
-          initialDelaySeconds: 30
-          periodSeconds: 10
-          timeoutSeconds: 5
-          successThreshold: 1
-          failureThreshold: 5
-{{ end }}
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 1000
-{{ if and (eq .ConfigItems.skipper_local_sandbox_bridge "true") (eq .ConfigItems.enable_apimonitoring "true")}}
-        volumeMounts:
-          - name: routes
-            mountPath: /etc/routes
-          - name: filters
-            mountPath: /etc/config/default-filters
-{{ else if eq .ConfigItems.skipper_local_sandbox_bridge "true"}}
-        volumeMounts:
-          - name: routes
-            mountPath: /etc/routes
-{{ else if eq .ConfigItems.enable_apimonitoring "true"}}
+{{ if eq .ConfigItems.enable_apimonitoring "true"}}
         volumeMounts:
           - name: filters
             mountPath: /etc/config/default-filters
 {{ end }}
+{{ if eq .ConfigItems.tokeninfo_url "http://127.0.0.1:9021/oauth2/tokeninfo" }}
+      - name: tokeninfo
+        image: registry.opensource.zalan.do/foundation/platform-iam-tokeninfo:master-1
+        ports:
+        - containerPort: 9021
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 9021
+          periodSeconds: 3
+          failureThreshold: 2
+        lifecycle:
+          preStop:
+            exec:
+              command: ["sleep","45"]
+        resources:
+          limits:
+            cpu: "{{ .ConfigItems.skipper_ingress_tokeninfo_cpu }}"
+            memory: "{{ .ConfigItems.skipper_ingress_tokeninfo_memory }}"
+          requests:
+            cpu: "{{ .ConfigItems.skipper_ingress_tokeninfo_cpu }}"
+            memory: "{{ .ConfigItems.skipper_ingress_tokeninfo_memory }}"
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
+        env:
+        - name: BUSINESS_PARTNERS
+          value: 810d1d00-4312-43e5-bd31-d8373fdd24c7=com.zalando zalando-legacy=legacy
+        - name: OPENID_PROVIDER_CONFIGURATION_URL
+          value: "{{ .ConfigItems.openid_provider_cfg_url }}"
+        - name: ISSUER
+          value: "{{ .ConfigItems.openid_issuer }}"
+        - name: ENABLE_OPENTRACING
+          value: "true"
+        - name: OPENTRACING_LIGHTSTEP_COMPONENT_NAME
+          value: "tokeninfo-skipper-ingress"
+        - name: OPENTRACING_LIGHTSTEP_ACCESS_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: skipper-ingress
+              key: lightstep-token
+{{ end }}
       securityContext:
         fsGroup: 1000
-{{ if and (eq .ConfigItems.skipper_local_sandbox_bridge "true") (eq .ConfigItems.enable_apimonitoring "true")}}
-      volumes:
-        - name: filters
-          configMap:
-            name: skipper-default-filters
-            optional: true
-        - name: routes
-          configMap:
-            name: sandbox-tokeninfo-bridge-conf
-{{ else if eq .ConfigItems.enable_apimonitoring "true"}}
+{{ if eq .ConfigItems.enable_apimonitoring "true"}}
       volumes:
         - name: filters
           configMap:


### PR DESCRIPTION
This introduces the new way of running skipper-ingress (single container, multi process) as original introduced in #3660 + additional fixes not included in the original PR.

This enables us to have the configuration available in production cluster (we will disable it by default for now via config item: `skipper_single_container_enabled: "false"`)

Also includes opentracing changes from #3665 needed by monitoring team.