### PR TITLE
Set pdb max unavailable to 50% in test clusters

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -615,10 +615,11 @@ system_priority_class: "cluster-critical-nonpreempting"
 # configuration for the PDB controller
 {{if eq .Cluster.Environment "test" }}
 pdb_controller_non_ready_ttl: "1h"
+pdb_controller_max_unavailable: "50%"
 {{else}}
 pdb_controller_non_ready_ttl: ""
-{{end}}
 pdb_controller_max_unavailable: "1%"
+{{end}}
 
 # Log Kubernetes events to Scalyr
 kubernetes_event_logger_enabled: "true"


### PR DESCRIPTION
PDBs are setting a max unavailable of 1%. It allows disruption to
deployments with more than 10 replicas, which works great for production
workloads. The test clusters do not have large deployments and nodes
could contain pods of deployments with 0-9 replica, what makes it update
slow.

This commit sets the max unavailable used by the pdb controller to 50%
in tests clusters. This value would handle deployments with too few
replicas.