### PR TITLE
added space between expanded line of source domain to be rewritten

### DIFF
--- a/cluster/manifests/coredns-local/configmap-local.yaml
+++ b/cluster/manifests/coredns-local/configmap-local.yaml
@@ -80,7 +80,7 @@ data:
 
     # 10.2.0.0/16, 10.3.0.0/16 defines that this server is authority for revese
     # lookups for these ranges.
-    cluster.local:9254 10.2.0.0/16:9254 10.3.0.0/16:9254 {{ if eq .ConfigItems.tracing_coredns_route_traces_to_local_zone "true"}}{{ range $src := split .ConfigItems.tracing_coredns_global_traces_endpoint  "," }}{{ $src }}:9254{{ end }} {{ end }} {
+    cluster.local:9254 10.2.0.0/16:9254 10.3.0.0/16:9254 {{ if eq .ConfigItems.tracing_coredns_route_traces_to_local_zone "true"}}{{ range $src := split .ConfigItems.tracing_coredns_global_traces_endpoint  "," }}{{ $src }}:9254 {{ end }} {{ end }} {
         errors
         {{ if eq .ConfigItems.tracing_coredns_route_traces_to_local_zone "true"}}
           {{- with $cluster := .Cluster }}


### PR DESCRIPTION
Follow-up for https://github.com/zalando-incubator/kubernetes-on-aws/pull/4921
