### PR TITLE
Allow privilege escalation for restricted PSP

### DIFF
--- a/cluster/manifests/admission-control-proxy/daemonset.yaml
+++ b/cluster/manifests/admission-control-proxy/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cluster-autoscaler
-        image: registry.opensource.zalan.do/teapot/admission-controller:master-91
+        image: registry.opensource.zalan.do/teapot/admission-controller:master-96
         command:
           - /registry-proxy
           - --address=127.0.0.1:8285

--- a/cluster/manifests/psp/pod_security_policy.yaml
+++ b/cluster/manifests/psp/pod_security_policy.yaml
@@ -47,7 +47,8 @@ kind: PodSecurityPolicy
 metadata:
   name: restricted
 spec:
-  allowPrivilegeEscalation: false
+  allowPrivilegeEscalation: true
+  defaultAllowPrivilegeEscalation: false
   fsGroup:
     rule: RunAsAny
   runAsUser:

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -214,7 +214,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-91
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-96
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
This sets up a migration path from `privileged` to `restricted` PSP.

### How it works

1. `restricted` PSP is changed to `allowPrivilegeEscalation: true`, but defaults to false if nothing is specified by the users. This will allow pods relying on `sudo` to run with restricted PSP instead of privileged PSP.
2. Admission controller will inject `allowPrivilegeEscalation: false` in the `aws-credentials-waiter`. -> This ensures that any pod has the possibility of matching the `restricted` PSP if the other containers don't request anything considered privileged. Without this we could risk a non-privileged pod getting the privileged PSP which is not intended.

After this is rolled out ACID will be able to migrate away from privileged PSP. And after that we can track down the remaining user pods relying on privileged PSP. We expect the set of pods to be small at that point.