### PR TITLE
Update Kubernetes 1.21 AMI to master-189

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -458,7 +458,7 @@ coredns_max_upstream_concurrency: 2000 # 0 means there is no concurrency limits
 #
 # [0]: https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/8a9bd1cb2d094038a9e23e646421f8146b48886a/provisioner/template.go#L116
 kuberuntu_image_v1_20: {{ amiID "zalando-ubuntu-kubernetes-production-v1.20.11-master-188" "861068367966"}}
-kuberuntu_image_v1_21: {{ amiID "zalando-ubuntu-kubernetes-production-v1.21.5-master-188" "861068367966"}}
+kuberuntu_image_v1_21: {{ amiID "zalando-ubuntu-kubernetes-production-v1.21.5-master-189" "861068367966"}}
 
 # Feature toggle for auditing events
 audit_pod_events: "true"


### PR DESCRIPTION
Same as https://github.com/zalando-incubator/kubernetes-on-aws/pull/4697 but for Kubernetes 1.21.