### PR TITLE
Ensure communication between old and new Etcd Security Group.

### DIFF
--- a/cluster/etcd-stack.yaml
+++ b/cluster/etcd-stack.yaml
@@ -167,6 +167,14 @@ Resources:
       ToPort: 2479
       SourceSecurityGroupId: !GetAtt EtcdSecurityGroup.GroupId
 {{- if eq .Cluster.ConfigItems.etcd_stack_new_security_group "true"}}
+  EtcdIngressMembersNewSecurityGroup:
+    Type: "AWS::EC2::SecurityGroupIngress"
+    Properties:
+      GroupId: !GetAtt EtcdClusterSecurityGroup.GroupId
+      IpProtocol: tcp
+      FromPort: 2379
+      ToPort: 2479
+      SourceSecurityGroupId: !GetAtt EtcdSecurityGroup.GroupId
   EtcdClusterSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -192,6 +200,14 @@ Resources:
     Type: "AWS::EC2::SecurityGroupIngress"
     Properties:
       GroupId: !GetAtt EtcdClusterSecurityGroup.GroupId
+      IpProtocol: tcp
+      FromPort: 2379
+      ToPort: 2479
+      SourceSecurityGroupId: !GetAtt EtcdClusterSecurityGroup.GroupId
+  EtcdClusterIngressMembersOldSecurityGroup:
+    Type: "AWS::EC2::SecurityGroupIngress"
+    Properties:
+      GroupId: !GetAtt EtcdSecurityGroup.GroupId
       IpProtocol: tcp
       FromPort: 2379
       ToPort: 2479


### PR DESCRIPTION
We need to ensure communication during rotation of etcd instances to the new Security group. This PR adds Ingress rules to ensure communication between the old and the new security grroup.

Signed-off-by: rreis <rodrigo.gargravarr@gmail.com>