### PR TITLE
Use multi-arch image for kube-metrics-adapter

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:v0.1.19
+        image: container-registry.zalando.net/teapot/kube-metrics-adapter:v0.1.19-2-g3796948
         env:
         - name: AWS_REGION
           value: {{ .Region }}


### PR DESCRIPTION
This is the same as `v0.1.19` but uses a multi-arch image.