### PR TITLE
Consolidate prometheus into kubernetes application [3/3]

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -57,12 +57,6 @@ pre_apply:
 #   namespace: kube-system
 #   kind: DaemonSet
 #   propagation_policy: Orphan
-# step 2 (prometheus consolidation)
-- labels:
-    application: prometheus
-  namespace: kube-system
-  kind: StatefulSet
-  propagation_policy: Orphan
 
 # everything defined under here will be deleted after applying the manifests
 post_apply:

--- a/cluster/manifests/prometheus/service.yaml
+++ b/cluster/manifests/prometheus/service.yaml
@@ -4,7 +4,8 @@ metadata:
   name: prometheus
   namespace: kube-system
   labels:
-    application: prometheus
+    application: kubernetes
+    component: prometheus
 spec:
   type: ClusterIP
   ports:
@@ -12,4 +13,4 @@ spec:
       targetPort: 9090
       protocol: TCP
   selector:
-    application: prometheus
+    component: prometheus

--- a/cluster/manifests/prometheus/statefulset.yaml
+++ b/cluster/manifests/prometheus/statefulset.yaml
@@ -41,7 +41,7 @@ spec:
           value: "1"
       initContainers:
       - name: generate-config
-        image: registry.opensource.zalan.do/library/alpine-3.13:3.13-20211220
+        image: registry.opensource.zalan.do/library/alpine-3.13:3.13-20220126
         command:
         - /bin/sh
         args:

--- a/cluster/manifests/prometheus/statefulset.yaml
+++ b/cluster/manifests/prometheus/statefulset.yaml
@@ -24,8 +24,7 @@ spec:
     metadata:
       labels:
         statefulset: prometheus
-        application: prometheus
-        # application: kubernetes # step 3
+        application: kubernetes
         component: prometheus
         version: v2.32.1
       annotations:


### PR DESCRIPTION
Follow up to #4900, #4934

This is the third of a 3-step change to migrate prometheus statefulset to be a component of `kubernetes` instead of individual an application.

1. Label the pod spec with `statefulset: prometheus`, roll out to all clusters.
2. Change the selector to use the label `statefulset: prometheus` and use the deletions.yaml with `propagation_policy: Orphan` to delete the old statefulset (without deleting the pods) and create a new statefulset with the new selector.
3. Change the pod template labels for `application`.

Depends on #4934 being fully rolled out!