### PR TITLE
Update platform-iam-tokeninfo in stable to master-14

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -344,7 +344,7 @@ write_files:
           - mountPath: /etc/kubernetes/config
             name: kubernetes-configs
             readOnly: true
-        - image: registry.opensource.zalan.do/foundation/platform-iam-tokeninfo:master-13
+        - image: registry.opensource.zalan.do/foundation/platform-iam-tokeninfo:master-14
           name: tokeninfo
           ports:
             - containerPort: 9021
@@ -375,7 +375,7 @@ write_files:
               value: {{ .Cluster.ConfigItems.apiserver_business_partner_ids }}
 {{ if ne .Cluster.Environment "production" }}
         - name: tokeninfo-sandbox
-          image: registry.opensource.zalan.do/foundation/platform-iam-tokeninfo:master-13
+          image: registry.opensource.zalan.do/foundation/platform-iam-tokeninfo:master-14
           ports:
           - containerPort: 9022
           lifecycle:


### PR DESCRIPTION
WARNING: Goes directly to stable for testing purposes. Don't merge.

This updates platform-iam-tokeninfo to the latest version.

Mirror of https://github.com/zalando-incubator/kubernetes-on-aws/pull/4842 to stable.