### PR TITLE
Restart ExternalDNS after update just in case it's stuck

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -172,3 +172,7 @@ post_apply:
 - name: coredns-local-dnsmasq
   namespace: kube-system
   kind: Service
+- labels:
+    application: external-dns
+  namespace: kube-system
+  kind: Pod


### PR DESCRIPTION
Sometimes ExternalDNS gets stuck during master-rolling updates.

As a short-term solution restart ExternalDNS as part of the final apply phase to unblock it just in case it got stuck.