### PR TITLE
Start with the maximum memory for vertically-scaled deployments

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -261,16 +261,13 @@ prometheus_remote_min_backoff: "3s"
 prometheus_remote_max_backoff: "10s"
 
 metrics_service_cpu: "100m"
-metrics_service_mem: "200Mi"
 metrics_service_mem_max: "4Gi"
 metrics_server_metric_resolution: "15s"
 
 kube_aws_iam_controller_cpu: "5m"
-kube_aws_iam_controller_mem: "50Mi"
 kube_aws_iam_controller_mem_max: "1Gi"
 
 kube_state_metrics_cpu: "100m"
-kube_state_metrics_mem: "200Mi"
 kube_state_metrics_mem_max: "4Gi"
 kube_state_metrics_mem_min: "120Mi"
 

--- a/cluster/manifests/02-kube-aws-iam-controller/deployment.yaml
+++ b/cluster/manifests/02-kube-aws-iam-controller/deployment.yaml
@@ -36,10 +36,10 @@ spec:
         resources:
           limits:
             cpu: "{{.ConfigItems.kube_aws_iam_controller_cpu}}"
-            memory: "{{.ConfigItems.kube_aws_iam_controller_mem}}"
+            memory: "{{.ConfigItems.kube_aws_iam_controller_mem_max}}"
           requests:
             cpu: "{{.ConfigItems.kube_aws_iam_controller_cpu}}"
-            memory: "{{.ConfigItems.kube_aws_iam_controller_mem}}"
+            memory: "{{.ConfigItems.kube_aws_iam_controller_mem_max}}"
       tolerations:
       - key: node.kubernetes.io/role
         value: master

--- a/cluster/manifests/cronjob-fixer/deployment.yaml
+++ b/cluster/manifests/cronjob-fixer/deployment.yaml
@@ -31,7 +31,7 @@ spec:
           resources:
             limits:
               cpu: 5m
-              memory: 150Mi
+              memory: 4Gi
             requests:
               cpu: 5m
-              memory: 150Mi
+              memory: 4Gi

--- a/cluster/manifests/cronjob-monitor/deployment.yaml
+++ b/cluster/manifests/cronjob-monitor/deployment.yaml
@@ -31,7 +31,7 @@ spec:
           resources:
             limits:
               cpu: 5m
-              memory: 150Mi
+              memory: 4Gi
             requests:
               cpu: 5m
-              memory: 150Mi
+              memory: 4Gi

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -45,9 +45,12 @@ spec:
         - --txt-prefix={{ .ConfigItems.external_dns_ownership_prefix }}
         - --aws-batch-change-size=100
         resources:
+          requests:
+            cpu: 50m
+            memory: 4Gi
           limits:
             cpu: 50m
-            memory: 100Mi
+            memory: 4Gi
         livenessProbe:
           httpGet:
             path: /healthz

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -55,7 +55,7 @@ spec:
         resources:
           limits:
             cpu: 50m
-            memory: 100Mi
+            memory: 4Gi
           requests:
             cpu: 50m
-            memory: 100Mi
+            memory: 4Gi

--- a/cluster/manifests/kube-downscaler/deployment.yaml
+++ b/cluster/manifests/kube-downscaler/deployment.yaml
@@ -44,10 +44,10 @@ spec:
         resources:
           limits:
             cpu: 5m
-            memory: 150Mi
+            memory: 4Gi
           requests:
             cpu: 5m
-            memory: 150Mi
+            memory: 4Gi
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true

--- a/cluster/manifests/kube-janitor/deployment.yaml
+++ b/cluster/manifests/kube-janitor/deployment.yaml
@@ -42,11 +42,11 @@ spec:
         resources:
           limits:
             cpu: 5m
-            memory: 150Mi
+            memory: 4Gi
           requests:
             # this is a background app ==> low priority, low CPU requests
             cpu: 5m
-            memory: 150Mi
+            memory: 4Gi
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true

--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -54,10 +54,10 @@ spec:
         resources:
           limits:
             cpu: 10m
-            memory: 100Mi
+            memory: 4Gi
           requests:
             cpu: 10m
-            memory: 100Mi
+            memory: 4Gi
       volumes:
       {{ if eq .Environment "production" }}
       - name: credentials

--- a/cluster/manifests/kube-state-metrics/deployment.yaml
+++ b/cluster/manifests/kube-state-metrics/deployment.yaml
@@ -49,7 +49,10 @@ spec:
         resources:
           limits:
             cpu: "{{.ConfigItems.kube_state_metrics_cpu}}"
-            memory: "{{.ConfigItems.kube_state_metrics_mem}}"
+            memory: "{{.ConfigItems.kube_state_metrics_mem_max}}"
+          requests:
+            cpu: "{{.ConfigItems.kube_state_metrics_cpu}}"
+            memory: "{{.ConfigItems.kube_state_metrics_mem_max}}"
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true

--- a/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
@@ -40,10 +40,10 @@ spec:
           resources:
             limits:
               cpu: 5m
-              memory: 150Mi
+              memory: {{.ConfigItems.kubernetes_lifecycle_metrics_mem_max}}
             requests:
               cpu: 5m
-              memory: 150Mi
+              memory: {{.ConfigItems.kubernetes_lifecycle_metrics_mem_max}}
           readinessProbe:
             httpGet:
               path: /healthz

--- a/cluster/manifests/metrics-server/deployment.yaml
+++ b/cluster/manifests/metrics-server/deployment.yaml
@@ -39,10 +39,10 @@ spec:
         resources:
           limits:
             cpu: "{{.ConfigItems.metrics_service_cpu}}"
-            memory: "{{.ConfigItems.metrics_service_mem}}"
+            memory: "{{.ConfigItems.metrics_service_mem_max}}"
           requests:
             cpu: "{{.ConfigItems.metrics_service_cpu}}"
-            memory: "{{.ConfigItems.metrics_service_mem}}"
+            memory: "{{.ConfigItems.metrics_service_mem_max}}"
         ports:
         - containerPort: 4443
           name: https

--- a/cluster/manifests/pdb-controller/deployment.yaml
+++ b/cluster/manifests/pdb-controller/deployment.yaml
@@ -42,7 +42,7 @@ spec:
         resources:
           limits:
             cpu: 10m
-            memory: 50Mi
+            memory: 4Gi
           requests:
             cpu: 10m
-            memory: 50Mi
+            memory: 4Gi

--- a/cluster/manifests/stackset-controller/deployment.yaml
+++ b/cluster/manifests/stackset-controller/deployment.yaml
@@ -38,10 +38,10 @@ spec:
         resources:
           limits:
             cpu: 10m
-            memory: 100Mi
+            memory: {{.ConfigItems.stackset_controller_mem_max}}
           requests:
             cpu: 10m
-            memory: 100Mi
+            memory: {{.ConfigItems.stackset_controller_mem_max}}
         livenessProbe:
           failureThreshold: 10
           httpGet:


### PR DESCRIPTION
VPA OOM handling logic doesn't do anything unless we already have a recommendation value for this VPA. This means that new deployments can completely fail to start without manual intervention if they don't have enough memory out of the box. This should ideally be fixed in the VPA controller, but I'm not sure if anyone would have time to do this any time soon.

Instead, let's initialise the vertically scaled deployments with the maximum memory values instead of some other ones. This will lead to slightly higher resource consumption for new deployments, but it'll notice and adjust almost immediately. It also gives us a nice failsafe for the cases where VPA's admitter is down (since we didn't invest a lot into its availability).