### PR TITLE
Enable cluster autoscaler release 1.18 by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -10,7 +10,7 @@ autoscaling_max_empty_bulk_delete: "25"
 autoscaling_scale_down_unneeded_time: "10m"
 
 # the cluster autoscaler release to use, options are 1_12 and 1_18.
-cluster_autoscaler_release: "1_12"
+cluster_autoscaler_release: "1_18"
 
 # defines which expander the autoscaler should use
 cluster_autoscaler_expander: highest-priority

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -31,6 +31,8 @@ pipeline:
       env:
       - name: DEPLOYMENT_PATH
         value: test/e2e
+      - name: E2E_SKIP_CLUSTER_UPDATE
+        value: "true"
     end2end_tests:
       metadata:
         name: e2e
@@ -73,6 +75,8 @@ pipeline:
       env:
       - name: DEPLOYMENT_PATH
         value: test/e2e
+      - name: E2E_SKIP_CLUSTER_UPDATE
+        value: "true"
     end2end_tests:
       metadata:
         name: e2e
@@ -118,6 +122,8 @@ pipeline:
       env:
       - name: DEPLOYMENT_PATH
         value: test/e2e
+      - name: E2E_SKIP_CLUSTER_UPDATE
+        value: "true"
     end2end_tests:
       metadata:
         name: e2e
@@ -164,6 +170,8 @@ pipeline:
       env:
       - name: DEPLOYMENT_PATH
         value: test/e2e
+      - name: E2E_SKIP_CLUSTER_UPDATE
+        value: "true"
     end2end_tests:
       metadata:
         name: e2e


### PR DESCRIPTION
This is just to run e2e with 1.18.