### PR TITLE
update admission controller to support pod image checks

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -199,7 +199,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-122
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-123
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
Updates the admission controller with the ability to validate images during pod admission.

Changes are here: https://github.bus.zalan.do/teapot/admission-controller/pull/134

- [x] Merge after https://github.com/zalando-incubator/kubernetes-on-aws/pull/4495