### PR TITLE
[cherry-pick] Update image-policy-webhook

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -418,7 +418,7 @@ write_files:
           - name: BUSINESS_PARTNERS
             value: {{ .Cluster.ConfigItems.apiserver_business_partner_ids }}
 {{ end }}
-        - image: registry.opensource.zalan.do/teapot/image-policy-webhook:v0.5.5
+        - image: registry.opensource.zalan.do/teapot/image-policy-webhook:v0.5.6
           name: image-policy-webhook
           args:
           - --policy={{ .Cluster.ConfigItems.image_policy }}


### PR DESCRIPTION
Cherry-pick of #4175 to `alpha` to avoid being blocked by the 1.19.9 update.