### PR TITLE
Fix deployment-service RBAC

### DIFF
--- a/cluster/manifests/deployment-service/controller-rbac.yaml
+++ b/cluster/manifests/deployment-service/controller-rbac.yaml
@@ -59,6 +59,39 @@ roleRef:
   name: "deployment-service-controller"
   apiGroup: rbac.authorization.k8s.io
 ---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "deployment-service-executor-crd-access"
+  labels:
+    application: "deployment-service"
+    component: "controller"
+rules:
+  - apiGroups:
+      - "databases.spotahome.com/v1"
+    resources:
+      - redisfailovers
+    verbs:
+      - get
+      - list
+      - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "deployment-service-executor-crd-access"
+  labels:
+    application: "deployment-service"
+    component: "controller"
+roleRef:
+  kind: ClusterRole
+  name: "deployment-service-executor-crd-access"
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: zalando-iam:zalando:serice:k8sapi-local_deployment-service-executor
+---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/cluster/manifests/roles/deployment-service.yaml
+++ b/cluster/manifests/roles/deployment-service.yaml
@@ -35,39 +35,6 @@ subjects:
     kind: User
     name: zalando-iam:zalando:service:stups_deployment-service
 ---
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: "deployment-service-api-crd-access"
-  labels:
-    application: "deployment-service"
-    component: "api"
-rules:
-  - apiGroups:
-      - "databases.spotahome.com/v1"
-    resources:
-      - redisfailovers
-    verbs:
-      - get
-      - list
-      - watch
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: "deployment-service-api-crd-access"
-  labels:
-    application: "deployment-service"
-    component: "api"
-roleRef:
-  kind: ClusterRole
-  name: "deployment-service-api-crd-access"
-  apiGroup: rbac.authorization.k8s.io
-subjects:
-  - apiGroup: rbac.authorization.k8s.io
-    kind: User
-    name: zalando-iam:zalando:serice:stups_deployment-service
----
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:


### PR DESCRIPTION
The RBAC permissions provided by #5233 were incorrectly configured to be for the `deployment-service-api`. This removes those permissions and sets the correct permissions for the `deployment-service-controller` instead on the `deployment-service-executor` user.