### PR TITLE
e2e: use on-demand instead of spot

### DIFF
--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -54,16 +54,16 @@ clusters:
     profile: master-default
     min_size: 1
     max_size: 2
-  - discount_strategy: spot
-    instance_types: ["m5.xlarge", "m5a.xlarge", "m5a.2xlarge", "m5.2xlarge"]
+  - discount_strategy: none
+    instance_types: ["m5.xlarge"]
     name: default-worker-splitaz
     profile: worker-splitaz
     min_size: 0
     max_size: 21
     config_items:
       cpu_manager_policy: static
-  - discount_strategy: spot
-    instance_types: ["m5.xlarge", "m5a.xlarge", "m5a.2xlarge", "m5.2xlarge"]
+  - discount_strategy: none
+    instance_types: ["m5.xlarge"]
     config_items:
       availability_zones: "eu-central-1a"
       scaling_priority: "-100"
@@ -71,14 +71,14 @@ clusters:
     profile: worker-splitaz
     min_size: 0
     max_size: 21
-  - discount_strategy: spot
-    instance_types: ["m5d.xlarge", "m5ad.xlarge", "m5d.2xlarge", "m5ad.2xlarge"]
+  - discount_strategy: none
+    instance_types: ["m5d.xlarge"]
     name: worker-instance-storage
     profile: worker-splitaz
     min_size: 0
     max_size: 21
-  - discount_strategy: spot
-    instance_types: ["m5.xlarge", "m5a.xlarge", "m5a.2xlarge", "m5.2xlarge"]
+  - discount_strategy: none
+    instance_types: ["m5.xlarge"]
     name: worker-combined
     profile: worker-combined
     config_items:
@@ -87,7 +87,7 @@ clusters:
     min_size: 0
     max_size: 21
   - discount_strategy: spot
-    instance_types: ["m5a.large", "m5.large", "m5.xlarge", "m5a.xlarge"]
+    instance_types: ["m5a.large", "m5.large", "m5.xlarge", "m5a.xlarge", "t3.large", "t3.xlarge", "c5a.large", "c5a.xlarge"]
     min_size: 0
     max_size: 3
     profile: worker-splitaz


### PR DESCRIPTION
Slightly more money, but at least we won't have to retrigger the tests so often.