### PR TITLE
E2E: wait for the initial cluster to stabilise

### DIFF
--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -112,6 +112,9 @@ if [ "$create_cluster" = true ]; then
             --directory="$(pwd)/$BASE_CFG_PATH" \
             --debug \
             --registry=base_cluster.yaml
+
+        # Wait for the resources to be ready
+        ./wait-for-update.py --timeout 1200
     fi
 
     # generate updated clusters.yaml
@@ -131,9 +134,9 @@ if [ "$create_cluster" = true ]; then
         --debug \
         --registry=head_cluster.yaml
 
-    # wait for resouces to be ready
+    # Wait for the resources to be ready after the update
     # TODO: make a feature of CLM --wait-for-kube-system
-    "./wait-for-update.py" --timeout 1200
+    ./wait-for-update.py --timeout 1200
 fi
 
 if [ "$e2e" = true ]; then


### PR DESCRIPTION
Because we don't pre-create the worker nodes anymore, it's likely that CLM will apply the second update before CA even starts requesting nodes. This means that updates that only change the workers will not test the rolling part because there would be no nodes to roll yet. Fix by waiting for the cluster to become ready before we proceed with the update (and then wait again after the update).
Also fixes a minor issue in wait-for-update.py where it didn't print in realtime because of Python output buffering.