### PR TITLE
Making prometheus remote config retries configurable

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -183,15 +183,15 @@ prometheus_cpu_min: "0"
 prometheus_tsdb_retention_size: "disabled"
 prometheus_csi_ebs: "false"
 
-# The remote configs match the prometheus defaults:
+# Upstream defaults are too aggressive:
 # https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write
 prometheus_remote_write: "disabled"
 # Maximum time a sample will wait in buffer.
-prometheus_remote_batch_send_deadline: "5s"
+prometheus_remote_batch_send_deadline: "30s"
 # Initial retry delay. Gets doubled for every retry.
-prometheus_remote_min_backoff: "30ms"
+prometheus_remote_min_backoff: "3s"
 # Maximum retry delay.
-prometheus_remote_max_backoff: "100ms"
+prometheus_remote_max_backoff: "10s"
 
 # regex defining labels to be dropped when scraping from kube-state-metrics
 # Simple workaround for: https://github.com/kubernetes/kube-state-metrics/issues/1115

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -180,9 +180,18 @@ prometheus_cpu: "1000m"
 prometheus_mem: "4Gi"
 prometheus_mem_min: "2Gi"
 prometheus_cpu_min: "0"
-prometheus_remote_write: "disabled"
 prometheus_tsdb_retention_size: "disabled"
 prometheus_csi_ebs: "false"
+
+# The remote configs match the prometheus defaults:
+# https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write
+prometheus_remote_write: "disabled"
+# Maximum time a sample will wait in buffer.
+prometheus_remote_batch_send_deadline: "5s"
+# Initial retry delay. Gets doubled for every retry.
+prometheus_remote_min_backoff: "30ms"
+# Maximum retry delay.
+prometheus_remote_max_backoff: "100ms"
 
 # regex defining labels to be dropped when scraping from kube-state-metrics
 # Simple workaround for: https://github.com/kubernetes/kube-state-metrics/issues/1115

--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -70,6 +70,13 @@ data:
 {{ if ne .ConfigItems.prometheus_remote_write "disabled" }}
     remote_write:
     - url: {{ .ConfigItems.prometheus_remote_write }}
+      queue_config:
+        # Maximum time a sample will wait in buffer.
+        batch_send_deadline: {{ .ConfigItems.prometheus_remote_batch_send_deadline }}
+        # Initial retry delay. Gets doubled for every retry.
+        min_backoff: {{ .ConfigItems.prometheus_remote_min_backoff }}
+        # Maximum retry delay.
+        max_backoff: {{ .ConfigItems.prometheus_remote_max_backoff }}
       bearer_token_file: /meta/credentials/remote-write-token-secret
 {{ end }}
     scrape_configs:

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -189,6 +189,7 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/euank/go-kmsg-parser v2.0.0+incompatible h1:cHD53+PLQuuQyLZeriD1V/esuG4MuU0Pjs5y6iknohY=
 github.com/euank/go-kmsg-parser v2.0.0+incompatible/go.mod h1:MhmAMZ8V4CYH4ybgdRwPr2TU5ThnS43puaKEMpja1uw=
+github.com/evanphx/json-patch v0.0.0-20200808040245-162e5629780b/go.mod h1:NAJj0yf/KaRKURN6nyi7A9IZydMivZEm9oQLWNjfKDc=
 github.com/evanphx/json-patch v4.9.0+incompatible h1:kLcOMZeuLAJvL2BPWLMIj5oaZQobrkAqrL+WFZwQses=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d h1:105gxyaGwCFad8crR9dcMQWvV9Hvulu6hwUh4tWPJnM=
@@ -447,6 +448,7 @@ github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
+github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a/go.mod h1:wK6yTYYcgjHE1Z1QtXACPDjcFJyBskHEdagmnq3vsP8=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=


### PR DESCRIPTION
Can be modified per cluster. Keeping the global config items to the
upstream defaults.

Signed-off-by: Muaaz Saleem <muhammad.muaaz.saleem@zalando.de>