### PR TITLE
Make it possible to disable exec probe timeout

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -607,3 +607,7 @@ deploy_allow_lakeformation: "false"
 deploy_allow_ram: "false"
 
 experimental_nlb_alpn_h2_enabled: "true"
+
+# Enable/Disable ExecProbeTimeout (default in v1.20)
+# Can be disabled in case some workloads depends on the old behavior.
+exec_probe_timeout_enabled: "true"

--- a/cluster/node-pools/worker-default/userdata.yaml
+++ b/cluster/node-pools/worker-default/userdata.yaml
@@ -67,6 +67,9 @@ write_files:
 {{- if eq .Cluster.ConfigItems.enable_ephemeral_containers "true" }}
         EphemeralContainers: true
 {{- end }}
+{{- if eq .NodePool.ConfigItems.exec_probe_timeout_enabled "false" }}
+        ExecProbeTimeout: false
+{{- end }}
         GenericEphemeralVolume: {{ .Cluster.ConfigItems.enable_generic_ephemeral_volume }}
         SetHostnameAsFQDN: {{ .Cluster.ConfigItems.enable_hostname_as_fqdn }}
       podPidsLimit: {{ .NodePool.ConfigItems.pod_max_pids }}


### PR DESCRIPTION
The `ExecProbeTimeout` feature gate was introduced in Kubernetes v1.20 and is enabled by default. It fixes timeouts set for `exec` probes. This change could have a side-effect where existing exec probes start to fail if they were never working as expected in the first place.

This let's us disable the feature per clusters (or node pool) by settings `enable_exec_probe_timeout=false`. Note that this will roll the nodes as it's a setting on the `kubelet` config.

https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.20.md#no-really-you-must-read-this-before-you-upgrade