### PR TITLE
Update stack-set controller version for label fix

### DIFF
--- a/cluster/manifests/stackset-controller/deployment.yaml
+++ b/cluster/manifests/stackset-controller/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     application: kubernetes
     component: stackset-controller
-    version: "v1.3.54"
+    version: "v1.3.55"
 spec:
   replicas: 1
   selector:
@@ -18,7 +18,7 @@ spec:
         application: kubernetes
         component: stackset-controller
         deployment: stackset-controller
-        version: "v1.3.54"
+        version: "v1.3.55"
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
         prometheus.io/path: /metrics
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: stackset-controller
       containers:
       - name: stackset-controller
-        image: "container-registry.zalando.net/teapot/stackset-controller:v1.3.54"
+        image: "container-registry.zalando.net/teapot/stackset-controller:v1.3.55"
         args:
         - "--interval={{ .Cluster.ConfigItems.stackset_controller_sync_interval }}"
 {{- if eq .Cluster.ConfigItems.stackset_routegroup_support_enabled "true" }}


### PR DESCRIPTION
Updates the `stackset-controller` version to roll out the fix for https://github.bus.zalan.do/teapot/issues/issues/3304 where the labels for global `ingress` and `routegroup` are not reconciled.