### PR TITLE
Pull admission-controller from the new registry

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -200,7 +200,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: registry.opensource.zalan.do/teapot/admission-controller:master-146
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-149
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
Would be nice if it worked like that but I think we cannot pull the vanity URL from a static pod. Let's run e2e to confirm.