### PR TITLE
Config items to migrate Etcd security group.

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -8,7 +8,12 @@ Resources:
   EtcdSecurityGroupIngressFromMaster:
     Properties:
       FromPort: 2379
+{{- if eq .Cluster.ConfigItems.etcd_stack_security_group_temp "false"}}
       GroupId: !ImportValue 'etcd-cluster-etcd:security-group-id'
+{{- end }}
+{{- if eq .Cluster.ConfigItems.etcd_stack_security_group_temp "true"}}
+      GroupId: !ImportValue 'etcd-cluster-etcd:security-group-id-temp'
+{{- end }}
       IpProtocol: tcp
       SourceSecurityGroupId: !Ref MasterSecurityGroup
       ToPort: 2379

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -8,10 +8,10 @@ Resources:
   EtcdSecurityGroupIngressFromMaster:
     Properties:
       FromPort: 2379
-{{- if eq .Cluster.ConfigItems.etcd_stack_security_group_temp "false"}}
+{{- if eq .Cluster.ConfigItems.cluster_reference_etc_sg_temp "false"}}
       GroupId: !ImportValue 'etcd-cluster-etcd:security-group-id'
 {{- end }}
-{{- if eq .Cluster.ConfigItems.etcd_stack_security_group_temp "true"}}
+{{- if eq .Cluster.ConfigItems.cluster_reference_etc_sg_temp "true"}}
       GroupId: !ImportValue 'etcd-cluster-etcd:security-group-id-temp'
 {{- end }}
       IpProtocol: tcp

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -8,10 +8,10 @@ Resources:
   EtcdSecurityGroupIngressFromMaster:
     Properties:
       FromPort: 2379
-{{- if eq .Cluster.ConfigItems.cluster_reference_etc_sg_temp "false"}}
+{{- if eq .Cluster.ConfigItems.cluster_reference_etcd_sg_temp "false"}}
       GroupId: !ImportValue 'etcd-cluster-etcd:security-group-id'
 {{- end }}
-{{- if eq .Cluster.ConfigItems.cluster_reference_etc_sg_temp "true"}}
+{{- if eq .Cluster.ConfigItems.cluster_reference_etcd_sg_temp "true"}}
       GroupId: !ImportValue 'etcd-cluster-etcd:security-group-id-temp'
 {{- end }}
       IpProtocol: tcp

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -465,6 +465,7 @@ etcd_ami: {{ amiID "Taupage-AMI-20210504-093855" "861068367966"}}
 # recreating the security group, which is impossible because of cross-stack references.
 # TODO investigate if it can be migrated.
 etcd_stack_specify_vpc_in_security_group: "true"
+etcd_stack_security_group_temp: "false"
 
 dynamodb_service_link_enabled: "false"
 

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -466,6 +466,7 @@ etcd_ami: {{ amiID "Taupage-AMI-20210504-093855" "861068367966"}}
 # TODO investigate if it can be migrated.
 etcd_stack_specify_vpc_in_security_group: "true"
 etcd_stack_security_group_temp: "false"
+cluster_reference_etc_sg_temp: "false"
 
 dynamodb_service_link_enabled: "false"
 

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -466,7 +466,7 @@ etcd_ami: {{ amiID "Taupage-AMI-20210504-093855" "861068367966"}}
 # TODO investigate if it can be migrated.
 etcd_stack_specify_vpc_in_security_group: "true"
 etcd_stack_security_group_temp: "false"
-cluster_reference_etc_sg_temp: "false"
+cluster_reference_etcd_sg_temp: "false"
 
 dynamodb_service_link_enabled: "false"
 

--- a/cluster/etcd-stack.yaml
+++ b/cluster/etcd-stack.yaml
@@ -10,6 +10,13 @@ Outputs:
     Value: !GetAtt EtcdSecurityGroup.GroupId
     Export:
       Name: "etcd-cluster-etcd:security-group-id"
+{{- if eq .Cluster.ConfigItems.etcd_stack_security_group_temp "true"}}
+  EtcdSecurityGroupIdTemp:
+    Description: "Security Group ID of the etcd cluster"
+    Value: !GetAtt EtcdSecurityGroupTemp.GroupId
+    Export:
+      Name: "etcd-cluster-etcd:security-group-id-temp"
+{{- end }}
   LaunchTemplateId:
     Description: "Launch template ID of the etcd nodes"
     Value: !Ref LaunchTemplate
@@ -144,9 +151,29 @@ Resources:
 {{- if eq .Cluster.ConfigItems.etcd_stack_specify_vpc_in_security_group "true"}}
       VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
 {{- end }}
+{{- if eq .Cluster.ConfigItems.etcd_stack_security_group_temp "true"}}
+  EtcdSecurityGroupTemp:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Etcd Appliance Security Group
+      SecurityGroupIngress:
+      - IpProtocol: tcp
+        FromPort: 22
+        ToPort: 22
+        CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+      - IpProtocol: tcp
+        FromPort: 2381
+        ToPort: 2381
+        CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+      - IpProtocol: tcp
+        FromPort: 9100
+        ToPort: 9100
+        CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+      VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
       Tags:
         - Key: InfrastructureComponent
           Value: true
+{{- end }}
   EtcdIngressMembers:
     Type: "AWS::EC2::SecurityGroupIngress"
     Properties:

--- a/cluster/etcd-stack.yaml
+++ b/cluster/etcd-stack.yaml
@@ -151,6 +151,9 @@ Resources:
 {{- if eq .Cluster.ConfigItems.etcd_stack_specify_vpc_in_security_group "true"}}
       VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
 {{- end }}
+      Tags:
+        - Key: InfrastructureComponent
+          Value: true
 {{- if eq .Cluster.ConfigItems.etcd_stack_security_group_temp "true"}}
   EtcdSecurityGroupTemp:
     Type: AWS::EC2::SecurityGroup


### PR DESCRIPTION
Adds two config items:
* `etcd_stack_security_group_temp`: when set to `true`, creates a temporary Etcd security group.
*  `cluster_reference_etcd_sg_temp`: controls which etcd security group to reference in the main cluster CloudFormation template.

This will allow for clusters _without_ the `VpcId` set in the ETCD security grroup to use the pure CloudFormation etcd-`stack.yaml`, when we set `experimental_new_etcd_stack` to `true`. 

Signed-off-by: rreis <rodrigo.gargravarr@gmail.com>