### PR TITLE
Change Deployment Role policies by existing ones managed centrally

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -680,10 +680,10 @@ Resources:
         Version: 2012-10-17
       Path: /
       ManagedPolicyArns:
-        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/DenyEc2UsApSa"
-        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/DenyModifyShibboleth"
-        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/DenyDefault"
-        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/AllowPowerUser"
+        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-DenyEc2UsApSa"
+        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-DenyModifyShibboleth"
+        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-DenyDefault"
+        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-AllowPowerUser"
       RoleName: "{{.Cluster.LocalID}}-deployment"
     Type: 'AWS::IAM::Role'
   DeploymentSecretKey:
@@ -859,10 +859,10 @@ Resources:
             Action:
               - sts:AssumeRole
       ManagedPolicyArns:
-        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/DenyEc2UsApSa"
-        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/DenyModifyShibboleth"
-        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/DenyDefault"
-        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/AllowPowerUser"
+        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-DenyEc2UsApSa"
+        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-DenyModifyShibboleth"
+        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-DenyDefault"
+        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-AllowPowerUser"
 {{- if eq .Cluster.ConfigItems.deployment_service_ml_experiments_enabled "true"}}
   DeploymentControllerMLExperimentDeploymentRole:
     Type: AWS::IAM::Role

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -680,7 +680,10 @@ Resources:
         Version: 2012-10-17
       Path: /
       ManagedPolicyArns:
-        - !Ref DeploymentIAMPolicy
+        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/DenyEc2UsApSa"
+        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/DenyModifyShibboleth"
+        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/DenyDefault"
+        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/AllowPowerUser"
       RoleName: "{{.Cluster.LocalID}}-deployment"
     Type: 'AWS::IAM::Role'
   DeploymentSecretKey:
@@ -856,7 +859,10 @@ Resources:
             Action:
               - sts:AssumeRole
       ManagedPolicyArns:
-        - !Ref DeploymentIAMPolicy
+        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/DenyEc2UsApSa"
+        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/DenyModifyShibboleth"
+        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/DenyDefault"
+        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/AllowPowerUser"
 {{- if eq .Cluster.ConfigItems.deployment_service_ml_experiments_enabled "true"}}
   DeploymentControllerMLExperimentDeploymentRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
Replace Deployment Role locally defined policy by Centrally managed policies. This allow us to centrally enable new services for Teams and their Deployments.

Since we don't know the order that CF templates will be applied I'm first changing the role to use the new polices
Later I will create another PR to clean the role and config-defaults.yaml

The Policy names are not the best one, but should be enough for now. We will review Managed Policies content and names after Cyberweek, so we will create another PR later when needed.