### PR TITLE
Updates Skipper NLB configuration

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -67,7 +67,7 @@ skipper_topology_spread_enabled: "false"
 {{end}}
 
 # skipper default filters
-skipper_default_filters: 'enableAccessLog(4,5) -> lifo(2000,20000,"3s")'
+skipper_default_filters: 'enableAccessLog(4,5) -> lifo(2000,20000,"3s") -> rfcHost()'
 
 # skipper backend timeout defaults
 skipper_expect_continue_timeout_backend: "30s"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.13.108
+    version: v0.13.114
     component: ingress
 spec:
   strategy:
@@ -19,7 +19,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.13.108
+        version: v0.13.114
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -46,7 +46,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/teapot/skipper-internal:v0.13.108-177
+        image: registry.opensource.zalan.do/teapot/skipper-internal:v0.13.114-178
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -200,7 +200,7 @@ spec:
           - "-oauth2-callback-path={{ .ConfigItems.skipper_oauth2_redirect_url }}"
 {{ end }}
 {{ if or (eq .ConfigItems.nlb_switch "pre") (eq .ConfigItems.nlb_switch "exec") }}
-          - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https"
+          - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
           - "-forwarded-headers-exclude-cidrs=10.2.0.0/16,{{ .Values.vpc_ipv4_cidr}}"
 {{ end }}
         resources:

--- a/test/e2e/ingress.go
+++ b/test/e2e/ingress.go
@@ -619,7 +619,15 @@ var _____ = framework.KubeDescribe("Ingress tests simple NLB", func() {
 		replicas := int32(3)
 		targetPort := 9090
 		backendContent := "mytest"
-		route := fmt.Sprintf(`* -> inlineContent("%s") -> <shunt>`, backendContent)
+		route := fmt.Sprintf(`*
+			-> setResponseHeader("Request-Host", "${request.host}")
+			-> setResponseHeader("Request-X-Forwarded-For", "${request.header.X-Forwarded-For}")
+			-> setResponseHeader("Request-X-Forwarded-Proto", "${request.header.X-Forwarded-Proto}")
+			-> setResponseHeader("Request-X-Forwarded-Port", "${request.header.X-Forwarded-Port}")
+			-> inlineContent("%s")
+			-> <shunt>`,
+			backendContent)
+
 		waitTime := 10 * time.Minute
 
 		// CREATE setup
@@ -673,5 +681,21 @@ var _____ = framework.KubeDescribe("Ingress tests simple NLB", func() {
 		s, err := getBody(resp)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(s).To(Equal(backendContent))
+
+		By("Checking request X-Forwarded-* headers")
+		req, err = http.NewRequest("GET", "https://"+hostName+"/", nil)
+		Expect(err).NotTo(HaveOccurred())
+		resp, err = waitForResponseReturnResponse(req, 10*time.Second, isSuccess, false)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Header.Get("Request-X-Forwarded-For")).NotTo(Equal(""))
+		Expect(resp.Header.Get("Request-X-Forwarded-Port")).To(Equal("443"))
+		Expect(resp.Header.Get("Request-X-Forwarded-Proto")).To(Equal("https"))
+
+		By("Checking request with trailing dot in the hostname is normalized")
+		req, err = http.NewRequest("GET", "https://"+hostName+"./", nil)
+		Expect(err).NotTo(HaveOccurred())
+		resp, err = waitForResponseReturnResponse(req, 10*time.Second, isSuccess, false)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Header.Get("Request-Host")).To(Equal(hostName))
 	})
 })

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -250,22 +250,37 @@ func createSkipperPod(nameprefix, namespace, route string, labels map[string]str
 			Namespace: namespace,
 			Labels:    labels,
 		},
-		Spec: v1.PodSpec{
-			Containers: []v1.Container{
-				{
-					Name:  "skipper",
-					Image: "registry.opensource.zalan.do/pathfinder/skipper:v0.11.107",
-					Args: []string{
-						"skipper",
-						"-inline-routes",
-						route,
-						fmt.Sprintf("-address=:%d", port),
+		Spec: createSkipperPodSpec(route, int32(port)),
+	}
+}
+
+func createSkipperPodSpec(route string, port int32) corev1.PodSpec {
+	return corev1.PodSpec{
+		Containers: []corev1.Container{
+			{
+				Name:  "skipper",
+				Image: "registry.opensource.zalan.do/teapot/skipper:latest",
+				Args: []string{
+					"skipper",
+					"-inline-routes",
+					route,
+					"-address",
+					fmt.Sprintf(":%d", port),
+				},
+				Ports: []corev1.ContainerPort{
+					{
+						Name:          "http",
+						ContainerPort: port,
 					},
-					Ports: []v1.ContainerPort{
-						{
-							Name:          "http",
-							ContainerPort: int32(port),
-						},
+				},
+				Resources: corev1.ResourceRequirements{
+					Limits: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+						corev1.ResourceMemory: resource.MustParse("250Mi"),
+					},
+					Requests: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+						corev1.ResourceMemory: resource.MustParse("250Mi"),
 					},
 				},
 			},
@@ -394,35 +409,7 @@ func createSkipperBackendDeployment(nameprefix, namespace, route string, label m
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: label,
 				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name:  "skipper",
-							Image: "registry.opensource.zalan.do/pathfinder/skipper:v0.11.35",
-							Args: []string{
-								"skipper",
-								"-inline-routes",
-								route,
-							},
-							Ports: []corev1.ContainerPort{
-								{
-									Name:          "http",
-									ContainerPort: port,
-								},
-							},
-							Resources: corev1.ResourceRequirements{
-								Limits: map[corev1.ResourceName]resource.Quantity{
-									corev1.ResourceCPU:    resource.MustParse("100m"),
-									corev1.ResourceMemory: resource.MustParse("250Mi"),
-								},
-								Requests: map[corev1.ResourceName]resource.Quantity{
-									corev1.ResourceCPU:    resource.MustParse("100m"),
-									corev1.ResourceMemory: resource.MustParse("250Mi"),
-								},
-							},
-						},
-					},
-				},
+				Spec: createSkipperPodSpec(route, port),
 			},
 		},
 	}


### PR DESCRIPTION
* updates Skipper version
* adds `X-Forwarded-Port: 443` header for NLB requests
* adds `rfcHost` default filter

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>