### PR TITLE
etcd stack: fix the group references for vpc-less SGs

### DIFF
--- a/cluster/etcd-stack.yaml
+++ b/cluster/etcd-stack.yaml
@@ -30,7 +30,7 @@ Resources:
           - DeviceIndex: 0
             AssociatePublicIpAddress: true
             Groups:
-              - !Ref EtcdSecurityGroup
+              - !GetAtt EtcdSecurityGroup.GroupId
         EbsOptimized: false
         IamInstanceProfile:
           Name: !Ref AppServerInstanceProfile


### PR DESCRIPTION
Apparently `!Ref <SecurityGroup>` has [different semantics](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html#aws-properties-ec2-security-group-return-values) depending on whether the SG specifies the VPC or not. Switch to `GetAtt` instead.