### PR TITLE
Remove Kuberuntu v1.20 image

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -483,7 +483,6 @@ tracing_coredns_local_zone_traces_endpoint: ""
 # AMI id given the image name and the Image AWS account owner.
 #
 # [0]: https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/8a9bd1cb2d094038a9e23e646421f8146b48886a/provisioner/template.go#L116
-kuberuntu_image_v1_20: {{ amiID "zalando-ubuntu-kubernetes-production-v1.20.11-master-188" "861068367966"}}
 kuberuntu_image_v1_21: {{ amiID "zalando-ubuntu-kubernetes-production-v1.21.5-master-194" "861068367966"}}
 
 # Feature toggle for auditing events


### PR DESCRIPTION
Since the current Kubernetes version is 1.21, the `kuberuntu_image_v1_20`
is no longer needed. This commit removes it from the cluster config.