### PR TITLE
Add Default Config-items to Enable Kubernetes ServiceCIDR Migration.

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -373,6 +373,9 @@ teapot_admission_controller_deployment_default_max_unavailable: "1"
 teapot_admission_controller_inject_aws_waiter: "true"
 teapot_admission_controller_parent_resource_hash: "true"
 
+# Define ExternalIPs is not allowed
+teapot_admission_controller_check_service_resources: "true"
+
 ## Defaults are set per-cluster
 teapot_admission_controller_check_daemonset_resources: "true"
 teapot_admission_controller_daemonset_reserved_cpu: "8"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -167,6 +167,10 @@ zmon_kairosdb_url: "https://data-service.zmon.zalan.do/kairosdb-proxy"
 enable_skipper_eastwest_dns: "true"
 enable_skipper_eastwest: "false"
 
+# Configure skipper-internal ClusterIP to Coredns query
+skipper_internal_cluster_ip: "10.3.99.99"
+skipper_internal_cluster_ip_additional: "10.3.99.99"
+
 # enable temporay logging of ingress.cluster.local names
 # used to find services for which it's being used.
 skipper_eastwest_dns_log_enabled: "false"
@@ -507,6 +511,13 @@ coredns_log_forward: "false"
 # clusters and prevent CoreDNS from running out of memory in case of spikes.
 coredns_max_upstream_concurrency: 2000 # 0 means there is no concurrency limits
 
+# Temporarily added to support Kubernetes service range migration.
+coredns_cluster_ip_2: 10.3.0.11
+coredns_cluster_ip_1: 10.3.0.11
+# Coredns reverse lookup of kubernetes addresses
+coredns_cluster_cidr_local_zone: "2.10.in-addr.arpa."
+coredns_service_cluster_local_zone: "3.10.in-addr.arpa."
+
 tracing_coredns_route_traces_to_local_zone: "false"
 tracing_coredns_global_traces_endpoint: ""
 tracing_coredns_local_zone_traces_endpoint: ""
@@ -527,6 +538,18 @@ audittrail_url: "https://audittrail.cloud.zalando.com"
 audittrail_url: ""
 {{end}}
 audittrail_root_account_role: ""
+
+# kube-apiserver / kube-proxy container image name.
+# Temporarily added to help during the Kubernetes service network range migration.
+kube_apiserver_container_image_name: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/kube-apiserver-internal:v1.21.12-master-79
+kube_proxy_container_image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/kube-proxy-internal:v1.21.12-master-79
+
+# A CIDR notation IP range from which to assign service cluster IPs.
+# This must not overlap with any IP ranges assigned to nodes or pods.
+service_cluster_ip_range: "10.3.0.0/16"
+
+# CIDR Range for Pods in cluster
+cluster_cidr: "10.2.0.0/16"
 
 # CIDR configuration for nodes and pods
 # Changing this will change the number of nodes and pods we can schedule in the

--- a/cluster/manifests/01-admission-control/teapot.yaml
+++ b/cluster/manifests/01-admission-control/teapot.yaml
@@ -226,6 +226,7 @@ webhooks:
         apiGroups: [""]
         apiVersions: ["v1"]
         resources: ["namespaces"]
+{{- if eq .Cluster.ConfigItems.teapot_admission_controller_check_service_resources "true" }}
   - name: service-admitter.teapot.zalan.do
     clientConfig:
       url: "https://localhost:8085/service"
@@ -239,3 +240,4 @@ webhooks:
         apiGroups: [""]
         apiVersions: ["v1"]
         resources: ["services"]
+{{- end }}

--- a/cluster/manifests/coredns-local/configmap-local.yaml
+++ b/cluster/manifests/coredns-local/configmap-local.yaml
@@ -29,8 +29,8 @@ data:
       minimal-responses: yes
       extended-statistics: yes
       # support reverse lookup of kubernetes addresses
-      local-zone: "2.10.in-addr.arpa." transparent
-      local-zone: "3.10.in-addr.arpa." transparent
+      local-zone: "{{ .ConfigItems.coredns_cluster_cidr_local_zone }}" transparent
+      local-zone: "{{ .ConfigItems.coredns_service_cluster_local_zone }}" transparent
       # make metrics available for the unbound-telemetry container (127.0.0.1:9054)
       remote-control:
         control-enable: yes
@@ -39,10 +39,10 @@ data:
       name: "."
       forward-addr: 127.0.0.1@9254 # coredns
     forward-zone:
-      name: "2.10.in-addr.arpa."
+      name: "{{ .ConfigItems.coredns_cluster_cidr_local_zone }}"
       forward-addr: 127.0.0.1@9254 # coredns
     forward-zone:
-      name: "3.10.in-addr.arpa."
+      name: "{{ .ConfigItems.coredns_service_cluster_local_zone }}"
       forward-addr: 127.0.0.1@9254 # coredns
   Corefile: |
 {{ if and (ne .ConfigItems.custom_dns_zone "") (ne .ConfigItems.custom_dns_zone_nameservers "") }}
@@ -68,7 +68,8 @@ data:
 {{ end }}
         template IN A {
             match "^.*[.]ingress[.]cluster[.]local"
-            answer "{{"{{"}} .Name {{"}}"}} 60 IN A 10.3.99.99"
+            answer "{{"{{"}} .Name {{"}}"}} 60 IN A {{ .ConfigItems.skipper_internal_cluster_ip }}"
+            additional "{{"{{"}} .Name {{"}}"}} 60 IN A {{ .ConfigItems.skipper_internal_cluster_ip_additional }}"
             fallthrough
         }
         template IN AAAA {
@@ -79,9 +80,9 @@ data:
     }
 {{ end }}
 
-    # 10.2.0.0/16, 10.3.0.0/16 defines that this server is authority for revese
+    # Defines that this server is authority for reverse
     # lookups for these ranges.
-    cluster.local:9254 10.2.0.0/16:9254 10.3.0.0/16:9254 {{ if eq .ConfigItems.tracing_coredns_route_traces_to_local_zone "true"}}{{ range $src := split .ConfigItems.tracing_coredns_global_traces_endpoint  "," }}{{ $src }}:9254 {{ end }} {{ end }} {
+    cluster.local:9254 {{ .ConfigItems.cluster_cidr }}:9254 {{ .ConfigItems.service_cluster_ip_range }}:9254 {{ if eq .ConfigItems.tracing_coredns_route_traces_to_local_zone "true"}}{{ range $src := split .ConfigItems.tracing_coredns_global_traces_endpoint  "," }}{{ $src }}:9254 {{ end }} {{ end }} {
         errors
         {{ if eq .ConfigItems.tracing_coredns_route_traces_to_local_zone "true"}}
           {{- with $cluster := .Cluster }}

--- a/cluster/manifests/coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/coredns-local/daemonset-coredns.yaml
@@ -122,7 +122,8 @@ spec:
         - --neg-ttl=60
         # send requests to the last server first, only fallback to the previous ones if it's unreachable
         - --strict-order
-        - --server=10.3.0.11#53
+        - --server={{ .Cluster.ConfigItems.coredns_cluster_ip_2 }}#53
+        - --server={{ .Cluster.ConfigItems.coredns_cluster_ip_1 }}#53
         - --server=127.0.0.1#9254
         ports:
         - containerPort: 53

--- a/cluster/manifests/coredns-local/service-coredns.yaml
+++ b/cluster/manifests/coredns-local/service-coredns.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   selector:
     component: coredns
-  clusterIP: 10.3.0.11
+  clusterIP: {{ .Cluster.ConfigItems.coredns_cluster_ip_1 }}
   ports:
   - name: dns
     port: 53

--- a/cluster/manifests/flannel/configmap.yaml
+++ b/cluster/manifests/flannel/configmap.yaml
@@ -23,7 +23,7 @@ data:
     }
   net-conf.json: |
     {
-      "Network": "10.2.0.0/16",
+      "Network": "{{ .ConfigItems.cluster_cidr }}",
       "Backend": {
         "Type": "vxlan"
       }

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
       hostNetwork: true
       containers:
       - name: kube-proxy
-        image: nonexistent.zalan.do/teapot/kube-proxy:fixed
+        image: {{.Cluster.ConfigItems.kube_proxy_container_image}}
         args:
         - --hostname-override=$(HOSTNAME_OVERRIDE)
         - --config=/config/kube-proxy.yaml

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -113,7 +113,7 @@ spec:
 {{ end }}
 {{ if ne .ConfigItems.skipper_routesrv_enabled "exec" }}
           - "-kubernetes-east-west-range-domains=ingress.cluster.local"
-          - "-kubernetes-east-west-range-predicates=ClientIP(\"10.2.0.0/16\", \"{{ .Values.vpc_ipv4_cidr }}\")"
+          - "-kubernetes-east-west-range-predicates=ClientIP(\"{{ .Cluster.ConfigItems.cluster_cidr }}\", \"{{ .Values.vpc_ipv4_cidr }}\")"
 {{ end }}
           - "-proxy-preserve-host"
           - "-compress-encodings={{ .ConfigItems.skipper_compress_encodings }}"
@@ -216,7 +216,7 @@ spec:
 {{ end }}
 {{ if or (eq .ConfigItems.nlb_switch "pre") (eq .ConfigItems.nlb_switch "exec") }}
           - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
-          - "-forwarded-headers-exclude-cidrs=10.2.0.0/16,{{ .Values.vpc_ipv4_cidr}}"
+          - "-forwarded-headers-exclude-cidrs={{ .Cluster.ConfigItems.cluster_cidr }},{{ .Values.vpc_ipv4_cidr}}"
 {{ end }}
 {{ if ne .ConfigItems.skipper_ingress_inline_routes "" }}
           - "-inline-routes={{ .ConfigItems.skipper_ingress_inline_routes }}"
@@ -402,7 +402,7 @@ spec:
           - "-kubernetes-east-west-domain=.ingress.cluster.local"
 {{ end }}
           - "-kubernetes-east-west-range-domains=ingress.cluster.local"
-          - "-kubernetes-east-west-range-predicates=ClientIP(\"10.2.0.0/16\", \"{{ .Values.vpc_ipv4_cidr }}\")"
+          - "-kubernetes-east-west-range-predicates=ClientIP(\"{{ .Cluster.ConfigItems.cluster_cidr }}\", \"{{ .Values.vpc_ipv4_cidr }}\")"
           - "-reverse-source-predicate"
           - "-enable-api-usage-monitoring"
           - "-api-usage-monitoring-realm-keys=https://identity.zalando.com/realm"
@@ -411,7 +411,7 @@ spec:
           - "-default-filters-dir=/etc/config/default-filters"
 {{ if or (eq .ConfigItems.nlb_switch "pre") (eq .ConfigItems.nlb_switch "exec") }}
           - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
-          - "-forwarded-headers-exclude-cidrs=10.2.0.0/16,{{ .Values.vpc_ipv4_cidr}}"
+          - "-forwarded-headers-exclude-cidrs={{ .Cluster.ConfigItems.cluster_cidr }},{{ .Values.vpc_ipv4_cidr}}"
 {{ end }}
         resources:
           limits:

--- a/cluster/manifests/skipper/service-internal.yaml
+++ b/cluster/manifests/skipper/service-internal.yaml
@@ -8,7 +8,7 @@ metadata:
     component: ingress
 spec:
   type: ClusterIP
-  clusterIP: 10.3.99.99
+  clusterIP: {{ .ConfigItems.skipper_internal_cluster_ip }}
   ports:
     - port: 80
       targetPort: 9999

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -95,7 +95,7 @@ write_files:
         terminationGracePeriodSeconds: 80
         containers:
         - name: kube-apiserver
-          image: nonexistent.zalan.do/teapot/kube-apiserver:fixed
+          image: {{.Cluster.ConfigItems.kube_apiserver_container_image_name}}
           args:
           - --apiserver-count={{ .Values.apiserver_count }}
           - --bind-address=0.0.0.0
@@ -114,7 +114,7 @@ write_files:
           - --storage-media-type=application/vnd.kubernetes.protobuf
           - --encryption-provider-config=/etc/kubernetes/config/encryption-config.yaml
           - --allow-privileged=true
-          - --service-cluster-ip-range=10.3.0.0/16
+          - --service-cluster-ip-range={{.Cluster.ConfigItems.service_cluster_ip_range}}
           - --secure-port=443
           - --enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,ExtendedResourceToleration,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota,StorageObjectInUseProtection,PodSecurityPolicy,Priority,NodeRestriction
           - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
@@ -593,7 +593,7 @@ write_files:
           - --use-service-account-credentials=true
           - --configure-cloud-routes=false
           - --allocate-node-cidrs=true
-          - --cluster-cidr=10.2.0.0/16
+          - --cluster-cidr={{ .Cluster.ConfigItems.cluster_cidr}}
           - --node-cidr-mask-size={{ .Cluster.ConfigItems.node_cidr_mask_size }}
           - --kube-api-qps=50
           - --terminated-pod-gc-threshold=500


### PR DESCRIPTION
- The admission-controller denies externalIPs by default, but we need to change the externalIP to keep the old serviceIP available during the network service migration. the `teapot_admission_controller_check_service_resources=false` allows the usage of  externalIPs
- For the Kubernetes service migration, we need to use patched docker images for kube-proxy and kube-apiserver. The patch allows us to change the service clusterIP for the new IP in the new ServiceCIDR range, this behavior is not allowed by default.
Once the Kubernetes Service CIDR migration has completed this change should be undone by setting again the default docker images for kube-apiserver and kube-proxy
Patch: https://github.bus.zalan.do/teapot/kubernetes-pipeline/pull/71/files
- To avoid disruptions during the migration the configuration from coredns, flannel, and skipper-internal need to be updated with the new service CIDR range

For: https://github.bus.zalan.do/teapot/issues/issues/3243