### PR TITLE
Customise tcp retries as well

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -364,6 +364,9 @@ pod_max_pids: "4096"
 # the cpu management policy which should be used by the kubelet
 cpu_manager_policy: "none"
 
+# sysctl names allowed to be used in security policies, comma-separated
+allowed_unsafe_sysctls: "net.ipv4.tcp_keepalive_time,net.ipv4.tcp_keepalive_intvl,net.ipv4.tcp_keepalive_probes"
+
 # enable CSIMigration feature flag
 enable_csi_migration: "false"
 

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -365,7 +365,7 @@ pod_max_pids: "4096"
 cpu_manager_policy: "none"
 
 # sysctl names allowed to be used in security policies, comma-separated
-allowed_unsafe_sysctls: "net.ipv4.tcp_keepalive_time,net.ipv4.tcp_keepalive_intvl,net.ipv4.tcp_keepalive_probes"
+allowed_unsafe_sysctls: "net.ipv4.tcp_keepalive_time,net.ipv4.tcp_keepalive_intvl,net.ipv4.tcp_keepalive_probes,net.ipv4.tcp_syn_retries,net.ipv4.tcp_retries2"
 
 # enable CSIMigration feature flag
 enable_csi_migration: "false"

--- a/cluster/manifests/psp/pod_security_policy.yaml
+++ b/cluster/manifests/psp/pod_security_policy.yaml
@@ -20,9 +20,9 @@ spec:
   supplementalGroups:
     rule: RunAsAny
   allowedUnsafeSysctls:
-    - net.ipv4.tcp_keepalive_time
-    - net.ipv4.tcp_keepalive_intvl
-    - net.ipv4.tcp_keepalive_probes
+{{- range $sysctl := split .Cluster.ConfigItems.allowed_unsafe_sysctls "," }}
+    - {{$sysctl}}
+{{- end }}
   volumes:
   - '*'
   allowedCapabilities:
@@ -58,9 +58,9 @@ spec:
   supplementalGroups:
     rule: RunAsAny
   allowedUnsafeSysctls:
-    - net.ipv4.tcp_keepalive_time
-    - net.ipv4.tcp_keepalive_intvl
-    - net.ipv4.tcp_keepalive_probes
+{{- range $sysctl := split .Cluster.ConfigItems.allowed_unsafe_sysctls "," }}
+    - {{$sysctl}}
+{{- end }}
   volumes:
   - awsElasticBlockStore
   - configMap

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -69,9 +69,9 @@ write_files:
         cpu: "100m"
         memory: "282Mi"
       allowedUnsafeSysctls:
-        - net.ipv4.tcp_keepalive_time
-        - net.ipv4.tcp_keepalive_intvl
-        - net.ipv4.tcp_keepalive_probes
+{{- range $sysctl := split .Cluster.ConfigItems.allowed_unsafe_sysctls "," }}
+        - {{$sysctl}}
+{{- end }}
       authentication:
         anonymous:
           enabled: true

--- a/cluster/node-pools/worker-default/userdata.yaml
+++ b/cluster/node-pools/worker-default/userdata.yaml
@@ -83,9 +83,9 @@ write_files:
         cpu: "100m"
         memory: "282Mi"
       allowedUnsafeSysctls:
-        - net.ipv4.tcp_keepalive_time
-        - net.ipv4.tcp_keepalive_intvl
-        - net.ipv4.tcp_keepalive_probes
+{{- range $sysctl := split .Cluster.ConfigItems.allowed_unsafe_sysctls "," }}
+        - {{$sysctl}}
+{{- end }}
       authentication:
         anonymous:
           enabled: false


### PR DESCRIPTION
Add `tcp_syn_retries`/`tcp_retries2` to `allowed_unsafe_sysctls`, with a plan to automatically inject better values by default in the future.