### PR TITLE
Uses `podManagementPolicy: Parallel` for skipper-ingress-redis

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -10,6 +10,12 @@ pre_apply:
   kind: Deployment
 {{ end }}
 
+# skipper-ingress application consolidation, can be dropped after completion
+- labels:
+    application: skipper-ingress-redis
+  namespace: kube-system
+  kind: StatefulSet
+
 # everything defined under here will be deleted after applying the manifests
 post_apply:
 {{ if eq .ConfigItems.teapot_admission_controller_process_resources "true" }}

--- a/cluster/manifests/skipper/skipper-redis-service.yaml
+++ b/cluster/manifests/skipper/skipper-redis-service.yaml
@@ -2,7 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    application: skipper-ingress-redis
+    application: skipper-ingress
+    component: redis
   name: skipper-ingress-redis
   namespace: kube-system
 spec:
@@ -12,5 +13,6 @@ spec:
     protocol: TCP
     targetPort: 6379
   selector:
-    application: skipper-ingress-redis
+    application: skipper-ingress
+    component: redis
   type: ClusterIP

--- a/cluster/manifests/skipper/skipper-redis.yaml
+++ b/cluster/manifests/skipper/skipper-redis.yaml
@@ -2,7 +2,8 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:
-    application: skipper-ingress-redis
+    application: skipper-ingress
+    component: redis
     version: v6.2.4
   name: skipper-ingress-redis
   namespace: kube-system
@@ -11,12 +12,14 @@ spec:
   podManagementPolicy: Parallel
   selector:
     matchLabels:
-      application: skipper-ingress-redis
+      statefulset: skipper-ingress-redis
   serviceName: skipper-ingress-redis
   template:
     metadata:
       labels:
-        application: skipper-ingress-redis
+        statefulset: skipper-ingress-redis
+        application: skipper-ingress
+        component: redis
         version: v6.2.4
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
@@ -42,7 +45,11 @@ spec:
               - key: application
                 operator: In
                 values:
-                - skipper-ingress-redis
+                - skipper-ingress
+              - key: component
+                operator: In
+                values:
+                - redis
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       containers:
       - image: registry.opensource.zalan.do/library/redis-6-alpine:6-alpine-20210712

--- a/cluster/manifests/skipper/skipper-redis.yaml
+++ b/cluster/manifests/skipper/skipper-redis.yaml
@@ -8,6 +8,7 @@ metadata:
   namespace: kube-system
 spec:
   replicas: {{ .ConfigItems.skipper_redis_replicas }}
+  podManagementPolicy: Parallel
   selector:
     matchLabels:
       application: skipper-ingress-redis

--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -126,6 +126,8 @@ if [ "$create_cluster" = true ]; then
     fi
 
     # Update cluster
+    echo "Updating cluster ${CLUSTER_ID}: ${API_SERVER_URL}"
+
     clm provision \
         --token="${CLUSTER_ADMIN_TOKEN}" \
         --directory="$(pwd)/../.." \

--- a/test/e2e/wait-for-update.py
+++ b/test/e2e/wait-for-update.py
@@ -65,11 +65,13 @@ def main():
 
     deadline = datetime.now() + timedelta(seconds=args.timeout)
 
+    logging.info("Waiting for updates...")
     while datetime.now() < deadline:
         try:
             if all([update_complete("daemonset", daemonset_updated),
                     update_complete("deployment", deployment_updated),
                     update_complete("statefulset", statefulset_updated)]):
+                logging.info("All updates are complete, exiting.")
                 sys.exit(0)
         except subprocess.CalledProcessError:
             logging.info("kubectl failed, will retry...")


### PR DESCRIPTION
Converts `skipper-ingress-redis` into component to consolidate under the
same `skipper-ingress` application and to update `podManagementPolicy`.

`Parallel` pod management tells the StatefulSet controller to launch or
terminate all Pods in parallel, and to not wait for Pods to become
Running and Ready or completely terminated prior to launching or
terminating another Pod.

https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#parallel-pod-management

This should speedup Redis re-scaling

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>