### PR TITLE
Allow customizing the kube-scheduler image

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -664,7 +664,11 @@ write_files:
         hostNetwork: true
         containers:
         - name: kube-scheduler
+{{- if index .Cluster.ConfigItems "experimental_kube_scheduler_image" }}
+          image: {{.Cluster.ConfigItems.experimental_kube_scheduler_image}}
+{{- else }}
           image: nonexistent.zalan.do/teapot/kube-scheduler:fixed
+{{- end }}
           args:
           - --kubeconfig=/etc/kubernetes/scheduler-kubeconfig
           - --leader-elect=true


### PR DESCRIPTION
This is a temporary setup that will be migrated to a better one slightly later, right now I just want to test it in a couple of clusters. This allows customising the kube-scheduler image with an experimental config item.