### PR TITLE
remove originmarkers and update skipper

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.11.195
+    version: v0.11.204
     component: ingress
 spec:
   strategy:
@@ -19,7 +19,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.11.195
+        version: v0.11.204
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -51,7 +51,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/teapot/skipper:v0.11.195-37
+        image: registry.opensource.zalan.do/teapot/skipper:v0.11.204-46
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -127,7 +127,7 @@ spec:
             tag=application=skipper-ingress
             tag=account={{ .Cluster.Alias }}
             tag=cluster={{ .Cluster.Alias }}
-            tag=artifact=registry.opensource.zalan.do/teapot/skipper:v0.11.195
+            tag=artifact=registry.opensource.zalan.do/teapot/skipper:v0.11.204
             grpc-max-msg-size={{ .ConfigItems.skipper_ingress_lightstep_grpc_max_msg_size }}
             max-period={{ .ConfigItems.skipper_ingress_lightstep_max_period }}
             min-period={{ .ConfigItems.skipper_ingress_lightstep_min_period }}
@@ -147,7 +147,6 @@ spec:
           - "-read-timeout-server={{ .ConfigItems.skipper_read_timeout_server }}"
           - "-write-timeout-server={{ .ConfigItems.skipper_write_timeout_server }}"
           - '-default-filters-prepend={{ .ConfigItems.skipper_default_filters }}'
-          - "-route-creation-metrics"
 {{ if eq .ConfigItems.skipper_enable_tcp_queue "true" }}
           - "-enable-tcp-queue"
           - "-expected-bytes-per-request={{ .ConfigItems.skipper_expected_bytes_per_request }}"


### PR DESCRIPTION
remove originmarkers, which were a couple of times the reason for not needed route updates triggers which consume some CPU that lead to scale up in test clusters

update skipper also has
- apimonitoring filter fixes (remove spec reference and regexp are cached to speedup route creation)
- refactored the cluttered logic in makeBackendRequest
- refactored ingress tests
- fixed ingress named port mapping
- fixed routegroup supports backendprotocol annotation similar to ingress
- fixed GH code scanning findings (remove sensitive data from logs)
- fixed possible panic by concurrent access of non syncronized map in secrets.Registry#GetEncrypter function
- feature OIDC auth filters, Auth Code Options will be able to be dynamically set by a query parameter

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>