### PR TITLE
Update unbound to multi-arch

### DIFF
--- a/cluster/manifests/coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/coredns-local/daemonset-coredns.yaml
@@ -43,7 +43,7 @@ spec:
       containers:
 {{ if eq .Cluster.ConfigItems.dns_cache "unbound" }}
       - name: unbound
-        image: registry.opensource.zalan.do/teapot/unbound:1.13.1-1
+        image: container-registry.zalando.net/teapot/unbound:1.16.0-master-4
         args:
         - -d
         - -c
@@ -79,7 +79,7 @@ spec:
           readOnly: true
           subPath: unbound.conf
       - name: unbound-telemetry
-        image: registry.opensource.zalan.do/teapot/unbound-telemetry:master-1
+        image: container-registry.zalando.net/teapot/unbound-telemetry:master-2
         args:
         - tcp
         - --bind=0.0.0.0:9054


### PR DESCRIPTION
Updates the unbound containers to be multi-arch and latest version.

We had trouble with the previous version sometimes getting stuck in the past, hopefully this is fixed in the new version as `unbound` performs better than `dnsmasq` as a cache (when it's not stuck).

This is all still behind a config-item and disabled by default, but enables us to test unbound again also on ARM instances :)