### PR TITLE
Add protocol to port definitions

### DIFF
--- a/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
@@ -50,6 +50,7 @@ spec:
             memory: {{.Cluster.ConfigItems.vpa_mem}}
         ports:
         - containerPort: 8000
+          protocol: TCP
       volumes:
         - name: tls-certs
           secret:

--- a/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
@@ -40,3 +40,4 @@ spec:
             memory: {{.Cluster.ConfigItems.vpa_mem}}
         ports:
         - containerPort: 8080
+          protocol: TCP

--- a/cluster/manifests/01-vertical-pod-autoscaler/service.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/service.yaml
@@ -14,3 +14,4 @@ spec:
   ports:
     - port: 443
       targetPort: 8000
+      protocol: TCP

--- a/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
@@ -41,3 +41,4 @@ spec:
             memory: {{.Cluster.ConfigItems.vpa_mem}}
         ports:
         - containerPort: 8080
+          protocol: TCP

--- a/cluster/manifests/dashboard/deployment.yaml
+++ b/cluster/manifests/dashboard/deployment.yaml
@@ -41,6 +41,7 @@ spec:
             memory: 400Mi
         ports:
         - containerPort: 9090
+          protocol: TCP
         livenessProbe:
           httpGet:
             path: /

--- a/cluster/manifests/dashboard/scraper.yaml
+++ b/cluster/manifests/dashboard/scraper.yaml
@@ -13,6 +13,7 @@ spec:
   ports:
   - port: 8000
     targetPort: 8000
+    protocol: TCP
 
 ---
 
@@ -51,6 +52,7 @@ spec:
             memory: 200Mi
         ports:
         - containerPort: 8000
+          protocol: TCP
         livenessProbe:
           httpGet:
             scheme: HTTP

--- a/cluster/manifests/dashboard/service.yaml
+++ b/cluster/manifests/dashboard/service.yaml
@@ -14,3 +14,4 @@ spec:
   ports:
   - port: 80
     targetPort: 9090
+    protocol: TCP

--- a/cluster/manifests/kube-metrics-adapter/service.yaml
+++ b/cluster/manifests/kube-metrics-adapter/service.yaml
@@ -7,5 +7,6 @@ spec:
   ports:
   - port: 443
     targetPort: 443
+    protocol: TCP
   selector:
     application: kube-metrics-adapter

--- a/cluster/manifests/kube-node-ready/service.yaml
+++ b/cluster/manifests/kube-node-ready/service.yaml
@@ -14,5 +14,6 @@ spec:
     - port: 80
       nodePort: 30080
       targetPort: 8080
+      protocol: TCP
   selector:
     application: kube-node-ready

--- a/cluster/manifests/kube-state-metrics/deployment.yaml
+++ b/cluster/manifests/kube-state-metrics/deployment.yaml
@@ -30,8 +30,10 @@ spec:
         ports:
         - containerPort: 8080
           name: http-metrics
+          protocol: TCP
         - containerPort: 8081
           name: telemetry
+          protocol: TCP
         readinessProbe:
           httpGet:
             path: /

--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -48,3 +48,4 @@ spec:
             memory: 50Mi
         ports:
           - containerPort: 8000
+            protocol: TCP

--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -46,6 +46,7 @@ spec:
         - containerPort: 8181
           hostPort: 8181
           name: http
+          protocol: TCP
         securityContext:
           privileged: true
         readinessProbe:

--- a/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
@@ -29,6 +29,7 @@ spec:
           image: "pierone.stups.zalan.do/teapot/kubernetes-lifecycle-metrics:master-7"
           ports:
             - containerPort: 9090
+              protocol: TCP
           resources:
             limits:
               cpu: 5m

--- a/cluster/manifests/node-monitor/daemonset.yaml
+++ b/cluster/manifests/node-monitor/daemonset.yaml
@@ -70,6 +70,7 @@ spec:
             - name: cadvisor
               containerPort: 9101
               hostPort: 9101
+              protocol: TCP
         - image: registry.opensource.zalan.do/teapot/prometheus-node-exporter:v1.1.0
           args:
             - --collector.processes
@@ -82,6 +83,7 @@ spec:
             - name: prom-node-exp
               containerPort: 9100
               hostPort: 9100
+              protocol: TCP
           resources:
             requests:
               cpu: {{.Cluster.ConfigItems.node_exporter_cpu}}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -56,6 +56,7 @@ spec:
         - name: ingress-port
           containerPort: 9999
           hostPort: 9999
+          protocol: TCP
         env:
         - name: LIGHTSTEP_TOKEN
           valueFrom:


### PR DESCRIPTION
There's [a bug](https://github.com/kubernetes-sigs/structured-merge-diff/issues/130) with server-side apply that fails for port definitions that lack a `protocol` field. Most of our manifests have it set properly, so let's fix the remaining ones just in case we actually switch to it.