### PR TITLE
Include component label in prometheus metrics

### DIFF
--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -207,6 +207,9 @@ data:
         source_labels: ['__meta_kubernetes_pod_label_application']
         target_label: application
       - action: replace
+        source_labels: ['__meta_kubernetes_pod_label_component']
+        target_label: component
+      - action: replace
         source_labels: ['__meta_kubernetes_pod_name']
         target_label: pod_name
       - action: replace


### PR DESCRIPTION
This includes `component` label in metrics collected from pods. Prometheus collect metrics from itself (on port :9090) and since we changed to `application=kubernetes,component=prometheus` we are not able to filter on metrics from `prometheus` because the component label is missing. This fixes that issue.

Ref: #4945