### PR TITLE
Remove unused config item

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -413,10 +413,6 @@ enable_endpointsliceproxying: "false"
 # Enable FeatureGate HPAScaleToZero
 enable_hpa_scale_to_zero: "true"
 
-# Enable FeatureGate EvenPodsSpread (PodTopologySpread)
-# Enabled by default since v1.18
-enable_even_pods_spread: "true"
-
 # Enable FeatureGate EphemeralContainers (Alpha)
 # https://kubernetes.io/docs/tasks/debug-application-cluster/debug-running-pod/
 enable_ephemeral_containers: "false"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -10,11 +10,7 @@ autoscaling_max_empty_bulk_delete: "10"
 autoscaling_scale_down_unneeded_time: "10m"
 
 # the cluster autoscaler release to use, options are 1_12 and 1_18.
-{{if eq .Environment "production"}}
-cluster_autoscaler_release: "1_12"
-{{else}}
 cluster_autoscaler_release: "1_18"
-{{end}}
 
 # When true, enables the legacy behaviour for 1.18 where pools that are backed off
 # don't get reset to their pre-scale-out values. This basically means the ASGs
@@ -419,11 +415,7 @@ enable_hpa_scale_to_zero: "true"
 
 # Enable FeatureGate EvenPodsSpread (PodTopologySpread)
 # Enabled by default since v1.18
-{{if eq .Environment "production"}}
-enable_even_pods_spread: "false"
-{{else}}
 enable_even_pods_spread: "true"
-{{end}}
 
 # Enable FeatureGate EphemeralContainers (Alpha)
 # https://kubernetes.io/docs/tasks/debug-application-cluster/debug-running-pod/

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -139,7 +139,7 @@ write_files:
           - --authorization-mode=Webhook,RBAC
           - --authorization-webhook-config-file=/etc/kubernetes/config/authz.yaml
           - --admission-control-config-file=/etc/kubernetes/config/image-policy-webhook.yaml
-          - --feature-gates=TTLAfterFinished=true,BoundServiceAccountTokenVolume={{ .Cluster.ConfigItems.rotate_service_account_tokens }},EndpointSlice={{ .Cluster.ConfigItems.enable_endpointslice }},HPAScaleToZero={{ .Cluster.ConfigItems.enable_hpa_scale_to_zero }},VolumeSnapshotDataSource={{ .Cluster.ConfigItems.enable_csi_migration }},CSIMigration={{ .Cluster.ConfigItems.enable_csi_migration }},NonPreemptingPriority=true,EphemeralContainers={{ .Cluster.ConfigItems.enable_ephemeral_containers }},EvenPodsSpread={{ .Cluster.ConfigItems.enable_even_pods_spread }}
+          - --feature-gates=TTLAfterFinished=true,BoundServiceAccountTokenVolume={{ .Cluster.ConfigItems.rotate_service_account_tokens }},EndpointSlice={{ .Cluster.ConfigItems.enable_endpointslice }},HPAScaleToZero={{ .Cluster.ConfigItems.enable_hpa_scale_to_zero }},VolumeSnapshotDataSource={{ .Cluster.ConfigItems.enable_csi_migration }},CSIMigration={{ .Cluster.ConfigItems.enable_csi_migration }},NonPreemptingPriority=true,EphemeralContainers={{ .Cluster.ConfigItems.enable_ephemeral_containers }}
           - --anonymous-auth=false
           - --service-account-key-file=/etc/kubernetes/ssl/service-account-public-key.pem
           {{- if eq .Cluster.ConfigItems.rotate_service_account_tokens "true" }}
@@ -623,7 +623,7 @@ write_files:
           args:
           - --master=http://127.0.0.1:8080
           - --leader-elect=true
-          - --feature-gates=BoundServiceAccountTokenVolume={{ .Cluster.ConfigItems.rotate_service_account_tokens }},NonPreemptingPriority=true,EvenPodsSpread={{ .Cluster.ConfigItems.enable_even_pods_spread }}
+          - --feature-gates=BoundServiceAccountTokenVolume={{ .Cluster.ConfigItems.rotate_service_account_tokens }},NonPreemptingPriority=true
           - --profiling={{ .Cluster.ConfigItems.enable_control_plane_profiling }}
           env:
           - name: KUBE_MAX_PD_VOLS


### PR DESCRIPTION
Note: Don't merge before: https://github.com/zalando-incubator/kubernetes-on-aws/pull/3702

This removes an obsolete config item. Optional change.