### PR TITLE
Don't check application label on pod template of stackset

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -214,7 +214,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-111
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-113
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
Many users rely on labels from the top level stackset being injected into the pod template so they don't have to define it multiple times within a manifest.

In the previous version of the admission-controller we changed the behavior so it's no longer possible. This drops the application label check on pod template for stacksets again so we don't block users which have valid defined manifests.