### PR TITLE
Add a config item to enable new filenames for userdata

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -526,3 +526,6 @@ enable_control_plane_profiling: "false"
 # Enable use of Privileged PSP (running privileged pods) in non system namespaces.
 # TODO: remove once all clusters have been migrated away from privileged pods
 privileged_psp_enabled: "false"
+
+# TODO: remove after CLM is updated
+clm_new_userdata_path: "true"


### PR DESCRIPTION
This enabled the new names for the userdata files (https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/427). Once this is rolled out everywhere, we'll make them unconditional and drop the config item.

**Warning**: this rolls the nodes, so it should be combined with another change.