### PR TITLE
Update Kubernetes to v1.21.12

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -497,7 +497,7 @@ tracing_coredns_local_zone_traces_endpoint: ""
 # AMI id given the image name and the Image AWS account owner.
 #
 # [0]: https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/8a9bd1cb2d094038a9e23e646421f8146b48886a/provisioner/template.go#L116
-kuberuntu_image_v1_21: {{ amiID "zalando-ubuntu-kubernetes-production-v1.21.11-master-216" "861068367966"}}
+kuberuntu_image_v1_21: {{ amiID "zalando-ubuntu-kubernetes-production-v1.21.12-master-225" "861068367966"}}
 
 # Feature toggle for auditing events
 audit_pod_events: "true"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -497,7 +497,7 @@ tracing_coredns_local_zone_traces_endpoint: ""
 # AMI id given the image name and the Image AWS account owner.
 #
 # [0]: https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/8a9bd1cb2d094038a9e23e646421f8146b48886a/provisioner/template.go#L116
-kuberuntu_image_v1_21: {{ amiID "zalando-ubuntu-kubernetes-production-v1.21.12-master-225" "861068367966"}}
+kuberuntu_image_v1_21: {{ amiID "zalando-ubuntu-kubernetes-production-v1.21.12-master-226" "861068367966"}}
 
 # Feature toggle for auditing events
 audit_pod_events: "true"


### PR DESCRIPTION
This is an update of Kubernetes from `v1.21.11` to `v1.21.12`.

It's a little phony: The latest AMI was based on Ubuntu 22.04 but not rolled out. We reverted the AMI back to Ubuntu 20.04 for the meantime but kept all the changes that happened in-between. This AMI also pre-pulls its (multi-arch) images from our new registry.

This leaves us with this update, which doesn't change the Kernel version but increases the Kubernetes version, amongst a couple other small changes.

This is mostly here to run e2e tests on the latest AMI. It replaces https://github.com/zalando-incubator/kubernetes-on-aws/pull/5146.