### PR TITLE
Revert the Skipper HPA changes _correctly_

### DIFF
--- a/cluster/manifests/skipper/hpa.yaml
+++ b/cluster/manifests/skipper/hpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: skipper-ingress
@@ -16,8 +16,12 @@ spec:
   - type: Resource
     resource:
       name: cpu
-      targetAverageUtilization: {{ .ConfigItems.skipper_ingress_target_average_utilization_cpu }}
+      target:
+        type: Utilization
+        averageUtilization: {{ .ConfigItems.skipper_ingress_target_average_utilization_cpu }}
   - type: Resource
     resource:
       name: memory
-      targetAverageUtilization: {{ .ConfigItems.skipper_ingress_target_average_utilization_memory }}
+      target:
+        type: Utilization
+        averageUtilization: {{ .ConfigItems.skipper_ingress_target_average_utilization_memory }}


### PR DESCRIPTION
Reverting the API version as well means that the behaviour changes will not be reverted.