### PR TITLE
Enable gerry (zmon user) to monitor coredns endpoints from the outside

### DIFF
--- a/cluster/manifests/roles/zmon-external-check-rbac.yaml
+++ b/cluster/manifests/roles/zmon-external-check-rbac.yaml
@@ -1,0 +1,29 @@
+# This role is used to check coredns endpoints of a cluster from the outside.
+# The intention is to monitor a cluster from the outside in case DNS is broken
+# and ZMON inside the cluster would not work.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: zmon-external-check
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  resourceNames:
+  - coredns
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: zmon-external-check
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: zmon-external-check
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: zalando-iam:zalando:service:stups_gerry


### PR DESCRIPTION
This role is used to check coredns endpoints of a cluster from the outside.
The intention is to monitor a cluster from the outside in case DNS is broken and ZMON inside the cluster would not work.