### PR TITLE
Add support for SG Ingress ranges

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -344,9 +344,9 @@ Resources:
           FromPort: 22
           IpProtocol: tcp
           ToPort: 22
-{{- if index .Cluster.ConfigItems "open_port_ranges" }}
-{{- range $index, $element := portRanges .Cluster.ConfigItems.open_port_ranges }}
-        - CidrIp: 0.0.0.0/0
+{{- if index .Cluster.ConfigItems "open_sg_ingress_ranges" }}
+{{- range $index, $element := portRanges .Cluster.ConfigItems.open_sg_ingress_ranges }}
+        - CidrIp: {{ $element.CIDR }}
           FromPort: {{ $element.FromPort }}
           IpProtocol: tcp
           ToPort: {{ $element.ToPort }}


### PR DESCRIPTION
This adds support for setting Security Group Ingress range rules using the `open_sg_ingress_ranges` config item. It works similar to the previous `open_port_ranges` feature, but the format now includes the CIDR such that you can specify CIDRs other than `0.0.0.0/0`.

Ref: https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/429

I have added the relevant config items in all the clusters currently using the `open_port_ranges` feature.