### PR TITLE
Node auth: tweak the rate limits

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -501,7 +501,7 @@ collaborator_administrator_access: "true"
 collaborator_administrator_access: "false"
 {{end}}
 
-node_auth_rate_limit: "0.5"
+node_auth_rate_limit: "5.0"
 
 # enable legacy serviceaccounts for smooth RBAC migration
 enable_operator_sa: "false"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -501,6 +501,8 @@ collaborator_administrator_access: "true"
 collaborator_administrator_access: "false"
 {{end}}
 
+node_auth_rate_limit: "0.5"
+
 # enable legacy serviceaccounts for smooth RBAC migration
 enable_operator_sa: "false"
 enable_default_sa: "false"

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -296,6 +296,7 @@ write_files:
           args:
             - --node-auth-cluster-id={{.Cluster.ID}}
             - "--node-auth-role-arn=arn:aws:iam::{{accountID .Cluster.InfrastructureAccount}}:role/{{.Cluster.LocalID}}-worker"
+            - "--node-auth-rate-limit={{.Cluster.ConfigItems.node_auth_rate_limit}}"
             - --cluster-alias={{.Cluster.Alias}}
 
             # Collaborator roles


### PR DESCRIPTION
We have some clusters that scale up in chunks of 80+ nodes at a time. The node auth handler in our auth webhook defaults to a rate limit of 0.5 'DescribeInstances' which is extremely conservative and something we've set to avoid overloading AWS. Since these calls should be cached 99.9% of the time anyway, let's just increase the defaults to a much higher value and let the AWS throttling to rate limit us.