### PR TITLE
Admission controller: more control over automatic role creation

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -301,6 +301,9 @@ teapot_admission_controller_ignore_namespaces: "^kube-system$"
 teapot_admission_controller_crd_ensure_no_resources_on_delete: "true"
 {{end}}
 
+# Some third-party controllers use API groups that look like they belong to Kubernetes resources. Explicitly allow them anyway.
+teapot_admission_controller_crd_role_provisioning_allowed_api_groups: "flink.k8s.io"
+
 teapot_admission_controller_topology_spread: optin
 
 # etcd cluster

--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -38,6 +38,11 @@ data:
   deployment.default.rolling-update-max-unavailable: "{{ .Cluster.ConfigItems.teapot_admission_controller_deployment_default_max_unavailable }}"
 
   crd.resource-delete-protection.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_crd_ensure_no_resources_on_delete }}"
+{{- range $group := split .Cluster.ConfigItems.teapot_admission_controller_crd_role_provisioning_allowed_api_groups "," }}
+  "crd.role-provisioning.api-groups.{{$group}}": allow
+{{- end }}
+  # These API groups are internal and shouldn't be controllable by the users.
+  crd.role-provisioning.api-groups.deployment.zalando.org: skip
 
   priorityclass.preemption.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_preemption_enabled }}"
 

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -213,7 +213,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-97
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-99
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
 * Admission controller: support for explicitly enabling auto-roles for `k8s.io` API groups or disabling them for others
 * Add `teapot_admission_controller_crd_role_provisioning_allowed_api_groups` and allow `flink.k8s.io` because they've decided to use a `k8s.io` name for some reason
 * Disable role creation for `deployment.zalando.org`