### PR TITLE
Revert gp3 for spot.io

### DIFF
--- a/cluster/node-pools/worker-spotio-ocean/stack.yaml
+++ b/cluster/node-pools/worker-spotio-ocean/stack.yaml
@@ -29,7 +29,7 @@ Resources:
         rollConfig:
           roll:
             batchSizePercentage: "25"
-      # API Docs: https://docs.spot.io/api/#operation/OceanAWSLaunchSpecCreate
+      # API Docs: https://help.spot.io/spotinst-api/ocean/ocean-cloud-api/ocean-for-aws/create-2/
       ocean:
         name: "{{ .Cluster.Alias }}-{{ .NodePool.Name }}"
         controllerClusterId: "{{ .Cluster.LocalID }}-{{ .NodePool.Name }}"
@@ -71,12 +71,6 @@ Resources:
             {{ range $type := .NodePool.InstanceTypes }}
               - "{{ $type }}"
             {{ end }}
-          blockDeviceMappings:
-            - deviceName: /dev/sda1
-              ebs:
-                deleteOnTermination: {{$data.NodePool.ConfigItems.ebs_root_volume_delete_on_termination}}
-                volumeSize: {{$data.NodePool.ConfigItems.ebs_root_volume_size}}
-                volumeType: gp3
           launchSpecification:
             tags:
             - tagKey: kubernetes.io/cluster/{{ .Cluster.ID }}

--- a/cluster/node-pools/worker-spotio-ocean/stack.yaml
+++ b/cluster/node-pools/worker-spotio-ocean/stack.yaml
@@ -74,8 +74,8 @@ Resources:
           blockDeviceMappings:
             - deviceName: /dev/sda1
               ebs:
-                deleteOnTermination: {{.NodePool.ConfigItems.ebs_root_volume_delete_on_termination}}
-                volumeSize: {{.NodePool.ConfigItems.ebs_root_volume_size}}
+                deleteOnTermination: {{$data.NodePool.ConfigItems.ebs_root_volume_delete_on_termination}}
+                volumeSize: {{$data.NodePool.ConfigItems.ebs_root_volume_size}}
                 volumeType: gp3
           launchSpecification:
             tags:


### PR DESCRIPTION
I was looking at the wrong part of the API docs. The one that we're using doesn't support customising the block device mappings unfortunately.