### PR TITLE
Add the missing InfrastructureComponent tag to spotinst nodes

### DIFF
--- a/cluster/node-pools/worker-spotio-ocean/stack.yaml
+++ b/cluster/node-pools/worker-spotio-ocean/stack.yaml
@@ -143,6 +143,8 @@ Resources:
             tagValue: {{ .NodePool.Profile }}
           - tagKey: kubernetes.io/role/node-pool
             tagValue: "true"
+          - tagKey: InfrastructureComponent
+            tagValue: "true"
           # only node pools without taints should be attached to Ingress Load balancer
 {{- if or (not (index .NodePool.ConfigItems "taints")) (eq (index .NodePool.ConfigItems "taints") "dedicated=skipper-ingress:NoSchedule") }}
           - tagKey: zalando.org/ingress-enabled

--- a/cluster/node-pools/worker-spotio/stack.yaml
+++ b/cluster/node-pools/worker-spotio/stack.yaml
@@ -97,6 +97,8 @@ Resources:
             tagValue: {{ .NodePool.Profile }}
           - tagKey: kubernetes.io/role/node-pool
             tagValue: "true"
+          - tagKey: InfrastructureComponent
+            tagValue: "true"
           # only node pools without taints should be attached to Ingress Load balancer
 {{- if or (not (index .NodePool.ConfigItems "taints")) (eq (index .NodePool.ConfigItems "taints") "dedicated=skipper-ingress:NoSchedule") }}
           - tagKey: zalando.org/ingress-enabled


### PR DESCRIPTION
It's not propagated from the CF stack, so we have to set it manually.