### PR TITLE
admission-controller: STS replicas from HPA

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -201,7 +201,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-149
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-151
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
Add support for annotations:

* `zalando.org/create-using-hpa-replicas: <HPA name>`
* `zalando.org/update-using-hpa-replicas: <HPA name>`

Such that it's possible to add an HPA for an existing statefulset without replicas being reset to 1.

A similar feature was implemented for `Deployment`s in #4963 and now `StatefulSet`s are also supported.

