### PR TITLE
Move node-not-ready taint to admission-controller

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -508,14 +508,12 @@ enable_control_plane_profiling: "false"
 privileged_psp_enabled: "false"
 
 # Enable kube-node-ready-controller and node-not-ready taint
-#
-# Note: kube_node_ready_controller_enabled must be set to true AND rolled out
-# before kube_node_not_ready_taint_enabled is enabled, otherwise new nodes would
-# come up and never get ready during a rollout.
+teapot_addmission_controller_node_not_ready_taint: "true"
+
+# TODO: legacy remove after rollout.
 {{if eq .Cluster.Environment "production"}}
-kube_node_ready_controller_enabled: "false"
 kube_node_not_ready_taint_enabled: "false"
 {{ else }}
-kube_node_ready_controller_enabled: "true"
 kube_node_not_ready_taint_enabled: "true"
 {{ end }}
+

--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -55,3 +55,5 @@ data:
   pod.automatic-topology-spread.pools.dedicated.{{$group}}: "{{ $enabled }}"
 {{- end }}
 {{- end}}
+
+  node.node-not-ready-taint.enable: "{{ .Cluster.ConfigItems.teapot_addmission_controller_node_not_ready_taint }}"

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -214,7 +214,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-96
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-97
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
Instead of setting `zalando.org/node-not-ready` taints via kubelet flag, move it to admission-controller so it's simpler to enable/disable without rolling all the nodes.

Dropped `kube_node_ready_controller_enabled` as it was never actually used :facepalm: 

Enabled by default since we have run the controller for a while in test already