### PR TITLE
New etcd security group.

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -6,31 +6,39 @@ Metadata:
 Resources:
 {{ if ne .Cluster.ConfigItems.delete_vpc_resources "true" }}
   EtcdSecurityGroupIngressFromMaster:
+    Type: 'AWS::EC2::SecurityGroupIngress'
     Properties:
       FromPort: 2379
-{{- if eq .Cluster.ConfigItems.cluster_reference_etcd_sg_temp "false"}}
+      ToPort: 2379
       GroupId: !ImportValue 'etcd-cluster-etcd:security-group-id'
-{{- end }}
-{{- if eq .Cluster.ConfigItems.cluster_reference_etcd_sg_temp "true"}}
-      GroupId: !ImportValue 'etcd-cluster-etcd:security-group-id-temp'
-{{- end }}
       IpProtocol: tcp
       SourceSecurityGroupId: !Ref MasterSecurityGroup
-      ToPort: 2379
-    Type: 'AWS::EC2::SecurityGroupIngress'
   EtcdSecurityGroupTLSIngressFromMaster:
+    Type: 'AWS::EC2::SecurityGroupIngress'
     Properties:
       FromPort: 2479
-{{- if eq .Cluster.ConfigItems.cluster_reference_etcd_sg_temp "false"}}
+      ToPort: 2479
       GroupId: !ImportValue 'etcd-cluster-etcd:security-group-id'
-{{- end }}
-{{- if eq .Cluster.ConfigItems.cluster_reference_etcd_sg_temp "true"}}
-      GroupId: !ImportValue 'etcd-cluster-etcd:security-group-id-temp'
-{{- end }}
       IpProtocol: tcp
       SourceSecurityGroupId: !Ref MasterSecurityGroup
-      ToPort: 2479
+{{- if eq .Cluster.ConfigItems.etcd_stack_new_security_group "true"}}
+  EtcdClusterSecurityGroupIngressFromMaster:
     Type: 'AWS::EC2::SecurityGroupIngress'
+    Properties:
+      FromPort: 2379
+      ToPort: 2379
+      GroupId: !ImportValue 'etcd-cluster-etcd:etcd-security-group-id'
+      IpProtocol: tcp
+      SourceSecurityGroupId: !Ref MasterSecurityGroup
+  EtcdClusterSecurityGroupTLSIngressFromMaster:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Properties:
+      FromPort: 2479
+      ToPort: 2479
+      GroupId: !ImportValue 'etcd-cluster-etcd:etcd-security-group-id'
+      IpProtocol: tcp
+      SourceSecurityGroupId: !Ref MasterSecurityGroup
+{{- end }}
   IngressLoadBalancerSecurityGroup:
     Properties:
       GroupDescription: !Ref 'AWS::StackName'

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -474,10 +474,9 @@ etcd_scalyr_key: ""
 etcd_ami: {{ amiID "Taupage-AMI-20210504-093855" "861068367966"}}
 # Old etcd stacks have been created without an explicit VPC ID in the security group. This cannot be changed without
 # recreating the security group, which is impossible because of cross-stack references.
-# TODO investigate if it can be migrated.
 etcd_stack_specify_vpc_in_security_group: "true"
-etcd_stack_security_group_temp: "false"
-cluster_reference_etcd_sg_temp: "false"
+etcd_stack_new_security_group: "false"
+
 
 dynamodb_service_link_enabled: "false"
 

--- a/cluster/etcd-stack.yaml
+++ b/cluster/etcd-stack.yaml
@@ -45,6 +45,7 @@ Resources:
             AssociatePublicIpAddress: true
             Groups:
               - !GetAtt EtcdSecurityGroup.GroupId
+              - !GetAtt EtcdClusterSecurityGroup.GroupId
         EbsOptimized: false
         IamInstanceProfile:
           Name: !Ref AppServerInstanceProfile
@@ -163,7 +164,7 @@ Resources:
       ToPort: 2479
       SourceSecurityGroupId: !GetAtt EtcdSecurityGroup.GroupId
 {{- if eq .Cluster.ConfigItems.etcd_stack_new_security_group "true"}}
-  EtcdClusterSecurityGroupTemp:
+  EtcdClusterSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: Etcd Cluster Security Group

--- a/cluster/etcd-stack.yaml
+++ b/cluster/etcd-stack.yaml
@@ -10,12 +10,12 @@ Outputs:
     Value: !GetAtt EtcdSecurityGroup.GroupId
     Export:
       Name: "etcd-cluster-etcd:security-group-id"
-{{- if eq .Cluster.ConfigItems.etcd_stack_security_group_temp "true"}}
-  EtcdSecurityGroupIdTemp:
+{{- if eq .Cluster.ConfigItems.etcd_stack_new_security_group "true"}}
+  EtcdClusterSecurityGroupId:
     Description: "Security Group ID of the etcd cluster"
-    Value: !GetAtt EtcdSecurityGroupTemp.GroupId
+    Value: !GetAtt EtcdClusterSecurityGroup.GroupId
     Export:
-      Name: "etcd-cluster-etcd:security-group-id-temp"
+      Name: "etcd-cluster-etcd:etcd-security-group-id"
 {{- end }}
   LaunchTemplateId:
     Description: "Launch template ID of the etcd nodes"
@@ -162,11 +162,11 @@ Resources:
       FromPort: 2379
       ToPort: 2479
       SourceSecurityGroupId: !GetAtt EtcdSecurityGroup.GroupId
-{{- if eq .Cluster.ConfigItems.etcd_stack_security_group_temp "true"}}
-  EtcdSecurityGroupTemp:
+{{- if eq .Cluster.ConfigItems.etcd_stack_new_security_group "true"}}
+  EtcdClusterSecurityGroupTemp:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: Etcd Appliance Security Group
+      GroupDescription: Etcd Cluster Security Group
       SecurityGroupIngress:
       - IpProtocol: tcp
         FromPort: 22
@@ -184,14 +184,14 @@ Resources:
       Tags:
         - Key: InfrastructureComponent
           Value: true
-  EtcdIngressMembersTemp:
+  EtcdClusterIngressMembers:
     Type: "AWS::EC2::SecurityGroupIngress"
     Properties:
-      GroupId: !GetAtt EtcdSecurityGroupTemp.GroupId
+      GroupId: !GetAtt EtcdClusterSecurityGroup.GroupId
       IpProtocol: tcp
       FromPort: 2379
       ToPort: 2479
-      SourceSecurityGroupId: !GetAtt EtcdSecurityGroupTemp.GroupId
+      SourceSecurityGroupId: !GetAtt EtcdClusterSecurityGroup.GroupId
 {{- end }}
   EtcdBackupBucket:
     Type: AWS::S3::Bucket


### PR DESCRIPTION
The new security group definition for etcd will have the Vpc Id defined for all clusters. We will need to rotate etcd instances to use the new security group.

* Adds new opt-in config item to add new security group to etcd;
* Removes unused config items;
* Readability improvements.

Signed-off-by: rreis <rodrigo.gargravarr@gmail.com>