### PR TITLE
Update teapot/event-logger container image

### DIFF
--- a/cluster/manifests/event-logger/statefulset.yaml
+++ b/cluster/manifests/event-logger/statefulset.yaml
@@ -32,7 +32,7 @@ spec:
       serviceAccountName: kubernetes-event-logger
       containers:
       - name: logger
-        image: registry.opensource.zalan.do/teapot/event-logger:master-4
+        image: container-registry.zalando.net/teapot/event-logger:master-7
         args:
             - --snapshot-namespace=kube-system
             - --snapshot-name=kubernetes-event-logger


### PR DESCRIPTION
This PR updates the teapot/event-logger container image which also adds muti-arch capabliiy.
Ref: https://github.bus.zalan.do/teapot/issues/issues/3283