### PR TITLE
Improvements on scaling schedules chunks

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -126,8 +126,12 @@ enable_apimonitoring: "true"                       # TODO(sszuecs): cleanup cand
 
 
 # Kube-Metrics-Adapter
-## Scheduled scaling metrics: fade in/out over this period of time
+## Scheduled scaling metrics: ramp up/down over this period of time
 kube_metrics_adapter_default_scaling_window: "10m"
+## Scheduled scaling metrics: number of steps to scale. 5 allows at
+## least 20% of change between each schedule and enough change to
+## trigger the HPA.
+kube_metrics_adapter_scaling_schedule_ramp_steps: "5"
 ## ZMON KairosDB URL
 zmon_kairosdb_url: "https://data-service.zmon.zalan.do/kairosdb-proxy"
 

--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.15
+        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.16
         env:
         - name: AWS_REGION
           value: {{ .Region }}
@@ -37,6 +37,7 @@ spec:
         - --skipper-routegroup-metrics
         - --scaling-schedule
         - --scaling-schedule-default-scaling-window={{.Cluster.ConfigItems.kube_metrics_adapter_default_scaling_window}}
+        - --scaling-schedule-ramp-steps={{.Cluster.ConfigItems.kube_metrics_adapter_scaling_schedule_ramp_steps}}
         - --aws-external-metrics
         - --aws-region=eu-central-1
         - --aws-region=eu-west-1


### PR DESCRIPTION
This commit updates the kube-metrics-adapter to include the changes
introduced in [kube-metrics-adapter#374][kube-metrics-adapter_374]. It
sets the default values to 5 steps, allowing 20% chunks of scaling. In
simulations, any deployment bigger than 5 pods should face the issue of
the change being smaller than 10%.

[kube-metrics-adapter_374]: https://github.com/zalando-incubator/kube-metrics-adapter/pull/374