### PR TITLE
scale down policy for skipper-ingress 

### DIFF
--- a/cluster/manifests/skipper/hpa.yaml
+++ b/cluster/manifests/skipper/hpa.yaml
@@ -16,11 +16,15 @@ spec:
   - type: Resource
     resource:
       name: cpu
-      targetAverageUtilization: {{ .ConfigItems.skipper_ingress_target_average_utilization_cpu }}
+      target:
+        type: Utilization
+        averageUtilization: {{ .ConfigItems.skipper_ingress_target_average_utilization_cpu }}
   - type: Resource
     resource:
       name: memory
-      targetAverageUtilization: {{ .ConfigItems.skipper_ingress_target_average_utilization_memory }}
+      target:
+        type: Utilization
+        averageUtilization: {{ .ConfigItems.skipper_ingress_target_average_utilization_memory }}
   behavior:
     scaleDown:
       stabilizationWindowSeconds: 600

--- a/cluster/manifests/skipper/hpa.yaml
+++ b/cluster/manifests/skipper/hpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: skipper-ingress
@@ -21,3 +21,14 @@ spec:
     resource:
       name: memory
       targetAverageUtilization: {{ .ConfigItems.skipper_ingress_target_average_utilization_memory }}
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 600
+      policies:
+      - type: Pods
+        value: 10
+        periodSeconds: 60
+      - type: Percent
+        value: 100
+        periodSeconds: 60
+      selectPolicy: Min

--- a/cluster/manifests/skipper/hpa.yaml
+++ b/cluster/manifests/skipper/hpa.yaml
@@ -27,8 +27,8 @@ spec:
       policies:
       - type: Pods
         value: 10
-        periodSeconds: 60
+        periodSeconds: 120
       - type: Percent
         value: 100
-        periodSeconds: 60
+        periodSeconds: 120
       selectPolicy: Min


### PR DESCRIPTION
use proper scale down policy for skipper-ingress to allow only 10 instance per 2 minutes to scale down at max, such that ALB target groups are not creating issues dropping out skipper members

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>