### PR TITLE
suppress route update logs

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -51,6 +51,7 @@ skipper_ingress_cpu: "1000m"
 skipper_ingress_memory: "1Gi"
 skipper_ingress_tracing_buffer: "8192"
 enable_dedicate_nodepool_skipper: "false"
+skipper_suppress_route_update_logs: "true"
 {{if eq .Environment "e2e"}}
 skipper_topology_spread_enabled: "true"
 {{else}}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -161,6 +161,7 @@ spec:
           - "-status-checks=http://127.0.0.1:9021/health"
 {{ else }}
           - "-oauth2-tokeninfo-url={{ .ConfigItems.tokeninfo_url }}"
+          - "-suppress-route-update-logs={{ .ConfigItems.skipper_suppress_route_update_logs }}"
 {{ end }}
         resources:
           limits:


### PR DESCRIPTION
Currently, we are printing every route in the logs whenever there is an update or a full reset. This is not useful at scale, and we never used this detail when investigating past routing issues. For diagnostics of potential ongoing problems, we can use the /routes diagnostics endpoint.

This change suppresses the logs on updates, resulting in printing only the total number of reset/udpated/deleted routes.

Signed-off-by: Arpad Ryszka <arpad.ryszka@gmail.com>