### PR TITLE
etcd stack: add certificate expiry tags

### DIFF
--- a/cluster/etcd-cluster.yaml
+++ b/cluster/etcd-cluster.yaml
@@ -46,6 +46,10 @@ SenzaComponents:
       Value: "etcd-cluster"
     - Key: InfrastructureComponent
       Value: true
+    - Key: certificate-expiry-ca
+      Value: "{{Arguments.CertificateExpiryCA}}"
+    - Key: certificate-expiry-node
+      Value: "{{Arguments.CertificateExpiryNode}}"
 
 SenzaInfo:
   Parameters:
@@ -83,6 +87,12 @@ SenzaInfo:
   - ClientTLSEnabled:
       Description: "Whether to enable client-side TLS"
       Default: "false"
+  - CertificateExpiryCA:
+      Description: "Timestamp when the CA certificate expires"
+      Default: ""
+  - CertificateExpiryNode:
+      Description: "Timestamp when the node certificate expires"
+      Default: ""
   StackName: etcd-cluster
 
 Outputs:


### PR DESCRIPTION
We use this for monitoring, so we should set them when we create a new stack.

Related CLM PR: https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/444.