### PR TITLE
Add RouteGroup support for kube-metrics-adapter

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/01-rbac.yaml
+++ b/cluster/manifests/kube-metrics-adapter/01-rbac.yaml
@@ -74,6 +74,12 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - zalando.org
+  resources:
+  - routegroups
+  verbs:
+  - get
+- apiGroups:
   - autoscaling
   resources:
   - horizontalpodautoscalers

--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -24,13 +24,14 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.11
+        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.12
         env:
         - name: AWS_REGION
           value: {{ .Region }}
         args:
         - --prometheus-server=http://prometheus.kube-system.svc.cluster.local
         - --skipper-ingress-metrics
+        - --skipper-routegroup-metrics
         {{ if eq .ConfigItems.enable_scaling_schedule_metrics "true"}}
         - --scaling-schedule
         {{ end }}


### PR DESCRIPTION
Add support for RouteGroup based scaling in HPAs

Ref: https://github.com/zalando-incubator/kube-metrics-adapter/pull/349