### PR TITLE
Use scaling events in all clusters

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -20,11 +20,7 @@ cluster_autoscaler_max_pod_eviction_time: "3h"
 # Override terminationGracePeriodSeconds when evicting pods for scale down, if the pods' value is higher than this one
 cluster_autoscaler_max_graceful_termination_sec: "1209600" # 2 weeks
 
-{{if eq .Cluster.Environment "production"}}
-experimental_cluster_autoscaler_check_scaling_events: "false"
-{{else}}
 experimental_cluster_autoscaler_check_scaling_events: "true"
-{{end}}
 
 # ALB config created by kube-aws-ingress-controller
 kube_aws_ingress_controller_ssl_policy: "ELBSecurityPolicy-TLS-1-2-2017-01"


### PR DESCRIPTION
Enable #4564 in all clusters by default. We still keep the config item just in case, let's drop it a week later.