### PR TITLE
Use the internal scheduler build in all clusters

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -463,11 +463,7 @@ apiserver_nlb: "exclusive"
 # Supported values:
 #  - upstream: official Kubernetes version
 #  - zalando:  internal Zalando build with our custom patches
-{{ if eq .Cluster.Environment "production" }}
-kubernetes_scheduler_image: "upstream"
-{{ else }}
 kubernetes_scheduler_image: "zalando"
-{{ end }}
 
 # when set to true, service account tokens can be used from outside the cluster
 allow_external_service_accounts: "false"


### PR DESCRIPTION
We haven't observed any issues so far, and the metrics in the clusters where it was enabled seemed better.