### PR TITLE
Upgrade nvidia-gpu-device-plugin v0.10.0

### DIFF
--- a/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
+++ b/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
@@ -1,6 +1,6 @@
 # based on:
 #
-#   https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/device-plugins/nvidia-gpu/daemonset.yaml
+#   https://github.com/NVIDIA/k8s-device-plugin/blob/master/nvidia-device-plugin.yml
 #
 apiVersion: apps/v1
 kind: DaemonSet
@@ -9,7 +9,7 @@ metadata:
   namespace: kube-system
   labels:
     application: nvidia-gpu-device-plugin
-    version: 4baa941d8df91e5dc1736adea74ce54e564dd782
+    version: v0.10.0
 spec:
   updateStrategy:
     type: RollingUpdate
@@ -20,7 +20,7 @@ spec:
     metadata:
       labels:
         application: nvidia-gpu-device-plugin
-        version: 4baa941d8df91e5dc1736adea74ce54e564dd782
+        version: v0.10.0
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
@@ -47,11 +47,8 @@ spec:
           path: /dev
       containers:
       - name: nvidia-gpu-device-plugin
-        image: registry.opensource.zalan.do/teapot/nvidia-gpu-device-plugin:4baa941d8df91e5dc1736adea74ce54e564dd782
-        command:
-        - /usr/bin/nvidia-gpu-device-plugin
-        - -host-path=/opt/nvidia
-        - -logtostderr
+        image: registry.opensource.zalan.do/teapot/nvidia-gpu-device-plugin:v0.10.0
+        args: ["--fail-on-init-error=false"]
         resources:
           requests:
             cpu: 50m


### PR DESCRIPTION
The GPU plugin is now officially provided by NVIDIA.

The default image `command` has changed:

```diff
- /usr/bin/nvidia-gpu-device-plugin
+ /usr/bin/nvidia-device-plugin
```

The command line arguments also changed, only these are supported and we don't need to customize them AFAIK:

```
NAME:
   nvidia-device-plugin - A new cli application

USAGE:
   nvidia-device-plugin [global options] command [command options] [arguments...]

COMMANDS:
   help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --mig-strategy value          the desired strategy for exposing MIG devices on GPUs that support it:
                                   [none | single | mixed] (default: "none") [$MIG_STRATEGY]
   --fail-on-init-error          fail the plugin if an error is encountered during initialization, otherwise block indefinitely (default: true) [$FAIL_ON_INIT_ERROR]
   --pass-device-specs           pass the list of DeviceSpecs to the kubelet on Allocate() (default: false) [$PASS_DEVICE_SPECS]
   --device-list-strategy value  the desired strategy for passing the device list to the underlying runtime:
                                   [envvar | volume-mounts] (default: "envvar") [$DEVICE_LIST_STRATEGY]
   --device-id-strategy value    the desired strategy for passing device IDs to the underlying runtime:
                                   [uuid | index] (default: "uuid") [$DEVICE_ID_STRATEGY]
   --nvidia-driver-root value    the root path for the NVIDIA driver installation (typical values are '/' or '/run/nvidia/driver') (default: "/") [$NVIDIA_DRIVER_ROOT]
   --help, -h                    show help (default: false)
```