### PR TITLE
Add a name to the etcd launch template

### DIFF
--- a/cluster/etcd-stack.yaml
+++ b/cluster/etcd-stack.yaml
@@ -25,6 +25,7 @@ Resources:
   LaunchTemplate:
     Type: AWS::EC2::LaunchTemplate
     Properties:
+      LaunchTemplateName: 'etcd-cluster-etcd'
       LaunchTemplateData:
         NetworkInterfaces:
           - DeviceIndex: 0


### PR DESCRIPTION
It's not really necessary, but it's a bit less ugly and makes it easier to find in the UI.