### PR TITLE
skipper-ingress/hpa: remove `skipper_scaling_schedule_hyped_articles_target` config

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -231,13 +231,10 @@ skipper_oauth2_ui_login: "true"
 skipper_time_based_scaling_check_id: ""
 skipper_time_based_scaling_target: "1"
 # ClusterScalingSchedules
-# hyped-article-releases
-skipper_scaling_schedule_hyped_articles_target: ""
 # One or multiple cluster scaling schedules can be configured as a
 # comma-separated list of <cluster schedule name>=<target value> pairs.
-# E.g. to configure "weekdays" cluster schedule with a target value of 3 and
-# "weekends" with a target value of 5 set
-# skipper_cluster_scaling_schedules: "weekdays=3,weekends=5"
+# E.g. to configure "schedule1" cluster schedule with a target value of 3 and "schedule2" with a target value of 5 set
+# skipper_cluster_scaling_schedules: "schedule1=3,schedule2=5"
 skipper_cluster_scaling_schedules: ""
 
 # cadvisor settings

--- a/cluster/manifests/skipper/hpa.yaml
+++ b/cluster/manifests/skipper/hpa.yaml
@@ -41,19 +41,6 @@ spec:
             tag-application: "skipper-ingress"
             aggregators: last
 {{ end }}
-{{ if ne .ConfigItems.skipper_scaling_schedule_hyped_articles_target "" }}
-  - type: Object
-    object:
-      describedObject:
-        apiVersion: zalando.org/v1
-        kind: ClusterScalingSchedule
-        name: hyped-article-release
-      metric:
-        name: hyped-article-release
-      target:
-        averageValue: {{ .ConfigItems.skipper_scaling_schedule_hyped_articles_target }}
-        type: AverageValue
-{{ end }}
 {{ if ne .ConfigItems.skipper_cluster_scaling_schedules "" }}
   {{ range split .ConfigItems.skipper_cluster_scaling_schedules "," }}
   {{ $name_target := split . "=" }}


### PR DESCRIPTION
Removes `skipper_scaling_schedule_hyped_articles_target` in favour of
generic `skipper_cluster_scaling_schedules`.

Non-empty `skipper_scaling_schedule_hyped_articles_target` values are already converted to `skipper_cluster_scaling_schedules` and removed.

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>