### PR TITLE
Update to kube-metrics-adapter v0.1.18

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.17-6-g9d8359b
+        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.18
         env:
         - name: AWS_REGION
           value: {{ .Region }}


### PR DESCRIPTION
Updates to the latest kube-metrics-adapter version. The change is an update to go dependencies which addresses some CVEs (See https://github.com/zalando-incubator/kube-metrics-adapter/pull/401)