### PR TITLE
Cleanup the metrics for the apiserver components [1/2]

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -403,6 +403,17 @@ Resources:
         - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
           Value: owned
     Type: 'AWS::EC2::SecurityGroupIngress'
+  MasterSecurityGroupIngressFromWorkerToSkipperMetrics:
+    Properties:
+      FromPort: 9005
+      ToPort: 9005
+      GroupId: !Ref MasterSecurityGroup
+      IpProtocol: tcp
+      SourceSecurityGroupId: !Ref WorkerSecurityGroup
+      Tags:
+        - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
+          Value: owned
+    Type: 'AWS::EC2::SecurityGroupIngress'
   WorkerSecurityGroup:
     Properties:
       GroupDescription: !Ref 'AWS::StackName'

--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -84,7 +84,8 @@ data:
     - job_name: 'kubernetes-apiservers'
       scheme: https
       tls_config:
-        insecure_skip_verify: true
+        ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+        server_name: "kubernetes.default.svc.cluster.local"
       bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
       kubernetes_sd_configs:
       - role: pod
@@ -98,10 +99,10 @@ data:
       - action: replace
         source_labels: ['__meta_kubernetes_pod_label_application']
         target_label: application
-    - job_name: 'teapot-admission-controller'
-      scheme: https
-      tls_config:
-        insecure_skip_verify: true
+    - &apiserver_container_metric
+      job_name: 'teapot-admission-controller'
+      scheme: http
+      metrics_path: "/admission-controller"
       kubernetes_sd_configs:
       - role: pod
         namespaces:
@@ -110,26 +111,22 @@ data:
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_label_application, __meta_kubernetes_pod_container_port_number]
         action: keep
-        regex: kube-apiserver;8085
+        regex: kube-apiserver;9005
       - action: replace
         source_labels: ['__meta_kubernetes_pod_label_application']
         target_label: application
-    - job_name: 'routegroups-admission-webhook'
-      scheme: https
-      tls_config:
-        insecure_skip_verify: true
-      kubernetes_sd_configs:
-        - role: pod
-          namespaces:
-            names:
-              - kube-system
-      relabel_configs:
-        - source_labels: [__meta_kubernetes_pod_label_application, __meta_kubernetes_pod_container_port_number]
-          action: keep
-          regex: kube-apiserver;9085
-        - action: replace
-          source_labels: ['__meta_kubernetes_pod_label_application']
-          target_label: application
+    - <<: *apiserver_container_metric
+      job_name: "auth-webhook"
+      metrics_path: "/auth-webhook"
+    - <<: *apiserver_container_metric
+      job_name: "routegroups-admission-webhook"
+      metrics_path: "/routegroups-admission-webhook"
+    - <<: *apiserver_container_metric
+      job_name: "image-policy-webhook"
+      metrics_path: "/image-policy-webhook"
+    - <<: *apiserver_container_metric
+      job_name: "aws-encryption-provider"
+      metrics_path: "/aws-encryption-provider"
     - job_name: 'kube-state-metrics'
       scheme: http
       honor_labels: true

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -233,7 +233,7 @@ write_files:
               readOnly: true
 {{- if or (eq .Cluster.ConfigItems.routegroups_validation "provisioned") (eq .Cluster.ConfigItems.routegroups_validation "enabled") }}
         - name: routegroups-admission-webhook
-          image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.151
+          image: registry.opensource.zalan.do/teapot/skipper:v0.13.48
           args:
             - webhook
             - --address=:9085
@@ -412,7 +412,7 @@ write_files:
               exec:
                 command: ["/bin/sh", "-c",  " sleep 60"]
         - name: skipper-proxy
-          image: registry.opensource.zalan.do/pathfinder/skipper:v0.11.150
+          image: registry.opensource.zalan.do/teapot/skipper:v0.13.48
           args:
           - skipper
           - -access-log-strip-query
@@ -462,6 +462,68 @@ write_files:
           - mountPath: /etc/kubernetes/ssl
             name: ssl-certs-kubernetes
             readOnly: true
+        - name: skipper-metrics
+          image: registry.opensource.zalan.do/teapot/skipper:v0.13.48
+          args:
+          - skipper
+          - -access-log-strip-query
+          - -address=:9005
+          - -support-listener=:9905
+          - -insecure
+          - -runtime-metrics
+          - -enable-connection-metrics
+          - -enable-prometheus-metrics
+          - -write-timeout-server=60m
+          - -inline-routes
+          - |
+            admission_controller: Path("/admission-controller")
+              -> disableAccessLog()
+              -> setPath("/metrics")
+              -> "https://127.0.0.1:8085";
+            auth_webhook: Path("/auth-webhook")
+              -> disableAccessLog()
+              -> setPath("/metrics")
+              -> "http://127.0.0.1:8081";
+            routegroups_admission_webhook: Path("/routegroups-admission-webhook")
+              -> disableAccessLog()
+              -> setPath("/metrics")
+              -> "https://127.0.0.1:9085";
+            image_policy_webhook: Path("/image-policy-webhook")
+              -> disableAccessLog()
+              -> setPath("/metrics")
+              -> "http://127.0.0.1:8083";
+            aws_encryption_provider: Path("/aws-encryption-provider")
+              -> disableAccessLog()
+              -> setPath("/metrics")
+              -> "http://localhost:8086";
+            skipper_proxy: Path("/skipper-proxy")
+              -> disableAccessLog()
+              -> setPath("/metrics")
+              -> "http://127.0.0.1:9911";
+            skipper_metrics: Path("/skipper-metrics")
+              -> disableAccessLog()
+              -> setPath("/metrics")
+              -> "http://127.0.0.1:9905";
+            healthz: Path("/healthz")
+              -> disableAccessLog()
+              -> status(200)
+              -> inlineContent("ok")
+              -> <shunt>;
+          ports:
+          - containerPort: 9005
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 9005
+            timeoutSeconds: 5
+          resources:
+            requests:
+              cpu: 100m
+              memory: 250Mi
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
         - name: aws-encryption-provider
           image: registry.opensource.zalan.do/teapot/aws-encryption-provider:master-1
           command:


### PR DESCRIPTION
The current setup for the API server components leaves a lot to be desired:
 * metrics for some of them aren't scraped at all
 * we have to open the component's port to scrape it, even though they have other endpoints that should not be accessible
 * these ports are opened to the whole VPC instead of only the workers (or even something with auth).

This PR improves that. Instead of continuing with the current approach, we instead add a new skipper container that proxies the metrics of other API server components, and then configure them as individual Prometheus targets.

In addition to that, it also updates all the Skipper images in the API server to something that's not ancient, and fixes the TLS configuration for the API server target.