### PR TITLE
Tag control plane EC2 instances with application/component tags

### DIFF
--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -36,6 +36,12 @@ Resources:
       - Key: zalando.org/pod-max-pids
         PropagateAtLaunch: true
         Value: "{{ .NodePool.ConfigItems.pod_max_pids }}"
+      - Key: application
+        Value: kubernetes
+        PropagateAtLaunch: true
+      - Key: component
+        Value: control-plane
+        PropagateAtLaunch: true
       VPCZoneIdentifier:
 {{ with $values := .Values }}
 {{ range $az := $values.availability_zones }}


### PR DESCRIPTION
In order to make it simpler to see control plane cost in AWS cost explorer tag the control plane instances with `application=kubernetes,component=control-plane`.

Use the generic component name `control-plane` as we run multiple components on the node, but just need a way to identify the whole EC2 instance in AWS Cost explorer costs.