### PR TITLE
admission-controller: update version to ignore zero HPA replicas on deployment creation

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -200,7 +200,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-139
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-140
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
admission-controller supports `zalando.org/create-using-hpa-replicas: <HPA name>` annotation that sets deployment replicas from HPA desired replicas. This change ignores zero desired replicas value to avoid moving deployment into [implicit maintenance mode](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#implicit-maintenance-mode-deactivation).

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>