### PR TITLE
kube-state-metrics: add more node labels to the allowlist

### DIFF
--- a/cluster/manifests/kube-state-metrics/deployment.yaml
+++ b/cluster/manifests/kube-state-metrics/deployment.yaml
@@ -29,7 +29,7 @@ spec:
         image: registry.opensource.zalan.do/teapot/kube-state-metrics:v2.2.0
         args:
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments,verticalpodautoscalers
-        - --metric-labels-allowlist=pods=[application,component],nodes=[topology.kubernetes.io/zone]
+        - --metric-labels-allowlist=pods=[application,component],nodes=[topology.kubernetes.io/zone,node.kubernetes.io/instance-type,node.kubernetes.io/node-pool,node.kubernetes.io/role,dedicated]
         ports:
         - containerPort: 8080
           name: http-metrics


### PR DESCRIPTION
With these in place, we could easily run aggregated queries to e.g. calculate the total amount of wasted space on all the nodes in a node pool or a node pool group. Doing it without those is still possible, obviously, but would result in hundreds of queries to Prometheus and would require us to do the aggregation in ad-hoc code instead.