### PR TITLE
spotio: use -XX:+ExitOnOutOfMemoryError

### DIFF
--- a/cluster/manifests/spotio-controller/deployment.yaml
+++ b/cluster/manifests/spotio-controller/deployment.yaml
@@ -37,6 +37,8 @@ spec:
             resourceFieldRef:
               divisor: 1Ki
               resource: limits.memory
+        - name: JAVA_OPTS
+          value: "-XX:+ExitOnOutOfMemoryError"
         - name: SPOTINST_TOKEN
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
We want it to crash and restart on OOM errors, not get stuck doing nothing. The vendor didn't want to do it by default, so we have to specify it ourselves.