### PR TITLE
Don't use an FQDN for the status service URL

### DIFF
--- a/cluster/manifests/infrastructure-configs/deployment-config.yaml
+++ b/cluster/manifests/infrastructure-configs/deployment-config.yaml
@@ -16,7 +16,7 @@ data:
   oidc-subject-prefix: "{{.Cluster.LocalID}}.{{.Cluster.Alias}}.zalan.do:sub: system:serviceaccount"
 {{- if eq .Cluster.ConfigItems.deployment_service_enabled "true" }}
   s3-bucket-name: "zalando-deployment-service-{{accountID .Cluster.InfrastructureAccount}}-{{.Cluster.LocalID}}"
-  status-service-url: "https://deployment-status-service.{{.Values.hosted_zone}}."
+  status-service-url: "https://deployment-status-service.{{.Values.hosted_zone}}"
   deployment-role-arn: "arn:aws:iam::{{accountID .Cluster.InfrastructureAccount}}:role/{{.Cluster.LocalID}}-deployment-service-deployment"
 {{- if eq .Cluster.ConfigItems.deployment_service_ml_experiments_enabled "true"}}
   ml-experiment-deployment-role-arn: "arn:aws:iam::{{accountID .Cluster.InfrastructureAccount}}:role/{{.Cluster.LocalID}}-deployment-service-ml-experiment-deployment"


### PR DESCRIPTION
There's no real reason to do this, so let's drop the trailing dot.