### PR TITLE
Disable unbound until further tests

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -473,12 +473,8 @@ external_dns_ownership_prefix: ""
 # domains that should be ignored by ExternalDNS
 external_dns_excluded_domains: cluster.local
 
-# select which cache to use for Cluster DNS
-{{ if eq .Cluster.Environment "production" }}
+# select which cache to use for Cluster DNS: unbound or dnsmasq.
 dns_cache: "dnsmasq"
-{{ else }}
-dns_cache: "unbound"
-{{ end }}
 
 expirimental_dns_unbound_liveness_probe: "true"
 


### PR DESCRIPTION
Most probably due to 1.20 [fix on the kubelet exec probe timeouts][0],
unbound is constantly restarting on different clusters. Until further
investigation and decision on the dns cache topic, let's disable unbound
by default. It can still be enabled by setting `dns_cache` to `unbound`.

[0]: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.20.md#no-really-you-must-read-this-before-you-upgrade