### PR TITLE
Use existing role for anonymous OIDC discovery

### DIFF
--- a/cluster/manifests/roles/public-openid-discovery.yaml
+++ b/cluster/manifests/roles/public-openid-discovery.yaml
@@ -1,20 +1,15 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: public-openid-discovery
-rules:
-- nonResourceURLs: ["/openid/v1/jwks", "/.well-known/openid-configuration"]
-  verbs: ["get"]
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: public-openid-discovery
+  name: anonymous-service-account-issuer-discovery
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: public-openid-discovery
+  name: system:service-account-issuer-discovery
 subjects:
 - apiGroup: rbac.authorization.k8s.io
-  kind: User
-  name: system:anonymous
+  kind: Group
+  name: system:authenticated
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:unauthenticated


### PR DESCRIPTION
Update to #4143 

This uses an already existing RBAC role which does the same as what we created manually. Additionally it allows access for both `authenticated` and `unauthenticated` (Thanks for pointing it out @linki).

I will manually drop the one called `public-openid-discovery` as it's only in dev so far.