### PR TITLE
[STABLE] Add option to switch to ELBv1 for APIServer

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -51,6 +51,7 @@ Resources:
           Value: owned
       ToPort: 10250
     Type: 'AWS::EC2::SecurityGroupIngress'
+{{- if ne .Cluster.ConfigItems.apiserver_nlb "disabled" }}
   MasterLoadBalancerNLB:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
@@ -107,8 +108,68 @@ Resources:
       LoadBalancerArn: !Ref MasterLoadBalancerNLB
       Port: 443
       Protocol: TLS
+{{- end }}
+{{- if ne .Cluster.ConfigItems.apiserver_nlb "exclusive" }}
+  MasterLoadBalancer:
+    Properties:
+      ConnectionDrainingPolicy:
+        Enabled: true
+        Timeout: 60
+      ConnectionSettings:
+        IdleTimeout: 3600
+      CrossZone: 'true'
+      HealthCheck:
+        HealthyThreshold: '2'
+        Interval: '10'
+        Target: 'HTTP:8080/healthz'
+        Timeout: '5'
+        UnhealthyThreshold: '2'
+      Listeners:
+        - InstancePort: {{ if eq .ConfigItems.apiserver_proxy "true" }}8443{{ else }}443{{ end }}
+          InstanceProtocol: SSL
+          LoadBalancerPort: 443
+          PolicyNames: []
+          Protocol: SSL
+          SSLCertificateId: "{{.Values.load_balancer_certificate}}"
+      LoadBalancerName: "{{.Cluster.LocalID}}"
+      Scheme: internet-facing
+      SecurityGroups:
+        - !Ref MasterLoadBalancerSecurityGroup
+      Subnets:
+{{ with $values := .Values }}
+{{ range $az := $values.availability_zones }}
+        - "{{ index $values.subnets $az }}"
+{{ end }}
+{{ end }}
+      Tags:
+        - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
+          Value: owned
+        - Key: "application"
+          Value: kube-apiserver
+        - Key: "component"
+          Value: "kube-apiserver"
+    Type: 'AWS::ElasticLoadBalancing::LoadBalancer'
+  MasterLoadBalancerSecurityGroup:
+    Properties:
+      GroupDescription: !Ref 'AWS::StackName'
+      SecurityGroupIngress:
+        - CidrIp: 0.0.0.0/0
+          FromPort: -1
+          IpProtocol: icmp
+          ToPort: -1
+        - CidrIp: 0.0.0.0/0
+          FromPort: 443
+          IpProtocol: tcp
+          ToPort: 443
+      Tags:
+        - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
+          Value: owned
+      VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
+    Type: 'AWS::EC2::SecurityGroup'
+{{- end }}
   MasterLoadBalancerVersionDomain:
     Properties:
+    {{- if or (eq .Cluster.ConfigItems.apiserver_nlb "active") (eq .Cluster.ConfigItems.apiserver_nlb "promoted") (eq .Cluster.ConfigItems.apiserver_nlb "exclusive") }}
       AliasTarget:
         DNSName: !GetAtt
           - MasterLoadBalancerNLB
@@ -116,6 +177,15 @@ Resources:
         HostedZoneId: !GetAtt
           - MasterLoadBalancerNLB
           - CanonicalHostedZoneID
+    {{- else }}
+      AliasTarget:
+        DNSName: !GetAtt
+          - MasterLoadBalancer
+          - DNSName
+        HostedZoneId: !GetAtt
+          - MasterLoadBalancer
+          - CanonicalHostedZoneNameID
+    {{- end }}
       HostedZoneName: "{{.Values.hosted_zone}}."
       Name: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}."
       Type: A
@@ -124,6 +194,7 @@ Resources:
     Properties:
       GroupDescription: !Ref 'AWS::StackName'
       SecurityGroupIngress:
+{{- if and (ne .Cluster.ConfigItems.apiserver_nlb "disabled") (ne .Cluster.ConfigItems.apiserver_nlb "provisioned") }}
         - CidrIp: 0.0.0.0/0
           FromPort: {{ if eq .ConfigItems.apiserver_proxy "true" }}8443{{ else }}443{{ end }}
           IpProtocol: tcp
@@ -132,6 +203,7 @@ Resources:
           FromPort: 8080
           IpProtocol: tcp
           ToPort: 8080
+{{- end }}
         - CidrIp: 0.0.0.0/0
           FromPort: -1
           IpProtocol: icmp
@@ -192,6 +264,30 @@ Resources:
           Value: owned
       ToPort: 8472
     Type: 'AWS::EC2::SecurityGroupIngress'
+{{- if ne .Cluster.ConfigItems.apiserver_nlb "exclusive" }}
+  MasterSecurityGroupIngressFromLoadBalancer:
+    Properties:
+      FromPort: {{ if eq .ConfigItems.apiserver_proxy "true" }}8443{{ else }}443{{ end }}
+      GroupId: !Ref MasterSecurityGroup
+      IpProtocol: tcp
+      SourceSecurityGroupId: !Ref MasterLoadBalancerSecurityGroup
+      Tags:
+        - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
+          Value: owned
+      ToPort: {{ if eq .ConfigItems.apiserver_proxy "true" }}8443{{ else }}443{{ end }}
+    Type: 'AWS::EC2::SecurityGroupIngress'
+  MasterSecurityGroupIngressFromLoadBalancerHealthCheck:
+    Properties:
+      FromPort: 8080
+      GroupId: !Ref MasterSecurityGroup
+      IpProtocol: tcp
+      SourceSecurityGroupId: !Ref MasterLoadBalancerSecurityGroup
+      Tags:
+        - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
+          Value: owned
+      ToPort: 8080
+    Type: 'AWS::EC2::SecurityGroupIngress'
+{{- end }}
   MasterSecurityGroupIngressFromMaster:
     Properties:
       FromPort: 443
@@ -1922,10 +2018,18 @@ Outputs:
       Name: '{{ .Cluster.ID}}:master-files-encryption-key'
     Value: !Ref MasterFilesEncryptionKey
 {{- if ne .Cluster.ConfigItems.delete_vpc_resources "true" }}
+{{- if ne .Cluster.ConfigItems.apiserver_nlb "exclusive" }}
+  MasterLoadBalancer:
+    Export:
+      Name: '{{.Cluster.ID}}:master-load-balancer'
+    Value: !Ref MasterLoadBalancer
+{{- end }}
+{{- if ne .Cluster.ConfigItems.apiserver_nlb "disabled" }}
   MasterLoadBalancerNLBTargetGroup:
     Export:
       Name: '{{.Cluster.ID}}:master-load-balancer-nlb-target-group'
     Value: !Ref MasterLoadBalancerNLBTargetGroup
+{{- end }}
   MasterSecurityGroup:
     Export:
       Name: '{{.Cluster.ID}}:master-security-group'

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -306,6 +306,17 @@ serialize_image_pulls: "false"
 # when set to true, routes external traffic to the apiserver through a skipper sidecar
 apiserver_proxy: "true"
 
+# defines the rollout status of the NLB for the API server. The options are:
+#
+#   disabled:    no NLB will be provisioned
+#   provisioned: NLB will be provisioned but not hooked up to the ASG
+#   hooked:      NLB will be provisioned and hooked up to the ASG but DNS still points to the ELB
+#   active:      NLB will be fully functional and DNS points to the NLB
+#   promoted:    NLB will be fully functional and ELB will be unhooked
+#   exclusive:   NLB will be fully functional and ELB will be removed
+#
+apiserver_nlb: "exclusive"
+
 # when set to true, service account tokens can be used from outside the cluster
 # requires apiserver_proxy to be set to "true"
 allow_external_service_accounts: "false"

--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -21,6 +21,10 @@ Resources:
       LaunchTemplate:
         LaunchTemplateId: !Ref LaunchTemplate
         Version: !GetAtt LaunchTemplate.LatestVersionNumber
+{{- if and (ne .Cluster.ConfigItems.apiserver_nlb "promoted") (ne .Cluster.ConfigItems.apiserver_nlb "exclusive") }}
+      LoadBalancerNames:
+      - !ImportValue '{{ .Cluster.ID }}:master-load-balancer'
+{{- end }}
       MinSize: '{{ .NodePool.MinSize }}'
       MaxSize: '{{ .NodePool.MaxSize }}'
       Tags:
@@ -39,8 +43,10 @@ Resources:
         - "{{ index $values.subnets $az }}"
 {{ end }}
 {{ end }}
+{{- if and (ne .Cluster.ConfigItems.apiserver_nlb "disabled") (ne .Cluster.ConfigItems.apiserver_nlb "provisioned") }}
       TargetGroupARNs:
       - !ImportValue '{{ .Cluster.ID }}:master-load-balancer-nlb-target-group'
+{{- end }}
     Type: 'AWS::AutoScaling::AutoScalingGroup'
   LaunchTemplate:
     Properties:


### PR DESCRIPTION
Based on revert of #3373

Add the option to switch API-server LB back to ELBv1 instead of NLB. This is helpful when migrating between subnets because the NLB does NOT allow removing subnets once created so it's impossible to migrate an NLB without deleting it. ELBv1 does not have this limitation.

Ref: https://github.com/zalando-incubator/kubernetes-on-aws/pull/3714