### PR TITLE
Revert to older image for admission-controller-proxy

### DIFF
--- a/cluster/manifests/admission-control-proxy/daemonset.yaml
+++ b/cluster/manifests/admission-control-proxy/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cluster-autoscaler
-        image: registry.opensource.zalan.do/teapot/admission-controller:master-96
+        image: registry.opensource.zalan.do/teapot/admission-controller:master-91
         command:
           - /registry-proxy
           - --address=127.0.0.1:8285


### PR DESCRIPTION
Newer image doesn't have the proxy inside anymore because of #3871 

Revert updating the image so we can still rely on the proxy for #3961 