### PR TITLE
Add cdp app to ClusterRoleBinding

### DIFF
--- a/cluster/manifests/roles/cdp-controller-rbac.yaml
+++ b/cluster/manifests/roles/cdp-controller-rbac.yaml
@@ -124,3 +124,6 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
   name: zalando-iam:zalando:service:stups_cdp-controller
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: zalando-iam:zalando:service:stups_cdp


### PR DESCRIPTION
Add ClusterRoleBinding for 'cdp' service to support migration from 'cdp-controller'