### PR TITLE
Update cluster-autoscaler to include per-node-group metric

### DIFF
--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     application: kube-cluster-autoscaler
     {{- if eq .Cluster.ConfigItems.cluster_autoscaler_release "1_18" }}
-    version: v1.18.2-internal.14
+    version: v1.18.2-internal.15
     {{- else }}
     version: v1.12.2-internal-2.17
     {{- end }}
@@ -21,7 +21,7 @@ spec:
       labels:
         application: kube-cluster-autoscaler
         {{- if eq .Cluster.ConfigItems.cluster_autoscaler_release "1_18" }}
-        version: v1.18.2-internal.14
+        version: v1.18.2-internal.15
         {{- else }}
         version: v1.12.2-internal-2.17
         {{- end }}
@@ -44,7 +44,7 @@ spec:
       containers:
       - name: cluster-autoscaler
         {{- if eq .Cluster.ConfigItems.cluster_autoscaler_release "1_18" }}
-        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.18.2-internal.14
+        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.18.2-internal.15
         {{- else }}
         image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.12.2-internal-2.17
         {{- end }}

--- a/cluster/manifests/kube-cluster-autoscaler/service.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/service.yaml
@@ -1,0 +1,20 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: kube-cluster-autoscaler
+  namespace: kube-system
+  labels:
+    application: kube-cluster-autoscaler
+  annotations:
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8085"
+    prometheus.io/scrape: "true"
+spec:
+  type: ClusterIP
+  ports:
+    - name: monitor
+      port: 8085
+      targetPort: 8085
+      protocol: TCP
+  selector:
+    application: kube-cluster-autoscaler


### PR DESCRIPTION
Exposes a metric to see whether a node group is in backoff state. Backoff state is permanent in our fork until a node group can get new instances. This helps to detect whether it is waiting for nodes unusually long.

```
cluster_autoscaler_node_group_in_backoff{node_group="AutoScalingGroup-1P6...DQ98"} 0
cluster_autoscaler_node_group_in_backoff{node_group="AutoScalingGroup-15U...68YB"} 1
```

Could also be used in combination with

```
cluster_autoscaler_node_groups_count{node_group_type="autoscaled"} 2
```

to get a fraction of affected node pools compared to the total. Might help identifying more/less affected clusters.