### PR TITLE
etcd stack: support vpc-less security groups

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -409,6 +409,10 @@ etcd_instance_type: "t3.medium"
 etcd_docker_image: "registry.opensource.zalan.do/teapot/etcd-cluster:3.4.16-master-9"
 etcd_scalyr_key: ""
 etcd_ami: {{ amiID "Taupage-AMI-20210504-093855" "861068367966"}}
+# Old etcd stacks have been created without an explicit VPC ID in the security group. This cannot be changed without
+# recreating the security group, which is impossible because of cross-stack references.
+# TODO investigate if it can be migrated.
+etcd_stack_specify_vpc_in_security_group: "true"
 
 dynamodb_service_link_enabled: "false"
 

--- a/cluster/etcd-stack.yaml
+++ b/cluster/etcd-stack.yaml
@@ -135,7 +135,9 @@ Resources:
         FromPort: 9100
         ToPort: 9100
         CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+{{- if eq .Cluster.ConfigItems "etcd_stack_specify_vpc_in_security_group" "true"}}
       VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
+{{- }}
       Tags:
         - Key: InfrastructureComponent
           Value: true


### PR DESCRIPTION
Very old stacks don't specify the VPC ID for the security group. Unfortunately, CF doesn't allow to change this without recreating the resource (even if it'd be set to the same effective value), which is impossible due to cross-stack references. Let's add a config item for now and then figure out how to migrate it properly later.