### PR TITLE
Drop unused config items from e2e

### DIFF
--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -10,12 +10,6 @@ clusters:
   api_server_url: ${API_SERVER_URL}
   channel: ${1}
   config_items:
-    scalyr_access_key: no-key-defined
-    scalyr_read_key: no-key-defined
-    scalyr_server: no-key-defined
-    gerry_mint_bucket: zalando-stups-mint-${AWS_ACCOUNT}-${REGION}
-    zmon_worker_plugin_sql_user:
-    zmon_worker_plugin_sql_pass:
     zmon_root_account_role: ${ZMON_ROOT_ACCOUNT_ROLE}
     audittrail_root_account_role: ${AUDITTRAIL_ROOT_ACCOUNT_ROLE}
     apiserver_etcd_prefix: /registry-${LOCAL_ID}
@@ -23,8 +17,6 @@ clusters:
     etcd_s3_backup_bucket: zalando-kubernetes-etcd-${AWS_ACCOUNT}-${REGION}
     etcd_endpoints: "${ETCD_ENDPOINTS}"
     image_policy: e2e
-    instana_key: ''
-    jira_secrets: '{\"username\": \"user\", \"password\": \"pass\", \"magic_token\": \"token\"}'
     ca_key_decompressed: ${CA_KEY}
     ca_cert_decompressed: ${CA_CERT}
     apiserver_key_decompressed: ${APISERVER_KEY}


### PR DESCRIPTION
These config items are no longer in use and thus can be dropped from e2e config.