### PR TITLE
Enable image checks via admission-controller in production

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -321,7 +321,7 @@ teapot_admission_controller_daemonset_reserved_memory: "64Gi"
 {{if eq .Cluster.Environment "production"}}
 teapot_admission_controller_validate_application_label: "true"
 teapot_admission_controller_validate_base_images: "true"
-teapot_admission_controller_validate_pod_images: "false"
+teapot_admission_controller_validate_pod_images: "true"
 teapot_admission_controller_validate_pod_template_resources: "true"
 teapot_admission_controller_preemption_enabled: "true"
 teapot_admission_controller_postgresql_delete_protection_enabled: "true"


### PR DESCRIPTION
This enables image checks in the pod-admission phase for all namespaces in production clusters. This is the same behaviour as currently achieved with image-policy-webhook.

In this configuration admission-controller will take care of rejecting non-compliant images and image-policy-webhook (which validates after according to my tests) serves as a backup in case admission-controller let's anything through.

This update is instant and doesn't require a master roll. It can be rolled by back reverting this PR or by running:

```console
$ zregistry clusters config-items set -k teapot_admission_controller_validate_pod_images -v false --cluster-alias <cluster-alias>
```

This will disable admission-controller's pod-admission image checks and use image-policy-webhook instead.

In a follow up PR, we're going to set `image_policy: dev` which disables the fallback and subsequently remove image-policy-webhook from the manifests. Doing it via the config item first is easier to rollback.

While in the transition phase, make sure to **NOT SET**
```yaml
teapot_admission_controller_validate_pod_images: "false"
image_policy: dev
```
at the same time as this would allow non-compliant images to be deployed to production clusters.

Use either:
```yaml
teapot_admission_controller_validate_pod_images: "true"
image_policy: dev
```
or
```yaml
teapot_admission_controller_validate_pod_images: "false"
image_policy: trusted
```

**NOTE** that with the new setup we're currently not able to detect non-compliant images in e2e clusters and they would only surface in the first production cluster. Take extra care not to use non-compliant images in kubernetes system components until we're able to detect them again in e2e tests.