### PR TITLE
Add application label selector to Prometheus service

### DIFF
--- a/cluster/manifests/prometheus/service.yaml
+++ b/cluster/manifests/prometheus/service.yaml
@@ -13,4 +13,5 @@ spec:
       targetPort: 9090
       protocol: TCP
   selector:
+    application: kubernetes
     component: prometheus


### PR DESCRIPTION
Follow up to #4945

Use both `application` and `component` label for service selector.