### PR TITLE
Fix kube-metrics-adapter issues with new ZMON TSDB

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -90,7 +90,7 @@ enable_apimonitoring: "true"                       # TODO(sszuecs): cleanup cand
 ## Enable the kube-metrics-adapter time-based metrics.
 enable_scaling_schedule_metrics: "true"
 ## ZMON KairosDB URL
-zmon_kairosdb_url: "https://zmon-kairosdb-read-old.platform-infrastructure.zalan.do"
+zmon_kairosdb_url: "https://data-service.zmon.zalan.do/kairosdb-proxy"
 
 # skipper east-west feature
 # enable_skipper_eastwest is the legacy feature gate for the automatic

--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.10-72-g446b7f0
+        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.11
         env:
         - name: AWS_REGION
           value: {{ .Region }}


### PR DESCRIPTION
This commit updates the `kube-metrics-adapter` deployment to its [last
release][0]. From the version we were using the main change is the
changes to ZMON client and fixes for compatibility with the ZMON new
time series database.

As a consequence, we can revert the `zmon_kairosdb_url` config item to
the main ZMON address, instead of the legacy endpoint.

[0]: https://github.com/zalando-incubator/kube-metrics-adapter/releases/tag/v0.1.11