### PR TITLE
redis: default to 512Mi memory

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -77,7 +77,7 @@ skipper_write_timeout_server: "60s"
 # skipper redis settings
 skipper_redis_replicas: 2
 skipper_redis_cpu: "100m"
-skipper_redis_memory: "100Mi"
+skipper_redis_memory: "512Mi"
 
 # skipper api GW features
 enable_apimonitoring: "true"                       # TODO(sszuecs): cleanup candidate to reduce amount of branches in deployment


### PR DESCRIPTION
We've increased the Skipper HPA max _a lot_, redis now OOMs sometimes just keeping the connections open. Let's overprovision it by default.