### PR TITLE
Allow using session manager for connecting to instances

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -450,6 +450,15 @@ Resources:
                   - 'ecr:GetAuthorizationToken'
                 Effect: Allow
                 Resource: '*'
+              # allow connecting via Session Manager
+              - Action:
+                - "ssm:UpdateInstanceInformation"
+                - "ssmmessages:CreateControlChannel"
+                - "ssmmessages:CreateDataChannel"
+                - "ssmmessages:OpenControlChannel"
+                - "ssmmessages:OpenDataChannel"
+                Effect: Allow
+                Resource: "*"
 {{ if eq .Cluster.Environment "e2e" }}
 # Add extra permissions to worker IAM role to test that if a pod manages to get
 # the WorkerIAMRole assigned it can list a specific s3 bucket.
@@ -1219,6 +1228,15 @@ Resources:
                   - 'ecr:GetAuthorizationToken'
                 Effect: Allow
                 Resource: '*'
+              # allow connecting via Session Manager
+              - Action:
+                - "ssm:UpdateInstanceInformation"
+                - "ssmmessages:CreateControlChannel"
+                - "ssmmessages:CreateDataChannel"
+                - "ssmmessages:OpenControlChannel"
+                - "ssmmessages:OpenDataChannel"
+                Effect: Allow
+                Resource: "*"
             Version: 2012-10-17
           PolicyName: root
     Type: 'AWS::IAM::Role'


### PR DESCRIPTION
This enables the use of AWS session manager as an alternative to connect to kubernetes nodes compared to ssh.

Ref: https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager.html

Essentially you would be able to do the following:

```
aws ssm start-session --target <instance-id-of-node>
```

And you will get a shell on the node. Eventually this could enable us to close port 22 on the nodes. For now it's just to test how well it works.