### PR TITLE
Add support for spot abstraction

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -328,6 +328,32 @@ teapot_admission_controller_topology_spread: optin
 
 teapot_admission_controller_validate_base_images: "false"
 
+# Supported providers: 'zalando' or 'spotio'
+teapot_admission_controller_node_lifecycle_provider: "zalando"
+
+# Enable and configure runtime-policy annotation
+{{if eq .Cluster.Environment "production"}}
+teapot_admission_controller_runtime_policy_enabled: "false"
+teapot_admission_controller_runtime_policy_default: "require-on-demand"
+{{else}}
+teapot_admission_controller_runtime_policy_enabled: "true"
+teapot_admission_controller_runtime_policy_default: "allow-spot"
+{{end}}
+# Enforce a certain policy (<empty>|allow-spot|require-on-demand) for a cluster,
+# leave empty for falling back to the default.
+teapot_admission_controller_runtime_policy_enforced: ""
+# Enable hard spot assignment. Only relevant when node_lifecycle_provider=zalando
+teapot_admission_controller_runtime_policy_spot_hard_assignment: "false"
+
+# Enable and configure prevent scale down annotation
+{{if eq .Cluster.Environment "production"}}
+teapot_admission_controller_prevent_scale_down_enabled: "false"
+teapot_admission_controller_prevent_scale_down_allowed: "true"
+{{else}}
+teapot_admission_controller_prevent_scale_down_enabled: "true"
+teapot_admission_controller_prevent_scale_down_allowed: "false"
+{{end}}
+
 # etcd cluster
 {{if eq .Cluster.Environment "production"}}
 etcd_instance_count: "5"

--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -65,3 +65,13 @@ data:
 {{- end}}
 
   node.node-not-ready-taint.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_node_not_ready_taint }}"
+
+  pod.node-lifecycle.provider: "{{ .Cluster.ConfigItems.teapot_admission_controller_node_lifecycle_provider }}"
+
+  pod.runtime-policy.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_runtime_policy_enabled }}"
+  pod.runtime-policy.default: "{{ .Cluster.ConfigItems.teapot_admission_controller_runtime_policy_default }}"
+  pod.runtime-policy.enforced: "{{ .Cluster.ConfigItems.teapot_admission_controller_runtime_policy_enforced }}"
+  pod.runtime-policy.spot-hard-assignment: "{{ .Cluster.ConfigItems.teapot_admission_controller_runtime_policy_spot_hard_assignment }}"
+
+  pod.prevent-scale-down.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_prevent_scale_down_enabled }}"
+  pod.prevent-scale-down.allowed: "{{ .Cluster.ConfigItems.teapot_admission_controller_prevent_scale_down_allowed }}"

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -214,7 +214,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-107
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-111
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
From the user perspective we introduce two pod annotations:

* **RuntimePolicy**: `zalando.org/runtime-policy=allow-spot|require-on-demand` - Pods with this annotation are either allowed to run on spot or must run on on-demand instances.
* **PreventScaleDown**: `zalando.org/prevent-scale-down=true` - Pods with this annotation doesn't get evicted from nodes where the autoscaler would like to clear a node for better packing of pods. (Less disruptions).

This is the first step of rolling out the feature where we only enable it in test clusters for now.