### PR TITLE
Allow to enable Lake Formation and RAM deploy

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -728,6 +728,9 @@ Resources:
                   - 'kinesis:*'
                   - 'kinesisanalytics:*'
                   - 'kms:*'
+                  {{ if eq .Cluster.ConfigItems.deploy_allow_lakeformation "true" }}
+                  - 'lakeformation:*'
+                  {{ end }}
                   - 'lambda:*'
                   - 'lex:*'
                   - 'logs:*'
@@ -736,6 +739,9 @@ Resources:
                   - 'pricing:Describe*'
                   - 'pricing:Get*'
                   - 'quicksight:*'
+                  {{ if eq .Cluster.ConfigItems.deploy_allow_ram "true" }}
+                  - 'ram:*'
+                  {{ end }}
                   - 'rds:*'
                   - 'redshift:*'
                   - 'rekognition:*'

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -586,3 +586,10 @@ node_auth: "supported"
 okta_auth_enabled: "false"
 okta_auth_issuer_url: ""
 okta_auth_client_id: "kubernetes.cluster.{{.Cluster.Alias}}"
+
+# Deploy
+# This session contains config items to enable and disable the the
+# permission for the Role {{.Cluster.LocalID}}-deployment. It allows
+# CDP to deploy resources of the specified types.
+deploy_allow_lakeformation: "false"
+deploy_allow_ram: "false"


### PR DESCRIPTION
This commit allow us to enable the deployment of `ram:*` and
`lakeformation:*` in specific clusters via the config items
`deploy_allow_lakeformation` and `deploy_allow_ram`.