### PR TITLE
[e2e] Increase GPU nodepool options

### DIFF
--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -161,7 +161,7 @@ clusters:
       labels: dedicated=spotio
       taints: dedicated=spotio:NoSchedule
   - discount_strategy: spot
-    instance_types: ["p3.2xlarge", "g2.2xlarge", "g3s.xlarge", "g3.4xlarge"]
+    instance_types: ["g4dn.xlarge", "g4dn.2xlarge", "p3.2xlarge", "g2.2xlarge", "g3s.xlarge", "g3.4xlarge"]
     name: worker-gpu
     profile: worker-default
     min_size: 0


### PR DESCRIPTION
This commit adds new GPU instances types to the e2e gpu node pool. It
aims to handle possible shortage of GPU instances breaking e2e tests in
an unpredictable way.