### PR TITLE
Reenable the kubelet restart test

### DIFF
--- a/test/e2e/node_test.go
+++ b/test/e2e/node_test.go
@@ -112,9 +112,6 @@ var _ = framework.KubeDescribe("Node tests", func() {
 	})
 
 	It("Should handle kubelet restarts successfully [Slow] [Zalando]", func() {
-		// Temporarily skip the test for now
-		Skip("Doesn't work with the old AMI")
-
 		ns := f.Namespace.Name
 
 		pausePod := createTestPod(ns)


### PR DESCRIPTION
Not doing it in https://github.com/zalando-incubator/kubernetes-on-aws/pull/4325 since that whole PR might have to be recreated, this way it's more explicit.