### PR TITLE
[Cherry-pick] Support scraping Prometheus metrics via pod entities

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -196,6 +196,13 @@ prometheus_remote_max_backoff: "10s"
 # TODO: remove when kube-state-metrics is fixed
 prometheus_kube_state_metrics_drop_labels: ""
 
+# control migration from endpoint to pod based scraping entities
+# enable scraping metrics based on pod entities
+prometheus_pod_entity_scrape: "false"
+# enable scraping metrics based on endpoints entities (deprecated)
+# this is the default if prometheus_pod_entity_scrape=false
+prometheus_endpoints_entity_scrape: "false"
+
 metrics_service_cpu: "100m"
 metrics_service_mem: "200Mi"
 metrics_service_mem_max: "4Gi"

--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -20,6 +20,9 @@ spec:
         version: master-24
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "7980"
+        prometheus.io/scrape: "true"
     spec:
       serviceAccountName: audittrail-adapter
       priorityClassName: system-node-critical

--- a/cluster/manifests/coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/coredns-local/daemonset-coredns.yaml
@@ -25,6 +25,10 @@ spec:
         component: cluster-dns
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
+        prometheus.io/path: /metrics
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9153" # coredns
+        prometheus.io/sidecar-port: "9054" # dnsmasq/unbound
     spec:
       initContainers:
       - name: ensure-apiserver

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -19,6 +19,9 @@ spec:
         version: v0.7.6
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_both}}"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "7979"
+        prometheus.io/scrape: "true"
     spec:
       dnsConfig:
         options:

--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -19,6 +19,9 @@ spec:
         version: v1.18.2-internal.25
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
     spec:
       dnsConfig:
         options:

--- a/cluster/manifests/kube-node-ready-controller/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready-controller/daemonset.yaml
@@ -17,6 +17,9 @@ spec:
         application: kube-node-ready-controller
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
     spec:
       dnsConfig:
         options:

--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -18,6 +18,9 @@ spec:
         version: v0.2.7
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_both}}"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scrape: "true"
     spec:
       dnsConfig:
         options:

--- a/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
@@ -17,6 +17,9 @@ spec:
         application: kubernetes-lifecycle-metrics
         version: master-9
       annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
         kubernetes-log-watcher/scalyr-parser: '[{"container": "kubernetes-lifecycle-metrics", "parser": "system-json-escaped-json"}]'
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:

--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -180,6 +180,54 @@ data:
        - source_labels: [ __name__ ]
          regex: 'node_textfile.*'
          action: drop
+{{ if eq .Cluster.ConfigItems.prometheus_pod_entity_scrape "true" }}
+    - job_name: "kubernetes-pods"
+      scheme: http
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+            - kube-system
+      relabel_configs:
+      # Look for the Prometheus annotations and scrape based on those
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+        action: keep
+        regex: ^true$
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scheme]
+        action: replace
+        target_label: __scheme__
+        regex: (https?)
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+        action: replace
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        target_label: __address__
+      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_sidecar_port]
+        action: replace
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        target_label: __address__
+      - action: replace
+        source_labels: ['__meta_kubernetes_pod_ip']
+        target_label: pod_ip
+      - action: replace
+        source_labels: ['__meta_kubernetes_namespace']
+        target_label: namespace
+      - action: replace
+        source_labels: ['__meta_kubernetes_pod_label_application']
+        target_label: application
+      - action: replace
+        source_labels: ['__meta_kubernetes_pod_name']
+        target_label: pod_name
+      - action: replace
+        source_labels: ['__meta_kubernetes_pod_node_name']
+        target_label: node_name
+{{ end }}
+{{ if or (ne .Cluster.ConfigItems.prometheus_pod_entity_scrape "true") (eq .Cluster.ConfigItems.prometheus_endpoints_entity_scrape "true") }}
     - job_name: 'kubernetes-service-endpoints'
       scheme: http
       kubernetes_sd_configs:
@@ -218,6 +266,7 @@ data:
       - action: replace
         source_labels: ['__meta_kubernetes_pod_node_name']
         target_label: node_name
+{{ end }}
     - job_name: 'cadvisor'
       scheme: http
       honor_labels: true

--- a/cluster/manifests/prometheus/statefulset.yaml
+++ b/cluster/manifests/prometheus/statefulset.yaml
@@ -21,6 +21,10 @@ spec:
   serviceName: prometheus
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
       labels:
         application: prometheus
         version: v2.25.0

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -26,6 +26,9 @@ spec:
           [{"container": "skipper-ingress", "parser": "skipper-access-log"}]
         config/hash: {{"secret.yaml" | manifestHash}}
         logging/destination: "{{.Cluster.ConfigItems.log_destination_local}}"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9911"
+        prometheus.io/scrape: "true"
     spec:
       affinity:
         podAntiAffinity:

--- a/cluster/manifests/stackset-controller/deployment.yaml
+++ b/cluster/manifests/stackset-controller/deployment.yaml
@@ -18,6 +18,9 @@ spec:
         version: "v1.3.24"
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "7979"
+        prometheus.io/scrape: "true"
     spec:
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       serviceAccountName: stackset-controller


### PR DESCRIPTION
Cherry-picks #4086 separately to beta to have it applied before the changes causing a roll of nodes. This way the changes will be applied for OnDelete daemonset with the rollout of v1.19.8.