### PR TITLE
skipper-ingress: rename cluster scaling schedule config item

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -230,12 +230,12 @@ skipper_time_based_scaling_target: "1"
 # ClusterScalingSchedules
 # hyped-article-releases
 skipper_scaling_schedule_hyped_articles_target: ""
-# One or multiple custom schedules can be configured as a
-# comma-separated list of <schedule name>=<target value> pairs.
-# E.g. to configure "weekdays" schedule with a target value of 3 and
+# One or multiple cluster scaling schedules can be configured as a
+# comma-separated list of <cluster schedule name>=<target value> pairs.
+# E.g. to configure "weekdays" cluster schedule with a target value of 3 and
 # "weekends" with a target value of 5 set
-# skipper_scaling_schedule_custom: "weekdays=3,weekends=5"
-skipper_scaling_schedule_custom: ""
+# skipper_cluster_scaling_schedules: "weekdays=3,weekends=5"
+skipper_cluster_scaling_schedules: ""
 
 # cadvisor settings
 cadvisor_cpu: "150m"

--- a/cluster/manifests/skipper/hpa.yaml
+++ b/cluster/manifests/skipper/hpa.yaml
@@ -54,19 +54,19 @@ spec:
         averageValue: {{ .ConfigItems.skipper_scaling_schedule_hyped_articles_target }}
         type: AverageValue
 {{ end }}
-{{ if ne .ConfigItems.skipper_scaling_schedule_custom "" }}
-  {{ range split .ConfigItems.skipper_scaling_schedule_custom "," }}
-  {{ $schedule := split . "=" }}
+{{ if ne .ConfigItems.skipper_cluster_scaling_schedules "" }}
+  {{ range split .ConfigItems.skipper_cluster_scaling_schedules "," }}
+  {{ $name_target := split . "=" }}
   - type: Object
     object:
       describedObject:
         apiVersion: zalando.org/v1
         kind: ClusterScalingSchedule
-        name: {{ index $schedule 0 }}
+        name: {{ index $name_target 0 }}
       metric:
-        name: {{ index $schedule 0 }}
+        name: {{ index $name_target 0 }}
       target:
-        averageValue: {{ index $schedule 1 }}
+        averageValue: {{ index $name_target 1 }}
         type: AverageValue
   {{ end }}
 {{ end }}


### PR DESCRIPTION
The new name is generic, hints that config is for cluster-wide schedules
and supports multiple values.

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>