### PR TITLE
add scale down policy for skipper-ingress

### DIFF
--- a/cluster/manifests/skipper/hpa.yaml
+++ b/cluster/manifests/skipper/hpa.yaml
@@ -25,3 +25,14 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ .ConfigItems.skipper_ingress_target_average_utilization_memory }}
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 600
+      policies:
+      - type: Pods
+        value: 10
+        periodSeconds: 60
+      - type: Percent
+        value: 100
+        periodSeconds: 60
+      selectPolicy: Min


### PR DESCRIPTION
use proper scale down policy for skipper-ingress to allow only 10 instance per 2 minutes to scale down at max, such that ALB target groups are not creating issues dropping out skipper members

was fixed in v1.19.3 and v1.18.11

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>