### PR TITLE
HOTFIX change kairosDB URL

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -86,8 +86,11 @@ skipper_redis_write_timeout: "25ms"
 enable_apimonitoring: "true"                       # TODO(sszuecs): cleanup candidate to reduce amount of branches in deployment
 
 
-# Enable the kube-metrics-adapter time-based metrics.
+# Kube-Metrics-Adapter
+## Enable the kube-metrics-adapter time-based metrics.
 enable_scaling_schedule_metrics: "true"
+## ZMON KairosDB URL
+zmon_kairosdb_url: "https://zmon-kairosdb-read-old.platform-infrastructure.zalan.do/"
 
 # skipper east-west feature
 # enable_skipper_eastwest is the legacy feature gate for the automatic

--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - --aws-region=eu-west-1
         - --skipper-backends-annotation=zalando.org/backend-weights
         {{ if eq .Environment "production" }}
-        - --zmon-kariosdb-endpoint=https://data-service.zmon.zalan.do/kairosdb-proxy
+        - --zmon-kariosdb-endpoint="{{.Cluster.ConfigItems.zmon_kairosdb_url}}"
         {{ end }}
         volumeMounts:
         {{ if eq .Environment "production" }}


### PR DESCRIPTION
This commit changes the kairiosDB URL in all the kube-metrics-adapter
deployments as a hotfix due to the recent metrics backend migration.
Further work will investigate why queries fail with the new database and
rollback this hotfix.