### PR TITLE
Admission controller: add a token for the base image check

### DIFF
--- a/cluster/manifests/admission-control-credentials/credentials.yaml
+++ b/cluster/manifests/admission-control-credentials/credentials.yaml
@@ -1,14 +1,14 @@
-{{ if eq .Environment "production" }}
 apiVersion: "zalando.org/v1"
 kind: PlatformCredentialsSet
 metadata:
-   name: admission-controller-credentials
-   namespace: kube-system
-   labels:
-     application: kube-apiserver
+  name: admission-controller-credentials
+  namespace: kube-system
+  labels:
+    application: kube-apiserver
 spec:
-   application: kube-apiserver
-   tokens:
-     kio:
-       privileges: []
-{{ end }}
+  application: kube-apiserver
+  tokens:
+    kio:
+      privileges: []
+    docker-meta:
+      privileges: []


### PR DESCRIPTION
This will be needed for a follow-up PR. Additionally, deploy the PCS to all clusters, because it doesn't break anything.