### PR TITLE
Add more gpu instance types to increase chances for spot

### DIFF
--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -97,7 +97,7 @@ clusters:
       labels: dedicated=node-tests
       taints: dedicated=node-tests:NoSchedule
   - discount_strategy: spot
-    instance_types: ["p2.xlarge", "p3.2xlarge", "g3s.xlarge", "g4dn.xlarge"]
+    instance_types: ["p2.xlarge", "p3.2xlarge", "g3s.xlarge", "g3.4xlarge", "g4dn.xlarge", "g4dn.2xlarge", "g4ad.xlarge", "g4ad.2xlarge"]
     name: worker-gpu
     profile: worker-splitaz
     min_size: 0

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -97,7 +97,7 @@ clusters:
       labels: dedicated=node-tests
       taints: dedicated=node-tests:NoSchedule
   - discount_strategy: spot
-    instance_types: ["p2.xlarge", "p3.2xlarge", "g3s.xlarge", "g3.4xlarge", "g4dn.xlarge", "g4dn.2xlarge", "g4ad.xlarge", "g4ad.2xlarge"]
+    instance_types: ["p2.xlarge", "p3.2xlarge", "g3s.xlarge", "g3.4xlarge", "g4dn.xlarge", "g4dn.2xlarge"]
     name: worker-gpu
     profile: worker-splitaz
     min_size: 0

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -97,7 +97,7 @@ clusters:
       labels: dedicated=node-tests
       taints: dedicated=node-tests:NoSchedule
   - discount_strategy: spot
-    instance_types: ["p2.xlarge", "p3.2xlarge", "g3s.xlarge", "g3.4xlarge", "g4dn.xlarge", "g4dn.2xlarge"]
+    instance_types: ["p2.xlarge", "p3.2xlarge", "g3s.xlarge", "g3.4xlarge", "g4dn.xlarge", "g4dn.2xlarge", "g4dn.4xlarge"]
     name: worker-gpu
     profile: worker-splitaz
     min_size: 0
@@ -107,6 +107,17 @@ clusters:
       labels: zalando.org/nvidia-gpu=tesla
       taints: nvidia.com/gpu=present:NoSchedule
       scaling_priority: "-100"
+  - discount_strategy: none
+    instance_types: ["g4dn.xlarge"]
+    name: worker-gpu-on-demand
+    profile: worker-splitaz
+    min_size: 0
+    max_size: 6
+    config_items:
+      availability_zones: "eu-central-1a,eu-central-1b"
+      labels: zalando.org/nvidia-gpu=tesla
+      taints: nvidia.com/gpu=present:NoSchedule
+      scaling_priority: "-200"
   provider: zalando-aws
   region: ${REGION}
   owner: '${OWNER}'


### PR DESCRIPTION
e2e tests are currently failing very often due to spot shortage on GPU nodes.

We [recently reduced](https://github.com/zalando-incubator/kubernetes-on-aws/pull/4790/files#diff-9a99d741a98cf62976440d87f64f503aab0266cd1e406365c9cd05c7ccdf012e) the possible GPU instance types in e2e clusters which might be a contributing factor.

Let's add a couple more instance types with GPUs to increase our chances.