### PR TITLE
[cherry-pick] DS: add an optional ML Experiment deployment role

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -960,6 +960,22 @@ Resources:
               - sts:AssumeRole
       ManagedPolicyArns:
         - !Ref DeploymentIAMPolicy
+{{- if eq .Cluster.ConfigItems.deployment_service_ml_experiments_enabled "true"}}
+  DeploymentControllerMLExperimentDeploymentRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: "{{.Cluster.LocalID}}-deployment-service-ml-experiment-deployment"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !GetAtt DeploymentControllerRole.Arn
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/mlbuilder-permission-boundary"
+{{- end }}
   DeploymentStatusServiceRole:
     Type: AWS::IAM::Role
     Properties:

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -617,6 +617,7 @@ deployment_service_enabled: "true"
 {{ else }}
 deployment_service_enabled: "false"
 {{ end }}
+deployment_service_ml_experiments_enabled: "false"
 
 # Settings for the emergency access service
 # Service to use when checking incidents, valid values are 'jira' and 'opsgenie'. Temporary, will be dropped once

--- a/cluster/manifests/infrastructure-configs/deployment-config.yaml
+++ b/cluster/manifests/infrastructure-configs/deployment-config.yaml
@@ -18,4 +18,7 @@ data:
   s3-bucket-name: "zalando-deployment-service-{{accountID .Cluster.InfrastructureAccount}}-{{.Cluster.LocalID}}"
   status-service-url: "https://deployment-status-service.{{.Values.hosted_zone}}."
   deployment-role-arn: "arn:aws:iam::{{accountID .Cluster.InfrastructureAccount}}:role/{{.Cluster.LocalID}}-deployment-service-deployment"
+{{- if eq .Cluster.ConfigItems.deployment_service_ml_experiments_enabled "true"}}
+  ml-experiment-deployment-role-arn: "arn:aws:iam::{{accountID .Cluster.InfrastructureAccount}}:role/{{.Cluster.LocalID}}-deployment-service-ml-experiment-deployment"
+{{- end }}
 {{- end }}


### PR DESCRIPTION
#4536 to `stable`, since it's currently blocked by #4528.