### PR TITLE
Enable users to opt-in to topology spread

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -276,6 +276,12 @@ teapot_admission_controller_ignore_namespaces: "^kube-system$"
 teapot_admission_controller_crd_ensure_no_resources_on_delete: "true"
 {{end}}
 
+# set topology spread injection based on usage of CA 1.18
+{{if eq .Environment "production"}}
+teapot_admission_controller_topology_spread: disable
+{{else}}
+teapot_admission_controller_topology_spread: optin
+{{end}}
 
 # etcd cluster
 {{if eq .Environment "production"}}

--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -43,3 +43,5 @@ data:
   priorityclass.preemption.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_preemption_enabled }}"
 
   postgresql.delete-protection.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_postgresql_delete_protection_enabled }}"
+
+  pod.automatic-topology-spread.mode: "{{ .Cluster.ConfigItems.teapot_admission_controller_topology_spread }}"

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -211,7 +211,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-81
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-82
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
Updates admission controller and allows users to opt-in to pod spread injection. This can later be turned into a default-on+opt-out approach via config items.

For now, let's make this available as opt-in to the same channels that use CA 1.18 by default.

Opt in via:

```yaml
apiVersion: apps/v1
kind: Deployment
...
spec:
  template:
    metadata:
      annotations:
        zalando.org/topology-spread: "true"
...
```

Has the following effect:

```yaml
apiVersion: v1
kind: Pod
...
spec:
  topologySpreadConstraints:
  - labelSelector:
      matchLabels:
        parent-resource-hash: 846f4ef3bf811690fbcdc7be13a1a02041c6d961
    maxSkew: 1
    topologyKey: topology.kubernetes.io/zone
    whenUnsatisfiable: DoNotSchedule
...
```