### PR TITLE
Set skipper-ingress-redis replicas based on HPA

### DIFF
--- a/cluster/manifests/skipper/skipper-redis.yaml
+++ b/cluster/manifests/skipper/skipper-redis.yaml
@@ -4,6 +4,10 @@ metadata:
   labels:
     application: skipper-ingress-redis
     version: v6.2.7
+{{- if eq .ConfigItems.skipper_ingress_redis_autoscaling "true" }}
+  annotations:
+    zalando.org/update-using-hpa-replicas: skipper-ingress-redis
+{{- end }}
   name: skipper-ingress-redis
   namespace: kube-system
 spec:


### PR DESCRIPTION
This sets the replicas based on the HPA to ensure they are not reset to 1 when dropping the replicas field on the statefulset.

Depends on #5313 being fully rolled out!