### PR TITLE
VPA: increase max memory

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -189,7 +189,7 @@ prometheus_kube_state_metrics_drop_labels: ""
 
 metrics_service_cpu: "100m"
 metrics_service_mem: "200Mi"
-metrics_service_mem_max: "1Gi"
+metrics_service_mem_max: "4Gi"
 
 kube_aws_iam_controller_cpu: "5m"
 kube_aws_iam_controller_mem: "50Mi"
@@ -197,10 +197,10 @@ kube_aws_iam_controller_mem_max: "1Gi"
 
 kube_state_metrics_cpu: "100m"
 kube_state_metrics_mem: "200Mi"
-kube_state_metrics_mem_max: "1Gi"
+kube_state_metrics_mem_max: "4Gi"
 kube_state_metrics_mem_min: "120Mi"
 
-kubernetes_lifecycle_metrics_mem_max: "1Gi"
+kubernetes_lifecycle_metrics_mem_max: "4Gi"
 kubernetes_lifecycle_metrics_mem_min: "120Mi"
 
 # Kubernetes Downscaler (for non-production clusters)
@@ -439,7 +439,7 @@ spot_allocation_strategy: "capacity-optimized"
 # Stackset controller
 stackset_controller_sync_interval: "10s"
 stackset_controller_mem_min: "120Mi"
-stackset_controller_mem_max: "1Gi"
+stackset_controller_mem_max: "4Gi"
 
 # EBS settings for the root volume
 ebs_root_volume_size: "50"

--- a/cluster/manifests/cronjob-fixer/vpa.yaml
+++ b/cluster/manifests/cronjob-fixer/vpa.yaml
@@ -16,4 +16,4 @@ spec:
     containerPolicies:
     - containerName: cronjob-fixer
       maxAllowed:
-        memory: 1Gi
+        memory: 4Gi

--- a/cluster/manifests/external-dns/vpa.yaml
+++ b/cluster/manifests/external-dns/vpa.yaml
@@ -16,5 +16,4 @@ spec:
     containerPolicies:
     - containerName: external-dns
       maxAllowed:
-        cpu: 500m
-        memory: 2Gi
+        memory: 4Gi

--- a/cluster/manifests/ingress-controller/vpa.yaml
+++ b/cluster/manifests/ingress-controller/vpa.yaml
@@ -16,5 +16,4 @@ spec:
     containerPolicies:
     - containerName: kube-ingress-aws-controller
       maxAllowed:
-        cpu: 250m
-        memory: 1Gi
+        memory: 4Gi

--- a/cluster/manifests/kube-downscaler/vpa.yaml
+++ b/cluster/manifests/kube-downscaler/vpa.yaml
@@ -17,6 +17,5 @@ spec:
     containerPolicies:
     - containerName: downscaler
       maxAllowed:
-        cpu: 500m
-        memory: 2Gi
+        memory: 4Gi
 {{ end }}

--- a/cluster/manifests/kube-janitor/vpa.yaml
+++ b/cluster/manifests/kube-janitor/vpa.yaml
@@ -17,5 +17,5 @@ spec:
     containerPolicies:
     - containerName: janitor
       maxAllowed:
-        memory: 750Mi
+        memory: 4Gi
 {{ end }}

--- a/cluster/manifests/kube-metrics-adapter/vpa.yaml
+++ b/cluster/manifests/kube-metrics-adapter/vpa.yaml
@@ -16,4 +16,4 @@ spec:
     containerPolicies:
     - containerName: kube-metrics-adapter
       maxAllowed:
-        memory: 1Gi
+        memory: 4Gi

--- a/cluster/manifests/pdb-controller/vpa.yaml
+++ b/cluster/manifests/pdb-controller/vpa.yaml
@@ -16,4 +16,4 @@ spec:
     containerPolicies:
     - containerName: pdb-controller
       maxAllowed:
-        memory: 1Gi
+        memory: 4Gi


### PR DESCRIPTION
Increase VPA `maxAllowed.memory` to `4Gi` for most of the applications and drop `maxAllowed.cpu`. We're already bumping into these in some of the clusters, and `4Gi` should be schedulable anywhere.