### PR TITLE
fix: redis ratelimit used pipelines which are not safe to use

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.11.185
+    version: v0.11.187
     component: ingress
 spec:
   strategy:
@@ -20,7 +20,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.11.185
+        version: v0.11.187
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -52,7 +52,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/teapot/skipper:v0.11.185-27
+        image: registry.opensource.zalan.do/teapot/skipper:v0.11.187-29
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -128,7 +128,7 @@ spec:
             tag=application=skipper-ingress
             tag=account={{ .Cluster.Alias }}
             tag=cluster={{ .Cluster.Alias }}
-            tag=artifact=registry.opensource.zalan.do/teapot/skipper:v0.11.185
+            tag=artifact=registry.opensource.zalan.do/teapot/skipper:v0.11.187
             grpc-max-msg-size={{ .ConfigItems.skipper_ingress_lightstep_grpc_max_msg_size }}
             max-period={{ .ConfigItems.skipper_ingress_lightstep_max_period }}
             min-period={{ .ConfigItems.skipper_ingress_lightstep_min_period }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.11.187
+    version: v0.11.188
     component: ingress
 spec:
   strategy:
@@ -20,7 +20,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.11.187
+        version: v0.11.188
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -52,7 +52,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/teapot/skipper:v0.11.187-29
+        image: registry.opensource.zalan.do/teapot/skipper:v0.11.188-30
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -128,7 +128,7 @@ spec:
             tag=application=skipper-ingress
             tag=account={{ .Cluster.Alias }}
             tag=cluster={{ .Cluster.Alias }}
-            tag=artifact=registry.opensource.zalan.do/teapot/skipper:v0.11.187
+            tag=artifact=registry.opensource.zalan.do/teapot/skipper:v0.11.188
             grpc-max-msg-size={{ .ConfigItems.skipper_ingress_lightstep_grpc_max_msg_size }}
             max-period={{ .ConfigItems.skipper_ingress_lightstep_max_period }}
             min-period={{ .ConfigItems.skipper_ingress_lightstep_min_period }}

--- a/cluster/manifests/skipper/old_deployment.yaml
+++ b/cluster/manifests/skipper/old_deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.11.185
+    version: v0.11.187
     component: ingress
 spec:
   strategy:
@@ -20,7 +20,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.11.185
+        version: v0.11.187
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -52,7 +52,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.185
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.187
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -111,7 +111,7 @@ spec:
             tag=application=skipper-ingress
             tag=account={{ .Cluster.Alias }}
             tag=cluster={{ .Cluster.Alias }}
-            tag=artifact=registry.opensource.zalan.do/pathfinder/skipper:v0.11.185
+            tag=artifact=registry.opensource.zalan.do/pathfinder/skipper:v0.11.187
             grpc-max-msg-size={{ .ConfigItems.skipper_ingress_lightstep_grpc_max_msg_size }}
             max-period={{ .ConfigItems.skipper_ingress_lightstep_max_period }}
             min-period={{ .ConfigItems.skipper_ingress_lightstep_min_period }}

--- a/cluster/manifests/skipper/old_deployment.yaml
+++ b/cluster/manifests/skipper/old_deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.11.187
+    version: v0.11.188
     component: ingress
 spec:
   strategy:
@@ -20,7 +20,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.11.187
+        version: v0.11.188
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -52,7 +52,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.187
+        image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.188
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -111,7 +111,7 @@ spec:
             tag=application=skipper-ingress
             tag=account={{ .Cluster.Alias }}
             tag=cluster={{ .Cluster.Alias }}
-            tag=artifact=registry.opensource.zalan.do/pathfinder/skipper:v0.11.187
+            tag=artifact=registry.opensource.zalan.do/pathfinder/skipper:v0.11.188
             grpc-max-msg-size={{ .ConfigItems.skipper_ingress_lightstep_grpc_max_msg_size }}
             max-period={{ .ConfigItems.skipper_ingress_lightstep_max_period }}
             min-period={{ .ConfigItems.skipper_ingress_lightstep_min_period }}


### PR DESCRIPTION
fix: redis ratelimit used pipelines which are not safe to use: TCP RST, because of re-use of socket which were closed by the client

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>