### PR TITLE
CA: handle 'Cancelled' ASG events as well

### DIFF
--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -34,7 +34,7 @@ spec:
       containers:
       - name: cluster-autoscaler
 {{- if eq .Cluster.ConfigItems.experimental_cluster_autoscaler_check_scaling_events "true" }}
-        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.18.2-internal.29
+        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.18.2-internal.31
 {{- else }}
         image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.18.2-internal.27
 {{- end }}


### PR DESCRIPTION
Treat 'Cancelled' events as scale-up failures, ASG seems to only report those for weird issues on their side (see https://github.com/zalando-incubator/autoscaler/pull/81 for more details).