### PR TITLE
cdp-controller-rbac: create/delete batch/v1 Job

### DIFF
--- a/cluster/manifests/roles/cdp-controller-rbac.yaml
+++ b/cluster/manifests/roles/cdp-controller-rbac.yaml
@@ -26,6 +26,15 @@ rules:
   - list
   - watch
 - apiGroups:
+  - "batch"
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - create
+  - delete
+- apiGroups:
   - "apps"
   resources:
   - deployments


### PR DESCRIPTION
Hello! To allow users to simulate HTTP traffic to their app during gradual traffic switching, CDP needs to create (and eventually delete) Job resources. More details at https://github.bus.zalan.do/automata/issues/issues/3455.