### PR TITLE
exclude "tracing" namespace from nightly scale-down

### DIFF
--- a/cluster/manifests/kube-downscaler/deployment.yaml
+++ b/cluster/manifests/kube-downscaler/deployment.yaml
@@ -34,7 +34,7 @@ spec:
         image: registry.opensource.zalan.do/teapot/kube-downscaler:20.4.1
         args:
           - --interval=30
-          - --exclude-namespaces=kube-system,visibility
+          - --exclude-namespaces=kube-system,visibility,tracing
           # do not downscale ourselves, also keep Postgres Operator so excluded DBs can be managed
           - --exclude-deployments=kube-downscaler,postgres-operator
           - "--default-uptime={{ .ConfigItems.downscaler_default_uptime }}"


### PR DESCRIPTION
Prevent namespace `tracing` to be scaled down during after-office hours,
by adding it to the namespace exclusion list.