### PR TITLE
Add oidc-subject-key helper variable

### DIFF
--- a/cluster/manifests/infrastructure-configs/deployment-config.yaml
+++ b/cluster/manifests/infrastructure-configs/deployment-config.yaml
@@ -12,4 +12,5 @@ data:
   aws-available: "true"
   worker-role-arn: "arn:aws:iam::{{accountID .Cluster.InfrastructureAccount}}:role/{{.Cluster.LocalID}}-worker"
   oidc-provider-arn: "arn:aws:iam::{{accountID .Cluster.InfrastructureAccount}}:oidc-provider/{{.Cluster.LocalID}}.{{.Cluster.Alias}}.zalan.do"
+  oidc-subject-key: "{{.Cluster.LocalID}}.{{.Cluster.Alias}}.zalan.do:sub"
   oidc-subject-prefix: "{{.Cluster.LocalID}}.{{.Cluster.Alias}}.zalan.do:sub: system:serviceaccount"


### PR DESCRIPTION
This adds another helper variable that only contains the key instead of the super-magic key-value combination.

Usage within CDP deployments can change from the current (and deprecated):

```yaml
          Condition:
            StringEquals:
              {{{CDP_OIDC_SUBJECT_PREFIX}}}:default:aws-limits
```

to

```yaml

          Condition:
            StringEquals:
              "{{{CDP_OIDC_SUBJECT_KEY}}}": "system:serviceaccount:default:aws-limits"
```