### PR TITLE
Enable TSC for skipper and skipper redis

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -46,6 +46,11 @@ skipper_ingress_cpu: "1000m"
 skipper_ingress_memory: "1Gi"
 skipper_ingress_tracing_buffer: "8192"
 enable_dedicate_nodepool_skipper: "false"
+{{if eq .Environment "e2e"}}
+skipper_topology_spread_enabled: "true"
+{{else}}
+skipper_topology_spread_enabled: "false"
+{{end}}
 
 # skipper default filters
 skipper_default_filters: 'enableAccessLog(4,5) -> lifo(2000,20000,"3s")'

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -37,6 +37,15 @@ spec:
                   values:
                   - skipper-ingress
               topologyKey: kubernetes.io/hostname
+{{- if eq .ConfigItems.skipper_topology_spread_enabled "true" }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              application: skipper-ingress
+{{- end }}
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       serviceAccountName: skipper-ingress
       dnsPolicy: ClusterFirstWithHostNet

--- a/cluster/manifests/skipper/old_deployment.yaml
+++ b/cluster/manifests/skipper/old_deployment.yaml
@@ -37,6 +37,15 @@ spec:
                   values:
                   - skipper-ingress
               topologyKey: kubernetes.io/hostname
+{{- if eq .ConfigItems.skipper_topology_spread_enabled "true" }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              application: skipper-ingress
+{{- end }}
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       serviceAccountName: skipper-ingress
       dnsPolicy: ClusterFirstWithHostNet

--- a/cluster/manifests/skipper/skipper-redis.yaml
+++ b/cluster/manifests/skipper/skipper-redis.yaml
@@ -20,6 +20,15 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
     spec:
+{{- if eq .ConfigItems.skipper_topology_spread_enabled "true" }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              application: skipper-ingress-redis
+{{- end }}
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       containers:
       - image: registry.opensource.zalan.do/zmon/redis:4.0.9-master-6


### PR DESCRIPTION
This should allow spreading them more evenly between AZs. Currently only enabled in e2e, we'll test in individual clusters first.