### PR TITLE
Create OIDC Provider via CloudFormation

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -389,6 +389,19 @@ Resources:
 
 # end of vpc dependent resources
 {{ end }}
+{{ if eq .Cluster.ConfigItems.oidc_provider_cf "true" }}
+  OIDCProvider:
+    DeletionPolicy: Delete
+    Type: AWS::IAM::OIDCProvider
+    Properties:
+      ClientIdList:
+      - "sts.amazonaws.com"
+      Url: "https://{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+      ThumbprintList:
+      # SHA-1 sum of the root certificate in the trust chain for the certificate
+      # use to serve the open id discovery document.
+      - "9e99a48a9960b14926bb7f3b02e22da2b0ab7280"
+{{ end }}
   WorkerIAMRole:
     Properties:
       AssumeRolePolicyDocument:

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -695,3 +695,6 @@ deployment_service_cf_auto_expand_enabled: "false"
 
 # Will be dropped after the migration
 deployment_service_enabled: "true"
+
+# switch OIDC provider to be managed by Cloudformation
+oidc_provider_cf: "false"


### PR DESCRIPTION
CloudFormation now supports OIDC Providers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-oidcprovider.html

This would let us get rid of custom logic in CLM.

I tried to find a way to import the existing OIDC configuration according to the docs: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resource-import-existing-stack.html but it turns out that this is not supported:

```
An error occurred (ValidationError) when calling the CreateChangeSet operation: ResourceTypes [AWS::IAM:OIDCProvider] are not supported for Import
```

Instead I realized that the "import" can be done very simple by using `DeletionPolicy: Delete` on the resource. What will happen the first time the stack is applied with this new resource is that it will see a conflict because there is already an OIDC provider with the same name. It will then roll back the stack changes, deleting the OIDC provider (which was never actually created by CF) because of the `DeletionPolicy: Delete`. This will turn the stack status to ROLLBACK_COMPLETE and CLM will output an error. On the next run right after CLM will again apply the stack and this time, because the OIDC provider was previously removed, the update will succeed.

This will cause a small unavailability of the OIDC provider which would prevent the apps from refreshing credentials for a short amount of time. I think this is not an issue as credentials would be refreshed in the background by the apps (AWS SDK) and they would have previously fetched credentials available.

I put this behind a config item so it can be enabled per cluster so we can safely roll it out in small batches.