### PR TITLE
Add basic support for Okta auth

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -576,3 +576,7 @@ enable_control_plane_profiling: "false"
 # Warning: enabling/disabling should only be done one step at a time (e.g. exclusive->enabled->supported->disabled),
 # otherwise you can end up with nodes that can't join the cluster.
 node_auth: "supported"
+
+okta_auth_enabled: "false"
+okta_auth_issuer_url: ""
+okta_auth_client_id: "kubernetes.cluster.{{.Cluster.Alias}}"

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -176,3 +176,7 @@ post_apply:
     application: external-dns
   namespace: kube-system
   kind: Pod
+{{- if ne .Cluster.ConfigItems.okta_auth_enabled "true" }}
+- name: cluster-admin-okta
+  kind: ClusterRoleBinding
+{{- end }}

--- a/cluster/manifests/roles/cluster-admin-binding.yaml
+++ b/cluster/manifests/roles/cluster-admin-binding.yaml
@@ -1,0 +1,14 @@
+{{- if eq .Cluster.ConfigItems.okta_auth_enabled "true" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-admin-okta
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: okta:common/administrator
+{{- end }}

--- a/cluster/manifests/roles/collaborator-roles.yaml
+++ b/cluster/manifests/roles/collaborator-roles.yaml
@@ -34,3 +34,8 @@ subjects:
 - kind: Group
   name: CollaboratorEmergency
   apiGroup: rbac.authorization.k8s.io
+{{- if eq .Cluster.ConfigItems.okta_auth_enabled "true" }}
+- kind: Group
+  name: "okta:common/collaborator"
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/cluster/manifests/roles/poweruser-binding.yaml
+++ b/cluster/manifests/roles/poweruser-binding.yaml
@@ -21,3 +21,11 @@ subjects:
 - kind: Group
   name: Emergency
   apiGroup: rbac.authorization.k8s.io
+{{- if eq .Cluster.ConfigItems.okta_auth_enabled "true" }}
+- kind: Group
+  name: "okta:common/engineer"
+  apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: "okta:common/collaborator"
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/cluster/manifests/roles/readonly-binding.yaml
+++ b/cluster/manifests/roles/readonly-binding.yaml
@@ -12,6 +12,12 @@ subjects:
   apiGroup: rbac.authorization.k8s.io
 {{- if eq .Cluster.ConfigItems.okta_auth_enabled "true" }}
 - kind: Group
+  name: "okta:common/engineer"
+  apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: "okta:common/collaborator"
+  apiGroup: rbac.authorization.k8s.io
+- kind: Group
   name: "okta:common/read-only"
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/cluster/manifests/roles/readonly-binding.yaml
+++ b/cluster/manifests/roles/readonly-binding.yaml
@@ -10,3 +10,8 @@ subjects:
 - kind: Group
   name: ReadOnly
   apiGroup: rbac.authorization.k8s.io
+{{- if eq .Cluster.ConfigItems.okta_auth_enabled "true" }}
+- kind: Group
+  name: "okta:common/read-only"
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -127,6 +127,14 @@ write_files:
           - --authorization-webhook-version=v1
           - --token-auth-file=/etc/kubernetes/config/tokenfile.csv
           - --admission-control-config-file=/etc/kubernetes/config/image-policy-webhook.yaml
+{{- if eq .Cluster.ConfigItems.okta_auth_enabled "true" }}
+          - --oidc-issuer-url={{.Cluster.ConfigItems.okta_auth_issuer_url}}
+          - --oidc-client-id={{.Cluster.ConfigItems.okta_auth_client_id}}
+          - --oidc-username-claim=email
+          - "--oidc-username-prefix=okta:"
+          - --oidc-groups-claim=groups
+          - "--oidc-groups-prefix=okta:"
+{{- end }}
           - --feature-gates=TTLAfterFinished=true,BoundServiceAccountTokenVolume={{ .Cluster.ConfigItems.rotate_service_account_tokens }},HPAScaleToZero={{ .Cluster.ConfigItems.enable_hpa_scale_to_zero }},VolumeSnapshotDataSource={{ .Cluster.ConfigItems.enable_csi_migration }},CSIMigration={{ .Cluster.ConfigItems.enable_csi_migration }},NonPreemptingPriority=true,EphemeralContainers={{ .Cluster.ConfigItems.enable_ephemeral_containers }},GenericEphemeralVolume={{ .Cluster.ConfigItems.enable_generic_ephemeral_volume }},SetHostnameAsFQDN={{ .Cluster.ConfigItems.enable_hostname_as_fqdn }},ServiceAccountIssuerDiscovery=true
           - --service-account-key-file=/etc/kubernetes/ssl/service-account-public-key.pem
           - --service-account-signing-key-file=/etc/kubernetes/ssl/service-account-private-key.pem


### PR DESCRIPTION
This PR implements very basic support for Okta auth. If `okta_auth_enabled` is set to `true`, the API server is configured with an OIDC provider at `okta_auth_issuer_url`, using `okta_auth_client_id` for the client ID (defaults to `kubernetes.cluster.<alias>`, but can be customised for things like e2e/pet clusters). Users and groups will be prefixed with `okta:`, and the bindings for ReadOnly/PowerUser/Collaborator would include the corresponding Okta groups (`common/read-only`, `common/engineer` and `common/collaborator`).

The auth webhook and the admission controller are updated to add support for an extra administrator role in addition to `system:masters` (`okta:common/administrator`).