### PR TITLE
Handle CRDs with overlapping plural names

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -200,7 +200,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-134
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-137
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
When creating/updating/deleting CRDs our admission-controller will update corresponding RBAC roles to give users, edit/read access to the CRD based resources.

Before the roles were generated with a name based on the plural name defined in the CRD. Since this is not unique across CRDs in a cluster we could get overlapping roles meaning the role would only work for one of the CRD types. This update to the admission-controller fixes this by using the CRD names which are cluster unique for the role name generation.