### PR TITLE
Update kube-state-metrics to v2.0.0

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -206,11 +206,6 @@ prometheus_remote_min_backoff: "3s"
 # Maximum retry delay.
 prometheus_remote_max_backoff: "10s"
 
-# regex defining labels to be dropped when scraping from kube-state-metrics
-# Simple workaround for: https://github.com/kubernetes/kube-state-metrics/issues/1115
-# TODO: remove when kube-state-metrics is fixed
-prometheus_kube_state_metrics_drop_labels: ""
-
 metrics_service_cpu: "100m"
 metrics_service_mem: "200Mi"
 metrics_service_mem_max: "4Gi"

--- a/cluster/manifests/kube-state-metrics/deployment.yaml
+++ b/cluster/manifests/kube-state-metrics/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-state-metrics
-    version: v1.9.7
+    version: v2.0.0
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-state-metrics
-        version: v1.9.7
+        version: v2.0.0
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
@@ -26,9 +26,10 @@ spec:
       serviceAccountName: kube-state-metrics
       containers:
       - name: kube-state-metrics
-        image: registry.opensource.zalan.do/teapot/kube-state-metrics:v1.9.7
+        image: registry.opensource.zalan.do/teapot/kube-state-metrics:v2.0.0
         args:
-        - --collectors=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments,verticalpodautoscalers
+        - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments,verticalpodautoscalers
+        - --metric-labels-allowlist=pods=[application,component],nodes=[topology.kubernetes.io/zone]
         ports:
         - containerPort: 8080
           name: http-metrics

--- a/cluster/manifests/kube-state-metrics/rbac.yaml
+++ b/cluster/manifests/kube-state-metrics/rbac.yaml
@@ -47,11 +47,8 @@ rules:
   - list
   - watch
 - apiGroups:
-  - extensions
+  - networking.k8s.io
   resources:
-  - daemonsets
-  - deployments
-  - replicasets
   - ingresses
   verbs:
   - list

--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -151,10 +151,6 @@ data:
         target_label: node_name
       - action: labeldrop
         regex: "^(pod|node|container)$"
-{{ if ne .Cluster.ConfigItems.prometheus_kube_state_metrics_drop_labels "" }}
-      - regex: '{{ .Cluster.ConfigItems.prometheus_kube_state_metrics_drop_labels }}'
-        action: labeldrop
-{{ end }}
     - job_name: 'etcd-servers'
       scheme: http
       dns_sd_configs:


### PR DESCRIPTION
https://kubernetes.io/blog/2021/04/13/kube-state-metrics-v-2-0/

https://github.com/kubernetes/kube-state-metrics/releases/tag/v2.0.0

In this version it doesn't include all resource labels by default as Prometheus metric labels. I have limited it to `application` and `component` for pods and `topology.kubernetes.io/zone` for nodes as those are the only labels we use in our ZMON checks. This will reduce the cardinality in prometheus!