### PR TITLE
coredns/flannel: check API server availability first

### DIFF
--- a/cluster/manifests/coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/coredns-local/daemonset-coredns.yaml
@@ -24,6 +24,17 @@ spec:
         version: v1.8.1
         component: cluster-dns
     spec:
+      initContainers:
+      - name: ensure-apiserver
+        image: registry.opensource.zalan.do/teapot/ensure-apiserver:master-2
+        resources:
+          requests:
+            cpu: 1m
+            memory: 50Mi
+            ephemeral-storage: 256Mi
+          limits:
+            cpu: 1m
+            memory: 50Mi
       containers:
 {{ if eq .Cluster.ConfigItems.dns_cache "unbound" }}
       - name: unbound

--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -20,6 +20,17 @@ spec:
     spec:
       priorityClassName: system-node-critical
       serviceAccountName: flannel
+      initContainers:
+      - name: ensure-apiserver
+        image: registry.opensource.zalan.do/teapot/ensure-apiserver:master-2
+        resources:
+          requests:
+            cpu: 1m
+            memory: 50Mi
+            ephemeral-storage: 256Mi
+          limits:
+            cpu: 1m
+            memory: 50Mi
       containers:
       - name: delayed-install-cni
         image: registry.opensource.zalan.do/teapot/flannel-awaiter:master-4


### PR DESCRIPTION
Both flannel (or rather the apiserver-proxy container that we still have to run) and coredns crash during startup if the API server is not available. Because of a race with `kube-proxy` this happens very often and is usually mitigated by a restart or two. This is fairly annoying, because we still want to be alerted when these pods restart, but Kubernetes doesn't track enough information about the pods to exclude these restarts correctly. Instead of investing a lot into a custom monitoring tool, let's just add a small init container that would check the API server connectivity.