### PR TITLE
Update dnsmasq

### DIFF
--- a/cluster/manifests/coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/coredns-local/daemonset-coredns.yaml
@@ -26,26 +26,18 @@ spec:
     spec:
       containers:
       - name: dnsmasq
-        image: registry.opensource.zalan.do/teapot/k8s-dns-dnsmasq-nanny-amd64:1.15.7-1
+        image: registry.opensource.zalan.do/teapot/dnsmasq:master-1
         securityContext:
           privileged: true
-        livenessProbe:
-          httpGet:
-            path: /healthcheck/dnsmasq
-            port: 9054
-            scheme: HTTP
-          initialDelaySeconds: 60
-          timeoutSeconds: 5
+        readinessProbe:
+          tcpSocket:
+            port: 53
+          initialDelaySeconds: 10
+          timeoutSeconds: 3
           successThreshold: 1
-          failureThreshold: 5
+          failureThreshold: 3
         args:
-        - -v=2
-        - -logtostderr
-        - -configDir=/etc/k8s/dns/dnsmasq-nanny
-        - -restartDnsmasq=true
-        - --
         - --no-resolv
-        - --keep-in-foreground
         - --log-facility=-
         - --cache-size=50000
         - --dns-forward-max=500


### PR DESCRIPTION
 * Update dnsmasq, getting rid of the `nanny` wrapper as well.
 * Get rid of the liveness probe (which went to a completely different container anyway), add a readiness probe instead.