### PR TITLE
skipper-ingress: cleanup after deployment selector update

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -46,19 +46,6 @@ pre_apply:
   namespace: kube-system
   kind: Service
 
-# skipper-ingress selector.matchLabels update
-# - matches version before update
-# - version is updated with `-selector-update` suffix to run deletion only once
-# - uses `propagation_policy: Orphan` to keep exiting pods running
-# - deletion can be dropped after rollout along with version suffix removal
-- labels:
-    application: skipper-ingress
-    component: ingress
-    version: v0.13.178
-  namespace: kube-system
-  kind: Deployment
-  propagation_policy: Orphan
-
 # everything defined under here will be deleted after applying the manifests
 post_apply:
 {{ if eq .ConfigItems.teapot_admission_controller_process_resources "true" }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -4,16 +4,9 @@ metadata:
   name: skipper-ingress
   namespace: kube-system
   labels:
-    # skipper-ingress selector.matchLabels update
-    # - version is updated with `-selector-update` suffix to not match the version configured in deletions.yaml
-    #   so that deletion runs only once
-    # - `-selector-update` suffix can be dropped after rollout along with deletions.yaml cleanup
-    # - `zalando.org/create-using-hpa-replicas` annotation is added to prevent replicas reset to 1
     application: skipper-ingress
-    version: v0.13.179-selector-update
+    version: v0.13.179
     component: ingress
-  annotations:
-    zalando.org/create-using-hpa-replicas: skipper-ingress
 spec:
   strategy:
     rollingUpdate:


### PR DESCRIPTION
- [x] requires full rollout of the https://github.com/zalando-incubator/kubernetes-on-aws/pull/4980