### PR TITLE
Update cronjob version for aws-node-decommissioner

### DIFF
--- a/cluster/manifests/aws-node-decommissioner/cronjob.yaml
+++ b/cluster/manifests/aws-node-decommissioner/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: aws-node-decommissioner


### PR DESCRIPTION
Updates to the stable apiVersion supported since v1.21