### PR TITLE
e2e: increase the memory requests for the e2e run

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -144,10 +144,10 @@ pipeline:
           resources:
             limits:
               cpu: 500m
-              memory: 5Gi
+              memory: 2Gi
             requests:
               cpu: 500m
-              memory: 5Gi
+              memory: 2Gi
 
 - id: e2e-tests
   when:
@@ -179,11 +179,11 @@ pipeline:
           env: *e2e_env
           resources:
             limits:
-              cpu: 500m
-              memory: 5Gi
+              cpu: 2
+              memory: 8Gi
             requests:
-              cpu: 500m
-              memory: 5Gi
+              cpu: 2
+              memory: 8Gi
 
 - id: stackset-e2e-tests
   when:
@@ -215,10 +215,10 @@ pipeline:
           env: *e2e_env
           resources:
             limits:
-              cpu: 500m
+              cpu: 2
               memory: 1Gi
             requests:
-              cpu: 500m
+              cpu: 2
               memory: 1Gi
 
 - id: decommission-cluster
@@ -253,7 +253,7 @@ pipeline:
           resources:
             limits:
               cpu: 500m
-              memory: 5Gi
+              memory: 1Gi
             requests:
               cpu: 500m
-              memory: 5Gi
+              memory: 1Gi


### PR DESCRIPTION
The main e2e run has started crashing due to OOM kills recently, let's bump it a bit. Reduce the others since we don't really need that much memory there.