### PR TITLE
update admission-controller

### DIFF
--- a/cluster/manifests/01-admission-control/teapot.yaml
+++ b/cluster/manifests/01-admission-control/teapot.yaml
@@ -122,18 +122,6 @@ webhooks:
         apiGroups: ["apiextensions.k8s.io"]
         apiVersions: ["v1"]
         resources: ["customresourcedefinitions"]
-  - name: ingress-admitter.teapot.zalan.do
-    clientConfig:
-      url: "https://localhost:8085/ingress"
-      caBundle: "{{ .ConfigItems.ca_cert_decompressed }}"
-    admissionReviewVersions: ["v1beta1"]
-    failurePolicy: Fail
-    sideEffects: "NoneOnDryRun"
-    rules:
-      - operations: ["CREATE", "UPDATE"]
-        apiGroups: ["extensions", "networking.k8s.io"]
-        apiVersions: ["v1beta1"]
-        resources: ["ingresses"]
   - name: stack-admitter.teapot.zalan.do
     clientConfig:
       url: "https://localhost:8085/stack"

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -200,7 +200,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-144
+        - image: registry.opensource.zalan.do/teapot/admission-controller:master-146
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
update admission-controller

* Adds support for an additional environment variable used by the observability SDKs.
* Removed Ingress admitter because it was only used for migrating traffic ownership between ingress resources and stackset resources. This is no longer needed as all stacksets have the traffic ownership as desired.