### PR TITLE
Limit maximum scale-down to 10 instances at a time

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -6,7 +6,7 @@ autoscaling_buffer_pods: "0"
 cluster_autoscaler_cpu: "100m"
 cluster_autoscaler_memory: "300Mi"
 autoscaling_utilization_threshold: "1.0"
-autoscaling_max_empty_bulk_delete: "25"
+autoscaling_max_empty_bulk_delete: "10"
 autoscaling_scale_down_unneeded_time: "10m"
 
 # the cluster autoscaler release to use, options are 1_12 and 1_18.


### PR DESCRIPTION
AWS recommends to not scale down more than 10 instances at a time. Let's use the recommended number by default (this is also the default in CA itself). We do have a use case where we want to increase that number, therefore the config item is left in place.

