### PR TITLE
Create separated config item to EastWest range

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -81,11 +81,13 @@ enable_apimonitoring: "true"                       # TODO(sszuecs): cleanup cand
 # enable_skipper_eastwest_dns only enables DNS and assumes users define the
 # ingress.cluster.local names explicitly on ingress/routegroup/stacksets
 {{if eq .Cluster.Environment "production"}}
-enable_skipper_eastwest: "false"
 enable_skipper_eastwest_dns: "false"
-{{else}}
 enable_skipper_eastwest: "false"
+enable_skipper_eastwest_range: "false"
+{{else}}
 enable_skipper_eastwest_dns: "true"
+enable_skipper_eastwest: "false"
+enable_skipper_eastwest_range: "true"
 {{end}}
 # enable temporay logging of ingress.cluster.local names
 # used to find services for which it's being used.

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -91,7 +91,7 @@ spec:
           - "-enable-kubernetes-east-west"
           - "-kubernetes-east-west-domain=.ingress.cluster.local"
 {{ end }}
-{{ if eq .ConfigItems.enable_skipper_eastwest_dns "true"}}
+{{ if eq .ConfigItems.enable_skipper_eastwest_range "true"}}
           - "-kubernetes-east-west-range-domains=ingress.cluster.local"
           - "-kubernetes-east-west-range-predicates=ClientIP(\"10.2.0.0/16\", \"{{ .Values.vpc_ipv4_cidr }}\") && SourceFromLast(\"10.2.0.0/16\", \"{{ .Values.vpc_ipv4_cidr }}\")"
 {{ end }}


### PR DESCRIPTION
This commit introduces a config-item to enable and disable the Skipper's
EastWest Range feature.