### PR TITLE
Enable CloudFormation etcd in e2e.

### DIFF
--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -9,6 +9,7 @@ clusters:
   channel: ${1}
   config_items:
     zmon_root_account_role: ${ZMON_ROOT_ACCOUNT_ROLE}
+    experimental_new_etcd_stack: "true"
     audittrail_root_account_role: ${AUDITTRAIL_ROOT_ACCOUNT_ROLE}
     apiserver_etcd_prefix: /registry-${LOCAL_ID}
     apiserver_business_partner_ids: ${APISERVER_BUSINESS_PARTNER_IDS}


### PR DESCRIPTION
Enables the new CloudFormation etcd when provisioning e2e clusters.

Signed-off-by: rreis <rodrigo.gargravarr@gmail.com>