### PR TITLE
CA: don't override terminationGracePeriodSeconds

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -17,6 +17,9 @@ cluster_autoscaler_max_pod_eviction_time: "1h"
 cluster_autoscaler_max_pod_eviction_time: "3h"
 {{end}}
 
+# Override terminationGracePeriodSeconds when evicting pods for scale down, if the pods' value is higher than this one
+cluster_autoscaler_max_graceful_termination_sec: "1209600" # 2 weeks
+
 {{if eq .Cluster.Environment "production"}}
 experimental_cluster_autoscaler_check_scaling_events: "false"
 {{else}}

--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -59,6 +59,7 @@ spec:
           - --scale-down-delay-after-add=-1s
           - --backoff-no-full-scale-down=true
           - --max-pod-eviction-time={{ .Cluster.ConfigItems.cluster_autoscaler_max_pod_eviction_time }}
+          - --max-graceful-termination-sec={{ .Cluster.ConfigItems.cluster_autoscaler_max_graceful_termination_sec }}
           - --topology-spread-constraint-scale-factor=3
           - --disable-node-instances-cache=true
           - --scale-down-ignore-schedulable-pods=true


### PR DESCRIPTION
#4572 to `stable` (mostly to test PR updates on cherry-picks, but also to unblock a cluster update).