### PR TITLE
skipper+routesrv to same version, enable ingress v1 routesrv

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.13.150
+    version: v0.13.153
     component: ingress
 spec:
   strategy:
@@ -19,7 +19,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.13.150
+        version: v0.13.153
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -48,7 +48,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/teapot/skipper-internal:v0.13.150-202
+        image: registry.opensource.zalan.do/teapot/skipper-internal:v0.13.153-205
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -157,7 +157,7 @@ spec:
             tag=application=skipper-ingress
             tag=account={{ .Cluster.Alias }}
             tag=cluster={{ .Cluster.Alias }}
-            tag=artifact=registry.opensource.zalan.do/teapot/skipper-internal:v0.13.150-202
+            tag=artifact=registry.opensource.zalan.do/teapot/skipper-internal:v0.13.153-205
             max-buffered-spans={{ .ConfigItems.skipper_ingress_tracing_buffer }}
             grpc-max-msg-size={{ .ConfigItems.skipper_ingress_lightstep_grpc_max_msg_size }}
             max-period={{ .ConfigItems.skipper_ingress_lightstep_max_period }}

--- a/cluster/manifests/skipper/routesrv-deployment.yaml
+++ b/cluster/manifests/skipper/routesrv-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.13.137
+    version: v0.13.153
     component: routesrv
 spec:
   replicas: {{ .ConfigItems.skipper_routesrv_replicas }}
@@ -21,7 +21,7 @@ spec:
     metadata:
       labels:
         application: skipper-ingress
-        version: v0.13.137
+        version: v0.13.153
         component: routesrv
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -48,7 +48,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Cluster.ConfigItems.skipper_termination_grace_period }}
       containers:
       - name: routesrv
-        image: registry.opensource.zalan.do/teapot/skipper:v0.13.137
+        image: registry.opensource.zalan.do/teapot/skipper:v0.13.153
         ports:
         - name: ingress-port
           containerPort: 9990
@@ -58,6 +58,7 @@ spec:
           - "-kubernetes"
           - "-kubernetes-in-cluster"
           - "-kubernetes-path-mode=path-prefix"
+          - "-kubernetes-ingress-v1={{ .Cluster.ConfigItems.skipper_ingress_kubernetes_ingress_v1 }}"
           - "-address=:9990"
           - "-wait-for-healthcheck-interval={{ .Cluster.ConfigItems.skipper_wait_for_healthcheck_interval }}"
 {{ if eq .ConfigItems.enable_skipper_eastwest "true"}}


### PR DESCRIPTION
- deploy routesrv with enabled v1 ingress for non production environments
- deploy skipper with new healthcheck Shutodown() and remove empty tags on proxy span

https://github.com/zalando/skipper/compare/v0.13.150...v0.13.153

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>