### PR TITLE
Align dns names so they work in e2e

### DIFF
--- a/cluster/manifests/emergency-access-service/ingress.yaml
+++ b/cluster/manifests/emergency-access-service/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
     application: emergency-access-service
 spec:
   rules:
-  - host: emergency-access-service.{{ .Alias }}.zalan.do
+  - host: emergency-access-service.{{ .Values.hosted_zone }}
     http:
       paths:
       - backend:

--- a/cluster/manifests/prometheus/ingress.yaml
+++ b/cluster/manifests/prometheus/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
     application: prometheus
 spec:
   rules:
-  - host: system-prometheus.{{ .Alias }}.zalan.do
+  - host: system-prometheus.{{ .Values.hosted_zone }}
     http:
       paths:
       - backend:


### PR DESCRIPTION
We changed the cluster alias in e2e to be unique so that platform credential tokens could be provisioned into them.

However, the domain name for all e2e clusters didn't change which in combination broke several Ingresses that expect to be under the teapot-e2e.zalan.do domain, especially the ones that need an ACM cert.

This fixes it by using `Values.hosted_zone` similar to other places in our manifests.