### PR TITLE
Change Configs That Supported Kubernetes Servicecidr Migration 

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -393,9 +393,6 @@ teapot_admission_controller_deployment_default_max_unavailable: "1"
 teapot_admission_controller_inject_aws_waiter: "true"
 teapot_admission_controller_parent_resource_hash: "true"
 
-# Define ExternalIPs is not allowed
-teapot_admission_controller_check_service_resources: "true"
-
 ## Defaults are set per-cluster
 teapot_admission_controller_check_daemonset_resources: "true"
 teapot_admission_controller_daemonset_reserved_cpu: "8"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -184,8 +184,7 @@ enable_skipper_eastwest_dns: "true"
 enable_skipper_eastwest: "false"
 
 # Configure skipper-internal ClusterIP to Coredns query
-skipper_internal_cluster_ip: "10.3.99.99"
-skipper_internal_cluster_ip_additional: "10.3.99.99"
+skipper_internal_cluster_ip: "10.5.99.99"
 
 # enable temporay logging of ingress.cluster.local names
 # used to find services for which it's being used.
@@ -524,12 +523,11 @@ coredns_log_forward: "false"
 # clusters and prevent CoreDNS from running out of memory in case of spikes.
 coredns_max_upstream_concurrency: 2000 # 0 means there is no concurrency limits
 
-# Temporarily added to support Kubernetes service range migration.
-coredns_cluster_ip_2: 10.3.0.11
-coredns_cluster_ip_1: 10.3.0.11
+# Coredns clusterIP.
+coredns_cluster_ip_1: 10.5.0.11
 # Coredns reverse lookup of kubernetes addresses
 coredns_cluster_cidr_local_zone: "2.10.in-addr.arpa."
-coredns_service_cluster_local_zone: "3.10.in-addr.arpa."
+coredns_service_cluster_local_zone: "5.10.in-addr.arpa."
 
 tracing_coredns_route_traces_to_local_zone: "false"
 tracing_coredns_global_traces_endpoint: ""
@@ -551,11 +549,6 @@ audittrail_url: "https://audittrail.cloud.zalando.com"
 audittrail_url: ""
 {{end}}
 audittrail_root_account_role: ""
-
-# kube-apiserver / kube-proxy container image name.
-# Temporarily added to help during the Kubernetes service network range migration.
-kube_apiserver_container_image_name: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/kube-apiserver-internal:v1.21.12-master-79
-kube_proxy_container_image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/kube-proxy-internal:v1.21.12-master-79
 
 # A CIDR notation IP range from which to assign service cluster IPs.
 # This must not overlap with any IP ranges assigned to nodes or pods.

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -552,7 +552,7 @@ audittrail_root_account_role: ""
 
 # A CIDR notation IP range from which to assign service cluster IPs.
 # This must not overlap with any IP ranges assigned to nodes or pods.
-service_cluster_ip_range: "10.3.0.0/16"
+service_cluster_ip_range: "10.5.0.0/16"
 
 # CIDR Range for Pods in cluster
 cluster_cidr: "10.2.0.0/16"

--- a/cluster/manifests/01-admission-control/teapot.yaml
+++ b/cluster/manifests/01-admission-control/teapot.yaml
@@ -226,7 +226,6 @@ webhooks:
         apiGroups: [""]
         apiVersions: ["v1"]
         resources: ["namespaces"]
-{{- if eq .Cluster.ConfigItems.teapot_admission_controller_check_service_resources "true" }}
   - name: service-admitter.teapot.zalan.do
     clientConfig:
       url: "https://localhost:8085/service"
@@ -240,4 +239,3 @@ webhooks:
         apiGroups: [""]
         apiVersions: ["v1"]
         resources: ["services"]
-{{- end }}

--- a/cluster/manifests/coredns-local/configmap-local.yaml
+++ b/cluster/manifests/coredns-local/configmap-local.yaml
@@ -69,7 +69,6 @@ data:
         template IN A {
             match "^.*[.]ingress[.]cluster[.]local"
             answer "{{"{{"}} .Name {{"}}"}} 60 IN A {{ .ConfigItems.skipper_internal_cluster_ip }}"
-            additional "{{"{{"}} .Name {{"}}"}} 60 IN A {{ .ConfigItems.skipper_internal_cluster_ip_additional }}"
             fallthrough
         }
         template IN AAAA {

--- a/cluster/manifests/coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/coredns-local/daemonset-coredns.yaml
@@ -122,7 +122,6 @@ spec:
         - --neg-ttl=60
         # send requests to the last server first, only fallback to the previous ones if it's unreachable
         - --strict-order
-        - --server={{ .Cluster.ConfigItems.coredns_cluster_ip_2 }}#53
         - --server={{ .Cluster.ConfigItems.coredns_cluster_ip_1 }}#53
         - --server=127.0.0.1#9254
         ports:

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
       hostNetwork: true
       containers:
       - name: kube-proxy
-        image: {{.Cluster.ConfigItems.kube_proxy_container_image}}
+        image: nonexistent.zalan.do/teapot/kube-proxy:fixed
         args:
         - --hostname-override=$(HOSTNAME_OVERRIDE)
         - --config=/config/kube-proxy.yaml

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -96,7 +96,7 @@ write_files:
         terminationGracePeriodSeconds: 80
         containers:
         - name: kube-apiserver
-          image: {{.Cluster.ConfigItems.kube_apiserver_container_image_name}}
+          image: nonexistent.zalan.do/teapot/kube-apiserver:fixed
           args:
           - --apiserver-count={{ .Values.apiserver_count }}
           - --bind-address=0.0.0.0


### PR DESCRIPTION
This PR changes service CIDR network to `10.5.0.0/16` since all the current clusters were migrated as part of the task https://github.bus.zalan.do/teapot/issues/issues/3243.

The changes include:
 - Remove patched kube-apiserver and kube-proxy images
 - Remove feature-flag to allow externalIPs
 - Configure coredns and skipper to use IPs from the service CIDR  range 10.5.0.0/16
 - Set cluster service CIDR to 10.5.0.0/16 

Relate to #5166