### PR TITLE
Update node-exporter configuration

### DIFF
--- a/cluster/manifests/node-monitor/daemonset.yaml
+++ b/cluster/manifests/node-monitor/daemonset.yaml
@@ -77,7 +77,9 @@ spec:
             - --path.procfs=/host/proc
             - --path.sysfs=/host/sys
             - --path.rootfs=/host
-            - --collector.filesystem.ignored-mount-points=^/(dev|proc|run|sys|host|var/lib/lxcfs|opt/podruntime/docker/.+|opt/podruntime/kubelet/.+)($|/)
+            - --collector.filesystem.mount-points-exclude=^/(dev|proc|run|sys|host|var/lib/lxcfs|opt/podruntime/docker/.+|opt/podruntime/kubelet/.+)($|/)
+            - --collector.netdev.device-exclude=^veth.*$
+            - --collector.netclass.ignored-devices=^veth.*$
           name: prometheus-node-exporter
           ports:
             - name: prom-node-exp


### PR DESCRIPTION
 * Use the new argument name for `collector.filesystem.ignored-mount-points`
 * Ignore veth devices in netdev/netclass collectors, these are not really needed and there can be quite a lot of them on busy nodes