### PR TITLE
Update flannel

### DIFF
--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -57,23 +57,8 @@ spec:
           limits:
             cpu: 25m
             memory: 50Mi
-      - name: apiserver-proxy
-        image: registry.opensource.zalan.do/teapot/etcd-proxy:master-6
-        command:
-        - /bin/sh
-        args:
-        - -c
-        - "exec /etcd-proxy --listen-address 127.0.0.1:333 $KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT"
-        resources:
-          requests:
-            cpu: 25m
-            memory: 25Mi
-            ephemeral-storage: 256Mi
-          limits:
-            cpu: 25m
-            memory: 25Mi
       - name: kube-flannel
-        image: registry.opensource.zalan.do/teapot/flannel:v0.11.0-10
+        image: registry.opensource.zalan.do/teapot/flannel:v0.14.0-12
         command:
         - /opt/bin/flanneld
         args:
@@ -83,10 +68,6 @@ spec:
         - --healthz-port=10267
         - --v=2
         env:
-        - name: KUBERNETES_SERVICE_HOST
-          value: "127.0.0.1"
-        - name: KUBERNETES_SERVICE_PORT
-          value: "333"
         - name: POD_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
Mainly to pick up a client-go version not released some time last century, to benefit from the active pings and token reloading.