### PR TITLE
Upgrade kube-metrics-adapter

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.14
+        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.15
         env:
         - name: AWS_REGION
           value: {{ .Region }}


### PR DESCRIPTION
Deploy the new version of the kube-metrics-adapter. This version
includes a change in the ramp-up feature for ScalingSchedules, using
buckets of 10% increase for the metrics.