### PR TITLE
Update admission controller to generator CRD finalizer permissions

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -211,7 +211,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-78
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-79
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
Extend the poweruser role generated for CRDs to include permissions to update <resource>/finalizers