### PR TITLE
Update cronjob-monitor image from Open Source Registry to Container-Registry

### DIFF
--- a/cluster/manifests/cronjob-monitor/deployment.yaml
+++ b/cluster/manifests/cronjob-monitor/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: cronjob-monitor
       containers:
         - name: cronjob-monitor
-          image: "registry.opensource.zalan.do/teapot/cronjob-monitor:master-4"
+          image: "container-registry.zalando.net/teapot/cronjob-monitor:master-4"
           resources:
             limits:
               cpu: 5m


### PR DESCRIPTION
Update cronjob-monitor to no longer use the Open Source registry image.