### PR TITLE
Close apiserver port from the internet

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -129,7 +129,7 @@ Resources:
     Properties:
       GroupDescription: !Ref 'AWS::StackName'
       SecurityGroupIngress:
-        - CidrIp: 0.0.0.0/0
+        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
           FromPort: 8443
           IpProtocol: tcp
           ToPort: 8443


### PR DESCRIPTION
Follow up to #5223 disabling public access to the control plane nodes and only allow access via the NLB on port 8443.

Depends on #5223 being fully rolled out!