### PR TITLE
Allow CDP to manage elasticsearchdatasets

### DIFF
--- a/cluster/manifests/roles/cdp-controller-rbac.yaml
+++ b/cluster/manifests/roles/cdp-controller-rbac.yaml
@@ -82,6 +82,7 @@ rules:
   - "zalando.org"
   resources:
   - gradualdeployments
+  - elasticsearchdatasets
   verbs:
   - get
   - list


### PR DESCRIPTION
In order to deploy a CronJob that can manage elasticsearchdatasets CRs, cdp itself needs to hold these permissions.

For https://github.bus.zalan.do/zooport/issues/issues/2389