### PR TITLE
Update the kube-metrics-adapter

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.10-56-g6f9aba8
+        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.10-72-g446b7f0
         env:
         - name: AWS_REGION
           value: {{ .Region }}


### PR DESCRIPTION
This commit updates the kube-metrics-adapter. This update contains
multiple dependencies updates. The main changes are the [removal of the
check on the HTTP collector for `identifier` label](https://github.com/zalando-incubator/kube-metrics-adapter/pull/332)
and the [ignore of ContainerResource metrics](https://github.com/zalando-incubator/kube-metrics-adapter/pull/326).
The latter generates wrong error messages on the HPA using containers
identification for scaling.