### PR TITLE
Credentials provider: support restricted tokens

### DIFF
--- a/cluster/manifests/roles/credentials-provider-rbac.yaml
+++ b/cluster/manifests/roles/credentials-provider-rbac.yaml
@@ -38,3 +38,6 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
   name: zalando-iam:zalando:service:credentials-provider
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: zalando-iam:zalando:service:k8sapi_credentials-provider

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -269,7 +269,7 @@ write_files:
               name: ssl-certs-kubernetes
               readOnly: true
 {{- end}}
-        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:master-116
+        - image: registry.opensource.zalan.do/teapot/k8s-authnz-webhook:master-117
           name: webhook
           ports:
           - containerPort: 8081
@@ -298,6 +298,7 @@ write_files:
             - --node-auth-cluster-id={{.Cluster.ID}}
             - "--node-auth-role-arn=arn:aws:iam::{{accountID .Cluster.InfrastructureAccount}}:role/{{.Cluster.LocalID}}-worker"
 {{- end }}
+            - --cluster-alias={{.Cluster.Alias}}
 
             # Collaborator roles
             - --role-mapping=Administrator=cn=Administrator,ou=collaborators,ou=Kubernetes,ou=apps,dc=zalando,dc=net
@@ -330,6 +331,7 @@ write_files:
             - --enable-default-sa
 {{ end }}
             - --system-users=zalando-iam:zalando:service:credentials-provider
+            - --system-users=zalando-iam:zalando:service:k8sapi_credentials-provider
             - --system-users=system:serviceaccount:api-infrastructure:api-monitoring-controller
             - --collaborator-app-users=zalando-iam:zalando:service:stups_scalyr-key-rotation
           env:

--- a/test/e2e/authorisation_test.go
+++ b/test/e2e/authorisation_test.go
@@ -785,6 +785,11 @@ var _ = framework.KubeDescribe("Authorization tests [Authorization] [RBAC] [Zala
 					user("zalando-iam:zalando:service:credentials-provider"),
 				expect: allowed,
 			}, {
+				name: "system user (credentials-provider) should be allowed get secrets in kube-system.",
+				request: req().ns("kube-system").verb("get").res("secrets").
+					user("zalando-iam:zalando:service:k8sapi_credentials-provider"),
+				expect: allowed,
+			}, {
 				name: "system user (api-monitoring-controller) can update configmap 'skipper-default-filters' in kube-system.",
 				request: req().ns("kube-system").verb("update").res("configmaps").name("skipper-default-filters").
 					user("system:serviceaccount:api-infrastructure:api-monitoring-controller"),


### PR DESCRIPTION
 * Update the webhook to support `k8sapi`/`k8sapi-local` tokens
 * Add support for the new credentials provider user (but keep the old one for now)