### PR TITLE
Drop Muaaz and Henning from the approvers

### DIFF
--- a/.zappr.yaml
+++ b/.zappr.yaml
@@ -13,11 +13,9 @@ approvals:
         users:
           - aermakov-zalando
           - gargravarr
-          - hjacobs
           - jrake-revelant
           - linki
           - mikkeloscar
-          - muaazsaleem
           - szuecs
           - aryszka
           - jonathanbeber


### PR DESCRIPTION
Truncate this to only the active team members.