### PR TITLE
Migrate to NLB with TCP healthcheck [1/x]

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -52,6 +52,7 @@ Resources:
       ToPort: 10250
     Type: 'AWS::EC2::SecurityGroupIngress'
 {{- if ne .Cluster.ConfigItems.apiserver_nlb "disabled" }}
+{{- if ne .Cluster.ConfigItems.apiserver_nlb_tcp "exclusive" }}
   MasterLoadBalancerNLB:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
@@ -109,6 +110,62 @@ Resources:
       Port: 443
       Protocol: TLS
 {{- end }}
+  MasterLoadBalancerNLBTCP:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: "{{.Cluster.LocalID}}-nlb-tcp"
+      LoadBalancerAttributes:
+        - Key: load_balancing.cross_zone.enabled
+          Value: true
+      Scheme: internet-facing
+      Subnets:
+  {{ with $values := .Values }}
+  {{ range $az := $values.availability_zones }}
+        - "{{ index $values.subnets $az }}"
+  {{ end }}
+  {{ end }}
+      Tags:
+        - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
+          Value: owned
+        - Key: "application"
+          Value: kube-apiserver
+        - Key: "component"
+          Value: "kube-apiserver"
+      Type: network
+  MasterLoadBalancerNLBTargetGroupTCP:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckIntervalSeconds: 10
+      HealthCheckPort: {{ if eq .ConfigItems.apiserver_proxy "true" }}8443{{ else }}443{{ end }}
+      HealthCheckProtocol: TCP
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 2
+      Name: "{{.Cluster.LocalID}}-nlb-tcp"
+      Port: {{ if eq .ConfigItems.apiserver_proxy "true" }}8443{{ else }}443{{ end }}
+      Protocol: TLS
+      Tags:
+        - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
+          Value: owned
+        - Key: "application"
+          Value: kube-apiserver
+        - Key: "component"
+          Value: "kube-apiserver"
+      VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
+      TargetGroupAttributes:
+        - Key: deregistration_delay.timeout_seconds
+          Value: 60
+  MasterLoadBalancerNLBListenerTCP:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      Certificates:
+        - CertificateArn: "{{.Values.load_balancer_certificate}}"
+      DefaultActions:
+      - Type: forward
+        TargetGroupArn: !Ref MasterLoadBalancerNLBTargetGroupTCP
+      LoadBalancerArn: !Ref MasterLoadBalancerNLBTCP
+      Port: 443
+      Protocol: TLS
+{{- end }}
 {{- if ne .Cluster.ConfigItems.apiserver_nlb "exclusive" }}
   MasterLoadBalancer:
     Properties:
@@ -121,7 +178,7 @@ Resources:
       HealthCheck:
         HealthyThreshold: '2'
         Interval: '10'
-        Target: 'HTTP:8080/healthz'
+        Target: 'SSL:{{ if eq .ConfigItems.apiserver_proxy "true" }}8443{{ else }}443{{ end }}'
         Timeout: '5'
         UnhealthyThreshold: '2'
       Listeners:
@@ -170,6 +227,15 @@ Resources:
   MasterLoadBalancerVersionDomain:
     Properties:
     {{- if or (eq .Cluster.ConfigItems.apiserver_nlb "active") (eq .Cluster.ConfigItems.apiserver_nlb "promoted") (eq .Cluster.ConfigItems.apiserver_nlb "exclusive") }}
+    {{- if or (eq .Cluster.ConfigItems.apiserver_nlb_tcp "active") (eq .Cluster.ConfigItems.apiserver_nlb_tcp "promoted") (eq .Cluster.ConfigItems.apiserver_nlb_tcp "exclusive") }}
+      AliasTarget:
+        DNSName: !GetAtt
+          - MasterLoadBalancerNLBTCP
+          - DNSName
+        HostedZoneId: !GetAtt
+          - MasterLoadBalancerNLBTCP
+          - CanonicalHostedZoneID
+    {{- else }}
       AliasTarget:
         DNSName: !GetAtt
           - MasterLoadBalancerNLB
@@ -177,6 +243,7 @@ Resources:
         HostedZoneId: !GetAtt
           - MasterLoadBalancerNLB
           - CanonicalHostedZoneID
+    {{- end }}
     {{- else }}
       AliasTarget:
         DNSName: !GetAtt
@@ -1945,10 +2012,16 @@ Outputs:
     Value: !Ref MasterLoadBalancer
 {{- end }}
 {{- if ne .Cluster.ConfigItems.apiserver_nlb "disabled" }}
+{{- if ne .Cluster.ConfigItems.apiserver_nlb_tcp "exclusive" }}
   MasterLoadBalancerNLBTargetGroup:
     Export:
       Name: '{{.Cluster.ID}}:master-load-balancer-nlb-target-group'
     Value: !Ref MasterLoadBalancerNLBTargetGroup
+{{- end }}
+  MasterLoadBalancerNLBTargetGroupTCP:
+    Export:
+      Name: '{{.Cluster.ID}}:master-load-balancer-nlb-tcp-target-group'
+    Value: !Ref MasterLoadBalancerNLBTargetGroupTCP
 {{- end }}
   MasterSecurityGroup:
     Export:

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -424,6 +424,16 @@ apiserver_proxy: "true"
 #
 apiserver_nlb: "exclusive"
 
+# defines temporary rollout of NLB with TCP healthcheck. This assumes
+# apiserver_nlb=exclusive. The options are:
+#
+#   hooked:    New NLB is hooked up to ASG but DNS still points to old NLB
+#   active:    New NLB will be fully functional and DNS points to the new NLB
+#   promoted:  New NLB will be fully functional and old NLB will be unhooked
+#   exclusive: New NLB will be fully functional and old NLB will be removed
+#
+apiserver_nlb_tcp: "hooked"
+
 # when set to true, service account tokens can be used from outside the cluster
 # requires apiserver_proxy to be set to "true"
 allow_external_service_accounts: "false"

--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -45,7 +45,10 @@ Resources:
 {{ end }}
 {{- if and (ne .Cluster.ConfigItems.apiserver_nlb "disabled") (ne .Cluster.ConfigItems.apiserver_nlb "provisioned") }}
       TargetGroupARNs:
+{{- if and (ne .Cluster.ConfigItems.apiserver_nlb_tcp "exclusive") (ne .Cluster.ConfigItems.apiserver_nlb_tcp "promoted") }}
       - !ImportValue '{{ .Cluster.ID }}:master-load-balancer-nlb-target-group'
+{{- end }}
+      - !ImportValue '{{ .Cluster.ID }}:master-load-balancer-nlb-tcp-target-group'
 {{- end }}
     Type: 'AWS::AutoScaling::AutoScalingGroup'
   LaunchTemplate:


### PR DESCRIPTION
This sets up migration of the control plane NLB from HTTP healthcheck to port 8080 (insecure port) to TCP 443. This is needed in preparation of #4133 

The way it works:

1. By default deploy a new NLB with the suffix `-tcp`
2. Via the `apiserver_nlb_tcp` config item control the rollout and switch to the new NLB and decommissioning of the old one.

```yaml
# defines temporary rollout of NLB with TCP healthcheck. This assumes
# apiserver_nlb=exclusive. The options are:
#
#   hooked:    New NLB is hooked up to ASG but DNS still points to old NLB
#   active:    New NLB will be fully functional and DNS points to the new NLB
#   promoted:  New NLB will be fully functional and old NLB will be unhooked
#   exclusive: New NLB will be fully functional and old NLB will be removed
#
apiserver_nlb_tcp: "hooked"
```

We have to setup a new NLB because AWS doesn't support changing the healthcheck protocol of a running NLB :facepalm: 