### PR TITLE
Feature/autoscaling skipper redis

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -132,6 +132,7 @@ skipper_redis_pool_timeout: "250ms"
 skipper_redis_read_timeout: "25ms"
 skipper_redis_write_timeout: "25ms"
 
+skipper_ingress_redis_swarm_enabled: "true"
 skipper_ingress_redis_target_average_utilization_cpu: "30"
 skipper_ingress_redis_target_average_utilization_memory: "60"
 skipper_ingress_redis_min_replicas: "1"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -132,6 +132,10 @@ skipper_redis_pool_timeout: "250ms"
 skipper_redis_read_timeout: "25ms"
 skipper_redis_write_timeout: "25ms"
 
+# "true" enable autoscaling
+# "false" remove autoscaling
+# "" do not change
+skipper_ingress_redis_autoscaling: ""
 skipper_ingress_redis_swarm_enabled: "true"
 skipper_ingress_redis_target_average_utilization_cpu: "30"
 skipper_ingress_redis_target_average_utilization_memory: "60"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -132,6 +132,11 @@ skipper_redis_pool_timeout: "250ms"
 skipper_redis_read_timeout: "25ms"
 skipper_redis_write_timeout: "25ms"
 
+skipper_ingress_redis_target_average_utilization_cpu: "30"
+skipper_ingress_redis_target_average_utilization_memory: "60"
+skipper_ingress_redis_min_replicas: "1"
+skipper_ingress_redis_max_replicas: "100"
+
 skipper_cluster_ratelimit_max_group_shards: 1
 
 #

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -103,3 +103,9 @@ post_apply:
   namespace: kube-system
   kind: Deployment
 {{ end }}
+
+{{ if eq .ConfigItems.skipper_ingress_redis_autoscaling "false" }}
+- name: skipper-ingress-redis
+  namespace: kube-system
+  kind: HorizontalPodAutoscaler
+{{ end }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.13.227-284" }}
+{{ $internal_version := "v0.13.232-291" }}
 {{ $version := index (split $internal_version "-") 0 }}
 
 apiVersion: apps/v1
@@ -143,14 +143,21 @@ spec:
           - "-default-filters-dir=/etc/config/default-filters"
 {{ end }}
           - "-max-audit-body=0"
-{{ if ne .ConfigItems.skipper_redis_replicas "0" }}
+{{ if eq .ConfigItems.skipper_ingress_redis_swarm_enabled "true") }}
           - "-enable-swarm"
+  {{ if and (ne .ConfigItems.skipper_redis_replicas "0") (ne .ConfigItems.skipper_ingress_redis_autoscaling "true") }}
           - "-swarm-redis-urls={{ indexedList "skipper-ingress-redis-$.skipper-ingress-redis.kube-system.svc.cluster.local:6379" (parseInt64 .ConfigItems.skipper_redis_replicas) }}"
+  {{ end }}
           - "-swarm-redis-dial-timeout={{ .ConfigItems.skipper_redis_dial_timeout }}"
           - "-swarm-redis-pool-timeout={{ .ConfigItems.skipper_redis_pool_timeout }}"
           - "-swarm-redis-read-timeout={{ .ConfigItems.skipper_redis_read_timeout }}"
           - "-swarm-redis-write-timeout={{ .ConfigItems.skipper_redis_write_timeout }}"
           - "-cluster-ratelimit-max-group-shards={{ .ConfigItems.skipper_cluster_ratelimit_max_group_shards }}"
+  {{ if eq .ConfigItems.skipper_ingress_redis_autoscaling "true" }}
+          - "-kubernetes-redis-service-namespace=kube-system"
+          - "-kubernetes-redis-service-name=skipper-ingress-redis"
+          - "-kubernetes-redis-service-port=6379"
+  {{ end }}
 {{ end }}
           - "-histogram-metric-buckets=.0001,.00025,.0005,.00075,.001,.0025,.005,.0075,.01,.025,.05,.075,.1,.2,.3,.4,.5,.75,1,2,3,4,5,7,10,15,20,30,60,120,300,600"
           - >-

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -143,7 +143,7 @@ spec:
           - "-default-filters-dir=/etc/config/default-filters"
 {{ end }}
           - "-max-audit-body=0"
-{{ if eq .ConfigItems.skipper_ingress_redis_swarm_enabled "true") }}
+{{ if eq .ConfigItems.skipper_ingress_redis_swarm_enabled "true" }}
           - "-enable-swarm"
   {{ if and (ne .ConfigItems.skipper_redis_replicas "0") (ne .ConfigItems.skipper_ingress_redis_autoscaling "true") }}
           - "-swarm-redis-urls={{ indexedList "skipper-ingress-redis-$.skipper-ingress-redis.kube-system.svc.cluster.local:6379" (parseInt64 .ConfigItems.skipper_redis_replicas) }}"

--- a/cluster/manifests/skipper/hpa-redis.yaml
+++ b/cluster/manifests/skipper/hpa-redis.yaml
@@ -1,3 +1,4 @@
+{{ if eq .ConfigItems.skipper_ingress_redis_autoscaling "true" }}
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -25,8 +26,8 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ .ConfigItems.skipper_ingress_redis_target_average_utilization_memory }}
-{{ if ne .ConfigItems.skipper_redis_cluster_scaling_schedules "" }}
-  {{ range split .ConfigItems.skipper_redis_cluster_scaling_schedules "," }}
+{{ if ne .ConfigItems.skipper_ingress_redis_cluster_scaling_schedules "" }}
+  {{ range split .ConfigItems.skipper_ingress_redis_cluster_scaling_schedules "," }}
   {{ $name_target := split . "=" }}
   - type: Object
     object:
@@ -52,3 +53,4 @@ spec:
         value: 100
         periodSeconds: 60
       selectPolicy: Min
+{{ end }}

--- a/cluster/manifests/skipper/hpa-redis.yaml
+++ b/cluster/manifests/skipper/hpa-redis.yaml
@@ -1,0 +1,54 @@
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: skipper-ingress-redis
+  namespace: kube-system
+  labels:
+    application: skipper-ingress-redis
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: skipper-ingress-redis
+  minReplicas: {{ .ConfigItems.skipper_ingress_redis_min_replicas }}
+  maxReplicas: {{ .ConfigItems.skipper_ingress_redis_max_replicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .ConfigItems.skipper_ingress_redis_target_average_utilization_cpu }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ .ConfigItems.skipper_ingress_redis_target_average_utilization_memory }}
+{{ if ne .ConfigItems.skipper_redis_cluster_scaling_schedules "" }}
+  {{ range split .ConfigItems.skipper_redis_cluster_scaling_schedules "," }}
+  {{ $name_target := split . "=" }}
+  - type: Object
+    object:
+      describedObject:
+        apiVersion: zalando.org/v1
+        kind: ClusterScalingSchedule
+        name: {{ index $name_target 0 }}
+      metric:
+        name: {{ index $name_target 0 }}
+      target:
+        averageValue: {{ index $name_target 1 }}
+        type: AverageValue
+  {{ end }}
+{{ end }}
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 600
+      policies:
+      - type: Pods
+        value: 10
+        periodSeconds: 60
+      - type: Percent
+        value: 100
+        periodSeconds: 60
+      selectPolicy: Min

--- a/cluster/manifests/skipper/skipper-redis.yaml
+++ b/cluster/manifests/skipper/skipper-redis.yaml
@@ -7,7 +7,9 @@ metadata:
   name: skipper-ingress-redis
   namespace: kube-system
 spec:
+{{ if ne .ConfigItems.skipper_ingress_redis_autoscaling "true" }}
   replicas: {{ .ConfigItems.skipper_redis_replicas }}
+{{ end }}
   podManagementPolicy: Parallel
   selector:
     matchLabels:


### PR DESCRIPTION
By setting `skipper_ingress_redis_autoscaling="true"` we can enable autoscaling.
By setting `skipper_ingress_redis_autoscaling="false"` we can revert autoscaling.

@mikkeloscar do you know if setting `replicas: 2` in statefulset will interfere with hpa?
I remember there was an edge case which scaled down deployments in some kubernetes versions (don't know if this was fixed in the meantime.