### PR TITLE
Add support for STS-based node authentication

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -574,3 +574,14 @@ enable_control_plane_profiling: "false"
 clm_new_userdata_path: "true"
 
 experimental_proxy_use_serviceaccount: "true"
+
+# Defines the rollout status of the node auth feature. The possible values are:
+#
+#   disabled:   node auth is disabled on the API server side
+#   supported:  API servers support both node auth and the legacy shared secrets, NodeRestriction is disabled
+#   enabled:    same as supported, but the workers use node auth to authenticate instead of shared secrets. NodeRestriction is still disabled
+#   exclusive:  node auth is used exclusively, NodeRestriction is enabled, shared secrets are disabled
+#
+# Warning: enabling/disabling should only be done one step at a time (e.g. exclusive->enabled->supported->disabled),
+# otherwise you can end up with nodes that can't join the cluster.
+node_auth: "disabled"

--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -66,6 +66,18 @@ data:
 
   node.node-not-ready-taint.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_node_not_ready_taint }}"
 
+{{- if or (eq .Cluster.ConfigItems.node_auth "enabled") (eq .Cluster.ConfigItems.node_auth "exclusive") }}
+  node.node-role-label-conversion.enable: "false"
+{{- else }}
+  node.node-role-label-conversion.enable: "true"
+{{- end }}
+
+{{- if eq .Cluster.ConfigItems.node_auth "exclusive" }}
+  node.extended-node-restriction.enable: "true"
+{{- else }}
+  node.extended-node-restriction.enable: "false"
+{{- end }}
+
   pod.node-lifecycle.provider: "{{ .Cluster.ConfigItems.teapot_admission_controller_node_lifecycle_provider }}"
 
   pod.runtime-policy.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_runtime_policy_enabled }}"

--- a/cluster/manifests/kube-node-ready-controller/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready-controller/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: controller
-        image: pierone.stups.zalan.do/teapot/kube-node-ready-controller:master-7
+        image: pierone.stups.zalan.do/teapot/kube-node-ready-controller:master-9
         resources:
           requests:
             cpu: {{.Cluster.ConfigItems.kube_node_ready_controller_cpu}}

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -132,14 +132,14 @@ write_files:
           - --allow-privileged=true
           - --service-cluster-ip-range=10.3.0.0/16
           - --secure-port=443
-          - --enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,ExtendedResourceToleration,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota,StorageObjectInUseProtection,PodSecurityPolicy,ImagePolicyWebhook,Priority
+          - --enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,ExtendedResourceToleration,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota,StorageObjectInUseProtection,PodSecurityPolicy,ImagePolicyWebhook,Priority{{if eq .Cluster.ConfigItems.node_auth "exclusive"}},NodeRestriction{{end}}
           - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
           - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
           - --runtime-config=extensions/v1beta1/networkpolicies=true,batch/v2alpha1=true,policy/v1beta1=true,imagepolicy.k8s.io/v1alpha1=true,authorization.k8s.io/v1beta1=true,scheduling.k8s.io/v1alpha1=true,admissionregistration.k8s.io/v1beta1=true
           - --authentication-token-webhook-config-file=/etc/kubernetes/config/authn.yaml
           - --authentication-token-webhook-cache-ttl=10s
           - --cloud-provider=aws
-          - --authorization-mode=Webhook,RBAC
+          - --authorization-mode={{if ne .Cluster.ConfigItems.node_auth "disabled" }}Node,{{end}}Webhook,RBAC
           - --authorization-webhook-config-file=/etc/kubernetes/config/authz.yaml
           - --authorization-webhook-version=v1
           - --admission-control-config-file=/etc/kubernetes/config/image-policy-webhook.yaml
@@ -304,6 +304,11 @@ write_files:
               memory: 50Mi
           args:
             - --tokens-file=/etc/kubernetes/config/tokenfile.csv
+
+{{- if ne .Cluster.ConfigItems.node_auth "disabled" }}
+            - --node-auth-cluster-id={{.Cluster.ID}}
+            - "--node-auth-role-arn=arn:aws:iam::{{accountID .Cluster.InfrastructureAccount}}:role/{{.Cluster.LocalID}}-worker"
+{{- end }}
 
             # Collaborator roles
             - --role-mapping=Administrator=cn=Administrator,ou=collaborators,ou=Kubernetes,ou=apps,dc=zalando,dc=net
@@ -633,8 +638,11 @@ write_files:
 
   - owner: root:root
     path: /etc/kubernetes/config/tokenfile.csv
+    permissions: 0600
     content: |
+{{- if ne .Cluster.ConfigItems.node_auth "exclusive" }}
       {{ .Cluster.ConfigItems.worker_shared_secret }},kubelet,kubelet
+{{- end }}
 
   - owner: root:root
     path: /etc/kubernetes/config/image-policy-webhook.yaml

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -214,7 +214,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-115
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-116
           name: admission-controller
           lifecycle:
             preStop:

--- a/cluster/node-pools/worker-default/userdata.yaml
+++ b/cluster/node-pools/worker-default/userdata.yaml
@@ -38,7 +38,18 @@ write_files:
       users:
       - name: kubelet
         user:
+{{- if or (eq .Cluster.ConfigItems.node_auth "enabled") (eq .Cluster.ConfigItems.node_auth "exclusive") }}
+          exec:
+             apiVersion: client.authentication.k8s.io/v1alpha1
+             command: aws
+             args:
+               - eks
+               - get-token
+               - --cluster-name
+               - "{{.Cluster.ID}}"
+{{- else }}
           token: {{ .Cluster.ConfigItems.worker_shared_secret }}
+{{- end }}
       contexts:
       - context:
           cluster: local


### PR DESCRIPTION
This PR implements (but not enables) proper node auth instead of the hacky shared secret we use currently. The rollout is controlled by a single config item (`node_auth`) that can be set to one of the following:
 * `disabled` (default): only the auth webhook is updated, no other changes
 * `supported`: rolls the masters. Node auth support is enabled in the auth webhook and in the API server configuration, but no other changes are done.
 * `enabled`: rolls the workers. They now use AWS IAM for authentication instead of the shared secret, and the admission controller is reconfigured to disable the node relabeling in preparation for the next step. Shared secret auth still works.
 * `exclusive`: rolls the masters to remove support for the shared secrets and enable `NodeRestriction` plus the additional checks in the admission controller.

We still have a bunch of potential issues with the security side of this, but it's much better than what we have now.

**Important**: `enabled` and above also expect `experimental_proxy_use_serviceaccount` to be enabled. However I'd just enable it by default before going forward with the node auth changes because we haven't had any issues with it.