### PR TITLE
Consolidate more applications [3/X]

### DIFF
--- a/cluster/manifests/01-admission-control/teapot.yaml
+++ b/cluster/manifests/01-admission-control/teapot.yaml
@@ -3,7 +3,8 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: teapot-admission-controller
   labels:
-    application: teapot-admission-controller
+    application: kubernetes
+    component: teapot-admission-controller
 webhooks:
   - name: pod-admitter.teapot.zalan.do
     clientConfig:

--- a/cluster/manifests/02-kube-aws-iam-controller/deployment.yaml
+++ b/cluster/manifests/02-kube-aws-iam-controller/deployment.yaml
@@ -4,17 +4,20 @@ metadata:
   name: kube-aws-iam-controller
   namespace: kube-system
   labels:
-    application: kube-aws-iam-controller
+    application: kubernetes
+    component: aws-iam-controller
     version: v0.1.2
 spec:
   replicas: 1
   selector:
     matchLabels:
-      application: kube-aws-iam-controller
+      deployment: kube-aws-iam-controller
   template:
     metadata:
       labels:
-        application: kube-aws-iam-controller
+        application: kubernetes
+        component: aws-iam-controller
+        deployment: kube-aws-iam-controller
         version: v0.1.2
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"

--- a/cluster/manifests/02-kube-aws-iam-controller/vpa.yaml
+++ b/cluster/manifests/02-kube-aws-iam-controller/vpa.yaml
@@ -4,7 +4,8 @@ metadata:
   name: kube-aws-iam-controller
   namespace: kube-system
   labels:
-    application: kube-aws-iam-controller
+    application: kubernetes
+    component: aws-iam-controller
 spec:
   targetRef:
     apiVersion: apps/v1

--- a/cluster/manifests/03-ebs-csi/02-csi-driver.yaml
+++ b/cluster/manifests/03-ebs-csi/02-csi-driver.yaml
@@ -4,18 +4,21 @@ kind: DaemonSet
 metadata:
   name: csi-node-driver
   namespace: kube-system
+  labels:
+    application: kubernetes
+    component: csi-node-driver
 spec:
   selector:
     matchLabels:
-      application: container-storage-interface
-      component: driver
+      daemonset: csi-node-driver
   updateStrategy:
     type: RollingUpdate
   template:
     metadata:
       labels:
-        application: container-storage-interface
-        component: driver
+        application: kubernetes
+        component: csi-node-driver
+        daemonset: csi-node-driver
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:

--- a/cluster/manifests/03-ebs-csi/ebs-controller.yaml
+++ b/cluster/manifests/03-ebs-csi/ebs-controller.yaml
@@ -4,16 +4,19 @@ kind: DaemonSet
 metadata:
   name: ebs-csi-controller
   namespace: kube-system
+  labels:
+    application: kubernetes
+    component: ebs-csi-controller
 spec:
   selector:
     matchLabels:
-      application: container-storage-interface
-      component: ebs-controller
+      daemonset: ebs-csi-controller
   template:
     metadata:
       labels:
-        application: container-storage-interface
-        component: ebs-controller
+        application: kubernetes
+        component: ebs-csi-controller
+        daemonset: ebs-csi-controller
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:

--- a/cluster/manifests/aws-node-decommissioner/01-rbac.yaml
+++ b/cluster/manifests/aws-node-decommissioner/01-rbac.yaml
@@ -4,7 +4,8 @@ metadata:
   name: "aws-node-decommissioner"
   namespace: "kube-system"
   annotations:
-    application: aws-node-decommissioner
+    application: kubernetes
+    component: aws-node-decommissioner
     iam.amazonaws.com/role: "{{.LocalID}}-aws-node-decommissioner"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -12,7 +13,8 @@ kind: ClusterRole
 metadata:
   name: aws-node-decommissioner
   labels:
-    application: aws-node-decommissioner
+    application: kubernetes
+    component: aws-node-decommissioner
 rules:
 - apiGroups: [""]
   resources: ["nodes"]
@@ -25,7 +27,8 @@ kind: ClusterRoleBinding
 metadata:
   name: aws-node-decommissioner
   labels:
-    application: aws-node-decommissioner
+    application: kubernetes
+    component: aws-node-decommissioner
 roleRef:
   kind: ClusterRole
   name: aws-node-decommissioner

--- a/cluster/manifests/aws-node-decommissioner/cronjob.yaml
+++ b/cluster/manifests/aws-node-decommissioner/cronjob.yaml
@@ -4,7 +4,8 @@ metadata:
   name: aws-node-decommissioner
   namespace: "kube-system"
   labels:
-    application: aws-node-decommissioner
+    application: kubernetes
+    component: aws-node-decommissioner
 spec:
   schedule: "*/5 * * * *"
   concurrencyPolicy: Forbid
@@ -18,7 +19,8 @@ spec:
       template:
         metadata:
           labels:
-            application: aws-node-decommissioner
+            application: kubernetes
+            component: aws-node-decommissioner
           annotations:
             logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
         spec:

--- a/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
@@ -4,19 +4,22 @@ metadata:
   name: cluster-lifecycle-controller
   namespace: kube-system
   labels:
-    application: cluster-lifecycle-controller
+    application: kubernetes
+    component: cluster-lifecycle-controller
     version: master-23
 spec:
   replicas: 1
   selector:
     matchLabels:
-      application: cluster-lifecycle-controller
+      deployment: cluster-lifecycle-controller
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        application: cluster-lifecycle-controller
+        application: kubernetes
+        component: cluster-lifecycle-controller
+        deployment: cluster-lifecycle-controller
         version: master-23
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_both}}"

--- a/cluster/manifests/cronjob-fixer/deployment.yaml
+++ b/cluster/manifests/cronjob-fixer/deployment.yaml
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       labels:
+        deployment: cronjob-fixer
         application: kubernetes
         component: cronjob-fixer
       annotations:

--- a/cluster/manifests/cronjob-fixer/deployment.yaml
+++ b/cluster/manifests/cronjob-fixer/deployment.yaml
@@ -4,16 +4,18 @@ metadata:
   name: cronjob-fixer
   namespace: kube-system
   labels:
-    application: cronjob-fixer
+    application: kubernetes
+    component: cronjob-fixer
 spec:
   replicas: 1
   selector:
     matchLabels:
-      application: cronjob-fixer
+      deployment: cronjob-fixer
   template:
     metadata:
       labels:
-        application: cronjob-fixer
+        application: kubernetes
+        component: cronjob-fixer
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:

--- a/cluster/manifests/cronjob-fixer/vpa.yaml
+++ b/cluster/manifests/cronjob-fixer/vpa.yaml
@@ -4,7 +4,8 @@ metadata:
   name: cronjob-fixer
   namespace: kube-system
   labels:
-    application: cronjob-fixer
+    application: kubernetes
+    component: cronjob-fixer
 spec:
   targetRef:
     apiVersion: apps/v1

--- a/cluster/manifests/cronjob-monitor/deployment.yaml
+++ b/cluster/manifests/cronjob-monitor/deployment.yaml
@@ -4,16 +4,18 @@ metadata:
   name: cronjob-monitor
   namespace: kube-system
   labels:
-    application: cronjob-monitor
+    application: kubernetes
+    component: cronjob-monitor
 spec:
   replicas: 1
   selector:
     matchLabels:
-      application: cronjob-monitor
+      deployment: cronjob-monitor
   template:
     metadata:
       labels:
-        application: cronjob-monitor
+        application: kubernetes
+        component: cronjob-monitor
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:

--- a/cluster/manifests/cronjob-monitor/deployment.yaml
+++ b/cluster/manifests/cronjob-monitor/deployment.yaml
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       labels:
+        deployment: cronjob-monitor
         application: kubernetes
         component: cronjob-monitor
       annotations:

--- a/cluster/manifests/cronjob-monitor/vpa.yaml
+++ b/cluster/manifests/cronjob-monitor/vpa.yaml
@@ -4,7 +4,8 @@ metadata:
   name: cronjob-monitor
   namespace: kube-system
   labels:
-    application: cronjob-monitor
+    application: kubernetes
+    component: cronjob-monitor
 spec:
   targetRef:
     apiVersion: apps/v1

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -30,6 +30,13 @@ pre_apply:
   namespace: default
   kind: Deployment
 {{ end }}
+# Application consolidation, can be dropped later
+{{if eq .Cluster.Environment "e2e"}}
+- labels:
+    application: kube-aws-iam-controller
+  namespace: kube-system
+  kind: Deployment
+{{ end }}
 
 # everything defined under here will be deleted after applying the manifests
 post_apply:

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -95,6 +95,10 @@ pre_apply:
     application: autoscaling-buffer
   namespace: kube-system
   kind: Deployment
+- labels:
+    application: kube-node-ready-controller
+  namespace: kube-system
+  kind: Daemonset
 
 # everything defined under here will be deleted after applying the manifests
 post_apply:

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -57,6 +57,10 @@ pre_apply:
   namespace: kube-system
   kind: Deployment
 - labels:
+    application: pdb-controller
+  namespace: kube-system
+  kind: Deployment
+- labels:
     application: kubernetes-event-logger
   namespace: kube-system
   kind: StatefulSet

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -45,6 +45,10 @@ pre_apply:
   namespace: kube-system
   kind: Deployment
 - labels:
+    application: kube-static-egress-controller
+  namespace: kube-system
+  kind: Deployment
+- labels:
     application: kube-state-metrics
   namespace: kube-system
   kind: Deployment

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -84,6 +84,10 @@ pre_apply:
     application: cluster-lifecycle-controller
   namespace: kube-system
   kind: Deployment
+- labels:
+    application: efs-provisioner
+  namespace: kube-system
+  kind: Deployment
 {{ end }}
 
 # everything defined under here will be deleted after applying the manifests

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -45,6 +45,10 @@ pre_apply:
   namespace: kube-system
   kind: Deployment
 - labels:
+    application: kubernetes-event-logger
+  namespace: kube-system
+  kind: StatefulSet
+- labels:
     application: cronjob-monitor
   namespace: kube-system
   kind: Deployment

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -53,6 +53,10 @@ pre_apply:
   namespace: kube-system
   kind: Deployment
 - labels:
+    application: kubernetes-lifecycle-metrics
+  namespace: kube-system
+  kind: Deployment
+- labels:
     application: kubernetes-event-logger
   namespace: kube-system
   kind: StatefulSet

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -87,6 +87,14 @@ pre_apply:
     application: efs-provisioner
   namespace: kube-system
   kind: Deployment
+- labels:
+    application: kube-cluster-autoscaler
+  namespace: kube-system
+  kind: Daemonset
+- labels:
+    application: autoscaling-buffer
+  namespace: kube-system
+  kind: Deployment
 
 # everything defined under here will be deleted after applying the manifests
 post_apply:

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -36,6 +36,10 @@ pre_apply:
     application: kube-aws-iam-controller
   namespace: kube-system
   kind: Deployment
+- labels:
+    application: kube-metrics-adapter
+  namespace: kube-system
+  kind: Deployment
 {{ end }}
 
 # everything defined under here will be deleted after applying the manifests

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -80,6 +80,10 @@ pre_apply:
     application: kube-janitor
   namespace: kube-system
   kind: Deployment
+- labels:
+    application: cluster-lifecycle-controller
+  namespace: kube-system
+  kind: Deployment
 {{ end }}
 
 # everything defined under here will be deleted after applying the manifests

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -45,6 +45,10 @@ pre_apply:
   namespace: kube-system
   kind: Deployment
 - labels:
+    application: cronjob-monitor
+  namespace: kube-system
+  kind: Deployment
+- labels:
     application: cronjob-fixer
   namespace: kube-system
   kind: Deployment

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -45,6 +45,10 @@ pre_apply:
   namespace: kube-system
   kind: Deployment
 - labels:
+    application: kube-state-metrics
+  namespace: kube-system
+  kind: Deployment
+- labels:
     application: kubernetes-event-logger
   namespace: kube-system
   kind: StatefulSet

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -40,6 +40,10 @@ pre_apply:
     application: kube-metrics-adapter
   namespace: kube-system
   kind: Deployment
+- labels:
+    application: metrics-server
+  namespace: kube-system
+  kind: Deployment
 {{ end }}
 
 # everything defined under here will be deleted after applying the manifests

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -44,6 +44,10 @@ pre_apply:
     application: metrics-server
   namespace: kube-system
   kind: Deployment
+- labels:
+    application: cronjob-fixer
+  namespace: kube-system
+  kind: Deployment
 {{ end }}
 
 # everything defined under here will be deleted after applying the manifests

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -76,6 +76,10 @@ pre_apply:
     application: kube-downscaler
   namespace: kube-system
   kind: Deployment
+- labels:
+    application: kube-janitor
+  namespace: kube-system
+  kind: Deployment
 {{ end }}
 
 # everything defined under here will be deleted after applying the manifests

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -72,6 +72,10 @@ pre_apply:
     application: cronjob-fixer
   namespace: kube-system
   kind: Deployment
+- labels:
+    application: kube-downscaler
+  namespace: kube-system
+  kind: Deployment
 {{ end }}
 
 # everything defined under here will be deleted after applying the manifests

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -31,7 +31,6 @@ pre_apply:
   kind: Deployment
 {{ end }}
 # Application consolidation, can be dropped later
-{{if eq .Cluster.Environment "e2e"}}
 - labels:
     application: kube-aws-iam-controller
   namespace: kube-system
@@ -88,7 +87,6 @@ pre_apply:
     application: efs-provisioner
   namespace: kube-system
   kind: Deployment
-{{ end }}
 
 # everything defined under here will be deleted after applying the manifests
 post_apply:

--- a/cluster/manifests/efs-provisioner/depl-efs-provisioner.yaml
+++ b/cluster/manifests/efs-provisioner/depl-efs-provisioner.yaml
@@ -5,18 +5,21 @@ metadata:
   name: efs-provisioner
   namespace: kube-system
   labels:
-    application: efs-provisioner
+    application: kubernetes
+    component: efs-provisioner
     version: v2.4.0
 spec:
   strategy:
     type: Recreate
   selector:
     matchLabels:
-      application: efs-provisioner
+      deployment: efs-provisioner
   template:
     metadata:
       labels:
-        application: efs-provisioner
+        application: kubernetes
+        component: efs-provisioner
+        deployment: efs-provisioner
         version: v2.4.0
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"

--- a/cluster/manifests/event-logger/service.yaml
+++ b/cluster/manifests/event-logger/service.yaml
@@ -4,9 +4,11 @@ metadata:
   name: kubernetes-event-logger
   namespace: kube-system
   labels:
-    application: kubernetes-event-logger
+    application: kubernetes
+    component: event-logger
 spec:
   type: ClusterIP
   clusterIP: None
   selector:
-    application: kubernetes-event-logger
+    application: kubernetes
+    component: event-logger

--- a/cluster/manifests/event-logger/statefulset.yaml
+++ b/cluster/manifests/event-logger/statefulset.yaml
@@ -18,6 +18,7 @@ spec:
   template:
     metadata:
       labels:
+        statefulset: kubernetes-event-logger
         application: kubernetes
         component: event-logger
         version: master-3

--- a/cluster/manifests/event-logger/statefulset.yaml
+++ b/cluster/manifests/event-logger/statefulset.yaml
@@ -4,7 +4,8 @@ metadata:
   name: kubernetes-event-logger
   namespace: kube-system
   labels:
-    application: kubernetes-event-logger
+    application: kubernetes
+    component: event-logger
     version: master-3
   annotations:
     kubernetes-log-watcher/scalyr-parser: '[{"container": "logger", "parser": "json"}]'
@@ -12,12 +13,13 @@ spec:
   replicas: {{if eq .Cluster.ConfigItems.kubernetes_event_logger_enabled "true"}}1{{else}}0{{end}}
   selector:
     matchLabels:
-      application: kubernetes-event-logger
+      statefulset: kubernetes-event-logger
   serviceName: kubernetes-event-logger
   template:
     metadata:
       labels:
-        application: kubernetes-event-logger
+        application: kubernetes
+        component: event-logger
         version: master-3
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_both}}"

--- a/cluster/manifests/kube-cluster-autoscaler/01-rbac.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/01-rbac.yaml
@@ -4,7 +4,8 @@ metadata:
   name: cluster-autoscaler
   namespace: kube-system
   labels:
-    application: kube-cluster-autoscaler
+    application: kubernetes
+    component: kube-cluster-autoscaler
   annotations:
     iam.amazonaws.com/role: "{{ .LocalID }}-app-autoscaler"
 ---
@@ -13,7 +14,8 @@ kind: ClusterRole
 metadata:
   name: cluster-autoscaler
   labels:
-    application: kube-cluster-autoscaler
+    application: kubernetes
+    component: kube-cluster-autoscaler
 rules:
 - apiGroups: [""]
   resources: ["events", "endpoints"]
@@ -68,7 +70,8 @@ metadata:
   name: cluster-autoscaler
   namespace: kube-system
   labels:
-    application: kube-cluster-autoscaler
+    application: kubernetes
+    component: kube-cluster-autoscaler
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
@@ -83,7 +86,8 @@ kind: ClusterRoleBinding
 metadata:
   name: cluster-autoscaler
   labels:
-    application: kube-cluster-autoscaler
+    application: kubernetes
+    component: kube-cluster-autoscaler
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -99,7 +103,8 @@ metadata:
   name: cluster-autoscaler
   namespace: kube-system
   labels:
-    application: kube-cluster-autoscaler
+    application: kubernetes
+    component: kube-cluster-autoscaler
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment.yaml
@@ -6,20 +6,23 @@ metadata:
   name: autoscaling-buffer-{{$zone}}
   namespace: kube-system
   labels:
-    application: autoscaling-buffer
+    application: kubernetes
+    component: autoscaling-buffer
     zone: {{$zone}}
 spec:
   replicas: {{$data.ConfigItems.autoscaling_buffer_pods}}
   selector:
     matchLabels:
-      application: autoscaling-buffer
+      deployment: autoscaling-buffer
       zone: {{$zone}}
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        application: autoscaling-buffer
+        application: kubernetes
+        component: autoscaling-buffer
+        deployment: autoscaling-buffer
         zone: {{$zone}}
     spec:
       dnsConfig:

--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -4,17 +4,20 @@ metadata:
   name: kube-cluster-autoscaler
   namespace: kube-system
   labels:
-    application: kube-cluster-autoscaler
+    application: kubernetes
+    component: kube-cluster-autoscaler
 spec:
   selector:
     matchLabels:
-      application: kube-cluster-autoscaler
+      daemonset: kube-cluster-autoscaler
   updateStrategy:
     type: RollingUpdate
   template:
     metadata:
       labels:
-        application: kube-cluster-autoscaler
+        application: kubernetes
+        component: kube-cluster-autoscaler
+        daemonset: kube-cluster-autoscaler
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
         prometheus.io/path: /metrics

--- a/cluster/manifests/kube-cluster-autoscaler/pdb.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/pdb.yaml
@@ -2,11 +2,13 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    application: autoscaling-buffer
+    application: kubernetes
+    component: autoscaling-buffer
   name: autoscaling-buffer
   namespace: kube-system
 spec:
   maxUnavailable: "100%"
   selector:
     matchLabels:
-      application: autoscaling-buffer
+      application: kubernetes
+      component: autoscaling-buffer

--- a/cluster/manifests/kube-downscaler/deployment.yaml
+++ b/cluster/manifests/kube-downscaler/deployment.yaml
@@ -5,17 +5,20 @@ metadata:
   name: kube-downscaler
   namespace: kube-system
   labels:
-    application: kube-downscaler
+    application: kubernetes
+    component: kube-downscaler
     version: v20.4.1
 spec:
   replicas: 1
   selector:
     matchLabels:
-      application: kube-downscaler
+      deployment: kube-downscaler
   template:
     metadata:
       labels:
-        application: kube-downscaler
+        deployment: kube-downscaler
+        application: kubernetes
+        component: kube-downscaler
         version: v20.4.1
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"

--- a/cluster/manifests/kube-downscaler/vpa.yaml
+++ b/cluster/manifests/kube-downscaler/vpa.yaml
@@ -5,7 +5,8 @@ metadata:
   name: kube-downscaler
   namespace: kube-system
   labels:
-    application: kube-downscaler
+    application: kubernetes
+    component: kube-downscaler
 spec:
   targetRef:
     apiVersion: apps/v1

--- a/cluster/manifests/kube-janitor/deployment.yaml
+++ b/cluster/manifests/kube-janitor/deployment.yaml
@@ -5,17 +5,20 @@ metadata:
   name: kube-janitor
   namespace: kube-system
   labels:
-    application: kube-janitor
+    application: kubernetes
+    componet: kube-janitor
     version: v20.4.1
 spec:
   replicas: 1
   selector:
     matchLabels:
-      application: kube-janitor
+      deployment: kube-janitor
   template:
     metadata:
       labels:
-        application: kube-janitor
+        deployment: kube-janitor
+        application: kubernetes
+        componet: kube-janitor
         version: v20.4.1
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"

--- a/cluster/manifests/kube-janitor/vpa.yaml
+++ b/cluster/manifests/kube-janitor/vpa.yaml
@@ -5,7 +5,8 @@ metadata:
   name: kube-janitor
   namespace: kube-system
   labels:
-    application: kube-janitor
+    application: kubernetes
+    component: kube-janitor
 spec:
   targetRef:
     apiVersion: apps/v1

--- a/cluster/manifests/kube-metrics-adapter/credentials.yaml
+++ b/cluster/manifests/kube-metrics-adapter/credentials.yaml
@@ -5,9 +5,10 @@ metadata:
   name: "kube-metrics-adapter"
   namespace: kube-system
   labels:
-    application: "kube-metrics-adapter"
+    application: kubernetes
+    component: metrics-adapter
 spec:
-  application: "kube-metrics-adapter"
+  application: kubernetes
   tokens:
     zmon:
       privileges: []

--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -2,18 +2,21 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    application: kube-metrics-adapter
+    application: kubernetes
+    component: metrics-adapter
   name: kube-metrics-adapter
   namespace: kube-system
 spec:
   replicas: 1
   selector:
     matchLabels:
-      application: kube-metrics-adapter
+      deployment: kube-metrics-adapter
   template:
     metadata:
       labels:
-        application: kube-metrics-adapter
+        application: kubernetes
+        component: metrics-adapter
+        deployment: kube-metrics-adapter
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:

--- a/cluster/manifests/kube-metrics-adapter/service.yaml
+++ b/cluster/manifests/kube-metrics-adapter/service.yaml
@@ -9,4 +9,5 @@ spec:
     targetPort: 443
     protocol: TCP
   selector:
-    application: kube-metrics-adapter
+    application: kubernetes
+    component: metrics-adapter

--- a/cluster/manifests/kube-metrics-adapter/vpa.yaml
+++ b/cluster/manifests/kube-metrics-adapter/vpa.yaml
@@ -4,7 +4,8 @@ metadata:
   name: kube-metrics-adapter
   namespace: kube-system
   labels:
-    application: kube-metrics-adapter
+    application: kubernetes
+    component: metrics-adapter
 spec:
   targetRef:
     apiVersion: apps/v1

--- a/cluster/manifests/kube-node-ready-controller/01-rbac.yaml
+++ b/cluster/manifests/kube-node-ready-controller/01-rbac.yaml
@@ -4,14 +4,16 @@ metadata:
   name: kube-node-ready-controller
   namespace: kube-system
   labels:
-    application: kube-node-ready-controller
+    application: kubernetes
+    component: kube-node-ready-controller
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kube-node-ready-controller
   labels:
-    application: kube-node-ready-controller
+    application: kubernetes
+    component: kube-node-ready-controller
 rules:
 - apiGroups: [""]
   resources: ["nodes"]
@@ -40,7 +42,8 @@ kind: ClusterRoleBinding
 metadata:
   name: kube-node-ready-controller
   labels:
-    application: kube-node-ready-controller
+    application: kubernetes
+    component: kube-node-ready-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/cluster/manifests/kube-node-ready-controller/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready-controller/daemonset.yaml
@@ -4,17 +4,20 @@ metadata:
   name: kube-node-ready-controller
   namespace: kube-system
   labels:
-    application: kube-node-ready-controller
+    application: kubernetes
+    component: kube-node-ready-controller
 spec:
   selector:
     matchLabels:
-      application: kube-node-ready-controller
+      daemonset: kube-node-ready-controller
   updateStrategy:
     type: RollingUpdate
   template:
     metadata:
       labels:
-        application: kube-node-ready-controller
+        application: kubernetes
+        component: kube-node-ready-controller
+        daemonset: kube-node-ready-controller
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
         prometheus.io/path: /metrics

--- a/cluster/manifests/kube-state-metrics/deployment.yaml
+++ b/cluster/manifests/kube-state-metrics/deployment.yaml
@@ -4,17 +4,19 @@ metadata:
   name: kube-state-metrics
   namespace: kube-system
   labels:
-    application: kube-state-metrics
+    application: kubernetes
+    component: kube-state-metrics
     version: v2.2.0
 spec:
   replicas: 1
   selector:
     matchLabels:
-      application: kube-state-metrics
+      deployment: kube-state-metrics
   template:
     metadata:
       labels:
-        application: kube-state-metrics
+        application: kubernetes
+        component: kube-state-metrics
         version: v2.2.0
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"

--- a/cluster/manifests/kube-state-metrics/deployment.yaml
+++ b/cluster/manifests/kube-state-metrics/deployment.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       labels:
+        deployment: kube-state-metrics
         application: kubernetes
         component: kube-state-metrics
         version: v2.2.0

--- a/cluster/manifests/kube-state-metrics/rbac.yaml
+++ b/cluster/manifests/kube-state-metrics/rbac.yaml
@@ -4,14 +4,16 @@ metadata:
   name: kube-state-metrics
   namespace: kube-system
   labels:
-    application: kube-state-metrics
+    application: kubernetes
+    component: kube-state-metrics
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kube-state-metrics
   labels:
-    application: kube-state-metrics
+    application: kubernetes
+    component: kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -26,7 +28,8 @@ kind: ClusterRole
 metadata:
   name: kube-state-metrics
   labels:
-    application: kube-state-metrics
+    application: kubernetes
+    component: kube-state-metrics
 rules:
 - apiGroups:
   - ""

--- a/cluster/manifests/kube-state-metrics/service.yaml
+++ b/cluster/manifests/kube-state-metrics/service.yaml
@@ -4,7 +4,8 @@ metadata:
   name: kube-state-metrics
   namespace: kube-system
   labels:
-    application: kube-state-metrics
+    application: kubernetes
+    component: kube-state-metrics
 spec:
   type: ClusterIP
   ports:
@@ -12,4 +13,5 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    application: kube-state-metrics
+    application: kubernetes
+    component: kube-state-metrics

--- a/cluster/manifests/kube-state-metrics/vpa.yaml
+++ b/cluster/manifests/kube-state-metrics/vpa.yaml
@@ -4,7 +4,8 @@ metadata:
   name: kube-state-metrics
   namespace: kube-system
   labels:
-    application: kube-state-metrics
+    application: kubernetes
+    component: kube-state-metrics
 spec:
   targetRef:
     apiVersion: apps/v1

--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -4,17 +4,19 @@ metadata:
   name: kube-static-egress-controller
   namespace: kube-system
   labels:
-    application: kube-static-egress-controller
+    application: kubernetes
+    component: kube-static-egress-controller
     version: v0.2.8
 spec:
   replicas: {{if eq .Cluster.ConfigItems.static_egress_controller_enabled "true"}}1{{else}}0{{end}}
   selector:
     matchLabels:
-      application: kube-static-egress-controller
+      deployment: kube-static-egress-controller
   template:
     metadata:
       labels:
-        application: kube-static-egress-controller
+        application: kubernetes
+        component: kube-static-egress-controller
         version: v0.2.8
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_both}}"

--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       labels:
+        deployment: kube-static-egress-controller
         application: kubernetes
         component: kube-static-egress-controller
         version: v0.2.8

--- a/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       labels:
+        deployment: kubernetes-lifecycle-metrics
         application: kubernetes
         component: lifecycle-metrics
         version: master-9

--- a/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
@@ -4,17 +4,19 @@ metadata:
   name: kubernetes-lifecycle-metrics
   namespace: kube-system
   labels:
-    application: kubernetes-lifecycle-metrics
+    application: kubernetes
+    component: lifecycle-metrics
     version: master-9
 spec:
   replicas: 1
   selector:
     matchLabels:
-      application: kubernetes-lifecycle-metrics
+      deployment: kubernetes-lifecycle-metrics
   template:
     metadata:
       labels:
-        application: kubernetes-lifecycle-metrics
+        application: kubernetes
+        component: lifecycle-metrics
         version: master-9
       annotations:
         prometheus.io/path: /metrics

--- a/cluster/manifests/kubernetes-lifecycle-metrics/vpa.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/vpa.yaml
@@ -4,7 +4,8 @@ metadata:
   name: kubernetes-lifecycle-metrics-vpa
   namespace: kube-system
   labels:
-    application: kubernetes-lifecycle-metrics
+    application: kubernetes
+    component: lifecycle-metrics
 spec:
   targetRef:
     apiVersion: apps/v1

--- a/cluster/manifests/metrics-server/deployment.yaml
+++ b/cluster/manifests/metrics-server/deployment.yaml
@@ -4,18 +4,21 @@ metadata:
   name: metrics-server
   namespace: kube-system
   labels:
-    application: metrics-server
+    application: kubernetes
+    component: metrics-server
     version: v0.5.0
 spec:
   replicas: 1
   selector:
     matchLabels:
-      application: metrics-server
+      deployment: metrics-server
   template:
     metadata:
       name: metrics-server
       labels:
-        application: metrics-server
+        application: kubernetes
+        component: metrics-server
+        deployment: metrics-server
         version: v0.5.0
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"

--- a/cluster/manifests/metrics-server/metrics-server-vpa.yaml
+++ b/cluster/manifests/metrics-server/metrics-server-vpa.yaml
@@ -4,7 +4,8 @@ metadata:
   name: metrics-server-vpa
   namespace: kube-system
   labels:
-    application: metrics-server
+    application: kubernetes
+    component: metrics-server
 spec:
   targetRef:
     apiVersion: apps/v1

--- a/cluster/manifests/metrics-server/service.yaml
+++ b/cluster/manifests/metrics-server/service.yaml
@@ -4,11 +4,13 @@ metadata:
   name: metrics-server
   namespace: kube-system
   labels:
-    application: metrics-server
+    application: kubernetes
+    component: metrics-server
     kubernetes.io/name: "Metrics-server"
 spec:
   selector:
-    application: metrics-server
+    application: kubernetes
+    component: metrics-server
   ports:
   - port: 443
     protocol: TCP

--- a/cluster/manifests/pdb-controller/deployment.yaml
+++ b/cluster/manifests/pdb-controller/deployment.yaml
@@ -4,17 +4,19 @@ metadata:
   name: pdb-controller
   namespace: kube-system
   labels:
-    application: pdb-controller
+    application: kubernetes
+    component: pdb-controller
     version: v0.0.17
 spec:
   replicas: 1
   selector:
     matchLabels:
-      application: pdb-controller
+      deployment: pdb-controller
   template:
     metadata:
       labels:
-        application: pdb-controller
+        application: kubernetes
+        component: pdb-controller
         version: v0.0.17
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"

--- a/cluster/manifests/pdb-controller/deployment.yaml
+++ b/cluster/manifests/pdb-controller/deployment.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       labels:
+        deployment: pdb-controller
         application: kubernetes
         component: pdb-controller
         version: v0.0.17

--- a/cluster/manifests/pdb-controller/vpa.yaml
+++ b/cluster/manifests/pdb-controller/vpa.yaml
@@ -4,7 +4,8 @@ metadata:
   name: pdb-controller
   namespace: kube-system
   labels:
-    application: pdb-controller
+    application: kubernetes
+    component: pdb-controller
 spec:
   targetRef:
     apiVersion: apps/v1


### PR DESCRIPTION
Change more stuff to use the `kubernetes` application:
 * `kube-aws-iam-controller`
 * `kube-metrics-adapter`
 * `metrics-server`
 * `csi-node-driver`/`ebs-csi-controller`
 * `kube-static-egress-controller`
* `kube-state-metrics`
* `kubernetes-lifecycle-metrics`
* `pdb-controller`
* `event-logger`
* `cronjob-monitor`
* `cronjob-fixer`
* `aws-node-decommissioner`
* `kube-downscaler`
* `kube-janitor`
* `cluster-lifecycle-controller`
* `efs-provisioner`
* `kube-node-ready-controller`
* `kube-cluster-autoscaler`/`autoscaling-buffer`
