### PR TITLE
Use real multiarch image for redis

### DIFF
--- a/cluster/manifests/skipper/skipper-redis.yaml
+++ b/cluster/manifests/skipper/skipper-redis.yaml
@@ -46,7 +46,7 @@ spec:
                 - skipper-ingress-redis
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       containers:
-      - image: container-registry.zalando.net/library/redis-6-alpine:6-alpine-20220614
+      - image: container-registry.zalando.net/library/redis-6-alpine:6-alpine-20220622
         name: skipper-ingress-redis
         args:
         - /usr/local/bin/docker-entrypoint.sh


### PR DESCRIPTION
Previous version of the image was not multi-arch, this one is :)