### PR TITLE
Base image check: enable by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -285,18 +285,21 @@ teapot_admission_controller_daemonset_reserved_memory: "64Gi"
 
 {{if eq .Cluster.Environment "production"}}
 teapot_admission_controller_validate_application_label: "true"
+teapot_admission_controller_validate_base_images: "true"
 teapot_admission_controller_validate_pod_template_resources: "true"
 teapot_admission_controller_preemption_enabled: "true"
 teapot_admission_controller_postgresql_delete_protection_enabled: "true"
 teapot_admission_controller_namespace_delete_protection_enabled: "true"
 {{else if eq .Cluster.Environment "e2e"}}
 teapot_admission_controller_validate_application_label: "false"
+teapot_admission_controller_validate_base_images: "false"
 teapot_admission_controller_validate_pod_template_resources: "false"
 teapot_admission_controller_preemption_enabled: "true"
 teapot_admission_controller_postgresql_delete_protection_enabled: "false"
 teapot_admission_controller_namespace_delete_protection_enabled: "false"
 {{else}}
 teapot_admission_controller_validate_application_label: "false"
+teapot_admission_controller_validate_base_images: "false"
 teapot_admission_controller_validate_pod_template_resources: "true"
 teapot_admission_controller_preemption_enabled: "false"
 teapot_admission_controller_postgresql_delete_protection_enabled: "false"
@@ -318,8 +321,6 @@ teapot_admission_controller_node_not_ready_taint: "true"
 teapot_admission_controller_crd_role_provisioning_allowed_api_groups: "flink.k8s.io"
 
 teapot_admission_controller_topology_spread: optin
-
-teapot_admission_controller_validate_base_images: "false"
 
 # Supported providers: 'zalando' or 'spotio'
 teapot_admission_controller_node_lifecycle_provider: "zalando"


### PR DESCRIPTION
It's enabled in all clusters now, let's switch to using the default instead.