### PR TITLE
Consolidate DaemonSet applications/components [3/3]

### DIFF
--- a/cluster/manifests/coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/coredns-local/daemonset-coredns.yaml
@@ -19,8 +19,7 @@ spec:
     metadata:
       labels:
         daemonset: coredns
-        application: coredns
-        # application: kubernetes # step 3
+        application: kubernetes
         component: coredns
         instance: node-dns
         version: v1.8.7

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -10,42 +10,6 @@ pre_apply:
   kind: Deployment
 {{ end }}
 
-# step 2 ds consolidation
-- labels:
-    application: kube-proxy
-  namespace: kube-system
-  kind: DaemonSet
-  propagation_policy: Orphan
-- labels:
-    application: coredns
-  namespace: kube-system
-  kind: DaemonSet
-  propagation_policy: Orphan
-- labels:
-    application: kube-node-ready
-  namespace: kube-system
-  kind: DaemonSet
-  propagation_policy: Orphan
-- labels:
-    application: kube2iam
-  namespace: kube-system
-  kind: DaemonSet
-  propagation_policy: Orphan
-- labels:
-    application: flannel
-  namespace: kube-system
-  kind: DaemonSet
-  propagation_policy: Orphan
-- labels:
-    application: node-monitor
-  namespace: kube-system
-  kind: DaemonSet
-  propagation_policy: Orphan
-- labels:
-    application: node-monitor
-  namespace: kube-system
-  kind: Service
-
 # everything defined under here will be deleted after applying the manifests
 post_apply:
 {{ if eq .ConfigItems.teapot_admission_controller_process_resources "true" }}

--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -17,8 +17,7 @@ spec:
     metadata:
       labels:
         daemonset: kube-flannel
-        application: flannel
-        # application: kubernetes # step 3
+        application: kubernetes
         component: flannel
         version: v0.15.1-14
       annotations:

--- a/cluster/manifests/kube-node-ready/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready/daemonset.yaml
@@ -19,8 +19,7 @@ spec:
     metadata:
       labels:
         daemonset: kube-node-ready
-        application: kube-node-ready
-        # application: kubernetes # step 3
+        application: kubernetes
         component: kube-node-ready
         version: {{$version}}
       annotations:

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -17,8 +17,7 @@ spec:
       name: kube-proxy
       labels:
         daemonset: kube-proxy
-        application: kube-proxy
-        # application: kubernetes # step 3
+        application: kubernetes
         component: kube-proxy
       annotations:
         config/hash: {{"configmap.yaml" | manifestHash}}

--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -17,8 +17,7 @@ spec:
     metadata:
       labels:
         daemonset: kube2iam
-        application: kube2iam
-        # application: kubernetes # step 3
+        application: kubernetes
         component: kube2iam
         version: 0.10.11
       annotations:

--- a/cluster/manifests/node-monitor/daemonset.yaml
+++ b/cluster/manifests/node-monitor/daemonset.yaml
@@ -16,8 +16,7 @@ spec:
     metadata:
       labels:
         daemonset: node-monitor
-        application: node-monitor
-        # application: kubernetes # step 3
+        application: kubernetes
         component: node-monitor
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"


### PR DESCRIPTION
Follow up to #4898, #4975

This is the last of a 3-step change to migrate 6 daemonsets to be components of `kubernetes` instead of individual applications.

1. Label the pod spec with `daemonset: <name>`, roll out to all clusters and wait for pods/nodes to be completely rotated.
2. Change the selector to use the label `daemonset: <name>` and use the deletions.yaml with `propagation_policy: Orphan` to delete the old daemonset (without deleting the pods) and create a new daemonset with the new selector.
3. Change the pod template labels for `application` and `component` and wait for all nodes/pods to be rotated.