### PR TITLE
Cleanup kube-node-ready-controller related config

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -301,6 +301,9 @@ teapot_admission_controller_ignore_namespaces: "^kube-system$"
 teapot_admission_controller_crd_ensure_no_resources_on_delete: "true"
 {{end}}
 
+# Enable kube-node-ready-controller and node-not-ready taint
+teapot_admission_controller_node_not_ready_taint: "true"
+
 # Some third-party controllers use API groups that look like they belong to Kubernetes resources. Explicitly allow them anyway.
 teapot_admission_controller_crd_role_provisioning_allowed_api_groups: "flink.k8s.io"
 
@@ -519,13 +522,3 @@ enable_control_plane_profiling: "false"
 # Enable use of Privileged PSP (running privileged pods) in non system namespaces.
 # TODO: remove once all clusters have been migrated away from privileged pods
 privileged_psp_enabled: "false"
-
-# Enable kube-node-ready-controller and node-not-ready taint
-teapot_addmission_controller_node_not_ready_taint: "true"
-
-# TODO: legacy remove after rollout.
-{{if eq .Cluster.Environment "production"}}
-kube_node_not_ready_taint_enabled: "false"
-{{ else }}
-kube_node_not_ready_taint_enabled: "true"
-{{ end }}

--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -59,4 +59,4 @@ data:
 {{- end }}
 {{- end}}
 
-  node.node-not-ready-taint.enable: "{{ .Cluster.ConfigItems.teapot_addmission_controller_node_not_ready_taint }}"
+  node.node-not-ready-taint.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_node_not_ready_taint }}"

--- a/cluster/node-pools/worker-default/userdata.yaml
+++ b/cluster/node-pools/worker-default/userdata.yaml
@@ -7,7 +7,7 @@ write_files:
   - owner: root:root
     path: /etc/kubernetes/secrets.env
     content: |
-      NODEPOOL_TAINTS={{ if eq .NodePool.ConfigItems.kube_node_not_ready_taint_enabled "true" }}zalando.org/node-not-ready=:NoSchedule{{end}}{{if index .NodePool.ConfigItems "taints"}}{{ if eq .NodePool.ConfigItems.kube_node_not_ready_taint_enabled "true" }},{{ end }}{{.NodePool.ConfigItems.taints}}{{end}}
+      NODEPOOL_TAINTS={{if index .NodePool.ConfigItems "taints"}}{{.NodePool.ConfigItems.taints}}{{end}}
       NODE_LABELS={{ .Values.node_labels }}{{if eq .NodePool.Profile "worker-spotio-ocean"}},spot.io=true{{end}},node.kubernetes.io/distro=ubuntu{{if index .NodePool.ConfigItems "labels"}},{{.NodePool.ConfigItems.labels}}{{end}}
       NODEPOOL_NAME={{ .NodePool.Name }}
       KUBELET_ROLE=worker


### PR DESCRIPTION
Cleans up the config items used for `kube-node-ready-controller` feature.

* Remove setting taint via kubelet, was moved to admission-controller (this will roll nodes in test clusters)
* Move `teapot_admission_controller_node_not_ready_taint` to the other admission-controller configs and fix the name.