### PR TITLE
Binpack skipper pods

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -58,6 +58,10 @@ skipper_ingress_min_replicas: "2"
 {{end}}
 skipper_ingress_cpu: "1000m"
 skipper_ingress_memory: "1Gi"
+# When set to true (and dedicated node pool for skipper is also true) the
+# daemonset overhead will be substracted from the cpu settings such
+# that skipper will perfectly fit on the node.
+skipper_ingress_binpack: "false"
 # skipper node-pool
 enable_dedicate_nodepool_skipper: "true"
 {{if eq .Cluster.Environment "e2e"}}
@@ -373,6 +377,11 @@ teapot_admission_controller_parent_resource_hash: "true"
 teapot_admission_controller_check_daemonset_resources: "true"
 teapot_admission_controller_daemonset_reserved_cpu: "8"
 teapot_admission_controller_daemonset_reserved_memory: "64Gi"
+
+kubelet_system_reserved_cpu: "100m"
+kubelet_system_reserved_memory: "164Mi"
+kubelet_kube_reserved_cpu: "100m"
+kubelet_kube_reserved_memory: "282Mi"
 
 {{if eq .Cluster.Environment "production"}}
 teapot_admission_controller_validate_application_label: "true"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -227,12 +227,22 @@ spec:
           {{ end }}
 {{ end }}
         resources:
+{{ if and (eq .Cluster.ConfigItems.enable_dedicate_nodepool_skipper "true") (eq .Cluster.ConfigItems.skipper_ingress_binpack "true") }}
+{{ $cpu_requests := split (printf "%s -%s -%s" .Cluster.ConfigItems.skipper_ingress_cpu .Cluster.ConfigItems.teapot_admission_controller_daemonset_reserved_cpu .Cluster.ConfigItems.kubelet_system_reserved_cpu) " " | sumQuantities }}
+          limits:
+            cpu: "{{ $cpu_requests }}"
+            memory: "{{ .ConfigItems.skipper_ingress_memory }}"
+          requests:
+            cpu: "{{ $cpu_requests }}"
+            memory: "{{ .ConfigItems.skipper_ingress_memory }}"
+{{ else }}
           limits:
             cpu: "{{ .ConfigItems.skipper_ingress_cpu }}"
             memory: "{{ .ConfigItems.skipper_ingress_memory }}"
           requests:
             cpu: "{{ .ConfigItems.skipper_ingress_cpu }}"
             memory: "{{ .ConfigItems.skipper_ingress_memory }}"
+{{ end }}
         readinessProbe:
           httpGet:
             path: /kube-system/healthz

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -47,11 +47,11 @@ write_files:
       kubeAPIQPS: 50
       kubeAPIBurst: 50
       systemReserved:
-        cpu: "100m"
-        memory: "164Mi"
+        cpu: "{{ .Cluster.ConfigItems.kubelet_system_reserved_cpu }}"
+        memory: "{{ .Cluster.ConfigItems.kubelet_system_reserved_memory }}"
       kubeReserved:
-        cpu: "100m"
-        memory: "282Mi"
+        cpu: "{{ .Cluster.ConfigItems.kubelet_kube_reserved_cpu }}"
+        memory: "{{ .Cluster.ConfigItems.kubelet_kube_reserved_memory }}"
       allowedUnsafeSysctls:
 {{- range $sysctl := split .Cluster.ConfigItems.allowed_unsafe_sysctls "," }}
         - {{$sysctl}}

--- a/cluster/node-pools/worker-splitaz/userdata.yaml
+++ b/cluster/node-pools/worker-splitaz/userdata.yaml
@@ -87,11 +87,11 @@ write_files:
       kubeAPIQPS: 50
       kubeAPIBurst: 50
       systemReserved:
-        cpu: "100m"
-        memory: "164Mi"
+        cpu: "{{ .Cluster.ConfigItems.kubelet_system_reserved_cpu }}"
+        memory: "{{ .Cluster.ConfigItems.kubelet_system_reserved_memory }}"
       kubeReserved:
-        cpu: "100m"
-        memory: "282Mi"
+        cpu: "{{ .Cluster.ConfigItems.kubelet_kube_reserved_cpu }}"
+        memory: "{{ .Cluster.ConfigItems.kubelet_kube_reserved_memory }}"
       allowedUnsafeSysctls:
 {{- range $sysctl := split .Cluster.ConfigItems.allowed_unsafe_sysctls "," }}
         - {{$sysctl}}


### PR DESCRIPTION
### Problem

In most/all clusters we configure a dedicated node pool for skipper consisting of `c` type instances (`c5.large`, `c5.xlarge`, etc.). Commonly we request 1,2,3,4 CPUs for the skipper-ingress pods which can result in a big overhead (allocation slack) on the nodes as illustrated in the following example:

We requests 2 cpus for skipper-ingress pods, a c5.large has 2 CPUs but because of the daemonset overhead skipper-ingress will not fit on such a node, instead a c5.xlarge (4 CPUs) is needed. This means for a 2 CPU skipper pod, we need a 4 CPU node leading to almost 50% waste.

### Proposed solution

This introduces a config item: `skipper_ingress_binpack` (default=false) which when set to true will substract the daemonset + kubelet cpu overhead from the skipper cpu requests when skipper-ingress runs on a dedicated node pool.

This means that if the CPU requests for skipper-ingress is set to e.g. 2000m, we will substract the daemonset overhead (518m) and the kubelet overhead (2x100m) and end up with a request of `1282m` which will let the pod fit on a c5.large instead of a `c5.xlarge`.

Of cause we also lower the scaling target for the HPA so if it's e.g. set to 50% it will scale after `769m` instead of at `1200m` (50% target + 10% HPA change overhead).
I'm not sure about the impact of this, but the config item is set to false by default so we can try it out in select clusters before applying everywhere.

This also means when the config-item is enabled we should only request CPUs (2, 4, 8 etc.) to follow the instance types. E.g. requesting 5 CPUs would lead to running on a c5.2xlarge (8 CPUs) with a huge overhead, when the config-item is enabled.

We only substract CPU and not Memory because we run skipper ingress with 1:1 vCPU/GiB ratio and thus there are plenty of space for memory as the c instances has a ratio of 1:2.

Depends on the template function `sumQuantities` added to CLM: https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/591