### PR TITLE
remove extra char in kairosDB URL

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -90,7 +90,7 @@ enable_apimonitoring: "true"                       # TODO(sszuecs): cleanup cand
 ## Enable the kube-metrics-adapter time-based metrics.
 enable_scaling_schedule_metrics: "true"
 ## ZMON KairosDB URL
-zmon_kairosdb_url: "https://zmon-kairosdb-read-old.platform-infrastructure.zalan.do/"
+zmon_kairosdb_url: "https://zmon-kairosdb-read-old.platform-infrastructure.zalan.do"
 
 # skipper east-west feature
 # enable_skipper_eastwest is the legacy feature gate for the automatic


### PR DESCRIPTION
This extra char makes the query return ` unexpected response code: 404"`