### PR TITLE
ingress: enable incoming request host normalization

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -75,7 +75,7 @@ skipper_topology_spread_enabled: "false"
 {{end}}
 
 # skipper default filters
-skipper_default_filters: 'enableAccessLog(4,5) -> lifo(2000,20000,"3s") -> rfcHost()'
+skipper_default_filters: 'enableAccessLog(4,5) -> lifo(2000,20000,"3s")'
 
 # skipper backend timeout defaults
 skipper_expect_continue_timeout_backend: "30s"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -92,6 +92,7 @@ spec:
           - "skipper"
 {{ if eq .ConfigItems.skipper_routesrv_enabled "true" }}
           - "-routes-urls=http://skipper-ingress-routesrv.kube-system.svc.cluster.local/routes"
+          - "-normalize-host"
 {{ else }}
           - "-kubernetes"
           - "-kubernetes-in-cluster"


### PR DESCRIPTION
Host normalization (https://github.com/zalando/skipper/pull/1911) is enabled
by `-kubernetes` or by `-normalize-host` flags and obviates `rfcHost` filter.

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>