### PR TITLE
Autoscaling fixes

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1,8 +1,8 @@
 # Autoscaling settings
 autoscaling_scale_down_enabled: "true"
-autoscaling_buffer_cpu: "2"
-autoscaling_buffer_memory: "10Gi"
-autoscaling_buffer_pods: "0"
+autoscaling_buffer_cpu: "1m"
+autoscaling_buffer_memory: "10Mi"
+autoscaling_buffer_pods: "1"
 cluster_autoscaler_cpu: "100m"
 cluster_autoscaler_memory: "300Mi"
 autoscaling_utilization_threshold: "1.0"

--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     application: kube-cluster-autoscaler
     {{- if eq .Cluster.ConfigItems.cluster_autoscaler_release "1_18" }}
-    version: v1.18.2-internal.15
+    version: v1.18.2-internal.16
     {{- else }}
     version: v1.12.2-internal-2.17
     {{- end }}
@@ -21,7 +21,7 @@ spec:
       labels:
         application: kube-cluster-autoscaler
         {{- if eq .Cluster.ConfigItems.cluster_autoscaler_release "1_18" }}
-        version: v1.18.2-internal.15
+        version: v1.18.2-internal.16
         {{- else }}
         version: v1.12.2-internal-2.17
         {{- end }}
@@ -44,7 +44,7 @@ spec:
       containers:
       - name: cluster-autoscaler
         {{- if eq .Cluster.ConfigItems.cluster_autoscaler_release "1_18" }}
-        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.18.2-internal.15
+        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.18.2-internal.16
         {{- else }}
         image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.12.2-internal-2.17
         {{- end }}


### PR DESCRIPTION
 * Update CA to fix a bug which breaks autoscaling if upcoming nodes are present ([PR](https://github.com/zalando-incubator/autoscaler/pull/64)).
 * Reenable buffer pods by default (at 1m/10Mi) to ensure that we have at least one instance in each AZ. This is needed for TSC to work correctly.