### PR TITLE
Still support old OIDC keys path [1/2]

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -460,6 +460,10 @@ write_files:
             k: Path("/openid/v1/jwks")
               -> disableAccessLog()
               -> "http://127.0.0.1:8080";
+            k2: Path("/openid-configuration/keys.json")
+              -> setPath("/openid/v1/jwks")
+              -> disableAccessLog()
+              -> "http://127.0.0.1:8080";
             all: *
               -> disableAccessLog()
               -> "https://127.0.0.1:443";


### PR DESCRIPTION
Instead of https://github.com/zalando-incubator/kubernetes-on-aws/pull/4010 to play it a bit safer.

Enable support for legacy OIDC keys path.

So this one is "no-op" for dev and alpha.