### PR TITLE
skipper-ingress: cleanup after `selector.matchLabels` update

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -64,19 +64,15 @@ pre_apply:
   kind: StatefulSet
   propagation_policy: Orphan
 #
-# skipper-ingress selector.matchLabels update
-# - matches version before update
-# - version is updated with `-selector-update` suffix to run deletion only once
-# - uses `propagation_policy: Orphan` to keep exiting pods running
-# - deletion can be dropped after rollout along with version suffix removal
+# skipper-ingress selector.matchLabels update cleanup
+# - removes old orphaned replicasets that do not match updated `deployment: skipper-ingress` selector
 #
 - labels:
     application: skipper-ingress
     component: ingress
-    version: v0.13.170
   namespace: kube-system
-  kind: Deployment
-  propagation_policy: Orphan
+  kind: ReplicaSet
+  has_owner: false
 
 # everything defined under here will be deleted after applying the manifests
 post_apply:

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -6,15 +6,7 @@ metadata:
   labels:
     application: skipper-ingress
     component: ingress
-    #
-    # skipper-ingress selector.matchLabels update
-    # - version is updated with `-selector-update` suffix to not match the version configured in deletions.yaml
-    #   so that deletion runs only once
-    # - `-selector-update` suffix can be dropped after rollout along with deletions.yaml cleanup
-    # - `zalando.org/create-using-hpa-replicas` annotation is added to prevent replicas reset to 1
-    version: v0.13.170-selector-update
-  annotations:
-    zalando.org/create-using-hpa-replicas: skipper-ingress
+    version: v0.13.170
 spec:
   strategy:
     rollingUpdate:


### PR DESCRIPTION
- [ ] requires #4948 rollout

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>