### PR TITLE
Update kube-janitor image

### DIFF
--- a/cluster/manifests/kube-janitor/deployment.yaml
+++ b/cluster/manifests/kube-janitor/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       containers:
       - name: janitor
         # see https://github.com/hjacobs/kube-janitor/releases
-        image: registry.opensource.zalan.do/teapot/kube-janitor:20.4.1
+        image: container-registry.zalando.net/teapot/kube-janitor:20.4.1
         args:
           # run every minute
           - --interval=60

--- a/cluster/manifests/kube-janitor/deployment.yaml
+++ b/cluster/manifests/kube-janitor/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       containers:
       - name: janitor
         # see https://github.com/hjacobs/kube-janitor/releases
-        image: container-registry.zalando.net/teapot/kube-janitor:20.4.1
+        image: container-registry.zalando.net/teapot/kube-janitor:20.4.1-master-16
         args:
           # run every minute
           - --interval=60


### PR DESCRIPTION
Update the `kube-janitor` image to use the ECR registry instead.