### PR TITLE
Automatic TSC: non-default node pool support + other improvements

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -277,12 +277,7 @@ teapot_admission_controller_ignore_namespaces: "^kube-system$"
 teapot_admission_controller_crd_ensure_no_resources_on_delete: "true"
 {{end}}
 
-# set topology spread injection based on usage of CA 1.18
-{{if eq .Environment "production"}}
-teapot_admission_controller_topology_spread: disable
-{{else}}
 teapot_admission_controller_topology_spread: optin
-{{end}}
 
 # etcd cluster
 {{if eq .Environment "production"}}

--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -45,3 +45,10 @@ data:
   postgresql.delete-protection.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_postgresql_delete_protection_enabled }}"
 
   pod.automatic-topology-spread.mode: "{{ .Cluster.ConfigItems.teapot_admission_controller_topology_spread }}"
+{{- range $group, $enabled := zoneDistributedNodePoolGroups .Cluster.NodePools }}
+{{- if eq $group "" }}
+  pod.automatic-topology-spread.pools.default: "{{ $enabled }}"
+{{- else }}
+  pod.automatic-topology-spread.pools.dedicated.{{$group}}: "{{ $enabled }}"
+{{- end }}
+{{- end}}

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -129,7 +129,7 @@ write_files:
           - --allow-privileged=true
           - --service-cluster-ip-range=10.3.0.0/16
           - --secure-port=443
-          - --enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota,StorageObjectInUseProtection,PodSecurityPolicy,ImagePolicyWebhook,Priority,ExtendedResourceToleration
+          - --enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,ExtendedResourceToleration,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota,StorageObjectInUseProtection,PodSecurityPolicy,ImagePolicyWebhook,Priority
           - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
           - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
           - --runtime-config=extensions/v1beta1/networkpolicies=true,batch/v2alpha1=true,policy/v1beta1=true,imagepolicy.k8s.io/v1alpha1=true,authorization.k8s.io/v1beta1=true,scheduling.k8s.io/v1alpha1=true,admissionregistration.k8s.io/v1beta1=true{{ if eq .Cluster.ConfigItems.enable_endpointslice "true" }},discovery.k8s.io/v1alpha1=true{{ end }}

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -211,7 +211,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-82
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-86
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
 * Generate per-node pool configuration for the automatic TSC injection
 * Update the admission controller (dedicated node pool support + explicit config for the default pool)
 * Move the ExtendedResourceToleration so it works before our webhook