### PR TITLE
Support single Ocean spot.io setup

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1857,6 +1857,61 @@ Resources:
             Resource: "*"
             Action:
             - "kms:Decrypt"
+{{- if and (index .Cluster.ConfigItems "spotio_account_id") (index .Cluster.ConfigItems "spotio_access_token") }}
+  SpotIOOceanCluster:
+    Type: Custom::ocean
+    Properties:
+      ServiceToken: !Sub "arn:aws:lambda:${AWS::Region}:178579023202:function:spotinst-cloudformation"
+      accessToken: "{{ .Cluster.ConfigItems.spotio_access_token }}"
+      accountId: "{{ .Cluster.ConfigItems.spotio_account_id }}"
+      autoTag: true
+      updatePolicy:
+        shouldUpdateTargetCapacity: false
+        shouldRoll: "false" # disable rolling update, this is managed by CLM,CLC
+        rollConfig:
+          roll:
+            batchSizePercentage: "25"
+      # API Docs: https://help.spot.io/spotinst-api/ocean/ocean-cloud-api/ocean-for-aws/create-2/
+      ocean:
+        name: "{{ .Cluster.Alias }}-{{ .Cluster.ID }}"
+        controllerClusterId: "{{ .Cluster.LocalID }}"
+        region: !Ref AWS::Region
+        autoScaler:
+          isEnabled: true
+          cooldown: 180 # 3 min. This seems to be the minimum value
+          # maximum resources which can be allocated to the cluster
+          # Use very high values as we have the limit set via the
+          # capacity.maximum (NodePool.MaxSize)
+          resourceLimits:
+            maxMemoryGib: 1500000
+            maxVCpu: 75000
+          down:
+            # evaluationPeriods: 3
+            maxScaleDownPercentage: 100
+          headroom: # disable headroom/preprovisioned instances
+            cpuPerUnit: 0
+            memoryPerUnit: 0
+            numOfUnits: 0
+          isAutoConfig: false
+        capacity:
+          minimum: 0
+          maximum: {{ nodeCIDRMaxNodes (parseInt64 .Cluster.ConfigItems.node_cidr_mask_size) (parseInt64 .Cluster.ConfigItems.reserved_nodes) }}
+          target: 0 # default target (should just be zero)
+        strategy:
+          fallbackToOd: {{ .Cluster.ConfigItems.spotio_ocean_fallback_to_ondemand }}
+          utilizeReservedInstances: {{ .Cluster.ConfigItems.spotio_ocean_utilize_reserved_instances }}
+        compute:
+          subnetIds:
+          {{- with $values := .Values }}
+          {{- range $az := $values.availability_zones }}
+            - "{{ index $values.subnets $az }}"
+          {{- end }}
+          {{- end }}
+          launchSpecification:
+            useAsTemplateOnly: true
+            securityGroupIds:
+            - !Ref WorkerSecurityGroup
+{{- end }}
 Outputs:
   MasterIAMRole:
     Export:
@@ -1904,3 +1959,10 @@ Outputs:
     Export:
       Name: '{{ .Cluster.ID}}:etcd-encryption-key'
     Value: !Ref EtcdEncryptionKey
+{{- if and (index .Cluster.ConfigItems "spotio_account_id") (index .Cluster.ConfigItems "spotio_access_token") }}
+  OceanId:
+    Description: The spot.io Ocean ID
+    Value: !Ref SpotIOOceanCluster
+    Export:
+      Name: "{{ .Cluster.ID }}:spotio-ocean-id"
+{{- end }}

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -499,6 +499,7 @@ system_priority_class: "cluster-critical-nonpreempting"
 #
 # Default configuration per ocean, can be configured on individual node pools.
 spotio_ocean_spot_percentage: "100"
+spotio_spot_percentage: "100" # per node pool setting
 spotio_ocean_fallback_to_ondemand: "true"
 spotio_ocean_utilize_reserved_instances: "false"
 

--- a/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: cluster-lifecycle-controller
-    version: master-19
+    version: master-22
 spec:
   replicas: 1
   selector:
@@ -17,7 +17,7 @@ spec:
     metadata:
       labels:
         application: cluster-lifecycle-controller
-        version: master-19
+        version: master-22
     spec:
       dnsConfig:
         options:
@@ -32,7 +32,7 @@ spec:
         operator: Exists
       containers:
       - name: cluster-lifecycle-controller
-        image: registry.opensource.zalan.do/teapot/cluster-lifecycle-controller:master-19
+        image: registry.opensource.zalan.do/teapot/cluster-lifecycle-controller:master-22
         args:
             - --drain-grace-period={{.ConfigItems.drain_grace_period}}
             - --drain-min-pod-lifetime={{.ConfigItems.drain_min_pod_lifetime}}

--- a/cluster/manifests/e2e-resources/pool-reserve.yaml
+++ b/cluster/manifests/e2e-resources/pool-reserve.yaml
@@ -1,5 +1,5 @@
 {{ if eq .Environment "e2e" }}
-{{ range $pool := split "default-worker-splitaz,default-worker,worker-limit-az,worker-instance-storage" "," }}
+{{ range $pool := split "default-worker-splitaz,default-worker,worker-limit-az,worker-instance-storage,default-worker-spotio" "," }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -21,7 +21,15 @@ spec:
         pool: "{{$pool}}"
     spec:
       nodeSelector:
+      {{ if eq $pool "default-worker-spotio" }}
+        dedicated: spotio
+      tolerations:
+        - effect: NoSchedule
+          key: dedicated
+          value: spotio
+      {{ else }}
         node.kubernetes.io/node-pool: "{{$pool}}"
+      {{ end }}
       terminationGracePeriodSeconds: 0
       containers:
       - name: pause

--- a/cluster/manifests/spotio-controller/deployment_legacy.yaml
+++ b/cluster/manifests/spotio-controller/deployment_legacy.yaml
@@ -1,23 +1,27 @@
 {{ if and (index .Cluster.ConfigItems "spotio_account_id") (index .Cluster.ConfigItems "spotio_access_token") }}
+{{ with $data := . }}
+{{ range $nodePool := .Cluster.NodePools }}
+{{ if eq $nodePool.Profile "worker-spotio-ocean" }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: spotinst-kubernetes-cluster-controller
+  name: spotinst-kubernetes-cluster-controller-{{ $nodePool.Name }}
   namespace: kube-system
   labels:
     application: spotinst-kubernetes-cluster-controller
-    component: "ocean"
+    component: "{{ $nodePool.Name }}"
 spec:
   replicas: 1
   selector:
     matchLabels:
       application: spotinst-kubernetes-cluster-controller # TODO: this label name is REQUIRED by the controller
-      component: "ocean"
+      component: "{{ $nodePool.Name }}"
   template:
     metadata:
       labels:
         application: spotinst-kubernetes-cluster-controller
-        component: "ocean"
+        component: "{{ $nodePool.Name }}"
       annotations:
         config/hash: {{"secret.yaml" | manifestHash}}
     spec:
@@ -41,9 +45,9 @@ spec:
               key: spotinst.token
               name: spotinst-kubernetes-cluster-controller
         - name: SPOTINST_ACCOUNT
-          value: "{{ .Cluster.ConfigItems.spotio_account_id }}"
+          value: "{{ $data.ConfigItems.spotio_account_id }}"
         - name: CLUSTER_IDENTIFIER
-          value: "{{ .Cluster.LocalID }}"
+          value: "{{ $data.LocalID }}-{{ $nodePool.Name }}"
         - name: DISABLE_AUTO_UPDATE
           value: "true"
         - name: POD_ID
@@ -62,6 +66,7 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         livenessProbe:
+          failureThreshold: 3
           httpGet:
             path: /healthcheck
             port: 4401
@@ -70,26 +75,19 @@ spec:
           periodSeconds: 20
           successThreshold: 1
           timeoutSeconds: 2
-          failureThreshold: 3
-        readinessProbe:
-          httpGet:
-            path: /healthcheck
-            port: 4401
-          initialDelaySeconds: 20
-          periodSeconds: 20
-          timeoutSeconds: 2
-          successThreshold: 1
-          failureThreshold: 3
         resources:
           limits:
-            cpu: "{{ .Cluster.ConfigItems.spotio_ocean_controller_cpu }}"
-            memory: "{{ .Cluster.ConfigItems.spotio_ocean_controller_memory }}"
+            cpu: "{{ $data.ConfigItems.spotio_ocean_controller_cpu }}"
+            memory: "{{ $data.ConfigItems.spotio_ocean_controller_memory }}"
           requests:
-            cpu: "{{ .Cluster.ConfigItems.spotio_ocean_controller_cpu }}"
-            memory: "{{ .Cluster.ConfigItems.spotio_ocean_controller_memory }}"
+            cpu: "{{ $data.ConfigItems.spotio_ocean_controller_cpu }}"
+            memory: "{{ $data.ConfigItems.spotio_ocean_controller_memory }}"
       serviceAccountName: spotinst-kubernetes-cluster-controller
       tolerations:
       - key: node.kubernetes.io/role
         value: master
         effect: NoSchedule
+{{ end }}
+{{ end }}
+{{ end }}
 {{ end }}

--- a/cluster/node-pools/worker-default/userdata.yaml
+++ b/cluster/node-pools/worker-default/userdata.yaml
@@ -8,7 +8,7 @@ write_files:
     path: /etc/kubernetes/secrets.env
     content: |
       NODEPOOL_TAINTS={{if index .NodePool.ConfigItems "taints"}}{{.NodePool.ConfigItems.taints}}{{end}}
-      NODE_LABELS={{ .Values.node_labels }}{{if eq .NodePool.Profile "worker-spotio-ocean"}},spot.io=true{{end}},node.kubernetes.io/distro=ubuntu{{if index .NodePool.ConfigItems "labels"}},{{.NodePool.ConfigItems.labels}}{{end}}
+      NODE_LABELS={{ .Values.node_labels }}{{ if .NodePool.IsSpotIO }},spot.io=true{{end}},node.kubernetes.io/distro=ubuntu{{if index .NodePool.ConfigItems "labels"}},{{.NodePool.ConfigItems.labels}}{{end}}
       NODEPOOL_NAME={{ .NodePool.Name }}
       KUBELET_ROLE=worker
       ON_DEMAND_WORKER_REPLACEMENT_STRATEGY={{ .Cluster.ConfigItems.on_demand_worker_replacement_strategy }}

--- a/cluster/node-pools/worker-spotio/files.yaml
+++ b/cluster/node-pools/worker-spotio/files.yaml
@@ -1,0 +1,1 @@
+../worker-default/files.yaml

--- a/cluster/node-pools/worker-spotio/stack.yaml
+++ b/cluster/node-pools/worker-spotio/stack.yaml
@@ -1,0 +1,111 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Kubernetes spot.io node pool stack
+Metadata:
+  Tags:
+    InfrastructureComponent: "true"
+
+Mappings:
+  Images:
+    eu-central-1:
+      MachineImage: "{{ .NodePool.ConfigItems.kuberuntu_image_v1_19 }}"
+
+Resources:
+  AutoScalingInstanceProfile:
+    Properties:
+      Path: /
+      Roles:
+      - !ImportValue "{{ .Cluster.ID }}:worker-iam-role"
+    Type: "AWS::IAM::InstanceProfile"
+  SpotinstOceanLaunchSpec:
+    Type: Custom::oceanLaunchSpec
+    Properties:
+      ServiceToken: !Sub "arn:aws:lambda:${AWS::Region}:178579023202:function:spotinst-cloudformation"
+      accessToken: "{{ .Cluster.ConfigItems.spotio_access_token }}"
+      accountId: "{{ .Cluster.ConfigItems.spotio_account_id }}"
+      # allow force deleting, when deleting spot.io node pool
+      parameters:
+        delete:
+          forceDelete: true
+      oceanLaunchSpec:
+        name: "{{ .NodePool.Name }}"
+        oceanId: !ImportValue "{{ .Cluster.ID }}:spotio-ocean-id"
+        imageId: !FindInMap
+        - Images
+        - !Ref "AWS::Region"
+        - MachineImage
+        userData: "{{ .UserData }}"
+        iamInstanceProfile:
+          arn: !GetAtt
+            - AutoScalingInstanceProfile
+            - Arn
+        strategy:
+          spotPercentage: {{ .NodePool.ConfigItems.spotio_spot_percentage }}
+        associatePublicIpAddress: true
+        instanceTypes:
+{{- range $type := .NodePool.InstanceTypes }}
+        - "{{ $type }}"
+{{- end }}
+        blockDeviceMappings:
+          - deviceName: /dev/sda1
+            ebs:
+              deleteOnTermination: {{.NodePool.ConfigItems.ebs_root_volume_delete_on_termination}}
+              volumeSize: {{.NodePool.ConfigItems.ebs_root_volume_size}}
+              volumeType: gp3
+        securityGroupIds:
+        - !ImportValue '{{ .Cluster.ID }}:worker-security-group'
+        subnetIds:
+        {{- with $values := .Values }}
+        {{- range $az := $values.availability_zones }}
+          - "{{ index $values.subnets $az }}"
+        {{- end }}
+        {{- end }}
+        labels:
+        - key: "spot.io"
+          value: "true"
+        - key: "lifecycle-status"
+          value: "ready"
+{{- if index .NodePool.ConfigItems "labels"}}
+  {{- range split .NodePool.ConfigItems.labels ","}}
+    {{- $label := split . "="}}
+        - key: {{index $label 0}}
+          value: {{index $label 1}}
+  {{- end}}
+{{end}}
+{{- if index .NodePool.ConfigItems "taints"}}
+        taints:
+  {{- range split .NodePool.ConfigItems.taints ","}}
+    {{- $taint := split . "="}}
+      {{- with $value := index $taint 1 }}
+        {{- $valueEffect := split $value ":" }}
+        - key: {{index $taint 0}}
+          value: {{index $valueEffect 0}}
+          effect: {{index $valueEffect 1}}
+      {{- end}}
+  {{- end}}
+{{end}}
+        tags:
+          - tagKey: kubernetes.io/cluster/{{ .Cluster.ID }}
+            tagValue: owned
+          - tagKey: Name
+            tagValue: "{{ .NodePool.Name }} ({{ .Cluster.ID }})"
+            # TODO: evaluate how much of this we need?
+          - tagKey: node.kubernetes.io/role # used by ingress controller to detect nodes for LB
+            tagValue: worker
+          - tagKey: node.kubernetes.io/node-pool
+            tagValue: {{ .NodePool.Name }}
+          - tagKey: node.kubernetes.io/node-pool-profile
+            tagValue: {{ .NodePool.Profile }}
+          - tagKey: kubernetes.io/role/node-pool
+            tagValue: "true"
+          # only node pools without taints should be attached to Ingress Load balancer
+{{- if or (not (index .NodePool.ConfigItems "taints")) (eq (index .NodePool.ConfigItems "taints") "dedicated=skipper-ingress:NoSchedule") }}
+          - tagKey: zalando.org/ingress-enabled
+            tagValue: "true"
+{{- end }}
+          - tagKey: spot.io/type
+            tagValue: launchSpec
+          - tagKey: spot.io/ocean-id # used by CLM to lookup information from instance
+            tagValue: !ImportValue "{{ .Cluster.ID }}:spotio-ocean-id"
+        autoScale:
+          # disable headroom/preprovisioned instances
+          headrooms: []

--- a/cluster/node-pools/worker-spotio/userdata.yaml
+++ b/cluster/node-pools/worker-spotio/userdata.yaml
@@ -1,0 +1,1 @@
+../worker-default/userdata.yaml

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -41,6 +41,8 @@ clusters:
     routegroups_validation: "enabled"
     stackset_routegroup_support_enabled: "true"
     stackset_ingress_source_switch_ttl: "1m"
+    spotio_account_id: "${SPOTIO_ACCOUNT_ID}"
+    spotio_access_token: "${SPOTIO_ACCESS_TOKEN}"
   criticality_level: 1
   environment: e2e
   id: ${CLUSTER_ID}
@@ -83,6 +85,72 @@ clusters:
     profile: worker-default
     min_size: 0
     max_size: 21
+  - name: default-worker-spotio
+    profile: worker-spotio
+    instance_types:
+    - m5a.large
+    - c4.large
+    - c4.xlarge
+    - c4.2xlarge
+    - c4.4xlarge
+    - c5.large
+    - c5.xlarge
+    - c5.2xlarge
+    - c5.4xlarge
+    - m4.large
+    - m4.xlarge
+    - m4.2xlarge
+    - m4.4xlarge
+    - m5.large
+    - m5.xlarge
+    - m5.2xlarge
+    - m5.4xlarge
+    - r4.large
+    - r4.xlarge
+    - r4.2xlarge
+    - r4.4xlarge
+    - r5.large
+    - r5.xlarge
+    - r5.2xlarge
+    - r5.4xlarge
+    - c5n.large
+    - c5n.xlarge
+    - c5n.2xlarge
+    - c5n.4xlarge
+    - m5n.large
+    - m5n.xlarge
+    - m5n.2xlarge
+    - m5n.4xlarge
+    - r5n.large
+    - r5n.xlarge
+    - r5n.2xlarge
+    - r5n.4xlarge
+    - c5d.large
+    - c5d.xlarge
+    - c5d.2xlarge
+    - c5d.4xlarge
+    - m5d.large
+    - m5d.xlarge
+    - m5d.2xlarge
+    - m5d.4xlarge
+    - r5d.large
+    - r5d.xlarge
+    - r5d.2xlarge
+    - r5d.4xlarge
+    - m5dn.large
+    - m5dn.xlarge
+    - m5dn.2xlarge
+    - m5dn.4xlarge
+    - r5dn.large
+    - r5dn.xlarge
+    - r5dn.2xlarge
+    - r5dn.4xlarge
+    discount_strategy: none
+    min_size: 0
+    max_size: 21
+    config_items:
+      labels: dedicated=spotio
+      taints: dedicated=spotio:NoSchedule
   - discount_strategy: spot
     instance_types: ["p3.2xlarge", "g2.2xlarge", "g3s.xlarge", "g3.4xlarge"]
     name: worker-gpu

--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -178,7 +178,10 @@ if [ "$e2e" = true ]; then
     ginkgo -nodes=25 -flakeAttempts=2 \
         -focus="(\[Conformance\]|\[StatefulSetBasic\]|\[Feature:StatefulSet\]\s\[Slow\].*mysql|\[Zalando\])" \
         -skip="(should.resolve.DNS.of.partial.qualified.names.for.the.cluster|should.resolve.DNS.of.partial.qualified.names.for.services|should.be.able.to.change.the.type.from.ExternalName.to.NodePort|should.be.able.to.create.a.functioning.NodePort.service|should.have.session.affinity.work.for.NodePort.service|should.have.session.affinity.timeout.work.for.NodePort.service|should.be.able.to.switch.session.affinity.for.NodePort.service|\[Serial\]|Should.create.gradual.traffic.routes|Should.create.blue-green.routes)" \
-        "e2e.test" -- -delete-namespace-on-failure=false -non-blocking-taints=node.kubernetes.io/role,nvidia.com/gpu -report-dir=junit_reports
+        "e2e.test" -- \
+        -delete-namespace-on-failure=false \
+        -non-blocking-taints=node.kubernetes.io/role,nvidia.com/gpu,dedicated \
+        -report-dir=junit_reports
     TEST_RESULT="$?"
 
     set -e


### PR DESCRIPTION
This introduces a new node pool profile `worker-spotio` which is modeled different from `worker-spotio-ocean`. Instead of creating one Ocean per node pool, we can now create a single Ocean per cluster and create "Virtual Node Groups" as node pools.

Benefits of this are:
1. We no longer need to run one spotinst controller per spotio node pool, but only need one for the overarching Ocean cluster.
2. Better control of when spot.io should scale based on taints/labels. Allows us to run it along side the CA (when we correctly configure taints/labels)

The intention is to later drop support for the `worker-spotio-ocean` node profile, but it's left for now to ensure smooth migration path.

~Additionally this adds a proposed node label: `cluster-lifecycle-controller.zalan.do/instance-manager` to be read by CLC to decide how to terminate an instance (ec2 or via ASG), this is a bit more abstracted compared to relying on the node profile name as we currently do.~

Additionally this updates the Cluster Lifecycle Controller to fall back to terminate instances via EC2 API if they are not managed by an ASG.

## Dependency

* [x] Update to CLM: https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/401
* [x] Update to CLC: ~Support `cluster-lifecycle-controller.zalan.do/instance-manager`~
* [x] Handle cleanup of spotio node pools?