### PR TITLE
Promote https health check for APIserver NLB

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -428,7 +428,7 @@ apiserver_nlb: "exclusive"
 #   promoted:  New NLB will be fully functional and old NLB will be unhooked
 #   exclusive: New NLB will be fully functional and old NLB will be removed
 #
-apiserver_nlb_https: "hooked"
+apiserver_nlb_https: "promoted"
 
 # when set to true, service account tokens can be used from outside the cluster
 allow_external_service_accounts: "false"


### PR DESCRIPTION
The migration from `hooked` -> `exclusive` is already done for the active clusters. This change is mostly to allow smooth transition for e2e. After this we can drop the whole config item.