### PR TITLE
Update StackSet controller

### DIFF
--- a/cluster/manifests/stackset-controller/deployment.yaml
+++ b/cluster/manifests/stackset-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: stackset-controller
-    version: "v1.3.20"
+    version: "v1.3.22"
 spec:
   replicas: 1
   selector:
@@ -15,13 +15,13 @@ spec:
     metadata:
       labels:
         application: stackset-controller
-        version: "v1.3.20"
+        version: "v1.3.22"
     spec:
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       serviceAccountName: stackset-controller
       containers:
       - name: stackset-controller
-        image: "registry.opensource.zalan.do/teapot/stackset-controller:v1.3.20"
+        image: "registry.opensource.zalan.do/teapot/stackset-controller:v1.3.22"
         args:
         - "--interval={{ .Cluster.ConfigItems.stackset_controller_sync_interval }}"
 {{- if eq .Cluster.ConfigItems.stackset_routegroup_support_enabled "true" }}

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/spf13/viper v1.4.0
 	github.com/szuecs/routegroup-client v0.17.8-0.20200915193527-b33447c7d964
 	github.com/zalando-incubator/kube-aws-iam-controller v0.1.2
-	github.com/zalando-incubator/stackset-controller v1.3.20
+	github.com/zalando-incubator/stackset-controller v1.3.22
 	k8s.io/api v0.19.7
 	k8s.io/apimachinery v0.19.7
 	k8s.io/apiserver v0.0.0

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -785,8 +785,8 @@ github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoH
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
-github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 h1:b6uOv7YOFK0TYG7HtkIgExQo+2RdLuwRft63jn2HWj8=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/szuecs/routegroup-client v0.17.8-0.20200915193527-b33447c7d964 h1:Bh/qR2x6IAid0nkU5ko61eLUGVk6bJiY/OnI6+0BSEk=
@@ -819,8 +819,8 @@ github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zalando-incubator/kube-aws-iam-controller v0.1.2 h1:uEXMHnd7wuXk3gAZ8iiOnL9XVUqA1iuDQzQFsa3ywA4=
 github.com/zalando-incubator/kube-aws-iam-controller v0.1.2/go.mod h1:7RQdyNqtYaKEWVavXUFlrE8A+QsGe/hkBba2RyG5V4o=
-github.com/zalando-incubator/stackset-controller v1.3.20 h1:fWC1GEOxtmqRIBAZ5qsBx5UTV3W2Z5Hq8nlz3SJM6t4=
-github.com/zalando-incubator/stackset-controller v1.3.20/go.mod h1:HwjUH54mPeQFpw6C+NZcg0irXY4OMdudg7aWWHj+nOQ=
+github.com/zalando-incubator/stackset-controller v1.3.22 h1:ZnOSs2hvIflXVB6faWFGKUP3UdrK5Ax0mxoA1Pqa58o=
+github.com/zalando-incubator/stackset-controller v1.3.22/go.mod h1:DGL2RkWff0l/dJcbs5YrdIJfNf5J8HZwxE9ouRFL9us=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.5 h1:XAzx9gjCb0Rxj7EoqcClPD1d5ZBxZJk0jbuoPHenBt0=


### PR DESCRIPTION
This commit updates the StackSet controller and its E2E tests to the
v1.3.22. This version brings a bug fix on Stack's annotations heritage.
Check the [release][0] for more details.

[0]: https://github.com/zalando-incubator/stackset-controller/releases/tag/v1.3.22