### PR TITLE
Remove unused port 8080 from control plane SG

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -131,10 +131,6 @@ Resources:
           FromPort: 8443
           IpProtocol: tcp
           ToPort: 8443
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 8080
-          IpProtocol: tcp
-          ToPort: 8080
         - CidrIp: 0.0.0.0/0
           FromPort: -1
           IpProtocol: icmp


### PR DESCRIPTION
Since https://github.com/zalando-incubator/kubernetes-on-aws/pull/4133 we disabled the insecure port (8080) on the api-server. We can therefore also remove the port from the security group as it's no longer relevant.