### PR TITLE
Remove custom parser from `journald-reader`

### DIFF
--- a/cluster/manifests/node-monitor/daemonset.yaml
+++ b/cluster/manifests/node-monitor/daemonset.yaml
@@ -15,8 +15,6 @@ spec:
     metadata:
       labels:
         application: node-monitor
-      annotations:
-        kubernetes-log-watcher/scalyr-parser: '[{"container": "journald-reader", "parser": "journald"}]'
     spec:
       hostNetwork: true
       hostPID: true


### PR DESCRIPTION
Python-based `journald-reader`doesn't need a custom parser