### PR TITLE
Update AdmissionController and KubeMetricsAdapter

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.17
+        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.17-3-g2ccd690
         env:
         - name: AWS_REGION
           value: {{ .Region }}

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -200,7 +200,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-132
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-133
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
- Apply default values to `preStop` and `terminationGracePeriodSeconds`
- Use labels hash in the custom metrics store
- Define stronger types for metrics store