### PR TITLE
Enable delete protection for PG/NS resources in production clusters

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -264,8 +264,6 @@ teapot_admission_controller_deployment_default_max_surge: "5%"
 teapot_admission_controller_deployment_default_max_unavailable: "1"
 teapot_admission_controller_inject_aws_waiter: "true"
 teapot_admission_controller_parent_resource_hash: "true"
-teapot_admission_controller_postgresql_delete_protection_enabled: "false"
-teapot_admission_controller_namespace_delete_protection_enabled: "false"
 
 ## Defaults are set per-cluster
 teapot_admission_controller_check_daemonset_resources: "true"
@@ -276,14 +274,20 @@ teapot_admission_controller_daemonset_reserved_memory: "64Gi"
 teapot_admission_controller_validate_application_label: "true"
 teapot_admission_controller_validate_pod_template_resources: "true"
 teapot_admission_controller_preemption_enabled: "true"
+teapot_admission_controller_postgresql_delete_protection_enabled: "true"
+teapot_admission_controller_namespace_delete_protection_enabled: "true"
 {{else if eq .Environment "e2e"}}
 teapot_admission_controller_validate_application_label: "false"
 teapot_admission_controller_validate_pod_template_resources: "false"
 teapot_admission_controller_preemption_enabled: "true"
+teapot_admission_controller_postgresql_delete_protection_enabled: "false"
+teapot_admission_controller_namespace_delete_protection_enabled: "false"
 {{else}}
 teapot_admission_controller_validate_application_label: "false"
 teapot_admission_controller_validate_pod_template_resources: "true"
 teapot_admission_controller_preemption_enabled: "false"
+teapot_admission_controller_postgresql_delete_protection_enabled: "false"
+teapot_admission_controller_namespace_delete_protection_enabled: "false"
 {{end}}
 
 {{if eq .Environment "e2e"}}


### PR DESCRIPTION
This worked fine in a test cluster, let's roll it out.