### PR TITLE
Update stackset-controller to v1.3.37

### DIFF
--- a/cluster/manifests/stackset-controller/deployment.yaml
+++ b/cluster/manifests/stackset-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: stackset-controller
-    version: "v1.3.36"
+    version: "v1.3.37"
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: stackset-controller
-        version: "v1.3.36"
+        version: "v1.3.37"
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
         prometheus.io/path: /metrics
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: stackset-controller
       containers:
       - name: stackset-controller
-        image: "registry.opensource.zalan.do/teapot/stackset-controller:v1.3.36"
+        image: "registry.opensource.zalan.do/teapot/stackset-controller:v1.3.37"
         args:
         - "--interval={{ .Cluster.ConfigItems.stackset_controller_sync_interval }}"
 {{- if eq .Cluster.ConfigItems.stackset_routegroup_support_enabled "true" }}

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/spf13/viper v1.7.0
 	github.com/szuecs/routegroup-client v0.17.8-0.20200915193527-b33447c7d964
 	github.com/zalando-incubator/kube-aws-iam-controller v0.1.2
-	github.com/zalando-incubator/stackset-controller v1.3.34
+	github.com/zalando-incubator/stackset-controller v1.3.37
 	go.opencensus.io v0.22.4 // indirect
 	google.golang.org/api v0.22.0 // indirect
 	honnef.co/go/tools v0.0.1-2020.1.4 // indirect

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -807,8 +807,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zalando-incubator/kube-aws-iam-controller v0.1.2 h1:uEXMHnd7wuXk3gAZ8iiOnL9XVUqA1iuDQzQFsa3ywA4=
 github.com/zalando-incubator/kube-aws-iam-controller v0.1.2/go.mod h1:7RQdyNqtYaKEWVavXUFlrE8A+QsGe/hkBba2RyG5V4o=
-github.com/zalando-incubator/stackset-controller v1.3.34 h1:E2yf5DNl4ZUiry9TtUdt9DS8BDtcY8DqZ0G8XJfcvx4=
-github.com/zalando-incubator/stackset-controller v1.3.34/go.mod h1:cb0N/eUjM1TG8sRvBFBCgZOPB67KuSt7ofzLJcv6xDM=
+github.com/zalando-incubator/stackset-controller v1.3.37 h1:RewWUy/IRJ6GumskUYUShfALFV5RYl/gR7JZLaLxof4=
+github.com/zalando-incubator/stackset-controller v1.3.37/go.mod h1:cb0N/eUjM1TG8sRvBFBCgZOPB67KuSt7ofzLJcv6xDM=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.5 h1:XAzx9gjCb0Rxj7EoqcClPD1d5ZBxZJk0jbuoPHenBt0=


### PR DESCRIPTION
Updates the stackset-controller to v1.3.37

* Use a much higher QPS values for E2E

https://github.com/zalando-incubator/stackset-controller/releases/tag/v1.3.37