### PR TITLE
Migrate ebs-csi-controller to OIDC credentials

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -565,7 +565,7 @@ Resources:
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
             Condition:
-              StringLike:
+              StringEquals:
                 "{{ .Cluster.LocalID }}.{{ .Values.hosted_zone }}:sub": "system:serviceaccount:kube-system:cluster-autoscaler"
         Version: 2012-10-17
       Path: /
@@ -827,7 +827,7 @@ Resources:
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
             Condition:
-              StringLike:
+              StringEquals:
                 "{{ .Cluster.LocalID }}.{{ .Values.hosted_zone }}:sub": "system:serviceaccount:kube-system:external-dns"
         Version: 2012-10-17
       Path: /
@@ -851,7 +851,7 @@ Resources:
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
             Condition:
-              StringLike:
+              StringEquals:
                 "{{ .Cluster.LocalID }}.{{ .Values.hosted_zone }}:sub": "system:serviceaccount:kube-system:kube-ingress-aws-controller"
         Version: 2012-10-17
       Path: /
@@ -959,7 +959,7 @@ Resources:
           Action:
             - 'sts:AssumeRoleWithWebIdentity'
           Condition:
-            StringLike:
+            StringEquals:
               "{{ .Cluster.LocalID }}.{{ .Values.hosted_zone }}:sub": "system:serviceaccount:kube-system:cluster-lifecycle-controller"
         Version: 2012-10-17
       Path: /
@@ -1013,7 +1013,7 @@ Resources:
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
             Condition:
-              StringLike:
+              StringEquals:
                 "{{ .Cluster.LocalID }}.{{ .Values.hosted_zone }}:sub": "system:serviceaccount:kube-system:kube-node-ready"
           - Action:
               - 'sts:AssumeRole'
@@ -1104,7 +1104,7 @@ Resources:
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
             Condition:
-              StringLike:
+              StringEquals:
                 "{{ .Cluster.LocalID }}.{{ .Values.hosted_zone }}:sub": "system:serviceaccount:kube-system:etcd-backup"
           - Action:
               - 'sts:AssumeRole'
@@ -1147,7 +1147,7 @@ Resources:
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
             Condition:
-              StringLike:
+              StringEquals:
                 "{{ .Cluster.LocalID }}.{{ .Values.hosted_zone }}:sub": "system:serviceaccount:kube-system:kube-static-egress-controller"
         Version: 2012-10-17
       Path: /
@@ -1394,7 +1394,7 @@ Resources:
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
             Condition:
-              StringLike:
+              StringEquals:
                 "{{ .Cluster.LocalID }}.{{ .Values.hosted_zone }}:sub": "system:serviceaccount:kube-system:custom-metrics-apiserver"
         Version: 2012-10-17
       Path: /
@@ -1422,6 +1422,14 @@ Resources:
     Properties:
       AssumeRolePolicyDocument:
         Statement:
+          - Effect: Allow
+            Principal:
+              Federated: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+            Action:
+              - 'sts:AssumeRoleWithWebIdentity'
+            Condition:
+              StringEquals:
+                "{{ .Cluster.LocalID }}.{{ .Values.hosted_zone }}:sub": "system:serviceaccount:kube-system:ebs-csi-controller"
           - Action:
               - 'sts:AssumeRole'
             Effect: Allow
@@ -1616,7 +1624,7 @@ Resources:
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
             Condition:
-              StringLike:
+              StringEquals:
                 "{{ .Cluster.LocalID }}.{{ .Values.hosted_zone }}:sub": "system:serviceaccount:kube-system:aws-node-decommissioner"
       Path: /
       Policies:
@@ -1639,7 +1647,7 @@ Resources:
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
             Condition:
-              StringLike:
+              StringEquals:
                 "{{ .Cluster.LocalID }}.{{ .Values.hosted_zone }}:sub": "system:serviceaccount:kube-system:emergency-access-service"
         Version: 2012-10-17
       Path: /
@@ -1673,7 +1681,7 @@ Resources:
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
             Condition:
-              StringLike:
+              StringEquals:
                 "{{ .Cluster.LocalID }}.{{ .Values.hosted_zone }}:sub": "system:serviceaccount:kube-system:audittrail-adapter"
         Version: 2012-10-17
       Path: /

--- a/cluster/manifests/03-ebs-csi/01-rbac.yaml
+++ b/cluster/manifests/03-ebs-csi/01-rbac.yaml
@@ -4,6 +4,8 @@ kind: ServiceAccount
 metadata:
   name: ebs-csi-controller
   namespace: kube-system
+  annotations:
+    iam.amazonaws.com/role: "{{ .LocalID }}-ebs-csi-controller"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/cluster/manifests/03-ebs-csi/controller-aws-iam-role.yaml
+++ b/cluster/manifests/03-ebs-csi/controller-aws-iam-role.yaml
@@ -1,7 +1,0 @@
-apiVersion: zalando.org/v1
-kind: AWSIAMRole
-metadata:
-  name: ebs-csi-controller-iam-credentials
-  namespace: kube-system
-spec:
-  roleReference: {{ .LocalID}}-ebs-csi-controller

--- a/cluster/manifests/03-ebs-csi/ebs-controller.yaml
+++ b/cluster/manifests/03-ebs-csi/ebs-controller.yaml
@@ -24,9 +24,6 @@ spec:
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
-          # must be set for the AWS SDK/AWS CLI to find the credentials file.
-            - name: AWS_SHARED_CREDENTIALS_FILE # used by golang SDK
-              value: /meta/aws-iam/credentials.process
           image: registry.opensource.zalan.do/teapot/ebs-csi-driver:v0.5.0-master-2
           livenessProbe:
             failureThreshold: 5
@@ -51,9 +48,6 @@ spec:
           volumeMounts:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
-            - name: aws-iam-credentials
-              mountPath: /meta/aws-iam
-              readOnly: true
         - args:
             - --csi-address=$(ADDRESS)
             - --v=5
@@ -79,7 +73,6 @@ spec:
             - --csi-address=$(ADDRESS)
             - --v=5
             - --leader-election=true
-            - --leader-election-type=leases
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -137,7 +130,4 @@ spec:
       volumes:
         - emptyDir: {}
           name: socket-dir
-        - name: aws-iam-credentials
-          secret:
-            secretName: ebs-csi-controller-iam-credentials
 {{- end }}

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -139,3 +139,7 @@ post_apply:
 - name: admission-controller-proxy
   kind: DaemonSet
   namespace: kube-system
+- name: ebs-csi-controller-iam-credentials
+  namespace: kube-system
+  kind: AWSIAMRole
+  apiVersion: zalando.org/v1


### PR DESCRIPTION
Migrate EBS CSI Controller to OIDC credentials. It's currently not is use but doesn't harm to already do it.