### PR TITLE
Remove legacy jwks path

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -460,10 +460,6 @@ write_files:
             k: Path("/openid/v1/jwks")
               -> disableAccessLog()
               -> "http://127.0.0.1:8080";
-            k2: Path("/openid-configuration/keys.json")
-              -> setPath("/openid/v1/jwks")
-              -> disableAccessLog()
-              -> "http://127.0.0.1:8080";
             all: *
               -> disableAccessLog()
               -> "https://127.0.0.1:443";


### PR DESCRIPTION
With https://github.com/zalando-incubator/kubernetes-on-aws/pull/4015 merged to all channels we can get rid of supporting the old jwks path (and use Kubernetes' default).