### PR TITLE
Add readiness checks to kube-proxy & flannel

### DIFF
--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -79,6 +79,8 @@ spec:
         args:
         - --ip-masq
         - --kube-subnet-mgr
+        - --healthz-ip=127.0.0.1
+        - --healthz-port=10257
         - --v=2
         env:
         - name: KUBERNETES_SERVICE_HOST
@@ -101,6 +103,11 @@ spec:
           limits:
             cpu: "{{ .Cluster.ConfigItems.flannel_cpu }}"
             memory: "{{ .Cluster.ConfigItems.flannel_memory }}"
+        readinessProbe:
+          httpGet:
+            host: 127.0.0.1
+            port: 10257
+            path: /healthz
         securityContext:
           privileged: true
         volumeMounts:

--- a/cluster/manifests/kube-proxy/configmap.yaml
+++ b/cluster/manifests/kube-proxy/configmap.yaml
@@ -24,7 +24,7 @@ data:
     featureGates:
       BoundServiceAccountTokenVolume: {{ .Cluster.ConfigItems.rotate_service_account_tokens }}
       EndpointSliceProxying: {{ .Cluster.ConfigItems.enable_endpointsliceproxying }}
-    healthzBindAddress: 0.0.0.0:10256
+    healthzBindAddress: 127.0.0.1:10256
     hostnameOverride: ""
     iptables:
       masqueradeAll: false

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -46,6 +46,11 @@ spec:
               fieldPath: spec.nodeName
         securityContext:
           privileged: true
+        readinessProbe:
+          httpGet:
+            host: 127.0.0.1
+            port: 10256
+            path: /healthz
         resources:
           requests:
             cpu: {{.Cluster.ConfigItems.kube_proxy_cpu}}


### PR DESCRIPTION
These were missing for some reason, causing nodes to come up completely broken (but marked as healthy).