### PR TITLE
Legacy spot.io deployment: add the logging policy as well

### DIFF
--- a/cluster/manifests/spotio-controller/deployment_legacy.yaml
+++ b/cluster/manifests/spotio-controller/deployment_legacy.yaml
@@ -24,6 +24,7 @@ spec:
         component: "{{ $nodePool.Name }}"
       annotations:
         config/hash: {{"secret.yaml" | manifestHash}}
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
       # TODO: run on master?
       # nodeSelector:


### PR DESCRIPTION
This was missed because of a race condition between 2 PRs. @mikkeloscar FYI