### PR TITLE
Disable tracking of zmon-appliance worker pods in Prometheus

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -722,3 +722,6 @@ observability_metrics_port: "8443"
 
 # list of comma separated buckets which are accessible by zmon
 zmon_accessible_s3_buckets: ""
+
+# disable zmon-appliance worker tracking in Prometheus
+disable_zmon_appliance_worker_tracking: "true"

--- a/cluster/manifests/node-monitor/daemonset.yaml
+++ b/cluster/manifests/node-monitor/daemonset.yaml
@@ -45,7 +45,7 @@ spec:
             - --docker_only
             - --raw_cgroup_prefix_whitelist=/system.slice/kubelet.service
             - --store_container_labels=false
-            - --whitelisted_container_labels=io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace,io.kubernetes.pod.uid,application
+            - --whitelisted_container_labels=io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace,io.kubernetes.pod.uid,application,component
           resources:
             requests:
               cpu: "{{ .ConfigItems.cadvisor_cpu }}"

--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -139,6 +139,11 @@ data:
         action: keep
         regex: kube-state-metrics
       metric_relabel_configs:
+{{- if eq .Cluster.ConfigItems.disable_zmon_appliance_worker_tracking "true" }}
+      - action: drop
+        source_labels: [pod]
+        regex: "zmon-appliance-worker-.*"
+{{- end }}
       - action: replace
         source_labels: [pod]
         target_label: pod_name
@@ -260,6 +265,11 @@ data:
         source_labels: ['__meta_kubernetes_pod_node_name']
         target_label: node_name
       metric_relabel_configs:
+{{- if eq .Cluster.ConfigItems.disable_zmon_appliance_worker_tracking "true" }}
+      - action: drop
+        source_labels: ["container_label_application", "container_label_component"]
+        regex: "zmon-appliance;worker"
+{{- end }}
       - action: replace
         source_labels: ['container_label_application']
         target_label: application


### PR DESCRIPTION
Our current monitoring works like this:

1. Prometheus scrapes information about pods
2. For each pod, ZMON worker executes a check which is one or more calls to prometheus querying data about the pod.
3. If the check execution takes longer, ZMON worker scales up to compensate.
4. Since we track all pods in Prometheus, more zmon worker pods leads to more load on prometheus which lead to response times, which leads to longer check execution time, which again leads to zmon worker scaling out.

This circular effect can sometimes result in hundreds or thousands of zmon worker pods running which is not very cost effecient.

As an attempt to easy the problem a bit, this PR introduces a config item (true by default) to disable tracking of ZMON worker pods in Prometheus. The theory is that if we don't track the pods, there is less load and it's less likely that this crazy scale-up happen. It needs to be validated in practice.