### PR TITLE
Promote TCP NLB for e2e [3/X]

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -433,7 +433,7 @@ apiserver_nlb: "exclusive"
 #   promoted:  New NLB will be fully functional and old NLB will be unhooked
 #   exclusive: New NLB will be fully functional and old NLB will be removed
 #
-apiserver_nlb_tcp: "hooked"
+apiserver_nlb_tcp: "promoted"
 
 # when set to true, service account tokens can be used from outside the cluster
 # requires apiserver_proxy to be set to "true"


### PR DESCRIPTION
This has already been done for all clusters via config items. However in order to drop the old NLB also in e2e, we need to promote it first.