### PR TITLE
Consolidate external-dns into kubernetes application

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -23,6 +23,10 @@ pre_apply:
     application: nvidia-gpu-device-plugin
   namespace: kube-system
   kind: DaemonSet
+- labels:
+    application: external-dns
+  namespace: kube-system
+  kind: Deployment
 
 # everything defined under here will be deleted after applying the manifests
 post_apply:

--- a/cluster/manifests/external-dns/01-rbac.yaml
+++ b/cluster/manifests/external-dns/01-rbac.yaml
@@ -5,7 +5,8 @@ metadata:
   name: external-dns
   namespace: kube-system
   labels:
-    application: external-dns
+    application: kubernetes
+    component: external-dns
   annotations:
     iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
 ---
@@ -15,7 +16,8 @@ kind: ClusterRole
 metadata:
   name: external-dns
   labels:
-    application: external-dns
+    application: kubernetes
+    component: external-dns
 rules:
 - apiGroups: [""]
   resources: ["services", "endpoints", "pods", "nodes"]
@@ -32,7 +34,8 @@ kind: ClusterRoleBinding
 metadata:
   name: external-dns
   labels:
-    application: external-dns
+    application: kubernetes
+    component: external-dns
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -4,18 +4,21 @@ metadata:
   name: external-dns
   namespace: kube-system
   labels:
-    application: external-dns
+    application: kubernetes
+    component: external-dns
     version: v0.9.0
 spec:
   strategy:
     type: Recreate
   selector:
     matchLabels:
-      application: external-dns
+      deployment: external-dns
   template:
     metadata:
       labels:
-        application: external-dns
+        application: kubernetes
+        component: external-dns
+        deployment: external-dns
         version: v0.9.0
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_both}}"

--- a/cluster/manifests/external-dns/vpa.yaml
+++ b/cluster/manifests/external-dns/vpa.yaml
@@ -4,7 +4,8 @@ metadata:
   name: external-dns
   namespace: kube-system
   labels:
-    application: external-dns
+    application: kubernetes
+    component: external-dns
 spec:
   targetRef:
     apiVersion: apps/v1


### PR DESCRIPTION
This PR consolidates the `external-dns` deployment to the kubernetes application.