### PR TITLE
skipper add profilers

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -69,6 +69,11 @@ skipper_default_filters: 'enableAccessLog(4,5) -> lifo(2000,20000,"3s")'
 skipper_ingress_inline_routes: ""
 skipper_ingress_refuse_payload: ""
 
+# skipper profiling settings, 0 keeps default, <0 disable, >0 enable with value
+skipper_block_profile_rate: 0
+skipper_mutex_profile_fraction: 0
+skipper_memory_profile_rate: 0
+
 # skipper backend timeout defaults
 skipper_expect_continue_timeout_backend: "30s"
 skipper_keepalive_backend: "30s"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: v0.13.170
+    version: v0.13.178
     component: ingress
 spec:
   strategy:
@@ -20,7 +20,7 @@ spec:
       labels:
         deployment: skipper-ingress
         application: skipper-ingress
-        version: v0.13.170
+        version: v0.13.178
         component: ingress
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
@@ -49,7 +49,7 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: registry.opensource.zalan.do/teapot/skipper-internal:v0.13.170-222
+        image: registry.opensource.zalan.do/teapot/skipper-internal:v0.13.178-230
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -120,6 +120,9 @@ spec:
 {{ end }}
           - "-disable-metrics-compat"
           - "-enable-profile"
+          - "-memory-profile-rate={{ .ConfigItems.skipper_memory_profile_rate }}"
+          - "-block-profile-rate={{ .ConfigItems.skipper_block_profile_rate }}"
+          - "-mutex-profile-fraction={{ .ConfigItems.skipper_mutex_profile_fraction }}"
           - "-debug-listener=:9922"
           - "-enable-ratelimits"
           - "-experimental-upgrade"
@@ -158,7 +161,7 @@ spec:
             tag=application=skipper-ingress
             tag=account={{ .Cluster.Alias }}
             tag=cluster={{ .Cluster.Alias }}
-            tag=artifact=registry.opensource.zalan.do/teapot/skipper-internal:v0.13.170-222
+            tag=artifact=registry.opensource.zalan.do/teapot/skipper-internal:v0.13.178-230
             max-buffered-spans={{ .ConfigItems.skipper_ingress_tracing_buffer }}
             grpc-max-msg-size={{ .ConfigItems.skipper_ingress_lightstep_grpc_max_msg_size }}
             max-period={{ .ConfigItems.skipper_ingress_lightstep_max_period }}


### PR DESCRIPTION
- add block and mutex profilers which are disabled by default
- memory profiler is now configurable

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>