### PR TITLE
Use special labels to allow metrics to be deduped

### DIFF
--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -63,8 +63,9 @@ data:
     global:
       scrape_interval: 15s
       external_labels:
-        prometheus_replica: @@POD_NAME@@
         cluster: {{ .Cluster.Alias }}
+        prom_ha_cluster: {{ .Cluster.Alias }}
+        prom_ha_instance: @@POD_NAME@@
     rule_files:
     - "prometheus.rules.yaml"
 {{ if ne .ConfigItems.prometheus_remote_write "disabled" }}


### PR DESCRIPTION
Dedup pushed metrics according to https://grafana.com/blog/2019/10/03/deduping-ha-prometheus-samples-in-cortex/