### PR TITLE
Drop the experimental_cluster_autoscaler_check_scaling_events CI

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -20,8 +20,6 @@ cluster_autoscaler_max_pod_eviction_time: "3h"
 # Override terminationGracePeriodSeconds when evicting pods for scale down, if the pods' value is higher than this one
 cluster_autoscaler_max_graceful_termination_sec: "1209600" # 2 weeks
 
-experimental_cluster_autoscaler_check_scaling_events: "true"
-
 # ALB config created by kube-aws-ingress-controller
 kube_aws_ingress_controller_ssl_policy: "ELBSecurityPolicy-TLS-1-2-2017-01"
 kube_aws_ingress_controller_idle_timeout: "1m"

--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -33,11 +33,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cluster-autoscaler
-{{- if eq .Cluster.ConfigItems.experimental_cluster_autoscaler_check_scaling_events "true" }}
         image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.18.2-internal.31
-{{- else }}
-        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.18.2-internal.27
-{{- end }}
         command:
           - ./cluster-autoscaler
           - --v=1


### PR DESCRIPTION
It's unlikely we'll have to roll back, and we should just fix the autoscaler instead.