### PR TITLE
fix: skipper idle timeout, NLB has 350s

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -88,7 +88,7 @@ skipper_tls_timeout_backend: "1m"
 skipper_close_idle_conns_period: "20s"
 
 # skipper server timeout defaults
-skipper_idle_timeout_server: "62s"
+skipper_idle_timeout_server: "352s"
 skipper_read_timeout_server: "5m"
 skipper_write_timeout_server: "0"
 


### PR DESCRIPTION
fix: idle timeout of NLB has 350s fixed according to https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#connection-idle-timeout , +2s for skipper

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>