### PR TITLE
Run kube-proxy with a service account [node auth 1/X]

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -538,3 +538,9 @@ privileged_psp_enabled: "false"
 
 # TODO: remove after CLM is updated
 clm_new_userdata_path: "true"
+
+{{if eq .Cluster.Environment "production"}}
+experimental_proxy_use_serviceaccount: "false"
+{{else}}
+experimental_proxy_use_serviceaccount: "true"
+{{end}}

--- a/cluster/manifests/kube-proxy/configmap.yaml
+++ b/cluster/manifests/kube-proxy/configmap.yaml
@@ -12,7 +12,9 @@ data:
       acceptContentTypes: ""
       burst: 10
       contentType: application/vnd.kubernetes.protobuf
+{{- if ne .Cluster.ConfigItems.experimental_proxy_use_serviceaccount "true" }}
       kubeconfig: /etc/kubernetes/kubeconfig
+{{- end }}
       qps: 5
     clusterCIDR: ""
     configSyncPeriod: 15m0s

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -36,6 +36,12 @@ spec:
         - --config=/config/kube-proxy.yaml
         - --v=2
         env:
+{{- if eq .Cluster.ConfigItems.experimental_proxy_use_serviceaccount "true" }}
+        - name: KUBERNETES_SERVICE_HOST
+          value: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+        - name: KUBERNETES_SERVICE_PORT
+          value: "443"
+{{- end }}
         - name: HOSTNAME_OVERRIDE
           valueFrom:
             fieldRef:
@@ -51,22 +57,37 @@ spec:
             cpu: {{.Cluster.ConfigItems.kube_proxy_cpu}}
             memory: {{.Cluster.ConfigItems.kube_proxy_memory}}
         volumeMounts:
+{{- if eq .Cluster.ConfigItems.experimental_proxy_use_serviceaccount "true" }}
+        - name: kube-api-token
+          mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+{{- else }}
         - name: kubeconfig
           mountPath: /etc/kubernetes/kubeconfig
           readOnly: true
         - name: etc-kube-ssl
           mountPath: /etc/kubernetes/ssl
           readOnly: true
+{{- end }}
         - name: kube-proxy-config
           mountPath: /config
           readOnly: true
       volumes:
+{{- if eq .Cluster.ConfigItems.experimental_proxy_use_serviceaccount "true" }}
+      - name: kube-api-token
+        projected:
+          defaultMode: 420
+          sources:
+            - serviceAccountToken:
+                expirationSeconds: 3600
+                path: token
+{{- else }}
       - name: kubeconfig
         hostPath:
           path: /etc/kubernetes/kubeconfig
       - name: etc-kube-ssl
         hostPath:
           path: /etc/kubernetes/ssl
+{{- end }}
       - name: kube-proxy-config
         configMap:
           name: kube-proxy-config

--- a/cluster/manifests/kube-proxy/rbac.yaml
+++ b/cluster/manifests/kube-proxy/rbac.yaml
@@ -1,13 +1,9 @@
-# "fake" service account only used for attaching privileged PSP. kube-proxy will
-# use the 'kubelet' identity (via kubeconfig file) because it needs to bootstrap
-# before service IPs are avilable and therefore can't use the default
-# serviceAccount identity which would try to connect to the apiserver via the
-# service IP instead of the public address.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kube-proxy
   namespace: kube-system
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -22,3 +18,16 @@ subjects:
 - kind: ServiceAccount
   name: kube-proxy
   namespace: kube-system
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kube-proxy-node-proxier
+subjects:
+  - kind: ServiceAccount
+    name: kube-proxy
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: system:node-proxier
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This is one of the preparation steps for rolling out proper node authnz.

Currently, `kube-proxy` runs with the kubelet's hardcoded credentials that have a lot of permissions. This will be a lot more annoying to implement once we switch to node auth, and we don't really need it. Implement the following changes instead to make it better:
 * Disable token automounting for the service account (we're not using it anyway in any of the configurations)
 * Provision a proper binding for the built-in `system:node-proxier` role
 * If `experimental_proxy_use_serviceaccount` is enabled (only enabled in test for now), run kube-proxy with a mode where it picks up the in-cluster configuration, but override the API server URL to the public hostname. Additionally, use a projected token in this case, because the non-rotated ones would be blocked by our security measures.