### PR TITLE
Consolidate prometheus into kubernetes application [2/3]

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -58,11 +58,11 @@ pre_apply:
 #   kind: DaemonSet
 #   propagation_policy: Orphan
 # step 2 (prometheus consolidation)
-# - labels:
-#     application: prometheus
-#   namespace: kube-system
-#   kind: StatefulSet
-#   propagation_policy: Orphan
+- labels:
+    application: prometheus
+  namespace: kube-system
+  kind: StatefulSet
+  propagation_policy: Orphan
 
 # everything defined under here will be deleted after applying the manifests
 post_apply:

--- a/cluster/manifests/prometheus/statefulset.yaml
+++ b/cluster/manifests/prometheus/statefulset.yaml
@@ -4,8 +4,7 @@ metadata:
   annotations:
     pdb-controller.zalando.org/non-ready-ttl: "5m"
   labels:
-    application: prometheus
-    # application: kubernetes # step 2
+    application: kubernetes
     component: prometheus
     version: v2.32.1
 {{- if ne .ConfigItems.prometheus_csi_ebs "true" }}
@@ -19,8 +18,7 @@ spec:
   podManagementPolicy: Parallel
   selector:
     matchLabels:
-      application: prometheus
-      # statefulset: prometheus # step 2
+      statefulset: prometheus
   serviceName: prometheus
   template:
     metadata:


### PR DESCRIPTION
Follow up to #4900

This is the second of a 3-step change to migrate prometheus statefulset to be a component of `kubernetes` instead of individual an application.

1. Label the pod spec with `statefulset: prometheus`, roll out to all clusters.
2. Change the selector to use the label `statefulset: prometheus` and use the deletions.yaml with `propagation_policy: Orphan` to delete the old statefulset (without deleting the pods) and create a new statefulset with the new selector.
3. Change the pod template labels for `application`.