### PR TITLE
ingress controller handles fabricgateway resources 

### DIFF
--- a/cluster/manifests/ingress-controller/01-rbac.yaml
+++ b/cluster/manifests/ingress-controller/01-rbac.yaml
@@ -30,6 +30,7 @@ rules:
   - zalando.org
   resources:
   - routegroups
+  - fabricgateways
   verbs:
   - get
   - list
@@ -38,6 +39,7 @@ rules:
   - zalando.org
   resources:
   - routegroups/status
+  - fabricgateways/status
   verbs:
   - patch
   - update

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.12.16
+    version: v0.12.25
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.12.16
+        version: v0.12.25
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_both}}"
     spec:
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: kube-ingress-aws-controller
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.12.16
+        image: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller:v0.12.25
         args:
         - --stack-termination-protection
         - --ssl-policy={{ .ConfigItems.kube_aws_ingress_controller_ssl_policy }}


### PR DESCRIPTION
ingress controller handles fabricgateway resources to create cloud load balancers and adds status to fabricgateway resources, but this will be overwritten by fabric controller. If we stop fabric controller the status field would stay, such that we can create DNS records with that data

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>