### PR TITLE
Use node pool's architecture to decide which AMI to use

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -504,7 +504,8 @@ tracing_coredns_local_zone_traces_endpoint: ""
 # AMI id given the image name and the Image AWS account owner.
 #
 # [0]: https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/8a9bd1cb2d094038a9e23e646421f8146b48886a/provisioner/template.go#L116
-kuberuntu_image_v1_21: {{ amiID "zalando-ubuntu-kubernetes-production-v1.21.12-master-226" "861068367966"}}
+kuberuntu_image_v1_21_amd64: {{ amiID "zalando-ubuntu-kubernetes-production-v1.21.12-amd64-master-231" "861068367966" }}
+kuberuntu_image_v1_21_arm64: {{ amiID "zalando-ubuntu-kubernetes-production-v1.21.12-arm64-master-231" "861068367966" }}
 
 # Feature toggle for auditing events
 audit_pod_events: "true"

--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -7,7 +7,8 @@ Metadata:
 Mappings:
   Images:
     eu-central-1:
-      MachineImage: '{{ .NodePool.ConfigItems.kuberuntu_image_v1_21 }}'
+      # Use the node pool's architecture to construct the config item name that we're using to get the AMI name.
+      MachineImage: '{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_21_" .Values.InstanceInfo.Architecture) }}'
 
 Resources:
   AutoScalingGroup:

--- a/cluster/node-pools/worker-combined/stack.yaml
+++ b/cluster/node-pools/worker-combined/stack.yaml
@@ -7,7 +7,8 @@ Metadata:
 Mappings:
   Images:
     eu-central-1:
-      MachineImage: '{{ .NodePool.ConfigItems.kuberuntu_image_v1_21 }}'
+      # Use the node pool's architecture to construct the config item name that we're using to get the AMI name.
+      MachineImage: '{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_21_" .Values.InstanceInfo.Architecture) }}'
 
 Resources:
   AutoScalingGroup:

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -7,7 +7,8 @@ Metadata:
 Mappings:
   Images:
     eu-central-1:
-      MachineImage: '{{ .NodePool.ConfigItems.kuberuntu_image_v1_21 }}'
+      # Use the node pool's architecture to construct the config item name that we're using to get the AMI name.
+      MachineImage: '{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_21_" .Values.InstanceInfo.Architecture) }}'
 
 Resources:
 {{ with $data := . }}


### PR DESCRIPTION
This PR uses a function that's introduce in https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/590 and therefore must be merged afterwards.

~~It moves the resolution of an AMI name to its ID into the node pool and out of the global defaults. This allows to take the node pool's architecture into account so that it can select a different AMI based on the instance type.~~

~~The default value is now a "nice" AMI name that _can_ contain an `$ARCH` variable, e.g.~~

```yaml
kuberuntu_image_v1_21_amd64: {{ amiID zalando-ubuntu-kubernetes-production-v1.21.12-amd64-master-229 "<owner>" }}
kuberuntu_image_v1_21_arm64: {{ amiID zalando-ubuntu-kubernetes-production-v1.21.12-arm64-master-229 "<owner>" }}
```

~~This variable will be replaced by the node pool's correct architecture so that CPU architecture and AMI work together.~~

~~If no `$ARCH` variable is present then this works similar to `amiID`.~~

~~Since it's sort of backwards compatible one could think about adding it to `amiID` itself. However, the additional of 3 parameter complicates things so this solution was just easier.~~

After merging https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/590 a node pool's architecture is available at `.Values.InstanceInfo.Architecture`. Given the Config Item structure above we can then do the following in the template:

```
MachineImage: '{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_21_" .Values.InstanceInfo.Architecture) }}'
```

which will pick up the right config item from the defaults, either
```
index .NodePool.ConfigItems "kuberuntu_image_v1_21_amd64"
index .NodePool.ConfigItems "kuberuntu_image_v1_21_arm64"
```

which is the same as:
```
.NodePool.ConfigItems.kuberuntu_image_v1_21_amd64
.NodePool.ConfigItems.kuberuntu_image_v1_21_arm64
```