### PR TITLE
Worker SG: allow UDP as well

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -390,6 +390,10 @@ Resources:
           IpProtocol: tcp
           ToPort: 32767
         - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+          FromPort: 30000
+          IpProtocol: udp
+          ToPort: 32767
+        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
           FromPort: 53
           IpProtocol: tcp
           ToPort: 53


### PR DESCRIPTION
Open up the UDP port range for the VPC in addition to TCP ports.