### PR TITLE
Fix etcd templating.

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -21,7 +21,12 @@ Resources:
   EtcdSecurityGroupTLSIngressFromMaster:
     Properties:
       FromPort: 2479
+{{- if eq .Cluster.ConfigItems.cluster_reference_etcd_sg_temp "false"}}
       GroupId: !ImportValue 'etcd-cluster-etcd:security-group-id'
+{{- end }}
+{{- if eq .Cluster.ConfigItems.cluster_reference_etcd_sg_temp "true"}}
+      GroupId: !ImportValue 'etcd-cluster-etcd:security-group-id-temp'
+{{- end }}
       IpProtocol: tcp
       SourceSecurityGroupId: !Ref MasterSecurityGroup
       ToPort: 2479


### PR DESCRIPTION
Template and config items defined in https://github.com/zalando-incubator/kubernetes-on-aws/pull/4917 missed a reference in `cluster.yaml`. This PR adds the missing templating. 

Signed-off-by: rreis <rodrigo.gargravarr@gmail.com>