### PR TITLE
Consolidate emergency-access-service in kubernetes app

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -39,6 +39,10 @@ pre_apply:
     component: metrics-scraper
   namespace: kube-system
   kind: Deployment
+- labels:
+    application: emergency-access-service
+  namespace: kube-system
+  kind: Deployment
 
 # everything defined under here will be deleted after applying the manifests
 post_apply:

--- a/cluster/manifests/emergency-access-service/01-rbac.yaml
+++ b/cluster/manifests/emergency-access-service/01-rbac.yaml
@@ -4,6 +4,9 @@ kind: ServiceAccount
 metadata:
   name: emergency-access-service
   namespace: kube-system
+  labels:
+    application: kubernetes
+    component: emergency-access-service
   annotations:
     iam.amazonaws.com/role: "{{ .LocalID }}-emergency-access-service"
 ---
@@ -12,6 +15,9 @@ kind: Role
 metadata:
   name: emergency-access-service
   namespace: kube-system
+  labels:
+    application: kubernetes
+    component: emergency-access-service
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
@@ -26,6 +32,9 @@ kind: RoleBinding
 metadata:
   name: emergency-access-service
   namespace: kube-system
+  labels:
+    application: kubernetes
+    component: emergency-access-service
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/cluster/manifests/emergency-access-service/credentials.yaml
+++ b/cluster/manifests/emergency-access-service/credentials.yaml
@@ -5,9 +5,10 @@ metadata:
    name: "emergency-access-service"
    namespace: kube-system
    labels:
-     application: "emergency-access-service"
+     application: kubernetes
+     component: emergency-access-service
 spec:
-   application: "emergency-access-service"
+   application: kubernetes
    tokens:
      audittrail:
        privileges:

--- a/cluster/manifests/emergency-access-service/deployment.yaml
+++ b/cluster/manifests/emergency-access-service/deployment.yaml
@@ -5,16 +5,19 @@ metadata:
   name: emergency-access-service
   namespace: kube-system
   labels:
-    application: emergency-access-service
+    application: kubernetes
+    component: emergency-access-service
 spec:
   replicas: 1
   selector:
     matchLabels:
-      application: emergency-access-service
+      deployment: emergency-access-service
   template:
     metadata:
       labels:
-        application: emergency-access-service
+        application: kubernetes
+        component: emergency-access-service
+        deployment: emergency-access-service
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
           [{"container": "emergency-access-service", "parser": "json-structured-log"}]

--- a/cluster/manifests/emergency-access-service/ingress.yaml
+++ b/cluster/manifests/emergency-access-service/ingress.yaml
@@ -8,7 +8,8 @@ metadata:
     zalando.org/skipper-filter: |
       oauthTokeninfoAnyScope("uid")
   labels:
-    application: emergency-access-service
+    application: kubernetes
+    component: emergency-access-service
 spec:
   rules:
   - host: emergency-access-service.{{ .Values.hosted_zone }}

--- a/cluster/manifests/emergency-access-service/secret.yaml
+++ b/cluster/manifests/emergency-access-service/secret.yaml
@@ -5,7 +5,8 @@ metadata:
   name: emergency-access-service-secrets
   namespace: kube-system
   labels:
-    application: emergency-access-service
+    application: kubernetes
+    component: emergency-access-service
 type: Opaque
 data:
   opsgenie-api-key: "{{ .ConfigItems.emergency_access_service_opsgenie_api_key | base64 }}"

--- a/cluster/manifests/emergency-access-service/service.yaml
+++ b/cluster/manifests/emergency-access-service/service.yaml
@@ -5,10 +5,11 @@ metadata:
   name: emergency-access-service
   namespace: kube-system
   labels:
-    application: emergency-access-service
+    application: kubernetes
+    component: emergency-access-service
 spec:
   selector:
-    application: emergency-access-service
+    deployment: emergency-access-service
   type: ClusterIP
   ports:
     - port: 80


### PR DESCRIPTION
Consolidates the `emergency-access-service` into the `kubernetes` application as `component`.

Part of application scoping efforts defined https://github.bus.zalan.do/teapot/issues/issues/3292
The issue for migration is https://github.bus.zalan.do/teapot/issues/issues/3068

References: 
- [Original Issue](https://github.bus.zalan.do/teapot/issues/issues/2517)
- [Sample Consolidation](https://github.com/zalando-incubator/kubernetes-on-aws/pull/5265/files)
