### PR TITLE
Add Skipper East-West Range feature support

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -91,6 +91,10 @@ spec:
           - "-enable-kubernetes-east-west"
           - "-kubernetes-east-west-domain=.ingress.cluster.local"
 {{ end }}
+{{ if eq .ConfigItems.enable_skipper_eastwest_dns "true"}}
+          - "-kubernetes-east-west-range-domains=ingress.cluster.local"
+          - "-kubernetes-east-west-range-predicates=ClientIP(\"10.2.0.0/16\", \"{{ .Values.vpc_ipv4_cidr }}\") && SourceFromLast(\"10.2.0.0/16\", \"{{ .Values.vpc_ipv4_cidr }}\")"
+{{ end }}
           - "-proxy-preserve-host"
           - "-serve-host-metrics"
           - "-disable-metrics-compat"


### PR DESCRIPTION
This commit enables the Skipper [EastWest Range][0] feature, on clusters
that already have the `enable_skipper_eastwest_dns` config set to true.
It uses the predicates `ClientIP` and `SourceFromLast` as
[discussed][1]. It uses the, until now, hardcoded PODs' CIDR,
`10.2.0.0/16` and the value `vpc_ipv4_cidr`.

[0]: https://skipper.docs.zalando.net/tutorials/operations/#east-west-range
[1]: https://github.com/zalando/skipper/issues/1526#issuecomment-756903746