### PR TITLE
Revert "add lightstep propagators to skipper"

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -103,8 +103,6 @@ skipper_ingress_lightstep_min_period: "500ms"
 skipper_ingress_lightstep_max_period: "2500ms"
 # set to "log-events" to enable
 skipper_ingress_lightstep_log_events: ""
-# set to "lightstep,b3" to also pickup "zipkin"/"B3" spans (https://docs.lightstep.com/docs/use-jaeger-agent-with-lightstep)
-skipper_ingress_lightstep_propagators: "lightstep"
 lightstep_token: ""
 tracing_collector_host: "tracing.stups.zalan.do"
 

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.12.13
+    version: v0.12.0
     component: ingress
 spec:
   strategy:
@@ -19,7 +19,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.12.13
+        version: v0.12.0
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -51,7 +51,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/teapot/skipper-internal:v0.12.13-61
+        image: registry.opensource.zalan.do/teapot/skipper-internal:v0.12.0-48
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -131,7 +131,6 @@ spec:
             grpc-max-msg-size={{ .ConfigItems.skipper_ingress_lightstep_grpc_max_msg_size }}
             max-period={{ .ConfigItems.skipper_ingress_lightstep_max_period }}
             min-period={{ .ConfigItems.skipper_ingress_lightstep_min_period }}
-            propagators={{ .Cluster.ConfigItems.skipper_ingress_lightstep_propagators }}
             {{ .Cluster.ConfigItems.skipper_ingress_lightstep_log_events }}
           - "-opentracing-excluded-proxy-tags={{ .ConfigItems.skipper_ingress_opentracing_excluded_proxy_tags }}"
 {{ if eq .ConfigItems.skipper_ingress_opentracing_backend_name_tag "true" }}


### PR DESCRIPTION
Reverts zalando-incubator/kubernetes-on-aws#3860 because of issues with the opentracing headers.