### PR TITLE
Update Ubuntu Image

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -489,7 +489,7 @@ tracing_coredns_local_zone_traces_endpoint: ""
 # AMI id given the image name and the Image AWS account owner.
 #
 # [0]: https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/8a9bd1cb2d094038a9e23e646421f8146b48886a/provisioner/template.go#L116
-kuberuntu_image_v1_21: {{ amiID "zalando-ubuntu-kubernetes-production-v1.21.5-master-194" "861068367966"}}
+kuberuntu_image_v1_21: {{ amiID "zalando-ubuntu-kubernetes-production-v1.21.9-master-207" "861068367966"}}
 
 # Feature toggle for auditing events
 audit_pod_events: "true"

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -118,6 +118,15 @@ clusters:
       labels: zalando.org/nvidia-gpu=tesla
       taints: nvidia.com/gpu=present:NoSchedule
       scaling_priority: "-200"
+  - discount_strategy: spot
+    instance_types: ["m5a.large", "m5.large", "m5.xlarge", "m5a.xlarge", "t3.large", "t3.xlarge", "c5a.large", "c5a.xlarge"]
+    min_size: 0
+    max_size: 3
+    profile: worker-splitaz
+    name: node-reboot-tests
+    config_items:
+      labels: dedicated=node-reboot-tests
+      taints: dedicated=node-reboot-tests:NoSchedule
   provider: zalando-aws
   region: ${REGION}
   owner: '${OWNER}'

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -118,8 +118,8 @@ clusters:
       labels: zalando.org/nvidia-gpu=tesla
       taints: nvidia.com/gpu=present:NoSchedule
       scaling_priority: "-200"
-  - discount_strategy: spot
-    instance_types: ["m5a.large", "m5.large", "m5.xlarge", "m5a.xlarge", "t3.large", "t3.xlarge", "c5a.large", "c5a.xlarge"]
+  - discount_strategy: none
+    instance_types: ["m5.xlarge"]
     min_size: 0
     max_size: 3
     profile: worker-splitaz

--- a/test/e2e/node_test.go
+++ b/test/e2e/node_test.go
@@ -25,8 +25,8 @@ var _ = describe("Node tests", func() {
 		cs = f.ClientSet
 	})
 
-	createTestPod := func(namespace string) *corev1.Pod {
-		pausePod := nodeTestPod(namespace, "pause")
+	createTestPod := func(namespace string, nodePool string) *corev1.Pod {
+		pausePod := nodeTestPod(namespace, nodePool, "pause")
 		pausePod.Spec.Containers = []corev1.Container{pauseContainer()}
 		pausePod.Spec.RestartPolicy = corev1.RestartPolicyNever
 
@@ -44,7 +44,7 @@ var _ = describe("Node tests", func() {
 	It("Should react to spot termination notices [Slow] [Zalando] [Spot]", func() {
 		ns := f.Namespace.Name
 
-		pausePod := createTestPod(ns)
+		pausePod := createTestPod(ns, "node-tests")
 
 		nodeName := pausePod.Spec.NodeName
 		By("Ensuring that the node is schedulable initially")
@@ -114,7 +114,7 @@ var _ = describe("Node tests", func() {
 	It("Should handle kubelet restarts successfully [Slow] [Zalando]", func() {
 		ns := f.Namespace.Name
 
-		pausePod := createTestPod(ns)
+		pausePod := createTestPod(ns, "node-tests")
 
 		By(fmt.Sprintf("Restarting kubelet on node %s", pausePod.Spec.NodeName))
 		boolTrue := true
@@ -177,11 +177,10 @@ var _ = describe("Node tests", func() {
 		framework.ExpectNoError(err, "Could not create a test pod")
 		framework.ExpectNoError(e2epod.WaitForPodSuccessInNamespace(f.ClientSet, testPod.Name, testPod.Namespace))
 	})
-
 	It("Should handle node restart [Slow] [Zalando]", func() {
 		ns := f.Namespace.Name
 
-		pod := createTestPod(ns)
+		pod := createTestPod(ns, "node-reboot-tests")
 		nodeName := pod.Spec.NodeName
 		gracefulSeconds := int64(0)
 

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -529,11 +529,9 @@ func pauseContainer() v1.Container {
 	}
 }
 
-// nodeTestPod returns a v1.Pod with the selector, tolerations and anti-affinity predicates that would result in the pod
-// running on the node-tests node pool in a dedicated mode, with just one pod per node
-func nodeTestPod(namespace string, name string) *v1.Pod {
-	poolName := "node-tests"
-
+// nodeTestPod returns a v1.Pod with the selector, tolerations and anti-affinity predicates that
+// would result in the pod on a specific pool in a dedicated mode, with just one pod per node
+func nodeTestPod(namespace string, poolName string, name string) *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,


### PR DESCRIPTION
- Terminate restarted nodes
  A restarted node must not be trusted, it should be deleted.