### PR TITLE
Add role for image scanner.

### DIFF
--- a/cluster/manifests/roles/image-scanner.yaml
+++ b/cluster/manifests/roles/image-scanner.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: container-image-scanner
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: container-image-scanner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: container-image-scanner
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: zalando-iam:zalando:service:stups_image-scanner


### PR DESCRIPTION
Adds the necessary permissions for the image scanner app from secops.

Signed-off-by: rreis <rodrigo.gargravarr@gmail.com>