### PR TITLE
Add NoSchedule taint to old nodes

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -255,6 +255,8 @@ drain_min_unhealthy_sibling_lifetime: "1h"
 drain_force_evict_interval: "5m"
 node_update_prepare_replacement_node: "false" # don't wait for a replacement instance for on-demand pools in test clusters
 {{end}}
+# add NoSchedule taints to nodes being replaced
+decommission_node_no_schedule_taint: "true"
 
 # Teapot admission controller
 teapot_admission_controller_default_cpu_request: "25m"


### PR DESCRIPTION
In our current cluster update strategy (rolling of the nodes) we have been adding a `PreferNoScheduleTaint` to the "old" nodes which should be replaced. The idea was that pods being drained from old nodes should prefer to schedule on "new" nodes (without the taint) and fallback to the old node in case no capacity was available on new nodes, with the thinking **it's better to schedule somewhere, rather than not at all.**

The problem with this approach is that in practice pods of old nodes will for most of the time be scheduled on old nodes because having the `PreferNoScheduleTaint` means the autoscaler will not trigger and scale out a new node.
This leads to pods needing to be drained multiple times OR that the users explicitly have to ensure the pods are scheduled on new nodes via a nodeSelector: `lifecycle-status=ready` as we do for postgres and es operator.

We have made many improvements to autoscaling since our update strategy was introduced in the form of fallback pools, Pod Scheduling SLO etc. and we should therefore now have the confidence to rely on autoscaling for providing capacity rather than falling back to the old nodes.

This PR changes the taint set on old nodes from `PreferNoSchedule` to `NoSchedule` such that no pods can run on the old nodes after they have been marked for decommissioning. It's possible to revert this behavior per cluster if desired.

The config item used is understood by CLM: https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/f0930bf305a20bb5ecac21228510cb1fcbed6491/provisioner/clusterpy.go#L767

