### PR TITLE
Cleanup etcd config items.

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -5,25 +5,6 @@ Metadata:
     InfrastructureComponent: "true"
 Resources:
 {{ if ne .Cluster.ConfigItems.delete_vpc_resources "true" }}
-{{- if eq .Cluster.ConfigItems.etcd_stack_old_security_group "true"}}
-  EtcdSecurityGroupIngressFromMaster:
-    Type: 'AWS::EC2::SecurityGroupIngress'
-    Properties:
-      FromPort: 2379
-      ToPort: 2379
-      GroupId: !ImportValue 'etcd-cluster-etcd:security-group-id'
-      IpProtocol: tcp
-      SourceSecurityGroupId: !Ref MasterSecurityGroup
-  EtcdSecurityGroupTLSIngressFromMaster:
-    Type: 'AWS::EC2::SecurityGroupIngress'
-    Properties:
-      FromPort: 2479
-      ToPort: 2479
-      GroupId: !ImportValue 'etcd-cluster-etcd:security-group-id'
-      IpProtocol: tcp
-      SourceSecurityGroupId: !Ref MasterSecurityGroup
-{{- end }}
-{{- if eq .Cluster.ConfigItems.etcd_stack_new_security_group "true"}}
   EtcdClusterSecurityGroupIngressFromMaster:
     Type: 'AWS::EC2::SecurityGroupIngress'
     Properties:
@@ -40,7 +21,6 @@ Resources:
       GroupId: !ImportValue 'etcd-cluster-etcd:etcd-security-group-id'
       IpProtocol: tcp
       SourceSecurityGroupId: !Ref MasterSecurityGroup
-{{- end }}
   IngressLoadBalancerSecurityGroup:
     Properties:
       GroupDescription: !Ref 'AWS::StackName'

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -472,12 +472,6 @@ etcd_instance_type: "t3.medium"
 etcd_docker_image: "registry.opensource.zalan.do/teapot/etcd-cluster:3.4.16-master-10"
 etcd_scalyr_key: ""
 etcd_ami: {{ amiID "Taupage-AMI-20210504-093855" "861068367966"}}
-# Old etcd stacks have been created without an explicit VPC ID in the security group. This cannot be changed without
-# recreating the security group, which is impossible because of cross-stack references.
-etcd_stack_specify_vpc_in_security_group: "true"
-etcd_stack_new_security_group: "false"
-etcd_stack_old_security_group: "true"
-
 
 dynamodb_service_link_enabled: "false"
 

--- a/cluster/etcd-stack.yaml
+++ b/cluster/etcd-stack.yaml
@@ -5,18 +5,11 @@ Metadata:
     InfrastructureComponent: "true"
     "kubernetes:component": "etcd-cluster"
 Outputs:
-  EtcdSecurityGroupId:
-    Description: "Security Group ID of the etcd cluster"
-    Value: !GetAtt EtcdSecurityGroup.GroupId
-    Export:
-      Name: "etcd-cluster-etcd:security-group-id"
-{{- if eq .Cluster.ConfigItems.etcd_stack_new_security_group "true"}}
   EtcdClusterSecurityGroupId:
     Description: "Security Group ID of the etcd cluster"
     Value: !GetAtt EtcdClusterSecurityGroup.GroupId
     Export:
       Name: "etcd-cluster-etcd:etcd-security-group-id"
-{{- end }}
   LaunchTemplateId:
     Description: "Launch template ID of the etcd nodes"
     Value: !Ref LaunchTemplate
@@ -44,11 +37,7 @@ Resources:
           - DeviceIndex: 0
             AssociatePublicIpAddress: true
             Groups:
-{{- if eq .Cluster.ConfigItems.etcd_stack_new_security_group "false"}}
-              - !GetAtt EtcdSecurityGroup.GroupId
-{{- else }}
               - !GetAtt EtcdClusterSecurityGroup.GroupId
-{{- end }}
         EbsOptimized: false
         IamInstanceProfile:
           Name: !Ref AppServerInstanceProfile
@@ -135,46 +124,6 @@ Resources:
       AutoScalingGroupName: !Ref AppServer
       Cooldown: "60"
       ScalingAdjustment: "1"
-  EtcdSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupDescription: Etcd Appliance Security Group
-      SecurityGroupIngress:
-      - IpProtocol: tcp
-        FromPort: 22
-        ToPort: 22
-        CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-      - IpProtocol: tcp
-        FromPort: 2381
-        ToPort: 2381
-        CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-      - IpProtocol: tcp
-        FromPort: 9100
-        ToPort: 9100
-        CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-{{- if eq .Cluster.ConfigItems.etcd_stack_specify_vpc_in_security_group "true"}}
-      VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
-{{- end }}
-      Tags:
-        - Key: InfrastructureComponent
-          Value: true
-  EtcdIngressMembers:
-    Type: "AWS::EC2::SecurityGroupIngress"
-    Properties:
-      GroupId: !GetAtt EtcdSecurityGroup.GroupId
-      IpProtocol: tcp
-      FromPort: 2379
-      ToPort: 2479
-      SourceSecurityGroupId: !GetAtt EtcdSecurityGroup.GroupId
-{{- if eq .Cluster.ConfigItems.etcd_stack_new_security_group "true"}}
-  EtcdIngressMembersNewSecurityGroup:
-    Type: "AWS::EC2::SecurityGroupIngress"
-    Properties:
-      GroupId: !GetAtt EtcdClusterSecurityGroup.GroupId
-      IpProtocol: tcp
-      FromPort: 2379
-      ToPort: 2479
-      SourceSecurityGroupId: !GetAtt EtcdSecurityGroup.GroupId
   EtcdClusterSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -212,7 +161,6 @@ Resources:
       FromPort: 2379
       ToPort: 2479
       SourceSecurityGroupId: !GetAtt EtcdClusterSecurityGroup.GroupId
-{{- end }}
   EtcdBackupBucket:
     Type: AWS::S3::Bucket
     DeletionPolicy: Retain


### PR DESCRIPTION
Removes etcd config items and sections used to migrate etcd to senza-less CloudFormation (see https://github.com/zalando-incubator/kubernetes-on-aws/pull/4968, https://github.com/zalando-incubator/kubernetes-on-aws/pull/4972 https://github.com/zalando-incubator/kubernetes-on-aws/pull/4973, https://github.com/zalando-incubator/kubernetes-on-aws/pull/4977).

**This will break current open PRs**. Open PRs need to be updated to the latest `dev` branch.

Signed-off-by: rreis <rodrigo.gargravarr@gmail.com>