### PR TITLE
Consolidate apiserver/controller-manager/scheduler [1/X]

### DIFF
--- a/cluster/manifests/admission-control-credentials/credentials.yaml
+++ b/cluster/manifests/admission-control-credentials/credentials.yaml
@@ -4,9 +4,10 @@ metadata:
   name: admission-controller-credentials
   namespace: kube-system
   labels:
-    application: kube-apiserver
+    application: kubernetes
+    component: kube-apiserver
 spec:
-  application: kube-apiserver
+  application: kubernetes
   tokens:
     kio:
       privileges: []

--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -88,12 +88,15 @@ data:
           names:
             - kube-system
       relabel_configs:
-      - source_labels: [__meta_kubernetes_pod_label_application, __meta_kubernetes_pod_container_port_number]
+      - source_labels: [__meta_kubernetes_pod_label_application, __meta_kubernetes_pod_label_component, __meta_kubernetes_pod_container_port_number]
         action: keep
-        regex: kube-apiserver;443
+        regex: kubernetes;kube-apiserver;443
       - action: replace
         source_labels: ['__meta_kubernetes_pod_label_application']
         target_label: application
+      - action: replace
+        source_labels: ['__meta_kubernetes_pod_label_component']
+        target_label: component
     - &apiserver_container_metric
       job_name: 'teapot-admission-controller'
       scheme: http
@@ -104,12 +107,15 @@ data:
           names:
             - kube-system
       relabel_configs:
-      - source_labels: [__meta_kubernetes_pod_label_application, __meta_kubernetes_pod_container_port_number]
+      - source_labels: [__meta_kubernetes_pod_label_application, __meta_kubernetes_pod_label_component, __meta_kubernetes_pod_container_port_number]
         action: keep
-        regex: kube-apiserver;9005
+        regex: kubernetes;kube-apiserver;9005
       - action: replace
         source_labels: ['__meta_kubernetes_pod_label_application']
         target_label: application
+      - action: replace
+        source_labels: ['__meta_kubernetes_pod_label_component']
+        target_label: component
     - <<: *apiserver_container_metric
       job_name: "auth-webhook"
       metrics_path: "/auth-webhook"

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -79,7 +79,8 @@ write_files:
         name: kube-apiserver
         namespace: kube-system
         labels:
-          application: kube-apiserver
+          application: kubernetes
+          component: kube-apiserver
         annotations:
           kubernetes-log-watcher/scalyr-parser: |
             [{"container": "webhook", "parser": "json-structured-log"}]
@@ -583,7 +584,8 @@ write_files:
         name: kube-controller-manager
         namespace: kube-system
         labels:
-          application: kube-controller-manager
+          application: kubernetes
+          component: kube-controller-manager
         annotations:
           logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
       spec:
@@ -652,7 +654,8 @@ write_files:
         name: kube-scheduler
         namespace: kube-system
         labels:
-          application: kube-scheduler
+          application: kubernetes
+          component: kube-scheduler
         annotations:
           logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
       spec:

--- a/test/e2e/infra.go
+++ b/test/e2e/infra.go
@@ -44,10 +44,13 @@ var _ = framework.KubeDescribe("Infrastructure tests", func() {
 
 })
 
-func podsForApplication(cs kubernetes.Interface, application string) ([]v1.Pod, error) {
+func podsForApplication(cs kubernetes.Interface, component string) ([]v1.Pod, error) {
 	matchingPods, err := cs.CoreV1().Pods(kubeapi.NamespaceSystem).List(context.TODO(), metav1.ListOptions{
 		LabelSelector: metav1.FormatLabelSelector(&metav1.LabelSelector{
-			MatchLabels: map[string]string{"application": application},
+			MatchLabels: map[string]string{
+				"application": "kubernetes",
+				"component":   component,
+			},
 		}),
 	})
 	if err != nil {


### PR DESCRIPTION
Change the mirror pods on the masters (apiserver, controller-manager and scheduler) to components of the `kubernetes` application instead of using their own application IDs. We will lose Prometheus metrics for the duration of the rotation, but it doesn't seem like a big deal.