### PR TITLE
Change flannel health port to not overlap

### DIFF
--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -80,7 +80,7 @@ spec:
         - --ip-masq
         - --kube-subnet-mgr
         - --healthz-ip=127.0.0.1
-        - --healthz-port=10257
+        - --healthz-port=10267
         - --v=2
         env:
         - name: KUBERNETES_SERVICE_HOST
@@ -106,7 +106,7 @@ spec:
         readinessProbe:
           httpGet:
             host: 127.0.0.1
-            port: 10257
+            port: 10267
             path: /healthz
         securityContext:
           privileged: true


### PR DESCRIPTION
Change flannel health port to avoid overlapping with the kube-controller manager port.

https://github.com/kubernetes/kubernetes/blob/5575935422cc1cf5169dfc8847cb587aa47bac5a/pkg/cluster/ports/ports.go#L45