### PR TITLE
Add OIDC provider and subject prefix to deployment config

### DIFF
--- a/cluster/manifests/infrastructure-configs/deployment-config.yaml
+++ b/cluster/manifests/infrastructure-configs/deployment-config.yaml
@@ -11,3 +11,5 @@ data:
   create-namespaces: "true"
   aws-available: "true"
   worker-role-arn: "arn:aws:iam::{{accountID .Cluster.InfrastructureAccount}}:role/{{.Cluster.LocalID}}-worker"
+  oidc-provider-arn: "arn:aws:iam::{{accountID .Cluster.InfrastructureAccount}}:oidc-provider/{{.Cluster.LocalID}}.{{.Cluster.Alias}}.zalan.do"
+  oidc-subject-prefix: "{{.Cluster.LocalID}}.{{.Cluster.Alias}}.zalan.do:sub: system:serviceaccount"


### PR DESCRIPTION
This generates and adds OIDC provider and subject to the deployment config so it can be accessed by cdp-steps.