### PR TITLE
Remove obsolete permission fixes for mounted tokens

### DIFF
--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -61,8 +61,6 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 1000
-      securityContext:
-        fsGroup: 1000
       volumes:
       - name: platform-iam-credentials
         secret:

--- a/cluster/manifests/dashboard/deployment.yaml
+++ b/cluster/manifests/dashboard/deployment.yaml
@@ -62,8 +62,6 @@ spec:
           runAsNonRoot: true
           runAsUser: 1001
           runAsGroup: 2001
-      securityContext:
-        fsGroup: 2001
       volumes:
       - name: kubernetes-dashboard-certs
         secret:

--- a/cluster/manifests/emergency-access-service/deployment.yaml
+++ b/cluster/manifests/emergency-access-service/deployment.yaml
@@ -108,8 +108,6 @@ spec:
         securityContext:
           runAsNonRoot: true
           runAsUser: 1000
-      securityContext:
-        fsGroup: 1000
       volumes:
       - name: platform-iam-credentials
         secret:

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -61,5 +61,3 @@ spec:
           runAsUser: 65534
           capabilities:
             drop: ["ALL"]
-      securityContext:
-        fsGroup: 65534

--- a/cluster/manifests/kube-state-metrics/deployment.yaml
+++ b/cluster/manifests/kube-state-metrics/deployment.yaml
@@ -59,5 +59,3 @@ spec:
           runAsUser: 65534
           capabilities:
             drop: ["ALL"]
-      securityContext:
-        fsGroup: 65534

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -265,8 +265,6 @@ spec:
             mountPath: /etc/skipper/secret
             readOnly: true
 {{ end }}
-      securityContext:
-        fsGroup: 1000
       volumes:
 {{ if eq .ConfigItems.skipper_local_tokeninfo "bridge"}}
         - name: routes


### PR DESCRIPTION
As a related but not required step of https://github.com/zalando-incubator/kubernetes-on-aws/pull/4669 this removes obsolete `fsGroup` settings that were done to fix permission issues when reading service account tokens for non-privileged containers.

The tokens are implemented via projected volumes and include:
* tokens for OIDC-based auth to AWS
* Expiring Service Account tokens (https://github.com/zalando-incubator/kubernetes-on-aws/pull/4669)

The permission issues with projected tokens have been fixed.

It's basically a revert of https://github.com/zalando-incubator/kubernetes-on-aws/pull/2839/commits/9fa125152367b2a54e77cb728b3cb11ee1086b59