### PR TITLE
Update the admission controller

### DIFF
--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -65,13 +65,6 @@ data:
 {{- end}}
 
   node.node-not-ready-taint.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_node_not_ready_taint }}"
-
-{{- if or (eq .Cluster.ConfigItems.node_auth "enabled") (eq .Cluster.ConfigItems.node_auth "exclusive") }}
-  node.node-role-label-conversion.enable: "false"
-{{- else }}
-  node.node-role-label-conversion.enable: "true"
-{{- end }}
-
 {{- if eq .Cluster.ConfigItems.node_auth "exclusive" }}
   node.extended-node-restriction.enable: "true"
 {{- else }}

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -191,7 +191,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-117
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-120
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
Changes:
 * Treat the Okta administrators as cluster administrators for the rolebinding admitter
 * Drop the node relabeling feature, since it was moved to the node-ready-controller
 * Improve the base image error messages a bit