### PR TITLE
Reduce stackset test parallelism

### DIFF
--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -208,7 +208,7 @@ fi
 if [ "$stackset_e2e" = true ]; then
     namespace="stackset-e2e-$(date +'%H%M%S')"
     kubectl create namespace "$namespace"
-    E2E_NAMESPACE="${namespace}" ./stackset-e2e -test.parallel 64
+    E2E_NAMESPACE="${namespace}" ./stackset-e2e -test.parallel 20
 fi
 
 if [ "$decommission_cluster" = true ]; then


### PR DESCRIPTION
The stackset tests fail in half of the e2e runs, which is pretty annoying. Logs are full of throttling warnings, so let's see if reducing the parallelism would help. This shouldn't change the total time an e2e run takes because stackset tests run in parallel with the normal ones anyway.