### PR TITLE
skipper-ingress: rollback `selector.matchLabels` update

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -23,16 +23,15 @@ pre_apply:
   kind: StatefulSet
   propagation_policy: Orphan
 #
-# skipper-ingress selector.matchLabels update
-# - matches version before update
-# - version is updated with `-selector-update` suffix to run deletion only once
+# skipper-ingress selector.matchLabels update rollback
+# - matches version after update
+# - version is reverted to `v0.13.170` run deletion only once
 # - uses `propagation_policy: Orphan` to keep exiting pods running
-# - deletion can be dropped after rollout along with version suffix removal
 #
 - labels:
     application: skipper-ingress
     component: ingress
-    version: v0.13.170
+    version: v0.13.170-selector-update
   namespace: kube-system
   kind: Deployment
   propagation_policy: Orphan

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,14 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    #
-    # skipper-ingress selector.matchLabels update
-    # - version is updated with `-selector-update` suffix to not match the version configured in deletions.yaml
-    #   so that deletion runs only once
-    # - `-selector-update` suffix can be dropped after rollout along with deletions.yaml cleanup
-    # - DO NOT UPDATE pod template until selector.matchLabels update rollout is complete because
-    #   ownership transfer using `propagation_policy: Orphan` only works if pod template was not changed
-    version: v0.13.170-selector-update
+    version: v0.13.170
     component: ingress
 spec:
   strategy:
@@ -21,7 +14,7 @@ spec:
       maxUnavailable: 0
   selector:
     matchLabels:
-      deployment: skipper-ingress
+      application: skipper-ingress
   template:
     metadata:
       labels:


### PR DESCRIPTION
Update of `selector.matchLabels` requires deployment re-creation but the
new deployment scales down existing replica set to 1.

Rollbacks #4885

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>