### PR TITLE
Disable TLS1.0/1.1 on APIServer Load Balancer

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -102,6 +102,7 @@ Resources:
     Properties:
       AlpnPolicy:
         - {{ if eq .Cluster.ConfigItems.experimental_nlb_alpn_h2_enabled "true" }}HTTP2Preferred{{else}}None{{end}}
+      SslPolicy: "ELBSecurityPolicy-TLS-1-2-2017-01"
       Certificates:
         - CertificateArn: "{{.Values.load_balancer_certificate}}"
       DefaultActions:
@@ -135,6 +136,12 @@ Resources:
           SSLCertificateId: "{{.Values.load_balancer_certificate}}"
       LoadBalancerName: "{{.Cluster.LocalID}}"
       Scheme: internet-facing
+      Policies:
+      - PolicyName: "SSLNegotiation-Policy"
+        PolicyType: "SSLNegotiationPolicyType"
+        Attributes:
+        - Name: "Reference-Security-Policy"
+          Value: "ELBSecurityPolicy-TLS-1-2-2017-01"
       SecurityGroups:
         - !Ref MasterLoadBalancerSecurityGroup
       Subnets:


### PR DESCRIPTION
For Ingress we set the default TLS policy on ALBs/NLBs to `ELBSecurityPolicy-TLS-1-2-2017-01`. Set the same policy for the load balancer used for the APIServers in order to disable TLS1.0/1.1 and improve security in our setup.

If not set specifically it will default to: `ELBSecurityPolicy-2016-08`

Ref: https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-security-policy-table.html