### PR TITLE
Update Cluster Autoscaler

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -19,12 +19,12 @@ cluster_autoscaler_keep_backed_off_pools_scaled_up: "true"
 
 # How long to wait for pod eviction when scaling down.
 {{if eq .Environment "production"}}
-cluster_autoscaler_max_pod_eviction_time: "2m"
-cluster_autoscaler_disable_node_instances_cache: "false"
+cluster_autoscaler_max_pod_eviction_time: "1h"
 {{else}}
 cluster_autoscaler_max_pod_eviction_time: "3h"
-cluster_autoscaler_disable_node_instances_cache: "true"
 {{end}}
+
+cluster_autoscaler_disable_node_instances_cache: "true"
 
 # defines which expander the autoscaler should use
 cluster_autoscaler_expander: highest-priority

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -25,6 +25,7 @@ cluster_autoscaler_max_pod_eviction_time: "3h"
 {{end}}
 
 cluster_autoscaler_disable_node_instances_cache: "true"
+cluster_autoscaler_scale_down_ignore_schedulable_pods: "true"
 
 # defines which expander the autoscaler should use
 cluster_autoscaler_expander: highest-priority

--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     application: kube-cluster-autoscaler
     {{- if eq .Cluster.ConfigItems.cluster_autoscaler_release "1_18" }}
-    version: v1.18.2-internal.21
+    version: v1.18.2-internal.24
     {{- else }}
     version: v1.12.2-internal-2.17
     {{- end }}
@@ -21,7 +21,7 @@ spec:
       labels:
         application: kube-cluster-autoscaler
         {{- if eq .Cluster.ConfigItems.cluster_autoscaler_release "1_18" }}
-        version: v1.18.2-internal.21
+        version: v1.18.2-internal.24
         {{- else }}
         version: v1.12.2-internal-2.17
         {{- end }}
@@ -44,7 +44,7 @@ spec:
       containers:
       - name: cluster-autoscaler
         {{- if eq .Cluster.ConfigItems.cluster_autoscaler_release "1_18" }}
-        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.18.2-internal.21
+        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.18.2-internal.24
         {{- else }}
         image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.12.2-internal-2.17
         {{- end }}

--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -72,6 +72,7 @@ spec:
           - --max-pod-eviction-time={{ .Cluster.ConfigItems.cluster_autoscaler_max_pod_eviction_time }}
           - --topology-spread-constraint-scale-factor=3
           - --disable-node-instances-cache={{ .Cluster.ConfigItems.cluster_autoscaler_disable_node_instances_cache }}
+          - --scale-down-ignore-schedulable-pods={{ .Cluster.ConfigItems.cluster_autoscaler_scale_down_ignore_schedulable_pods }}
           {{- end }}
         resources:
           requests:


### PR DESCRIPTION
Changes:
 * Saner scale-down behaviour (it's no longer blocked while the cluster is scaling up, https://github.com/zalando-incubator/autoscaler/pull/72)
 * Metrics for scale-down (https://github.com/zalando-incubator/autoscaler/pull/73)
 * Node cache disabled in all clusters, scale-down timeout change to 1 hour in production ones