### PR TITLE
Update the application/component for the etcd-backup job [2/X]

### DIFF
--- a/cluster/manifests/etcd-backup/cronjob.yaml
+++ b/cluster/manifests/etcd-backup/cronjob.yaml
@@ -4,8 +4,8 @@ metadata:
   name: etcd-backup
   namespace: kube-system
   labels:
-    application: etcd-backup
-    version: "master-12"
+    application: kubernetes
+    component: etcd-backup
 spec:
   schedule: "*/1 * * * *"
   concurrencyPolicy: Forbid
@@ -18,8 +18,8 @@ spec:
       template:
         metadata:
           labels:
-            application: etcd-backup
-            version: "master-12"
+            application: kubernetes
+            component: etcd-backup
           annotations:
             logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
         spec:


### PR DESCRIPTION
Not strictly necessary, but easy to roll out.