### PR TITLE
Set protectKernelDefaults=true for kubelet

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -69,6 +69,7 @@ write_files:
         webhook:
           cacheAuthorizedTTL: "5m"
           cacheUnauthorizedTTL: "30s"
+      protectKernelDefaults: true
 
   - owner: root:root
     path: /etc/kubernetes/manifests/kube-apiserver.yaml

--- a/cluster/node-pools/worker-splitaz/userdata.yaml
+++ b/cluster/node-pools/worker-splitaz/userdata.yaml
@@ -109,6 +109,7 @@ write_files:
         webhook:
           cacheAuthorizedTTL: "5m"
           cacheUnauthorizedTTL: "30s"
+      protectKernelDefaults: true
 
 {{- if ( and ( ne .Cluster.ConfigItems.vm_dirty_background_bytes "" ) ( ne .Cluster.ConfigItems.vm_dirty_bytes "" ) )}}
   - owner: root:root


### PR DESCRIPTION
Suggested configuration from kube-bench. Test that it works in our setup.

This just makes sure that kubelet does NOT make sysctl changes but instead verify the settings and fails to start if the settings are not as expected.