### PR TITLE
do not enable admission-controller's pod image in production by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -320,7 +320,7 @@ teapot_admission_controller_daemonset_reserved_memory: "64Gi"
 {{if eq .Cluster.Environment "production"}}
 teapot_admission_controller_validate_application_label: "true"
 teapot_admission_controller_validate_base_images: "true"
-teapot_admission_controller_validate_pod_images: "true"
+teapot_admission_controller_validate_pod_images: "false"
 teapot_admission_controller_validate_pod_template_resources: "true"
 teapot_admission_controller_preemption_enabled: "true"
 teapot_admission_controller_postgresql_delete_protection_enabled: "true"


### PR DESCRIPTION
Follow up on https://github.com/zalando-incubator/kubernetes-on-aws/pull/4490

Let's not enable image checks in pod-admission by default in production. This way we can safely roll out new versions of admission-controller to all channels and enable image-checks per cluster afterwards.