### PR TITLE
pump the version of cadvisor

### DIFF
--- a/cluster/manifests/node-monitor/daemonset.yaml
+++ b/cluster/manifests/node-monitor/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: node-monitor
       containers:
         - name: cadvisor
-          image: registry.opensource.zalan.do/teapot/cadvisor:v0.34.0-master-5
+          image: registry.opensource.zalan.do/teapot/cadvisor:v0.44.0
           args:
             - --port=9101
             - --housekeeping_interval=10s


### PR DESCRIPTION
pump the version of cadvisor
changelog: https://github.com/google/cadvisor/compare/v0.34.0...v0.44.0

motivation:
rolling the ubuntu AMI was very slow because of Cadvisor entering crash loop `mountpoint for cpu not found`
pumping the version seems to solve the issue
https://github.com/google/cadvisor/issues/1943

also, the changelog mentions a few bugfixes to metrics collection 