### PR TITLE
Allow to deploy AWS Batch

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -751,6 +751,7 @@ Resources:
                   - 'aws-portal:ViewUsage'
                   - 'backup-storage:*'
                   - 'backup:*'
+                  - 'batch:*'
                   - 'budgets:ViewBudget'
                   - 'cassandra:*'
                   - 'ce:*'


### PR DESCRIPTION
AWS Batch has been enabled in all accounts and should be deployable via CDP.