### PR TITLE
Adds `statefulset: skipper-ingress-redis` label

### DIFF
--- a/cluster/manifests/skipper/skipper-redis.yaml
+++ b/cluster/manifests/skipper/skipper-redis.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       labels:
+        statefulset: skipper-ingress-redis
         application: skipper-ingress-redis
         version: v6.2.4
       annotations:


### PR DESCRIPTION
This is a preparation step for `skipper-ingress` application
consolidation, see similar #4611

This allows `matchLabels` to use unique `statefulset: skipper-ingress-redis`
label instead of the `application` label.

The change of `matchLabels` requires statefulset re-creation which would
be performed separately along with `podManagementPolicy` change, see
https://github.com/zalando-incubator/kubernetes-on-aws/pull/4819#issuecomment-997974635

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>