### PR TITLE
Updates ingress-controller

### DIFF
--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.12.5
+    version: v0.12.9
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.12.5
+        version: v0.12.9
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_both}}"
     spec:
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: kube-ingress-aws-controller
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.12.5
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.12.9
         args:
         - --stack-termination-protection
         - --ssl-policy={{ .ConfigItems.kube_aws_ingress_controller_ssl_policy }}


### PR DESCRIPTION
https://github.com/zalando-incubator/kube-ingress-aws-controller/compare/v0.12.5...v0.12.9

```
Bump github.com/aws/aws-sdk-go from 1.40.53 to 1.41.14
Collects reconciliation metrics
Implementation of IngressClassName (Kubernetes 1.18+) for filtering
allow v1 ingress
```
Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>