### PR TITLE
Update admission-controller to master-132

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -200,7 +200,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-129
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-132
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
This version fixes a bug where an AZ block is considered active although the configured blocked `zoneName` is an empty string. This turned off automatic pod spread injection even though no zone is actually supposed to be blocked.