### PR TITLE
Update ingress-controller and adjust EW range rule

### DIFF
--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.11.14
+    version: v0.11.20
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.11.14
+        version: v0.11.20
     spec:
       dnsConfig:
         options:
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: kube-ingress-aws-controller
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.11.14
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.11.20
         args:
         - --stack-termination-protection
         - --ssl-policy={{ .ConfigItems.kube_aws_ingress_controller_ssl_policy }}
@@ -35,6 +35,9 @@ spec:
         - --nlb-cross-zone
         {{ end }}
         - --cluster-local-domain=cluster.local
+{{ if eq .ConfigItems.enable_skipper_eastwest_range "true"}}
+        - --deny-internal-domains
+{{ end }}
         - "--additional-stack-tags=InfrastructureComponent=true"
         env:
         - name: CUSTOM_FILTERS

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -94,7 +94,7 @@ spec:
 {{ end }}
 {{ if eq .ConfigItems.enable_skipper_eastwest_range "true"}}
           - "-kubernetes-east-west-range-domains=ingress.cluster.local"
-          - "-kubernetes-east-west-range-predicates=ClientIP(\"10.2.0.0/16\", \"{{ .Values.vpc_ipv4_cidr }}\") && SourceFromLast(\"10.2.0.0/16\", \"{{ .Values.vpc_ipv4_cidr }}\")"
+          - "-kubernetes-east-west-range-predicates=ClientIP(\"10.2.0.0/16\", \"{{ .Values.vpc_ipv4_cidr }}\")"
 {{ end }}
           - "-proxy-preserve-host"
           - "-serve-host-metrics"


### PR DESCRIPTION
In #3952 we enabled the Skipper [EastWest Range][0] feature using the
predicates `ClientIP` and `SourceFromLast` as [discussed][1]. It
introduced a problem: other skipper deployments running inside clusters
(not the ingress one) could receive traffic and route it back to the
`skipper-ingress` deployment. This traffic would be denied, since the
`X-Forwarded-For` header won't be handled and its value is as of an
external IP.

This commit updates the kube-ingress-aws-controller to the version
`v0.11.19`. This new version brings among, a fix for NLB HealthCheck
timeouts and dependencies updates, the feature to [deny traffic for
internal domains][2] on the ALB level. It allow us to change the skipper
[east-west range][0] feature to block traffic based just on the
`ClientIP` predicate. This commit, therefore, removes the
`SourceFromLast` predicates previously configured.

[0]: https://skipper.docs.zalando.net/tutorials/operations/#east-west-range
[1]: https://github.com/zalando/skipper/issues/1526#issuecomment-756903746
[2]: https://github.com/zalando-incubator/kube-ingress-aws-controller#deny-traffic-for-internal-domains