### PR TITLE
Allow logging-agent to use OIDC AWS credentials

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1473,6 +1473,14 @@ Resources:
                 - ''
                 - - 'arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/'
                   - !Ref MasterIAMRole
+          - Action:
+              - 'sts:AssumeRoleWithWebIdentity'
+            Effect: Allow
+            Principal:
+              Federated: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+            Condition:
+              StringLike:
+                "{{ .Cluster.LocalID }}.{{ .Values.hosted_zone }}:sub": "system:serviceaccount:visibility:logging-agent"
       Policies:
         - PolicyName: AllowS3BucketAccess
           PolicyDocument:


### PR DESCRIPTION
To allow the logging agent pods to access its own role via OIDC we have
to adjust the IAM role with a new assume role policy. This commit
creates it and removes the older policies attached to the worker and
master role. It is under a config `logging_agent_enable_oidc_iam` which
defaults to false.