### PR TITLE
set write timeout to 0, Go http server default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -55,7 +55,7 @@ skipper_close_idle_conns_period: "20s"
 # skipper server timeout defaults
 skipper_idle_timeout_server: "62s"
 skipper_read_timeout_server: "5m"
-skipper_write_timeout_server: "60s"
+skipper_write_timeout_server: "0"
 
 # skipper startup settings
 {{if eq .Cluster.Environment "production"}}


### PR DESCRIPTION
needs to be explicitly set to 0 because skipper has a 60s default

Signed-off-by: Arpad Ryszka <arpad.ryszka@gmail.com>