### PR TITLE
Revert "Worker SG: allow UDP as well"

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -469,10 +469,6 @@ Resources:
           IpProtocol: tcp
           ToPort: 32767
         - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 30000
-          IpProtocol: udp
-          ToPort: 32767
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
           FromPort: 53
           IpProtocol: tcp
           ToPort: 53


### PR DESCRIPTION
We don't actually have any users for this, and we've agreed that we could do better even with the TCP setup. Let's revert this for now.