### PR TITLE
Create ClusterRole for ScalingSchedule Controller

### DIFF
--- a/cluster/manifests/roles/scaling-schedules-controller-rbac.yaml
+++ b/cluster/manifests/roles/scaling-schedules-controller-rbac.yaml
@@ -1,0 +1,32 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: scaling-schedules-controller
+rules:
+- apiGroups:
+  - "zalando.org"
+  resources:
+  - scalingschedules
+  - clusterscalingschedules
+  verbs:
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - create
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: scaling-schedules-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: scaling-schedules-controller
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: zalando-iam:zalando:service:stups_scaling-schedules-controller


### PR DESCRIPTION
The ScalingSchedule Controller requires access to the
`[Cluster]ScalingSchedule` in all the clusters. This commit creates a
new `ClusterRole` and binds it to the `scaling-schedules-controller`
application in Kio.