### PR TITLE
Switch default storage class to gp3 by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -702,4 +702,4 @@ deployment_service_cf_auto_expand_enabled: "false"
 deployment_service_enabled: "true"
 
 # Standard storageclass gp3 volume type
-storageclass_standard_gp3: "false"
+storageclass_standard_gp3: "true"


### PR DESCRIPTION
So that new clusters start using gp3.