### PR TITLE
Admission controller: AZ block feature

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -425,6 +425,9 @@ teapot_admission_controller_prevent_scale_down_allowed: "true"
 teapot_admission_controller_prevent_scale_down_allowed: "false"
 {{end}}
 
+# Prevent the use of a particular AZ as much as possible
+blocked_availability_zone: ""
+
 # etcd cluster
 {{if eq .Cluster.Environment "production"}}
 etcd_instance_count: "5"

--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -84,6 +84,15 @@ data:
 {{- end }}
 {{- end}}
 
+  pod.az-block.zone-name: "{{ .Cluster.ConfigItems.blocked_availability_zone }}"
+{{- range $group, $enabled := zoneDistributedNodePoolGroups .Cluster.NodePools }}
+{{- if eq $group "" }}
+  pod.az-block.pools.default: "{{ $enabled }}"
+{{- else }}
+  pod.az-block.pools.dedicated.{{$group}}: "{{ $enabled }}"
+{{- end }}
+{{- end}}
+
   node.node-not-ready-taint.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_node_not_ready_taint }}"
   node.extended-node-restriction.enable: "true"
 

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -200,7 +200,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-125
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-127
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
Add a new config item, `blocked_availability_zone`, that allows us to prevent the use of a particular availability zone as much as possible. Using a more generic name here because while it's only used with the admission controller right now, it could affect more things in the future.