### PR TITLE
update Kubernetes AMI to new naming scheme

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -500,7 +500,7 @@ tracing_coredns_local_zone_traces_endpoint: ""
 # AMI id given the image name and the Image AWS account owner.
 #
 # [0]: https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/8a9bd1cb2d094038a9e23e646421f8146b48886a/provisioner/template.go#L116
-kuberuntu_image_v1_21: {{ amiID "zalando-ubuntu-kubernetes-production-v1.21.12-master-227" "861068367966"}}
+kuberuntu_image_v1_21: {{ amiID "zalando-ubuntu-kubernetes-production-v1.21.12-amd64-master-229" "861068367966"}}
 
 # Feature toggle for auditing events
 audit_pod_events: "true"


### PR DESCRIPTION
Updates the Kubernetes AMI to its latest version. AMI should be identical to https://github.com/zalando-incubator/kubernetes-on-aws/pull/5171.