### PR TITLE
Drop legacy NLB with TCP healthcheck

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -52,63 +52,6 @@ Resources:
       ToPort: 10250
     Type: 'AWS::EC2::SecurityGroupIngress'
 {{- if ne .Cluster.ConfigItems.apiserver_nlb "disabled" }}
-{{- if ne .Cluster.ConfigItems.apiserver_nlb_https "exclusive" }}
-  MasterLoadBalancerNLBTCP:
-    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
-    Properties:
-      Name: "{{.Cluster.LocalID}}-nlb-tcp"
-      LoadBalancerAttributes:
-        - Key: load_balancing.cross_zone.enabled
-          Value: true
-      Scheme: internet-facing
-      Subnets:
-  {{ with $values := .Values }}
-  {{ range $az := $values.availability_zones }}
-        - "{{ index $values.subnets $az }}"
-  {{ end }}
-  {{ end }}
-      Tags:
-        - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
-          Value: owned
-        - Key: "application"
-          Value: kube-apiserver
-        - Key: "component"
-          Value: "kube-apiserver"
-      Type: network
-  MasterLoadBalancerNLBTargetGroupTCP:
-    Type: AWS::ElasticLoadBalancingV2::TargetGroup
-    Properties:
-      HealthCheckIntervalSeconds: 10
-      HealthCheckPort: 8443
-      HealthCheckProtocol: TCP
-      HealthyThresholdCount: 2
-      UnhealthyThresholdCount: 2
-      Name: "{{.Cluster.LocalID}}-nlb-tcp"
-      Port: 8443
-      Protocol: TLS
-      Tags:
-        - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
-          Value: owned
-        - Key: "application"
-          Value: kube-apiserver
-        - Key: "component"
-          Value: "kube-apiserver"
-      VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
-      TargetGroupAttributes:
-        - Key: deregistration_delay.timeout_seconds
-          Value: 60
-  MasterLoadBalancerNLBListenerTCP:
-    Type: AWS::ElasticLoadBalancingV2::Listener
-    Properties:
-      Certificates:
-        - CertificateArn: "{{.Values.load_balancer_certificate}}"
-      DefaultActions:
-      - Type: forward
-        TargetGroupArn: !Ref MasterLoadBalancerNLBTargetGroupTCP
-      LoadBalancerArn: !Ref MasterLoadBalancerNLBTCP
-      Port: 443
-      Protocol: TLS
-{{- end }}
   MasterLoadBalancerNLB:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
@@ -227,7 +170,6 @@ Resources:
   MasterLoadBalancerVersionDomain:
     Properties:
     {{- if or (eq .Cluster.ConfigItems.apiserver_nlb "active") (eq .Cluster.ConfigItems.apiserver_nlb "promoted") (eq .Cluster.ConfigItems.apiserver_nlb "exclusive") }}
-    {{- if or (eq .Cluster.ConfigItems.apiserver_nlb_https "active") (eq .Cluster.ConfigItems.apiserver_nlb_https "promoted") (eq .Cluster.ConfigItems.apiserver_nlb_https "exclusive") }}
       AliasTarget:
         DNSName: !GetAtt
           - MasterLoadBalancerNLB
@@ -235,15 +177,6 @@ Resources:
         HostedZoneId: !GetAtt
           - MasterLoadBalancerNLB
           - CanonicalHostedZoneID
-    {{- else }}
-      AliasTarget:
-        DNSName: !GetAtt
-          - MasterLoadBalancerNLBTCP
-          - DNSName
-        HostedZoneId: !GetAtt
-          - MasterLoadBalancerNLBTCP
-          - CanonicalHostedZoneID
-    {{- end }}
     {{- else }}
       AliasTarget:
         DNSName: !GetAtt
@@ -2008,12 +1941,6 @@ Outputs:
     Value: !Ref MasterLoadBalancer
 {{- end }}
 {{- if ne .Cluster.ConfigItems.apiserver_nlb "disabled" }}
-{{- if ne .Cluster.ConfigItems.apiserver_nlb_https "exclusive" }}
-  MasterLoadBalancerNLBTargetGroupTCP:
-    Export:
-      Name: '{{.Cluster.ID}}:master-load-balancer-nlb-tcp-target-group'
-    Value: !Ref MasterLoadBalancerNLBTargetGroupTCP
-{{- end }}
   MasterLoadBalancerNLBTargetGroup:
     Export:
       Name: '{{.Cluster.ID}}:master-load-balancer-nlb-target-group'

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -428,16 +428,6 @@ serialize_image_pulls: "false"
 #
 apiserver_nlb: "exclusive"
 
-# defines temporary rollout of NLB with HTTPS healthcheck. This assumes
-# apiserver_nlb=exclusive. The options are:
-#
-#   hooked:    New NLB is hooked up to ASG but DNS still points to old NLB
-#   active:    New NLB will be fully functional and DNS points to the new NLB
-#   promoted:  New NLB will be fully functional and old NLB will be unhooked
-#   exclusive: New NLB will be fully functional and old NLB will be removed
-#
-apiserver_nlb_https: "promoted"
-
 # when set to true, service account tokens can be used from outside the cluster
 allow_external_service_accounts: "false"
 # issue service account tokens with expiration time.

--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -48,9 +48,6 @@ Resources:
 {{ end }}
 {{- if and (ne .Cluster.ConfigItems.apiserver_nlb "disabled") (ne .Cluster.ConfigItems.apiserver_nlb "provisioned") }}
       TargetGroupARNs:
-{{- if and (ne .Cluster.ConfigItems.apiserver_nlb_https "exclusive") (ne .Cluster.ConfigItems.apiserver_nlb_https "promoted") }}
-      - !ImportValue '{{ .Cluster.ID }}:master-load-balancer-nlb-tcp-target-group'
-{{- end }}
       - !ImportValue '{{ .Cluster.ID }}:master-load-balancer-nlb-target-group'
 {{- end }}
     Type: 'AWS::AutoScaling::AutoScalingGroup'


### PR DESCRIPTION
Completely drops the NLB with TCP healthcheck (superseded by the NLB with HTTPS healthcheck).

**Note**:  #4237 must be fully rolled out first.