### PR TITLE
node_auth: enabled->exclusive [2/2]

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -581,7 +581,7 @@ enable_control_plane_profiling: "false"
 #
 # Warning: enabling/disabling should only be done one step at a time (e.g. exclusive->enabled->supported->disabled),
 # otherwise you can end up with nodes that can't join the cluster.
-node_auth: "enabled"
+node_auth: "exclusive"
 
 okta_auth_enabled: "false"
 okta_auth_issuer_url: ""


### PR DESCRIPTION
This is a replacement for #4257. Unfortunately, going directly from supported to exclusive doesn't work because the workers lose connection to the masters and the upgrade breaks down. We have to roll it out in two steps if we want e2e to work.

Do not merge at the same time as #4259!