### PR TITLE
default NLB with internal annotation should fallback to ALB

### DIFF
--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.12.14
+    version: v0.12.16
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.12.14
+        version: v0.12.16
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_both}}"
     spec:
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: kube-ingress-aws-controller
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.12.14
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.12.16
         args:
         - --stack-termination-protection
         - --ssl-policy={{ .ConfigItems.kube_aws_ingress_controller_ssl_policy }}


### PR DESCRIPTION
- default NLB with internal annotation should fallback to ALB https://github.com/zalando-incubator/kube-ingress-aws-controller/releases/tag/v0.12.16
- can be overridden by users with lb annotation set to nlb

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>