### PR TITLE
Kube1.21 dependencies

### DIFF
--- a/cluster/manifests/deployment-service/controller-statefulset.yaml
+++ b/cluster/manifests/deployment-service/controller-statefulset.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
         - name: "deployment-service-controller"
-          image: "pierone.stups.zalan.do/teapot/deployment-controller:master-84"
+          image: "pierone.stups.zalan.do/teapot/deployment-controller:master-87"
           args:
             - "--config-namespace=kube-system"
           env:

--- a/cluster/manifests/deployment-service/status-service-deployment.yaml
+++ b/cluster/manifests/deployment-service/status-service-deployment.yaml
@@ -1,5 +1,5 @@
 {{ $image   := "pierone.stups.zalan.do/teapot/deployment-status-service" }}
-{{ $version := "master-84" }}
+{{ $version := "master-87" }}
 
 apiVersion: apps/v1
 kind: Deployment

--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.16
+        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.17
         env:
         - name: AWS_REGION
           value: {{ .Region }}

--- a/cluster/manifests/stackset-controller/01-stack-crd.yaml
+++ b/cluster/manifests/stackset-controller/01-stack-crd.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: stacks.zalando.org
 spec:
@@ -1186,11 +1186,78 @@ spec:
                                                 ANDed.
                                               type: object
                                           type: object
+                                        namespaceSelector:
+                                          description: A label query over the set
+                                            of namespaces that the term applies to.
+                                            The term is applied to the union of the
+                                            namespaces selected by this field and
+                                            the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces
+                                            list means "this pod's namespace". An
+                                            empty selector ({}) matches all namespaces.
+                                            This field is alpha-level and is only
+                                            honored when PodAffinityNamespaceSelector
+                                            feature is enabled.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
                                         namespaces:
-                                          description: namespaces specifies which
-                                            namespaces the labelSelector applies to
-                                            (matches against); null or empty list
-                                            means "this pod's namespace"
+                                          description: namespaces specifies a static
+                                            list of namespace names that the term
+                                            applies to. The term is applied to the
+                                            union of the namespaces listed in this
+                                            field and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null
+                                            namespaceSelector means "this pod's namespace"
                                           items:
                                             type: string
                                           type: array
@@ -1292,10 +1359,73 @@ spec:
                                             only "value". The requirements are ANDed.
                                           type: object
                                       type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces. This
+                                        field is alpha-level and is only honored when
+                                        PodAffinityNamespaceSelector feature is enabled.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
                                     namespaces:
-                                      description: namespaces specifies which namespaces
-                                        the labelSelector applies to (matches against);
-                                        null or empty list means "this pod's namespace"
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace"
                                       items:
                                         type: string
                                       type: array
@@ -1397,11 +1527,78 @@ spec:
                                                 ANDed.
                                               type: object
                                           type: object
+                                        namespaceSelector:
+                                          description: A label query over the set
+                                            of namespaces that the term applies to.
+                                            The term is applied to the union of the
+                                            namespaces selected by this field and
+                                            the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces
+                                            list means "this pod's namespace". An
+                                            empty selector ({}) matches all namespaces.
+                                            This field is alpha-level and is only
+                                            honored when PodAffinityNamespaceSelector
+                                            feature is enabled.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
                                         namespaces:
-                                          description: namespaces specifies which
-                                            namespaces the labelSelector applies to
-                                            (matches against); null or empty list
-                                            means "this pod's namespace"
+                                          description: namespaces specifies a static
+                                            list of namespace names that the term
+                                            applies to. The term is applied to the
+                                            union of the namespaces listed in this
+                                            field and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null
+                                            namespaceSelector means "this pod's namespace"
                                           items:
                                             type: string
                                           type: array
@@ -1503,10 +1700,73 @@ spec:
                                             only "value". The requirements are ANDed.
                                           type: object
                                       type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces. This
+                                        field is alpha-level and is only honored when
+                                        PodAffinityNamespaceSelector feature is enabled.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
                                     namespaces:
-                                      description: namespaces specifies which namespaces
-                                        the labelSelector applies to (matches against);
-                                        null or empty list means "this pod's namespace"
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace"
                                       items:
                                         type: string
                                       type: array
@@ -2064,6 +2324,23 @@ spec:
                                   required:
                                   - port
                                   type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is an alpha field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                  format: int64
+                                  type: integer
                                 timeoutSeconds:
                                   description: 'Number of seconds after which the
                                     probe times out. Defaults to 1 second. Minimum
@@ -2239,6 +2516,23 @@ spec:
                                   required:
                                   - port
                                   type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is an alpha field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                  format: int64
+                                  type: integer
                                 timeoutSeconds:
                                   description: 'Number of seconds after which the
                                     probe times out. Defaults to 1 second. Minimum
@@ -2248,7 +2542,7 @@ spec:
                               type: object
                             resources:
                               description: 'Compute Resources required by this container.
-                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                               properties:
                                 limits:
                                   additionalProperties:
@@ -2258,7 +2552,7 @@ spec:
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   description: 'Limits describes the maximum amount
-                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                   type: object
                                 requests:
                                   additionalProperties:
@@ -2271,7 +2565,7 @@ spec:
                                     of compute resources required. If Requests is
                                     omitted for a container, it defaults to Limits
                                     if that is explicitly specified, otherwise to
-                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                   type: object
                               type: object
                             securityContext:
@@ -2551,6 +2845,23 @@ spec:
                                   required:
                                   - port
                                   type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is an alpha field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                  format: int64
+                                  type: integer
                                 timeoutSeconds:
                                   description: 'Number of seconds after which the
                                     probe times out. Defaults to 1 second. Minimum
@@ -3275,6 +3586,23 @@ spec:
                                   required:
                                   - port
                                   type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is an alpha field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                  format: int64
+                                  type: integer
                                 timeoutSeconds:
                                   description: 'Number of seconds after which the
                                     probe times out. Defaults to 1 second. Minimum
@@ -3437,6 +3765,23 @@ spec:
                                   required:
                                   - port
                                   type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is an alpha field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                  format: int64
+                                  type: integer
                                 timeoutSeconds:
                                   description: 'Number of seconds after which the
                                     probe times out. Defaults to 1 second. Minimum
@@ -3457,7 +3802,7 @@ spec:
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   description: 'Limits describes the maximum amount
-                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                   type: object
                                 requests:
                                   additionalProperties:
@@ -3470,7 +3815,7 @@ spec:
                                     of compute resources required. If Requests is
                                     omitted for a container, it defaults to Limits
                                     if that is explicitly specified, otherwise to
-                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                   type: object
                               type: object
                             securityContext:
@@ -3741,6 +4086,23 @@ spec:
                                   required:
                                   - port
                                   type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is an alpha field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                  format: int64
+                                  type: integer
                                 timeoutSeconds:
                                   description: 'Number of seconds after which the
                                     probe times out. Defaults to 1 second. Minimum
@@ -4478,6 +4840,23 @@ spec:
                                   required:
                                   - port
                                   type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is an alpha field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                  format: int64
+                                  type: integer
                                 timeoutSeconds:
                                   description: 'Number of seconds after which the
                                     probe times out. Defaults to 1 second. Minimum
@@ -4653,6 +5032,23 @@ spec:
                                   required:
                                   - port
                                   type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is an alpha field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                  format: int64
+                                  type: integer
                                 timeoutSeconds:
                                   description: 'Number of seconds after which the
                                     probe times out. Defaults to 1 second. Minimum
@@ -4662,7 +5058,7 @@ spec:
                               type: object
                             resources:
                               description: 'Compute Resources required by this container.
-                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                               properties:
                                 limits:
                                   additionalProperties:
@@ -4672,7 +5068,7 @@ spec:
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   description: 'Limits describes the maximum amount
-                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                   type: object
                                 requests:
                                   additionalProperties:
@@ -4685,7 +5081,7 @@ spec:
                                     of compute resources required. If Requests is
                                     omitted for a container, it defaults to Limits
                                     if that is explicitly specified, otherwise to
-                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                   type: object
                               type: object
                             securityContext:
@@ -4965,6 +5361,23 @@ spec:
                                   required:
                                   - port
                                   type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is an alpha field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                  format: int64
+                                  type: integer
                                 timeoutSeconds:
                                   description: 'Number of seconds after which the
                                     probe times out. Defaults to 1 second. Minimum
@@ -5384,9 +5797,10 @@ spec:
                         description: Optional duration in seconds the pod needs to
                           terminate gracefully. May be decreased in delete request.
                           Value must be non-negative integer. The value zero indicates
-                          delete immediately. If this value is nil, the default grace
-                          period will be used instead. The grace period is the duration
-                          in seconds after the processes running in the pod are sent
+                          stop immediately via the kill signal (no opportunity to
+                          shut down). If this value is nil, the default grace period
+                          will be used instead. The grace period is the duration in
+                          seconds after the processes running in the pod are sent
                           a termination signal and the time when the processes are
                           forcibly halted with a kill signal. Set this value longer
                           than the expected cleanup time for your process. Defaults
@@ -5961,14 +6375,14 @@ spec:
                               type: object
                             ephemeral:
                               description: "Ephemeral represents a volume that is
-                                handled by a cluster storage driver (Alpha feature).
-                                The volume's lifecycle is tied to the pod that defines
-                                it - it will be created before the pod starts, and
-                                deleted when the pod is removed. \n Use this if: a)
-                                the volume is only needed while the pod runs, b) features
-                                of normal volumes like restoring from snapshot or
-                                capacity    tracking are needed, c) the storage driver
-                                is specified through a storage class, and d) the storage
+                                handled by a cluster storage driver. The volume's
+                                lifecycle is tied to the pod that defines it - it
+                                will be created before the pod starts, and deleted
+                                when the pod is removed. \n Use this if: a) the volume
+                                is only needed while the pod runs, b) features of
+                                normal volumes like restoring from snapshot or capacity
+                                \   tracking are needed, c) the storage driver is
+                                specified through a storage class, and d) the storage
                                 driver supports dynamic volume provisioning through
                                 \   a PersistentVolumeClaim (see EphemeralVolumeSource
                                 for more    information on the connection between
@@ -5980,12 +6394,10 @@ spec:
                                 to be used that way - see the documentation of the
                                 driver for more information. \n A pod can use both
                                 types of ephemeral volumes and persistent volumes
-                                at the same time."
+                                at the same time. \n This is a beta feature and only
+                                available when the GenericEphemeralVolume feature
+                                gate is enabled."
                               properties:
-                                readOnly:
-                                  description: Specifies a read-only configuration
-                                    for the volume. Defaults to false (read/write).
-                                  type: boolean
                                 volumeClaimTemplate:
                                   description: "Will be used to create a stand-alone
                                     PVC to provision the volume. The pod in which
@@ -6079,7 +6491,7 @@ spec:
                                                 x-kubernetes-int-or-string: true
                                               description: 'Limits describes the maximum
                                                 amount of compute resources allowed.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                               type: object
                                             requests:
                                               additionalProperties:
@@ -6094,7 +6506,7 @@ spec:
                                                 a container, it defaults to Limits
                                                 if that is explicitly specified, otherwise
                                                 to an implementation-defined value.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                               type: object
                                           type: object
                                         selector:

--- a/cluster/manifests/stackset-controller/01-stackset-crd.yaml
+++ b/cluster/manifests/stackset-controller/01-stackset-crd.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: stacksets.zalando.org
 spec:
@@ -1513,12 +1513,91 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                namespaceSelector:
+                                                  description: A label query over
+                                                    the set of namespaces that the
+                                                    term applies to. The term is applied
+                                                    to the union of the namespaces
+                                                    selected by this field and the
+                                                    ones listed in the namespaces
+                                                    field. null selector and null
+                                                    or empty namespaces list means
+                                                    "this pod's namespace". An empty
+                                                    selector ({}) matches all namespaces.
+                                                    This field is alpha-level and
+                                                    is only honored when PodAffinityNamespaceSelector
+                                                    feature is enabled.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
                                                 namespaces:
                                                   description: namespaces specifies
-                                                    which namespaces the labelSelector
-                                                    applies to (matches against);
-                                                    null or empty list means "this
-                                                    pod's namespace"
+                                                    a static list of namespace names
+                                                    that the term applies to. The
+                                                    term is applied to the union of
+                                                    the namespaces listed in this
+                                                    field and the ones selected by
+                                                    namespaceSelector. null or empty
+                                                    namespaces list and null namespaceSelector
+                                                    means "this pod's namespace"
                                                   items:
                                                     type: string
                                                   type: array
@@ -1633,11 +1712,85 @@ spec:
                                                     are ANDed.
                                                   type: object
                                               type: object
+                                            namespaceSelector:
+                                              description: A label query over the
+                                                set of namespaces that the term applies
+                                                to. The term is applied to the union
+                                                of the namespaces selected by this
+                                                field and the ones listed in the namespaces
+                                                field. null selector and null or empty
+                                                namespaces list means "this pod's
+                                                namespace". An empty selector ({})
+                                                matches all namespaces. This field
+                                                is alpha-level and is only honored
+                                                when PodAffinityNamespaceSelector
+                                                feature is enabled.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
                                             namespaces:
-                                              description: namespaces specifies which
-                                                namespaces the labelSelector applies
-                                                to (matches against); null or empty
-                                                list means "this pod's namespace"
+                                              description: namespaces specifies a
+                                                static list of namespace names that
+                                                the term applies to. The term is applied
+                                                to the union of the namespaces listed
+                                                in this field and the ones selected
+                                                by namespaceSelector. null or empty
+                                                namespaces list and null namespaceSelector
+                                                means "this pod's namespace"
                                               items:
                                                 type: string
                                               type: array
@@ -1754,12 +1907,91 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                namespaceSelector:
+                                                  description: A label query over
+                                                    the set of namespaces that the
+                                                    term applies to. The term is applied
+                                                    to the union of the namespaces
+                                                    selected by this field and the
+                                                    ones listed in the namespaces
+                                                    field. null selector and null
+                                                    or empty namespaces list means
+                                                    "this pod's namespace". An empty
+                                                    selector ({}) matches all namespaces.
+                                                    This field is alpha-level and
+                                                    is only honored when PodAffinityNamespaceSelector
+                                                    feature is enabled.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
                                                 namespaces:
                                                   description: namespaces specifies
-                                                    which namespaces the labelSelector
-                                                    applies to (matches against);
-                                                    null or empty list means "this
-                                                    pod's namespace"
+                                                    a static list of namespace names
+                                                    that the term applies to. The
+                                                    term is applied to the union of
+                                                    the namespaces listed in this
+                                                    field and the ones selected by
+                                                    namespaceSelector. null or empty
+                                                    namespaces list and null namespaceSelector
+                                                    means "this pod's namespace"
                                                   items:
                                                     type: string
                                                   type: array
@@ -1874,11 +2106,85 @@ spec:
                                                     are ANDed.
                                                   type: object
                                               type: object
+                                            namespaceSelector:
+                                              description: A label query over the
+                                                set of namespaces that the term applies
+                                                to. The term is applied to the union
+                                                of the namespaces selected by this
+                                                field and the ones listed in the namespaces
+                                                field. null selector and null or empty
+                                                namespaces list means "this pod's
+                                                namespace". An empty selector ({})
+                                                matches all namespaces. This field
+                                                is alpha-level and is only honored
+                                                when PodAffinityNamespaceSelector
+                                                feature is enabled.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
                                             namespaces:
-                                              description: namespaces specifies which
-                                                namespaces the labelSelector applies
-                                                to (matches against); null or empty
-                                                list means "this pod's namespace"
+                                              description: namespaces specifies a
+                                                static list of namespace names that
+                                                the term applies to. The term is applied
+                                                to the union of the namespaces listed
+                                                in this field and the ones selected
+                                                by namespaceSelector. null or empty
+                                                namespaces list and null namespaceSelector
+                                                means "this pod's namespace"
                                               items:
                                                 type: string
                                               type: array
@@ -2490,6 +2796,26 @@ spec:
                                           required:
                                           - port
                                           type: object
+                                        terminationGracePeriodSeconds:
+                                          description: Optional duration in seconds
+                                            the pod needs to terminate gracefully
+                                            upon probe failure. The grace period is
+                                            the duration in seconds after the processes
+                                            running in the pod are sent a termination
+                                            signal and the time when the processes
+                                            are forcibly halted with a kill signal.
+                                            Set this value longer than the expected
+                                            cleanup time for your process. If this
+                                            value is nil, the pod's terminationGracePeriodSeconds
+                                            will be used. Otherwise, this value overrides
+                                            the value provided by the pod spec. Value
+                                            must be non-negative integer. The value
+                                            zero indicates stop immediately via the
+                                            kill signal (no opportunity to shut down).
+                                            This is an alpha field and requires enabling
+                                            ProbeTerminationGracePeriod feature gate.
+                                          format: int64
+                                          type: integer
                                         timeoutSeconds:
                                           description: 'Number of seconds after which
                                             the probe times out. Defaults to 1 second.
@@ -2685,6 +3011,26 @@ spec:
                                           required:
                                           - port
                                           type: object
+                                        terminationGracePeriodSeconds:
+                                          description: Optional duration in seconds
+                                            the pod needs to terminate gracefully
+                                            upon probe failure. The grace period is
+                                            the duration in seconds after the processes
+                                            running in the pod are sent a termination
+                                            signal and the time when the processes
+                                            are forcibly halted with a kill signal.
+                                            Set this value longer than the expected
+                                            cleanup time for your process. If this
+                                            value is nil, the pod's terminationGracePeriodSeconds
+                                            will be used. Otherwise, this value overrides
+                                            the value provided by the pod spec. Value
+                                            must be non-negative integer. The value
+                                            zero indicates stop immediately via the
+                                            kill signal (no opportunity to shut down).
+                                            This is an alpha field and requires enabling
+                                            ProbeTerminationGracePeriod feature gate.
+                                          format: int64
+                                          type: integer
                                         timeoutSeconds:
                                           description: 'Number of seconds after which
                                             the probe times out. Defaults to 1 second.
@@ -2695,7 +3041,7 @@ spec:
                                     resources:
                                       description: 'Compute Resources required by
                                         this container. Cannot be updated. More info:
-                                        https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                       properties:
                                         limits:
                                           additionalProperties:
@@ -2706,7 +3052,7 @@ spec:
                                             x-kubernetes-int-or-string: true
                                           description: 'Limits describes the maximum
                                             amount of compute resources allowed. More
-                                            info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                           type: object
                                         requests:
                                           additionalProperties:
@@ -2720,7 +3066,7 @@ spec:
                                             If Requests is omitted for a container,
                                             it defaults to Limits if that is explicitly
                                             specified, otherwise to an implementation-defined
-                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                           type: object
                                       type: object
                                     securityContext:
@@ -3034,6 +3380,26 @@ spec:
                                           required:
                                           - port
                                           type: object
+                                        terminationGracePeriodSeconds:
+                                          description: Optional duration in seconds
+                                            the pod needs to terminate gracefully
+                                            upon probe failure. The grace period is
+                                            the duration in seconds after the processes
+                                            running in the pod are sent a termination
+                                            signal and the time when the processes
+                                            are forcibly halted with a kill signal.
+                                            Set this value longer than the expected
+                                            cleanup time for your process. If this
+                                            value is nil, the pod's terminationGracePeriodSeconds
+                                            will be used. Otherwise, this value overrides
+                                            the value provided by the pod spec. Value
+                                            must be non-negative integer. The value
+                                            zero indicates stop immediately via the
+                                            kill signal (no opportunity to shut down).
+                                            This is an alpha field and requires enabling
+                                            ProbeTerminationGracePeriod feature gate.
+                                          format: int64
+                                          type: integer
                                         timeoutSeconds:
                                           description: 'Number of seconds after which
                                             the probe times out. Defaults to 1 second.
@@ -3822,6 +4188,26 @@ spec:
                                           required:
                                           - port
                                           type: object
+                                        terminationGracePeriodSeconds:
+                                          description: Optional duration in seconds
+                                            the pod needs to terminate gracefully
+                                            upon probe failure. The grace period is
+                                            the duration in seconds after the processes
+                                            running in the pod are sent a termination
+                                            signal and the time when the processes
+                                            are forcibly halted with a kill signal.
+                                            Set this value longer than the expected
+                                            cleanup time for your process. If this
+                                            value is nil, the pod's terminationGracePeriodSeconds
+                                            will be used. Otherwise, this value overrides
+                                            the value provided by the pod spec. Value
+                                            must be non-negative integer. The value
+                                            zero indicates stop immediately via the
+                                            kill signal (no opportunity to shut down).
+                                            This is an alpha field and requires enabling
+                                            ProbeTerminationGracePeriod feature gate.
+                                          format: int64
+                                          type: integer
                                         timeoutSeconds:
                                           description: 'Number of seconds after which
                                             the probe times out. Defaults to 1 second.
@@ -4003,6 +4389,26 @@ spec:
                                           required:
                                           - port
                                           type: object
+                                        terminationGracePeriodSeconds:
+                                          description: Optional duration in seconds
+                                            the pod needs to terminate gracefully
+                                            upon probe failure. The grace period is
+                                            the duration in seconds after the processes
+                                            running in the pod are sent a termination
+                                            signal and the time when the processes
+                                            are forcibly halted with a kill signal.
+                                            Set this value longer than the expected
+                                            cleanup time for your process. If this
+                                            value is nil, the pod's terminationGracePeriodSeconds
+                                            will be used. Otherwise, this value overrides
+                                            the value provided by the pod spec. Value
+                                            must be non-negative integer. The value
+                                            zero indicates stop immediately via the
+                                            kill signal (no opportunity to shut down).
+                                            This is an alpha field and requires enabling
+                                            ProbeTerminationGracePeriod feature gate.
+                                          format: int64
+                                          type: integer
                                         timeoutSeconds:
                                           description: 'Number of seconds after which
                                             the probe times out. Defaults to 1 second.
@@ -4024,7 +4430,7 @@ spec:
                                             x-kubernetes-int-or-string: true
                                           description: 'Limits describes the maximum
                                             amount of compute resources allowed. More
-                                            info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                           type: object
                                         requests:
                                           additionalProperties:
@@ -4038,7 +4444,7 @@ spec:
                                             If Requests is omitted for a container,
                                             it defaults to Limits if that is explicitly
                                             specified, otherwise to an implementation-defined
-                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                           type: object
                                       type: object
                                     securityContext:
@@ -4342,6 +4748,26 @@ spec:
                                           required:
                                           - port
                                           type: object
+                                        terminationGracePeriodSeconds:
+                                          description: Optional duration in seconds
+                                            the pod needs to terminate gracefully
+                                            upon probe failure. The grace period is
+                                            the duration in seconds after the processes
+                                            running in the pod are sent a termination
+                                            signal and the time when the processes
+                                            are forcibly halted with a kill signal.
+                                            Set this value longer than the expected
+                                            cleanup time for your process. If this
+                                            value is nil, the pod's terminationGracePeriodSeconds
+                                            will be used. Otherwise, this value overrides
+                                            the value provided by the pod spec. Value
+                                            must be non-negative integer. The value
+                                            zero indicates stop immediately via the
+                                            kill signal (no opportunity to shut down).
+                                            This is an alpha field and requires enabling
+                                            ProbeTerminationGracePeriod feature gate.
+                                          format: int64
+                                          type: integer
                                         timeoutSeconds:
                                           description: 'Number of seconds after which
                                             the probe times out. Defaults to 1 second.
@@ -5147,6 +5573,26 @@ spec:
                                           required:
                                           - port
                                           type: object
+                                        terminationGracePeriodSeconds:
+                                          description: Optional duration in seconds
+                                            the pod needs to terminate gracefully
+                                            upon probe failure. The grace period is
+                                            the duration in seconds after the processes
+                                            running in the pod are sent a termination
+                                            signal and the time when the processes
+                                            are forcibly halted with a kill signal.
+                                            Set this value longer than the expected
+                                            cleanup time for your process. If this
+                                            value is nil, the pod's terminationGracePeriodSeconds
+                                            will be used. Otherwise, this value overrides
+                                            the value provided by the pod spec. Value
+                                            must be non-negative integer. The value
+                                            zero indicates stop immediately via the
+                                            kill signal (no opportunity to shut down).
+                                            This is an alpha field and requires enabling
+                                            ProbeTerminationGracePeriod feature gate.
+                                          format: int64
+                                          type: integer
                                         timeoutSeconds:
                                           description: 'Number of seconds after which
                                             the probe times out. Defaults to 1 second.
@@ -5342,6 +5788,26 @@ spec:
                                           required:
                                           - port
                                           type: object
+                                        terminationGracePeriodSeconds:
+                                          description: Optional duration in seconds
+                                            the pod needs to terminate gracefully
+                                            upon probe failure. The grace period is
+                                            the duration in seconds after the processes
+                                            running in the pod are sent a termination
+                                            signal and the time when the processes
+                                            are forcibly halted with a kill signal.
+                                            Set this value longer than the expected
+                                            cleanup time for your process. If this
+                                            value is nil, the pod's terminationGracePeriodSeconds
+                                            will be used. Otherwise, this value overrides
+                                            the value provided by the pod spec. Value
+                                            must be non-negative integer. The value
+                                            zero indicates stop immediately via the
+                                            kill signal (no opportunity to shut down).
+                                            This is an alpha field and requires enabling
+                                            ProbeTerminationGracePeriod feature gate.
+                                          format: int64
+                                          type: integer
                                         timeoutSeconds:
                                           description: 'Number of seconds after which
                                             the probe times out. Defaults to 1 second.
@@ -5352,7 +5818,7 @@ spec:
                                     resources:
                                       description: 'Compute Resources required by
                                         this container. Cannot be updated. More info:
-                                        https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                       properties:
                                         limits:
                                           additionalProperties:
@@ -5363,7 +5829,7 @@ spec:
                                             x-kubernetes-int-or-string: true
                                           description: 'Limits describes the maximum
                                             amount of compute resources allowed. More
-                                            info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                           type: object
                                         requests:
                                           additionalProperties:
@@ -5377,7 +5843,7 @@ spec:
                                             If Requests is omitted for a container,
                                             it defaults to Limits if that is explicitly
                                             specified, otherwise to an implementation-defined
-                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                           type: object
                                       type: object
                                     securityContext:
@@ -5691,6 +6157,26 @@ spec:
                                           required:
                                           - port
                                           type: object
+                                        terminationGracePeriodSeconds:
+                                          description: Optional duration in seconds
+                                            the pod needs to terminate gracefully
+                                            upon probe failure. The grace period is
+                                            the duration in seconds after the processes
+                                            running in the pod are sent a termination
+                                            signal and the time when the processes
+                                            are forcibly halted with a kill signal.
+                                            Set this value longer than the expected
+                                            cleanup time for your process. If this
+                                            value is nil, the pod's terminationGracePeriodSeconds
+                                            will be used. Otherwise, this value overrides
+                                            the value provided by the pod spec. Value
+                                            must be non-negative integer. The value
+                                            zero indicates stop immediately via the
+                                            kill signal (no opportunity to shut down).
+                                            This is an alpha field and requires enabling
+                                            ProbeTerminationGracePeriod feature gate.
+                                          format: int64
+                                          type: integer
                                         timeoutSeconds:
                                           description: 'Number of seconds after which
                                             the probe times out. Defaults to 1 second.
@@ -6143,14 +6629,15 @@ spec:
                                 description: Optional duration in seconds the pod
                                   needs to terminate gracefully. May be decreased
                                   in delete request. Value must be non-negative integer.
-                                  The value zero indicates delete immediately. If
-                                  this value is nil, the default grace period will
-                                  be used instead. The grace period is the duration
-                                  in seconds after the processes running in the pod
-                                  are sent a termination signal and the time when
-                                  the processes are forcibly halted with a kill signal.
-                                  Set this value longer than the expected cleanup
-                                  time for your process. Defaults to 30 seconds.
+                                  The value zero indicates stop immediately via the
+                                  kill signal (no opportunity to shut down). If this
+                                  value is nil, the default grace period will be used
+                                  instead. The grace period is the duration in seconds
+                                  after the processes running in the pod are sent
+                                  a termination signal and the time when the processes
+                                  are forcibly halted with a kill signal. Set this
+                                  value longer than the expected cleanup time for
+                                  your process. Defaults to 30 seconds.
                                 format: int64
                                 type: integer
                               tolerations:
@@ -6785,34 +7272,32 @@ spec:
                                       type: object
                                     ephemeral:
                                       description: "Ephemeral represents a volume
-                                        that is handled by a cluster storage driver
-                                        (Alpha feature). The volume's lifecycle is
-                                        tied to the pod that defines it - it will
-                                        be created before the pod starts, and deleted
-                                        when the pod is removed. \n Use this if: a)
-                                        the volume is only needed while the pod runs,
-                                        b) features of normal volumes like restoring
-                                        from snapshot or capacity    tracking are
-                                        needed, c) the storage driver is specified
-                                        through a storage class, and d) the storage
-                                        driver supports dynamic volume provisioning
-                                        through    a PersistentVolumeClaim (see EphemeralVolumeSource
-                                        for more    information on the connection
-                                        between this volume type    and PersistentVolumeClaim).
-                                        \n Use PersistentVolumeClaim or one of the
-                                        vendor-specific APIs for volumes that persist
-                                        for longer than the lifecycle of an individual
-                                        pod. \n Use CSI for light-weight local ephemeral
-                                        volumes if the CSI driver is meant to be used
-                                        that way - see the documentation of the driver
-                                        for more information. \n A pod can use both
-                                        types of ephemeral volumes and persistent
-                                        volumes at the same time."
+                                        that is handled by a cluster storage driver.
+                                        The volume's lifecycle is tied to the pod
+                                        that defines it - it will be created before
+                                        the pod starts, and deleted when the pod is
+                                        removed. \n Use this if: a) the volume is
+                                        only needed while the pod runs, b) features
+                                        of normal volumes like restoring from snapshot
+                                        or capacity    tracking are needed, c) the
+                                        storage driver is specified through a storage
+                                        class, and d) the storage driver supports
+                                        dynamic volume provisioning through    a PersistentVolumeClaim
+                                        (see EphemeralVolumeSource for more    information
+                                        on the connection between this volume type
+                                        \   and PersistentVolumeClaim). \n Use PersistentVolumeClaim
+                                        or one of the vendor-specific APIs for volumes
+                                        that persist for longer than the lifecycle
+                                        of an individual pod. \n Use CSI for light-weight
+                                        local ephemeral volumes if the CSI driver
+                                        is meant to be used that way - see the documentation
+                                        of the driver for more information. \n A pod
+                                        can use both types of ephemeral volumes and
+                                        persistent volumes at the same time. \n This
+                                        is a beta feature and only available when
+                                        the GenericEphemeralVolume feature gate is
+                                        enabled."
                                       properties:
-                                        readOnly:
-                                          description: Specifies a read-only configuration
-                                            for the volume. Defaults to false (read/write).
-                                          type: boolean
                                         volumeClaimTemplate:
                                           description: "Will be used to create a stand-alone
                                             PVC to provision the volume. The pod in
@@ -6916,7 +7401,7 @@ spec:
                                                       description: 'Limits describes
                                                         the maximum amount of compute
                                                         resources allowed. More info:
-                                                        https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                                        https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                       type: object
                                                     requests:
                                                       additionalProperties:
@@ -6932,7 +7417,7 @@ spec:
                                                         it defaults to Limits if that
                                                         is explicitly specified, otherwise
                                                         to an implementation-defined
-                                                        value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                                        value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                       type: object
                                                   type: object
                                                 selector:

--- a/cluster/manifests/stackset-controller/deployment.yaml
+++ b/cluster/manifests/stackset-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: stackset-controller
-    version: "v1.3.45"
+    version: "v1.3.46"
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: stackset-controller
-        version: "v1.3.45"
+        version: "v1.3.46"
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
         prometheus.io/path: /metrics
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: stackset-controller
       containers:
       - name: stackset-controller
-        image: "registry.opensource.zalan.do/teapot/stackset-controller:v1.3.45"
+        image: "registry.opensource.zalan.do/teapot/stackset-controller:v1.3.46"
         args:
         - "--interval={{ .Cluster.ConfigItems.stackset_controller_sync_interval }}"
 {{- if eq .Cluster.ConfigItems.stackset_routegroup_support_enabled "true" }}

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -200,7 +200,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-129
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-130
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
#### Upgrade the StacksetController 1d28b63

This commit updates the StacksetController to the v1.3.46 version. This
new version updates the kubernetes deps version to 1.21.5

#### Upgrade kube-metrics-adapter. 48e1e90

This commit upgrades to the new version of kube-metrics-adapter. This
release includes new kubernetes dependencies for the version 1.21.5.

####  Update the admission-controller 1a755a2
This commit upgrades the admission-controller version to include kube
1.21.5 dependencies.

####  Update deployment-service 800452a

This commit upgrades the deployment-service to its last version
containing the update of Kubernetes deps to 1.21.5.

The jump of 3 versions is due to retriggers of the pipeline.