### PR TITLE
Update Stackset controller and CRDs

### DIFF
--- a/cluster/manifests/stackset-controller/01-stack-crd.yaml
+++ b/cluster/manifests/stackset-controller/01-stack-crd.yaml
@@ -209,6 +209,19 @@ spec:
                         averageUtilization:
                           format: int32
                           type: integer
+                        clusterScalingSchedule:
+                          description: MetricsClusterScalingSchedule specifies the
+                            ClusterScalingSchedule object which should be used for
+                            scaling.
+                          properties:
+                            name:
+                              description: The name of the referenced ClusterScalingSchedule
+                                object.
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                          required:
+                          - name
+                          type: object
                         endpoint:
                           description: MetricsEndpoint specified the endpoint where
                             the custom endpoint where the metrics can be queried
@@ -240,6 +253,18 @@ spec:
                           - name
                           - region
                           type: object
+                        scalingSchedule:
+                          description: MetricsScalingSchedule specifies the ScalingSchedule
+                            object which should be used for scaling.
+                          properties:
+                            name:
+                              description: The name of the referenced ScalingSchedule
+                                object.
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                          required:
+                          - name
+                          type: object
                         type:
                           description: AutoscalerMetricType is the type of the metric
                             used for scaling.
@@ -250,6 +275,8 @@ spec:
                           - PodJSON
                           - Ingress
                           - ZMON
+                          - ScalingSchedule
+                          - ClusterScalingSchedule
                           type: string
                         zmon:
                           description: MetricsZMON specifies the ZMON check which

--- a/cluster/manifests/stackset-controller/01-stackset-crd.yaml
+++ b/cluster/manifests/stackset-controller/01-stackset-crd.yaml
@@ -432,6 +432,19 @@ spec:
                                 averageUtilization:
                                   format: int32
                                   type: integer
+                                clusterScalingSchedule:
+                                  description: MetricsClusterScalingSchedule specifies
+                                    the ClusterScalingSchedule object which should
+                                    be used for scaling.
+                                  properties:
+                                    name:
+                                      description: The name of the referenced ClusterScalingSchedule
+                                        object.
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
                                 endpoint:
                                   description: MetricsEndpoint specified the endpoint
                                     where the custom endpoint where the metrics can
@@ -464,6 +477,19 @@ spec:
                                   - name
                                   - region
                                   type: object
+                                scalingSchedule:
+                                  description: MetricsScalingSchedule specifies the
+                                    ScalingSchedule object which should be used for
+                                    scaling.
+                                  properties:
+                                    name:
+                                      description: The name of the referenced ScalingSchedule
+                                        object.
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
                                 type:
                                   description: AutoscalerMetricType is the type of
                                     the metric used for scaling.
@@ -474,6 +500,8 @@ spec:
                                   - PodJSON
                                   - Ingress
                                   - ZMON
+                                  - ScalingSchedule
+                                  - ClusterScalingSchedule
                                   type: string
                                 zmon:
                                   description: MetricsZMON specifies the ZMON check

--- a/cluster/manifests/stackset-controller/deployment.yaml
+++ b/cluster/manifests/stackset-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: stackset-controller
-    version: "v1.3.28"
+    version: "v1.3.34"
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: stackset-controller
-        version: "v1.3.28"
+        version: "v1.3.34"
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
         prometheus.io/path: /metrics
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: stackset-controller
       containers:
       - name: stackset-controller
-        image: "registry.opensource.zalan.do/teapot/stackset-controller:v1.3.28"
+        image: "registry.opensource.zalan.do/teapot/stackset-controller:v1.3.34"
         args:
         - "--interval={{ .Cluster.ConfigItems.stackset_controller_sync_interval }}"
 {{- if eq .Cluster.ConfigItems.stackset_routegroup_support_enabled "true" }}


### PR DESCRIPTION
This commit updates the stackset controller and the stack[set] CRDs
definitions.

Apart from updates the most notable changes are:
- the creation of two new metrics for the `autoscaler` config:
  `[Cluster]ScalingSchedule`. It's  reflected in the CRD update.
- the addition of both Stack[Set]s resources to the 'all' category
- The support for ContainerResource metric. **Note** that this change is
  not enabled in our clusters yet, it requires kubernetes 1.20. This
  change is also not reflected in the CRDs.

The e2e tests are not updated yet, they will be updated with kube-1.20
and the enabled features do not have any e2e tests.

It includes the following releases:

- https://github.com/zalando-incubator/stackset-controller/releases/tag/v1.3.34
- https://github.com/zalando-incubator/stackset-controller/releases/tag/v1.3.33
- https://github.com/zalando-incubator/stackset-controller/releases/tag/v1.3.32
- https://github.com/zalando-incubator/stackset-controller/releases/tag/v1.3.31
- https://github.com/zalando-incubator/stackset-controller/releases/tag/v1.3.30
- https://github.com/zalando-incubator/stackset-controller/releases/tag/v1.3.29