### PR TITLE
Adapt for upgraded Ingress version

### DIFF
--- a/cluster/manifests/roles/ingress-host-sync.yaml
+++ b/cluster/manifests/roles/ingress-host-sync.yaml
@@ -4,7 +4,6 @@ metadata:
   name: ingress-host-sync
 rules:
 - apiGroups:
-  - extensions # TODO: remove once only networking.k8s.io is in use
   - networking.k8s.io
   resources:
   - ingresses

--- a/cluster/manifests/roles/kube-resource-report-rbac.yaml
+++ b/cluster/manifests/roles/kube-resource-report-rbac.yaml
@@ -8,7 +8,7 @@ rules:
   verbs:
   - get
   - list
-- apiGroups: ["extensions", "networking.k8s.io"]
+- apiGroups: ["networking.k8s.io"]
   resources: ["ingresses"]
   verbs:
   - list

--- a/cluster/manifests/roles/readonly-role.yaml
+++ b/cluster/manifests/roles/readonly-role.yaml
@@ -169,7 +169,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - extensions
   - networking.k8s.io
   resources:
   - ingresses

--- a/test/e2e/kube_metrics_adapter_test.go
+++ b/test/e2e/kube_metrics_adapter_test.go
@@ -14,7 +14,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscaling "k8s.io/api/autoscaling/v2beta1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/networking/v1beta1"
+	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -84,7 +84,7 @@ var _ = describe("[HPA] Horizontal pod autoscaling (scale resource: Custom Metri
 		port := 80
 		targetPort := 8000
 		targetUrl := hostName + "/metrics"
-		ingress := createIngress(DeploymentName, hostName, f.Namespace.Name, labels, nil, port)
+		ingress := createIngress(DeploymentName, hostName, f.Namespace.Name, "/", netv1.PathTypePrefix, labels, nil, port)
 		tc := CustomMetricTestCase{
 			framework:       f,
 			kubeClient:      cs,
@@ -118,7 +118,7 @@ var _ = describe("[HPA] Horizontal pod autoscaling (scale resource: Custom Metri
 		port := 80
 		targetPort := 8000
 		targetUrl := hostName + "/metrics"
-		ingress := createIngress(DeploymentName, hostName, f.Namespace.Name, labels, nil, port)
+		ingress := createIngress(DeploymentName, hostName, f.Namespace.Name, "/", netv1.PathTypePrefix, labels, nil, port)
 		tc := CustomMetricTestCase{
 			framework:       f,
 			kubeClient:      cs,
@@ -179,7 +179,7 @@ type CustomMetricTestCase struct {
 	pod             *corev1.Pod
 	initialReplicas int
 	scaledReplicas  int
-	ingress         *v1beta1.Ingress
+	ingress         *netv1.Ingress
 	routegroup      *rgv1.RouteGroup
 	service         *corev1.Service
 	auxDeployments  []*appsv1.Deployment
@@ -210,7 +210,7 @@ func (tc *CustomMetricTestCase) Run() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Create an Ingress since RPS based scaling relies on it
-		ingressCreate, err := tc.kubeClient.NetworkingV1beta1().Ingresses(ns).Create(context.TODO(), tc.ingress, metav1.CreateOptions{})
+		ingressCreate, err := tc.kubeClient.NetworkingV1().Ingresses(ns).Create(context.TODO(), tc.ingress, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		_, err = tc.jig.WaitForIngressAddress(tc.kubeClient, ns, ingressCreate.Name, 10*time.Minute)


### PR DESCRIPTION
Given the enablement of Ingress v1 in all clusters, align update of `v1beta1` to `v1`.