### PR TITLE
Update cluster autoscaler

### DIFF
--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -36,7 +36,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cluster-autoscaler
-        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.18.2-internal.35
+        image: registry.opensource.zalan.do/teapot/kube-cluster-autoscaler:v1.18.2-internal.36
         command:
           - ./cluster-autoscaler
           - --v=1


### PR DESCRIPTION
This commit updates autoscaler with the changes in
https://github.com/zalando-incubator/autoscaler/pull/87. It just updates
the available instance types.