### PR TITLE
Update teapot//kube-static-egress-controller

### DIFF
--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -32,7 +32,7 @@ spec:
       serviceAccountName: kube-static-egress-controller
       containers:
       - name: controller
-        image: registry.opensource.zalan.do/teapot/kube-static-egress-controller:v0.2.11
+        image: container-registry.zalando.net/teapot/kube-static-egress-controller:v0.2.12
         args:
         - "--provider=aws"
         - "--vpc-id={{.Cluster.ConfigItems.vpc_id}}"


### PR DESCRIPTION
The updated image allows arm64 and it is part of https://github.bus.zalan.do/teapot/issues/issues/3283