### PR TITLE
Admission controller: base image validation

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -312,6 +312,8 @@ teapot_admission_controller_crd_role_provisioning_allowed_api_groups: "flink.k8s
 
 teapot_admission_controller_topology_spread: optin
 
+teapot_admission_controller_validate_base_images: "false"
+
 # etcd cluster
 {{if eq .Cluster.Environment "production"}}
 etcd_instance_count: "5"

--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -34,6 +34,11 @@ data:
   podfactory.application-label-check.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_validate_application_label }}"
   podfactory.application-label-check.minimum-creation-time: "{{ .Cluster.ConfigItems.teapot_admission_controller_application_min_creation_time }}"
 
+  podfactory.base-image-check.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_validate_base_images }}"
+{{- if index .Cluster.ConfigItems "teapot_admission_controller_validate_base_images_namespaces" }}
+  podfactory.base-image-check.namespaces: "{{ .Cluster.ConfigItems.teapot_admission_controller_validate_base_images_namespaces }}"
+{{- end }}
+
   deployment.default.rolling-update-max-surge: "{{ .Cluster.ConfigItems.teapot_admission_controller_deployment_default_max_surge }}"
   deployment.default.rolling-update-max-unavailable: "{{ .Cluster.ConfigItems.teapot_admission_controller_deployment_default_max_unavailable }}"
 

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -214,7 +214,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-99
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-106
           name: admission-controller
           lifecycle:
             preStop:
@@ -238,8 +238,9 @@ write_files:
             - --tls-key-file=/etc/kubernetes/ssl/admission-controller-key.pem
 {{- if index .Cluster.ConfigItems "application_registry_url" }}
             - --application-registry-url={{.Cluster.ConfigItems.application_registry_url}}
-            - --application-registry-token-secret-name=admission-controller-credentials
-            - --application-registry-token-secret-key=kio-token-secret
+{{- end }}
+{{- if index .Cluster.ConfigItems "docker_meta_url" }}
+            - --docker-meta-url={{.Cluster.ConfigItems.docker_meta_url}}
 {{- end }}
           ports:
             - containerPort: 8085


### PR DESCRIPTION
If `teapot_admission_controller_validate_base_images` is set to `true` (currently defaults to `false` for all clusters), enable the base image check for all pod factories (deployments/statefulsets/jobs/etc). This requires the cluster's `docker_meta_url` to be set to be meaningful; it'll be configured in the private config repo.
Additionally, if `teapot_admission_controller_validate_base_images_namespaces` is set, the validation will only run in the namespaces that match this regex (`kube-system` is allowed by default, so this setting should only be used for testing).