### PR TITLE
Update ExternalDNS to v0.7.4

### DIFF
--- a/cluster/manifests/external-dns/01-rbac.yaml
+++ b/cluster/manifests/external-dns/01-rbac.yaml
@@ -20,7 +20,7 @@ metadata:
     application: external-dns
 rules:
 - apiGroups: [""]
-  resources: ["services"]
+  resources: ["services", "endpoints", "pods", "nodes"]
   verbs: ["list"]
 - apiGroups: ["extensions"]
   resources: ["ingresses"]

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: external-dns
-    version: v0.7.1
+    version: v0.7.3
 spec:
   strategy:
     type: Recreate
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: external-dns
-        version: v0.7.1
+        version: v0.7.3
 {{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "false"}}
       annotations:
@@ -32,7 +32,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.7.1
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.7.3
         args:
         - --source=service
         - --source=ingress

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: external-dns
-    version: v0.7.3
+    version: v0.7.4
 spec:
   strategy:
     type: Recreate
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: external-dns
-        version: v0.7.3
+        version: v0.7.4
 {{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "false"}}
       annotations:
@@ -32,7 +32,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.7.3
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.7.4
         args:
         - --source=service
         - --source=ingress


### PR DESCRIPTION
Update ExternalDNS to v0.7.4

end to end tests passing for:
- v0.7.2 :heavy_check_mark: 
- v0.7.3 :heavy_check_mark: 
- v0.7.4 :heavy_check_mark: 