### PR TITLE
Cleanup application/component labels

### DIFF
--- a/cluster/manifests/coredns-local/configmap-local.yaml
+++ b/cluster/manifests/coredns-local/configmap-local.yaml
@@ -4,7 +4,8 @@ metadata:
   name: coredns-local
   namespace: kube-system
   labels:
-    application: coredns
+    application: kubernetes
+    component: coredns
 data:
   unbound.conf: |
     server:

--- a/cluster/manifests/flannel/configmap.yaml
+++ b/cluster/manifests/flannel/configmap.yaml
@@ -4,7 +4,8 @@ metadata:
   name: kube-flannel-cfg
   namespace: kube-system
   labels:
-    application: flannel
+    application: kubernetes
+    component: flannel
 data:
   cni-conf.json: |
     {

--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -2,7 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    application: prometheus
+    application: kubernetes
+    component: prometheus
   name: prometheus-conf
   namespace: kube-system
 data:

--- a/cluster/manifests/prometheus/ingress.yaml
+++ b/cluster/manifests/prometheus/ingress.yaml
@@ -7,7 +7,8 @@ metadata:
     zalando.org/skipper-filter: |
       oauthTokeninfoAnyKV("realm", "/employees", "realm", "/services")
   labels:
-    application: prometheus
+    application: kubernetes
+    component: prometheus
 spec:
   rules:
   - host: system-prometheus.{{ .Values.hosted_zone }}

--- a/cluster/manifests/prometheus/prometheus-vpa.yaml
+++ b/cluster/manifests/prometheus/prometheus-vpa.yaml
@@ -4,7 +4,8 @@ metadata:
   name: prometheus-vpa
   namespace: kube-system
   labels:
-    application: prometheus
+    application: kubernetes
+    component: prometheus
 spec:
   targetRef:
     apiVersion: apps/v1

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -53,16 +53,19 @@ pipeline:
       - name: IAM_ROLE_ARN
         value: "arn:aws:iam::925511348110:role/cluster-lifecycle-manager-entrypoint"
       - name: APPLICATION
-        value: kubernetes-on-aws-e2e
+        value: kubernetes
+      - name: COMPONENT
+        value: e2e
     end2end_tests:
       metadata:
         name: e2e
         labels:
-          application: kubernetes-on-aws-e2e
+          application: kubernetes
+          component: e2e
         annotations:
           zalando.org/runtime-policy: require-on-demand
       spec:
-        serviceAccountName: kubernetes-on-aws-e2e
+        serviceAccountName: kubernetes-e2e
         restartPolicy: Never
         containers:
         - name: e2e
@@ -81,77 +84,77 @@ pipeline:
             - name: HOSTED_ZONE
               valueFrom:
                 configMapKeyRef:
-                  name: kubernetes-on-aws-e2e-config
+                  name: kubernetes-e2e-config
                   key: "HOSTED_ZONE"
             - name: REGION
               valueFrom:
                 configMapKeyRef:
-                  name: kubernetes-on-aws-e2e-config
+                  name: kubernetes-e2e-config
                   key: "REGION"
             - name: AWS_ACCOUNT
               valueFrom:
                 secretKeyRef:
-                  name: kubernetes-on-aws-e2e-config-secret
+                  name: kubernetes-e2e-config-secret
                   key: "AWS_ACCOUNT"
             - name: ZMON_ROOT_ACCOUNT_ROLE
               valueFrom:
                 secretKeyRef:
-                  name: kubernetes-on-aws-e2e-config-secret
+                  name: kubernetes-e2e-config-secret
                   key: "ZMON_ROOT_ACCOUNT_ROLE"
             - name: AUDITTRAIL_ROOT_ACCOUNT_ROLE
               valueFrom:
                 secretKeyRef:
-                  name: kubernetes-on-aws-e2e-config-secret
+                  name: kubernetes-e2e-config-secret
                   key: "AUDITTRAIL_ROOT_ACCOUNT_ROLE"
             - name: APISERVER_BUSINESS_PARTNER_IDS
               valueFrom:
                 secretKeyRef:
-                  name: kubernetes-on-aws-e2e-config-secret
+                  name: kubernetes-e2e-config-secret
                   key: "APISERVER_BUSINESS_PARTNER_IDS"
             - name: LIGHTSTEP_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: kubernetes-on-aws-e2e-config-secret
+                  name: kubernetes-e2e-config-secret
                   key: "LIGHTSTEP_TOKEN"
             - name: OWNER
               valueFrom:
                 secretKeyRef:
-                  name: kubernetes-on-aws-e2e-config-secret
+                  name: kubernetes-e2e-config-secret
                   key: "OWNER"
             - name: VPC_ID
               valueFrom:
                 secretKeyRef:
-                  name: kubernetes-on-aws-e2e-config-secret
+                  name: kubernetes-e2e-config-secret
                   key: "VPC_ID"
             - name: EFS_ID
               valueFrom:
                 secretKeyRef:
-                  name: kubernetes-on-aws-e2e-config-secret
+                  name: kubernetes-e2e-config-secret
                   key: "EFS_ID"
             - name: ETCD_CLIENT_CA_CERT
               valueFrom:
                 secretKeyRef:
-                  name: kubernetes-on-aws-e2e-config-secret
+                  name: kubernetes-e2e-config-secret
                   key: "ETCD_CLIENT_CA_CERT"
             - name: ETCD_CLIENT_CA_KEY
               valueFrom:
                 secretKeyRef:
-                  name: kubernetes-on-aws-e2e-config-secret
+                  name: kubernetes-e2e-config-secret
                   key: "ETCD_CLIENT_CA_KEY"
             - name: ETCD_SCALYR_KEY
               valueFrom:
                 secretKeyRef:
-                  name: kubernetes-on-aws-e2e-config-secret
+                  name: kubernetes-e2e-config-secret
                   key: "ETCD_SCALYR_KEY"
             - name: OKTA_AUTH_ISSUER_URL
               valueFrom:
                 secretKeyRef:
-                  name: kubernetes-on-aws-e2e-config-secret
+                  name: kubernetes-e2e-config-secret
                   key: "OKTA_AUTH_ISSUER_URL"
             - name: CLUSTER_ADMIN_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: kubernetes-on-aws-e2e-credentials
+                  name: kubernetes-e2e-credentials
                   key: "cluster-token-secret"
           resources:
             limits:
@@ -177,11 +180,12 @@ pipeline:
       metadata:
         name: e2e
         labels:
-          application: kubernetes-on-aws-e2e
+          application: kubernetes
+          component: e2e
         annotations:
           zalando.org/runtime-policy: require-on-demand
       spec:
-        serviceAccountName: kubernetes-on-aws-e2e
+        serviceAccountName: kubernetes-e2e
         restartPolicy: Never
         containers:
         - name: e2e
@@ -213,11 +217,12 @@ pipeline:
       metadata:
         name: e2e
         labels:
-          application: kubernetes-on-aws-e2e
+          application: kubernetes
+          component: e2e
         annotations:
           zalando.org/runtime-policy: require-on-demand
       spec:
-        serviceAccountName: kubernetes-on-aws-e2e
+        serviceAccountName: kubernetes-e2e
         restartPolicy: Never
         containers:
         - name: e2e
@@ -249,11 +254,12 @@ pipeline:
       metadata:
         name: e2e
         labels:
-          application: kubernetes-on-aws-e2e
+          application: kubernetes
+          component: e2e
         annotations:
           zalando.org/runtime-policy: require-on-demand
       spec:
-        serviceAccountName: kubernetes-on-aws-e2e
+        serviceAccountName: kubernetes-e2e
         restartPolicy: Never
         containers:
         - name: e2e
@@ -287,11 +293,12 @@ pipeline:
       metadata:
         name: e2e
         labels:
-          application: kubernetes-on-aws-e2e
+          application: kubernetes
+          component: e2e
         annotations:
           zalando.org/runtime-policy: require-on-demand
       spec:
-        serviceAccountName: kubernetes-on-aws-e2e
+        serviceAccountName: kubernetes-e2e
         restartPolicy: Never
         containers:
         - name: e2e

--- a/test/e2e/apply/config.yaml
+++ b/test/e2e/apply/config.yaml
@@ -3,7 +3,8 @@ kind: ConfigMap
 metadata:
   labels:
     application: "{{{APPLICATION}}}"
-  name: "{{{APPLICATION}}}-config"
+    component: "{{{COMPONENT}}}"
+  name: "{{{APPLICATION}}}-{{{COMPONENT}}}-config"
 data:
   HOSTED_ZONE: "teapot-e2e.zalan.do"
   REGION: "eu-central-1"

--- a/test/e2e/apply/pcs.yaml
+++ b/test/e2e/apply/pcs.yaml
@@ -1,10 +1,10 @@
 apiVersion: zalando.org/v1
 kind: PlatformCredentialsSet
 metadata:
-  name: "{{{APPLICATION}}}-credentials"
+  name: "{{{APPLICATION}}}-{{{COMPONENT}}}-credentials"
 spec:
   application: "{{{APPLICATION}}}"
   token_version: "v2"
   tokens:
     cluster:
-      privileges: [ ]
+      privileges: []

--- a/test/e2e/apply/pdb.yaml
+++ b/test/e2e/apply/pdb.yaml
@@ -1,9 +1,10 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: "{{{APPLICATION}}}"
+  name: "{{{APPLICATION}}}-{{{COMPONENT}}}"
 spec:
   maxUnavailable: 0
   selector:
     matchLabels:
       application: "{{{APPLICATION}}}"
+      component: "{{{COMPONENT}}}"

--- a/test/e2e/apply/secret.yaml
+++ b/test/e2e/apply/secret.yaml
@@ -3,7 +3,8 @@ kind: Secret
 metadata:
   labels:
     application: "{{{APPLICATION}}}"
-  name: "{{{APPLICATION}}}-config-secret"
+    component: "{{{COMPONENT}}}"
+  name: "{{{APPLICATION}}}-{{{COMPONENT}}}-config-secret"
 data:
   APISERVER_BUSINESS_PARTNER_IDS: "deployment-secret:2:stups-test:AQICAHjXIrc66g/+P4X1Gl4MKcInWmwpFxivAqFGMI0fr9DvCwHXvjlTSy6xdvtOFGwvk/K9AAAAizCBiAYJKoZIhvcNAQcGoHsweQIBADB0BgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDI3M2uHJxu1Jil6cCQIBEIBHuhx2zqt5UHNiuMVWcimzcnCNxaQ7UcdiMz4q9Sl/nVNlzH8SdwzT2LYS7X+/GsEWJkC2DUpcdMtXcqRaCIhhg71pqdDkNYg="
   AUDITTRAIL_ROOT_ACCOUNT_ROLE: "deployment-secret:2:stups-test:AQICAHjXIrc66g/+P4X1Gl4MKcInWmwpFxivAqFGMI0fr9DvCwFA15cAu5Zv+eGm55PJ7pb0AAAAlTCBkgYJKoZIhvcNAQcGoIGEMIGBAgEAMHwGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMUAVhXZuDkP9Nf5HgAgEQgE8YF0sEjodDrJTYJTtF5OgJqE0Prt5Gjn94upihElN8hw9/s/7JBatS4+lBnLpVY6ToZl4Y3xq+RBdu3kEXfmFfZ6kJbt3OhhGuBA8tnddU"

--- a/test/e2e/apply/serviceaccount.yaml
+++ b/test/e2e/apply/serviceaccount.yaml
@@ -1,8 +1,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: "{{{APPLICATION}}}"
+  name: "{{{APPLICATION}}}-{{{COMPONENT}}}"
   labels:
     application: "{{{APPLICATION}}}"
+    component: "{{{COMPONENT}}}"
   annotations:
     iam.amazonaws.com/role: "{{{IAM_ROLE_ARN}}}"

--- a/test/e2e/audit.go
+++ b/test/e2e/audit.go
@@ -23,8 +23,8 @@ import (
 
 var (
 	auditTestUser = authnv1.UserInfo{
-		Username: "zalando-iam:zalando:service:stups_kubernetes-on-aws-e2e",
-		UID:      "zalando-iam:zalando:service:stups_kubernetes-on-aws-e2e",
+		Username: "zalando-iam:zalando:service:stups_kubernetes",
+		UID:      "zalando-iam:zalando:service:stups_kubernetes",
 		Groups: []string{
 			"system:masters",
 			"zalando-iam:realm:services",


### PR DESCRIPTION
* Cleanup old application labels on various resources after they have been consolidated into a component of the `kubernetes` application.
* Use `kubernetes/e2e` for the e2e test run instead of a dedicated application.

Depends on #5150 being fully rolled out.