### PR TITLE
Workers: switch to using node auth [2/X]

### DIFF
--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -64,6 +64,8 @@ data:
 {{- end }}
 {{- end}}
 
+  node.node-role-label-conversion.enable: "false"
+  node.extended-node-restriction.enable: "false"
   node.node-not-ready-taint.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_node_not_ready_taint }}"
 
   pod.node-lifecycle.provider: "{{ .Cluster.ConfigItems.teapot_admission_controller_node_lifecycle_provider }}"

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -139,7 +139,7 @@ write_files:
           - --authentication-token-webhook-config-file=/etc/kubernetes/config/authn.yaml
           - --authentication-token-webhook-cache-ttl=10s
           - --cloud-provider=aws
-          - --authorization-mode=Webhook,RBAC
+          - --authorization-mode=Node,Webhook,RBAC
           - --authorization-webhook-config-file=/etc/kubernetes/config/authz.yaml
           - --authorization-webhook-version=v1
           - --admission-control-config-file=/etc/kubernetes/config/image-policy-webhook.yaml
@@ -278,7 +278,7 @@ write_files:
               name: ssl-certs-kubernetes
               readOnly: true
 {{- end}}
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.8.0
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook-test:pr-136-15
           name: webhook
           ports:
           - containerPort: 8081
@@ -304,6 +304,9 @@ write_files:
               memory: 50Mi
           args:
             - --tokens-file=/etc/kubernetes/config/tokenfile.csv
+
+            - --node-auth-cluster-id={{.Cluster.ID}}
+            - "--node-auth-role-arn=arn:aws:iam::{{accountID .Cluster.InfrastructureAccount}}:role/{{.Cluster.LocalID}}-worker"
 
             # Collaborator roles
             - --role-mapping=Administrator=cn=Administrator,ou=collaborators,ou=Kubernetes,ou=apps,dc=zalando,dc=net
@@ -636,6 +639,7 @@ write_files:
 
   - owner: root:root
     path: /etc/kubernetes/config/tokenfile.csv
+    permissions: 0600
     content: |
       {{ .Cluster.ConfigItems.worker_shared_secret }},kubelet,kubelet
 

--- a/cluster/node-pools/worker-default/userdata.yaml
+++ b/cluster/node-pools/worker-default/userdata.yaml
@@ -38,7 +38,14 @@ write_files:
       users:
       - name: kubelet
         user:
-          token: {{ .Cluster.ConfigItems.worker_shared_secret }}
+          exec:
+            apiVersion: client.authentication.k8s.io/v1alpha1
+            command: aws
+            args:
+              - eks
+              - get-token
+              - --cluster-name
+              - "{{.Cluster.ID}}"
       contexts:
       - context:
           cluster: local


### PR DESCRIPTION
Follow-up to #4116, switch to using node auth. This changes the workers to use the AWS IAM-based tokens and changes the admission controller configuration to prepare for enablement of NodeRestriction.

**Important**: this depends on both #4116 and the changes in #4099. It should also probably use a config item instead, I'll change the PRs later.