### PR TITLE
kube-metrics-adapter CRDs for time-based scaling

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -79,6 +79,10 @@ skipper_redis_write_timeout: "25ms"
 # skipper api GW features
 enable_apimonitoring: "true"                       # TODO(sszuecs): cleanup candidate to reduce amount of branches in deployment
 
+
+# Enable the kube-metrics-adapter time-based metrics.
+enable_scaling_schedule_metrics: "true"
+
 # skipper east-west feature
 # enable_skipper_eastwest is the legacy feature gate for the automatic
 # ingress.cluster.local addresses created by skipper.

--- a/cluster/manifests/kube-metrics-adapter/01-rbac.yaml
+++ b/cluster/manifests/kube-metrics-adapter/01-rbac.yaml
@@ -81,6 +81,15 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - zalando.org
+  resources:
+  - clusterscalingschedules
+  - scalingschedules
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/cluster/manifests/kube-metrics-adapter/cluster_scaling_schedules_crd.yaml
+++ b/cluster/manifests/kube-metrics-adapter/cluster_scaling_schedules_crd.yaml
@@ -1,0 +1,119 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
+  name: clusterscalingschedules.zalando.org
+spec:
+  group: zalando.org
+  names:
+    kind: ClusterScalingSchedule
+    listKind: ClusterScalingScheduleList
+    plural: clusterscalingschedules
+    singular: clusterscalingschedule
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ClusterScalingSchedule describes a cluster scoped time based
+          metric to be used in autoscaling operations.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ScalingScheduleSpec is the spec part of the ScalingSchedule.
+            properties:
+              schedules:
+                description: Schedules is the list of schedules for this ScalingSchedule
+                  resource. All the schedules defined here will result on the value
+                  to the same metric. New metrics require a new ScalingSchedule resource.
+                items:
+                  description: Schedule is the schedule details to be used inside
+                    a ScalingSchedule.
+                  properties:
+                    date:
+                      description: Defines the starting date of a OneTime schedule.
+                        It has to be a RFC3339 formated date.
+                      format: date-time
+                      type: string
+                    durationMinutes:
+                      description: The duration in minutes that the configured value
+                        will be returned for the defined schedule.
+                      type: integer
+                    period:
+                      description: Defines the details of a Repeating schedule.
+                      properties:
+                        days:
+                          description: The days that this schedule will be active.
+                          items:
+                            description: ScheduleDay represents the valid inputs for
+                              days in a SchedulePeriod.
+                            enum:
+                            - Mon
+                            - Tue
+                            - Wed
+                            - Thu
+                            - Fru
+                            - Sat
+                            - Sun
+                            type: string
+                          type: array
+                        startTime:
+                          description: The startTime has the format HH:MM
+                          pattern: (([0-1][0-9])|([2][0-3])):([0-5][0-9])
+                          type: string
+                        timezone:
+                          description: The location name corresponding to a file in
+                            the IANA Time Zone database, like Europe/Berlin.
+                          type: string
+                      required:
+                      - days
+                      - startTime
+                      - timezone
+                      type: object
+                    type:
+                      description: Defines if the schedule is a OneTime schedule or
+                        Repeating one. If OneTime, date has to be defined. If Repeating,
+                        Period has to be defined.
+                      enum:
+                      - OneTime
+                      - Repeating
+                      type: string
+                    value:
+                      description: The metric value that will be returned for the
+                        defined schedule.
+                      type: integer
+                  required:
+                  - durationMinutes
+                  - type
+                  - value
+                  type: object
+                type: array
+            required:
+            - schedules
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -24,13 +24,16 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.10
+        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.10-56-g6f9aba8
         env:
         - name: AWS_REGION
           value: {{ .Region }}
         args:
         - --prometheus-server=http://prometheus.kube-system.svc.cluster.local
         - --skipper-ingress-metrics
+        {{ if eq .ConfigItems.enable_scaling_schedule_metrics "true"}}
+        - --scaling-schedule
+        {{ end }}
         - --aws-external-metrics
         - --aws-region=eu-central-1
         - --aws-region=eu-west-1

--- a/cluster/manifests/kube-metrics-adapter/scaling_schedules_crd.yaml
+++ b/cluster/manifests/kube-metrics-adapter/scaling_schedules_crd.yaml
@@ -1,0 +1,119 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
+  name: scalingschedules.zalando.org
+spec:
+  group: zalando.org
+  names:
+    kind: ScalingSchedule
+    listKind: ScalingScheduleList
+    plural: scalingschedules
+    singular: scalingschedule
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ScalingSchedule describes a namespaced time based metric to be
+          used in autoscaling operations.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ScalingScheduleSpec is the spec part of the ScalingSchedule.
+            properties:
+              schedules:
+                description: Schedules is the list of schedules for this ScalingSchedule
+                  resource. All the schedules defined here will result on the value
+                  to the same metric. New metrics require a new ScalingSchedule resource.
+                items:
+                  description: Schedule is the schedule details to be used inside
+                    a ScalingSchedule.
+                  properties:
+                    date:
+                      description: Defines the starting date of a OneTime schedule.
+                        It has to be a RFC3339 formated date.
+                      format: date-time
+                      type: string
+                    durationMinutes:
+                      description: The duration in minutes that the configured value
+                        will be returned for the defined schedule.
+                      type: integer
+                    period:
+                      description: Defines the details of a Repeating schedule.
+                      properties:
+                        days:
+                          description: The days that this schedule will be active.
+                          items:
+                            description: ScheduleDay represents the valid inputs for
+                              days in a SchedulePeriod.
+                            enum:
+                            - Mon
+                            - Tue
+                            - Wed
+                            - Thu
+                            - Fru
+                            - Sat
+                            - Sun
+                            type: string
+                          type: array
+                        startTime:
+                          description: The startTime has the format HH:MM
+                          pattern: (([0-1][0-9])|([2][0-3])):([0-5][0-9])
+                          type: string
+                        timezone:
+                          description: The location name corresponding to a file in
+                            the IANA Time Zone database, like Europe/Berlin.
+                          type: string
+                      required:
+                      - days
+                      - startTime
+                      - timezone
+                      type: object
+                    type:
+                      description: Defines if the schedule is a OneTime schedule or
+                        Repeating one. If OneTime, date has to be defined. If Repeating,
+                        Period has to be defined.
+                      enum:
+                      - OneTime
+                      - Repeating
+                      type: string
+                    value:
+                      description: The metric value that will be returned for the
+                        defined schedule.
+                      type: integer
+                  required:
+                  - durationMinutes
+                  - type
+                  - value
+                  type: object
+                type: array
+            required:
+            - schedules
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
This commit updates the kube-metrics-adapter version, to include the new
feature of time-based scaling. It installs the new CRDs and starts the
server with a defined config flag. It also updates the RBAC permissions
to allow the server to get, list and watch the new CRDs.