### PR TITLE
Use spot/on-demand abstraction annotation for e2e

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -45,10 +45,10 @@ pipeline:
         name: e2e
         labels:
           application: teapot-kubernetes-e2e
+        annotations:
+          zalando.org/runtime-policy: require-on-demand
       spec:
         serviceAccountName: kubernetes-on-aws-e2e
-        nodeSelector:
-          aws.amazon.com/spot: "false"
         restartPolicy: Never
         containers:
         - name: e2e
@@ -168,10 +168,10 @@ pipeline:
         name: e2e
         labels:
           application: teapot-kubernetes-e2e
+        annotations:
+          zalando.org/runtime-policy: require-on-demand
       spec:
         serviceAccountName: kubernetes-on-aws-e2e
-        nodeSelector:
-          aws.amazon.com/spot: "false"
         restartPolicy: Never
         containers:
         - name: e2e
@@ -208,10 +208,10 @@ pipeline:
         name: e2e
         labels:
           application: teapot-kubernetes-e2e
+        annotations:
+          zalando.org/runtime-policy: require-on-demand
       spec:
         serviceAccountName: kubernetes-on-aws-e2e
-        nodeSelector:
-          aws.amazon.com/spot: "false"
         restartPolicy: Never
         containers:
         - name: e2e
@@ -249,10 +249,10 @@ pipeline:
         name: e2e
         labels:
           application: teapot-kubernetes-e2e
+        annotations:
+          zalando.org/runtime-policy: require-on-demand
       spec:
         serviceAccountName: kubernetes-on-aws-e2e
-        nodeSelector:
-          aws.amazon.com/spot: "false"
         restartPolicy: Never
         containers:
         - name: e2e


### PR DESCRIPTION
Switch to the new abstracted annotation for running on `on-demand` instances.