### PR TITLE
metrics-server: Fix target port

### DIFF
--- a/cluster/manifests/metrics-server/service.yaml
+++ b/cluster/manifests/metrics-server/service.yaml
@@ -12,4 +12,4 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 4443


### PR DESCRIPTION
Follow up to #4021 the pod port was changed and thus the service pointed to the wrong one.