### PR TITLE
Fix go templating in CoreDNS config

### DIFF
--- a/cluster/manifests/coredns-local/configmap-local.yaml
+++ b/cluster/manifests/coredns-local/configmap-local.yaml
@@ -83,9 +83,11 @@ data:
     cluster.local:9254 10.2.0.0/16:9254 10.3.0.0/16:9254 {{ if eq .ConfigItems.tracing_coredns_route_traces_to_local_zone "true"}}{{ range $src := split .ConfigItems.tracing_coredns_global_traces_endpoint  "," }}{{ $src }}:9254{{ end }} {{ end }} {
         errors
         {{ if eq .ConfigItems.tracing_coredns_route_traces_to_local_zone "true"}}
+          {{- with $cluster := .Cluster }}
           {{ range $src := split .ConfigItems.tracing_coredns_global_traces_endpoint  "," }}
-        rewrite name exact {{ $src }} {{ .ConfigItems.tracing_coredns_local_zone_traces_endpoint }}
+        rewrite name exact {{ $src }} {{ $cluster.ConfigItems.tracing_coredns_local_zone_traces_endpoint }}
           {{ end }}
+          {{- end }}
         {{ end }}
         kubernetes {
             pods insecure


### PR DESCRIPTION
Follow up to #4921 fixing a small issue with the template scoping.