### PR TITLE
Fix typo for Friday ScalingSchedule

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/cluster_scaling_schedules_crd.yaml
+++ b/cluster/manifests/kube-metrics-adapter/cluster_scaling_schedules_crd.yaml
@@ -63,13 +63,13 @@ spec:
                             description: ScheduleDay represents the valid inputs for
                               days in a SchedulePeriod.
                             enum:
+                            - Sun
                             - Mon
                             - Tue
                             - Wed
                             - Thu
-                            - Fru
+                            - Fri
                             - Sat
-                            - Sun
                             type: string
                           type: array
                         startTime:

--- a/cluster/manifests/kube-metrics-adapter/scaling_schedules_crd.yaml
+++ b/cluster/manifests/kube-metrics-adapter/scaling_schedules_crd.yaml
@@ -63,13 +63,13 @@ spec:
                             description: ScheduleDay represents the valid inputs for
                               days in a SchedulePeriod.
                             enum:
+                            - Sun
                             - Mon
                             - Tue
                             - Wed
                             - Thu
-                            - Fru
+                            - Fri
                             - Sat
-                            - Sun
                             type: string
                           type: array
                         startTime:


### PR DESCRIPTION
The current CRD has a typo on the definition for repeating schedules on
Friday.