### PR TITLE
credentials-provider: fully migrate to restricted tokens [2/2]

### DIFF
--- a/cluster/manifests/roles/credentials-provider-rbac.yaml
+++ b/cluster/manifests/roles/credentials-provider-rbac.yaml
@@ -37,7 +37,4 @@ roleRef:
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
-  name: zalando-iam:zalando:service:credentials-provider
-- apiGroup: rbac.authorization.k8s.io
-  kind: User
   name: zalando-iam:zalando:service:k8sapi_credentials-provider

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -332,7 +332,6 @@ write_files:
 {{ if eq .Cluster.ConfigItems.enable_default_sa "true"}}
             - --enable-default-sa
 {{ end }}
-            - --system-users=zalando-iam:zalando:service:credentials-provider
             - --system-users=zalando-iam:zalando:service:k8sapi_credentials-provider
             - --system-users=system:serviceaccount:api-infrastructure:api-monitoring-controller
             - --collaborator-app-users=zalando-iam:zalando:service:stups_scalyr-key-rotation

--- a/test/e2e/authorisation_test.go
+++ b/test/e2e/authorisation_test.go
@@ -782,11 +782,6 @@ var _ = framework.KubeDescribe("Authorization tests [Authorization] [RBAC] [Zala
 			}, {
 				name: "system user (credentials-provider) should be allowed get secrets in kube-system.",
 				request: req().ns("kube-system").verb("get").res("secrets").
-					user("zalando-iam:zalando:service:credentials-provider"),
-				expect: allowed,
-			}, {
-				name: "system user (credentials-provider) should be allowed get secrets in kube-system.",
-				request: req().ns("kube-system").verb("get").res("secrets").
 					user("zalando-iam:zalando:service:k8sapi_credentials-provider"),
 				expect: allowed,
 			}, {


### PR DESCRIPTION
Follow-up to #4278. Do not merge until the new version of credentials-provider has been rolled out to all environments!