### PR TITLE
Update stackset controller

### DIFF
--- a/cluster/manifests/stackset-controller/deployment.yaml
+++ b/cluster/manifests/stackset-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: stackset-controller
-    version: "v1.3.24"
+    version: "v1.3.25"
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: stackset-controller
-        version: "v1.3.24"
+        version: "v1.3.25"
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
         prometheus.io/path: /metrics
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: stackset-controller
       containers:
       - name: stackset-controller
-        image: "registry.opensource.zalan.do/teapot/stackset-controller:v1.3.24"
+        image: "registry.opensource.zalan.do/teapot/stackset-controller:v1.3.25"
         args:
         - "--interval={{ .Cluster.ConfigItems.stackset_controller_sync_interval }}"
 {{- if eq .Cluster.ConfigItems.stackset_routegroup_support_enabled "true" }}

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/spf13/viper v1.4.0
 	github.com/szuecs/routegroup-client v0.17.8-0.20200915193527-b33447c7d964
 	github.com/zalando-incubator/kube-aws-iam-controller v0.1.2
-	github.com/zalando-incubator/stackset-controller v1.3.24
+	github.com/zalando-incubator/stackset-controller v1.3.25
 	k8s.io/api v0.19.7
 	k8s.io/apimachinery v0.19.7
 	k8s.io/apiserver v0.0.0

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -774,8 +774,8 @@ github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zalando-incubator/kube-aws-iam-controller v0.1.2 h1:uEXMHnd7wuXk3gAZ8iiOnL9XVUqA1iuDQzQFsa3ywA4=
 github.com/zalando-incubator/kube-aws-iam-controller v0.1.2/go.mod h1:7RQdyNqtYaKEWVavXUFlrE8A+QsGe/hkBba2RyG5V4o=
-github.com/zalando-incubator/stackset-controller v1.3.24 h1:fX6dvg/Prbc/uWihg8aSZQuhCdJ60Y7JQT/aprLz5VM=
-github.com/zalando-incubator/stackset-controller v1.3.24/go.mod h1:DGL2RkWff0l/dJcbs5YrdIJfNf5J8HZwxE9ouRFL9us=
+github.com/zalando-incubator/stackset-controller v1.3.25 h1:+A6Q3S5jvT8ca2j8Q/hVKVTyzmNFUBRLgTYvhoFrdO8=
+github.com/zalando-incubator/stackset-controller v1.3.25/go.mod h1:DGL2RkWff0l/dJcbs5YrdIJfNf5J8HZwxE9ouRFL9us=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.5 h1:XAzx9gjCb0Rxj7EoqcClPD1d5ZBxZJk0jbuoPHenBt0=


### PR DESCRIPTION
This commit updates the stackset controller to the release [v1.3.25][0].
This releases includes a fix to hash metric names labels to avoid it
gets longer than 63 characters.

[0]: https://github.com/zalando-incubator/stackset-controller/releases/tag/v1.3.25