### PR TITLE
Update pause container to current version

### DIFF
--- a/cluster/manifests/e2e-resources/pool-reserve.yaml
+++ b/cluster/manifests/e2e-resources/pool-reserve.yaml
@@ -36,7 +36,7 @@ spec:
       terminationGracePeriodSeconds: 0
       containers:
       - name: pause
-        image: registry.opensource.zalan.do/teapot/pause-amd64:3.2
+        image: registry.opensource.zalan.do/teapot/pause-amd64:3.4.1
         resources:
           limits:
             cpu: 1m

--- a/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 0
       containers:
       - name: pause
-        image: registry.opensource.zalan.do/teapot/pause-amd64:3.2
+        image: registry.opensource.zalan.do/teapot/pause-amd64:3.4.1
         resources:
           limits:
             cpu: {{$data.ConfigItems.autoscaling_buffer_cpu}}

--- a/test/e2e/audit.go
+++ b/test/e2e/audit.go
@@ -49,7 +49,7 @@ var _ = describe("Audit", func() {
 			Spec: apiv1.PodSpec{
 				Containers: []apiv1.Container{{
 					Name:  "pause",
-					Image: "registry.opensource.zalan.do/teapot/pause-amd64:3.2",
+					Image: "registry.opensource.zalan.do/teapot/pause-amd64:3.4.1",
 				}},
 			},
 		}

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -46,7 +46,7 @@ import (
 
 const (
 	awsCliImage  = "registry.opensource.zalan.do/teapot/awscli:master-1"
-	pauseImage   = "registry.opensource.zalan.do/teapot/pause-amd64:3.2"
+	pauseImage   = "registry.opensource.zalan.do/teapot/pause-amd64:3.4.1"
 	appLabelName = "application"
 )
 


### PR DESCRIPTION
This is the default pause container defined by kubelet for our version. Since we overwrite it or define it add various places we need to update it from time to time.

```console
$ kubelet --version
Kubernetes v1.21.11
$ kubelet --help | grep pause
      --pod-infra-container-image string                         Specified image will not be pruned by the image garbage collector. When container-runtime is set to 'docker', all containers in each pod will use the network/ipc namespaces from this image. Other CRI implementations have their own configuration to set this image. (default "k8s.gcr.io/pause:3.4.1")
```