### PR TITLE
Do not make image ignoring settings available as config items

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -342,7 +342,19 @@ teapot_admission_controller_daemonset_reserved_memory: "64Gi"
 {{if eq .Cluster.Environment "production"}}
 teapot_admission_controller_validate_application_label: "true"
 teapot_admission_controller_validate_base_images: "true"
+
+# Check container image compliance in production clusters. Be careful when thinking about changing this: Setting it to
+# false will allow any container image to run in production clusters.
+#
+# If you are seeing issues with "docker-meta" check the next config field to allow-list certain namespaces.
 teapot_admission_controller_validate_pod_images: "true"
+
+# If you are seeing issues with the container image compliance checker dependency "docker-meta" you can designate
+# a subset of namespaces to be allowed regardless with a regular expression on the namespace, e.g.:
+#
+# if docker-meta is down, do not reject container images running in `kube-system`
+# teapot_admission_controller_validate_pod_images_soft_fail_namespaces: "^kube-system$"
+
 teapot_admission_controller_validate_pod_template_resources: "true"
 teapot_admission_controller_preemption_enabled: "true"
 teapot_admission_controller_postgresql_delete_protection_enabled: "true"
@@ -350,9 +362,10 @@ teapot_admission_controller_namespace_delete_protection_enabled: "true"
 {{else if eq .Cluster.Environment "e2e"}}
 teapot_admission_controller_validate_application_label: "false"
 teapot_admission_controller_validate_base_images: "false"
+
+# Check container image compliance in e2e clusters. There are some exceptions to allow the e2e test suite to run.
 teapot_admission_controller_validate_pod_images: "true"
-teapot_admission_controller_validate_pod_images_namespaces: "^(image-policy-test-enabled-.*|kube-system|visibility)$"
-teapot_admission_controller_validate_pod_images_ignored_images: "^k8s.gcr.io/pause:.+$"
+
 teapot_admission_controller_validate_pod_template_resources: "false"
 teapot_admission_controller_preemption_enabled: "true"
 teapot_admission_controller_postgresql_delete_protection_enabled: "false"
@@ -360,7 +373,10 @@ teapot_admission_controller_namespace_delete_protection_enabled: "false"
 {{else}}
 teapot_admission_controller_validate_application_label: "false"
 teapot_admission_controller_validate_base_images: "false"
+
+# Do not check container image compliance in test clusters.
 teapot_admission_controller_validate_pod_images: "false"
+
 teapot_admission_controller_validate_pod_template_resources: "true"
 teapot_admission_controller_preemption_enabled: "false"
 teapot_admission_controller_postgresql_delete_protection_enabled: "false"

--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -39,18 +39,24 @@ data:
   podfactory.base-image-check.namespaces: "{{ .Cluster.ConfigItems.teapot_admission_controller_validate_base_images_namespaces }}"
 {{- end }}
 
+  # This setting enables and disables the container image compliance checks
   pod.image-check.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_validate_pod_images }}"
-{{- if index .Cluster.ConfigItems "teapot_admission_controller_validate_pod_images_namespaces" }}
-  pod.image-check.namespaces: "{{ .Cluster.ConfigItems.teapot_admission_controller_validate_pod_images_namespaces }}"
-{{- end }}
-{{- if index .Cluster.ConfigItems "teapot_admission_controller_validate_pod_images_ignore_namespaces" }}
-  pod.image-check.ignore-namespaces: "{{ .Cluster.ConfigItems.teapot_admission_controller_validate_pod_images_ignore_namespaces }}"
-{{- end }}
+
 {{- if index .Cluster.ConfigItems "teapot_admission_controller_validate_pod_images_soft_fail_namespaces" }}
+  # In case docker-meta is down, all containers in these configured namespaces are allowed, defaults to none if not configured
   pod.image-check.soft-fail-namespaces: "{{ .Cluster.ConfigItems.teapot_admission_controller_validate_pod_images_soft_fail_namespaces }}"
 {{- end }}
-{{- if index .Cluster.ConfigItems "teapot_admission_controller_validate_pod_images_ignored_images" }}
-  pod.image-check.ignored-images: "{{ .Cluster.ConfigItems.teapot_admission_controller_validate_pod_images_ignored_images }}"
+
+{{- if eq .Cluster.Environment "e2e" }}
+  # Special settings only configured for e2e clusters
+  #
+  # DO NOT USE THESE IN PRODUCTION CLUSTERS
+
+  # Limit the namespaces where container image checks are required, defaults to all if not configured
+  pod.image-check.namespaces: "^(image-policy-test-enabled-.*|kube-system|visibility)$"
+
+  # Always allow certain container images regardless of namespace, defaults to none if not configured
+  pod.image-check.ignored-images: "^k8s.gcr.io/pause:.+$"
 {{- end }}
 
   deployment.default.rolling-update-max-surge: "{{ .Cluster.ConfigItems.teapot_admission_controller_deployment_default_max_surge }}"


### PR DESCRIPTION
This doesn't expose the image-ignoring settings in admission-controller as config items since they are only needed in e2e clusters and we want to make it hard for people to change them.

The only exposed configuration is a general knob for turning it on and off with a big warning and the soft-fail setting which is unused as long as docker-meta is available.

Also added more comments to explain these settings.