### PR TITLE
Drop worker_shared_secret from the e2e script [2/2]

### DIFF
--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -45,8 +45,6 @@ export LOCAL_ID="${LOCAL_ID:-"e2e-${CDP_BUILD_VERSION}"}"
 export API_SERVER_URL="https://${LOCAL_ID}.${HOSTED_ZONE}"
 export INFRASTRUCTURE_ACCOUNT="aws:${AWS_ACCOUNT}"
 export CLUSTER_ID="${INFRASTRUCTURE_ACCOUNT}:${REGION}:${LOCAL_ID}"
-WORKER_SHARED_SECRET="$(pwgen 30 -n1)"
-export WORKER_SHARED_SECRET
 
 # Generate a new key for this E2E run
 SERVICE_ACCOUNT_PRIVATE_KEY="$(openssl genrsa | base64 | tr -d '\n')"


### PR DESCRIPTION
Can't be done in one go without breaking e2e, so this has to be separate.