### PR TITLE
fix: skipper goroutine leak with special filter config 

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.13.81
+    version: v0.13.84
     component: ingress
 spec:
   strategy:
@@ -19,7 +19,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.13.81
+        version: v0.13.84
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -46,7 +46,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/teapot/skipper-internal:v0.13.81-153
+        image: registry-write.opensource.zalan.do/teapot/skipper-internal:v0.13.84-156
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -136,7 +136,7 @@ spec:
             tag=application=skipper-ingress
             tag=account={{ .Cluster.Alias }}
             tag=cluster={{ .Cluster.Alias }}
-            tag=artifact=registry.opensource.zalan.do/teapot/skipper-internal:v0.13.81-153
+            tag=artifact=registry.opensource.zalan.do/teapot/skipper-internal:v0.13.84-156
             max-buffered-spans={{ .ConfigItems.skipper_ingress_tracing_buffer }}
             grpc-max-msg-size={{ .ConfigItems.skipper_ingress_lightstep_grpc_max_msg_size }}
             max-period={{ .ConfigItems.skipper_ingress_lightstep_max_period }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -46,7 +46,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry-write.opensource.zalan.do/teapot/skipper-internal:v0.13.84-156
+        image: registry.opensource.zalan.do/teapot/skipper-internal:v0.13.84-156
         ports:
         - name: ingress-port
           containerPort: 9999


### PR DESCRIPTION
- fix: skipper goroutine leak with special filter config breaker() with teeLoppback()
- fix: CVE-2021-25740 kubernetes/kubernetes#103675 allowed externalNames

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>