### PR TITLE
CA: disable node instances cache (test only)

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -20,8 +20,10 @@ cluster_autoscaler_keep_backed_off_pools_scaled_up: "true"
 # How long to wait for pod eviction when scaling down.
 {{if eq .Environment "production"}}
 cluster_autoscaler_max_pod_eviction_time: "2m"
+cluster_autoscaler_disable_node_instances_cache: "false"
 {{else}}
 cluster_autoscaler_max_pod_eviction_time: "3h"
+cluster_autoscaler_disable_node_instances_cache: "true"
 {{end}}
 
 # defines which expander the autoscaler should use

--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     application: kube-cluster-autoscaler
     {{- if eq .Cluster.ConfigItems.cluster_autoscaler_release "1_18" }}
-    version: v1.18.2-internal.20
+    version: v1.18.2-internal.21
     {{- else }}
     version: v1.12.2-internal-2.17
     {{- end }}
@@ -21,7 +21,7 @@ spec:
       labels:
         application: kube-cluster-autoscaler
         {{- if eq .Cluster.ConfigItems.cluster_autoscaler_release "1_18" }}
-        version: v1.18.2-internal.20
+        version: v1.18.2-internal.21
         {{- else }}
         version: v1.12.2-internal-2.17
         {{- end }}
@@ -44,7 +44,7 @@ spec:
       containers:
       - name: cluster-autoscaler
         {{- if eq .Cluster.ConfigItems.cluster_autoscaler_release "1_18" }}
-        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.18.2-internal.20
+        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.18.2-internal.21
         {{- else }}
         image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.12.2-internal-2.17
         {{- end }}
@@ -71,6 +71,7 @@ spec:
           - --backoff-no-full-scale-down={{ .Cluster.ConfigItems.cluster_autoscaler_keep_backed_off_pools_scaled_up }}
           - --max-pod-eviction-time={{ .Cluster.ConfigItems.cluster_autoscaler_max_pod_eviction_time }}
           - --topology-spread-constraint-scale-factor=3
+          - --disable-node-instances-cache={{ .Cluster.ConfigItems.cluster_autoscaler_disable_node_instances_cache }}
           {{- end }}
         resources:
           requests:


### PR DESCRIPTION
It doesn't really do anything useful and causes issues when scaling down (see [the PR](https://github.com/zalando-incubator/autoscaler/pull/70) for more details). Let's try disabling it, starting with the test clusters.