### PR TITLE
Add liveness probe to unbound DNS cache

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -458,6 +458,8 @@ dns_cache: "dnsmasq"
 dns_cache: "unbound"
 {{ end }}
 
+expirimental_dns_unbound_liveness_probe: "true"
+
 # DNS container resources
 dns_dnsmasq_cpu: "100m"
 dns_dnsmasq_mem: "50Mi"

--- a/cluster/manifests/coredns-local/configmap-local.yaml
+++ b/cluster/manifests/coredns-local/configmap-local.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   unbound.conf: |
     server:
-      directory: "/opt/unbound/etc/unbound/"
+      directory: "/etc/unbound/"
       interface: 0.0.0.0
       interface-automatic: yes
       # Drop user privileges after binding the port.

--- a/cluster/manifests/coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/coredns-local/daemonset-coredns.yaml
@@ -43,7 +43,11 @@ spec:
       containers:
 {{ if eq .Cluster.ConfigItems.dns_cache "unbound" }}
       - name: unbound
-        image: registry.opensource.zalan.do/teapot/unbound:1.13.1
+        image: registry.opensource.zalan.do/teapot/unbound:1.13.1-1
+        args:
+        - -d
+        - -c
+        - /etc/unbound/unbound.conf
         ports:
         - containerPort: 53
           name: dns-udp
@@ -51,6 +55,18 @@ spec:
         - containerPort: 53
           name: dns-tcp
           protocol: TCP
+{{- if eq .Cluster.ConfigItems.expirimental_dns_unbound_liveness_probe "true" }}
+        livenessProbe:
+          exec:
+            command:
+            - dig
+            - "+short"
+            - "@127.0.0.1"
+            - "kubernetes.default.svc.cluster.local"
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 5
+{{- end }}
         resources:
           requests:
             ephemeral-storage: 256Mi
@@ -58,7 +74,7 @@ spec:
             cpu: {{.Cluster.ConfigItems.dns_unbound_cpu}}
             memory: {{.Cluster.ConfigItems.dns_unbound_mem}}
         volumeMounts:
-        - mountPath: /opt/unbound/etc/unbound/unbound.conf
+        - mountPath: /etc/unbound/unbound.conf
           name: config-volume
           readOnly: true
           subPath: unbound.conf


### PR DESCRIPTION
This adds a `livenessProbe` to the unbound DNS cache container which uses `dig` to check if the internal kubernetes apiserver service endpoint is resolvable.

The purpose of this is to detect if `unbound` gets stuck for some reason such that it can be killed and re-created.

Depends on a new `unbound` image with `dig` (internal PR).