### PR TITLE
Use multiarch image for skipper routesrv

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -374,7 +374,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Cluster.ConfigItems.skipper_termination_grace_period }}
       containers:
       - name: routesrv
-        image: registry.opensource.zalan.do/teapot/skipper:{{ $version }}
+        image: container-registry.zalando.net/teapot/skipper:{{ $version }}
         ports:
         - name: ingress-port
           containerPort: 9990


### PR DESCRIPTION
The component is not yet active, but since we have multi-arch image, let's already switch.