### PR TITLE
nlb switch preparation

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -33,11 +33,9 @@ kube_aws_ingress_controller_cert_polling_interval: "2m"
 kube_aws_ingress_default_lb_type: "application"
 
 # ALB to NLB switch
-# "pre": skipper-ingress clone routes with SourceFromLast and adds an addtional route with ClientIP instead of SourceFromLast
+# "pre": skipper-ingress will create XFF headers for requests passing NLB
 # "exec": same as "pre" and kube-ingress-aws-controller will default to NLB
-# "post": skipper-ingress edit routes with SourceFromLast and replaces SourceFromLast with ClientIP and kube-ingress-aws-controller will default to NLB
-# "final": skipper-ingress does not modify routes and kube-ingress-aws-controller defaults to NLB
-# after removing it you need to set kube_aws_ingress_default_lb_type: "network" above
+# after removing it you need to set kube_aws_ingress_default_lb_type: "network" above and cleanup skipper and ingress-ctl deployment.yaml
 {{if eq .Cluster.Channel "dev"}}
 nlb_switch: "pre"
 {{else if eq .Cluster.Channel "alpha"}}

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -41,7 +41,7 @@ spec:
         - --deny-internal-domains
 {{ end }}
         - "--additional-stack-tags=InfrastructureComponent=true"
-        {{ if or (eq .Cluster.ConfigItems.nlb_switch "exec") (eq .Cluster.ConfigItems.nlb_switch "post") (eq .Cluster.ConfigItems.nlb_switch "final") }}
+        {{ if eq .Cluster.ConfigItems.nlb_switch "exec" }}
         - --load-balancer-type="network"
 {{else}}
         - --load-balancer-type={{ .Cluster.ConfigItems.kube_aws_ingress_default_lb_type }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -189,7 +189,7 @@ spec:
           - "-oauth2-token-cookie-name={{.ConfigItems.skipper_oauth2_cookie_name }}"
           - "-oauth2-callback-path={{ .ConfigItems.skipper_oauth2_redirect_url }}"
 {{ end }}
-{{ if or (eq .ConfigItems.default_nlb "pre") (eq .ConfigItems.nlb_switch "exec") }}
+{{ if or (eq .ConfigItems.nlb_switch "pre") (eq .ConfigItems.nlb_switch "exec") }}
           - "-forwarded-headers=X-Forwarded-For"
           - "-forwarded-headers-exclude-cidrs=10.2.0.0/16,{{ .Values.vpc_ipv4_cidr}}"
 {{ end }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -189,10 +189,9 @@ spec:
           - "-oauth2-token-cookie-name={{.ConfigItems.skipper_oauth2_cookie_name }}"
           - "-oauth2-callback-path={{ .ConfigItems.skipper_oauth2_redirect_url }}"
 {{ end }}
-{{ if or (eq .ConfigItems.nlb_switch "pre") (eq .ConfigItems.nlb_switch "exec") }}
-          - "-clone-route='/SourceFromLast[(](.*)[)]/ClientIP($1)/'"
-{{ else if eq .ConfigItems.nlb_switch "post" }}
-          - "-edit-route='/SourceFromLast[(](.*)[)]/ClientIP($1)/'"
+{{ if or (eq .ConfigItems.default_nlb "pre") (eq .ConfigItems.nlb_switch "exec") }}
+          - "-forwarded-headers=X-Forwarded-For"
+          - "-forwarded-headers-exclude-cidrs=10.2.0.0/16,{{ .Values.vpc_ipv4_cidr}}"
 {{ end }}
         resources:
           limits:


### PR DESCRIPTION
change simplifies deployment, because skipper sets XFF header as ALB does for requests passing NLB only
another simplification is that kube-ingress-aws-controller checks if ALB features are in use and will not change to NLB if conflicting settings are specified

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>