### PR TITLE
Import DS resources from the internal repo

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -760,7 +760,6 @@ Resources:
       Bucket: !Ref DeploymentServiceBucket
       PolicyDocument:
         Statement:
-{{- if eq .Cluster.ConfigItems.deployment_service_enabled "true" }}
           - NotAction:
               - s3:GetObject
               - s3:DeleteObject
@@ -774,7 +773,6 @@ Resources:
               AWS:
                 - !GetAtt DeploymentControllerRole.Arn
                 - !GetAtt DeploymentStatusServiceRole.Arn
-{{- end }}
 {{- if ne .Cluster.ConfigItems.deployment_service_api_role_arn "" }}
           - Action:
               - s3:PutObject
@@ -794,16 +792,13 @@ Resources:
             Condition:
               ArnNotEquals:
                 aws:PrincipalArn:
-{{- if eq .Cluster.ConfigItems.deployment_service_enabled "true" }}
                   - !GetAtt DeploymentControllerRole.Arn
                   - !GetAtt DeploymentStatusServiceRole.Arn
-{{- end }}
 {{- if ne .Cluster.ConfigItems.deployment_service_api_role_arn "" }}
                   - "{{.Cluster.ConfigItems.deployment_service_api_role_arn}}"
 {{- end }}
                   - !Sub "arn:aws:iam::${AWS::AccountId}:role/cluster-lifecycle-manager-entrypoint"
                   - !Sub "arn:aws:iam::${AWS::AccountId}:role/Shibboleth-Administrator"
-{{- if eq .Cluster.ConfigItems.deployment_service_enabled "true" }}
   DeploymentControllerRole:
     Type: AWS::IAM::Role
     Properties:
@@ -926,7 +921,6 @@ Resources:
                   - 'cloudformation:DescribeStacks'
                 Effect: Allow
                 Resource: '*'
-{{- end }}
   ExternalDNSIAMRole:
     Properties:
       AssumeRolePolicyDocument:

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -652,11 +652,15 @@ experimental_nlb_alpn_h2_enabled: "true"
 exec_probe_timeout_enabled: "true"
 
 # Settings for the deployment service
+deployment_service_controller_cpu: "100m"
+deployment_service_controller_memory: "1Gi"
+deployment_service_status_service_cpu: "100m"
+deployment_service_status_service_memory: "250Mi"
 deployment_service_api_role_arn: ""
-{{ if eq .Cluster.Environment "e2e" }}
-deployment_service_enabled: "true"
-{{ else }}
-deployment_service_enabled: "false"
-{{ end }}
+deployment_service_tokeninfo_url: ""
+deployment_service_lightstep_token: ""
 deployment_service_ml_experiments_enabled: "false"
 deployment_service_cf_auto_expand_enabled: "false"
+
+# Will be dropped after the migration
+deployment_service_enabled: "true"

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -75,15 +75,3 @@ post_apply:
 - name: cluster-admin-okta
   kind: ClusterRoleBinding
 {{- end }}
-{{- if ne .Cluster.ConfigItems.deployment_service_enabled "true" }}
-- kind: ClusterRole
-  name: deployment-service-api-task-access
-- kind: ClusterRoleBinding
-  name: deployment-service-api-task-access
-- kind: Role
-  namespace: kube-system
-  name: deployment-service-api-read-config
-- kind: RoleBinding
-  namespace: kube-system
-  name: deployment-service-api-read-config
-{{- end }}

--- a/cluster/manifests/deployment-service/00-crd.yaml
+++ b/cluster/manifests/deployment-service/00-crd.yaml
@@ -1,0 +1,184 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  name: cdpdeploymenttasks.deployment.zalando.org
+spec:
+  group: deployment.zalando.org
+  names:
+    kind: CDPDeploymentTask
+    listKind: CDPDeploymentTaskList
+    plural: cdpdeploymenttasks
+    singular: cdpdeploymenttask
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: CDPDeploymentTask represents a task that deploys Kubernetes or
+          CloudFormation resources to the cluster.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CDPDeploymentTaskSpec is the spec part of the CDPDeploymentTask.
+            properties:
+              aborted:
+                description: If set to true, the controller should stop processing
+                  the deployment task and change its phase to Aborted.
+                type: boolean
+              changeCause:
+                description: A human-readable description of the current deployment,
+                  to be used as the change cause in deployments and other resources
+                  that support it.
+                type: string
+              deploymentID:
+                description: CDP deployment ID
+                type: string
+              manifestSet:
+                description: The ID of the manifest set in the cluster's S3 bucket.
+                type: string
+              pipelineID:
+                description: CDP pipeline ID
+                type: string
+              taskKind:
+                description: The kind of this deployment task. Currently only 'Standard'
+                  and 'MLExperiment' tasks are supported. If unset, the task is considered
+                  to use the 'Standard' kind.
+                enum:
+                - Standard
+                - MLExperiment
+                type: string
+              timeoutSeconds:
+                description: The duration for how long to wait for Kubernetes resources
+                  to become ready. If the task is not yet finished, the controller
+                  would stop processing it and moved it to the Expired state.
+                format: int64
+                type: integer
+            required:
+            - deploymentID
+            - manifestSet
+            - pipelineID
+            - timeoutSeconds
+            type: object
+          status:
+            description: CDPDeploymentTaskStatus is the status part of the CDPDeploymentTask.
+            properties:
+              finishedAt:
+                description: The timestamp when this deployment task has finished.
+                format: date-time
+                type: string
+              message:
+                description: A human-readable description of the current status of
+                  the deployment task.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed CDPDeploymentTask.
+                format: int64
+                type: integer
+              phase:
+                default: Created
+                description: 'Phase reflects the current lifecycle phase of the deployment
+                  task. The following values are currently available:  Created: deployment
+                  task was submitted to the cluster, the controller will deploy the
+                  resources described in it.  WaitingForResources: resources described
+                  in the task have been deployed to the cluster, the controller is
+                  waiting for the update to be finished.  Aborted: deployment task
+                  has been aborted by setting spec.aborted to true.  Succeeded: deployment
+                  task has finished successfully.  Failed: deployment task has finished
+                  with an error.  Expired: deployment task hasn''t finished before
+                  the timeout.'
+                enum:
+                - Created
+                - Deploying
+                - WaitingForResources
+                - Aborted
+                - Succeeded
+                - Failed
+                - Expired
+                type: string
+              resources:
+                description: List of resources in this task.
+                items:
+                  properties:
+                    cloudFormation:
+                      properties:
+                        region:
+                          type: string
+                        stackID:
+                          type: string
+                        stackResources:
+                          items:
+                            properties:
+                              logicalID:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                            - logicalID
+                            - type
+                            type: object
+                          type: array
+                      required:
+                      - region
+                      - stackID
+                      type: object
+                    kubernetes:
+                      properties:
+                        apiVersion:
+                          type: string
+                        kind:
+                          type: string
+                        namespace:
+                          type: string
+                      required:
+                      - apiVersion
+                      - kind
+                      type: object
+                    name:
+                      type: string
+                    phase:
+                      enum:
+                      - WaitingForDeployment
+                      - ExecutingDeployment
+                      - DeploymentExecuted
+                      type: string
+                  required:
+                  - name
+                  - phase
+                  type: object
+                type: array
+              resourcesDeployedAt:
+                description: The timestamp when the resources have been deployed.
+                  For Kubernetes resources this means that they've been applied to
+                  the cluster, for CloudFormation this means that the stack updates
+                  have finished as well.
+                format: date-time
+                type: string
+              updatedAt:
+                description: The timestamp when this deployment task was last updated
+                  by the controller.
+                format: date-time
+                type: string
+            required:
+            - phase
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/cluster/manifests/deployment-service/controller-credentials.yaml
+++ b/cluster/manifests/deployment-service/controller-credentials.yaml
@@ -1,0 +1,14 @@
+apiVersion: zalando.org/v1
+kind: PlatformCredentialsSet
+metadata:
+  name: "deployment-service-controller-credentials"
+  namespace: "kube-system"
+  labels:
+    application: "deployment-service"
+    component: "controller"
+spec:
+  application: "deployment-service"
+  tokens:
+    status-service:
+      kind: KubernetesAPILocal
+      privileges: []

--- a/cluster/manifests/deployment-service/controller-deployment-credentials.yaml
+++ b/cluster/manifests/deployment-service/controller-deployment-credentials.yaml
@@ -1,0 +1,14 @@
+apiVersion: zalando.org/v1
+kind: PlatformCredentialsSet
+metadata:
+  name: "deployment-service-controller-deployment-credentials"
+  namespace: "kube-system"
+  labels:
+    application: "deployment-service"
+    component: "controller"
+spec:
+  application: "deployment-service-executor"
+  tokens:
+    kubernetes-api:
+      kind: KubernetesAPILocal
+      privileges: []

--- a/cluster/manifests/deployment-service/controller-rbac.yaml
+++ b/cluster/manifests/deployment-service/controller-rbac.yaml
@@ -1,0 +1,127 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "deployment-service-controller"
+  namespace: "kube-system"
+  labels:
+    application: "deployment-service"
+    component: "controller"
+  annotations:
+    iam.amazonaws.com/role: "{{.Cluster.LocalID}}-deployment-service-controller"
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "deployment-service-controller"
+  labels:
+    application: "deployment-service"
+    component: "controller"
+rules:
+  - apiGroups:
+      - deployment.zalando.org
+    resources:
+      - cdpdeploymenttasks
+      - cdpdeploymenttasks/status
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+      - deletecollection
+  - apiGroups:
+      - ""
+      - "events.k8s.io"
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
+      - get
+      - list
+      - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "deployment-service-controller"
+  labels:
+    application: "deployment-service"
+    component: "controller"
+subjects:
+  - kind: ServiceAccount
+    name: "deployment-service-controller"
+    namespace: "kube-system"
+roleRef:
+  kind: ClusterRole
+  name: "deployment-service-controller"
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "deployment-service-executor-poweruser"
+  labels:
+    application: "deployment-service"
+    component: "controller"
+roleRef:
+  kind: ClusterRole
+  name: poweruser
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: zalando-iam:zalando:service:k8sapi-local_deployment-service-executor
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "deployment-service-executor-readonly"
+  labels:
+    application: "deployment-service"
+    component: "controller"
+roleRef:
+  kind: ClusterRole
+  name: readonly
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: zalando-iam:zalando:service:k8sapi-local_deployment-service-executor
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "deployment-service-controller"
+  namespace: "kube-system"
+  labels:
+    application: "deployment-service"
+    component: "controller"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+    resourceNames:
+      - deployment-config
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "deployment-service-controller"
+  namespace: "kube-system"
+  labels:
+    application: "deployment-service"
+    component: "controller"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "deployment-service-controller"
+subjects:
+  - kind: ServiceAccount
+    name: "deployment-service-controller"
+    namespace: "kube-system"

--- a/cluster/manifests/deployment-service/controller-service.yaml
+++ b/cluster/manifests/deployment-service/controller-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "deployment-service-controller"
+  namespace: "kube-system"
+  labels:
+    application: "deployment-service"
+    component: "controller"
+spec:
+  type: ClusterIP
+  selector:
+    application: "deployment-service"
+    component: "controller"
+  clusterIP: None

--- a/cluster/manifests/deployment-service/controller-statefulset.yaml
+++ b/cluster/manifests/deployment-service/controller-statefulset.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: "deployment-service-controller"
+  namespace: "kube-system"
+  labels:
+    application: "deployment-service"
+    component: "controller"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      application: "deployment-service"
+      component: "controller"
+  serviceName: "deployment-service-controller"
+  template:
+    metadata:
+      labels:
+        application: "deployment-service"
+        component: "controller"
+      annotations:
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scrape: "true"
+    spec:
+      serviceAccountName: "deployment-service-controller"
+      terminationGracePeriodSeconds: 300
+      containers:
+        - name: "deployment-service-controller"
+          image: "pierone.stups.zalan.do/teapot/deployment-controller:master-83"
+          args:
+            - "--config-namespace=kube-system"
+          env:
+            - name: AWS_REGION
+              value: "{{.Cluster.Region}}"
+          volumeMounts:
+            - mountPath: /meta/credentials
+              name: credentials
+            - mountPath: /meta/deployment-credentials
+              name: deployment-credentials
+          resources:
+            requests:
+              cpu: "{{.Cluster.ConfigItems.deployment_service_controller_cpu}}"
+              memory: "{{.Cluster.ConfigItems.deployment_service_controller_memory}}"
+            limits:
+              cpu: "{{.Cluster.ConfigItems.deployment_service_controller_cpu}}"
+              memory: "{{.Cluster.ConfigItems.deployment_service_controller_memory}}"
+          ports:
+            - containerPort: 8080
+              name: http
+          readinessProbe:
+            httpGet:
+              port: 8080
+              path: /healthz
+      volumes:
+        - name: credentials
+          secret:
+            secretName: "deployment-service-controller-credentials"
+        - name: deployment-credentials
+          secret:
+            secretName: "deployment-service-controller-deployment-credentials"

--- a/cluster/manifests/deployment-service/status-service-deployment.yaml
+++ b/cluster/manifests/deployment-service/status-service-deployment.yaml
@@ -1,0 +1,82 @@
+{{ $image   := "pierone.stups.zalan.do/teapot/deployment-status-service" }}
+{{ $version := "master-83" }}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "deployment-service-status-service"
+  namespace: "kube-system"
+  labels:
+    application: "deployment-service"
+    component: "status-service"
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      application: "deployment-service"
+      component: "status-service"
+  template:
+    metadata:
+      labels:
+        application: "deployment-service"
+        component: "status-service"
+      annotations:
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
+    spec:
+      serviceAccountName: "deployment-service-status-service"
+      containers:
+        - name: "deployment-service-status-service"
+          image: "{{$image}}:{{$version}}"
+          args:
+            - --readonly-principal=realm=/services,uid=stups_deployment-service
+            - --readonly-principal=realm=/services,uid=k8sapi-local_deployment-service
+            - --config-namespace=kube-system
+            - --host=0.0.0.0
+            - --port=8080
+            - --scheme=http
+          env:
+            - name: TOKENINFO_URL
+              value: "{{.Cluster.ConfigItems.deployment_service_tokeninfo_url}}"
+            - name: AWS_REGION
+              value: "{{.Cluster.Region}}"
+            - name: _PLATFORM_APPLICATION
+              value: deployment-service
+            - name: _PLATFORM_COMPONENT
+              value: status-service
+            - name: _PLATFORM_OPENTRACING_LIGHTSTEP_ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: deployment-service-status-service
+                  key: lightstep-token
+            - name: _PLATFORM_OPENTRACING_LIGHTSTEP_COLLECTOR_HOST
+              value: tracing.platform-infrastructure.zalan.do
+            - name: _PLATFORM_OPENTRACING_LIGHTSTEP_COLLECTOR_PORT
+              value: "8443"
+            - name: _PLATFORM_OPENTRACING_TAG_ACCOUNT
+              value: "{{.Cluster.Alias}}"
+            - name: _PLATFORM_OPENTRACING_TAG_APPLICATION
+              value: deployment-service
+            - name: _PLATFORM_OPENTRACING_TAG_ARTIFACT
+              value: "{{$image}}:{{$version}}"
+            - name: _PLATFORM_OPENTRACING_TAG_ZONE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.annotations['topology.kubernetes.io/zone']
+          ports:
+            - containerPort: 8080
+              name: http
+          resources:
+            requests:
+              cpu: "{{.Cluster.ConfigItems.deployment_service_status_service_cpu}}"
+              memory: "{{.Cluster.ConfigItems.deployment_service_status_service_memory}}"
+            limits:
+              cpu: "{{.Cluster.ConfigItems.deployment_service_status_service_cpu}}"
+              memory: "{{.Cluster.ConfigItems.deployment_service_status_service_memory}}"
+          readinessProbe:
+            httpGet:
+              port: 8080
+              path: /healthz

--- a/cluster/manifests/deployment-service/status-service-ingress.yaml
+++ b/cluster/manifests/deployment-service/status-service-ingress.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: "deployment-service-status-service"
+  namespace: "kube-system"
+  labels:
+    application: "deployment-service"
+    component: "status-service"
+spec:
+  rules:
+    - host: "deployment-status-service.{{.Values.hosted_zone}}"
+      http:
+        paths:
+          - backend:
+              service:
+                name: "deployment-service-status-service"
+                port:
+                  name: http
+            pathType: ImplementationSpecific

--- a/cluster/manifests/deployment-service/status-service-rbac.yaml
+++ b/cluster/manifests/deployment-service/status-service-rbac.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "deployment-service-status-service"
+  namespace: "kube-system"
+  labels:
+    application: "deployment-service"
+    component: "status-service"
+  annotations:
+    iam.amazonaws.com/role: "{{.Cluster.LocalID}}-deployment-service-status-service"
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "deployment-service-status-service"
+  labels:
+    application: "deployment-service"
+    component: "status-service"
+rules:
+  - apiGroups:
+      - deployment.zalando.org
+    resources:
+      - cdpdeploymenttasks
+    verbs: ["get", "list", "watch"]
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - events
+      - services
+      - persistentvolumeclaims
+    verbs: ["get", "list", "watch"]
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - deployment-config
+    verbs: ["get", "list", "watch"]
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - statefulsets
+      - replicasets
+    verbs: ["get", "list", "watch"]
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs: ["get", "list", "watch"]
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs: ["get", "list", "watch"]
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs: ["get", "list", "watch"]
+  - apiGroups:
+      - zalando.org
+    resources:
+      - stacksets
+      - stacks
+      - platformcredentialssets
+      - routegroups
+      - fabricgateways
+      - fabriceventstreams
+    verbs: ["get", "list", "watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "deployment-service-status-service"
+  labels:
+    application: "deployment-service"
+    component: "status-service"
+subjects:
+  - kind: ServiceAccount
+    name: "deployment-service-status-service"
+    namespace: "kube-system"
+roleRef:
+  kind: ClusterRole
+  name: "deployment-service-status-service"
+  apiGroup: rbac.authorization.k8s.io

--- a/cluster/manifests/deployment-service/status-service-secret.yaml
+++ b/cluster/manifests/deployment-service/status-service-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "deployment-service-status-service"
+  namespace: "kube-system"
+  labels:
+    application: "deployment-service"
+    component: "status-service"
+type: Opaque
+data:
+  lightstep-token: "{{ .ConfigItems.deployment_service_lightstep_token | base64 }}"

--- a/cluster/manifests/deployment-service/status-service-service.yaml
+++ b/cluster/manifests/deployment-service/status-service-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "deployment-service-status-service"
+  namespace: "kube-system"
+  labels:
+    application: "deployment-service"
+    component: "status-service"
+spec:
+  type: ClusterIP
+  selector:
+    application: "deployment-service"
+    component: "status-service"
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http

--- a/cluster/manifests/deployment-service/status-service-vpa.yaml
+++ b/cluster/manifests/deployment-service/status-service-vpa.yaml
@@ -1,0 +1,21 @@
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: "deployment-service-status-service"
+  namespace: "kube-system"
+  labels:
+    application: "deployment-service"
+    component: "status-service"
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: "deployment-service-status-service"
+  updatePolicy:
+    updateMode: Auto
+  resourcePolicy:
+    containerPolicies:
+    - containerName: "deployment-service-status-service"
+      minAllowed:
+        cpu: {{.Cluster.ConfigItems.deployment_service_status_service_cpu}}
+        memory: {{.Cluster.ConfigItems.deployment_service_status_service_memory}}

--- a/cluster/manifests/infrastructure-configs/deployment-config.yaml
+++ b/cluster/manifests/infrastructure-configs/deployment-config.yaml
@@ -14,7 +14,6 @@ data:
   oidc-provider-arn: "arn:aws:iam::{{accountID .Cluster.InfrastructureAccount}}:oidc-provider/{{.Cluster.LocalID}}.{{.Cluster.Alias}}.zalan.do"
   oidc-subject-key: "{{.Cluster.LocalID}}.{{.Cluster.Alias}}.zalan.do:sub"
   oidc-subject-prefix: "{{.Cluster.LocalID}}.{{.Cluster.Alias}}.zalan.do:sub: system:serviceaccount"
-{{- if eq .Cluster.ConfigItems.deployment_service_enabled "true" }}
   s3-bucket-name: "zalando-deployment-service-{{accountID .Cluster.InfrastructureAccount}}-{{.Cluster.LocalID}}"
   status-service-url: "https://deployment-status-service.{{.Values.hosted_zone}}"
   deployment-role-arn: "arn:aws:iam::{{accountID .Cluster.InfrastructureAccount}}:role/{{.Cluster.LocalID}}-deployment-service-deployment"
@@ -22,4 +21,3 @@ data:
   ml-experiment-deployment-role-arn: "arn:aws:iam::{{accountID .Cluster.InfrastructureAccount}}:role/{{.Cluster.LocalID}}-deployment-service-ml-experiment-deployment"
 {{- end }}
   cloudformation-enable-auto-expand: "{{.Cluster.ConfigItems.deployment_service_cf_auto_expand_enabled}}"
-{{- end }}

--- a/cluster/manifests/roles/deployment-service.yaml
+++ b/cluster/manifests/roles/deployment-service.yaml
@@ -1,4 +1,3 @@
-{{- if eq .Cluster.ConfigItems.deployment_service_enabled "true" }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -70,4 +69,3 @@ subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: User
     name: zalando-iam:zalando:service:stups_deployment-service
-{{- end }}


### PR DESCRIPTION
We don't change it that often, so let's migrate it to the public repo. Dropping the config item to disable it as well, for now (although it's still kept in place until the manifests have been deleted from the internal one).