### PR TITLE
Updates kube-apiserver Skipper version

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -242,7 +242,7 @@ write_files:
               readOnly: true
 {{- if or (eq .Cluster.ConfigItems.routegroups_validation "provisioned") (eq .Cluster.ConfigItems.routegroups_validation "enabled") }}
         - name: routegroups-admission-webhook
-          image: registry.opensource.zalan.do/teapot/skipper:v0.13.53
+          image: registry.opensource.zalan.do/teapot/skipper:v0.13.150
           args:
             - webhook
             - --address=:9085
@@ -409,7 +409,7 @@ write_files:
             value: {{ .Cluster.ConfigItems.apiserver_business_partner_ids }}
 {{ end }}
         - name: skipper-proxy
-          image: registry.opensource.zalan.do/teapot/skipper:v0.13.53
+          image: registry.opensource.zalan.do/teapot/skipper:v0.13.150
           args:
           - skipper
           - -access-log-strip-query
@@ -460,7 +460,7 @@ write_files:
             name: ssl-certs-kubernetes
             readOnly: true
         - name: skipper-metrics
-          image: registry.opensource.zalan.do/teapot/skipper:v0.13.53
+          image: registry.opensource.zalan.do/teapot/skipper:v0.13.150
           args:
           - skipper
           - -access-log-strip-query


### PR DESCRIPTION
Updates to the latest version that also includes a change to mute
`http: TLS handshake error ... EOF` errors (https://github.com/zalando/skipper/pull/1904)

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>