### PR TITLE
Patch image with termination logic patch

### DIFF
--- a/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
@@ -37,7 +37,7 @@ spec:
         operator: Exists
       containers:
       - name: cluster-lifecycle-controller
-        image: container-registry.zalando.net/teapot/cluster-lifecycle-controller:master-26
+        image: container-registry.zalando.net/teapot/cluster-lifecycle-controller:master-28
         args:
             - --drain-grace-period={{.ConfigItems.drain_grace_period}}
             - --drain-min-pod-lifetime={{.ConfigItems.drain_min_pod_lifetime}}


### PR DESCRIPTION
Updates the CLC image to the version which has the pod forced termination logic improvement implemented [here](https://github.bus.zalan.do/teapot/cluster-lifecycle-controller/pull/32).