### PR TITLE
cdp-controller: drop the old role binding

### DIFF
--- a/cluster/manifests/roles/cdp-controller-rbac.yaml
+++ b/cluster/manifests/roles/cdp-controller-rbac.yaml
@@ -123,7 +123,4 @@ roleRef:
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
-  name: zalando-iam:zalando:service:credprov-cdp-controller-cluster-token
-- apiGroup: rbac.authorization.k8s.io
-  kind: User
   name: zalando-iam:zalando:service:stups_cdp-controller


### PR DESCRIPTION
This is a follow-up to https://github.com/zalando-incubator/kubernetes-on-aws/pull/2891. We somehow forgot to drop the old binding after CDP has migrated, let's drop it now.