### PR TITLE
Update the etcd instances to use an external volume

### DIFF
--- a/cluster/etcd-cluster.yaml
+++ b/cluster/etcd-cluster.yaml
@@ -33,10 +33,15 @@ SenzaComponents:
       scalyr_account_key: '{{Arguments.ScalyrAccountKey}}'
       mounts:
         /home/etcd:
-          partition: none
-          filesystem: tmpfs
-          erase_on_boot: false
-          options: size=2g
+          partition: /dev/xvdb
+          filesystem: ext4
+          erase_on_boot: true
+    BlockDeviceMappings:
+      - DeviceName: /dev/xvdb
+        Ebs:
+          VolumeSize: "32"
+          DeleteOnTermination: true
+          VolumeType: "gp3"
     Type: Senza::TaupageAutoScalingGroup
     AutoScaling:
       Minimum: "{{Arguments.InstanceCount}}"

--- a/cluster/etcd-stack.yaml
+++ b/cluster/etcd-stack.yaml
@@ -27,6 +27,12 @@ Resources:
     Properties:
       LaunchTemplateName: 'etcd-cluster-etcd'
       LaunchTemplateData:
+        BlockDeviceMappings:
+          - DeviceName: /dev/xvdb
+            Ebs:
+              VolumeSize: "32"
+              DeleteOnTermination: true
+              VolumeType: "gp3"
         NetworkInterfaces:
           - DeviceIndex: 0
             AssociatePublicIpAddress: true
@@ -50,10 +56,9 @@ Resources:
             HOSTED_ZONE: "{{.Cluster.Alias}}.zalan.do"
           mounts:
             /home/etcd:
-              erase_on_boot: false
-              filesystem: tmpfs
-              options: size=2g
-              partition: none
+              partition: /dev/xvdb
+              filesystem: ext4
+              erase_on_boot: true
           notify_cfn:
             resource: AppServer
             stack: etcd-cluster-etcd


### PR DESCRIPTION
This updates both stacks to use an EBS volume with a hardcoded size of 32Gi. We could, of course, make the whole thing configurable and allow switching between the ramdisk and EBS setups, or to allow customising the storage size, but at the moment we hope that it won't actually be needed.