### PR TITLE
Admission control: validate stacksets

### DIFF
--- a/cluster/manifests/01-admission-control/teapot.yaml
+++ b/cluster/manifests/01-admission-control/teapot.yaml
@@ -145,6 +145,18 @@ webhooks:
         apiGroups: ["zalando.org"]
         apiVersions: ["v1"]
         resources: ["stacks"]
+  - name: stackset-admitter.teapot.zalan.do
+    clientConfig:
+      url: "https://localhost:8085/stackset"
+      caBundle: "{{ .ConfigItems.ca_cert_decompressed }}"
+    admissionReviewVersions: ["v1beta1"]
+    failurePolicy: Fail
+    sideEffects: "NoneOnDryRun"
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["zalando.org"]
+        apiVersions: ["v1"]
+        resources: ["stacksets"]
   - name: hpa-admitter.teapot.zalan.do
     clientConfig:
       url: "https://localhost:8085/hpa"

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -214,7 +214,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-106
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-107
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
Extend the usual checks (application labels, container resources, etc) to stacksets.