### PR TITLE
skipper-ingress: update `selector.matchLabels`

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -22,6 +22,20 @@ pre_apply:
   namespace: kube-system
   kind: StatefulSet
   propagation_policy: Orphan
+#
+# skipper-ingress selector.matchLabels update
+# - matches version before update
+# - version is updated with `-selector-update` suffix to run deletion only once
+# - uses `propagation_policy: Orphan` to keep exiting pods running
+# - deletion can be dropped after rollout along with version suffix removal
+#
+- labels:
+    application: skipper-ingress
+    component: ingress
+    version: v0.13.170
+  namespace: kube-system
+  kind: Deployment
+  propagation_policy: Orphan
 
 # everything defined under here will be deleted after applying the manifests
 post_apply:

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,7 +5,14 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.13.170
+    #
+    # skipper-ingress selector.matchLabels update
+    # - version is updated with `-selector-update` suffix to not match the version configured in deletions.yaml
+    #   so that deletion runs only once
+    # - `-selector-update` suffix can be dropped after rollout along with deletions.yaml cleanup
+    # - DO NOT UPDATE pod template until selector.matchLabels update rollout is complete because
+    #   ownership transfer using `propagation_policy: Orphan` only works if pod template was not changed
+    version: v0.13.170-selector-update
     component: ingress
 spec:
   strategy:
@@ -14,7 +21,7 @@ spec:
       maxUnavailable: 0
   selector:
     matchLabels:
-      application: skipper-ingress
+      deployment: skipper-ingress
   template:
     metadata:
       labels:


### PR DESCRIPTION
`skipper-ingress` HPA, although targets deployment by name, uses its
selector labels to get metrics
https://github.com/kubernetes/kubernetes/issues/78761#issuecomment-670815813
which also match `routesrv` pods.

Updates `selector.matchLabels` to use `kind: name` label that matches
only `ingress` component pods (similar to #4611 and #4847).

Deployment selector is immutable therefore update requires deployment re-creation.
To re-create deployment without deleting pods `propagation_policy: Orphan` is used.

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>