### PR TITLE
eastwest: Enable better control for migration

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -62,11 +62,22 @@ skipper_redis_memory: "100Mi"
 
 # skipper api GW features
 enable_apimonitoring: "true"                       # TODO(sszuecs): cleanup candidate to reduce amount of branches in deployment
+
+# skipper east-west feature
+# enable_skipper_eastwest is the legacy feature gate for the automatic
+# ingress.cluster.local addresses created by skipper.
+# enable_skipper_eastwest_dns only enables DNS and assumes users define the
+# ingress.cluster.local names explicitly on ingress/routegroup/stacksets
 {{if eq .Environment "production"}}
 enable_skipper_eastwest: "false"
+enable_skipper_eastwest_dns: "false"
 {{else}}
-enable_skipper_eastwest: "true"
+enable_skipper_eastwest: "false"
+enable_skipper_eastwest_dns: "true"
 {{end}}
+# enable temporay logging of ingress.cluster.local names
+# used to find services for which it's being used.
+skipper_eastwest_dns_log_enabled: "false"
 
 # skipper tcp lifo
 # See: https://opensource.zalando.com/skipper/operation/operation/#tcp-lifo

--- a/cluster/manifests/coredns-local/configmap-local.yaml
+++ b/cluster/manifests/coredns-local/configmap-local.yaml
@@ -23,8 +23,11 @@ data:
     }
 {{ end }}
 
-{{ if eq .ConfigItems.enable_skipper_eastwest "true"}}
+{{ if eq .ConfigItems.enable_skipper_eastwest_dns "true"}}
     ingress.cluster.local:9254 {
+{{ if eq .ConfigItems.skipper_eastwest_dns_log_enabled "true"}}
+        log
+{{ end }}
         template IN A {
             match "^.*[.]ingress[.]cluster[.]local"
             answer "{{"{{"}} .Name {{"}}"}} 60 IN A 10.3.99.99"


### PR DESCRIPTION
In order to migrate from the legacy version of the east-west feature where skipper automatically creates east-west routes to a new model where users have to explicitly define internal ingress names in stackset/ingress this introduced some more config-items to allow for a smooth migration per cluster.

 `enable_skipper_eastwest` Was the original toggle which enabled the automatic routes in skipper + DNS for `*.ingress.cluster.local` names. This has now been split in two:
* `enable_skipper_eastwest` - enables the automatic routes in skipper
* `enable_skipper_eastwest_dns` - enables the DNS support for `*.ingress.cluster.local`.

Based on this it will be possible to slowly disable the automatic skipper routes per cluster once users has migrated away form those.

The migration plan is as follows:
* [x] Set `enable_skipper_eastwest` and `enable_skipper_eastwest_dns` for all clusters where `enable_skipper_eastwest` is currently true.
* Merge this PR
* Disable `enable_skipper_eastwest` cluster by cluster. The toggle `skipper_eastwest_dns_log_enabled` can be used to temporarily enable DNS logging to ensure that no one is calling the legacy names before disabling them.