### PR TITLE
Consolidate prometheus into kubernetes application [1/3]

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -41,6 +41,12 @@ pre_apply:
 #   namespace: kube-system
 #   kind: DaemonSet
 #   propagation_policy: Orphan
+# step 2 (prometheus consolidation)
+# - labels:
+#     application: prometheus
+#   namespace: kube-system
+#   kind: StatefulSet
+#   propagation_policy: Orphan
 
 # everything defined under here will be deleted after applying the manifests
 post_apply:

--- a/cluster/manifests/prometheus/statefulset.yaml
+++ b/cluster/manifests/prometheus/statefulset.yaml
@@ -5,6 +5,8 @@ metadata:
     pdb-controller.zalando.org/non-ready-ttl: "5m"
   labels:
     application: prometheus
+    # application: kubernetes # step 2
+    component: prometheus
     version: v2.32.1
 {{- if ne .ConfigItems.prometheus_csi_ebs "true" }}
   name: prometheus
@@ -18,11 +20,15 @@ spec:
   selector:
     matchLabels:
       application: prometheus
+      # statefulset: prometheus # step 2
   serviceName: prometheus
   template:
     metadata:
       labels:
+        statefulset: prometheus
         application: prometheus
+        # application: kubernetes # step 3
+        component: prometheus
         version: v2.32.1
       annotations:
         config/hash: {{"configmap.yaml" | manifestHash}}


### PR DESCRIPTION
This is the first of a 3-step change to migrate prometheus statefulset to be a component of `kubernetes` instead of individual an application.

1. Label the pod spec with `statefulset: prometheus`, roll out to all clusters.
2. Change the selector to use the label `statefulset: prometheus` and use the deletions.yaml with `propagation_policy: Orphan` to delete the old statefulset (without deleting the pods) and create a new statefulset with the new selector.
3. Change the pod template labels for `application`.