### PR TITLE
Don't use images from docker hub in stackset e2e

### DIFF
--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/spf13/viper v1.4.0
 	github.com/szuecs/routegroup-client v0.17.8-0.20200915193527-b33447c7d964
 	github.com/zalando-incubator/kube-aws-iam-controller v0.1.2
-	github.com/zalando-incubator/stackset-controller v1.3.6
+	github.com/zalando-incubator/stackset-controller v1.3.7
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	k8s.io/api v0.18.9
 	k8s.io/apimachinery v0.18.9

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -779,6 +779,8 @@ github.com/zalando-incubator/kube-aws-iam-controller v0.1.2 h1:uEXMHnd7wuXk3gAZ8
 github.com/zalando-incubator/kube-aws-iam-controller v0.1.2/go.mod h1:7RQdyNqtYaKEWVavXUFlrE8A+QsGe/hkBba2RyG5V4o=
 github.com/zalando-incubator/stackset-controller v1.3.6 h1:ANRkotqBnVfYLN1na+WQ/UHEZfPctAU5NlpMKrDARtg=
 github.com/zalando-incubator/stackset-controller v1.3.6/go.mod h1:9ZUcYq0S102MP5r6yEg2R33pPThm5bSckRxqRw3LfaA=
+github.com/zalando-incubator/stackset-controller v1.3.7 h1:+KT7yt2PsE5HQB7ZjyyQFy7hGZQir6HLNc8HzNyHxgc=
+github.com/zalando-incubator/stackset-controller v1.3.7/go.mod h1:9ZUcYq0S102MP5r6yEg2R33pPThm5bSckRxqRw3LfaA=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3 h1:MUGmc65QhB3pIlaQ5bB4LwqSj6GIonVJXpZiaKNyaKk=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=


### PR DESCRIPTION
Update stackset e2e tests to not use images from docker hub.