### PR TITLE
Drop admission controller proxy [1/2]

### DIFF
--- a/cluster/manifests/admission-control-credentials/credentials.yaml
+++ b/cluster/manifests/admission-control-credentials/credentials.yaml
@@ -1,0 +1,14 @@
+{{ if eq .Environment "production" }}
+apiVersion: "zalando.org/v1"
+kind: PlatformCredentialsSet
+metadata:
+   name: admission-controller-credentials
+   namespace: kube-system
+   labels:
+     application: kube-apiserver
+spec:
+   application: kube-apiserver
+   tokens:
+     kio:
+       privileges: []
+{{ end }}


### PR DESCRIPTION
The admission controller can now use a secret directly, so we don't need the proxy hack anymore. This PR adds a credentials set for the admission controller explicitly so we could drop the proxy in a followup PR.