### PR TITLE
Kube Resource Report: Fix API group for listing RouteGroups

### DIFF
--- a/cluster/manifests/roles/kube-resource-report-rbac.yaml
+++ b/cluster/manifests/roles/kube-resource-report-rbac.yaml
@@ -12,7 +12,7 @@ rules:
   resources: ["ingresses"]
   verbs:
   - list
-- apiGroups: ["zalando.org/v1"]
+- apiGroups: ["zalando.org"]
   resources: ["routegroups"]
   verbs:
   - list


### PR DESCRIPTION
[Kubernetes Resource Report](https://codeberg.org/hjacobs/kube-resource-report) lacks access to RouteGroups (`--enable-routegroups` CLI option of `kube-resource-report`).

Fixes https://github.com/zalando-incubator/kubernetes-on-aws/pull/4025/files#r919028120