### PR TITLE
Adds skipper `deployment` labels

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -18,6 +18,7 @@ spec:
   template:
     metadata:
       labels:
+        deployment: skipper-ingress
         application: skipper-ingress
         version: v0.13.160
         component: ingress

--- a/cluster/manifests/skipper/routesrv-deployment.yaml
+++ b/cluster/manifests/skipper/routesrv-deployment.yaml
@@ -20,6 +20,7 @@ spec:
   template:
     metadata:
       labels:
+        deployment: skipper-ingress-routesrv
         application: skipper-ingress
         version: v0.13.153
         component: routesrv


### PR DESCRIPTION
This allows `matchLabels` to use unique `deployment: skipper-ingress`
and `deployment: skipper-ingress-routesrv` labels instead of the `application` and `component`.

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>