### PR TITLE
fix: rules should be updated more often

### DIFF
--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -57,6 +57,7 @@ data:
   prometheus.yml: |-
     global:
       scrape_interval: 15s
+      evaluation_interval: 15s
       external_labels:
         prometheus_replica: @@POD_NAME@@
         cluster: {{ .Cluster.Alias }}


### PR DESCRIPTION
fix: evaluation_interval is one minute but we scrape every 15s and we loose granularity

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>