### PR TITLE
Uses `podManagementPolicy: Parallel` for skipper-ingress-redis [take 2]

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -9,6 +9,17 @@ pre_apply:
   namespace: default
   kind: Deployment
 {{ end }}
+#
+# skipper-ingress-redis podManagementPolicy update
+# - matches version before update
+# - version is updated with `-parallel` suffix
+# - deletion can be dropped after completion along with version suffix removal
+#
+- labels:
+    application: skipper-ingress-redis
+    version: v6.2.4
+  namespace: kube-system
+  kind: StatefulSet
 
 # everything defined under here will be deleted after applying the manifests
 post_apply:

--- a/cluster/manifests/skipper/skipper-redis.yaml
+++ b/cluster/manifests/skipper/skipper-redis.yaml
@@ -3,18 +3,25 @@ kind: StatefulSet
 metadata:
   labels:
     application: skipper-ingress-redis
-    version: v6.2.4
+    #
+    # skipper-ingress-redis podManagementPolicy update
+    # - version is updated with `-parallel` suffix to not match the version configured in deletions.yaml
+    # - `-parallel` suffix can be dropped after completion along with deletions.yaml cleanup
+    #
+    version: v6.2.4-parallel
   name: skipper-ingress-redis
   namespace: kube-system
 spec:
   replicas: {{ .ConfigItems.skipper_redis_replicas }}
+  podManagementPolicy: Parallel
   selector:
     matchLabels:
-      application: skipper-ingress-redis
+      statefulset: skipper-ingress-redis
   serviceName: skipper-ingress-redis
   template:
     metadata:
       labels:
+        statefulset: skipper-ingress-redis
         application: skipper-ingress-redis
         version: v6.2.4
       annotations:

--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -126,6 +126,8 @@ if [ "$create_cluster" = true ]; then
     fi
 
     # Update cluster
+    echo "Updating cluster ${CLUSTER_ID}: ${API_SERVER_URL}"
+
     clm provision \
         --token="${CLUSTER_ADMIN_TOKEN}" \
         --directory="$(pwd)/../.." \

--- a/test/e2e/wait-for-update.py
+++ b/test/e2e/wait-for-update.py
@@ -65,11 +65,13 @@ def main():
 
     deadline = datetime.now() + timedelta(seconds=args.timeout)
 
+    logging.info("Waiting for updates...")
     while datetime.now() < deadline:
         try:
             if all([update_complete("daemonset", daemonset_updated),
                     update_complete("deployment", deployment_updated),
                     update_complete("statefulset", statefulset_updated)]):
+                logging.info("All updates are complete, exiting.")
                 sys.exit(0)
         except subprocess.CalledProcessError:
             logging.info("kubectl failed, will retry...")


### PR DESCRIPTION
Similar to https://github.com/zalando-incubator/kubernetes-on-aws/pull/4816 but without application/component label changes.

`Parallel` pod management tells the StatefulSet controller to launch or
terminate all Pods in parallel, and to not wait for Pods to become
Running and Ready or completely terminated prior to launching or
terminating another Pod.

https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#parallel-pod-management

This should speedup Redis re-scaling.

To avoid
```
updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden
```
due to change of `podManagementPolicy` the statefulset is recreated via
pre-apply deletion that runs once.

Also changes selector `matchLabels` to allow template `application` label change in the future.

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>