### PR TITLE
AMI update / internal scheduler build

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -455,7 +455,11 @@ apiserver_nlb: "exclusive"
 # Supported values:
 #  - upstream: official Kubernetes version
 #  - zalando:  internal Zalando build with our custom patches
+{{ if eq .Cluster.Environment "production" }}
 kubernetes_scheduler_image: "upstream"
+{{ else }}
+kubernetes_scheduler_image: "zalando"
+{{ end }}
 
 # when set to true, service account tokens can be used from outside the cluster
 allow_external_service_accounts: "false"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -451,6 +451,12 @@ serialize_image_pulls: "false"
 #
 apiserver_nlb: "exclusive"
 
+# Version of the scheduler used by the master nodes.
+# Supported values:
+#  - upstream: official Kubernetes version
+#  - zalando:  internal Zalando build with our custom patches
+kubernetes_scheduler_image: "upstream"
+
 # when set to true, service account tokens can be used from outside the cluster
 allow_external_service_accounts: "false"
 # issue service account tokens with expiration time.

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -402,8 +402,7 @@ coredns_max_upstream_concurrency: 2000 # 0 means there is no concurrency limits
 # AMI id given the image name and the Image AWS account owner.
 #
 # [0]: https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/8a9bd1cb2d094038a9e23e646421f8146b48886a/provisioner/template.go#L116
-kuberuntu_image_v1_19: {{ amiID "zalando-ubuntu-kubernetes-production-v1.19.10-master-161" "861068367966"}}
-kuberuntu_image_v1_20: {{ amiID "zalando-ubuntu-kubernetes-production-v1.20.8-master-167" "861068367966"}}
+kuberuntu_image_v1_20: {{ amiID "zalando-ubuntu-kubernetes-production-v1.20.9-master-176" "861068367966"}}
 
 # Feature toggle for auditing events
 audit_pod_events: "true"

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -664,11 +664,7 @@ write_files:
         hostNetwork: true
         containers:
         - name: kube-scheduler
-{{- if index .Cluster.ConfigItems "experimental_kube_scheduler_image" }}
-          image: {{.Cluster.ConfigItems.experimental_kube_scheduler_image}}
-{{- else }}
-          image: nonexistent.zalan.do/teapot/kube-scheduler:fixed
-{{- end }}
+          image: nonexistent.zalan.do/teapot/{{if eq .Cluster.ConfigItems.kubernetes_scheduler_image "zalando" }}kube-scheduler-internal{{else}}kube-scheduler{{end}}:fixed
           args:
           - --kubeconfig=/etc/kubernetes/scheduler-kubeconfig
           - --leader-elect=true


### PR DESCRIPTION
AMI changes:
 * Internal packaging improvements.
 * Update to v1.20.9/v1.21.3.
 * Downgrade back to the 5.4 kernel.
 * Include the internal scheduler image.

Add a new config item, `kubernetes_scheduler_image` (possible values `zalando`/`upstream`) that controls which kube-scheduler build to run, the official one or the one with custom Zalando patches.

Enable the internal Zalando scheduler by default in e2e/test clusters.