### PR TITLE
update ExternalDNS to v0.7.6

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: external-dns
-    version: v0.7.4
+    version: v0.7.6
 spec:
   strategy:
     type: Recreate
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: external-dns
-        version: v0.7.4
+        version: v0.7.6
 {{ if eq .Cluster.ConfigItems.teapot_admission_controller_service_account_iam "false" }}
 {{ if eq .ConfigItems.kube_aws_iam_controller_kube_system_enable "false"}}
       annotations:
@@ -32,7 +32,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.7.4
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.7.6
         args:
         - --source=service
         - --source=ingress


### PR DESCRIPTION
https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.7.5
https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.7.6

Noticeable change is the introduction of https://github.com/kubernetes-sigs/external-dns/pull/1915 which reduces ExternalDNS' scope to A and CNAME records. This was the case before v0.7.5 and is again the default in v0.7.6.