### PR TITLE
Enables NLB HTTP redirect

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -361,7 +361,7 @@ Resources:
 {{- end }}
 {{- end }}
         - CidrIp: {{ if eq .Cluster.ConfigItems.kube_aws_ingress_controller_nlb_enabled "true" }}"0.0.0.0/0"{{else}}"{{.Values.vpc_ipv4_cidr}}"{{end}}
-          FromPort: 9999
+          FromPort: 9998
           IpProtocol: tcp
           ToPort: 9999
 {{- if ne .Cluster.ConfigItems.skipper_redis_replicas "0"}}

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -25,7 +25,7 @@ kube_aws_ingress_controller_ssl_policy: "ELBSecurityPolicy-TLS-1-2-2017-01"
 kube_aws_ingress_controller_idle_timeout: "1m"
 kube_aws_ingress_controller_deregistration_delay_timeout: "10s"
 # allow using NLBs for ingress
-# This opens port 9999 (skipper-ingress) on all worker nodes.
+# This opens skipper-ingress ports 9998 and 9999 on all worker nodes
 kube_aws_ingress_controller_nlb_enabled: "true"
 kube_aws_ingress_controller_nlb_cross_zone: "true"
 kube_aws_ingress_controller_cert_polling_interval: "2m"
@@ -33,7 +33,12 @@ kube_aws_ingress_controller_cert_polling_interval: "2m"
 kube_aws_ingress_default_lb_type: "application"
 
 # ALB to NLB switch
-# "pre": skipper-ingress will create XFF headers for requests passing NLB
+# "pre":
+# - kube-ingress-aws-controller will configure NLB to forward HTTPS requests
+#   to skipper-ingress on port 9999 and HTTP requests to port 9998
+# - skipper-ingress on port 9999 will add X-Forwarded-For=<client IP> and X-Forwarded-Proto=https headers to requests from NLB
+# - skipper-ingress on port 9998 will reply with 308 Permanent Redirect to https
+#
 # "exec": same as "pre" and kube-ingress-aws-controller will default to NLB
 # after removing it you need to set kube_aws_ingress_default_lb_type: "network" above and cleanup skipper and ingress-ctl deployment.yaml
 {{if eq .Cluster.Channel "dev"}}

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.12.1
+    version: v0.12.2
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.12.1
+        version: v0.12.2
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_both}}"
     spec:
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: kube-ingress-aws-controller
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.12.1
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.12.2
         args:
         - --stack-termination-protection
         - --ssl-policy={{ .ConfigItems.kube_aws_ingress_controller_ssl_policy }}
@@ -41,6 +41,10 @@ spec:
         - --deny-internal-domains
 {{ end }}
         - "--additional-stack-tags=InfrastructureComponent=true"
+        {{ if or (eq .ConfigItems.nlb_switch "pre") (eq .ConfigItems.nlb_switch "exec") }}
+        - --nlb-http-enabled
+        - --nlb-http-target-port=9998
+        {{ end }}
         {{ if eq .Cluster.ConfigItems.nlb_switch "exec" }}
         - --load-balancer-type="network"
 {{else}}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.13.100
+    version: v0.13.108
     component: ingress
 spec:
   strategy:
@@ -19,7 +19,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.13.100
+        version: v0.13.108
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -46,12 +46,18 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/teapot/skipper-internal:v0.13.100-172
+        image: registry.opensource.zalan.do/teapot/skipper-internal:v0.13.108-177
         ports:
         - name: ingress-port
           containerPort: 9999
           hostPort: 9999
           protocol: TCP
+{{ if or (eq .ConfigItems.nlb_switch "pre") (eq .ConfigItems.nlb_switch "exec") }}
+        - name: http-redirect
+          containerPort: 9998
+          hostPort: 9998
+          protocol: TCP
+{{ end }}
         env:
         - name: LIGHTSTEP_TOKEN
           valueFrom:
@@ -73,6 +79,10 @@ spec:
 {{ end }}
 {{ if eq .ConfigItems.skipper_local_tokeninfo "bridge" }}
         - name: LOCAL_TOKENINFO_SANDBOX
+          value: "true"
+{{ end }}
+{{ if or (eq .ConfigItems.nlb_switch "pre") (eq .ConfigItems.nlb_switch "exec") }}
+        - name: HTTP_REDIRECT
           value: "true"
 {{ end }}
         args:
@@ -136,7 +146,7 @@ spec:
             tag=application=skipper-ingress
             tag=account={{ .Cluster.Alias }}
             tag=cluster={{ .Cluster.Alias }}
-            tag=artifact=registry.opensource.zalan.do/teapot/skipper-internal:v0.13.100-172
+            tag=artifact=registry.opensource.zalan.do/teapot/skipper-internal:v0.13.108-177
             max-buffered-spans={{ .ConfigItems.skipper_ingress_tracing_buffer }}
             grpc-max-msg-size={{ .ConfigItems.skipper_ingress_lightstep_grpc_max_msg_size }}
             max-period={{ .ConfigItems.skipper_ingress_lightstep_max_period }}
@@ -226,7 +236,7 @@ spec:
             - -ce
             # Check all sub processes in the container and fail if one of them fails.
             # wget will exit with non-zero status code if the HTTP code is no 2xx.
-            # production tokeinfo, sandbox tokeninfo, bridge
+            # production tokeninfo, sandbox tokeninfo, bridge
             - "wget -T 1 -q -O /dev/null http://127.0.0.1:9021/health; wget -T 1 -q -O /dev/null http://127.0.0.1:9121/health; wget -T 1 -q -O /dev/null http://127.0.0.1:9000/healthz"
           initialDelaySeconds: {{ .ConfigItems.skipper_liveness_init_delay_seconds }}
           periodSeconds: 10

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -32,6 +32,7 @@ clusters:
     efs_id: ${EFS_ID}
     webhook_id: ${INFRASTRUCTURE_ACCOUNT}:${REGION}:kube-aws-test
     kube_aws_ingress_controller_nlb_enabled: "true"
+    nlb_switch: "pre"
     vm_dirty_bytes: 134217728
     vm_dirty_background_bytes: 67108864
     prometheus_tsdb_retention_size: enabled

--- a/test/e2e/ingress.go
+++ b/test/e2e/ingress.go
@@ -159,7 +159,7 @@ var __ = framework.KubeDescribe("Ingress tests simple", func() {
 		_, err = cs.NetworkingV1beta1().Ingresses(ns).Get(context.TODO(), ing.Name, metav1.GetOptions{ResourceVersion: "0"})
 		Expect(err).NotTo(HaveOccurred())
 
-		//  skipper http -> https redirect
+		// skipper http -> https redirect
 		By("Waiting for skipper route to default redirect from http to https, to see that our ingress-controller and skipper works")
 		err = waitForResponse(addr, "http", waitTime, isRedirect, true)
 		Expect(err).NotTo(HaveOccurred())
@@ -370,7 +370,7 @@ var ___ = framework.KubeDescribe("Ingress tests paths", func() {
 		_, err = cs.NetworkingV1beta1().Ingresses(ns).Get(context.TODO(), ing.Name, metav1.GetOptions{ResourceVersion: "0"})
 		Expect(err).NotTo(HaveOccurred())
 
-		//  skipper http -> https redirect
+		// skipper http -> https redirect
 		By("Waiting for skipper route to default redirect from http to https, to see that our ingress-controller and skipper works")
 		err = waitForResponse(addr, "http", waitTime, isRedirect, true)
 		Expect(err).NotTo(HaveOccurred())
@@ -521,7 +521,7 @@ var ____ = framework.KubeDescribe("Ingress tests custom routes", func() {
 		_, err = cs.NetworkingV1beta1().Ingresses(ns).Get(context.TODO(), ing.Name, metav1.GetOptions{ResourceVersion: "0"})
 		Expect(err).NotTo(HaveOccurred())
 
-		//  skipper http -> https redirect
+		// skipper http -> https redirect
 		By("Waiting for skipper route to default redirect from http to https, to see that our ingress-controller and skipper works")
 		err = waitForResponse(addr, "http", waitTime, isRedirect, true)
 		Expect(err).NotTo(HaveOccurred())
@@ -644,10 +644,10 @@ var _____ = framework.KubeDescribe("Ingress tests simple NLB", func() {
 		_, err = cs.NetworkingV1beta1().Ingresses(ns).Get(context.TODO(), ing.Name, metav1.GetOptions{ResourceVersion: "0"})
 		Expect(err).NotTo(HaveOccurred())
 
-		// //  skipper http -> https redirect
-		// By("Waiting for skipper route to default redirect from http to https, to see that our ingress-controller and skipper works")
-		// err = waitForResponse(addr, "http", waitTime, isRedirect, true)
-		// Expect(err).NotTo(HaveOccurred())
+		// skipper http -> https redirect
+		By("Waiting for skipper route to default redirect from http to https, to see that our ingress-controller and skipper works")
+		err = waitForResponse(addr, "http", waitTime, isRedirect, true)
+		Expect(err).NotTo(HaveOccurred())
 
 		// NLB ready
 		By("Waiting for NLB to create endpoint " + addr + " and skipper route, to see that our ingress-controller and skipper works")


### PR DESCRIPTION
Updates `skipper` and `kube-ingress-aws-controller` and enables NLB HTTP redirect