### PR TITLE
Add external-dns config-item policy and annotation

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -616,6 +616,8 @@ custom_dns_zone_nameservers: "" # space seperated list of nameserver IP addresse
 external_dns_ownership_prefix: ""
 # domains that should be ignored by ExternalDNS
 external_dns_excluded_domains: cluster.local
+# synchronization policy between Kubernetes and AWS Route53 (default: sync, options: sync, upsert-only, create-only)
+external_dns_policy: sync
 
 # select which cache to use for Cluster DNS: unbound or dnsmasq.
 dns_cache: "dnsmasq"

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -44,6 +44,8 @@ spec:
         - --txt-owner-id={{ .Region }}:{{ .LocalID }}
         - --txt-prefix={{ .ConfigItems.external_dns_ownership_prefix }}
         - --aws-batch-change-size=100
+        - --annotation-filter=external-dns.alpha.kubernetes.io/exclude notin (true)
+        - --policy={{ .ConfigItems.external_dns_policy }}
         resources:
           requests:
             cpu: 50m


### PR DESCRIPTION
This commit adds the config-tiem `external_dns_policy` that allows
change the syncronazition policy between Kuberntes and AWS Route53,
the main idea is to use it together with the annotation
`external-dns.alpha.kubernetes.io/exclude: true`.

To the serviceCIDR migration  we need to add an temporary ExternalIP to the
Kubernetes services, but we want to keep the Loadbalancer hostname and avoid
external-dns updates the Route53 entry with the ExternalIP.

To achieve that behavior, we need to temporarily set the external_dns_policy to
upsert-only, and add the annotatation `external-dns.alpha.kubernetes.io/exclude: true`
to the Kubernetes service that has the ExternalIP. Then, external-dns should create
and update the Route53, but will not delete AWS Route53 entries.

For https://github.bus.zalan.do/teapot/issues/issues/3243