### PR TITLE
Update the AMI

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -466,7 +466,7 @@ tracing_coredns_local_zone_traces_endpoint: ""
 #
 # [0]: https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/8a9bd1cb2d094038a9e23e646421f8146b48886a/provisioner/template.go#L116
 kuberuntu_image_v1_20: {{ amiID "zalando-ubuntu-kubernetes-production-v1.20.11-master-188" "861068367966"}}
-kuberuntu_image_v1_21: {{ amiID "zalando-ubuntu-kubernetes-production-v1.21.5-master-188" "861068367966"}}
+kuberuntu_image_v1_21: {{ amiID "zalando-ubuntu-kubernetes-production-v1.21.5-master-194" "861068367966"}}
 
 # Feature toggle for auditing events
 audit_pod_events: "true"


### PR DESCRIPTION
Changes:
 * Remove the image-policy-webhook files (https://github.com/zalando-incubator/kubernetes-on-aws/pull/4697)
 * Update Docker/containerd to fix the CVEs
 * SSH key updates
 * Update the internal build of the scheduler to support a timeout on the TSC predicate