### PR TITLE
[HOTFIX] Remove quotes from kairosDB URL

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - --aws-region=eu-west-1
         - --skipper-backends-annotation=zalando.org/backend-weights
         {{ if eq .Environment "production" }}
-        - --zmon-kariosdb-endpoint="{{.Cluster.ConfigItems.zmon_kairosdb_url}}"
+        - --zmon-kariosdb-endpoint={{.Cluster.ConfigItems.zmon_kairosdb_url}}
         {{ end }}
         volumeMounts:
         {{ if eq .Environment "production" }}


### PR DESCRIPTION
Extra quotes in the URL make it break the parser:
```
level=error msg="Failed to collect metrics: parse \"\\\"https://zmon-kairosdb-read-old.platform-infrastructure.zalan.do\\\"\": first path segment in URL cannot contain colon"
```