### PR TITLE
Update Kubernetes and NVIDIA docker

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -390,7 +390,7 @@ coredns_max_upstream_concurrency: 2000 # 0 means there is no concurrency limits
 # AMI id given the image name and the Image AWS account owner.
 #
 # [0]: https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/8a9bd1cb2d094038a9e23e646421f8146b48886a/provisioner/template.go#L116
-kuberuntu_image_v1_19: {{ amiID "zalando-ubuntu-kubernetes-production-v1.19.10-master-161" "861068367966"}}
+kuberuntu_image_v1_19: {{ amiID "zalando-ubuntu-kubernetes-production-v1.19.11-master-163" "861068367966"}}
 
 # Feature toggle for auditing events
 audit_pod_events: "true"

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -2,7 +2,7 @@
 
 BINARY       ?= kubernetes-on-aws-e2e
 VERSION      ?= $(shell git describe --tags --always --dirty)
-KUBE_VERSION ?= v1.19.10
+KUBE_VERSION ?= v1.19.11
 IMAGE        ?= pierone.stups.zalan.do/teapot/$(BINARY)
 TAG          ?= $(VERSION)
 DOCKERFILE   ?= Dockerfile

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -17,10 +17,10 @@ require (
 	github.com/szuecs/routegroup-client v0.17.8-0.20200915193527-b33447c7d964
 	github.com/zalando-incubator/kube-aws-iam-controller v0.1.2
 	github.com/zalando-incubator/stackset-controller v1.3.26
-	k8s.io/api v0.19.10
-	k8s.io/apimachinery v0.19.10
+	k8s.io/api v0.19.11
+	k8s.io/apimachinery v0.19.11
 	k8s.io/apiserver v0.0.0
-	k8s.io/client-go v0.19.10
+	k8s.io/client-go v0.19.11
 	k8s.io/kubernetes v0.0.0
 )
 


### PR DESCRIPTION
This commit updates the kubernetes version and the NVIDIA docker
runtime:

- https://github.com/kubernetes/kubernetes/releases/tag/v1.19.11
- https://github.com/NVIDIA/nvidia-docker/releases/tag/v2.6.0
- https://github.com/NVIDIA/nvidia-container-runtime/releases/tag/v3.5.0