### PR TITLE
Update the admission controller

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -214,7 +214,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-113
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-115
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
Follow-up to #4134. This reenables application label validation on stacksets, but this time it's implemented correctly.