### PR TITLE
Configure logging/destination for all system pods

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -172,6 +172,9 @@ journald_reader_memory: "30Mi"
 # Logging settings
 logging_s3_bucket: "zalando-logging-{{.InfrastructureAccount | getAWSAccountID}}-{{.Region}}"
 scalyr_team_token: ""
+log_destination_infra: "scalyr/stups"
+log_destination_both: "scalyr/*"
+log_destination_local: "scalyr/default"
 
 vpa_cpu: "200m"
 vpa_mem: "500Mi"

--- a/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
@@ -21,6 +21,7 @@ spec:
         version: v0.6.1-internal.12
       annotations:
         config/hash: {{"02-secret.yaml" | manifestHash}}
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       serviceAccountName: vpa-admission-controller

--- a/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
@@ -19,6 +19,8 @@ spec:
         application: vertical-pod-autoscaler
         component: recommender
         version: v0.6.1-internal.12
+      annotations:
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
       serviceAccountName: vpa-recommender
       containers:

--- a/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
@@ -19,6 +19,8 @@ spec:
         application: vertical-pod-autoscaler
         component: updater
         version: v0.6.1-internal.12
+      annotations:
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
       serviceAccountName: vpa-updater
       containers:

--- a/cluster/manifests/02-kube-aws-iam-controller/deployment.yaml
+++ b/cluster/manifests/02-kube-aws-iam-controller/deployment.yaml
@@ -16,6 +16,8 @@ spec:
       labels:
         application: kube-aws-iam-controller
         version: v0.1.2
+      annotations:
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
       serviceAccountName: kube-aws-iam-controller
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"

--- a/cluster/manifests/03-ebs-csi/02-csi-driver.yaml
+++ b/cluster/manifests/03-ebs-csi/02-csi-driver.yaml
@@ -16,6 +16,8 @@ spec:
       labels:
         application: container-storage-interface
         component: driver
+      annotations:
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
       initContainers:
         - name: cleanup

--- a/cluster/manifests/03-ebs-csi/ebs-controller.yaml
+++ b/cluster/manifests/03-ebs-csi/ebs-controller.yaml
@@ -14,6 +14,8 @@ spec:
       labels:
         application: container-storage-interface
         component: ebs-controller
+      annotations:
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
       containers:
         - args:

--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -18,6 +18,8 @@ spec:
       labels:
         application: audittrail-adapter
         version: master-24
+      annotations:
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
       serviceAccountName: audittrail-adapter
       priorityClassName: system-node-critical

--- a/cluster/manifests/aws-node-decommissioner/cronjob.yaml
+++ b/cluster/manifests/aws-node-decommissioner/cronjob.yaml
@@ -19,6 +19,8 @@ spec:
         metadata:
           labels:
             application: aws-node-decommissioner
+          annotations:
+            logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
         spec:
           serviceAccountName: aws-node-decommissioner
           restartPolicy: Never

--- a/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       labels:
         application: cluster-lifecycle-controller
         version: master-22
+      annotations:
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_both}}"
     spec:
       dnsConfig:
         options:

--- a/cluster/manifests/coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/coredns-local/daemonset-coredns.yaml
@@ -23,6 +23,8 @@ spec:
         instance: node-dns
         version: v1.8.1
         component: cluster-dns
+      annotations:
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
       initContainers:
       - name: ensure-apiserver

--- a/cluster/manifests/cronjob-fixer/deployment.yaml
+++ b/cluster/manifests/cronjob-fixer/deployment.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         application: cronjob-fixer
+      annotations:
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
       dnsConfig:
         options:

--- a/cluster/manifests/dashboard/deployment.yaml
+++ b/cluster/manifests/dashboard/deployment.yaml
@@ -21,6 +21,8 @@ spec:
         component: dashboard
         version: v2.0.4
         kubernetes.io/cluster-service: "true"
+      annotations:
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
       dnsConfig:
         options:

--- a/cluster/manifests/dashboard/scraper.yaml
+++ b/cluster/manifests/dashboard/scraper.yaml
@@ -38,6 +38,8 @@ spec:
         application: kubernetes-dashboard
         component: metrics-scraper
         version: v1.0.4
+      annotations:
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
       serviceAccountName: kubernetes-dashboard
       containers:

--- a/cluster/manifests/efs-provisioner/depl-efs-provisioner.yaml
+++ b/cluster/manifests/efs-provisioner/depl-efs-provisioner.yaml
@@ -18,6 +18,8 @@ spec:
       labels:
         application: efs-provisioner
         version: v2.4.0
+      annotations:
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
       dnsConfig:
         options:

--- a/cluster/manifests/emergency-access-service/deployment.yaml
+++ b/cluster/manifests/emergency-access-service/deployment.yaml
@@ -20,6 +20,7 @@ spec:
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
           [{"container": "emergency-access-service", "parser": "json-structured-log"}]
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_both}}"
     spec:
       dnsConfig:
         options:

--- a/cluster/manifests/etcd-backup/cronjob.yaml
+++ b/cluster/manifests/etcd-backup/cronjob.yaml
@@ -20,6 +20,8 @@ spec:
           labels:
             application: etcd-backup
             version: "master-12"
+          annotations:
+            logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
         spec:
           serviceAccountName: etcd-backup
           dnsConfig:

--- a/cluster/manifests/event-logger/statefulset.yaml
+++ b/cluster/manifests/event-logger/statefulset.yaml
@@ -19,6 +19,8 @@ spec:
       labels:
         application: kubernetes-event-logger
         version: master-3
+      annotations:
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_both}}"
     spec:
       dnsConfig:
         options:

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -17,6 +17,8 @@ spec:
       labels:
         application: external-dns
         version: v0.7.6
+      annotations:
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_both}}"
     spec:
       dnsConfig:
         options:

--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -17,6 +17,8 @@ spec:
       labels:
         application: flannel
         version: v0.11.0-10
+      annotations:
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
       priorityClassName: system-node-critical
       serviceAccountName: flannel

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -16,6 +16,8 @@ spec:
       labels:
         application: kube-ingress-aws-controller
         version: v0.11.20
+      annotations:
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_both}}"
     spec:
       dnsConfig:
         options:

--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -17,6 +17,8 @@ spec:
       labels:
         application: kube-cluster-autoscaler
         version: v1.18.2-internal.25
+      annotations:
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
       dnsConfig:
         options:

--- a/cluster/manifests/kube-downscaler/deployment.yaml
+++ b/cluster/manifests/kube-downscaler/deployment.yaml
@@ -17,6 +17,8 @@ spec:
       labels:
         application: kube-downscaler
         version: v20.4.1
+      annotations:
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
       dnsConfig:
         options:

--- a/cluster/manifests/kube-janitor/deployment.yaml
+++ b/cluster/manifests/kube-janitor/deployment.yaml
@@ -17,6 +17,8 @@ spec:
       labels:
         application: kube-janitor
         version: v20.4.1
+      annotations:
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
       dnsConfig:
         options:

--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         application: kube-metrics-adapter
+      annotations:
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
       dnsConfig:
         options:

--- a/cluster/manifests/kube-node-ready-controller/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready-controller/daemonset.yaml
@@ -15,6 +15,8 @@ spec:
     metadata:
       labels:
         application: kube-node-ready-controller
+      annotations:
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
       dnsConfig:
         options:

--- a/cluster/manifests/kube-node-ready/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready/daemonset.yaml
@@ -19,6 +19,8 @@ spec:
       labels:
         application: kube-node-ready
         version: {{$version}}
+      annotations:
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
       affinity:
         nodeAffinity:

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -18,6 +18,7 @@ spec:
         application: kube-proxy
       annotations:
         config/hash: {{"configmap.yaml" | manifestHash}}
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
       priorityClassName: system-node-critical
       serviceAccountName: kube-proxy

--- a/cluster/manifests/kube-state-metrics/deployment.yaml
+++ b/cluster/manifests/kube-state-metrics/deployment.yaml
@@ -16,6 +16,8 @@ spec:
       labels:
         application: kube-state-metrics
         version: v1.9.7
+      annotations:
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
       dnsConfig:
         options:

--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -16,6 +16,8 @@ spec:
       labels:
         application: kube-static-egress-controller
         version: v0.2.7
+      annotations:
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_both}}"
     spec:
       dnsConfig:
         options:

--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -17,6 +17,8 @@ spec:
       labels:
         application: kube2iam
         version: 0.10.11
+      annotations:
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
       dnsConfig:
         options:

--- a/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
@@ -18,6 +18,7 @@ spec:
         version: master-9
       annotations:
         kubernetes-log-watcher/scalyr-parser: '[{"container": "kubernetes-lifecycle-metrics", "parser": "system-json-escaped-json"}]'
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
       dnsConfig:
         options:

--- a/cluster/manifests/metrics-server/deployment.yaml
+++ b/cluster/manifests/metrics-server/deployment.yaml
@@ -17,6 +17,8 @@ spec:
       labels:
         application: metrics-server
         version: v0.4.2
+      annotations:
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
       dnsConfig:
         options:

--- a/cluster/manifests/node-monitor/daemonset.yaml
+++ b/cluster/manifests/node-monitor/daemonset.yaml
@@ -17,6 +17,7 @@ spec:
         application: node-monitor
       annotations:
         kubernetes-log-watcher/scalyr-parser: '[{"container": "journald-reader", "parser": "journald"}]'
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
       hostNetwork: true
       hostPID: true

--- a/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
+++ b/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
@@ -21,6 +21,8 @@ spec:
       labels:
         application: nvidia-gpu-device-plugin
         version: 4baa941d8df91e5dc1736adea74ce54e564dd782
+      annotations:
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
       serviceAccountName: nvidia
       tolerations:

--- a/cluster/manifests/pdb-controller/deployment.yaml
+++ b/cluster/manifests/pdb-controller/deployment.yaml
@@ -16,6 +16,8 @@ spec:
       labels:
         application: pdb-controller
         version: v0.0.15
+      annotations:
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
       dnsConfig:
         options:

--- a/cluster/manifests/prometheus/statefulset.yaml
+++ b/cluster/manifests/prometheus/statefulset.yaml
@@ -26,6 +26,7 @@ spec:
         version: v2.25.0
       annotations:
         config/hash: {{"configmap.yaml" | manifestHash}}
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
       serviceAccountName: prometheus
       dnsConfig:

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         kubernetes-log-watcher/scalyr-parser: |
           [{"container": "skipper-ingress", "parser": "skipper-access-log"}]
         config/hash: {{"secret.yaml" | manifestHash}}
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_local}}"
     spec:
       affinity:
         podAntiAffinity:

--- a/cluster/manifests/skipper/skipper-redis.yaml
+++ b/cluster/manifests/skipper/skipper-redis.yaml
@@ -19,6 +19,7 @@ spec:
         version: v4.0.9
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
 {{- if eq .ConfigItems.skipper_topology_spread_enabled "true" }}
       topologySpreadConstraints:

--- a/cluster/manifests/spotio-controller/deployment.yaml
+++ b/cluster/manifests/spotio-controller/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         component: "ocean"
       annotations:
         config/hash: {{"secret.yaml" | manifestHash}}
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
       # TODO: run on master?
       # nodeSelector:

--- a/cluster/manifests/stackset-controller/deployment.yaml
+++ b/cluster/manifests/stackset-controller/deployment.yaml
@@ -16,6 +16,8 @@ spec:
       labels:
         application: stackset-controller
         version: "v1.3.23"
+      annotations:
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       serviceAccountName: stackset-controller

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -99,6 +99,7 @@ write_files:
         annotations:
           kubernetes-log-watcher/scalyr-parser: |
             [{"container": "webhook", "parser": "json-structured-log"}]
+          logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
       spec:
         priorityClassName: system-node-critical
         tolerations:
@@ -531,6 +532,8 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-controller-manager
+        annotations:
+          logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
       spec:
         priorityClassName: system-node-critical
         tolerations:
@@ -598,6 +601,8 @@ write_files:
         namespace: kube-system
         labels:
           application: kube-scheduler
+        annotations:
+          logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
       spec:
         priorityClassName: system-node-critical
         tolerations:


### PR DESCRIPTION
We can now send logs to a dedicated Scalyr account, which would help a lot with the querying and debugging. This PR configure the `logging/destination` annotation for all kube-system pods. Most of the pods are configured with `scalyr/stups`, so the logs would only be available to us, but there are exceptions:
 * `external-dns`, `kube-ingress-aws-controller` and `kube-static-egress-controller` log to both accounts. Unfortunately they don't report errors in a nice way (e.g. using events), so it'd be impossible for the users to debug otherwise.
 * `cluster-lifecycle-controller`, `emergency-access-service` and `kubernetes-event-logger` log to both accounts as well. These are used by the users when they investigate something, and they don't log that much.
 * `skipper-ingress` logs only to the cluster's account due to the amount of logs it creates. We don't want to duplicate those needlessly.