### PR TITLE
Disable validate query log by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -78,6 +78,7 @@ skipper_topology_spread_enabled: "false"
 skipper_suppress_route_update_logs: "true"
 
 skipper_validate_query: "true"
+skipper_validate_query_log: "false"
 
 # skipper default filters
 skipper_default_filters: 'enableAccessLog(4,5) -> lifo(2000,20000,"3s")'

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -95,6 +95,7 @@ spec:
           - "run.sh"
           - "skipper"
           - "-validate-query={{ .ConfigItems.skipper_validate_query }}"
+          - "-validate-query-log={{ .Cluster.ConfigItems.skipper_validate_query_log }}"
 {{ if eq .ConfigItems.skipper_routesrv_enabled "exec" }}
           - "-routes-urls=http://skipper-ingress-routesrv.kube-system.svc.cluster.local/routes"
           - "-normalize-host"


### PR DESCRIPTION
Follow up to #5222 where validate query logging was introduced.

This disable the log by default and allows enabling per cluster. The reason we want to disable by default is to avoid excess logging and thereby excess logging costs.