### PR TITLE
Support permanent scale-up for CA v1.18

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -12,6 +12,11 @@ autoscaling_scale_down_unneeded_time: "10m"
 # the cluster autoscaler release to use, options are 1_12 and 1_18.
 cluster_autoscaler_release: "1_12"
 
+# When true, enables the legacy behaviour for 1.18 where pools that are backed off
+# don't get reset to their pre-scale-out values. This basically means the ASGs
+# keep trying to get a node while CA already moves on to the next ASG.
+cluster_autoscaler_keep_backed_off_pools_scaled_up: "true"
+
 # defines which expander the autoscaler should use
 cluster_autoscaler_expander: highest-priority
 

--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     application: kube-cluster-autoscaler
     {{- if eq .Cluster.ConfigItems.cluster_autoscaler_release "1_18" }}
-    version: v1.18.2-internal.12
+    version: v1.18.2-internal.13
     {{- else }}
     version: v1.12.2-internal-2.17
     {{- end }}
@@ -21,7 +21,7 @@ spec:
       labels:
         application: kube-cluster-autoscaler
         {{- if eq .Cluster.ConfigItems.cluster_autoscaler_release "1_18" }}
-        version: v1.18.2-internal.12
+        version: v1.18.2-internal.13
         {{- else }}
         version: v1.12.2-internal-2.17
         {{- end }}
@@ -42,7 +42,7 @@ spec:
       containers:
       - name: cluster-autoscaler
         {{- if eq .Cluster.ConfigItems.cluster_autoscaler_release "1_18" }}
-        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.18.2-internal.12
+        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.18.2-internal.13
         {{- else }}
         image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.12.2-internal-2.17
         {{- end }}
@@ -65,6 +65,9 @@ spec:
           - --max-empty-bulk-delete={{ .Cluster.ConfigItems.autoscaling_max_empty_bulk_delete }}
           - --scale-down-unneeded-time={{ .Cluster.ConfigItems.autoscaling_scale_down_unneeded_time }}
           - --scale-down-delay-after-add=-1s
+          {{- if eq .Cluster.ConfigItems.cluster_autoscaler_release "1_18" }}
+          - --backoff-no-full-scale-down={{ .Cluster.ConfigItems.cluster_autoscaler_keep_backed_off_pools_scaled_up }}
+          {{- end }}
         resources:
           requests:
             cpu: {{.Cluster.ConfigItems.cluster_autoscaler_cpu}}


### PR DESCRIPTION
This deploys CA 1.18 with the permanent scale up feature. Here: run e2e with old 1.12 version.