### PR TITLE
Postpone rollout of changed oidc iam role annotation

### DIFF
--- a/cluster/manifests/01-admission-control/teapot.yaml
+++ b/cluster/manifests/01-admission-control/teapot.yaml
@@ -167,7 +167,7 @@ webhooks:
     sideEffects: "NoneOnDryRun"
     matchPolicy: Equivalent
     rules:
-      - operations: [ "CREATE", "UPDATE", "DELETE" ]
+      - operations: [ "DELETE" ]
         apiGroups: [""]
         apiVersions: ["v1"]
         resources: ["serviceaccounts"]

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -211,7 +211,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-94
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-89
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
retroactively splits merged PR https://github.com/zalando-incubator/kubernetes-on-aws/pull/3917 into two because updating masters before manifest update will break things.