### PR TITLE
fix: only add skipper-ingress node pools to the TG 

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -60,10 +60,11 @@ skipper_ingress_cpu: "1000m"
 skipper_ingress_memory: "1Gi"
 # skipper node-pool
 enable_dedicate_nodepool_skipper: "true"
-skipper_attach_only_to_skipper_node_pool: "true"
 {{if eq .Cluster.Environment "e2e"}}
+skipper_attach_only_to_skipper_node_pool: "false"
 skipper_topology_spread_enabled: "true"
 {{else}}
+skipper_attach_only_to_skipper_node_pool: "true"
 skipper_topology_spread_enabled: "false"
 {{end}}
 skipper_suppress_route_update_logs: "true"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -58,17 +58,15 @@ skipper_ingress_min_replicas: "2"
 {{end}}
 skipper_ingress_cpu: "1000m"
 skipper_ingress_memory: "1Gi"
-{{if eq .Cluster.Environment "e2e"}}
-enable_dedicate_nodepool_skipper: "false"
-{{else}}
+# skipper node-pool
 enable_dedicate_nodepool_skipper: "true"
-{{end}}
-skipper_suppress_route_update_logs: "true"
+skipper_attach_only_to_skipper_node_pool: "true"
 {{if eq .Cluster.Environment "e2e"}}
 skipper_topology_spread_enabled: "true"
 {{else}}
 skipper_topology_spread_enabled: "false"
 {{end}}
+skipper_suppress_route_update_logs: "true"
 
 # skipper default filters
 skipper_default_filters: 'enableAccessLog(4,5) -> lifo(2000,20000,"3s")'

--- a/cluster/node-pools/worker-combined/stack.yaml
+++ b/cluster/node-pools/worker-combined/stack.yaml
@@ -51,11 +51,17 @@ Resources:
       - Key: node.kubernetes.io/role
         PropagateAtLaunch: true
         Value: worker
-# only node pools without taints should be attached to Ingress Load balancer
-{{- if or (not (index .NodePool.ConfigItems "taints")) (eq (index .NodePool.ConfigItems "taints") "dedicated=skipper-ingress:NoSchedule") }}
+# only skipper-ingress node pools should be attached to Ingress Load balancer
+{{- if and (eq .Cluster.ConfigItems.skipper_attach_only_to_skipper_node_pool "true") (eq (index .NodePool.ConfigItems "taints") "dedicated=skipper-ingress:NoSchedule") }}
       - Key: zalando.org/ingress-enabled
         Value: "true"
         PropagateAtLaunch: true
+# only node pools without taints should be attached to Ingress Load balancer
+{{- else if and (not (eq .Cluster.ConfigItems.skipper_attach_only_to_skipper_node_pool "true")) (or (not (index .NodePool.ConfigItems "taints")) (eq (index .NodePool.ConfigItems "taints") "dedicated=skipper-ingress:NoSchedule")) }}
+      - Key: zalando.org/ingress-enabled
+        Value: "true"
+        PropagateAtLaunch: true
+}}
 {{- end }}
       - Key: k8s.io/cluster-autoscaler/enabled
         PropagateAtLaunch: true

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -55,8 +55,13 @@ Resources:
       - Key: node.kubernetes.io/role
         PropagateAtLaunch: true
         Value: worker
+# only skipper-ingress node pools should be attached to Ingress Load balancer
+{{- if and (eq $data.Cluster.ConfigItems.skipper_attach_only_to_skipper_node_pool "true") (eq (index $data.NodePool.ConfigItems "taints") "dedicated=skipper-ingress:NoSchedule") }}
+      - Key: zalando.org/ingress-enabled
+        Value: "true"
+        PropagateAtLaunch: true
 # only node pools without taints should be attached to Ingress Load balancer
-{{- if or (not (index $data.NodePool.ConfigItems "taints")) (eq (index $data.NodePool.ConfigItems "taints") "dedicated=skipper-ingress:NoSchedule") }}
+{{- else if and (not (eq $data.Cluster.ConfigItems.skipper_attach_only_to_skipper_node_pool "true")) (or (not (index $data.NodePool.ConfigItems "taints")) (eq (index $data.NodePool.ConfigItems "taints") "dedicated=skipper-ingress:NoSchedule")) }}
       - Key: zalando.org/ingress-enabled
         Value: "true"
         PropagateAtLaunch: true

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -90,6 +90,15 @@ clusters:
     min_size: 0
     max_size: 21
   - discount_strategy: spot
+    instance_types: ["c5.large", "c5a.large", "m5a.large", "m5.large", "t3.large"]
+    min_size: 0
+    max_size: 9
+    profile: worker-splitaz
+    name: skipper-ingress-node
+    config_items:
+      labels: dedicated=skipper-ingress
+      taints: dedicated=skipper-ingress:NoSchedule
+  - discount_strategy: spot
     instance_types: ["m5a.large", "m5.large", "m5.xlarge", "m5a.xlarge", "t3.large", "t3.xlarge", "c5a.large", "c5a.xlarge"]
     min_size: 0
     max_size: 3


### PR DESCRIPTION
fix: only add skipper-ingress node pools to the TG members to increase node scalability

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>