### PR TITLE
VPA: don't spam the logs

### DIFF
--- a/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
@@ -27,6 +27,11 @@ spec:
       containers:
       - name: admission-controller
         image: registry.opensource.zalan.do/teapot/vpa-admission-controller:v0.6.1-internal.12
+        command:
+          - /admission-controller
+        args:
+          - --v=1
+          - --logtostderr
         volumeMounts:
           - name: tls-certs
             mountPath: "/etc/tls-certs"

--- a/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
@@ -25,8 +25,8 @@ spec:
       - name: recommender
         image: registry.opensource.zalan.do/teapot/vpa-recommender:v0.6.1-internal.12
         args:
-        - --stderrthreshold=info
-        - --v=5
+        - --logtostderr
+        - --v=1
         - --memory-saver
         - --pod-recommendation-min-memory-mb=50
         command:

--- a/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
@@ -27,8 +27,8 @@ spec:
         command:
           - ./updater
         args:
-          - --v=4
-          - --stderrthreshold=info
+          - --v=1
+          - --logtostderr
           - --min-replicas=1
           - --pod-lifetime-update-threshold=12h
           - --evict-after-oom-threshold=12h


### PR DESCRIPTION
V=4 logs contain a lot of noise that we don't need.