### PR TITLE
Enable node auth support by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -580,4 +580,4 @@ enable_control_plane_profiling: "false"
 #
 # Warning: enabling/disabling should only be done one step at a time (e.g. exclusive->enabled->supported->disabled),
 # otherwise you can end up with nodes that can't join the cluster.
-node_auth: "disabled"
+node_auth: "supported"


### PR DESCRIPTION
Other than sporadic DescribeInstances requests, this shouldn't have any effects. Let's enable it by default.