### PR TITLE
[2/3] Reduce skipper metrics dimension

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -127,6 +127,14 @@ tracing_collector_host: "tracing.stups.zalan.do"
 # replacement for the automatically generated counter of the
 # skipper_serve_host_duration_seconds_count metric.
 skipper_serve_host_counter: "true"
+# skipper_serve_method_metric sets the flag -serve-method-metric. It
+# defines if the http method is included in the dimension
+# of the skipper_serve_host_duration_seconds_bucket metric.
+skipper_serve_method_metric: "false"
+# skipper_serve_status_code_metric sets the flag -serve-status-code-metric. It
+# defines if the http response status code is included in the dimension
+# of the skipper_serve_host_duration_seconds_bucket metric.
+skipper_serve_status_code_metric: "false"
 
 # disabled|provisioned|enabled routegroup validation ( skipper webhook )
 # can be one of disabled|provisioned|enabled

--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -11,7 +11,7 @@ data:
     - name: skipper code by host
       rules:
       - record: job:skipper_code_by_host:sum
-        expr: sum(rate(skipper_serve_host_duration_seconds_count{application="skipper-ingress"}[1m])) by (code)
+        expr: sum(rate(skipper_serve_host_count{application="skipper-ingress"}[1m])) by (code)
 
     - name: skipper sum rate serve_host_duration by bucket
       rules:
@@ -56,7 +56,7 @@ data:
     - name: skipper sum rate serve_host_duration count by host,code
       rules:
       - record: job:skipper_count_by_host_code:sum
-        expr: sum(rate(skipper_serve_host_duration_seconds_count{}[1m])) by (host,code)
+        expr: sum(rate(skipper_serve_host_count{}[1m])) by (host,code)
 
 
   prometheus.yml: |-

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -102,6 +102,8 @@ spec:
 {{ end }}
           - "-proxy-preserve-host"
           - "-serve-host-metrics"
+          - "-serve-method-metric={{ .ConfigItems.skipper_serve_method_metric }}"
+          - "-serve-status-code-metric={{ .ConfigItems.skipper_serve_status_code_metric }}"
 {{ if eq .ConfigItems.skipper_serve_host_counter "true"}}
           - "-serve-host-counter"
 {{ end }}


### PR DESCRIPTION
This commit removes the response http status code and the http method
from the skipper_serve_host_duration_seconds_bucket metric. It reduces
the number of metrics generated by skipper ingress. More details in
https://github.com/zalando/skipper/pull/1755.

Also, it  configure the prometheus jobs to use the new metric enabled
during #4235.