### PR TITLE
Use HTTPS for Control Plane LB health checks

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -52,6 +52,7 @@ Resources:
       ToPort: 10250
     Type: 'AWS::EC2::SecurityGroupIngress'
 {{- if ne .Cluster.ConfigItems.apiserver_nlb "disabled" }}
+{{- if ne .Cluster.ConfigItems.apiserver_nlb_https "exclusive" }}
   MasterLoadBalancerNLBTCP:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
@@ -108,6 +109,63 @@ Resources:
       Port: 443
       Protocol: TLS
 {{- end }}
+  MasterLoadBalancerNLB:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: "{{.Cluster.LocalID}}-nlb"
+      LoadBalancerAttributes:
+        - Key: load_balancing.cross_zone.enabled
+          Value: true
+      Scheme: internet-facing
+      Subnets:
+  {{ with $values := .Values }}
+  {{ range $az := $values.availability_zones }}
+        - "{{ index $values.subnets $az }}"
+  {{ end }}
+  {{ end }}
+      Tags:
+        - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
+          Value: owned
+        - Key: "application"
+          Value: kube-apiserver
+        - Key: "component"
+          Value: "kube-apiserver"
+      Type: network
+  MasterLoadBalancerNLBTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckIntervalSeconds: 10
+      HealthCheckPort: {{ if eq .ConfigItems.apiserver_proxy "true" }}8443{{ else }}443{{ end }}
+      HealthCheckProtocol: HTTPS
+      HealthCheckPath: "/healthz"
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 2
+      Name: "{{.Cluster.LocalID}}-nlb"
+      Port: {{ if eq .ConfigItems.apiserver_proxy "true" }}8443{{ else }}443{{ end }}
+      Protocol: TLS
+      Tags:
+        - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
+          Value: owned
+        - Key: "application"
+          Value: kube-apiserver
+        - Key: "component"
+          Value: "kube-apiserver"
+      VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
+      TargetGroupAttributes:
+        - Key: deregistration_delay.timeout_seconds
+          Value: 60
+  MasterLoadBalancerNLBListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      Certificates:
+        - CertificateArn: "{{.Values.load_balancer_certificate}}"
+      DefaultActions:
+      - Type: forward
+        TargetGroupArn: !Ref MasterLoadBalancerNLBTargetGroup
+      LoadBalancerArn: !Ref MasterLoadBalancerNLB
+      Port: 443
+      Protocol: TLS
+{{- end }}
 {{- if ne .Cluster.ConfigItems.apiserver_nlb "exclusive" }}
   MasterLoadBalancer:
     Properties:
@@ -120,7 +178,7 @@ Resources:
       HealthCheck:
         HealthyThreshold: '2'
         Interval: '10'
-        Target: 'SSL:{{ if eq .ConfigItems.apiserver_proxy "true" }}8443{{ else }}443{{ end }}'
+        Target: 'HTTPS:{{ if eq .ConfigItems.apiserver_proxy "true" }}8443{{ else }}443{{ end }}/healthz'
         Timeout: '5'
         UnhealthyThreshold: '2'
       Listeners:
@@ -169,6 +227,15 @@ Resources:
   MasterLoadBalancerVersionDomain:
     Properties:
     {{- if or (eq .Cluster.ConfigItems.apiserver_nlb "active") (eq .Cluster.ConfigItems.apiserver_nlb "promoted") (eq .Cluster.ConfigItems.apiserver_nlb "exclusive") }}
+    {{- if or (eq .Cluster.ConfigItems.apiserver_nlb_https "active") (eq .Cluster.ConfigItems.apiserver_nlb_https "promoted") (eq .Cluster.ConfigItems.apiserver_nlb_https "exclusive") }}
+      AliasTarget:
+        DNSName: !GetAtt
+          - MasterLoadBalancerNLB
+          - DNSName
+        HostedZoneId: !GetAtt
+          - MasterLoadBalancerNLB
+          - CanonicalHostedZoneID
+    {{- else }}
       AliasTarget:
         DNSName: !GetAtt
           - MasterLoadBalancerNLBTCP
@@ -176,6 +243,7 @@ Resources:
         HostedZoneId: !GetAtt
           - MasterLoadBalancerNLBTCP
           - CanonicalHostedZoneID
+    {{- end }}
     {{- else }}
       AliasTarget:
         DNSName: !GetAtt
@@ -1944,10 +2012,16 @@ Outputs:
     Value: !Ref MasterLoadBalancer
 {{- end }}
 {{- if ne .Cluster.ConfigItems.apiserver_nlb "disabled" }}
+{{- if ne .Cluster.ConfigItems.apiserver_nlb_https "exclusive" }}
   MasterLoadBalancerNLBTargetGroupTCP:
     Export:
       Name: '{{.Cluster.ID}}:master-load-balancer-nlb-tcp-target-group'
     Value: !Ref MasterLoadBalancerNLBTargetGroupTCP
+{{- end }}
+  MasterLoadBalancerNLBTargetGroup:
+    Export:
+      Name: '{{.Cluster.ID}}:master-load-balancer-nlb-target-group'
+    Value: !Ref MasterLoadBalancerNLBTargetGroup
 {{- end }}
   MasterSecurityGroup:
     Export:

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -425,6 +425,16 @@ apiserver_proxy: "true"
 #
 apiserver_nlb: "exclusive"
 
+# defines temporary rollout of NLB with HTTPS healthcheck. This assumes
+# apiserver_nlb=exclusive. The options are:
+#
+#   hooked:    New NLB is hooked up to ASG but DNS still points to old NLB
+#   active:    New NLB will be fully functional and DNS points to the new NLB
+#   promoted:  New NLB will be fully functional and old NLB will be unhooked
+#   exclusive: New NLB will be fully functional and old NLB will be removed
+#
+apiserver_nlb_https: "hooked"
+
 # when set to true, service account tokens can be used from outside the cluster
 # requires apiserver_proxy to be set to "true"
 allow_external_service_accounts: "false"

--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -48,7 +48,10 @@ Resources:
 {{ end }}
 {{- if and (ne .Cluster.ConfigItems.apiserver_nlb "disabled") (ne .Cluster.ConfigItems.apiserver_nlb "provisioned") }}
       TargetGroupARNs:
+{{- if and (ne .Cluster.ConfigItems.apiserver_nlb_https "exclusive") (ne .Cluster.ConfigItems.apiserver_nlb_https "promoted") }}
       - !ImportValue '{{ .Cluster.ID }}:master-load-balancer-nlb-tcp-target-group'
+{{- end }}
+      - !ImportValue '{{ .Cluster.ID }}:master-load-balancer-nlb-target-group'
 {{- end }}
     Type: 'AWS::AutoScaling::AutoScalingGroup'
   LaunchTemplate:


### PR DESCRIPTION
In #4138 we introduced a way to migrate to TCP based health check (instead of `HTTP`). Turns out I read the docs wrong :facepalm: and we can use `HTTPS` instead which will avoid error logs on the skipper-proxy.

```
2021/03/22 13:15:22 http: TLS handshake error from 172.31.7.147:2250: EOF
2021/03/22 13:15:22 http: TLS handshake error from 172.31.3.130:36167: EOF
2021/03/22 13:15:22 http: TLS handshake error from 172.31.16.106:27014: EOF
 ```

This implements the same (convoluted) migration path as in #4138 but from TCP to HTTPS instead of HTTP to TCP. As always we need to create a new LB and switch DNS as you can't modify the health check protocol of a running NLB :man_facepalming: 

```yaml
# defines temporary rollout of NLB with HTTPS healthcheck. This assumes
# apiserver_nlb=exclusive. The options are:
#
#   hooked:    New NLB is hooked up to ASG but DNS still points to old NLB
#   active:    New NLB will be fully functional and DNS points to the new NLB
#   promoted:  New NLB will be fully functional and old NLB will be unhooked
#   exclusive: New NLB will be fully functional and old NLB will be removed
#
apiserver_nlb_https: "hooked"
```