### PR TITLE
Fix sidecar port scrape

### DIFF
--- a/cluster/manifests/coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/coredns-local/daemonset-coredns.yaml
@@ -27,8 +27,7 @@ spec:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
         prometheus.io/path: /metrics
         prometheus.io/scrape: "true"
-        prometheus.io/port: "9153" # coredns
-        prometheus.io/sidecar-port: "9054" # dnsmasq/unbound
+        prometheus.io/port: "9153"
     spec:
       initContainers:
       - name: ensure-apiserver

--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -206,11 +206,32 @@ data:
         regex: ([^:]+)(?::\d+)?;(\d+)
         replacement: $1:$2
         target_label: __address__
-      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_sidecar_port]
-        action: replace
-        regex: ([^:]+)(?::\d+)?;(\d+)
-        replacement: $1:$2
-        target_label: __address__
+      - action: replace
+        source_labels: ['__meta_kubernetes_pod_ip']
+        target_label: pod_ip
+      - action: replace
+        source_labels: ['__meta_kubernetes_namespace']
+        target_label: namespace
+      - action: replace
+        source_labels: ['__meta_kubernetes_pod_label_application']
+        target_label: application
+      - action: replace
+        source_labels: ['__meta_kubernetes_pod_name']
+        target_label: pod_name
+      - action: replace
+        source_labels: ['__meta_kubernetes_pod_node_name']
+        target_label: node_name
+    - job_name: 'coredns-cache-metrics'
+      scheme: http
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+            - kube-system
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_application, __meta_kubernetes_pod_container_port_number]
+        action: keep
+        regex: coredns;9054
       - action: replace
         source_labels: ['__meta_kubernetes_pod_ip']
         target_label: pod_ip


### PR DESCRIPTION
Turns out what I did and argued for in https://github.com/zalando-incubator/kubernetes-on-aws/pull/4086/files#r582626549 didn't actually work for two ports in a single pod :(

This fixes the problem by introducing two almost identical jobs just the port annotation being different. It's not super pretty, but based on our previous discussion and what I found in this long prometheus issue https://github.com/prometheus/prometheus/issues/3756, then I don't have a better idea right now.

WDYT? @aermakov-zalando @jonathanbeber 