### PR TITLE
Expose the architecture so that cluster-autoscaler can use it

### DIFF
--- a/cluster/node-pools/worker-combined/stack.yaml
+++ b/cluster/node-pools/worker-combined/stack.yaml
@@ -73,6 +73,9 @@ Resources:
       - Key: k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/node-pool
         PropagateAtLaunch: true
         Value: {{ .NodePool.Name }}
+      - Key: k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/arch
+        PropagateAtLaunch: true
+        Value: {{ .Values.InstanceInfo.Architecture }}
       - Key: k8s.io/cluster-autoscaler/node-template/label/lifecycle-status
         PropagateAtLaunch: true
         Value: ready

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -76,6 +76,9 @@ Resources:
       - Key: k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/node-pool
         PropagateAtLaunch: true
         Value: {{ $data.NodePool.Name }}
+      - Key: k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/arch
+        PropagateAtLaunch: true
+        Value: {{ $data.Values.InstanceInfo.Architecture }}
       - Key: k8s.io/cluster-autoscaler/node-template/label/lifecycle-status
         PropagateAtLaunch: true
         Value: ready


### PR DESCRIPTION
Expose the architecture as a node template label for Cluster Autoscaler. This way it can correctly start nodes if we start using these labels.

This is untested but I want to see if this works.
