### PR TITLE
Enable node_auth=exclusive by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -589,7 +589,7 @@ enable_control_plane_profiling: "false"
 #
 # Warning: enabling/disabling should only be done one step at a time (e.g. exclusive->enabled->supported->disabled),
 # otherwise you can end up with nodes that can't join the cluster.
-node_auth: "supported"
+node_auth: "exclusive"
 
 okta_auth_enabled: "false"
 okta_auth_issuer_url: ""


### PR DESCRIPTION
We're close to enabling it fully, so update the defaults to avoid having to update new clusters. I've manually set it to `supported` in the clusters that haven't been updated yet.