### PR TITLE
e2e-fix: Avoid zero padding of week number

### DIFF
--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -198,7 +198,7 @@ if [ "$e2e" = true ]; then
            '{timestamp: now | todate, success: ($exitStatus == 0), targetBranch: $targetBranch, author: $author, prNumber: $prNumber, head: $head, version: $buildVersion }' \
            > junit_reports/metadata.json
 
-        TARGET_DIR="$(printf "junit-reports/%04d-%02d/%s" "$(date +%Y)" "$(date +%V)" "$LOCAL_ID")"
+        TARGET_DIR="$(printf "junit-reports/%04d-%02d/%s" "$(date +%Y)" "$(date +%-V)" "$LOCAL_ID")"
         echo "Uploading test results to S3 ($TARGET_DIR)"
         aws s3 cp \
           --acl bucket-owner-full-control \


### PR DESCRIPTION
Fixes an issue where bash interprets the week numbers as an invalid octal:

```
printf "junit-reports/%04d-%02d/%s" "$(date +%Y)" "$(date +%V)" "local"
bash: printf: 08: invalid octal number
```

This issue only happens in CW08 and CW09 :sweat_smile: Fix is to avoid the zero padding in the `date` week number output.