### PR TITLE
Fix DENY policy so oversight is easier

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -793,7 +793,16 @@ Resources:
             Principal:
               AWS: "{{.Cluster.ConfigItems.deployment_service_api_role_arn}}"
 {{- end }}
-          - Action: "s3:*"
+          - Action:
+              - s3:Put*
+              - s3:Create*
+              - s3:Update*
+              - s3:List*
+              - s3:GetObject*
+              - s3:Delete*
+              - s3:Restore*
+              - s3:Update*
+              - s3:Replicate*
             Effect: Deny
             Resource:
               - !Sub "arn:aws:s3:::${DeploymentServiceBucket}/*"


### PR DESCRIPTION
Currently DENY policy makes it difficult to properly govern this bucket. In particular, oversight systems cannot see the configuration. This makes it difficult to spot issues and have confidence all is good.

NOTE: This does not grant access. One still needs access to be able to be able to log in to the bucket. However, this explicitly denies listing, getting, deleting, and putting objects.