### PR TITLE
Reduce the deregistration delay

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -19,11 +19,7 @@ cluster_autoscaler_max_pod_eviction_time: "3h"
 # ALB config created by kube-aws-ingress-controller
 kube_aws_ingress_controller_ssl_policy: "ELBSecurityPolicy-TLS-1-2-2017-01"
 kube_aws_ingress_controller_idle_timeout: "1m"
-{{if eq .Cluster.Environment "e2e"}}
-kube_aws_ingress_controller_deregistration_delay_timeout: "1m"
-{{else}}
-kube_aws_ingress_controller_deregistration_delay_timeout: "5m"
-{{end}}
+kube_aws_ingress_controller_deregistration_delay_timeout: "10s"
 # allow using NLBs for ingress
 # This opens port 9999 (skipper-ingress) on all worker nodes.
 kube_aws_ingress_controller_nlb_enabled: "false"


### PR DESCRIPTION
The deregistration delay setting for the LBs managed by the ingress controller doesn't really make a lot of sense. By the time we're terminating the node, there are no pods running on it, so the only thing we achieve with the delay is an extra 5 minute wait interval on every node termination. This slows down rolling upgrades and downscaling a lot, especially in large clusters.

Unfortunately I don't think it can be disabled (because the default is 5 minutes), but 10 seconds is low enough to not matter.