### PR TITLE
Drop node_auth and worker_shared_secret from the manifests [1/2]

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -586,17 +586,6 @@ stackset_ingress_source_switch_ttl: "5m"
 # Enable/Disable profiling for Kubernetes components
 enable_control_plane_profiling: "false"
 
-# Defines the rollout status of the node auth feature. The possible values are:
-#
-#   disabled:   node auth is disabled on the API server side
-#   supported:  API servers support both node auth and the legacy shared secrets, NodeRestriction is disabled
-#   enabled:    same as supported, but the workers use node auth to authenticate instead of shared secrets. NodeRestriction is still disabled
-#   exclusive:  node auth is used exclusively, NodeRestriction is enabled, shared secrets are disabled
-#
-# Warning: enabling/disabling should only be done one step at a time (e.g. exclusive->enabled->supported->disabled),
-# otherwise you can end up with nodes that can't join the cluster.
-node_auth: "exclusive"
-
 okta_auth_enabled: "false"
 okta_auth_issuer_url: ""
 okta_auth_client_id: "kubernetes.cluster.{{.Cluster.Alias}}"

--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -65,11 +65,7 @@ data:
 {{- end}}
 
   node.node-not-ready-taint.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_node_not_ready_taint }}"
-{{- if eq .Cluster.ConfigItems.node_auth "exclusive" }}
   node.extended-node-restriction.enable: "true"
-{{- else }}
-  node.extended-node-restriction.enable: "false"
-{{- end }}
 
   pod.node-lifecycle.provider: "{{ .Cluster.ConfigItems.teapot_admission_controller_node_lifecycle_provider }}"
 

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -117,14 +117,14 @@ write_files:
           - --secure-port=443
           - --insecure-port=0
           - --port=0
-          - --enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,ExtendedResourceToleration,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota,StorageObjectInUseProtection,PodSecurityPolicy,ImagePolicyWebhook,Priority{{if eq .Cluster.ConfigItems.node_auth "exclusive"}},NodeRestriction{{end}}
+          - --enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,ExtendedResourceToleration,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota,StorageObjectInUseProtection,PodSecurityPolicy,ImagePolicyWebhook,Priority,NodeRestriction
           - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
           - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
           - --runtime-config=extensions/v1beta1/networkpolicies=true,batch/v2alpha1=true,policy/v1beta1=true,imagepolicy.k8s.io/v1alpha1=true,authorization.k8s.io/v1beta1=true,scheduling.k8s.io/v1alpha1=true,admissionregistration.k8s.io/v1beta1=true
           - --authentication-token-webhook-config-file=/etc/kubernetes/config/authn.yaml
           - --authentication-token-webhook-cache-ttl=10s
           - --cloud-provider=aws
-          - --authorization-mode={{if ne .Cluster.ConfigItems.node_auth "disabled" }}Node,{{end}}Webhook,RBAC
+          - --authorization-mode=Node,Webhook,RBAC
           - --authorization-webhook-config-file=/etc/kubernetes/config/authz.yaml
           - --authorization-webhook-version=v1
           - --token-auth-file=/etc/kubernetes/config/tokenfile.csv
@@ -296,10 +296,8 @@ write_files:
               cpu: 50m
               memory: 50Mi
           args:
-{{- if ne .Cluster.ConfigItems.node_auth "disabled" }}
             - --node-auth-cluster-id={{.Cluster.ID}}
             - "--node-auth-role-arn=arn:aws:iam::{{accountID .Cluster.InfrastructureAccount}}:role/{{.Cluster.LocalID}}-worker"
-{{- end }}
             - --cluster-alias={{.Cluster.Alias}}
 
             # Collaborator roles
@@ -706,10 +704,7 @@ write_files:
   - owner: root:root
     path: /etc/kubernetes/config/tokenfile.csv
     permissions: 0600
-    content: |
-{{- if ne .Cluster.ConfigItems.node_auth "exclusive" }}
-      {{ .Cluster.ConfigItems.worker_shared_secret }},kubelet,kubelet,system:masters
-{{- end }}
+    content: ""
 
   - owner: root:root
     path: /etc/kubernetes/config/image-policy-webhook.yaml

--- a/cluster/node-pools/worker-default/userdata.yaml
+++ b/cluster/node-pools/worker-default/userdata.yaml
@@ -38,7 +38,6 @@ write_files:
       users:
       - name: kubelet
         user:
-{{- if or (eq .Cluster.ConfigItems.node_auth "enabled") (eq .Cluster.ConfigItems.node_auth "exclusive") }}
           exec:
              apiVersion: client.authentication.k8s.io/v1alpha1
              command: aws
@@ -47,9 +46,6 @@ write_files:
                - get-token
                - --cluster-name
                - "{{.Cluster.ID}}"
-{{- else }}
-          token: {{ .Cluster.ConfigItems.worker_shared_secret }}
-{{- end }}
       contexts:
       - context:
           cluster: local

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -19,7 +19,6 @@ clusters:
     image_policy: e2e
     service_account_private_key: ${SERVICE_ACCOUNT_PRIVATE_KEY}
     vpa_enabled: "true"
-    worker_shared_secret: ${WORKER_SHARED_SECRET}
     lightstep_token: "${LIGHTSTEP_TOKEN}"
     zmon_agent_replicas: '0'
     zmon_aws_agent_replicas: '0'


### PR DESCRIPTION
We don't plan on reverting this, so let's drop the feature flag.