### PR TITLE
Remove custom parser from `journald-reader`

### DIFF
--- a/cluster/manifests/node-monitor/daemonset.yaml
+++ b/cluster/manifests/node-monitor/daemonset.yaml
@@ -16,7 +16,6 @@ spec:
       labels:
         application: node-monitor
       annotations:
-        kubernetes-log-watcher/scalyr-parser: '[{"container": "journald-reader", "parser": "journald"}]'
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
       hostNetwork: true


### PR DESCRIPTION
Related to https://github.com/zalando-incubator/kubernetes-on-aws/pull/3985 and https://github.com/zalando-incubator/kubernetes-on-aws/pull/3995