### PR TITLE
Revert "skipper-ingress: update `selector.matchLabels`"

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -63,17 +63,15 @@ pre_apply:
   namespace: kube-system
   kind: StatefulSet
   propagation_policy: Orphan
+
 #
-# skipper-ingress selector.matchLabels update
-# - matches version before update
-# - version is updated with `-selector-update` suffix to run deletion only once
-# - uses `propagation_policy: Orphan` to keep exiting pods running
-# - deletion can be dropped after rollout along with version suffix removal
+# Reverts skipper-ingress selector.matchLabels update
+# - matches `v0.13.170-selector-update` version to revert already partially rolled out update
 #
 - labels:
     application: skipper-ingress
     component: ingress
-    version: v0.13.170
+    version: v0.13.170-selector-update
   namespace: kube-system
   kind: Deployment
   propagation_policy: Orphan

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,16 +5,8 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
+    version: v0.13.170
     component: ingress
-    #
-    # skipper-ingress selector.matchLabels update
-    # - version is updated with `-selector-update` suffix to not match the version configured in deletions.yaml
-    #   so that deletion runs only once
-    # - `-selector-update` suffix can be dropped after rollout along with deletions.yaml cleanup
-    # - `zalando.org/create-using-hpa-replicas` annotation is added to prevent replicas reset to 1
-    version: v0.13.170-selector-update
-  annotations:
-    zalando.org/create-using-hpa-replicas: skipper-ingress
 spec:
   strategy:
     rollingUpdate:
@@ -22,7 +14,7 @@ spec:
       maxUnavailable: 0
   selector:
     matchLabels:
-      deployment: skipper-ingress
+      application: skipper-ingress
   template:
     metadata:
       labels:


### PR DESCRIPTION
There is an edge case when HPA does not have status which results in
deployment replicas set to zero by the `zalando.org/create-using-hpa-replicas` which triggers implicit maintenance mode
and prevents HPA from scaling up the deployment.
The edge case is observed during e2e tests or on the new clusters.
See https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#implicit-maintenance-mode-deactivation

This reverts commit 2c54a541509b5eb09cd2b2ab36fe070a304587b4.