### PR TITLE
Consolidate nvidia-gpu-device-plugin into kubernetes

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -19,6 +19,10 @@ pre_apply:
     volume-type: gp3
   kind: StorageClass
 {{ end }}
+- labels:
+    application: nvidia-gpu-device-plugin
+  namespace: kube-system
+  kind: DaemonSet
 
 # everything defined under here will be deleted after applying the manifests
 post_apply:

--- a/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
+++ b/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
@@ -8,18 +8,21 @@ metadata:
   name: nvidia-gpu-device-plugin
   namespace: kube-system
   labels:
-    application: nvidia-gpu-device-plugin
+    application: kubernetes
+    component: nvidia-gpu-device-plugin
     version: v0.10.0
 spec:
   updateStrategy:
     type: RollingUpdate
   selector:
     matchLabels:
-      application: nvidia-gpu-device-plugin
+      daemonset: nvidia-gpu-device-plugin
   template:
     metadata:
       labels:
-        application: nvidia-gpu-device-plugin
+        daemonset: nvidia-gpu-device-plugin
+        application: kubernetes
+        component: nvidia-gpu-device-plugin
         version: v0.10.0
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"


### PR DESCRIPTION
Consolidate the `nvidia-gpu-device-plugin` daemonset into a component of `kubernetes` instead of being a dedicated application.

Since the Daemonset pods only runs on node startup and only runs on GPU nodes it's save to just delete the daemonset and then re-create it. Therefore we simply migrate it by:

1. Deleting the daemonset if it has `application=nvidia-gpu-device-plugin` as label (via `deletions.yaml`)
2. Applying the new daemonset with `application=kubernetes,component=nvidia-gpu-device-plugin`

In a follow up PR after the rollout, the deletions.yaml entry can be dropped again.