### PR TITLE
Add CRD ClusterRole and Binding

### DIFF
--- a/cluster/manifests/roles/deployment-service.yaml
+++ b/cluster/manifests/roles/deployment-service.yaml
@@ -35,6 +35,39 @@ subjects:
     kind: User
     name: zalando-iam:zalando:service:stups_deployment-service
 ---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "deployment-service-api-crd-access"
+  labels:
+    application: "deployment-service"
+    component: "api"
+rules:
+  - apiGroups:
+      - "databases.spotahome.com/v1"
+    resources:
+      - redisfailovers
+    verbs:
+      - get
+      - list
+      - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "deployment-service-api-crd-access"
+  labels:
+    application: "deployment-service"
+    component: "api"
+roleRef:
+  kind: ClusterRole
+  name: "deployment-service-api-crd-access"
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: zalando-iam:zalando:serice:stups_deployment-service
+---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:


### PR DESCRIPTION
The `deployment-service` needs certain RBAC permissions to be able to deploy the `redis-operator`. This patch adds a new `ClusterRole` and `ClusterRoleBinding` to the `deployment-service`'s user allowing it privileges for the `redisfailover` type as needed. 

This can be expanded with more rules later to add similar RBAC permissions for more CRDs in the future.