### PR TITLE
Update Kubernetes AMI to master-189

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -457,7 +457,7 @@ coredns_max_upstream_concurrency: 2000 # 0 means there is no concurrency limits
 # AMI id given the image name and the Image AWS account owner.
 #
 # [0]: https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/8a9bd1cb2d094038a9e23e646421f8146b48886a/provisioner/template.go#L116
-kuberuntu_image_v1_20: {{ amiID "zalando-ubuntu-kubernetes-production-v1.20.11-master-188" "861068367966"}}
+kuberuntu_image_v1_20: {{ amiID "zalando-ubuntu-kubernetes-production-v1.20.11-master-189" "861068367966"}}
 
 # Feature toggle for auditing events
 audit_pod_events: "true"


### PR DESCRIPTION
Updates the AMI to its latest version which drops files related to the old image validation method: https://github.bus.zalan.do/teapot/kubernetes-on-ubuntu/pull/188/files

Not really necessary to roll this out separately but I want to make sure e2e passes with this.