### PR TITLE
Downgrade to Kubernetes v1.20.6

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -394,7 +394,7 @@ coredns_max_upstream_concurrency: 2000 # 0 means there is no concurrency limits
 #
 # [0]: https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/8a9bd1cb2d094038a9e23e646421f8146b48886a/provisioner/template.go#L116
 kuberuntu_image_v1_19: {{ amiID "zalando-ubuntu-kubernetes-production-v1.19.10-master-161" "861068367966"}}
-kuberuntu_image_v1_20: {{ amiID "zalando-ubuntu-kubernetes-production-v1.20.7-master-165" "861068367966"}}
+kuberuntu_image_v1_20: {{ amiID "zalando-ubuntu-kubernetes-production-v1.20.6-master-166" "861068367966"}}
 
 # Feature toggle for auditing events
 audit_pod_events: "true"

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -2,7 +2,7 @@
 
 BINARY       ?= kubernetes-on-aws-e2e
 VERSION      ?= $(shell git describe --tags --always --dirty)
-KUBE_VERSION ?= v1.20.7
+KUBE_VERSION ?= v1.20.6
 IMAGE        ?= pierone.stups.zalan.do/teapot/$(BINARY)
 TAG          ?= $(VERSION)
 DOCKERFILE   ?= Dockerfile


### PR DESCRIPTION
Downgrade to Kubernetes v1.20.6 to avoid kubelet panics bug introduced in v1.20.7 (https://github.com/kubernetes/kubernetes/issues/102480)