### PR TITLE
Add ClusterRole/ClusterRoleBinding and config-item for hyped-articles-lifecycle-management controller

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -764,3 +764,6 @@ zmon_accessible_s3_buckets: ""
 
 # disable zmon-appliance worker tracking in Prometheus
 disable_zmon_appliance_worker_tracking: "true"
+
+# Add ClusterRole for clusters required by hyped-article-lifecycle-management controller
+hyped_article_lifecycle_management: "false"

--- a/cluster/manifests/roles/hyped-articles-lifecycle-rbac.yaml
+++ b/cluster/manifests/roles/hyped-articles-lifecycle-rbac.yaml
@@ -1,0 +1,33 @@
+{{- if eq .Cluster.ConfigItems.hyped_article_lifecycle_management "true" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hyped-articles-lifecycle-management
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - articles-protection-config
+  - article-protection-config
+  verbs:
+  - get
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hyped-articles-lifecycle-management
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hyped-articles-lifecycle-management
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: zalando-iam:zalando:service:stups_hyped-articles-lifecycle-management
+{{- end }}


### PR DESCRIPTION
Related Teapot Issue: [Enable hyped article configmaps for application: hyped-articles-lifecycle-management](https://github.bus.zalan.do/teapot/issues/issues/3285).

> For hyped article releases the Purchase Risk Management team is responsible for distributing a list of articles which need to be handled (e.g. protected) in a certain way. This information is distributed via configmaps to various Kubernetes clusters and the relevant applications then mount the configmaps to read the information.

> In order to allow a controller to update the configmaps we need to give it access in dedicated clusters.

> The controller has the application ID: `hyped-articles-lifecycle-management` and needs permissions according to this [sheet](https://docs.google.com/spreadsheets/d/1Eql94dotMm8MW1chIptcnSr9iba4TpWXrvsDXHHg1ps/edit#gid=0).

This PR introduces a ClusterRole/ClusterRoleBinding providing the hyped-articles-lifecycle-management controller access to the relevant configmaps. It also adds a config-item which will then be enabled in the specific clusters which the controller requires access to.