### PR TITLE
EAS: add Opsgenie support

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -618,3 +618,8 @@ deployment_service_enabled: "true"
 {{ else }}
 deployment_service_enabled: "false"
 {{ end }}
+
+# Settings for the emergency access service
+# Service to use when checking incidents, valid values are 'jira' and 'opsgenie'. Temporary, will be dropped once
+# we fully migrate away from Jira.
+emergency_access_service_incident_backend: "jira"

--- a/cluster/manifests/emergency-access-service/deployment.yaml
+++ b/cluster/manifests/emergency-access-service/deployment.yaml
@@ -44,7 +44,7 @@ spec:
             cpu: 25m
             memory: 25Mi
       - name: emergency-access-service
-        image: "pierone.stups.zalan.do/teapot/emergency-access-service:master-75"
+        image: "pierone.stups.zalan.do/teapot/emergency-access-service:master-78"
         args:
         - --insecure-http
         - --community={{ .Owner }}
@@ -55,7 +55,9 @@ spec:
         - --token-url=https://info.services.auth.zalando.com/oauth2/tokeninfo
         # enable audittrail reporting
         - --audittrail-url=https://audittrail.cloud.zalando.com
+{{- if ne .Cluster.ConfigItems.emergency_access_service_incident_backend "opsgenie" }}
         - --jira-url={{.Cluster.ConfigItems.emergency_access_service_jira_url}}
+{{- end }}
         - --environment={{ .Environment }}
         - --s3-bucket-name=zalando-audittrail-{{accountID .InfrastructureAccount}}-{{.LocalID}}
         env:
@@ -67,6 +69,13 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+{{- if eq .Cluster.ConfigItems.emergency_access_service_incident_backend "opsgenie" }}
+        - name: OPSGENIE_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: emergency-access-service-secrets
+              key: opsgenie-api-key
+{{- end }}
         - name: AWS_REGION
           value: {{.Region}}
         - name: OPENTRACING_LIGHTSTEP_ACCESS_TOKEN
@@ -86,9 +95,11 @@ spec:
         - name: platform-iam-credentials
           mountPath: /meta/credentials
           readOnly: true
+{{- if ne .Cluster.ConfigItems.emergency_access_service_incident_backend "opsgenie" }}
         - name: secrets
           mountPath: /meta/secrets
           readOnly: true
+{{- end }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -115,7 +126,9 @@ spec:
       - name: platform-iam-credentials
         secret:
           secretName: "emergency-access-service"
+{{- if ne .Cluster.ConfigItems.emergency_access_service_incident_backend "opsgenie" }}
       - name: secrets
         secret:
           secretName: "emergency-access-service-secrets"
+{{- end }}
 {{ end }}

--- a/cluster/manifests/emergency-access-service/secret.yaml
+++ b/cluster/manifests/emergency-access-service/secret.yaml
@@ -11,5 +11,6 @@ data:
   # value in the following format:
   # {"username": "user", "password": "pass", "magic_token": "token"}
   jira-secrets: "{{ .ConfigItems.emergency_access_service_jira_secrets | base64 }}"
+  opsgenie-api-key: "{{ .ConfigItems.emergency_access_service_opsgenie_api_key | base64 }}"
   opentracing-lightstep-access-token: "{{ .ConfigItems.lightstep_token | base64 }}"
 {{ end }}


### PR DESCRIPTION
 * Update EAS to the new version
 * Add a new temporary config item, `emergency_access_service_incident_backend` (with `jira` or `opsgenie` as valid values) to control which service to use