### PR TITLE
Add RBAC for aws-tagging-service

### DIFF
--- a/cluster/manifests/roles/aws-tagging-service-rbac.yaml
+++ b/cluster/manifests/roles/aws-tagging-service-rbac.yaml
@@ -1,0 +1,29 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aws-tagging-service
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - persistentvolumeclaims
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aws-tagging-service
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aws-tagging-service
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: zalando-iam:zalando:service:stups_aws-tagging-service


### PR DESCRIPTION
Adds RBAC for aws-tagging-service which is running in one cluster and accessing all other clusters to tag AWS resources for cost allocation.

It needs access to volumes and services to map information from Kubernetes to the corresponding AWS resources.