### PR TITLE
Enable OIDC provider via CF by default

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -389,9 +389,7 @@ Resources:
 
 # end of vpc dependent resources
 {{ end }}
-{{ if eq .Cluster.ConfigItems.oidc_provider_cf "true" }}
   OIDCProvider:
-    DeletionPolicy: Delete
     Type: AWS::IAM::OIDCProvider
     Properties:
       ClientIdList:
@@ -401,7 +399,6 @@ Resources:
       # SHA-1 sum of the root certificate in the trust chain for the certificate
       # use to serve the open id discovery document.
       - "9e99a48a9960b14926bb7f3b02e22da2b0ab7280"
-{{ end }}
   WorkerIAMRole:
     Properties:
       AssumeRolePolicyDocument:

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -695,6 +695,3 @@ deployment_service_cf_auto_expand_enabled: "false"
 
 # Will be dropped after the migration
 deployment_service_enabled: "true"
-
-# switch OIDC provider to be managed by Cloudformation
-oidc_provider_cf: "false"


### PR DESCRIPTION
Follow up to #4861 to enable OIDC Provider management via cloudformation by default everywhere.

This will not work for e2e because we rely on CLM retrying the applying of the stack as it would fail the first time as explained in #4861 So we need to merge this through all channels to avoid breaking e2e for other PRs. 

Depends on #4861 being fully rolled out.