### PR TITLE
PowerUser: allow get on pods/{exec, portforward, proxy}, services/proxy

### DIFF
--- a/cluster/manifests/roles/poweruser-role.yaml
+++ b/cluster/manifests/roles/poweruser-role.yaml
@@ -46,6 +46,15 @@ rules:
 - apiGroups:
   - ''
   resources:
+  - pods/exec
+  - pods/portforward
+  - pods/proxy
+  - services/proxy
+  verbs:
+  - get
+- apiGroups:
+  - ''
+  resources:
   - secrets
   verbs:
   - create


### PR DESCRIPTION
This apparently exists as a separate verb, for whatever reason. It'd be nice if Kubernetes RBAC was based on semantics, not particularities of their HTTP API, but for now let's just allow it.