### PR TITLE
Allow SizeMemoryBackedVolumes featureGate

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -767,3 +767,6 @@ disable_zmon_appliance_worker_tracking: "true"
 
 # Add ClusterRole for clusters required by hyped-article-lifecycle-management controller
 hyped_article_lifecycle_management: "false"
+
+# enable SizeMemoryBackedVolumes feature flag
+enable_size_memory_backed_volumes: "false"

--- a/cluster/manifests/kube-proxy/configmap.yaml
+++ b/cluster/manifests/kube-proxy/configmap.yaml
@@ -24,6 +24,7 @@ data:
     featureGates:
       BoundServiceAccountTokenVolume: {{ .Cluster.ConfigItems.rotate_service_account_tokens }}
       EndpointSliceProxying: {{ .Cluster.ConfigItems.enable_endpointsliceproxying }}
+      SizeMemoryBackedVolumes: {{ .Cluster.ConfigItems.enable_size_memory_backed_volumes }}
     healthzBindAddress: 127.0.0.1:10256
     hostnameOverride: ""
     iptables:

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -28,6 +28,7 @@ write_files:
       featureGates:
         BoundServiceAccountTokenVolume: {{ .Cluster.ConfigItems.rotate_service_account_tokens }}
         CSIMigration: {{ .Cluster.ConfigItems.enable_csi_migration }}
+        SizeMemoryBackedVolumes: {{ .Cluster.ConfigItems.enable_size_memory_backed_volumes }}
 {{- if eq .Cluster.ConfigItems.enable_ephemeral_containers "true" }}
         EphemeralContainers: true
 {{- end }}

--- a/cluster/node-pools/worker-splitaz/userdata.yaml
+++ b/cluster/node-pools/worker-splitaz/userdata.yaml
@@ -64,6 +64,7 @@ write_files:
       featureGates:
         BoundServiceAccountTokenVolume: {{ .Cluster.ConfigItems.rotate_service_account_tokens }}
         CSIMigration: {{ .Cluster.ConfigItems.enable_csi_migration }}
+        SizeMemoryBackedVolumes: {{ .Cluster.ConfigItems.enable_size_memory_backed_volumes }}
 {{- if eq .Cluster.ConfigItems.enable_ephemeral_containers "true" }}
         EphemeralContainers: true
 {{- end }}


### PR DESCRIPTION
[`SizeMemoryBackedVolumes`](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) enables kubelets to determine the size limit for
memory-backed volumes. This commit enables this feature by flag.