### PR TITLE
Disable privileged PSP by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -487,3 +487,7 @@ stackset_ingress_source_switch_ttl: "5m"
 
 # Enable/Disable profiling for Kubernetes components
 enable_control_plane_profiling: "false"
+
+# Enable use of Privileged PSP (running privileged pods) in non system namespaces.
+# TODO: remove once all clusters have been migrated away from privileged pods
+privileged_psp_enabled: "false"

--- a/cluster/manifests/roles/priviliged_psp_cluster_role.yaml
+++ b/cluster/manifests/roles/priviliged_psp_cluster_role.yaml
@@ -2,8 +2,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: privileged-psp
+{{ if eq .Cluster.ConfigItems.privileged_psp_enabled "true"}}
   labels:
     rbac.authorization.k8s.io/aggregate-to-poweruser: "true"
+{{ end }}
 rules:
 - apiGroups:
   - extensions


### PR DESCRIPTION
Disable use of Privileged PSP by PowerUsers by default.

This will mean that PowerUsers (or CDP) can't run privileged pods. It will only be possible to run privileged pods in `kube-system` namespace where we have use cases for this.

I have set `privileged_psp_enabled=true` for the 13 clusters where privileged pods are still running.