### PR TITLE
skipper tune startup

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -66,7 +66,7 @@ skipper_write_timeout_server: "60s"
 skipper_readiness_init_delay_seconds: 60
 skipper_liveness_init_delay_seconds: 30
 {{else}}
-skipper_readiness_init_delay_seconds: 31
+skipper_readiness_init_delay_seconds: 1
 skipper_liveness_init_delay_seconds: 30
 {{end}}
 

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -66,7 +66,7 @@ skipper_write_timeout_server: "60s"
 skipper_readiness_init_delay_seconds: 60
 skipper_liveness_init_delay_seconds: 30
 {{else}}
-skipper_readiness_init_delay_seconds: 1
+skipper_readiness_init_delay_seconds: 31
 skipper_liveness_init_delay_seconds: 30
 {{end}}
 

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -61,6 +61,15 @@ skipper_idle_timeout_server: "62s"
 skipper_read_timeout_server: "5m"
 skipper_write_timeout_server: "60s"
 
+# skipper startup settings
+{{if eq .Cluster.Environment "production"}}
+skipper_readiness_init_delay_seconds: 60
+skipper_liveness_init_delay_seconds: 30
+{{else}}
+skipper_readiness_init_delay_seconds: 1
+skipper_liveness_init_delay_seconds: 30
+{{end}}
+
 # skipper redis settings
 enable_dedicate_nodepool_skipper_redis: "false"
 skipper_redis_replicas: 2

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -203,7 +203,7 @@ spec:
           httpGet:
             path: /kube-system/healthz
             port: 9999
-          initialDelaySeconds: 60
+          initialDelaySeconds: "{{ .ConfigItems.skipper_readiness_init_delay_seconds }}"
           timeoutSeconds: 5
 {{ if eq .ConfigItems.skipper_local_tokeninfo "production" }}
         livenessProbe:
@@ -212,7 +212,7 @@ spec:
             port: 9021
             host: 127.0.0.1
             scheme: HTTP
-          initialDelaySeconds: 30
+          initialDelaySeconds: "{{ .ConfigItems.skipper_liveness_init_delay_seconds }}"
           periodSeconds: 10
           timeoutSeconds: 5
           successThreshold: 1
@@ -227,7 +227,7 @@ spec:
             # wget will exit with non-zero status code if the HTTP code is no 2xx.
             # production tokeinfo, sandbox tokeninfo, bridge
             - "wget -T 1 -q -O /dev/null http://127.0.0.1:9021/health; wget -T 1 -q -O /dev/null http://127.0.0.1:9121/health; wget -T 1 -q -O /dev/null http://127.0.0.1:9000/healthz"
-          initialDelaySeconds: 30
+          initialDelaySeconds: "{{ .ConfigItems.skipper_liveness_init_delay_seconds }}"
           periodSeconds: 10
           timeoutSeconds: 5
           successThreshold: 1

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -203,7 +203,7 @@ spec:
           httpGet:
             path: /kube-system/healthz
             port: 9999
-          initialDelaySeconds: "{{ .ConfigItems.skipper_readiness_init_delay_seconds }}"
+          initialDelaySeconds: {{ .ConfigItems.skipper_readiness_init_delay_seconds }}
           timeoutSeconds: 5
 {{ if eq .ConfigItems.skipper_local_tokeninfo "production" }}
         livenessProbe:
@@ -212,7 +212,7 @@ spec:
             port: 9021
             host: 127.0.0.1
             scheme: HTTP
-          initialDelaySeconds: "{{ .ConfigItems.skipper_liveness_init_delay_seconds }}"
+          initialDelaySeconds: {{ .ConfigItems.skipper_liveness_init_delay_seconds }}
           periodSeconds: 10
           timeoutSeconds: 5
           successThreshold: 1
@@ -227,7 +227,7 @@ spec:
             # wget will exit with non-zero status code if the HTTP code is no 2xx.
             # production tokeinfo, sandbox tokeninfo, bridge
             - "wget -T 1 -q -O /dev/null http://127.0.0.1:9021/health; wget -T 1 -q -O /dev/null http://127.0.0.1:9121/health; wget -T 1 -q -O /dev/null http://127.0.0.1:9000/healthz"
-          initialDelaySeconds: "{{ .ConfigItems.skipper_liveness_init_delay_seconds }}"
+          initialDelaySeconds: {{ .ConfigItems.skipper_liveness_init_delay_seconds }}
           periodSeconds: 10
           timeoutSeconds: 5
           successThreshold: 1

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/spf13/viper v1.4.0
 	github.com/szuecs/routegroup-client v0.17.8-0.20200915193527-b33447c7d964
 	github.com/zalando-incubator/kube-aws-iam-controller v0.1.2
-	github.com/zalando-incubator/stackset-controller v1.3.23
+	github.com/zalando-incubator/stackset-controller v1.3.24
 	k8s.io/api v0.19.7
 	k8s.io/apimachinery v0.19.7
 	k8s.io/apiserver v0.0.0

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -774,8 +774,8 @@ github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zalando-incubator/kube-aws-iam-controller v0.1.2 h1:uEXMHnd7wuXk3gAZ8iiOnL9XVUqA1iuDQzQFsa3ywA4=
 github.com/zalando-incubator/kube-aws-iam-controller v0.1.2/go.mod h1:7RQdyNqtYaKEWVavXUFlrE8A+QsGe/hkBba2RyG5V4o=
-github.com/zalando-incubator/stackset-controller v1.3.23 h1:8DYlQ1tA9OeR41sODiDrGZh+Y293zIp+9AkTk/0wjuM=
-github.com/zalando-incubator/stackset-controller v1.3.23/go.mod h1:DGL2RkWff0l/dJcbs5YrdIJfNf5J8HZwxE9ouRFL9us=
+github.com/zalando-incubator/stackset-controller v1.3.24 h1:fX6dvg/Prbc/uWihg8aSZQuhCdJ60Y7JQT/aprLz5VM=
+github.com/zalando-incubator/stackset-controller v1.3.24/go.mod h1:DGL2RkWff0l/dJcbs5YrdIJfNf5J8HZwxE9ouRFL9us=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.5 h1:XAzx9gjCb0Rxj7EoqcClPD1d5ZBxZJk0jbuoPHenBt0=


### PR DESCRIPTION
skipper tune startup, we use status checks to test dependencies and make sure we call LoadAll to populate routes successfully before starting the listener that can report the readinessProbe

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>