### PR TITLE
Add kube-node-ready-controller [1/2]

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -211,6 +211,9 @@ kube_state_metrics_mem_min: "120Mi"
 kubernetes_lifecycle_metrics_mem_max: "4Gi"
 kubernetes_lifecycle_metrics_mem_min: "120Mi"
 
+kube_node_ready_controller_cpu: "50m"
+kube_node_ready_controller_memory: "200Mi"
+
 # Kubernetes Downscaler (for non-production clusters)
 {{if eq .Cluster.Environment "test"}}
 downscaler_default_uptime: "Mon-Fri 07:30-20:30 Europe/Berlin"
@@ -491,3 +494,16 @@ enable_control_plane_profiling: "false"
 # Enable use of Privileged PSP (running privileged pods) in non system namespaces.
 # TODO: remove once all clusters have been migrated away from privileged pods
 privileged_psp_enabled: "false"
+
+# Enable kube-node-ready-controller and node-not-ready taint
+#
+# Note: kube_node_ready_controller_enabled must be set to true AND rolled out
+# before kube_node_not_ready_taint_enabled is enabled, otherwise new nodes would
+# come up and never get ready during a rollout.
+{{if eq .Cluster.Environment "production"}}
+kube_node_ready_controller_enabled: "false"
+kube_node_not_ready_taint_enabled: "false"
+{{ else }}
+kube_node_ready_controller_enabled: "true"
+kube_node_not_ready_taint_enabled: "false"
+{{ end }}

--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -34,7 +34,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cluster-autoscaler
-        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.18.2-internal.25
+        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.18.2-internal.27
         command:
           - ./cluster-autoscaler
           - --v=1

--- a/cluster/manifests/kube-node-ready-controller/01-rbac.yaml
+++ b/cluster/manifests/kube-node-ready-controller/01-rbac.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-node-ready-controller
+  namespace: kube-system
+  labels:
+    application: kube-node-ready-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-node-ready-controller
+  labels:
+    application: kube-node-ready-controller
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["watch", "list", "get", "update"]
+- apiGroups: [""]
+  resources:
+  - "pods"
+  verbs: ["watch", "list", "get"]
+- apiGroups: ["apps"]
+  resources: ["daemonsets"]
+  verbs: ["watch", "list", "get"]
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-node-ready-controller
+  labels:
+    application: kube-node-ready-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-node-ready-controller
+subjects:
+- kind: ServiceAccount
+  name: kube-node-ready-controller
+  namespace: kube-system

--- a/cluster/manifests/kube-node-ready-controller/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready-controller/daemonset.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-node-ready-controller
+  namespace: kube-system
+  labels:
+    application: kube-node-ready-controller
+spec:
+  selector:
+    matchLabels:
+      application: kube-node-ready-controller
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        application: kube-node-ready-controller
+    spec:
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+      serviceAccountName: kube-node-ready-controller
+      dnsPolicy: Default
+      tolerations:
+      - key: node.kubernetes.io/role
+        value: master
+        effect: NoSchedule
+      containers:
+      - name: controller
+        image: pierone.stups.zalan.do/teapot/kube-node-ready-controller:master-7
+        resources:
+          requests:
+            cpu: {{.Cluster.ConfigItems.kube_node_ready_controller_cpu}}
+            memory: {{.Cluster.ConfigItems.kube_node_ready_controller_memory}}
+      nodeSelector:
+        node.kubernetes.io/role: master

--- a/cluster/manifests/kube-node-ready-controller/service.yaml
+++ b/cluster/manifests/kube-node-ready-controller/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    application: kube-node-ready-controller
+  annotations:
+    prometheus.io/path: /metrics
+    prometheus.io/port: "9090"
+    prometheus.io/scrape: "true"
+  name: kube-node-ready-controller
+  namespace: kube-system
+spec:
+  selector:
+    application: kube-node-ready-controller
+  type: ClusterIP
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 9090

--- a/cluster/node-pools/worker-default/userdata.yaml
+++ b/cluster/node-pools/worker-default/userdata.yaml
@@ -7,7 +7,7 @@ write_files:
   - owner: root:root
     path: /etc/kubernetes/secrets.env
     content: |
-      NODEPOOL_TAINTS={{if index .NodePool.ConfigItems "taints"}}{{.NodePool.ConfigItems.taints}}{{end}}
+      NODEPOOL_TAINTS={{ if eq .NodePool.ConfigItems.kube_node_not_ready_taint_enabled "true" }}zalando.org/node-not-ready=:NoSchedule{{end}}{{if index .NodePool.ConfigItems "taints"}}{{ if eq .NodePool.ConfigItems.kube_node_not_ready_taint_enabled "true" }},{{ end }}{{.NodePool.ConfigItems.taints}}{{end}}
       NODE_LABELS={{ .Values.node_labels }}{{if eq .NodePool.Profile "worker-spotio-ocean"}},spot.io=true{{end}},node.kubernetes.io/distro=ubuntu{{if index .NodePool.ConfigItems "labels"}},{{.NodePool.ConfigItems.labels}}{{end}}
       NODEPOOL_NAME={{ .NodePool.Name }}
       KUBELET_ROLE=worker


### PR DESCRIPTION
Adds a controller that "marks" nodes ready once all daemonset pods are running and ready.

The purpose is to only schedule user pods on nodes that are considered ready (has all daemonset pods running and ready). This ensures that no user pods are scheduled on nodes that are broken on startup and thereby we don't need to page 24x7 for new nodes that are broken on startup.

### How it works

* Nodes are started with the taint `zalando.org/node-not-ready=:NoSchedule` such that only daemonset pods will be scheduled at startup.
* The `kube-node-ready-controller` (running HA as a daemonset on the master nodes) will watch for new nodes with the taint and check if all expected daemonset pods are ready
* If the pods are ready, the taint will be removed from the node and user pods will be able to be scheduled.
* If the pods are not ready the controller will recheck their state until they are ready OR the CA removes the node because it didn't get ready in time.

**NOTE:** This only enables the controller in test clusters. Once this is fully rolled out we can enable setting the taint on new nodes.