### PR TITLE
Bump Skipper version to the newest

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.13.126
+    version: v0.13.129
     component: ingress
 spec:
   strategy:
@@ -19,7 +19,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.13.126
+        version: v0.13.129
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -46,7 +46,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/teapot/skipper-internal:v0.13.126-179
+        image: registry.opensource.zalan.do/teapot/skipper-internal:v0.13.129-180
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -150,7 +150,7 @@ spec:
             tag=application=skipper-ingress
             tag=account={{ .Cluster.Alias }}
             tag=cluster={{ .Cluster.Alias }}
-            tag=artifact=registry.opensource.zalan.do/teapot/skipper-internal:v0.13.126-179
+            tag=artifact=registry.opensource.zalan.do/teapot/skipper-internal:v0.13.129-180
             max-buffered-spans={{ .ConfigItems.skipper_ingress_tracing_buffer }}
             grpc-max-msg-size={{ .ConfigItems.skipper_ingress_lightstep_grpc_max_msg_size }}
             max-period={{ .ConfigItems.skipper_ingress_lightstep_max_period }}

--- a/cluster/manifests/skipper/routesrv-deployment.yaml
+++ b/cluster/manifests/skipper/routesrv-deployment.yaml
@@ -46,7 +46,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Cluster.ConfigItems.skipper_termination_grace_period }}
       containers:
       - name: routesrv
-        image: registry.opensource.zalan.do/teapot/skipper:v0.13.126
+        image: registry.opensource.zalan.do/teapot/skipper:v0.13.129
         ports:
         - name: ingress-port
           containerPort: 9990


### PR DESCRIPTION
Signed-off-by: Marcin Zaremba <marcin.zaremba@zalando.de>

Bump Skipper version to the newest. Contains following changes:
- https://github.com/zalando/skipper/pull/1880
- https://github.com/zalando/skipper/pull/1881

Both changes concerning newly introduce `routesrv` component fixing:
- introducing a timeout to the client side of the change on Skipper (before no timeout was enforced)
- fixing a case in Kubernetes data client for Ingresses, where two conflicting `Header` predicates could have appeared, while enforcing http->https redirect
