### PR TITLE
Revert "Remove custom parser from `journald-reader`"

### DIFF
--- a/cluster/manifests/node-monitor/daemonset.yaml
+++ b/cluster/manifests/node-monitor/daemonset.yaml
@@ -15,6 +15,8 @@ spec:
     metadata:
       labels:
         application: node-monitor
+      annotations:
+        kubernetes-log-watcher/scalyr-parser: '[{"container": "journald-reader", "parser": "journald"}]'
     spec:
       hostNetwork: true
       hostPID: true


### PR DESCRIPTION
Reverts zalando-incubator/kubernetes-on-aws#3985.

Apparently the users can break the parsers at will, so let's use a separate one.