### PR TITLE
new skipper version -  lightstep protocol 

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.13.21
+    version: v0.13.28
     component: ingress
 spec:
   strategy:
@@ -19,7 +19,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.13.21
+        version: v0.13.28
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -51,7 +51,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/teapot/skipper-internal:v0.13.21-94
+        image: registry.opensource.zalan.do/teapot/skipper-internal:v0.13.28-101
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -136,7 +136,7 @@ spec:
             tag=application=skipper-ingress
             tag=account={{ .Cluster.Alias }}
             tag=cluster={{ .Cluster.Alias }}
-            tag=artifact=registry.opensource.zalan.do/teapot/skipper:v0.13.21
+            tag=artifact=registry.opensource.zalan.do/teapot/skipper:v0.13.28
             grpc-max-msg-size={{ .ConfigItems.skipper_ingress_lightstep_grpc_max_msg_size }}
             max-period={{ .ConfigItems.skipper_ingress_lightstep_max_period }}
             min-period={{ .ConfigItems.skipper_ingress_lightstep_min_period }}


### PR DESCRIPTION
- to be able to change the lightstep protocol from grpc to http
- Improves consistent hash endpoint selection strategy
- improve redis logging
- templating for Source, SourceFromLast and ClientIP predicates
- 
Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>