### PR TITLE
Update to Kubernetes v1.21.14, Linux 5.15

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -538,8 +538,8 @@ tracing_coredns_local_zone_traces_endpoint: ""
 # AMI id given the image name and the Image AWS account owner.
 #
 # [0]: https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/8a9bd1cb2d094038a9e23e646421f8146b48886a/provisioner/template.go#L116
-kuberuntu_image_v1_21_amd64: {{ amiID "zalando-ubuntu-kubernetes-production-v1.21.12-amd64-master-231" "861068367966" }}
-kuberuntu_image_v1_21_arm64: {{ amiID "zalando-ubuntu-kubernetes-production-v1.21.12-arm64-master-231" "861068367966" }}
+kuberuntu_image_v1_21_amd64: {{ amiID "zalando-ubuntu-kubernetes-production-v1.21.14-amd64-master-236" "861068367966" }}
+kuberuntu_image_v1_21_arm64: {{ amiID "zalando-ubuntu-kubernetes-production-v1.21.14-arm64-master-236" "861068367966" }}
 
 # Feature toggle for auditing events
 audit_pod_events: "true"

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -2,7 +2,7 @@
 
 BINARY       ?= kubernetes-on-aws-e2e
 VERSION      ?= $(shell git describe --tags --always --dirty)
-KUBE_VERSION ?= v1.21.12
+KUBE_VERSION ?= v1.21.14
 IMAGE        ?= pierone.stups.zalan.do/teapot/$(BINARY)
 TAG          ?= $(VERSION)
 DOCKERFILE   ?= Dockerfile

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -16,10 +16,10 @@ require (
 	github.com/zalando-incubator/kube-aws-iam-controller v0.1.2
 	gopkg.in/gcfg.v1 v1.2.3 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	k8s.io/api v0.21.12
-	k8s.io/apimachinery v0.21.12
+	k8s.io/api v0.21.14
+	k8s.io/apimachinery v0.21.14
 	k8s.io/apiserver v0.0.0
-	k8s.io/client-go v0.21.12
+	k8s.io/client-go v0.21.14
 	k8s.io/kubernetes v0.0.0
 )
 


### PR DESCRIPTION
This updates the AMI and includes two bigger updates:

* Update to [Kubernetes v1.21.14](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md#v12114)
* **Update from Linux kernel 5.4 to 5.15**