### PR TITLE
Enable SizeMemoryBackedVolumes by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -775,4 +775,4 @@ disable_zmon_appliance_worker_tracking: "true"
 hyped_article_lifecycle_management: "false"
 
 # enable SizeMemoryBackedVolumes feature flag
-enable_size_memory_backed_volumes: "false"
+enable_size_memory_backed_volumes: "true"


### PR DESCRIPTION
Set `enable_size_memory_backed_volumes` config to true so every cluster
has it enabled by default.