### PR TITLE
Master SG: drop the ingress rules that were only used for metrics [2/2]

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -280,25 +280,9 @@ Resources:
           IpProtocol: tcp
           ToPort: 22
         - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 8085
-          IpProtocol: tcp
-          ToPort: 8085
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 9085
-          IpProtocol: tcp
-          ToPort: 9085
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
           FromPort: 7980
           IpProtocol: tcp
           ToPort: 7980
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 8083
-          IpProtocol: tcp
-          ToPort: 8083
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 9911
-          IpProtocol: tcp
-          ToPort: 9911
         - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
           FromPort: 30080
           IpProtocol: tcp


### PR DESCRIPTION
These are now exposed via a dedicated Skipper (see #4199), so we can drop the ingress rules.

**Warning**: #4199 should be fully applied first, otherwise some of the metrics will be unavailable until the update is finished.