### PR TITLE
Add livenessProbe to kube-aws-iam-controller

### DIFF
--- a/cluster/manifests/02-kube-aws-iam-controller/deployment.yaml
+++ b/cluster/manifests/02-kube-aws-iam-controller/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       hostNetwork: true
       containers:
       - name: kube-aws-iam-controller
-        image: container-registry.zalando.net/teapot/kube-aws-iam-controller:v0.2.0
+        image: registry.opensource.zalan.do/teapot/kube-aws-iam-controller:v0.2.0-3-g8b47d5a
         args:
         - --debug
         - "--assume-role={{.Cluster.LocalID}}-worker"

--- a/cluster/manifests/02-kube-aws-iam-controller/deployment.yaml
+++ b/cluster/manifests/02-kube-aws-iam-controller/deployment.yaml
@@ -40,6 +40,13 @@ spec:
           requests:
             cpu: "{{.ConfigItems.kube_aws_iam_controller_cpu}}"
             memory: "{{.ConfigItems.kube_aws_iam_controller_mem_max}}"
+        livenessProbe:
+          httpGet: 
+            path: /healthz
+            port: 8080
+          failureThreshold: 5
+          initialDelaySeconds: 10
+          periodSeconds: 10
       tolerations:
       - key: node.kubernetes.io/role
         value: master

--- a/cluster/manifests/02-kube-aws-iam-controller/deployment.yaml
+++ b/cluster/manifests/02-kube-aws-iam-controller/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       hostNetwork: true
       containers:
       - name: kube-aws-iam-controller
-        image: registry.opensource.zalan.do/teapot/kube-aws-iam-controller:v0.2.0-3-g8b47d5a
+        image: container-registry.zalando.net/teapot/kube-aws-iam-controller:v0.2.0-3-g8b47d5a
         args:
         - --debug
         - "--assume-role={{.Cluster.LocalID}}-worker"


### PR DESCRIPTION
This adds patch for liveness probe endpoint to the `kube-aws-iam-controller` implemented here https://github.com/zalando-incubator/kube-aws-iam-controller/pull/60

Also adds the same liveness probe to the container.

This addresses the issue here https://github.bus.zalan.do/teapot/issues/issues/3294