### PR TITLE
Fix DENY policy so oversight is still possible

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -389,19 +389,6 @@ Resources:
 
 # end of vpc dependent resources
 {{ end }}
-{{ if eq .Cluster.ConfigItems.oidc_provider_cf "true" }}
-  OIDCProvider:
-    DeletionPolicy: Delete
-    Type: AWS::IAM::OIDCProvider
-    Properties:
-      ClientIdList:
-      - "sts.amazonaws.com"
-      Url: "https://{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
-      ThumbprintList:
-      # SHA-1 sum of the root certificate in the trust chain for the certificate
-      # use to serve the open id discovery document.
-      - "9e99a48a9960b14926bb7f3b02e22da2b0ab7280"
-{{ end }}
   WorkerIAMRole:
     Properties:
       AssumeRolePolicyDocument:
@@ -793,7 +780,16 @@ Resources:
             Principal:
               AWS: "{{.Cluster.ConfigItems.deployment_service_api_role_arn}}"
 {{- end }}
-          - Action: "s3:*"
+          - Action:
+              - s3:Put*
+              - s3:Create*
+              - s3:Update*
+              - s3:List*
+              - s3:GetObject*
+              - s3:Delete*
+              - s3:Restore*
+              - s3:Update*
+              - s3:Replicate*
             Effect: Deny
             Resource:
               - !Sub "arn:aws:s3:::${DeploymentServiceBucket}/*"


### PR DESCRIPTION
Currently DENY policy makes it impossible to fully govern this bucket.