### PR TITLE
Allow skipper to scale based on ScalingSchedules

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -200,8 +200,12 @@ skipper_oauth2_ui_login: "true"
 #
 # This section contains the config items related to time based scaling
 # for skipper
+# kube-zmon-scaling
 skipper_time_based_scaling_check_id: ""
 skipper_time_based_scaling_target: "1"
+# ClusterScalingSchedules
+# hyped-article-releases
+skipper_scaling_schedule_hyped_articles_target: ""
 
 # disables image-policy-webhook in all clusters
 image_policy: "dev"

--- a/cluster/manifests/skipper/hpa.yaml
+++ b/cluster/manifests/skipper/hpa.yaml
@@ -41,6 +41,19 @@ spec:
             tag-application: "skipper-ingress"
             aggregators: last
 {{ end }}
+{{ if ne .ConfigItems.skipper_scaling_schedule_hyped_articles_target "" }}
+  - type: Object
+    object:
+      describedObject:
+        apiVersion: zalando.org/v1
+        kind: ClusterScalingSchedule
+        name: hyped-article-release
+      metric:
+        name: hyped-article-release
+      target:
+        averageValue: {{ .ConfigItems.skipper_scaling_schedule_hyped_articles_target }}
+        type: AverageValue
+{{ end }}
   behavior:
     scaleDown:
       stabilizationWindowSeconds: 600


### PR DESCRIPTION
Currently we have skipper scaling based on ZMON. Since we are migrating
away from ZMON for time based scaling, we need to move skipper too for
`ClusterScalingSchedules`. This is the first one, for hyped-article
releases. We will have more once SRE department decide on the
distribution of `ScalingSchedules`. We will have to decide which ones
will scale skipper and in which average.

This commit adds a new object metric for skipper's HPA targeting on the
hyped-article-release `ClusterScalingSchedule` object deployed to all
clusters. The clusters' skippers will scale iff the config item
`skipper_scaling_schedule_hyped_articles_target` is defined.