### PR TITLE
kube-resource-report: fix Ingress apiGroup and allow listing RouteGroups

### DIFF
--- a/cluster/manifests/roles/kube-resource-report-rbac.yaml
+++ b/cluster/manifests/roles/kube-resource-report-rbac.yaml
@@ -8,8 +8,12 @@ rules:
   verbs:
   - get
   - list
-- apiGroups: ["extensions"]
+- apiGroups: ["extensions", "networking.k8s.io"]
   resources: ["ingresses"]
+  verbs:
+  - list
+- apiGroups: ["zalando.org/v1"]
+  resources: ["routegroups"]
   verbs:
   - list
 - apiGroups: ["metrics.k8s.io"]


### PR DESCRIPTION
The `extensions` API group for Ingress is deprecated and no longer used. Keep it for compatibility (allow roll-back) and add the current API group `networking.k8s.io`.

Also allow listing [RouteGroups](https://opensource.zalando.com/skipper/kubernetes/routegroups/).