### PR TITLE
Make sure next CLM version works well

### DIFF
--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -24,7 +24,7 @@ RUN chmod +x /usr/bin/kubectl
 COPY --from=builder /go/bin/ginkgo /usr/local/bin/ginkgo
 
 # copy CLM
-COPY --from=registry.opensource.zalan.do/teapot/cluster-lifecycle-manager:latest /clm /usr/bin/clm
+COPY --from=registry.opensource.zalan.do/teapot/cluster-lifecycle-manager-test:pr-590-2 /clm /usr/bin/clm
 COPY --from=pierone.stups.zalan.do/teapot/aws-account-creator:latest /aws-account-creator /usr/bin/aws-account-creator
 
 ADD . /workdir

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -24,7 +24,7 @@ RUN chmod +x /usr/bin/kubectl
 COPY --from=builder /go/bin/ginkgo /usr/local/bin/ginkgo
 
 # copy CLM
-COPY --from=registry.opensource.zalan.do/teapot/cluster-lifecycle-manager-test:pr-590-2 /clm /usr/bin/clm
+COPY --from=registry.opensource.zalan.do/teapot/cluster-lifecycle-manager-test:pr-590-4 /clm /usr/bin/clm
 COPY --from=pierone.stups.zalan.do/teapot/aws-account-creator:latest /aws-account-creator /usr/bin/aws-account-creator
 
 ADD . /workdir


### PR DESCRIPTION
Makes sure that when using the upcoming CLM version in https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/590 will work with the current setup.