### PR TITLE
Allow anonymous access to openid endpoint [2/x]

### DIFF
--- a/cluster/manifests/roles/public-openid-discovery.yaml
+++ b/cluster/manifests/roles/public-openid-discovery.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: public-openid-discovery
+rules:
+- nonResourceURLs: ["/openid/v1/jwks", "/.well-known/openid-configuration"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: public-openid-discovery
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: public-openid-discovery
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: system:anonymous


### PR DESCRIPTION
As a prerequisite for #4133 we need to provision an RBAC role that allows access to the openID endpoint which is requested by AWS OIDC in order to validate the AWS IAM credentials.

We can't do it together with #4133 because the role would be applied after the APIserver has been updated.

Note this requires setting `--anonymous-auth=true` on the APIserver (in #4133) which is discouraged in the [CIS Kubernetes Benchmark](https://www.cisecurity.org/benchmark/kubernetes/) unless RBAC is enabled as is the case for us.

(snippet from the benchmark)
![image](https://user-images.githubusercontent.com/128566/111138879-c0176980-8580-11eb-83bb-d4d2752c4e92.png)
