### PR TITLE
Allow ZMON access to list Step Function state machines and executions

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1485,6 +1485,12 @@ Resources:
               - Action: 'sagemaker:ListEndpoints'
                 Effect: Allow
                 Resource: '*'
+              - Action: 'states:ListStateMachines'
+                Effect: Allow
+                Resource: '*'
+              - Action: 'states:ListExecutions'
+                Effect: Allow
+                Resource: '*'
             Version: 2012-10-17
           PolicyName: root
       RoleName: "{{.Cluster.LocalID}}-app-zmon"


### PR DESCRIPTION
Allow ZMON access to list Step Function state machines and executions
Related ZMON worker PR: https://github.bus.zalan.do/metrics/zmon-worker/pull/187