### PR TITLE
journald-reader: enable by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -158,11 +158,7 @@ flannel_cpu: "25m"
 flannel_memory: "100Mi"
 
 # journald reader settings
-{{if eq .Cluster.Environment "production"}}
-journald_reader_enabled: "false"
-{{else}}
 journald_reader_enabled: "true"
-{{end}}
 journald_reader_cpu: "1m"
 journald_reader_memory: "30Mi"
 

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -39,7 +39,6 @@ clusters:
     routegroups_validation: "enabled"
     stackset_routegroup_support_enabled: "true"
     stackset_ingress_source_switch_ttl: "1m"
-    journald_reader_enabled: "true"
   criticality_level: 1
   environment: e2e
   id: ${CLUSTER_ID}


### PR DESCRIPTION
It's currently explicitly disabled in production clusters, we'll enable it one by one.