### PR TITLE
Prepare masters to serve the new jwks endpoint

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -464,6 +464,10 @@ write_files:
               -> setResponseHeader("Content-Type", "application/json")
               -> static("/openid-configuration/", "/var/www/openid-configuration/")
               -> <shunt>;
+            k2: Path("/openid/v1/jwks")
+              -> setResponseHeader("Content-Type", "application/json")
+              -> static("/openid-configuration/keys.json", "/var/www/openid-configuration/keys.json")
+              -> <shunt>;
           {{- end }}
             all: *
               -> disableAccessLog()


### PR DESCRIPTION
Already serve the new OIDC discovery keys path so we'll have a smooth migration.

Don't merge in favour of https://github.com/zalando-incubator/kubernetes-on-aws/pull/4011 but I want to see what e2e says about this.