### PR TITLE
add client IP as Tag to ingress Span

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.13.130
+    version: v0.13.132
     component: ingress
 spec:
   strategy:
@@ -19,7 +19,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.13.130
+        version: v0.13.132
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -46,7 +46,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/teapot/skipper-internal:v0.13.130-181
+        image: registry.opensource.zalan.do/teapot/skipper-internal:v0.13.132-183
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -152,7 +152,7 @@ spec:
             tag=application=skipper-ingress
             tag=account={{ .Cluster.Alias }}
             tag=cluster={{ .Cluster.Alias }}
-            tag=artifact=registry.opensource.zalan.do/teapot/skipper-internal:v0.13.130-181
+            tag=artifact=registry.opensource.zalan.do/teapot/skipper-internal:v0.13.132-183
             max-buffered-spans={{ .ConfigItems.skipper_ingress_tracing_buffer }}
             grpc-max-msg-size={{ .ConfigItems.skipper_ingress_lightstep_grpc_max_msg_size }}
             max-period={{ .ConfigItems.skipper_ingress_lightstep_max_period }}

--- a/cluster/manifests/skipper/routesrv-deployment.yaml
+++ b/cluster/manifests/skipper/routesrv-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.13.130
+    version: v0.13.132
     component: routesrv
 spec:
   replicas: {{ .ConfigItems.skipper_routesrv_replicas }}
@@ -21,7 +21,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.13.130
+        version: v0.13.132
         component: routesrv
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -46,7 +46,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Cluster.ConfigItems.skipper_termination_grace_period }}
       containers:
       - name: routesrv
-        image: registry.opensource.zalan.do/teapot/skipper:v0.13.130
+        image: registry.opensource.zalan.do/teapot/skipper:v0.13.132
         ports:
         - name: ingress-port
           containerPort: 9990


### PR DESCRIPTION
- add client IP as Tag to ingress Span
- add last parsed routeID to eskip parsing errors to simplify investigations

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>