### PR TITLE
Fix/skipper redis autoscaling

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -137,7 +137,7 @@ skipper_redis_write_timeout: "25ms"
 # "" do not change
 skipper_ingress_redis_autoscaling: ""
 skipper_ingress_redis_swarm_enabled: "true"
-skipper_ingress_redis_target_average_utilization_cpu: "30"
+skipper_ingress_redis_target_average_utilization_cpu: "60"
 skipper_ingress_redis_target_average_utilization_memory: "60"
 skipper_ingress_redis_min_replicas: "1"
 skipper_ingress_redis_max_replicas: "100"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -141,6 +141,7 @@ skipper_ingress_redis_target_average_utilization_cpu: "30"
 skipper_ingress_redis_target_average_utilization_memory: "60"
 skipper_ingress_redis_min_replicas: "1"
 skipper_ingress_redis_max_replicas: "100"
+skipper_ingress_redis_cluster_scaling_schedules: ""
 
 skipper_cluster_ratelimit_max_group_shards: 1
 

--- a/cluster/manifests/skipper/hpa-redis.yaml
+++ b/cluster/manifests/skipper/hpa-redis.yaml
@@ -11,7 +11,8 @@ spec:
     apiVersion: apps/v1
     kind: StatefulSet
     name: skipper-ingress-redis
-  minReplicas: {{ .ConfigItems.skipper_ingress_redis_min_replicas }}
+  minReplicas: {{ .ConfigItems.skipper_redis_replicas }}
+  #minReplicas: {{ .ConfigItems.skipper_ingress_redis_min_replicas }}
   maxReplicas: {{ .ConfigItems.skipper_ingress_redis_max_replicas }}
   metrics:
   - type: Resource


### PR DESCRIPTION
- fix: hpa manifest default was nil
- fix: set min replicas to current value to not scale in to 1 because of hpa
- hpa use 60% target to run more efficiently
