### PR TITLE
Enable prevent scale down annotation in all clusters

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -357,11 +357,10 @@ teapot_admission_controller_runtime_policy_enforced: ""
 teapot_admission_controller_runtime_policy_spot_hard_assignment: "false"
 
 # Enable and configure prevent scale down annotation
+teapot_admission_controller_prevent_scale_down_enabled: "true"
 {{if eq .Cluster.Environment "production"}}
-teapot_admission_controller_prevent_scale_down_enabled: "false"
 teapot_admission_controller_prevent_scale_down_allowed: "true"
 {{else}}
-teapot_admission_controller_prevent_scale_down_enabled: "true"
 teapot_admission_controller_prevent_scale_down_allowed: "false"
 {{end}}
 


### PR DESCRIPTION
We forgot to follow up on this, let's just enable it everywhere.