### PR TITLE
Add OIDC provider creation and deletion to CF stack

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -2006,6 +2006,101 @@ Resources:
             Resource: "*"
             Action:
             - "kms:Decrypt"
+  IdentityProvider:
+    Type: Custom::IdentityProvider
+    Properties:
+      ServiceToken: !GetAtt IdentityProviderCreator.Arn
+      Region: !Ref "AWS::Region"
+      ProviderName: "{{ .Cluster.LocalID }}.{{ .Values.hosted_zone }}"
+  IdentityProviderCreator:
+    Type: AWS::Lambda::Function
+    Properties:
+      Runtime: python2.7
+      Handler: index.lambda_handler
+      MemorySize: 128
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Timeout: 30
+      Code:
+        ZipFile: !Sub |
+          import boto3
+          from botocore.exceptions import ClientError
+          import json
+          import cfnresponse
+
+          iam = boto3.client("iam")
+
+          def create_provider(provider_name):
+            try:
+              resp = iam.create_open_id_connect_provider(
+                  Url= "https://" + provider_name,
+                  ClientIDList=['sts.amazonaws.com'],
+                  ThumbprintList=['9e99a48a9960b14926bb7f3b02e22da2b0ab7280']
+              )
+              return(True, resp['OpenIDConnectProviderArn'])
+            except Exception as e:
+              return (False, "Cannot create OpenID Connect provider: " + str(e))
+
+          def delete_provider(arn):
+            try:
+              resp = iam.delete_open_id_connect_provider(OpenIDConnectProviderArn=arn)
+              return (True, "OpenID Connect provider with ARN " + arn + " deleted")
+            except ClientError as e:
+              if e.response['Error']['Code'] == "NoSuchEntity":
+                # no need to delete a thing that doesn't exist
+                return (True, "OpenID Connect provider with ARN " + arn + " does not exist, deletion succeeded")
+              else:
+                return (False, "Cannot delete OpenID Connect provider with ARN " + arn + ": " + str(e))
+            except Exception as e:
+              return (False, "Cannot delete OpenID Connect provider with ARN " + arn + ": " + str(e))
+
+          def lambda_handler(event, context):
+            provider_name = event['ResourceProperties']['ProviderName']
+            # create a default ARN from the name; will be overwritten if we are creating
+            provider_arn = "arn:aws:iam::${AWS::AccountId}:oidc-provider/" + provider_name
+
+            if event['RequestType'] == 'Create':
+              res, provider_arn = create_provider(provider_name)
+              reason = "Creation succeeded"
+            elif event['RequestType'] == 'Delete':
+              res, reason = delete_provider(provider_arn)
+            else:
+              res = False
+              resp = "Unknown operation: " + event['RequestType']
+
+            responseData = {}
+            responseData['Reason'] = reason
+            if res:
+              cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData, provider_arn)
+            else:
+              cfnresponse.send(event, context, cfnresponse.FAILED, responseData, provider_arn)
+  LambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Path: /
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: root
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - iam:*OpenIDConnectProvider
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: "*"
 Outputs:
   MasterIAMRole:
     Export:


### PR DESCRIPTION
Allows to create and delete OIDC Identity Providers as part of the CloudFormation Stack.

Allows to remove manual management in CLM: https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/415