### PR TITLE
Revert "Use simpler and familiar way to specify OIDC IAM role"

### DIFF
--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -16,7 +16,6 @@ data:
   pod.parent-resource-hash.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_parent_resource_hash }}"
 {{- if or (eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true") (eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam_userdata "true") }}
   pod.service-account-iam.enable: "true"
-  pod.service-account-iam.base-aws-account-id: "{{ accountID .Cluster.InfrastructureAccount }}"
 {{- end }}
 {{- if eq .Cluster.ConfigItems.teapot_admission_controller_inject_aws_waiter "true" }}
   pod.aws-waiter.image: "registry.opensource.zalan.do/automata/aws-credentials-waiter:master-10"

--- a/cluster/manifests/01-admission-control/teapot.yaml
+++ b/cluster/manifests/01-admission-control/teapot.yaml
@@ -167,7 +167,7 @@ webhooks:
     sideEffects: "NoneOnDryRun"
     matchPolicy: Equivalent
     rules:
-      - operations: [ "CREATE", "UPDATE", "DELETE" ]
+      - operations: [ "DELETE" ]
         apiGroups: [""]
         apiVersions: ["v1"]
         resources: ["serviceaccounts"]

--- a/cluster/manifests/audittrail-adapter/01-rbac.yaml
+++ b/cluster/manifests/audittrail-adapter/01-rbac.yaml
@@ -7,7 +7,6 @@ metadata:
 {{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
   annotations:
     eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:role/{{ .LocalID }}-audittrail-adapter"
-    iam.amazonaws.com/role: "{{ .LocalID }}-audittrail-adapter"
 {{ end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cluster/manifests/aws-node-decommissioner/01-rbac.yaml
+++ b/cluster/manifests/aws-node-decommissioner/01-rbac.yaml
@@ -6,7 +6,6 @@ metadata:
   annotations:
     application: aws-node-decommissioner
     eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:role/{{.LocalID}}-aws-node-decommissioner"
-    iam.amazonaws.com/role: "{{.LocalID}}-aws-node-decommissioner"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/cluster/manifests/cluster-lifecycle-controller/01-rbac.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/01-rbac.yaml
@@ -6,7 +6,6 @@ metadata:
 {{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
   annotations:
     eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:role/{{ .LocalID }}-cluster-lifecycle-controller"
-    iam.amazonaws.com/role: "{{ .LocalID }}-cluster-lifecycle-controller"
 {{ end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cluster/manifests/emergency-access-service/01-rbac.yaml
+++ b/cluster/manifests/emergency-access-service/01-rbac.yaml
@@ -7,7 +7,6 @@ metadata:
 {{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
   annotations:
     eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:role/{{ .LocalID }}-emergency-access-service"
-    iam.amazonaws.com/role: "{{ .LocalID }}-emergency-access-service"
 {{ end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cluster/manifests/etcd-backup/01-rbac.yaml
+++ b/cluster/manifests/etcd-backup/01-rbac.yaml
@@ -6,7 +6,6 @@ metadata:
 {{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
   annotations:
     eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:role/{{ .Cluster.LocalID }}-etcd-backup"
-    iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-etcd-backup"
 {{ end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cluster/manifests/external-dns/01-rbac.yaml
+++ b/cluster/manifests/external-dns/01-rbac.yaml
@@ -9,7 +9,6 @@ metadata:
 {{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
   annotations:
     eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:role/{{ .LocalID }}-app-external-dns"
-    iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
 {{ end }}
 ---
 # allows to list services and ingresses

--- a/cluster/manifests/ingress-controller/01-rbac.yaml
+++ b/cluster/manifests/ingress-controller/01-rbac.yaml
@@ -6,7 +6,6 @@ metadata:
 {{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
   annotations:
     eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:role/{{ .Cluster.LocalID }}-app-ingr-ctrl"
-    iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-app-ingr-ctrl"
 {{ end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cluster/manifests/kube-cluster-autoscaler/01-rbac.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/01-rbac.yaml
@@ -8,7 +8,6 @@ metadata:
 {{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
   annotations:
     eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:role/{{ .LocalID }}-app-autoscaler"
-    iam.amazonaws.com/role: "{{ .LocalID }}-app-autoscaler"
 {{ end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cluster/manifests/kube-metrics-adapter/01-rbac.yaml
+++ b/cluster/manifests/kube-metrics-adapter/01-rbac.yaml
@@ -6,7 +6,6 @@ metadata:
 {{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
   annotations:
     eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:role/{{ .Cluster.LocalID }}-kube-metrics-adapter"
-    iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-kube-metrics-adapter"
 {{ end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cluster/manifests/kube-node-ready/01-rbac.yaml
+++ b/cluster/manifests/kube-node-ready/01-rbac.yaml
@@ -6,5 +6,4 @@ metadata:
 {{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
   annotations:
     eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:role/{{ .Cluster.LocalID }}-kube-node-ready"
-    iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-kube-node-ready"
 {{ end }}

--- a/cluster/manifests/kube-static-egress-controller/01-rbac.yaml
+++ b/cluster/manifests/kube-static-egress-controller/01-rbac.yaml
@@ -6,7 +6,6 @@ metadata:
 {{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "true" }}
   annotations:
     eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:role/{{ .LocalID }}-static-egress-controller"
-    iam.amazonaws.com/role: "{{ .LocalID }}-static-egress-controller"
 {{ end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -211,7 +211,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-94
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-89
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
Let's add back support for the eks annotation as we have a bunch of cdp based deployments and I don't want this to go to alpha to soon.