### PR TITLE
Update aws-node-decommissioner for multi-arch image

### DIFF
--- a/cluster/manifests/aws-node-decommissioner/cronjob.yaml
+++ b/cluster/manifests/aws-node-decommissioner/cronjob.yaml
@@ -28,7 +28,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: aws-node-decommissioner
-            image: container-registry.zalando.net/teapot/aws-node-decommissioner:master-9e467a36-master-14
+            image: container-registry.zalando.net/teapot/aws-node-decommissioner:master-dacee4e8-master-15
             args:
               - --debug
             resources:


### PR DESCRIPTION
Update to the newly built `aws-node-decommissioner` multi-arch image that was built in [this Gitlab MR](https://gitlab.com/gargravarr/aws-node-decommissioner/-/merge_requests/11) and republished in [this GHE PR](https://github.bus.zalan.do/teapot/aws-node-decommissioner-pipeline/pull/11).