### PR TITLE
Cleanup config items

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -79,12 +79,12 @@ Resources:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
       HealthCheckIntervalSeconds: 10
-      HealthCheckPort: {{ if eq .ConfigItems.apiserver_proxy "true" }}8443{{ else }}443{{ end }}
+      HealthCheckPort: 8443
       HealthCheckProtocol: TCP
       HealthyThresholdCount: 2
       UnhealthyThresholdCount: 2
       Name: "{{.Cluster.LocalID}}-nlb-tcp"
-      Port: {{ if eq .ConfigItems.apiserver_proxy "true" }}8443{{ else }}443{{ end }}
+      Port: 8443
       Protocol: TLS
       Tags:
         - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
@@ -135,13 +135,13 @@ Resources:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
       HealthCheckIntervalSeconds: 10
-      HealthCheckPort: {{ if eq .ConfigItems.apiserver_proxy "true" }}8443{{ else }}443{{ end }}
+      HealthCheckPort: 8443
       HealthCheckProtocol: HTTPS
       HealthCheckPath: "/readyz"
       HealthyThresholdCount: 2
       UnhealthyThresholdCount: 2
       Name: "{{.Cluster.LocalID}}-nlb"
-      Port: {{ if eq .ConfigItems.apiserver_proxy "true" }}8443{{ else }}443{{ end }}
+      Port: 8443
       Protocol: TLS
       Tags:
         - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
@@ -178,11 +178,11 @@ Resources:
       HealthCheck:
         HealthyThreshold: '2'
         Interval: '10'
-        Target: 'HTTPS:{{ if eq .ConfigItems.apiserver_proxy "true" }}8443{{ else }}443{{ end }}/healthz'
+        Target: 'HTTPS:8443/healthz'
         Timeout: '5'
         UnhealthyThreshold: '2'
       Listeners:
-        - InstancePort: {{ if eq .ConfigItems.apiserver_proxy "true" }}8443{{ else }}443{{ end }}
+        - InstancePort: 8443
           InstanceProtocol: SSL
           LoadBalancerPort: 443
           PolicyNames: []
@@ -263,9 +263,9 @@ Resources:
       SecurityGroupIngress:
 {{- if and (ne .Cluster.ConfigItems.apiserver_nlb "disabled") (ne .Cluster.ConfigItems.apiserver_nlb "provisioned") }}
         - CidrIp: 0.0.0.0/0
-          FromPort: {{ if eq .ConfigItems.apiserver_proxy "true" }}8443{{ else }}443{{ end }}
+          FromPort: 8443
           IpProtocol: tcp
-          ToPort: {{ if eq .ConfigItems.apiserver_proxy "true" }}8443{{ else }}443{{ end }}
+          ToPort: 8443
         - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
           FromPort: 8080
           IpProtocol: tcp
@@ -322,14 +322,14 @@ Resources:
 {{- if ne .Cluster.ConfigItems.apiserver_nlb "exclusive" }}
   MasterSecurityGroupIngressFromLoadBalancer:
     Properties:
-      FromPort: {{ if eq .ConfigItems.apiserver_proxy "true" }}8443{{ else }}443{{ end }}
+      FromPort: 8443
       GroupId: !Ref MasterSecurityGroup
       IpProtocol: tcp
       SourceSecurityGroupId: !Ref MasterLoadBalancerSecurityGroup
       Tags:
         - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
           Value: owned
-      ToPort: {{ if eq .ConfigItems.apiserver_proxy "true" }}8443{{ else }}443{{ end }}
+      ToPort: 8443
     Type: 'AWS::EC2::SecurityGroupIngress'
   MasterSecurityGroupIngressFromLoadBalancerHealthCheck:
     Properties:

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -571,9 +571,6 @@ stackset_ingress_source_switch_ttl: "5m"
 # Enable/Disable profiling for Kubernetes components
 enable_control_plane_profiling: "false"
 
-# TODO: remove after CLM is updated
-clm_new_userdata_path: "true"
-
 experimental_proxy_use_serviceaccount: "true"
 
 # Defines the rollout status of the node auth feature. The possible values are:

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -414,9 +414,6 @@ enable_csi_migration: "false"
 # pull images in parallel
 serialize_image_pulls: "false"
 
-# when set to true, routes external traffic to the apiserver through a skipper sidecar
-apiserver_proxy: "true"
-
 # defines the rollout status of the NLB for the API server. The options are:
 #
 #   disabled:    no NLB will be provisioned
@@ -439,7 +436,6 @@ apiserver_nlb: "exclusive"
 apiserver_nlb_https: "hooked"
 
 # when set to true, service account tokens can be used from outside the cluster
-# requires apiserver_proxy to be set to "true"
 allow_external_service_accounts: "false"
 # issue service account tokens with expiration time.
 rotate_service_account_tokens: "false"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -571,8 +571,6 @@ stackset_ingress_source_switch_ttl: "5m"
 # Enable/Disable profiling for Kubernetes components
 enable_control_plane_profiling: "false"
 
-experimental_proxy_use_serviceaccount: "true"
-
 # Defines the rollout status of the node auth feature. The possible values are:
 #
 #   disabled:   node auth is disabled on the API server side

--- a/cluster/manifests/kube-proxy/configmap.yaml
+++ b/cluster/manifests/kube-proxy/configmap.yaml
@@ -12,9 +12,6 @@ data:
       acceptContentTypes: ""
       burst: 10
       contentType: application/vnd.kubernetes.protobuf
-{{- if ne .Cluster.ConfigItems.experimental_proxy_use_serviceaccount "true" }}
-      kubeconfig: /etc/kubernetes/kubeconfig
-{{- end }}
       qps: 5
     clusterCIDR: ""
     configSyncPeriod: 15m0s

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -36,12 +36,10 @@ spec:
         - --config=/config/kube-proxy.yaml
         - --v=2
         env:
-{{- if eq .Cluster.ConfigItems.experimental_proxy_use_serviceaccount "true" }}
         - name: KUBERNETES_SERVICE_HOST
           value: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-{{- end }}
         - name: HOSTNAME_OVERRIDE
           valueFrom:
             fieldRef:
@@ -57,22 +55,12 @@ spec:
             cpu: {{.Cluster.ConfigItems.kube_proxy_cpu}}
             memory: {{.Cluster.ConfigItems.kube_proxy_memory}}
         volumeMounts:
-{{- if eq .Cluster.ConfigItems.experimental_proxy_use_serviceaccount "true" }}
         - name: kube-api-token
           mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-{{- else }}
-        - name: kubeconfig
-          mountPath: /etc/kubernetes/kubeconfig
-          readOnly: true
-        - name: etc-kube-ssl
-          mountPath: /etc/kubernetes/ssl
-          readOnly: true
-{{- end }}
         - name: kube-proxy-config
           mountPath: /config
           readOnly: true
       volumes:
-{{- if eq .Cluster.ConfigItems.experimental_proxy_use_serviceaccount "true" }}
       - name: kube-api-token
         projected:
           defaultMode: 420
@@ -80,14 +68,6 @@ spec:
             - serviceAccountToken:
                 expirationSeconds: 3600
                 path: token
-{{- else }}
-      - name: kubeconfig
-        hostPath:
-          path: /etc/kubernetes/kubeconfig
-      - name: etc-kube-ssl
-        hostPath:
-          path: /etc/kubernetes/ssl
-{{- end }}
       - name: kube-proxy-config
         configMap:
           name: kube-proxy-config


### PR DESCRIPTION
Drop experimental/unused config items in an attempt to simplify our configs:
 * `apiserver_proxy`
 * `clm_new_userdata_path`
 * `experimental_proxy_use_serviceaccount`.