### PR TITLE
Consolidate stackset-controller into kubernetes application

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -27,6 +27,10 @@ pre_apply:
     application: external-dns
   namespace: kube-system
   kind: Deployment
+- labels:
+    application: stackset-controller
+  namespace: kube-system
+  kind: Deployment
 
 # everything defined under here will be deleted after applying the manifests
 post_apply:

--- a/cluster/manifests/stackset-controller/deployment.yaml
+++ b/cluster/manifests/stackset-controller/deployment.yaml
@@ -4,17 +4,20 @@ metadata:
   name: stackset-controller
   namespace: kube-system
   labels:
-    application: stackset-controller
+    application: kubernetes
+    component: stackset-controller
     version: "v1.3.54"
 spec:
   replicas: 1
   selector:
     matchLabels:
-      application: stackset-controller
+      deployment: stackset-controller
   template:
     metadata:
       labels:
-        application: stackset-controller
+        application: kubernetes
+        component: stackset-controller
+        deployment: stackset-controller
         version: "v1.3.54"
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"

--- a/cluster/manifests/stackset-controller/rbac.yaml
+++ b/cluster/manifests/stackset-controller/rbac.yaml
@@ -4,11 +4,17 @@ kind: ServiceAccount
 metadata:
   name: stackset-controller
   namespace: kube-system
+  labels:
+    application: kubernetes
+    component: stackset-controller
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: stackset-controller
+  labels:
+    application: kubernetes
+    component: stackset-controller
 rules:
 - apiGroups:
   - "zalando.org"
@@ -98,6 +104,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: stackset-controller
+  labels:
+    application: kubernetes
+    component: stackset-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/cluster/manifests/stackset-controller/vpa.yaml
+++ b/cluster/manifests/stackset-controller/vpa.yaml
@@ -3,6 +3,9 @@ kind: VerticalPodAutoscaler
 metadata:
   name: stackset-controller
   namespace: kube-system
+  labels:
+    application: kubernetes
+    component: stackset-controller
 spec:
   targetRef:
     apiVersion: apps/v1


### PR DESCRIPTION
This PR consolidates the `stackset-controller` deployment to the kubernetes application.