### PR TITLE
Update to kube-metrics-adapter v0.1.19

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.19
+        image: container-registry.zalando.net/teapot/kube-metrics-adapter:v0.1.19-2-g3796948
         env:
         - name: AWS_REGION
           value: {{ .Region }}

--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.18
+        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.19
         env:
         - name: AWS_REGION
           value: {{ .Region }}

--- a/test/e2e/kube_metrics_adapter_test.go
+++ b/test/e2e/kube_metrics_adapter_test.go
@@ -71,40 +71,6 @@ var _ = describe("[HPA] Horizontal pod autoscaling (scale resource: Custom Metri
 
 	})
 
-	It("should scale down with Custom Metric of type Object from Skipper [Ingress] [CustomMetricsAutoscaling] [Zalando]", func() {
-		hostName := fmt.Sprintf("%s-%d.%s", DeploymentName, time.Now().UTC().Unix(), E2EHostedZone())
-
-		initialReplicas := 2
-		scaledReplicas := 1
-		metricValue := 10
-		metricTarget := int64(metricValue) * 2
-		labels := map[string]string{
-			"application": DeploymentName,
-		}
-		port := 80
-		targetPort := 8000
-		targetUrl := hostName + "/metrics"
-		ingress := createIngress(DeploymentName, hostName, f.Namespace.Name, "/", netv1.PathTypePrefix, labels, nil, port)
-		tc := CustomMetricTestCase{
-			framework:       f,
-			kubeClient:      cs,
-			jig:             jig,
-			initialReplicas: initialReplicas,
-			scaledReplicas:  scaledReplicas,
-			deployment:      simplePodDeployment(DeploymentName, int32(initialReplicas)),
-			ingress:         ingress,
-			hpa:             rpsBasedHPA(DeploymentName, ingress.Name, "extensions/v1beta1", "Ingress", metricTarget),
-			service:         createServiceTypeClusterIP(DeploymentName, labels, 80, targetPort),
-			auxDeployments: []*appsv1.Deployment{
-				createVegetaDeployment(targetUrl, metricValue),
-			},
-		}
-		tc.Run()
-	})
-
-	// TODO: this is almost identical to the test above, but tests that the
-	// HPA can scale when the referenced ingress uses the networking.k8s.io
-	// apiGroup
 	It("should scale down with Custom Metric of type Object from Skipper (networking.k8s.io) [Ingress] [CustomMetricsAutoscaling] [Zalando]", func() {
 		hostName := fmt.Sprintf("%s-%d.%s", DeploymentName, time.Now().UTC().Unix(), E2EHostedZone())
 


### PR DESCRIPTION
Update to latest version of kube-metrics-adapter which limits ingress
support to only `networking.k8s.io/v1`.

Signed-off-by: Katyanna Moura <amelie.kn@gmail.com>