### PR TITLE
fix and ease zmon s3 buckets

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1468,7 +1468,7 @@ Resources:
               {{range $bucket := split "," .Cluster.ConfigItems.zmon_accessible_s3_buckets}}
               - Action: 's3:GetObject'
                 Effect: Allow
-                Resource: '$bucket'
+                Resource: 'arn:aws:s3:::{{ $bucket }}/*'
               {{end}}
           {{end}}
               - Action: 'sqs:GetQueueAttributes'

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1465,7 +1465,7 @@ Resources:
                 Effect: Allow
                 Resource: '*'
           {{if ne "" .Cluster.ConfigItems.zmon_accessible_s3_buckets}}
-              {{range $bucket := split "," .Cluster.ConfigItems.zmon_accessible_s3_buckets}}
+              {{range $bucket := split .Cluster.ConfigItems.zmon_accessible_s3_buckets ","}}
               - Action: 's3:GetObject'
                 Effect: Allow
                 Resource: 'arn:aws:s3:::{{ $bucket }}/*'


### PR DESCRIPTION
* fix missing `{{}}`
* just require the bucket name, this still allows for `bucket_name` or `bucket_name/sub-folder` access