### PR TITLE
parameterize skipper for teardown handling

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -66,7 +66,7 @@ skipper_readiness_init_delay_seconds: 1
 skipper_liveness_init_delay_seconds: 30
 {{end}}
 # skipper termination settings
-skipper_terminationGracePeriod: "70"
+skipper_termination_grace_period: "70"
 skipper_wait_for_healthcheck_interval: "65s"
 
 # skipper redis settings

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -66,7 +66,7 @@ skipper_readiness_init_delay_seconds: 1
 skipper_liveness_init_delay_seconds: 30
 {{end}}
 # skipper termination settings
-skipper_terminationGracePeriod: "70s"
+skipper_terminationGracePeriod: "70"
 skipper_wait_for_healthcheck_interval: "65s"
 
 # skipper redis settings

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -65,6 +65,9 @@ skipper_liveness_init_delay_seconds: 30
 skipper_readiness_init_delay_seconds: 1
 skipper_liveness_init_delay_seconds: 30
 {{end}}
+# skipper termination settings
+skipper_terminationGracePeriod: "70s"
+skipper_wait_for_healthcheck_interval: "65s"
 
 # skipper redis settings
 enable_dedicate_nodepool_skipper_redis: "false"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -51,7 +51,7 @@ spec:
 {{- end }}
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       serviceAccountName: skipper-ingress
-      terminationGracePeriodSeconds: "{{ .Cluster.ConfigItems.skipper_terminationGracePeriod }}"
+      terminationGracePeriodSeconds: "{{ .Cluster.ConfigItems.skipper_termination_grace_period }}"
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       containers:

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -51,6 +51,7 @@ spec:
 {{- end }}
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       serviceAccountName: skipper-ingress
+      terminationGracePeriodSeconds: "{{ .Cluster.ConfigItems.skipper_terminationGracePeriod }}"
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       containers:
@@ -92,6 +93,7 @@ spec:
           - "-kubernetes-path-mode=path-prefix"
           - "-address=:9999"
           - "-wait-first-route-load"
+          - "-wait-for-healthcheck-interval={{ .Cluster.ConfigItems.skipper_wait_for_healthcheck_interval }}"
 {{ if eq .ConfigItems.enable_skipper_eastwest "true"}}
           - "-enable-kubernetes-east-west"
           - "-kubernetes-east-west-domain=.ingress.cluster.local"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -51,7 +51,7 @@ spec:
 {{- end }}
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       serviceAccountName: skipper-ingress
-      terminationGracePeriodSeconds: "{{ .Cluster.ConfigItems.skipper_termination_grace_period }}"
+      terminationGracePeriodSeconds: {{ .Cluster.ConfigItems.skipper_termination_grace_period }}
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       containers:


### PR DESCRIPTION
parameterize skipper for teardown handling if someone needs more than 30s for requests
Why >60s? Because we have timeouts of 1m and we want to let them finish their request or timing out correctly.

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>