### PR TITLE
Rename 'restricted' PSP to 'default'

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -165,3 +165,9 @@ post_apply:
   kind: PriorityClass
 - name: autoscaling-buffer
   kind: PriorityClass
+- kind: ClusterRole
+  name: restricted-psp
+- kind: ClusterRoleBinding
+  name: restricted-psp
+- kind: PodSecurityPolicy
+  name: restricted

--- a/cluster/manifests/psp/default.yaml
+++ b/cluster/manifests/psp/default.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: restricted
+  name: default
 spec:
   allowPrivilegeEscalation: false
   fsGroup:

--- a/cluster/manifests/psp/privileged.yaml
+++ b/cluster/manifests/psp/privileged.yaml
@@ -1,0 +1,43 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: privileged
+spec:
+  fsGroup:
+    rule: RunAsAny
+  privileged: true
+  allowPrivilegeEscalation: true
+  hostPID: true
+  hostNetwork: true
+  hostIPC: true
+  hostPorts:
+  - max: 10000
+    min: 50
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  allowedUnsafeSysctls:
+    - net.ipv4.tcp_keepalive_time
+    - net.ipv4.tcp_keepalive_intvl
+    - net.ipv4.tcp_keepalive_probes
+  volumes:
+  - '*'
+  allowedCapabilities:
+  - AUDIT_WRITE
+  - CHOWN
+  - DAC_OVERRIDE
+  - FOWNER
+  - FSETID
+  - KILL
+  - MKNOD
+  - NET_BIND_SERVICE
+  - NET_RAW
+  - SETFCAP
+  - SETGID
+  - SETPCAP
+  - SETUID
+  - SYS_CHROOT
+  - SYS_NICE

--- a/cluster/manifests/psp/restricted.yaml
+++ b/cluster/manifests/psp/restricted.yaml
@@ -1,50 +1,6 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: privileged
-spec:
-  fsGroup:
-    rule: RunAsAny
-  privileged: true
-  allowPrivilegeEscalation: true
-  hostPID: true
-  hostNetwork: true
-  hostIPC: true
-  hostPorts:
-  - max: 10000
-    min: 50
-  runAsUser:
-    rule: RunAsAny
-  seLinux:
-    rule: RunAsAny
-  supplementalGroups:
-    rule: RunAsAny
-  allowedUnsafeSysctls:
-    - net.ipv4.tcp_keepalive_time
-    - net.ipv4.tcp_keepalive_intvl
-    - net.ipv4.tcp_keepalive_probes
-  volumes:
-  - '*'
-  allowedCapabilities:
-  - AUDIT_WRITE
-  - CHOWN
-  - DAC_OVERRIDE
-  - FOWNER
-  - FSETID
-  - KILL
-  - MKNOD
-  - NET_BIND_SERVICE
-  - NET_RAW
-  - SETFCAP
-  - SETGID
-  - SETPCAP
-  - SETUID
-  - SYS_CHROOT
-  - SYS_NICE
----
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
   name: restricted
 spec:
   allowPrivilegeEscalation: false

--- a/cluster/manifests/roles/default_psp_cluster_role.yaml
+++ b/cluster/manifests/roles/default_psp_cluster_role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: restricted-psp
+  name: default-psp
   labels:
     rbac.authorization.k8s.io/aggregate-to-poweruser: "true"
 rules:
@@ -10,6 +10,6 @@ rules:
   resources:
   - podsecuritypolicies
   resourceNames:
-  - restricted
+  - default
   verbs:
   - use

--- a/cluster/manifests/roles/default_psp_cluster_role_binding.yaml
+++ b/cluster/manifests/roles/default_psp_cluster_role_binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: restricted-psp
+  name: default-psp
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: restricted-psp
+  name: default-psp
 subjects:
 - kind: Group
   name: system:serviceaccounts


### PR DESCRIPTION
We want to prevent the users from relying on the `privileged` PSP, but there doesn't seem to be an easy way to do this. Even if the users update their pods to not use any features of the `privileged` PSP, the pods will still use it if the service account has access to it (because it comes before `restricted` lexicographically). Dropping the `use` permission later will then break pod updates completely.

The simplest way to fix this is to simply rename the `restricted` PSP so it comes before `privileged`. After the users' pods are recreated, they'll pick it instead of the `privileged` one even if they have access to the latter, and then they can safely revoke their access without any effect.