### PR TITLE
Update image for aws-node-decommissioner

### DIFF
--- a/cluster/manifests/aws-node-decommissioner/cronjob.yaml
+++ b/cluster/manifests/aws-node-decommissioner/cronjob.yaml
@@ -28,7 +28,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: aws-node-decommissioner
-            image: container-registry.zalando.net/teapot/aws-node-decommissioner:master-9e467a36
+            image: container-registry.zalando.net/teapot/aws-node-decommissioner:master-9e467a36-master-14
             args:
               - --debug
             resources:

--- a/cluster/manifests/aws-node-decommissioner/cronjob.yaml
+++ b/cluster/manifests/aws-node-decommissioner/cronjob.yaml
@@ -28,7 +28,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: aws-node-decommissioner
-            image: registry.opensource.zalan.do/teapot/aws-node-decommissioner:master-9e467a36
+            image: container-registry.zalando.net/teapot/aws-node-decommissioner:master-9e467a36
             args:
               - --debug
             resources:


### PR DESCRIPTION
The `aws-node-decommissioner` image is moved from the opensource registry to the ECR registry.

Ref: https://github.bus.zalan.do/teapot/issues/issues/3283
