### PR TITLE
Add label volume-type label to storageclass

### DIFF
--- a/cluster/manifests/storageclass/storageclass.yaml
+++ b/cluster/manifests/storageclass/storageclass.yaml
@@ -6,6 +6,7 @@ metadata:
     storageclass.kubernetes.io/is-default-class: "true"
   labels:
     kubernetes.io/cluster-service: "true"
+    volume-type: "gp2"
 provisioner: kubernetes.io/aws-ebs
 parameters:
   type: gp2


### PR DESCRIPTION
pre-requisite for #5038 to make it simple to switch between gp2 and gp3 as default volume type. 