### PR TITLE
Add kube-node-ready-controller [2/2] (test)

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -515,5 +515,5 @@ kube_node_ready_controller_enabled: "false"
 kube_node_not_ready_taint_enabled: "false"
 {{ else }}
 kube_node_ready_controller_enabled: "true"
-kube_node_not_ready_taint_enabled: "false"
+kube_node_not_ready_taint_enabled: "true"
 {{ end }}


### PR DESCRIPTION
Follow up to #3907.

Enables setting the taint `zalando.org/node-not-ready=:NoSchedule` on new nodes. This will activate the kube-node-ready-controller functionality.

(This is only enabled in test clusters for now. Production will follow after we are confident with the new feature).

#3907 must be fully rolled out before this can be merged!