### PR TITLE
Update kubernetes-lifecycle-metrics

### DIFF
--- a/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kubernetes-lifecycle-metrics
-    version: master-7
+    version: master-9
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kubernetes-lifecycle-metrics
-        version: master-7
+        version: master-9
       annotations:
         kubernetes-log-watcher/scalyr-parser: '[{"container": "kubernetes-lifecycle-metrics", "parser": "system-json-escaped-json"}]'
     spec:
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: kubernetes-lifecycle-metrics
       containers:
         - name: kubernetes-lifecycle-metrics
-          image: "pierone.stups.zalan.do/teapot/kubernetes-lifecycle-metrics:master-7"
+          image: "pierone.stups.zalan.do/teapot/kubernetes-lifecycle-metrics:master-9"
           ports:
             - containerPort: 9090
               protocol: TCP


### PR DESCRIPTION
This commit updates kubernetes-lifecycle-metrics to its version
master-9. This version adds proper handling to
[`DeletedFinalStateUnknown`][0] objects. Also, as it updates from
master-7, the master-8 version updates the base docker image to a
Zalando compliant one.

[0]: https://pkg.go.dev/k8s.io/client-go@v1.5.1/1.5/tools/cache#DeletedFinalStateUnknown