### PR TITLE
Fix the bucket policy when DS is disabled

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -852,6 +852,7 @@ Resources:
       Bucket: !Ref DeploymentServiceBucket
       PolicyDocument:
         Statement:
+{{- if eq .Cluster.ConfigItems.deployment_service_enabled "true" }}
           - NotAction:
               - s3:GetObject
               - s3:DeleteObject
@@ -865,6 +866,7 @@ Resources:
               AWS:
                 - !GetAtt DeploymentControllerRole.Arn
                 - !GetAtt DeploymentStatusServiceRole.Arn
+{{- end }}
 {{- if ne .Cluster.ConfigItems.deployment_service_api_role_arn "" }}
           - Action:
               - s3:PutObject
@@ -884,8 +886,10 @@ Resources:
             Condition:
               ArnNotEquals:
                 aws:PrincipalArn:
+{{- if eq .Cluster.ConfigItems.deployment_service_enabled "true" }}
                   - !GetAtt DeploymentControllerRole.Arn
                   - !GetAtt DeploymentStatusServiceRole.Arn
+{{- end }}
 {{- if ne .Cluster.ConfigItems.deployment_service_api_role_arn "" }}
                   - "{{.Cluster.ConfigItems.deployment_service_api_role_arn}}"
 {{- end }}


### PR DESCRIPTION
The roles don't exist if the deployment is not enabled, so the bucket policy needs to adjusted accordingly.