### PR TITLE
cdp: deletecollection batch/v1 Job

### DIFF
--- a/cluster/manifests/roles/cdp-controller-rbac.yaml
+++ b/cluster/manifests/roles/cdp-controller-rbac.yaml
@@ -34,6 +34,7 @@ rules:
   - list
   - create
   - delete
+  - deletecollection
 - apiGroups:
   - "apps"
   resources:


### PR DESCRIPTION
Hello! Follow-up to #3905. cdp-controller actually deletes Jobs via label selector to avoid keeping track of Job names.