### PR TITLE
Increase the default instance sizes to avoid creating too many instances

### DIFF
--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -57,7 +57,7 @@ clusters:
     min_size: 1
     max_size: 2
   - discount_strategy: spot
-    instance_types: ["m4.large", "m5.large", "m5.xlarge", "m4.xlarge"]
+    instance_types: ["m5.xlarge", "m4.xlarge", "m4.2xlarge", "m5.2xlarge"]
     name: default-worker-splitaz
     profile: worker-splitaz
     min_size: 0
@@ -65,13 +65,13 @@ clusters:
     config_items:
       cpu_manager_policy: static
   - discount_strategy: spot
-    instance_types: ["m4.large", "m5.large", "m5.xlarge", "m4.xlarge"]
+    instance_types: ["m5.xlarge", "m4.xlarge", "m4.2xlarge", "m5.2xlarge"]
     name: default-worker
     profile: worker-default
     min_size: 0
     max_size: 21
   - discount_strategy: spot
-    instance_types: ["m4.large", "m5.large", "m5.xlarge", "m4.xlarge"]
+    instance_types: ["m5.xlarge", "m4.xlarge", "m4.2xlarge", "m5.2xlarge"]
     config_items:
       availability_zones: "eu-central-1a"
       scaling_priority: "-100"
@@ -80,7 +80,7 @@ clusters:
     min_size: 0
     max_size: 21
   - discount_strategy: spot
-    instance_types: ["m5d.large", "m5d.xlarge", "m5d.2xlarge"]
+    instance_types: ["m5d.xlarge", "m5d.2xlarge"]
     name: worker-instance-storage
     profile: worker-default
     min_size: 0


### PR DESCRIPTION
We run a lot of things by default, and in practice never get the smaller instances anyway. Avoid scale downs and extra node rotations by creating bigger instances from the start.