### PR TITLE
Enable etcd stack management in e2e.

### DIFF
--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -109,7 +109,7 @@ if [ "$create_cluster" = true ]; then
             --token="${CLUSTER_ADMIN_TOKEN}" \
             --directory="$(pwd)/$BASE_CFG_PATH" \
             --debug \
-            --registry=base_cluster.yaml
+            --registry=base_cluster.yaml \
             --manage-etcd-stack
 
         # Wait for the resources to be ready

--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -133,7 +133,8 @@ if [ "$create_cluster" = true ]; then
         --token="${CLUSTER_ADMIN_TOKEN}" \
         --directory="$(pwd)/../.." \
         --debug \
-        --registry=head_cluster.yaml
+        --registry=head_cluster.yaml \
+        --manage-etcd-stack
 
     # Wait for the resources to be ready after the update
     # TODO: make a feature of CLM --wait-for-kube-system

--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -110,6 +110,7 @@ if [ "$create_cluster" = true ]; then
             --directory="$(pwd)/$BASE_CFG_PATH" \
             --debug \
             --registry=base_cluster.yaml
+            --manage-etcd-stack
 
         # Wait for the resources to be ready
         ./wait-for-update.py --timeout 1200


### PR DESCRIPTION
Sets CLM flag to manage etcd senzaless CF stack.

Signed-off-by: rreis <rodrigo.gargravarr@gmail.com>