### PR TITLE
kube-proxy: use SA by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -577,8 +577,4 @@ privileged_psp_enabled: "false"
 # TODO: remove after CLM is updated
 clm_new_userdata_path: "true"
 
-{{if eq .Cluster.Environment "production"}}
-experimental_proxy_use_serviceaccount: "false"
-{{else}}
 experimental_proxy_use_serviceaccount: "true"
-{{end}}


### PR DESCRIPTION
We didn't have any issues in the test clusters, let's enable it by default. Config item is still there to allow for a quick rollback, I'd like to wait another couple of weeks before dropping it fully.