### PR TITLE
Consolidate vpa into kubernetes application

### DIFF
--- a/cluster/manifests/01-vertical-pod-autoscaler/02-secret.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/02-secret.yaml
@@ -4,8 +4,8 @@ metadata:
   name: vpa-tls-certs
   namespace: kube-system
   labels:
-    application: vertical-pod-autoscaler
-    component: admission-controller
+    application: kubernetes
+    component: vpa-admission-controller
 type: Opaque
 data:
   caKey.pem: ""

--- a/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
@@ -4,20 +4,20 @@ metadata:
   name: vpa-admission-controller
   namespace: kube-system
   labels:
-    application: vertical-pod-autoscaler
-    component: admission-controller
+    application: kubernetes
+    component: vpa-admission-controller
     version: v0.6.1-internal.12
 spec:
   replicas: 1
   selector:
     matchLabels:
-      application: vertical-pod-autoscaler
-      component: admission-controller
+      deployment: vpa-admission-controller
   template:
     metadata:
       labels:
-        application: vertical-pod-autoscaler
-        component: admission-controller
+        deployment: vpa-admission-controller
+        application: kubernetes
+        component: vpa-admission-controller
         version: v0.6.1-internal.12
       annotations:
         config/hash: {{"02-secret.yaml" | manifestHash}}

--- a/cluster/manifests/01-vertical-pod-autoscaler/rbac.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/rbac.yaml
@@ -4,7 +4,8 @@ kind: ClusterRole
 metadata:
   name: system:metrics-reader
   labels:
-    application: vertical-pod-autoscaler
+    application: kubernetes
+    component: vpa
 rules:
   - apiGroups:
       - "metrics.k8s.io"
@@ -19,7 +20,8 @@ kind: ClusterRole
 metadata:
   name: system:vpa-actor
   labels:
-    application: vertical-pod-autoscaler
+    application: kubernetes
+    component: vpa
 rules:
   - apiGroups:
       - ""
@@ -66,7 +68,8 @@ kind: ClusterRole
 metadata:
   name: system:vpa-checkpoint-actor
   labels:
-    application: vertical-pod-autoscaler
+    application: kubernetes
+    component: vpa
 rules:
   - apiGroups:
       - "poc.autoscaling.k8s.io"
@@ -103,7 +106,8 @@ kind: ClusterRole
 metadata:
   name: system:evictioner
   labels:
-    application: vertical-pod-autoscaler
+    application: kubernetes
+    component: vpa
 rules:
   - apiGroups:
       - "extensions"
@@ -129,7 +133,8 @@ kind: ClusterRoleBinding
 metadata:
   name: system:metrics-reader
   labels:
-    application: vertical-pod-autoscaler
+    application: kubernetes
+    component: vpa
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -144,7 +149,8 @@ kind: ClusterRoleBinding
 metadata:
   name: system:vpa-actor
   labels:
-    application: vertical-pod-autoscaler
+    application: kubernetes
+    component: vpa
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -162,7 +168,8 @@ kind: ClusterRoleBinding
 metadata:
   name: system:vpa-checkpoint-actor
   labels:
-    application: vertical-pod-autoscaler
+    application: kubernetes
+    component: vpa
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -177,7 +184,8 @@ kind: ClusterRole
 metadata:
   name: system:vpa-target-reader
   labels:
-    application: vertical-pod-autoscaler
+    application: kubernetes
+    component: vpa
 rules:
   - apiGroups:
       - ""
@@ -213,7 +221,8 @@ kind: ClusterRoleBinding
 metadata:
   name: system:vpa-target-reader-binding
   labels:
-    application: vertical-pod-autoscaler
+    application: kubernetes
+    component: vpa
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -234,7 +243,8 @@ kind: ClusterRoleBinding
 metadata:
   name: system:vpa-evictionter-binding
   labels:
-    application: vertical-pod-autoscaler
+    application: kubernetes
+    component: vpa
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -250,8 +260,8 @@ metadata:
   name: vpa-recommender
   namespace: kube-system
   labels:
-    application: vertical-pod-autoscaler
-    component: recommender
+    application: kubernetes
+    component: vpa-recommender
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -259,8 +269,8 @@ metadata:
   name: vpa-updater
   namespace: kube-system
   labels:
-    application: vertical-pod-autoscaler
-    component: updater
+    application: kubernetes
+    component: vpa-updater
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -268,16 +278,16 @@ metadata:
   name: vpa-admission-controller
   namespace: kube-system
   labels:
-    application: vertical-pod-autoscaler
-    component: admission-controller
+    application: kubernetes
+    component: vpa-admission-controller
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: system:admission-controller
   labels:
-    application: vertical-pod-autoscaler
-    component: admission-controller
+    application: kubernetes
+    component: vpa-admission-controller
 rules:
   - apiGroups:
       - ""
@@ -321,8 +331,8 @@ kind: ClusterRoleBinding
 metadata:
   name: system:admission-controller
   labels:
-    application: vertical-pod-autoscaler
-    component: admission-controller
+    application: kubernetes
+    component: vpa-admission-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
@@ -4,20 +4,20 @@ metadata:
   name: vpa-recommender
   namespace: kube-system
   labels:
-    application: vertical-pod-autoscaler
+    application: kubernetes
     component: recommender
     version: v0.6.1-internal.12
 spec:
   replicas: 1
   selector:
     matchLabels:
-      application: vertical-pod-autoscaler
-      component: recommender
+      deployment: vpa-recommender
   template:
     metadata:
       labels:
-        application: vertical-pod-autoscaler
-        component: recommender
+        deployment: vpa-recommender
+        application: kubernetes
+        component: vpa-recommender
         version: v0.6.1-internal.12
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"

--- a/cluster/manifests/01-vertical-pod-autoscaler/service.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/service.yaml
@@ -4,13 +4,12 @@ metadata:
   name: vpa-webhook
   namespace: kube-system
   labels:
-    application: vertical-pod-autoscaler
-    component: admission-controller
-    version: master
+    application: kubernetes
+    component: vpa-admission-controller
 spec:
   selector:
-    application: vertical-pod-autoscaler
-    component: admission-controller
+    application: kubernetes
+    component: vpa-admission-controller
   ports:
     - port: 443
       targetPort: 8000

--- a/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
@@ -4,20 +4,20 @@ metadata:
   name: vpa-updater
   namespace: kube-system
   labels:
-    application: vertical-pod-autoscaler
-    component: updater
+    application: kubernetes
+    component: vpa-updater
     version: v0.6.1-internal.12
 spec:
   replicas: 1
   selector:
     matchLabels:
-      application: vertical-pod-autoscaler
-      component: updater
+      deployment: vpa-updater
   template:
     metadata:
       labels:
-        application: vertical-pod-autoscaler
-        component: updater
+        deployment: vpa-updater
+        application: kubernetes
+        component: vpa-updater
         version: v0.6.1-internal.12
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -10,6 +10,22 @@ pre_apply:
   kind: Deployment
 {{ end }}
 
+# Delete old version of vpa components for recreating with new selector
+- labels:
+    application: vertical-pod-autoscaler
+    component: recommender
+  namespace: kube-system
+  kind: Deployment
+- labels:
+    application: vertical-pod-autoscaler
+    component: updater
+  namespace: kube-system
+  kind: Deployment
+- labels:
+    application: vertical-pod-autoscaler
+    component: admission-controller
+  namespace: kube-system
+  kind: Deployment
 # step 2
 # - labels:
 #     application: kube-proxy


### PR DESCRIPTION
This is a change to migrate vpa components to be components of `kubernetes` instead of a separate vpa application.

It changes the application and component labels for the different resources and uses the deletion trick with a selector for the old labels to delete the deployments once and have them re-created with the new labels after.

## TODO:

* [x] Check ZMON alerts.