### PR TITLE
Reenable extensions/v1beta1 for ingresses for ReadOnly role

### DIFF
--- a/cluster/manifests/roles/readonly-role.yaml
+++ b/cluster/manifests/roles/readonly-role.yaml
@@ -169,6 +169,7 @@ rules:
   - list
   - watch
 - apiGroups:
+  - extensions
   - networking.k8s.io
   resources:
   - ingresses


### PR DESCRIPTION
This permission is used by CDP/deployment-service as long as ingress resources of apiversion `extensions/v1beta1` are deployed. Therefore we can't disable this before the `extensions/v1beta1` api has been disabled.