### PR TITLE
Flip new/old SG Ingress.

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -5,7 +5,7 @@ Metadata:
     InfrastructureComponent: "true"
 Resources:
 {{ if ne .Cluster.ConfigItems.delete_vpc_resources "true" }}
-{{- if eq .Cluster.ConfigItems.etcd_stack_new_security_group "false"}}
+{{- if eq .Cluster.ConfigItems.etcd_stack_old_security_group "true"}}
   EtcdSecurityGroupIngressFromMaster:
     Type: 'AWS::EC2::SecurityGroupIngress'
     Properties:

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -5,6 +5,7 @@ Metadata:
     InfrastructureComponent: "true"
 Resources:
 {{ if ne .Cluster.ConfigItems.delete_vpc_resources "true" }}
+{{- if eq .Cluster.ConfigItems.etcd_stack_new_security_group "false"}}
   EtcdSecurityGroupIngressFromMaster:
     Type: 'AWS::EC2::SecurityGroupIngress'
     Properties:
@@ -21,6 +22,7 @@ Resources:
       GroupId: !ImportValue 'etcd-cluster-etcd:security-group-id'
       IpProtocol: tcp
       SourceSecurityGroupId: !Ref MasterSecurityGroup
+{{- end }}
 {{- if eq .Cluster.ConfigItems.etcd_stack_new_security_group "true"}}
   EtcdClusterSecurityGroupIngressFromMaster:
     Type: 'AWS::EC2::SecurityGroupIngress'

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -476,6 +476,7 @@ etcd_ami: {{ amiID "Taupage-AMI-20210504-093855" "861068367966"}}
 # recreating the security group, which is impossible because of cross-stack references.
 etcd_stack_specify_vpc_in_security_group: "true"
 etcd_stack_new_security_group: "false"
+etcd_stack_old_security_group: "true"
 
 
 dynamodb_service_link_enabled: "false"

--- a/cluster/etcd-stack.yaml
+++ b/cluster/etcd-stack.yaml
@@ -44,8 +44,9 @@ Resources:
           - DeviceIndex: 0
             AssociatePublicIpAddress: true
             Groups:
+{{- if eq .Cluster.ConfigItems.etcd_stack_new_security_group "false"}}
               - !GetAtt EtcdSecurityGroup.GroupId
-{{- if eq .Cluster.ConfigItems.etcd_stack_new_security_group "true"}}
+{{- else }}
               - !GetAtt EtcdClusterSecurityGroup.GroupId
 {{- end }}
         EbsOptimized: false


### PR DESCRIPTION
* Allows setting either the new or old security group on the launch template.
* Adds new config item to enable/disable old SG Ingress in Master security group. 

Signed-off-by: rreis <rodrigo.gargravarr@gmail.com>