### PR TITLE
Update to Prometheus v2.29.1

### DIFF
--- a/cluster/manifests/prometheus/statefulset.yaml
+++ b/cluster/manifests/prometheus/statefulset.yaml
@@ -5,7 +5,7 @@ metadata:
     pdb-controller.zalando.org/non-ready-ttl: "5m"
   labels:
     application: prometheus
-    version: v2.26.0
+    version: v2.29.1
 {{- if ne .ConfigItems.prometheus_csi_ebs "true" }}
   name: prometheus
 {{- else }}
@@ -23,7 +23,7 @@ spec:
     metadata:
       labels:
         application: prometheus
-        version: v2.26.0
+        version: v2.29.1
       annotations:
         config/hash: {{"configmap.yaml" | manifestHash}}
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
@@ -60,7 +60,7 @@ spec:
           mountPath: /prometheus
       containers:
       - name: prometheus
-        image: registry.opensource.zalan.do/teapot/prometheus:v2.26.0
+        image: registry.opensource.zalan.do/teapot/prometheus:v2.29.1
         args:
         - "--config.file=/prometheus/prometheus.yaml"
         - "--storage.tsdb.path=/prometheus/"


### PR DESCRIPTION
https://github.com/prometheus/prometheus/releases/tag/v2.27.0
https://github.com/prometheus/prometheus/releases/tag/v2.28.0
https://github.com/prometheus/prometheus/releases/tag/v2.29.0
https://github.com/prometheus/prometheus/releases/tag/v2.29.1