### PR TITLE
node-monitor - disable qdisc support

### DIFF
--- a/cluster/manifests/node-monitor/daemonset.yaml
+++ b/cluster/manifests/node-monitor/daemonset.yaml
@@ -75,7 +75,6 @@ spec:
           args:
 {{- if eq .Cluster.ConfigItems.node_exporter_experimental_metrics "true" }}
             - --collector.ethtool
-            - --collector.qdisc
 {{- end }}
             - --collector.processes
             - --path.procfs=/host/proc


### PR DESCRIPTION
we detected a memory leak in this pod running in kubernetes master nodes, try to disable qdisc support

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>