### PR TITLE
Allow to scale skipper based on time

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -164,6 +164,13 @@ skipper_ingress_encryption_key: ""
 skipper_oauth2_ui_login: "true"
 {{end}}
 
+# Skipper Time based scaling
+#
+# This section contains the config items related to time based scaling
+# for skipper
+skipper_time_based_scaling_check_id: ""
+skipper_time_based_scaling_target: "1"
+
 # Image Policy Webhook
 {{if eq .Cluster.Environment "production"}}
 image_policy: "trusted"

--- a/cluster/manifests/skipper/hpa.yaml
+++ b/cluster/manifests/skipper/hpa.yaml
@@ -25,6 +25,22 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ .ConfigItems.skipper_ingress_target_average_utilization_memory }}
+{{ if ne .ConfigItems.skipper_time_based_scaling_check_id "" }}
+  - type: External
+    external:
+      target:
+        averageValue: {{ .ConfigItems.skipper_time_based_scaling_target }}
+        type: AverageValue
+      metric:
+        name: zmon-check
+        selector:
+          matchLabels:
+            type: "zmon"
+            check-id: "{{ .ConfigItems.skipper_time_based_scaling_check_id }}"
+            key: ""
+            tag-application: "skipper-ingress"
+            aggregators: last
+{{ end }}
   behavior:
     scaleDown:
       stabilizationWindowSeconds: 600


### PR DESCRIPTION
This commit add an external metric to the skipper hpa when the config
item `skipper_time_based_scaling_enabled` is set to true. It allow us to
define zmon checks for skipper scaling based on time.