### PR TITLE
Skipper/routesrv [1/2]

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -105,6 +105,11 @@ skipper_redis_pool_timeout: "250ms"
 skipper_redis_read_timeout: "25ms"
 skipper_redis_write_timeout: "25ms"
 
+# skipper routesrv settings
+skipper_routesrv_replicas: 3
+skipper_routesrv_cpu: "100m"
+skipper_routesrv_memory: "1Gi"
+
 # skipper api GW features
 enable_apimonitoring: "true"                       # TODO(sszuecs): cleanup candidate to reduce amount of branches in deployment
 

--- a/cluster/manifests/skipper/routesrv-deployment.yaml
+++ b/cluster/manifests/skipper/routesrv-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.13.120
+    version: v0.13.121
     component: routesrv
 spec:
   replicas: "{{ .ConfigItems.skipper_routesrv_replicas }}"
@@ -21,7 +21,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.13.120
+        version: v0.13.121
         component: routesrv
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -46,7 +46,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Cluster.ConfigItems.skipper_termination_grace_period }}
       containers:
       - name: routesrv
-        image: registry.opensource.zalan.do/teapot/skipper:v0.13.120
+        image: registry.opensource.zalan.do/teapot/skipper:v0.13.121
         ports:
         - name: ingress-port
           containerPort: 9990
@@ -92,9 +92,9 @@ spec:
             memory: "{{ .ConfigItems.skipper_routesrv_memory }}"
         readinessProbe:
           httpGet:
-            path: /kube-system/healthz
+            path: /health
             port: 9990
-          initialDelaySeconds: {{ .ConfigItems.skipper_readiness_init_delay_seconds }}
+            #initialDelaySeconds: {{ .ConfigItems.skipper_readiness_init_delay_seconds }} # TODO: hope we don't need this anymore
           timeoutSeconds: 5
         securityContext:
           readOnlyRootFilesystem: true

--- a/cluster/manifests/skipper/routesrv-deployment.yaml
+++ b/cluster/manifests/skipper/routesrv-deployment.yaml
@@ -1,0 +1,112 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: skipper-ingress-routesrv
+  namespace: kube-system
+  labels:
+    application: skipper-ingress
+    version: v0.13.120
+    component: routesrv
+spec:
+  replicas: "{{ .ConfigItems.skipper_routesrv_replicas }}"
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      application: skipper-ingress
+      component: routesrv
+  template:
+    metadata:
+      labels:
+        application: skipper-ingress
+        version: v0.13.120
+        component: routesrv
+      annotations:
+        kubernetes-log-watcher/scalyr-parser: |
+          [{"container": "skipper-ingress", "parser": "skipper-access-log"}]
+        config/hash: {{"secret.yaml" | manifestHash}}
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_local}}"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9910"
+        prometheus.io/scrape: "true"
+    spec:
+{{- if eq .ConfigItems.skipper_topology_spread_enabled "true" }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              application: skipper-ingress
+{{- end }}
+      priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
+      serviceAccountName: skipper-ingress
+      terminationGracePeriodSeconds: {{ .Cluster.ConfigItems.skipper_termination_grace_period }}
+      containers:
+      - name: routesrv
+        image: registry.opensource.zalan.do/teapot/skipper:v0.13.120
+        ports:
+        - name: ingress-port
+          containerPort: 9990
+          protocol: TCP
+        args:
+          - "run.sh"
+          - "skipper"
+          - "-kubernetes"
+          - "-kubernetes-in-cluster"
+          - "-kubernetes-path-mode=path-prefix"
+          - "-address=:9990"
+          - "-wait-for-healthcheck-interval={{ .Cluster.ConfigItems.skipper_wait_for_healthcheck_interval }}"
+{{ if eq .ConfigItems.enable_skipper_eastwest "true"}}
+          - "-enable-kubernetes-east-west"
+          - "-kubernetes-east-west-domain=.ingress.cluster.local"
+{{ end }}
+{{ if eq .ConfigItems.enable_skipper_eastwest_range "true"}}
+          - "-kubernetes-east-west-range-domains=ingress.cluster.local"
+          - "-kubernetes-east-west-range-predicates=ClientIP(\"10.2.0.0/16\", \"{{ .Values.vpc_ipv4_cidr }}\")"
+{{ end }}
+          - "-reverse-source-predicate"
+{{ if eq .ConfigItems.enable_apimonitoring "true"}}
+          - "-enable-api-usage-monitoring" ## TODO: required in routesrv no?
+          - "-api-usage-monitoring-realm-keys=https://identity.zalando.com/realm"
+          - "-api-usage-monitoring-client-keys=https://identity.zalando.com/managed-id,sub"
+          - "-api-usage-monitoring-default-client-tracking-pattern=services[.].*"
+          - "-default-filters-dir=/etc/config/default-filters"
+{{ end }}
+#{{ if eq .ConfigItems.skipper_oauth2_ui_login "true" }}
+#          - "-enable-oauth2-grant-flow" ## TODO: required in routesrv no?
+#          - "-oauth2-callback-path={{ .ConfigItems.skipper_oauth2_redirect_url }}"
+#{{ end }}
+{{ if or (eq .ConfigItems.nlb_switch "pre") (eq .ConfigItems.nlb_switch "exec") }}
+          - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443" ## TODO: required in routesrv no?
+          - "-forwarded-headers-exclude-cidrs=10.2.0.0/16,{{ .Values.vpc_ipv4_cidr}}"
+{{ end }}
+        resources:
+          limits:
+            cpu: "{{ .ConfigItems.skipper_routesrv_cpu }}"
+            memory: "{{ .ConfigItems.skipper_routesrv_memory }}"
+          requests:
+            cpu: "{{ .ConfigItems.skipper_routesrv_cpu }}"
+            memory: "{{ .ConfigItems.skipper_routesrv_memory }}"
+        readinessProbe:
+          httpGet:
+            path: /kube-system/healthz
+            port: 9990
+          initialDelaySeconds: {{ .ConfigItems.skipper_readiness_init_delay_seconds }}
+          timeoutSeconds: 5
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
+{{ if eq .ConfigItems.enable_apimonitoring "true"}}
+        volumeMounts:
+          - name: filters
+            mountPath: /etc/config/default-filters
+      volumes:
+        - name: filters
+          configMap:
+            name: skipper-default-filters
+            optional: true
+{{ end }}

--- a/cluster/manifests/skipper/routesrv-deployment.yaml
+++ b/cluster/manifests/skipper/routesrv-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     version: v0.13.121
     component: routesrv
 spec:
-  replicas: "{{ .ConfigItems.skipper_routesrv_replicas }}"
+  replicas: {{ .ConfigItems.skipper_routesrv_replicas }}
   strategy:
     rollingUpdate:
       maxSurge: 1

--- a/cluster/manifests/skipper/routesrv-deployment.yaml
+++ b/cluster/manifests/skipper/routesrv-deployment.yaml
@@ -52,8 +52,7 @@ spec:
           containerPort: 9990
           protocol: TCP
         args:
-          - "run.sh"
-          - "skipper"
+          - "routesrv"
           - "-kubernetes"
           - "-kubernetes-in-cluster"
           - "-kubernetes-path-mode=path-prefix"

--- a/cluster/manifests/skipper/routesrv-service.yaml
+++ b/cluster/manifests/skipper/routesrv-service.yaml
@@ -1,0 +1,22 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: skipper-ingress-routesrv
+  namespace: kube-system
+  labels:
+    application: skipper-ingress
+    component: routesrv
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 80
+    targetPort: 9990
+    protocol: TCP
+  - name: support
+    port: 9910
+    targetPort: 9910
+    protocol: TCP
+  selector:
+    application: skipper-ingress
+    component: routesrv


### PR DESCRIPTION
This is the first step to deploy skipper kubernetes dataclient service to reduce load on apiserver

We need to deploy this in two steps such that we can validate that this component is serving the same routes as the current running skipper-ingress deployment.