### PR TITLE
CA: increase the scaledown timeout

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -17,6 +17,13 @@ cluster_autoscaler_release: "1_18"
 # keep trying to get a node while CA already moves on to the next ASG.
 cluster_autoscaler_keep_backed_off_pools_scaled_up: "true"
 
+# How long to wait for pod eviction when scaling down.
+{{if eq .Environment "production"}}
+cluster_autoscaler_max_pod_eviction_time: "2m"
+{{else}}
+cluster_autoscaler_max_pod_eviction_time: "3h"
+{{end}}
+
 # defines which expander the autoscaler should use
 cluster_autoscaler_expander: highest-priority
 

--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     application: kube-cluster-autoscaler
     {{- if eq .Cluster.ConfigItems.cluster_autoscaler_release "1_18" }}
-    version: v1.18.2-internal.16
+    version: v1.18.2-internal.19
     {{- else }}
     version: v1.12.2-internal-2.17
     {{- end }}
@@ -21,7 +21,7 @@ spec:
       labels:
         application: kube-cluster-autoscaler
         {{- if eq .Cluster.ConfigItems.cluster_autoscaler_release "1_18" }}
-        version: v1.18.2-internal.16
+        version: v1.18.2-internal.19
         {{- else }}
         version: v1.12.2-internal-2.17
         {{- end }}
@@ -44,7 +44,7 @@ spec:
       containers:
       - name: cluster-autoscaler
         {{- if eq .Cluster.ConfigItems.cluster_autoscaler_release "1_18" }}
-        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.18.2-internal.16
+        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.18.2-internal.19
         {{- else }}
         image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.12.2-internal-2.17
         {{- end }}
@@ -69,6 +69,7 @@ spec:
           - --scale-down-delay-after-add=-1s
           {{- if eq .Cluster.ConfigItems.cluster_autoscaler_release "1_18" }}
           - --backoff-no-full-scale-down={{ .Cluster.ConfigItems.cluster_autoscaler_keep_backed_off_pools_scaled_up }}
+          - --max-pod-eviction-time={{ .Cluster.ConfigItems.cluster_autoscaler_max_pod_eviction_time }}
           {{- end }}
         resources:
           requests:


### PR DESCRIPTION
 * Update CA (pod eviction timeout is now configurable, https://github.com/zalando-incubator/autoscaler/pull/68)
 * Set the eviction timeout to 3 hours (only in the test clusters for now)