### PR TITLE
Use gp3 for the root volume

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -444,6 +444,7 @@ stackset_controller_mem_min: "120Mi"
 stackset_controller_mem_max: "4Gi"
 
 # EBS settings for the root volume
+ebs_master_root_volume_size: "50"
 ebs_root_volume_size: "50"
 ebs_root_volume_delete_on_termination: "true"
 

--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -56,6 +56,12 @@ Resources:
         CreditSpecification:
           CpuCredits: unlimited
 {{ end }}
+        BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            DeleteOnTermination: {{.NodePool.ConfigItems.ebs_root_volume_delete_on_termination}}
+            VolumeSize: {{.NodePool.ConfigItems.ebs_master_root_volume_size}}
+            VolumeType: gp3
         NetworkInterfaces:
         - DeviceIndex: 0
           AssociatePublicIpAddress: true

--- a/cluster/node-pools/worker-default/stack.yaml
+++ b/cluster/node-pools/worker-default/stack.yaml
@@ -116,13 +116,12 @@ Resources:
     Properties:
       LaunchTemplateName: '{{.Cluster.LocalID}}-{{ .NodePool.Name }}'
       LaunchTemplateData:
-{{ if ne .NodePool.ConfigItems.ebs_root_volume_size "50" }}
         BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
             DeleteOnTermination: {{.NodePool.ConfigItems.ebs_root_volume_delete_on_termination}}
             VolumeSize: {{.NodePool.ConfigItems.ebs_root_volume_size}}
-{{ end }}
+            VolumeType: gp3
         NetworkInterfaces:
         - DeviceIndex: 0
           AssociatePublicIpAddress: true

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -126,13 +126,12 @@ Resources:
     Properties:
       LaunchTemplateName: '{{ $data.Cluster.LocalID }}-{{ $data.NodePool.Name }}'
       LaunchTemplateData:
-{{ if ne $data.NodePool.ConfigItems.ebs_root_volume_size "50" }}
         BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
             DeleteOnTermination: {{$data.NodePool.ConfigItems.ebs_root_volume_delete_on_termination}}
             VolumeSize: {{$data.NodePool.ConfigItems.ebs_root_volume_size}}
-{{ end }}
+            VolumeType: gp3
         NetworkInterfaces:
         - DeviceIndex: 0
           AssociatePublicIpAddress: true


### PR DESCRIPTION
It's cheaper and provides much better baseline performance, no reason not to switch.