### PR TITLE
Remove affinity configs from skipper

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -30,16 +30,6 @@ spec:
         prometheus.io/port: "9911"
         prometheus.io/scrape: "true"
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                - key: application
-                  operator: In
-                  values:
-                  - skipper-ingress
-              topologyKey: kubernetes.io/hostname
 {{- if eq .ConfigItems.skipper_topology_spread_enabled "true" }}
       topologySpreadConstraints:
         - maxSkew: 1


### PR DESCRIPTION
Skipper is already running as host network and host port, so we don't
need to rely on affinity to spread the pods. At the same time we
distrust cluster autoscaler is taking bad decisions when launching new
nodes based on that.

This commit removes the affinity configs currently configured for
skipper.