### PR TITLE
Add back VPA for spotio-controller

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -470,6 +470,7 @@ spotio_ocean_utilize_reserved_instances: "false"
 # configuration for spot.io controller
 spotio_ocean_controller_cpu: "50m"
 spotio_ocean_controller_memory: "512Mi"
+spotio_ocean_controller_memory_max: "2Gi"
 
 # Log Kubernetes events to Scalyr
 kubernetes_event_logger_enabled: "true"

--- a/cluster/manifests/spotio-controller/vpa.yaml
+++ b/cluster/manifests/spotio-controller/vpa.yaml
@@ -1,0 +1,21 @@
+{{ if and (index .Cluster.ConfigItems "spotio_account_id") (index .Cluster.ConfigItems "spotio_access_token") }}
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: spotinst-kubernetes-cluster-controller
+  namespace: kube-system
+  labels:
+    application: spotinst-kubernetes-cluster-controller
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: spotinst-kubernetes-cluster-controller
+  updatePolicy:
+    updateMode: Auto
+  resourcePolicy:
+    containerPolicies:
+    - containerName: controller
+      maxAllowed:
+        memory: {{.ConfigItems.spotio_ocean_controller_memory_max}}
+{{ end }}


### PR DESCRIPTION
With the OOMKills correctly handled in the spotio-controller https://github.com/zalando-incubator/kubernetes-on-aws/pull/3715 we can now add the VPA back.