### PR TITLE
Enable H2 on the API server's NLB

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -100,6 +100,8 @@ Resources:
   MasterLoadBalancerNLBListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:
+      AlpnPolicy:
+        - {{ if eq .Cluster.ConfigItems.experimental_nlb_alpn_h2_enabled "true" }}HTTP2Preferred{{else}}None{{end}}
       Certificates:
         - CertificateArn: "{{.Values.load_balancer_certificate}}"
       DefaultActions:

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -604,3 +604,5 @@ okta_auth_client_id: "kubernetes.cluster.{{.Cluster.Alias}}"
 # CDP to deploy resources of the specified types.
 deploy_allow_lakeformation: "false"
 deploy_allow_ram: "false"
+
+experimental_nlb_alpn_h2_enabled: "true"


### PR DESCRIPTION
Kubernetes maintainers, with their “amazing experience at building distributed systems”, only really fixed the timeout issues if the client<->API server uses HTTP/2 (it works at GKE I guess and everything else doesn't matter). Unfortunately they've also decided to hardcode extremely bad defaults (30 second keepalive) directly into the client components, which means that we can't really solve it without either compiling our own kubelet, going through a proxy, or reducing the missed keepalive probe count to 1. On the other hand, we can actually enable H2 on the NLB now, which seems to work fine, and it should hopefully make the configmap/secret timeout issue go away.
This is only marked experimental for the extremely unlikely case that we need to roll it back.