### PR TITLE
CA: use scaling events for faster error detection

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -17,6 +17,12 @@ cluster_autoscaler_max_pod_eviction_time: "1h"
 cluster_autoscaler_max_pod_eviction_time: "3h"
 {{end}}
 
+{{if eq .Cluster.Environment "production"}}
+experimental_cluster_autoscaler_check_scaling_events: "false"
+{{else}}
+experimental_cluster_autoscaler_check_scaling_events: "true"
+{{end}}
+
 # ALB config created by kube-aws-ingress-controller
 kube_aws_ingress_controller_ssl_policy: "ELBSecurityPolicy-TLS-1-2-2017-01"
 kube_aws_ingress_controller_idle_timeout: "1m"

--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-cluster-autoscaler
-    version: v1.18.2-internal.25
 spec:
   selector:
     matchLabels:
@@ -16,7 +15,6 @@ spec:
     metadata:
       labels:
         application: kube-cluster-autoscaler
-        version: v1.18.2-internal.25
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
         prometheus.io/path: /metrics
@@ -35,7 +33,11 @@ spec:
         effect: NoSchedule
       containers:
       - name: cluster-autoscaler
+{{- if eq .Cluster.ConfigItems.experimental_cluster_autoscaler_check_scaling_events "true" }}
+        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.18.2-internal.29
+{{- else }}
         image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.18.2-internal.27
+{{- end }}
         command:
           - ./cluster-autoscaler
           - --v=1


### PR DESCRIPTION
Add an experimental config item (`experimental_cluster_autoscaler_check_scaling_events`) to roll out the new Cluster Autoscaler version that can detect scaling issues and fallback a lot faster (see https://github.com/zalando-incubator/autoscaler/pull/78 for details). Enable it by default for all test clusters.