### PR TITLE
Revert "scale down policy for skipper-ingress "

### DIFF
--- a/cluster/manifests/skipper/hpa.yaml
+++ b/cluster/manifests/skipper/hpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: skipper-ingress
@@ -16,23 +16,8 @@ spec:
   - type: Resource
     resource:
       name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ .ConfigItems.skipper_ingress_target_average_utilization_cpu }}
+      targetAverageUtilization: {{ .ConfigItems.skipper_ingress_target_average_utilization_cpu }}
   - type: Resource
     resource:
       name: memory
-      target:
-        type: Utilization
-        averageUtilization: {{ .ConfigItems.skipper_ingress_target_average_utilization_memory }}
-  behavior:
-    scaleDown:
-      stabilizationWindowSeconds: 600
-      policies:
-      - type: Pods
-        value: 10
-        periodSeconds: 120
-      - type: Percent
-        value: 100
-        periodSeconds: 120
-      selectPolicy: Min
+      targetAverageUtilization: {{ .ConfigItems.skipper_ingress_target_average_utilization_memory }}


### PR DESCRIPTION
This is completely broken in 1.18.10; reverting until we update.