### PR TITLE
use kubernetes' default jwks path

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -151,7 +151,7 @@ write_files:
           {{- end }}
           - --service-account-signing-key-file=/etc/kubernetes/ssl/service-account-private-key.pem
           - --service-account-issuer={{ .Cluster.APIServerURL }}
-          - --service-account-jwks-uri={{ .Cluster.APIServerURL }}/openid-configuration/keys.json
+          - --service-account-jwks-uri={{ .Cluster.APIServerURL }}/openid/v1/jwks
           {{ if and (ne .Cluster.ConfigItems.audittrail_url "") (ne .Cluster.Environment "e2e") }}
           - --audit-webhook-config-file=/etc/kubernetes/config/audit.yaml
           - --audit-webhook-mode=batch


### PR DESCRIPTION
Just to avoid unnecessary confusion by using different key paths.

This should be sprinkled in with other required master updates since it's not urgent in any way.