### PR TITLE
WIP: etcd instance rotation

### DIFF
--- a/cluster/etcd-stack.yaml
+++ b/cluster/etcd-stack.yaml
@@ -211,14 +211,6 @@ Resources:
             - route53:ListResourceRecordSets
             - route53:GetChange
             Resource: "*"
-      - PolicyName: ASGCompleteLifecycle
-        PolicyDocument:
-          Version: "2012-10-17"
-          Statement:
-          - Effect: Allow
-            Action:
-            - autoscaling:CompleteLifecycleAction
-            Resource: [ !GetAtt AppServer.Arn ]
       - PolicyName: AmazonS3EtcdBackupWrite
         PolicyDocument:
           Version: "2012-10-17"

--- a/cluster/etcd-stack.yaml
+++ b/cluster/etcd-stack.yaml
@@ -211,6 +211,14 @@ Resources:
             - route53:ListResourceRecordSets
             - route53:GetChange
             Resource: "*"
+      - PolicyName: ASGCompleteLifecycle
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+          - Effect: Allow
+            Action:
+            - autoscaling:CompleteLifecycleAction
+            Resource: [ !GetAtt AppServer.Arn ]
       - PolicyName: AmazonS3EtcdBackupWrite
         PolicyDocument:
           Version: "2012-10-17"

--- a/cluster/etcd-stack.yaml
+++ b/cluster/etcd-stack.yaml
@@ -44,32 +44,29 @@ Resources:
         InstanceInitiatedShutdownBehavior: terminate
         ImageId: {{.Cluster.ConfigItems.etcd_ami}}
         InstanceType: {{.Cluster.ConfigItems.etcd_instance_type}}
-        UserData: !Base64 |
-          #taupage-ami-config
-          application_id: etcd-cluster
-          application_version: etcd
-          environment:
-            CLIENT_CERT: "{{.Values.etcd_client_server_cert}}"
-            CLIENT_KEY: "{{.Values.etcd_client_server_key}}"
-            CLIENT_TLS_ENABLED: 'true'
-            CLIENT_TRUSTED_CA: "{{.Values.etcd_client_ca_cert}}"
-            HOSTED_ZONE: "{{.Values.hosted_zone}}"
-          mounts:
-            /home/etcd:
-              partition: /dev/xvdb
-              filesystem: ext4
-              erase_on_boot: true
-          notify_cfn:
-            resource: AppServer
-            stack: etcd-cluster-etcd
-          ports:
-            2379: 2379
-            2380: 2380
-            2381: 2381
-            2479: 2479
-          runtime: Docker
-          scalyr_account_key: "{{.Values.etcd_scalyr_key}}"
-          source: "{{.Cluster.ConfigItems.etcd_docker_image}}"
+        UserData:
+          Fn::Base64: !Sub |
+            #cloud-config
+            write_files:
+              - path: /etc/scalyr-agent-2/userdata.yaml
+                permissions: 0644
+                content: |
+                  scalyr_api_key: "{{.Values.etcd_scalyr_key}}"
+                  stack_name: ${AWS::StackName}
+              - path: /etc/default/etcd
+                permissions: 0644
+                content: |
+                  ETCD_CERT_FILE=/etc/etcd/ssl/client.cert
+                  ETCD_KEY_FILE=/etc/etcd/ssl/client.key
+                  ETCD_TRUSTED_CA_FILE=/etc/etcd/ssl/ca.cert
+                  ETCD_CLIENT_TLS_ENABLED='true'
+                  ETCD_LOG_LEVEL=info
+                  HOSTED_ZONE="{{.Values.hosted_zone}}"
+                  S3_CERTS_BUCKET=s3://cluster-lifecycle-manager-170858875137-eu-central-1/kube-aws-test-1/etcd/etcd_ssl_certicates_test.userdata
+                  AWS_DEFAULT_REGION=eu-central-1
+            runcmd:
+              - [ cfn-signal, --success, 'true', --stack, ${AWS::StackName}, --resource, AppServer, --region, ${AWS::Region} ]
+              - [ complete-asg-lifecycle.py, 'etcd-server-lifecycle-hook' ]
   AppServer:
     Type: AWS::AutoScaling::AutoScalingGroup
     CreationPolicy:
@@ -78,7 +75,7 @@ Resources:
         Timeout: PT15M
     Properties:
       DesiredCapacity: {{.Cluster.ConfigItems.etcd_instance_count}}
-      HealthCheckGracePeriod: 300
+      HealthCheckGracePeriod: 0
       HealthCheckType: EC2
       LaunchTemplate:
         LaunchTemplateId: !Ref LaunchTemplate
@@ -110,6 +107,13 @@ Resources:
         - Key: certificate-expiry-node
           PropagateAtLaunch: true
           Value: {{certificateExpiry (base64Decode .Cluster.ConfigItems.etcd_client_server_cert)}}
+  AutoScalingLifecycleHook:
+    Type: "AWS::AutoScaling::LifecycleHook"
+    Properties:
+      AutoScalingGroupName: !Ref AppServer
+      LifecycleHookName: "etcd-server-lifecycle-hook"
+      LifecycleTransition: "autoscaling:EC2_INSTANCE_LAUNCHING"
+      HeartbeatTimeout: "300"
   AppServerScaleDown:
     Type: "AWS::AutoScaling::ScalingPolicy"
     Properties:
@@ -177,6 +181,8 @@ Resources:
   EtcdRole:
     Type: AWS::IAM::Role
     Properties:
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -227,6 +233,16 @@ Resources:
             Action:
             - s3:PutObject
             Resource: [ "arn:aws:s3:::{{.Cluster.ConfigItems.etcd_s3_backup_bucket}}/*" ]
+      - PolicyName: ASGCompleteLifecycle
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+          - Effect: Allow
+            Action:
+            - autoscaling:CompleteLifecycleAction
+            # The buggy CF doesn't allow to do something like !GetAtt AppServer.Arn
+            # Ref: https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/548
+            Resource: [ "arn:aws:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/etcd-cluster-etcd-AppServer*" ]
       - PolicyName: KMSDecrypt
         PolicyDocument:
           Version: "2012-10-17"

--- a/cluster/etcd-stack.yaml
+++ b/cluster/etcd-stack.yaml
@@ -219,6 +219,14 @@ Resources:
             Action:
             - s3:PutObject
             Resource: [ "arn:aws:s3:::{{.Cluster.ConfigItems.etcd_s3_backup_bucket}}/*" ]
+      - PolicyName: S3ClusterLifecycle
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+          - Effect: Allow
+            Action:
+            - s3:GetObject
+            Resource: 'arn:aws:s3:::*'
       - PolicyName: ASGCompleteLifecycle
         PolicyDocument:
           Version: "2012-10-17"

--- a/cluster/etcd-stack.yaml
+++ b/cluster/etcd-stack.yaml
@@ -128,12 +128,6 @@ Resources:
       AutoScalingGroupName: !Ref AppServer
       Cooldown: "60"
       ScalingAdjustment: "1"
-  AutoscalingLifecycleHook:
-    Properties:
-      AutoscalinggroupName: !Ref AppServer
-      LifecycleHookName: "etcd-server-lifecycle-hook"
-      LifecycleTransition: "autoscaling:EC2_INSTANCE_LAUNCHING"
-      HeartbeatTimeout: "300"
   EtcdClusterSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:

--- a/cluster/etcd-stack.yaml
+++ b/cluster/etcd-stack.yaml
@@ -124,6 +124,12 @@ Resources:
       AutoScalingGroupName: !Ref AppServer
       Cooldown: "60"
       ScalingAdjustment: "1"
+  AutoscalingLifecycleHook:
+    Properties:
+      AutoscalinggroupName: !Ref AppServer
+      LifecycleHookName: "etcd-server-lifecycle-hook"
+      LifecycleTransition: "autoscaling:EC2_INSTANCE_LAUNCHING"
+      HeartbeatTimeout: "300"
   EtcdClusterSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:


### PR DESCRIPTION
This Pull Request (PR) adds a Autoscaling Group (ASG) lifecycle hoot to the etcd manifest. A script in the base etcd AMI will complete the ASG lifecycle after verifying proper startup of etcd.

This hook is necessary for a correct use of [AWS Instance Refresh](https://aws.amazon.com/blogs/compute/introducing-instance-refresh-for-ec2-auto-scaling/), necessary after updating the ETCD manifest.

A follow-up feature will modify CLM to automate triggering Instance Refresh, in a similar way as when rotating master nodes.   
  
Signed-off-by: rreis <rodrigo.gargravarr@gmail.com>