### PR TITLE
[1/3] Update skipper and use new counter metric

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -120,6 +120,14 @@ skipper_ingress_lightstep_log_events: ""
 lightstep_token: ""
 tracing_collector_host: "tracing.stups.zalan.do"
 
+# Skipper new metrics
+# https://github.com/zalando/skipper/pull/1755
+# skipper_host_counter sets the flag -serve-host-counter. It generates a
+# new metric called skipper_serve_host_count. It will be used as
+# replacement for the automatically generated counter of the
+# skipper_serve_host_duration_seconds_count metric.
+skipper_serve_host_counter: "true"
+
 # disabled|provisioned|enabled routegroup validation ( skipper webhook )
 # can be one of disabled|provisioned|enabled
 routegroups_validation: "enabled"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.13.48
+    version: v0.13.53
     component: ingress
 spec:
   strategy:
@@ -19,7 +19,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.13.48
+        version: v0.13.53
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -55,7 +55,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/teapot/skipper-internal:v0.13.48-122
+        image: registry.opensource.zalan.do/teapot/skipper-internal:v0.13.53-127
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -102,6 +102,9 @@ spec:
 {{ end }}
           - "-proxy-preserve-host"
           - "-serve-host-metrics"
+{{ if eq .ConfigItems.skipper_serve_host_counter "true"}}
+          - "-serve-host-counter"
+{{ end }}
           - "-disable-metrics-compat"
           - "-enable-profile"
           - "-debug-listener=:9922"
@@ -139,7 +142,7 @@ spec:
             tag=application=skipper-ingress
             tag=account={{ .Cluster.Alias }}
             tag=cluster={{ .Cluster.Alias }}
-            tag=artifact=registry.opensource.zalan.do/teapot/skipper-internal:v0.13.48-122
+            tag=artifact=registry.opensource.zalan.do/teapot/skipper-internal:v0.13.53-127
             max-buffered-spans={{ .ConfigItems.skipper_ingress_tracing_buffer }}
             grpc-max-msg-size={{ .ConfigItems.skipper_ingress_lightstep_grpc_max_msg_size }}
             max-period={{ .ConfigItems.skipper_ingress_lightstep_max_period }}

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -233,7 +233,7 @@ write_files:
               readOnly: true
 {{- if or (eq .Cluster.ConfigItems.routegroups_validation "provisioned") (eq .Cluster.ConfigItems.routegroups_validation "enabled") }}
         - name: routegroups-admission-webhook
-          image: registry.opensource.zalan.do/teapot/skipper:v0.13.48
+          image: registry.opensource.zalan.do/teapot/skipper:v0.13.53
           args:
             - webhook
             - --address=:9085
@@ -412,7 +412,7 @@ write_files:
               exec:
                 command: ["/bin/sh", "-c",  " sleep 60"]
         - name: skipper-proxy
-          image: registry.opensource.zalan.do/teapot/skipper:v0.13.48
+          image: registry.opensource.zalan.do/teapot/skipper:v0.13.53
           args:
           - skipper
           - -access-log-strip-query
@@ -463,7 +463,7 @@ write_files:
             name: ssl-certs-kubernetes
             readOnly: true
         - name: skipper-metrics
-          image: registry.opensource.zalan.do/teapot/skipper:v0.13.48
+          image: registry.opensource.zalan.do/teapot/skipper:v0.13.53
           args:
           - skipper
           - -access-log-strip-query


### PR DESCRIPTION
This commit updates skipper to the [latest release][0] and creates a
feature flag to enable the new counter metric. This counter will replace
the automatically generated one from the
skipper_serve_route_duration_seconds metric, i.e.
`'s/skipper_serve_host_duration_seconds_count/skipper_serve_host_count/g'`.

This is the first commit of migration sequence of 3 commits, where we
will reduce the number of metrics generated by skipper-ingress, allowing
no metrics loss.

[0]: https://github.com/zalando/skipper/releases/tag/v0.13.53