### PR TITLE
Upgrading StackSet Controller to 1.3.8

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -466,6 +466,10 @@ kubernetes_event_logger_enabled: "true"
 
 # enable/disable routegroup support for stackset
 stackset_routegroup_support_enabled: "true"
+# The ttl before an ingress source is deleted when replaced with another
+# one.
+# E.g. switching from RouteGroup to Ingress or vice versa.
+stackset_ingress_source_switch_ttl: "5m"
 
 # Enable/Disable profiling for Kubernetes components
 enable_control_plane_profiling: "false"

--- a/cluster/manifests/stackset-controller/deployment.yaml
+++ b/cluster/manifests/stackset-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: stackset-controller
-    version: "v1.3.6"
+    version: "v1.3.8"
 spec:
   replicas: 1
   selector:
@@ -15,17 +15,18 @@ spec:
     metadata:
       labels:
         application: stackset-controller
-        version: "v1.3.6"
+        version: "v1.3.8"
     spec:
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       serviceAccountName: stackset-controller
       containers:
       - name: stackset-controller
-        image: "registry.opensource.zalan.do/teapot/stackset-controller:v1.3.6"
+        image: "registry.opensource.zalan.do/teapot/stackset-controller:v1.3.8"
         args:
         - "--interval={{ .Cluster.ConfigItems.stackset_controller_sync_interval }}"
 {{- if eq .Cluster.ConfigItems.stackset_routegroup_support_enabled "true" }}
         - "--enable-routegroup-support"
+        - "--ingress-source-switch-ttl={{ .Cluster.ConfigItems.stackset_ingress_source_switch_ttl }}"
 {{- end }}
         env:
           - name: CLUSTER_DOMAIN

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -55,6 +55,7 @@ clusters:
     autoscaling_scale_down_enabled: "${autoscaling_scale_down_enabled}"
     routegroups_validation: "enabled"
     stackset_routegroup_support_enabled: "true"
+    stackset_ingress_source_switch_ttl: "1m"
   criticality_level: 1
   environment: e2e
   id: ${CLUSTER_ID}

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/spf13/viper v1.4.0
 	github.com/szuecs/routegroup-client v0.17.8-0.20200915193527-b33447c7d964
 	github.com/zalando-incubator/kube-aws-iam-controller v0.1.2
-	github.com/zalando-incubator/stackset-controller v1.3.7
+	github.com/zalando-incubator/stackset-controller v1.3.8
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	k8s.io/api v0.18.9
 	k8s.io/apimachinery v0.18.9

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -777,10 +777,8 @@ github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zalando-incubator/kube-aws-iam-controller v0.1.2 h1:uEXMHnd7wuXk3gAZ8iiOnL9XVUqA1iuDQzQFsa3ywA4=
 github.com/zalando-incubator/kube-aws-iam-controller v0.1.2/go.mod h1:7RQdyNqtYaKEWVavXUFlrE8A+QsGe/hkBba2RyG5V4o=
-github.com/zalando-incubator/stackset-controller v1.3.6 h1:ANRkotqBnVfYLN1na+WQ/UHEZfPctAU5NlpMKrDARtg=
-github.com/zalando-incubator/stackset-controller v1.3.6/go.mod h1:9ZUcYq0S102MP5r6yEg2R33pPThm5bSckRxqRw3LfaA=
-github.com/zalando-incubator/stackset-controller v1.3.7 h1:+KT7yt2PsE5HQB7ZjyyQFy7hGZQir6HLNc8HzNyHxgc=
-github.com/zalando-incubator/stackset-controller v1.3.7/go.mod h1:9ZUcYq0S102MP5r6yEg2R33pPThm5bSckRxqRw3LfaA=
+github.com/zalando-incubator/stackset-controller v1.3.8 h1:xPdu0iKHWXpHa3MXa97GDVNWI2zxj44A5v0hjLLBgsk=
+github.com/zalando-incubator/stackset-controller v1.3.8/go.mod h1:9ZUcYq0S102MP5r6yEg2R33pPThm5bSckRxqRw3LfaA=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3 h1:MUGmc65QhB3pIlaQ5bB4LwqSj6GIonVJXpZiaKNyaKk=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=


### PR DESCRIPTION
The StackSet Controller version 1.3.8 introduces improved support for
Ingress to RouteGroup migration. Check the [release notes][0] for more
details.

This commit upgrades the StackSet controller version deployed to
clusters and its dependency used by the e2e tests.
Also, it adds a new config item called
`stackset_ingress_source_switch_ttl`, responsible for defining the value
of the flag [`--ingress-source-switch-ttl`][1] during the controller
execution. It's required to run the StackSet controller e2e tests as it
expects a TTL of 1 minute, but, also, it allows to configure different
TTLs for different clusters. The default value is 5 minutes.

[0]: https://github.com/zalando-incubator/stackset-controller/releases/tag/v1.3.8
[1]: https://github.com/zalando-incubator/stackset-controller/blob/e72232e799e5ff8ba5b51d29dc5ddff153907162/cmd/stackset-controller/main.go#L56