### PR TITLE
Support protocol in sg ingress ranges

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -419,7 +419,7 @@ Resources:
 {{- range $index, $element := sgIngressRanges .Cluster.ConfigItems.open_sg_ingress_ranges }}
         - CidrIp: {{ $element.CIDR }}
           FromPort: {{ $element.FromPort }}
-          IpProtocol: tcp
+          IpProtocol: {{ $element.Protocol }}
           ToPort: {{ $element.ToPort }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Allow customizing protocol in SG ingress ranges. Defaults to `tcp`.

Depends on https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/446