### PR TITLE
Update CA

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -20,6 +20,9 @@ cluster_autoscaler_max_pod_eviction_time: "3h"
 # Override terminationGracePeriodSeconds when evicting pods for scale down, if the pods' value is higher than this one
 cluster_autoscaler_max_graceful_termination_sec: "1209600" # 2 weeks
 
+# Prevent CA lock-ups caused by large amounts of pending pods. Can be disabled completely by setting to 0.
+cluster_autoscaler_max_usnchedulable_pods_considered: "1000"
+
 # ALB config created by kube-aws-ingress-controller
 kube_aws_ingress_controller_ssl_policy: "ELBSecurityPolicy-TLS-1-2-2017-01"
 kube_aws_ingress_controller_idle_timeout: "1m"

--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -36,7 +36,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cluster-autoscaler
-        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.18.2-internal.31
+        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.18.2-internal.35
         command:
           - ./cluster-autoscaler
           - --v=1
@@ -59,10 +59,10 @@ spec:
           - --backoff-no-full-scale-down=true
           - --max-pod-eviction-time={{ .Cluster.ConfigItems.cluster_autoscaler_max_pod_eviction_time }}
           - --max-graceful-termination-sec={{ .Cluster.ConfigItems.cluster_autoscaler_max_graceful_termination_sec }}
-          - --topology-spread-constraint-scale-factor=3
           - --disable-node-instances-cache=true
           - --scale-down-ignore-schedulable-pods=true
           - --unremovable-node-recheck-timeout={{.Cluster.ConfigItems.autoscaling_unremovable_node_recheck_timeout}}
+          - --max-unschedulable-pods-considered={{.Cluster.ConfigItems.cluster_autoscaler_max_usnchedulable_pods_considered}}
         resources:
           requests:
             cpu: {{.Cluster.ConfigItems.cluster_autoscaler_cpu}}


### PR DESCRIPTION
Changes:
 * TopologySpreadConstraints emulation (https://github.com/zalando-incubator/autoscaler/pull/83)
 * `--max-unschedulable-pods-considered` (https://github.com/zalando-incubator/autoscaler/pull/84)

This also sets `--max-unschedulable-pods-considered` to 1000 by default, we can disable it by setting to 0.