### PR TITLE
Use simpler and familiar way to specify OIDC IAM role

### DIFF
--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -16,6 +16,7 @@ data:
   pod.parent-resource-hash.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_parent_resource_hash }}"
 {{- if or (eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true") (eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam_userdata "true") }}
   pod.service-account-iam.enable: "true"
+  pod.service-account-iam.base-aws-account-id: "{{ accountID .Cluster.InfrastructureAccount }}"
 {{- end }}
 {{- if eq .Cluster.ConfigItems.teapot_admission_controller_inject_aws_waiter "true" }}
   pod.aws-waiter.image: "registry.opensource.zalan.do/automata/aws-credentials-waiter:master-10"

--- a/cluster/manifests/01-admission-control/teapot.yaml
+++ b/cluster/manifests/01-admission-control/teapot.yaml
@@ -167,7 +167,7 @@ webhooks:
     sideEffects: "NoneOnDryRun"
     matchPolicy: Equivalent
     rules:
-      - operations: [ "DELETE" ]
+      - operations: [ "CREATE", "UPDATE", "DELETE" ]
         apiGroups: [""]
         apiVersions: ["v1"]
         resources: ["serviceaccounts"]

--- a/cluster/manifests/audittrail-adapter/01-rbac.yaml
+++ b/cluster/manifests/audittrail-adapter/01-rbac.yaml
@@ -7,6 +7,7 @@ metadata:
 {{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
   annotations:
     eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:role/{{ .LocalID }}-audittrail-adapter"
+    iam.amazonaws.com/role: "{{ .LocalID }}-audittrail-adapter"
 {{ end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cluster/manifests/aws-node-decommissioner/01-rbac.yaml
+++ b/cluster/manifests/aws-node-decommissioner/01-rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     application: aws-node-decommissioner
     eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:role/{{.LocalID}}-aws-node-decommissioner"
+    iam.amazonaws.com/role: "{{.LocalID}}-aws-node-decommissioner"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/cluster/manifests/cluster-lifecycle-controller/01-rbac.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/01-rbac.yaml
@@ -6,6 +6,7 @@ metadata:
 {{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
   annotations:
     eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:role/{{ .LocalID }}-cluster-lifecycle-controller"
+    iam.amazonaws.com/role: "{{ .LocalID }}-cluster-lifecycle-controller"
 {{ end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cluster/manifests/emergency-access-service/01-rbac.yaml
+++ b/cluster/manifests/emergency-access-service/01-rbac.yaml
@@ -7,6 +7,7 @@ metadata:
 {{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
   annotations:
     eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:role/{{ .LocalID }}-emergency-access-service"
+    iam.amazonaws.com/role: "{{ .LocalID }}-emergency-access-service"
 {{ end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cluster/manifests/etcd-backup/01-rbac.yaml
+++ b/cluster/manifests/etcd-backup/01-rbac.yaml
@@ -6,6 +6,7 @@ metadata:
 {{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
   annotations:
     eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:role/{{ .Cluster.LocalID }}-etcd-backup"
+    iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-etcd-backup"
 {{ end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cluster/manifests/external-dns/01-rbac.yaml
+++ b/cluster/manifests/external-dns/01-rbac.yaml
@@ -9,6 +9,7 @@ metadata:
 {{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
   annotations:
     eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:role/{{ .LocalID }}-app-external-dns"
+    iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
 {{ end }}
 ---
 # allows to list services and ingresses

--- a/cluster/manifests/ingress-controller/01-rbac.yaml
+++ b/cluster/manifests/ingress-controller/01-rbac.yaml
@@ -6,6 +6,7 @@ metadata:
 {{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
   annotations:
     eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:role/{{ .Cluster.LocalID }}-app-ingr-ctrl"
+    iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-app-ingr-ctrl"
 {{ end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cluster/manifests/kube-cluster-autoscaler/01-rbac.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/01-rbac.yaml
@@ -8,6 +8,7 @@ metadata:
 {{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
   annotations:
     eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:role/{{ .LocalID }}-app-autoscaler"
+    iam.amazonaws.com/role: "{{ .LocalID }}-app-autoscaler"
 {{ end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cluster/manifests/kube-metrics-adapter/01-rbac.yaml
+++ b/cluster/manifests/kube-metrics-adapter/01-rbac.yaml
@@ -6,6 +6,7 @@ metadata:
 {{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
   annotations:
     eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:role/{{ .Cluster.LocalID }}-kube-metrics-adapter"
+    iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-kube-metrics-adapter"
 {{ end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cluster/manifests/kube-node-ready/01-rbac.yaml
+++ b/cluster/manifests/kube-node-ready/01-rbac.yaml
@@ -6,4 +6,5 @@ metadata:
 {{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
   annotations:
     eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:role/{{ .Cluster.LocalID }}-kube-node-ready"
+    iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-kube-node-ready"
 {{ end }}

--- a/cluster/manifests/kube-static-egress-controller/01-rbac.yaml
+++ b/cluster/manifests/kube-static-egress-controller/01-rbac.yaml
@@ -6,6 +6,7 @@ metadata:
 {{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
   annotations:
     eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:role/{{ .LocalID }}-static-egress-controller"
+    iam.amazonaws.com/role: "{{ .LocalID }}-static-egress-controller"
 {{ end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -211,7 +211,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-89
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-94
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
https://github.bus.zalan.do/teapot/admission-controller/pull/103 enables a simpler and more familiar way to specify the OIDC-based IAM role:

Renames `eks.amazonaws.com/role-arn` to the name kube2iam introduced and is widely used: `iam.amazonaws.com/role`. It avoids confusion by clarifying that we don't run on EKS. Both annotations are supported during the transition.

Instead of `iam.amazonaws.com/role: <full-arn>` one can specify an account-local role and omit the ARN prefix, e.g. `iam.amazonaws.com/role: my-fancy-role`.

Cross-account roles aren't supported out of the box yet but will require to specify the full ARN.

Furthermore, there are checks during Pod and ServiceAccount admission that catch malformed IAM role definitions.