### PR TITLE
Rollback containerd and docker versions

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -379,7 +379,7 @@ coredns_max_upstream_concurrency: 2000 # 0 means there is no concurrency limits
 # AMI id given the image name and the Image AWS account owner.
 #
 # [0]: https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/8a9bd1cb2d094038a9e23e646421f8146b48886a/provisioner/template.go#L116
-kuberuntu_image_v1_19: {{ amiID "zalando-ubuntu-kubernetes-production-v1.19.10-master-159" "861068367966"}}
+kuberuntu_image_v1_19: {{ amiID "zalando-ubuntu-kubernetes-production-v1.19.10-master-161" "861068367966"}}
 
 # Feature toggle for auditing events
 audit_pod_events: "true"


### PR DESCRIPTION
This commit updates the AMI to a new version rolling back the containerd
and docker version. The new versions have problems with Kubernetes:

- https://github.com/kubernetes/kubernetes/issues/101056
- https://github.com/containerd/containerd/issues/5274