### PR TITLE
Add missing skipper config-items

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -98,12 +98,18 @@ skipper_single_container_enabled: "true"
 skipper_ingress_tokeninfo_cpu: "1000m"
 skipper_ingress_tokeninfo_memory: "512Mi"
 {{if eq .Environment "production"}}
-tokeninfo_url: "http://127.0.0.1:9021/oauth2/tokeninfo"
+# only used when `skipper_single_container_enabled=false` or `skipper_local_tokeninfo=false`
+tokeninfo_url: "https://info.services.auth.zalando.com/oauth2/tokeninfo"
+openid_provider_cfg_url: "https://identity.zalando.com/.well-known/openid-configuration"
+openid_issuer: "https://identity.zalando.com"
 skipper_local_tokeninfo: "true"
 skipper_local_sandbox_tokeninfo: "false"          # TODO(sszuecs): delete CR entries
 skipper_local_sandbox_bridge: "false"             # TODO(sszuecs): delete CR entries
 {{else}}
-tokeninfo_url: "http://127.0.0.1:9000/oauth2/tokeninfo"
+# only used when `skipper_single_container_enabled=false` or `skipper_local_tokeninfo=false`
+tokeninfo_url: "https://sandbox-tokeninfo-bridge.stups.zalan.do/oauth2/tokeninfo"
+openid_provider_cfg_url: "https://sandbox.identity.zalando.com/.well-known/openid-configuration"
+openid_issuer: "https://sandbox.identity.zalando.com"
 skipper_local_tokeninfo: "true"
 skipper_local_sandbox_tokeninfo: "true"
 skipper_local_sandbox_bridge: "true"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -146,7 +146,13 @@ spec:
           - "-max-tcp-listener-concurrency={{ .ConfigItems.skipper_max_tcp_listener_concurrency }}"
           - "-max-tcp-listener-queue={{ .ConfigItems.skipper_max_tcp_listener_queue }}"
 {{ end }}
-          - "-oauth2-tokeninfo-url={{ .ConfigItems.tokeninfo_url }}"
+{{ if and (eq .Cluster.ConfigItems.skipper_local_tokeninfo "true") (eq .ConfigItems.skipper_local_sandbox_bridge "true") }}
+          - "-oauth2-tokeninfo-url=http://127.0.0.1:9000/oauth2/tokeninfo"
+{{ else if eq .Cluster.ConfigItems.skipper_local_tokeninfo "true" }}
+          - "-oauth2-tokeninfo-url=http://127.0.0.1:9021/oauth2/tokeninfo"
+{{ else }}
+          - "-oauth2-tokeninfo-url={{ .Cluster.ConfigItems.tokeninfo_url }}"
+{{ end }}
 {{ if and (and (eq .ConfigItems.skipper_local_sandbox_tokeninfo "true") (eq .ConfigItems.skipper_local_tokeninfo "true")) (eq .ConfigItems.skipper_local_sandbox_bridge "true") }}
           - "-status-checks=http://127.0.0.1:9021/health,http://127.0.0.1:9121/health,http://127.0.0.1:9000/healthz"
 {{ else if and (eq .ConfigItems.skipper_local_sandbox_tokeninfo "true") (eq .ConfigItems.skipper_local_tokeninfo "true") }}


### PR DESCRIPTION
Add missing config-items dropped in https://github.com/zalando-incubator/kubernetes-on-aws/pull/3660

Changed it so `tokeninfo_url` is derived from `skipper_local_tokeninfo`/`skipper_local_sandbox_bridge`.