### PR TITLE
Update AdmissionController

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -459,6 +459,8 @@ teapot_admission_controller_prevent_scale_down_allowed: "false"
 
 teapot_admission_controller_log4j_format_msg_no_lookups: "true"
 
+teapot_admission_controller_graceful_termination: "true"
+
 # Prevent the use of a particular AZ as much as possible
 blocked_availability_zone: ""
 

--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -110,3 +110,5 @@ data:
 
   pod.prevent-scale-down.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_prevent_scale_down_enabled }}"
   pod.prevent-scale-down.allowed: "{{ .Cluster.ConfigItems.teapot_admission_controller_prevent_scale_down_allowed }}"
+
+  pod.graceful-termination.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_graceful_termination }}"

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -200,7 +200,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-132
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-134
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
- Upgrade Kubernetes and its friends to 1.21
- Apply default values to `preStop` and `terminationGracePeriodSeconds`