### PR TITLE
Update k8s-dns images

### DIFF
--- a/cluster/manifests/coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/coredns-local/daemonset-coredns.yaml
@@ -96,7 +96,7 @@ spec:
 {{ end }}
 {{ if eq .Cluster.ConfigItems.dns_cache "dnsmasq" }}
       - name: dnsmasq
-        image: registry.opensource.zalan.do/teapot/k8s-dns-dnsmasq-nanny-amd64:1.15.7-1
+        image: registry.opensource.zalan.do/teapot/k8s-dns-dnsmasq-nanny-amd64:1.17.1
         securityContext:
           privileged: true
         livenessProbe:
@@ -138,7 +138,7 @@ spec:
             cpu: {{.Cluster.ConfigItems.dns_dnsmasq_cpu}}
             memory: {{.Cluster.ConfigItems.dns_dnsmasq_mem}}
       - name: sidecar
-        image: registry.opensource.zalan.do/teapot/k8s-dns-sidecar-amd64:1.15.7-1
+        image: registry.opensource.zalan.do/teapot/k8s-dns-sidecar-amd64:1.17.1
         securityContext:
           privileged: true
         livenessProbe:


### PR DESCRIPTION
This commit updates the versions of dnsmasq and dns-sidecar from 1.15.7 to 1.17.1.
Releases: https://github.com/kubernetes/dns/releases.