### PR TITLE
Update kube-metrics-adapter

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -110,8 +110,8 @@ enable_apimonitoring: "true"                       # TODO(sszuecs): cleanup cand
 
 
 # Kube-Metrics-Adapter
-## Enable the kube-metrics-adapter time-based metrics.
-enable_scaling_schedule_metrics: "true"
+## Scheduled scaling metrics: fade in/out over this period of time
+kube_metrics_adapter_default_scaling_window: "10m"
 ## ZMON KairosDB URL
 zmon_kairosdb_url: "https://data-service.zmon.zalan.do/kairosdb-proxy"
 

--- a/cluster/manifests/kube-metrics-adapter/cluster_scaling_schedules_crd.yaml
+++ b/cluster/manifests/kube-metrics-adapter/cluster_scaling_schedules_crd.yaml
@@ -37,6 +37,11 @@ spec:
           spec:
             description: ScalingScheduleSpec is the spec part of the ScalingSchedule.
             properties:
+              scalingWindowDurationMinutes:
+                description: Fade the scheduled values in and out over this many minutes.
+                  If unset, the default per-cluster value will be used.
+                format: int64
+                type: integer
               schedules:
                 description: Schedules is the list of schedules for this ScalingSchedule
                   resource. All the schedules defined here will result on the value
@@ -96,6 +101,7 @@ spec:
                     value:
                       description: The metric value that will be returned for the
                         defined schedule.
+                      format: int64
                       type: integer
                   required:
                   - durationMinutes

--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -35,9 +35,8 @@ spec:
         - --prometheus-server=http://prometheus.kube-system.svc.cluster.local
         - --skipper-ingress-metrics
         - --skipper-routegroup-metrics
-        {{ if eq .ConfigItems.enable_scaling_schedule_metrics "true"}}
         - --scaling-schedule
-        {{ end }}
+        - --scaling-schedule-default-scaling-window={{.Cluster.ConfigItems.kube_metrics_adapter_default_scaling_window}}
         - --aws-external-metrics
         - --aws-region=eu-central-1
         - --aws-region=eu-west-1

--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.12
+        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.14
         env:
         - name: AWS_REGION
           value: {{ .Region }}

--- a/cluster/manifests/kube-metrics-adapter/scaling_schedules_crd.yaml
+++ b/cluster/manifests/kube-metrics-adapter/scaling_schedules_crd.yaml
@@ -37,6 +37,11 @@ spec:
           spec:
             description: ScalingScheduleSpec is the spec part of the ScalingSchedule.
             properties:
+              scalingWindowDurationMinutes:
+                description: Fade the scheduled values in and out over this many minutes.
+                  If unset, the default per-cluster value will be used.
+                format: int64
+                type: integer
               schedules:
                 description: Schedules is the list of schedules for this ScalingSchedule
                   resource. All the schedules defined here will result on the value
@@ -96,6 +101,7 @@ spec:
                     value:
                       description: The metric value that will be returned for the
                         defined schedule.
+                      format: int64
                       type: integer
                   required:
                   - durationMinutes


### PR DESCRIPTION
Changes:
 * Fade-in/fade-out for scheduled scaling metrics (https://github.com/zalando-incubator/kube-metrics-adapter/pull/370)