### PR TITLE
Fix a typo in the kube-janitor labels

### DIFF
--- a/cluster/manifests/kube-janitor/deployment.yaml
+++ b/cluster/manifests/kube-janitor/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kubernetes
-    componet: kube-janitor
+    component: kube-janitor
     version: v20.4.1
 spec:
   replicas: 1
@@ -18,7 +18,7 @@ spec:
       labels:
         deployment: kube-janitor
         application: kubernetes
-        componet: kube-janitor
+        component: kube-janitor
         version: v20.4.1
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"


### PR DESCRIPTION
`componet`->`component`