### PR TITLE
Set the max_pid config item as node label

### DIFF
--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -37,6 +37,9 @@ Resources:
       - Key: node.kubernetes.io/role
         PropagateAtLaunch: true
         Value: master
+      - Key: zalando.org/pod-max-pids
+        PropagateAtLaunch: true
+        Value: "{{ .NodePool.ConfigItems.pod_max_pids }}"
       VPCZoneIdentifier:
 {{ with $values := .Values }}
 {{ range $az := $values.availability_zones }}

--- a/cluster/node-pools/worker-default/stack.yaml
+++ b/cluster/node-pools/worker-default/stack.yaml
@@ -85,7 +85,6 @@ Resources:
 {{- else }}
         Value: "0"
 {{- end }}
-
 {{- if index .NodePool.ConfigItems "labels"}}
   {{- range split .NodePool.ConfigItems.labels ","}}
     {{- $label := split . "="}}
@@ -105,6 +104,9 @@ Resources:
       - Key: 'zalando.de/cluster-local-id/{{ .Cluster.LocalID }}'
         PropagateAtLaunch: true
         Value: owned
+      - Key: zalando.org/pod-max-pids
+        PropagateAtLaunch: true
+        Value: "{{ .NodePool.ConfigItems.pod_max_pids }}"
       VPCZoneIdentifier:
 {{ with $values := .Values }}
 {{ range $az := $values.availability_zones }}

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -108,6 +108,9 @@ Resources:
       - Key: 'zalando.de/cluster-local-id/{{ $data.Cluster.LocalID }}'
         PropagateAtLaunch: true
         Value: owned
+      - Key: zalando.org/pod-max-pids
+        PropagateAtLaunch: true
+        Value: "{{ $data.NodePool.ConfigItems.pod_max_pids }}"
       VPCZoneIdentifier:
         - "{{ index $data.Values.subnets $az }}"
     Type: 'AWS::AutoScaling::AutoScalingGroup'

--- a/cluster/node-pools/worker-spotio-ocean/stack.yaml
+++ b/cluster/node-pools/worker-spotio-ocean/stack.yaml
@@ -154,6 +154,8 @@ Resources:
             tagValue: launchSpec
           - tagKey: spot.io/ocean-id # used by CLM to lookup information from instance
             tagValue: !Ref SpotinstOcean
+          - tagKey: zalando.org/pod-max-pids
+            tagValue: "{{ .NodePool.ConfigItems.pod_max_pids }}"
         autoScale:
           # disable headroom/preprovisioned instances
           headrooms: []

--- a/cluster/node-pools/worker-spotio/stack.yaml
+++ b/cluster/node-pools/worker-spotio/stack.yaml
@@ -108,6 +108,8 @@ Resources:
             tagValue: launchSpec
           - tagKey: spot.io/ocean-id # used by CLM to lookup information from instance
             tagValue: !ImportValue "{{ .Cluster.ID }}:spotio-ocean-id"
+          - tagKey: zalando.org/pod-max-pids
+            tagValue: "{{ .NodePool.ConfigItems.pod_max_pids }}"
         autoScale:
           # disable headroom/preprovisioned instances
           headrooms: []


### PR DESCRIPTION
This commit adds the nodepool config item `pod_max_pids` as a label to
allow users to get the value for each pod in the monitoring.