### PR TITLE
egress controller: support non-default VPCs

### DIFF
--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -32,6 +32,7 @@ spec:
         image: registry.opensource.zalan.do/teapot/kube-static-egress-controller:v0.2.7
         args:
         - "--provider=aws"
+        - "--vpc-id={{.Cluster.ConfigItems.vpc_id}}"
 {{- range $subnet := stupsNATSubnets .Values.vpc_ipv4_cidr }}
         - "--aws-nat-cidr-block={{ $subnet }}"
 {{- end }}


### PR DESCRIPTION
Automatic detection doesn't work, but we already have the VPC ID anyway.