### PR TITLE
add psp for postgres-operator that wants to have nice(2)

### DIFF
--- a/cluster/manifests/psp/pod_security_policy.yaml
+++ b/cluster/manifests/psp/pod_security_policy.yaml
@@ -40,6 +40,7 @@ spec:
   - SETPCAP
   - SETUID
   - SYS_CHROOT
+  - SYS_NICE
 ---
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -83,3 +84,4 @@ spec:
   - SETPCAP
   - SETUID
   - SYS_CHROOT
+  - SYS_NICE


### PR DESCRIPTION
This adds `SYS_NICE` as an allowed capability to the existing restricted PSP.

This means the capability is NOT enabled by default for pods running with the restricted PSP, but users can opt-in by adding:

```yaml
securityContext:
      capabilities:
        add: ["SYS_NICE"]
```

to their pods/containers. The only intended use case for now is for Postgres DBs.