### PR TITLE
Update admission-controller to master-128

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -200,7 +200,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-127
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-128
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
Updates admission-controller to the latest version.

Intended for https://github.com/zalando-incubator/kubernetes-on-aws/pull/4594/files#diff-97e81f763469bbcfe641e98ab59e4de571a2a33e97e7071d76afc94d9564eeb0 but rolled out separately to ensure the new version works before and after the update.