### PR TITLE
Add gp3 support for Persistent Volumes

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -531,11 +531,12 @@ enable_csi_migration: "false"
 # pull images in parallel
 serialize_image_pulls: "false"
 
-# Version of the scheduler used by the master nodes.
+# Version of the scheduler or controller-manager used by the master nodes.
 # Supported values:
 #  - upstream: official Kubernetes version
 #  - zalando:  internal Zalando build with our custom patches
 kubernetes_scheduler_image: "zalando"
+kubernetes_controller_manager_image: "zalando"
 
 # when set to true, service account tokens can be used from outside the cluster
 allow_external_service_accounts: "false"
@@ -699,3 +700,6 @@ deployment_service_cf_auto_expand_enabled: "false"
 
 # Will be dropped after the migration
 deployment_service_enabled: "true"
+
+# Standard storageclass gp3 volume type
+storageclass_standard_gp3: "false"

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -10,6 +10,16 @@ pre_apply:
   kind: Deployment
 {{ end }}
 
+{{ if eq .Cluster.ConfigItems.storageclass_standard_gp3 "true" }}
+- labels:
+    volume-type: gp2
+  kind: StorageClass
+{{ else }}
+- labels:
+    volume-type: gp3
+  kind: StorageClass
+{{ end }}
+
 # everything defined under here will be deleted after applying the manifests
 post_apply:
 {{ if eq .ConfigItems.teapot_admission_controller_process_resources "true" }}

--- a/cluster/manifests/storageclass/storageclass.yaml
+++ b/cluster/manifests/storageclass/storageclass.yaml
@@ -6,10 +6,10 @@ metadata:
     storageclass.kubernetes.io/is-default-class: "true"
   labels:
     kubernetes.io/cluster-service: "true"
-    volume-type: "gp2"
+    volume-type: {{ if eq .Cluster.ConfigItems.storageclass_standard_gp3 "true" }}gp3{{else}}gp2{{end}}
 provisioner: kubernetes.io/aws-ebs
 parameters:
-  type: gp2
+  type: {{ if eq .Cluster.ConfigItems.storageclass_standard_gp3 "true" }}gp3{{else}}gp2{{end}}
   # TODO: this assumes 3 zones per region
   zones: {{ .Cluster.Region }}a, {{ .Cluster.Region }}b, {{ .Cluster.Region }}c
 allowVolumeExpansion: true

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -580,7 +580,7 @@ write_files:
           effect: NoSchedule
         containers:
         - name: kube-controller-manager
-          image: nonexistent.zalan.do/teapot/kube-controller-manager:fixed
+          image: {{if eq .Cluster.ConfigItems.kubernetes_controller_manager_image "zalando" }}registry.opensource.zalan.do/teapot/kube-controller-manager-internal:v1.21.9-2{{else}}nonexistent.zalan.do/teapot/kube-controller-manager:fixed{{end}}
           args:
           - --kubeconfig=/etc/kubernetes/controller-manager-kubeconfig
           - --leader-elect=true


### PR DESCRIPTION
WIP: Attempt to add `gp3` volume support via patched controller manager

Using this patch not accepted upstream: https://github.com/kubernetes/kubernetes/pull/97237

Depends on #5045 