### PR TITLE
Include EtcdIngress in the template.

### DIFF
--- a/cluster/etcd-stack.yaml
+++ b/cluster/etcd-stack.yaml
@@ -180,7 +180,12 @@ Resources:
   EtcdIngressMembers:
     Type: "AWS::EC2::SecurityGroupIngress"
     Properties:
+{{- if eq .Cluster.ConfigItems.etcd_stack_security_group_temp "false"}}
       GroupId: !GetAtt EtcdSecurityGroup.GroupId
+{{- end }}
+{{- if eq .Cluster.ConfigItems.etcd_stack_security_group_temp "true"}}
+      GroupId: !GetAtt EtcdSecurityGroupTemp.GroupId
+{{- end }}
       IpProtocol: tcp
       FromPort: 2379
       ToPort: 2479


### PR DESCRIPTION
The SecurityGroupIngress also depends on the etcd security group. This PR allows controlling which security group is part of the ingress.

Signed-off-by: rreis <rodrigo.gargravarr@gmail.com>