### PR TITLE
Add cronjob-monitor

### DIFF
--- a/cluster/manifests/cronjob-monitor/deployment.yaml
+++ b/cluster/manifests/cronjob-monitor/deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cronjob-monitor
+  namespace: kube-system
+  labels:
+    application: cronjob-monitor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      application: cronjob-monitor
+  template:
+    metadata:
+      labels:
+        application: cronjob-monitor
+      annotations:
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
+    spec:
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+      serviceAccountName: cronjob-monitor
+      containers:
+        - name: cronjob-monitor
+          image: "registry.opensource.zalan.do/teapot/cronjob-monitor:master-1"
+          resources:
+            limits:
+              cpu: 5m
+              memory: 150Mi
+            requests:
+              cpu: 5m
+              memory: 150Mi

--- a/cluster/manifests/cronjob-monitor/rbac.yaml
+++ b/cluster/manifests/cronjob-monitor/rbac.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cronjob-monitor
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cronjob-monitor
+rules:
+- apiGroups: ["batch"]
+  resources: ["cronjobs"]
+  verbs: ["get", "list", "watch", "patch", "update"]
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cronjob-monitor
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cronjob-monitor
+subjects:
+- kind: ServiceAccount
+  name: cronjob-monitor
+  namespace: kube-system

--- a/cluster/manifests/cronjob-monitor/vpa.yaml
+++ b/cluster/manifests/cronjob-monitor/vpa.yaml
@@ -1,0 +1,19 @@
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: cronjob-monitor
+  namespace: kube-system
+  labels:
+    application: cronjob-monitor
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: cronjob-monitor
+  updatePolicy:
+    updateMode: Auto
+  resourcePolicy:
+    containerPolicies:
+    - containerName: cronjob-monitor
+      maxAllowed:
+        memory: 4Gi


### PR DESCRIPTION
This is a workaround for https://github.com/kubernetes/kubernetes/issues/75674, a small controller that tracks the last successful completion time in an annotation. Will be dropped once (if) it's actually implemented in Kubernetes.