### PR TITLE
kube-ingress-aws-controller: ingress v1 in test

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -27,6 +27,11 @@ cluster_autoscaler_max_usnchedulable_pods_considered: "1000"
 kube_aws_ingress_controller_ssl_policy: "ELBSecurityPolicy-TLS-1-2-2017-01"
 kube_aws_ingress_controller_idle_timeout: "1m"
 kube_aws_ingress_controller_deregistration_delay_timeout: "10s"
+{{if eq .Cluster.Environment "production"}}
+kube_aws_ingress_controller_ingress_version: "v1beta1"
+{{else}}
+kube_aws_ingress_controller_ingress_version: "v1"
+{{end}}
 # allow using NLBs for ingress
 # This opens skipper-ingress ports 9998 and 9999 on all worker nodes
 kube_aws_ingress_controller_nlb_enabled: "true"

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -51,6 +51,7 @@ spec:
         - --load-balancer-type={{ .Cluster.ConfigItems.kube_aws_ingress_default_lb_type }}
 {{end}}
         - --cert-polling-interval={{ .Cluster.ConfigItems.kube_aws_ingress_controller_cert_polling_interval }}
+        - --ingress-api-version=networking.k8s.io/{{ .Cluster.ConfigItems.kube_aws_ingress_controller_ingress_version }}
         env:
         - name: CUSTOM_FILTERS
           value: "tag:kubernetes.io/cluster/{{ .Cluster.ID }}=owned tag:node.kubernetes.io/role=worker tag:zalando.org/ingress-enabled=true"


### PR DESCRIPTION
kube-ingress-aws-controller switch to ingress v1 in all non production environments

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>