### PR TITLE
add v1beta1 crd enable config item for testing

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -237,6 +237,11 @@ skipper_time_based_scaling_target: "1"
 # skipper_cluster_scaling_schedules: "schedule1=3,schedule2=5"
 skipper_cluster_scaling_schedules: ""
 
+# kube-api-server settings
+# This parameter will be set to default 'true' when testing is in progress.
+# Will later be changed to default 'false' as a sane value.
+allow_v1beta1_crds: "true"
+
 # cadvisor settings
 cadvisor_cpu: "150m"
 cadvisor_memory: "150Mi"

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -120,7 +120,7 @@ write_files:
           - --enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,ExtendedResourceToleration,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota,StorageObjectInUseProtection,PodSecurityPolicy,Priority,NodeRestriction
           - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
           - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
-          - --runtime-config=extensions/v1beta1/networkpolicies=true,policy/v1beta1=true,authorization.k8s.io/v1beta1=true,scheduling.k8s.io/v1alpha1=true,admissionregistration.k8s.io/v1beta1=true
+          - --runtime-config=extensions/v1beta1/networkpolicies=true,policy/v1beta1=true,authorization.k8s.io/v1beta1=true,scheduling.k8s.io/v1alpha1=true,admissionregistration.k8s.io/v1beta1=true,apiextensions.k8s.io/v1beta1={{ .Cluster.ConfigItems.allow_v1beta1_crds }}
           - --authentication-token-webhook-config-file=/etc/kubernetes/config/authn.yaml
           - --authentication-token-webhook-cache-ttl=10s
           - --cloud-provider=aws


### PR DESCRIPTION
In the effort to upgrade the CRD versions, there's a need to disable entry of ``v1beta1`` CRDs into clusters while dealing with the migration of existing ones.

This ``config-item`` named ``allow_v1beta1_crds`` is being added to be used as follows:
1. The default value will remain ``true`` to match with the existing ``runtime-config`` of the ``api-server`` of a cluster.
2. Using ``zregistry`` the value will be switched to ``false`` on a test cluster to ensure it works as expected.
3. Upon there being no side-effects per testing, it will be slowly rolled out to other clusters, starting with the ones that have no ``v1beta1`` CRD object in them. Both production and test clusters.
4. The default value will then be changed to ``false``, which will rollout the change to the all the clusters.