### PR TITLE
Consolidate DaemonSet applications/components [1/3]

### DIFF
--- a/cluster/manifests/coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/coredns-local/daemonset-coredns.yaml
@@ -5,10 +5,11 @@ metadata:
   namespace: kube-system
   labels:
     application: coredns
+    # application: kubernetes # step 2
+    component: coredns
     version: v1.8.4
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
-    component: cluster-dns
 spec:
   updateStrategy:
     type: OnDelete
@@ -16,13 +17,16 @@ spec:
     matchLabels:
       application: coredns
       instance: node-dns
+      # daemonset: coredns # step 2
   template:
     metadata:
       labels:
+        daemonset: coredns
         application: coredns
+        # application: kubernetes # step 3
+        component: coredns
         instance: node-dns
         version: v1.8.4
-        component: cluster-dns
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
         prometheus.io/path: /metrics

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -10,6 +10,38 @@ pre_apply:
   kind: Deployment
 {{ end }}
 
+# step 2
+# - labels:
+#     application: kube-proxy
+#   namespace: kube-system
+#   kind: DaemonSet
+#   propagation_policy: Orphan
+# - labels:
+#     application: coredns
+#   namespace: kube-system
+#   kind: DaemonSet
+#   propagation_policy: Orphan
+# - labels:
+#     application: kube-node-ready
+#   namespace: kube-system
+#   kind: DaemonSet
+#   propagation_policy: Orphan
+# - labels:
+#     application: kube2iam
+#   namespace: kube-system
+#   kind: DaemonSet
+#   propagation_policy: Orphan
+# - labels:
+#     application: flannel
+#   namespace: kube-system
+#   kind: DaemonSet
+#   propagation_policy: Orphan
+# - labels:
+#     application: node-monitor
+#   namespace: kube-system
+#   kind: DaemonSet
+#   propagation_policy: Orphan
+
 # everything defined under here will be deleted after applying the manifests
 post_apply:
 {{ if eq .ConfigItems.teapot_admission_controller_process_resources "true" }}

--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: kube-system
   labels:
     application: flannel
+    # application: kubernetes # step 2
+    component: flannel
     version: v0.15.1-14
 spec:
   updateStrategy:
@@ -12,10 +14,14 @@ spec:
   selector:
     matchLabels:
       application: flannel
+      # daemonset: kube-flannel # step 2
   template:
     metadata:
       labels:
+        daemonset: kube-flannel
         application: flannel
+        # application: kubernetes # step 3
+        component: flannel
         version: v0.15.1-14
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"

--- a/cluster/manifests/kube-node-ready/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready/daemonset.yaml
@@ -7,6 +7,8 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-node-ready
+    # application: kubernetes # step 2
+    component: kube-node-ready
     version: {{$version}}
 spec:
   updateStrategy:
@@ -14,10 +16,14 @@ spec:
   selector:
     matchLabels:
       application: kube-node-ready
+      # daemonset: kube-node-ready # step 2
   template:
     metadata:
       labels:
+        daemonset: kube-node-ready
         application: kube-node-ready
+        # application: kubernetes # step 3
+        component: kube-node-ready
         version: {{$version}}
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -5,9 +5,12 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-proxy
+    # application: kubernetes # step 2
+    component: kube-proxy
 spec:
   selector:
     matchLabels:
+      # daemonset: kube-proxy # step 2
       application: kube-proxy
   updateStrategy:
     type: RollingUpdate
@@ -15,7 +18,10 @@ spec:
     metadata:
       name: kube-proxy
       labels:
+        daemonset: kube-proxy
         application: kube-proxy
+        # application: kubernetes # step 3
+        component: kube-proxy
       annotations:
         config/hash: {{"configmap.yaml" | manifestHash}}
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"

--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -5,17 +5,23 @@ metadata:
   namespace: kube-system
   labels:
     application: kube2iam
+    # application: kubernetes # step 2
+    component: kube2iam
     version: 0.10.11
 spec:
   selector:
     matchLabels:
       application: kube2iam
+      # daemonset: kube2iam # step 2
   updateStrategy:
     type: RollingUpdate
   template:
     metadata:
       labels:
+        daemonset: kube2iam
         application: kube2iam
+        # application: kubernetes # step 3
+        component: kube2iam
         version: 0.10.11
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"

--- a/cluster/manifests/node-monitor/daemonset.yaml
+++ b/cluster/manifests/node-monitor/daemonset.yaml
@@ -5,16 +5,22 @@ metadata:
   namespace: kube-system
   labels:
     application: node-monitor
+    # application: kubernetes # step 2
+    component: node-monitor
 spec:
   updateStrategy:
     type: RollingUpdate
   selector:
     matchLabels:
       application: node-monitor
+      # daemonset: node-monitor # step 2
   template:
     metadata:
       labels:
+        daemonset: node-monitor
         application: node-monitor
+        # application: kubernetes # step 3
+        component: node-monitor
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:


### PR DESCRIPTION
This is the first of a 3-step change to migrate 6 daemonsets to be components of `kubernetes` instead of individual applications.

1. Label the pod spec with `daemonset: <name>`, roll out to all clusters and wait for pods/nodes to be completely rotated.
2. Change the selector to use the label `daemonset: <name>` and use the deletions.yaml with `propagation_policy: Orphan` to delete the old daemonset (without deleting the pods) and create a new daemonset with the new selector.
3. Change the pod template labels for `application` and `component` and wait for all nodes/pods to be rotated.