### PR TITLE
Unbound as DNS cache [DNS v3.0]

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -318,7 +318,13 @@ dynamodb_service_link_enabled: "false"
 
 cluster_dns: "coredns"
 coredns_log_svc_names: "true"
-coredns_max_upstream_concurrency: 0 #0 means there is not concurrency limits
+# max concurrency for upstream (AWS VPC) DNS server
+#
+# AWS VPC DNS server has a limit of 1024 qps before packets are dropped.
+# This setting is tuned to allow a buffer compared to the normal DNS QPS in our
+# clusters and prevent CoreDNS from running out of memory in case of spikes.
+coredns_max_upstream_concurrency: 2000 # 0 means there is no concurrency limits
+
 
 # Kubernetes on Ubuntu AMI to use
 # note this configuration uses the [amiID][0] function. It returns the
@@ -401,11 +407,22 @@ external_dns_ownership_prefix: ""
 # domains that should be ignored by ExternalDNS
 external_dns_excluded_domains: cluster.local
 
+# select which cache to use for Cluster DNS
+{{ if eq .Cluster.Environment "production" }}
+dns_cache: "dnsmasq"
+{{ else }}
+dns_cache: "unbound"
+{{ end }}
+
 # DNS container resources
 dns_dnsmasq_cpu: "100m"
 dns_dnsmasq_mem: "50Mi"
 dns_dnsmasq_sidecar_cpu: "10m"
 dns_dnsmasq_sidecar_mem: "45Mi"
+dns_unbound_cpu: "100m"
+dns_unbound_mem: "50Mi"
+dns_unbound_telemetry_cpu: "10m"
+dns_unbound_telemetry_mem: "45Mi"
 dns_coredns_cpu: "50m"
 dns_coredns_mem: "100Mi"
 

--- a/cluster/manifests/coredns-local/configmap-local.yaml
+++ b/cluster/manifests/coredns-local/configmap-local.yaml
@@ -6,6 +6,43 @@ metadata:
   labels:
     application: coredns
 data:
+  unbound.conf: |
+    server:
+      directory: "/opt/unbound/etc/unbound/"
+      interface: 0.0.0.0
+      interface-automatic: yes
+      # Drop user privileges after binding the port.
+      username: "_unbound"
+      # Prevent the unbound server from forking into the background as a daemon
+      do-daemonize: no
+      # log to stderr
+      use-syslog: no
+      log-servfail: yes
+      # allow query localhost (coredns at 127.0.0.1:9254)
+      do-not-query-localhost: no
+      access-control: 0.0.0.0/0 allow
+      harden-dnssec-stripped: no
+      so-reuseport: yes
+      cache-min-ttl: 1
+      disable-dnssec-lame-check: yes
+      minimal-responses: yes
+      extended-statistics: yes
+      # support reverse lookup of kubernetes addresses
+      local-zone: "2.10.in-addr.arpa." transparent
+      local-zone: "3.10.in-addr.arpa." transparent
+      # make metrics available for the unbound-telemetry container (127.0.0.1:9054)
+      remote-control:
+        control-enable: yes
+        control-use-cert: no
+    forward-zone:
+      name: "."
+      forward-addr: 127.0.0.1@9254 # coredns
+    forward-zone:
+      name: "2.10.in-addr.arpa."
+      forward-addr: 127.0.0.1@9254 # coredns
+    forward-zone:
+      name: "3.10.in-addr.arpa."
+      forward-addr: 127.0.0.1@9254 # coredns
   Corefile: |
 {{ if and (ne .ConfigItems.custom_dns_zone "") (ne .ConfigItems.custom_dns_zone_nameservers "") }}
     {{ .ConfigItems.custom_dns_zone }}:9254 {

--- a/cluster/manifests/coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/coredns-local/daemonset-coredns.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: coredns
-    version: v1.7.1
+    version: v1.8.1
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
     component: cluster-dns
@@ -21,10 +21,48 @@ spec:
       labels:
         application: coredns
         instance: node-dns
-        version: v1.7.1
+        version: v1.8.1
         component: cluster-dns
     spec:
       containers:
+{{ if eq .Cluster.ConfigItems.dns_cache "unbound" }}
+      - name: unbound
+        image: registry.opensource.zalan.do/teapot/unbound:1.13.0
+        ports:
+        - containerPort: 53
+          name: dns-udp
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+        resources:
+          requests:
+            ephemeral-storage: 256Mi
+          limits:
+            cpu: {{.Cluster.ConfigItems.dns_unbound_cpu}}
+            memory: {{.Cluster.ConfigItems.dns_unbound_mem}}
+        volumeMounts:
+        - mountPath: /opt/unbound/etc/unbound/unbound.conf
+          name: config-volume
+          readOnly: true
+          subPath: unbound.conf
+      - name: unbound-telemetry
+        image: registry.opensource.zalan.do/teapot/unbound-telemetry:master-1
+        args:
+        - tcp
+        - --bind=0.0.0.0:9054
+        ports:
+        - name: metrics
+          containerPort: 9054
+          protocol: TCP
+        resources:
+          requests:
+            ephemeral-storage: 256Mi
+          limits:
+            cpu: {{.Cluster.ConfigItems.dns_unbound_telemetry_cpu}}
+            memory: {{.Cluster.ConfigItems.dns_unbound_telemetry_mem}}
+{{ end }}
+{{ if eq .Cluster.ConfigItems.dns_cache "dnsmasq" }}
       - name: dnsmasq
         image: registry.opensource.zalan.do/teapot/k8s-dns-dnsmasq-nanny-amd64:1.15.7-1
         securityContext:
@@ -95,8 +133,9 @@ spec:
           limits:
             cpu: {{.Cluster.ConfigItems.dns_dnsmasq_sidecar_cpu}}
             memory: {{.Cluster.ConfigItems.dns_dnsmasq_sidecar_mem}}
+{{ end }}
       - name: coredns
-        image: registry.opensource.zalan.do/teapot/coredns:1.7.1
+        image: registry.opensource.zalan.do/teapot/coredns:1.8.1
         args: [ "-conf", "/etc/coredns/Corefile" ]
         volumeMounts:
         - name: config-volume
@@ -148,3 +187,5 @@ spec:
           items:
           - key: Corefile
             path: Corefile
+          - key: unbound.conf
+            path: unbound.conf

--- a/cluster/manifests/coredns-local/rbac.yaml
+++ b/cluster/manifests/coredns-local/rbac.yaml
@@ -12,6 +12,9 @@ rules:
 - apiGroups: [""]
   resources: ["endpoints", "services", "pods", "namespaces"]
   verbs: ["list", "watch"]
+- apiGroups: ["discovery.k8s.io"]
+  resources: ["endpointslices"]
+  verbs: ["list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
This introduces [Unbound](https://www.nlnetlabs.nl/projects/unbound/about/) as an alternative DNS cache to dnsmasq. It's enabled by default in test clusters.

The choice of unbound is based on load tests performed with different setups as shown in the table below where unbound performs best in most cases:

 :heavy_check_mark: = best result

| experiment | CPU (max) | Memory (max) | success rate (max) (client) | error rate (max) (client) | latency p99 (client) |
|-----------------|--------|-----------|--------|----|--------|
| [external] coredns (1.8.1) | `820m` | `18.8MiB` :heavy_check_mark: | `7810` | `26` | `94ms` |
| [external] dnsmasq(old)+coredns | `360m` (`355m+5m+5m`) | `44.8MiB` (`22.6+10.3+11.9`) | `8790` | `17` | `121ms` |
| [external] unbound+coredns | `322m` (`317m+5m+0m`) :heavy_check_mark: | `32.9MiB` (`21.0+10.6+1.3`) | `9000` :heavy_check_mark: | `13` :heavy_check_mark: | `82ms` :heavy_check_mark: |
| --- | --- | --- | --- | --- |  --- |
| [internal] coredns (1.8.1) | `1346m` | `17.2MiB` :heavy_check_mark: | `12510` | `21` |  `2.7s` |
| [internal] dnsmasq(old)+coredns | `1874m` (`954m+919m+1m`) | `42.3MiB` (`19.1+11.1+12.1`) | `8180` | `177` | `5s` |
| [internal] unbound+coredns | `508m` (`503m+5m+0m`) :heavy_check_mark: | `33.3MiB` (`21.8+10.2+1.3`) | `15530` :heavy_check_mark: | `15` :heavy_check_mark: | `12.8ms` :heavy_check_mark:  |

Only single CoreDNS without a separate dns cache performs better on memory usage, however the CPU usage is much higher in that setup and therefore is unbound considered the best performing setup.

Additionally does it solve the problem of caching internal names which doesn't work with the current `dnsmasq` setup.

This also updated coredns to 1.8.1 which was used in the tests and it sets the `coredns_max_upstream_concurrency` to a somewhat conservative value based on the tests. With the caching in place it's unlikely we come anywhere near 2000 QPS on CoreDNS side, but even if we did CoreDNS would not run out of memory in this configuration based on tests (I was able to kill it with a setting `>2600`)