### PR TITLE
Drop permission to gerry mint bucket credentials for ZMON

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1474,9 +1474,6 @@ Resources:
               - Action: 's3:ListBucket'
                 Effect: Allow
                 Resource: '*'
-              - Action: 's3:GetObject'
-                Effect: Allow
-                Resource: "arn:aws:s3:::zalando-stups-mint-{{.Cluster.InfrastructureAccount | getAWSAccountID}}-{{.Cluster.Region}}/gerry/*"
               - Action: 'sqs:GetQueueAttributes'
                 Effect: Allow
                 Resource: '*'


### PR DESCRIPTION
This was used in the past by ZMON, but since September 2021 this is no longer in use, so drop the unneeded permissions.