### PR TITLE
Drop privileged PSP support for user workloads

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -570,10 +570,6 @@ stackset_ingress_source_switch_ttl: "5m"
 # Enable/Disable profiling for Kubernetes components
 enable_control_plane_profiling: "false"
 
-# Enable use of Privileged PSP (running privileged pods) in non system namespaces.
-# TODO: remove once all clusters have been migrated away from privileged pods
-privileged_psp_enabled: "false"
-
 # TODO: remove after CLM is updated
 clm_new_userdata_path: "true"
 

--- a/cluster/manifests/roles/priviliged_psp_cluster_role.yaml
+++ b/cluster/manifests/roles/priviliged_psp_cluster_role.yaml
@@ -2,10 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: privileged-psp
-{{ if eq .Cluster.ConfigItems.privileged_psp_enabled "true"}}
-  labels:
-    rbac.authorization.k8s.io/aggregate-to-poweruser: "true"
-{{ end }}
 rules:
 - apiGroups:
   - extensions

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -278,7 +278,7 @@ write_files:
               name: ssl-certs-kubernetes
               readOnly: true
 {{- end}}
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:v0.8.1
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:master-111
           name: webhook
           ports:
           - containerPort: 8081


### PR DESCRIPTION
We migrated all clusters away from using privileged PSP.

This PR:

 1. Removes the config_item that is no longer needed.
 2. Updates the authnz webhook to not support privileged PSP for legacy `operator` service account.