### PR TITLE
Restrict access to nodes/proxy, services/proxy

### DIFF
--- a/cluster/manifests/roles/readonly-binding.yaml
+++ b/cluster/manifests/roles/readonly-binding.yaml
@@ -21,3 +21,28 @@ subjects:
   name: "okta:common/read-only"
   apiGroup: rbac.authorization.k8s.io
 {{- end }}
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: readonly-dashboard
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: readonly-dashboard
+subjects:
+- kind: Group
+  name: ReadOnly
+  apiGroup: rbac.authorization.k8s.io
+{{- if eq .Cluster.ConfigItems.okta_auth_enabled "true" }}
+- kind: Group
+  name: "okta:common/engineer"
+  apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: "okta:common/collaborator"
+  apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: "okta:common/read-only"
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/cluster/manifests/roles/readonly-dashboard.yaml
+++ b/cluster/manifests/roles/readonly-dashboard.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: readonly-dashboard
+  namespace: kube-system
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "services/proxy" ]
+    verbs: [ "get" ]
+    resourceNames: [ "kubernetes-dashboard" ]

--- a/cluster/manifests/roles/readonly-role.yaml
+++ b/cluster/manifests/roles/readonly-role.yaml
@@ -29,7 +29,6 @@ rules:
   - namespaces/finalize
   - namespaces/status
   - nodes
-  - nodes/proxy
   - nodes/status
   - persistentvolumeclaims
   - persistentvolumeclaims/status
@@ -44,7 +43,6 @@ rules:
   - resourcequotas/status
   - serviceaccounts
   - services
-  - services/proxy
   - services/status
   verbs:
   - get


### PR DESCRIPTION
We shouldn't allow access for `services/proxy` for the ReadOnly role because of the potential security impact. It was most likely only added for the dashboard to work, so let's explicitly provide access to the dashboard only and restrict the rest. `nodes/proxy` shouldn't be allowed at all.