### PR TITLE
Increase timeout for image compliance e2e tests

### DIFF
--- a/test/e2e/apiserver.go
+++ b/test/e2e/apiserver.go
@@ -39,6 +39,7 @@ const (
 	compliantImage    = "registry.opensource.zalan.do/teapot/skipper:v0.13.98"       // this image tag is compliant
 	compliantImage2   = "registry.opensource.zalan.do/teapot/skipper:v0.13.97"       // this image tag is compliant as well
 	nonCompliantImage = "registry.opensource.zalan.do/teapot/skipper-test:pr-1845-1" // this image tag is not compliant
+	waitForPodTimeout = 5 * time.Minute
 )
 
 var _ = describe("Image Policy Tests (Deployment)", func() {
@@ -71,7 +72,7 @@ var _ = describe("Image Policy Tests (Deployment)", func() {
 		err = waitForDeploymentWithCondition(cs, namespace, deployment.Name, "MinimumReplicasAvailable", appsv1.DeploymentAvailable)
 		Expect(err).NotTo(HaveOccurred())
 
-		_, err = e2epod.WaitForPodsWithLabelRunningReady(cs, namespace, appLabelSelector(appLabel), replicas, 1*time.Minute)
+		_, err = e2epod.WaitForPodsWithLabelRunningReady(cs, namespace, appLabelSelector(appLabel), replicas, waitForPodTimeout)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -129,7 +130,7 @@ var _ = describe("Image Policy Tests (Deployment) (when disabled)", func() {
 		err = waitForDeploymentWithCondition(cs, namespace, deployment.Name, "MinimumReplicasAvailable", appsv1.DeploymentAvailable)
 		Expect(err).NotTo(HaveOccurred())
 
-		_, err = e2epod.WaitForPodsWithLabelRunningReady(cs, namespace, appLabelSelector(appLabel), replicas, 1*time.Minute)
+		_, err = e2epod.WaitForPodsWithLabelRunningReady(cs, namespace, appLabelSelector(appLabel), replicas, waitForPodTimeout)
 		Expect(err).NotTo(HaveOccurred())
 	})
 })
@@ -160,7 +161,7 @@ var _ = describe("Image Policy Tests (Pods)", func() {
 			Expect(err).NotTo(HaveOccurred())
 		}()
 
-		_, err = e2epod.WaitForPodsWithLabelRunningReady(cs, namespace, appLabelSelector(appLabel), 1, 1*time.Minute)
+		_, err = e2epod.WaitForPodsWithLabelRunningReady(cs, namespace, appLabelSelector(appLabel), 1, waitForPodTimeout)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -203,7 +204,7 @@ var _ = describe("Image Policy Tests (Pods) (when disabled)", func() {
 			Expect(err).NotTo(HaveOccurred())
 		}()
 
-		_, err = e2epod.WaitForPodsWithLabelRunningReady(cs, namespace, appLabelSelector(appLabel), 1, 1*time.Minute)
+		_, err = e2epod.WaitForPodsWithLabelRunningReady(cs, namespace, appLabelSelector(appLabel), 1, waitForPodTimeout)
 		Expect(err).NotTo(HaveOccurred())
 	})
 })
@@ -234,7 +235,7 @@ var _ = describe("Image Policy Tests (Pods Update Path)", func() {
 			Expect(err).NotTo(HaveOccurred())
 		}()
 
-		_, err = e2epod.WaitForPodsWithLabelRunningReady(cs, namespace, appLabelSelector(appLabel), 1, 1*time.Minute)
+		_, err = e2epod.WaitForPodsWithLabelRunningReady(cs, namespace, appLabelSelector(appLabel), 1, waitForPodTimeout)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Updating pod " + namePrefix + " in namespace " + namespace)
@@ -247,7 +248,7 @@ var _ = describe("Image Policy Tests (Pods Update Path)", func() {
 		_, err = cs.CoreV1().Pods(namespace).Update(context.TODO(), pod, metav1.UpdateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		_, err = e2epod.WaitForPodsWithLabelRunningReady(cs, namespace, appLabelSelector(appLabel), 1, 1*time.Minute)
+		_, err = e2epod.WaitForPodsWithLabelRunningReady(cs, namespace, appLabelSelector(appLabel), 1, waitForPodTimeout)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -269,7 +270,7 @@ var _ = describe("Image Policy Tests (Pods Update Path)", func() {
 			Expect(err).NotTo(HaveOccurred())
 		}()
 
-		_, err = e2epod.WaitForPodsWithLabelRunningReady(cs, namespace, appLabelSelector(appLabel), 1, 1*time.Minute)
+		_, err = e2epod.WaitForPodsWithLabelRunningReady(cs, namespace, appLabelSelector(appLabel), 1, waitForPodTimeout)
 		Expect(err).NotTo(HaveOccurred())
 
 		pod, err = cs.CoreV1().Pods(namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
@@ -310,7 +311,7 @@ var _ = describe("Image Policy Tests (Pods Update Path) (when disabled)", func()
 			Expect(err).NotTo(HaveOccurred())
 		}()
 
-		_, err = e2epod.WaitForPodsWithLabelRunningReady(cs, namespace, appLabelSelector(appLabel), 1, 1*time.Minute)
+		_, err = e2epod.WaitForPodsWithLabelRunningReady(cs, namespace, appLabelSelector(appLabel), 1, waitForPodTimeout)
 		Expect(err).NotTo(HaveOccurred())
 
 		pod, err = cs.CoreV1().Pods(namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
@@ -323,7 +324,7 @@ var _ = describe("Image Policy Tests (Pods Update Path) (when disabled)", func()
 		_, err = cs.CoreV1().Pods(namespace).Update(context.TODO(), pod, metav1.UpdateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		_, err = e2epod.WaitForPodsWithLabelRunningReady(cs, namespace, appLabelSelector(appLabel), 1, 1*time.Minute)
+		_, err = e2epod.WaitForPodsWithLabelRunningReady(cs, namespace, appLabelSelector(appLabel), 1, waitForPodTimeout)
 		Expect(err).NotTo(HaveOccurred())
 	})
 })
@@ -357,7 +358,7 @@ var _ = describe("Image Policy Tests (StatefulSet)", func() {
 
 		statefulset.WaitForRunningAndReady(cs, int32(replicas), statefulSet)
 
-		_, err = e2epod.WaitForPodsWithLabelRunningReady(cs, namespace, appLabelSelector(appLabel), replicas, 1*time.Minute)
+		_, err = e2epod.WaitForPodsWithLabelRunningReady(cs, namespace, appLabelSelector(appLabel), replicas, waitForPodTimeout)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -415,7 +416,7 @@ var _ = describe("Image Policy Tests (StatefulSet) (when disabled)", func() {
 
 		statefulset.WaitForRunningAndReady(cs, int32(replicas), statefulSet)
 
-		_, err = e2epod.WaitForPodsWithLabelRunningReady(cs, namespace, appLabelSelector(appLabel), replicas, 1*time.Minute)
+		_, err = e2epod.WaitForPodsWithLabelRunningReady(cs, namespace, appLabelSelector(appLabel), replicas, waitForPodTimeout)
 		Expect(err).NotTo(HaveOccurred())
 	})
 })
@@ -446,7 +447,7 @@ var _ = describe("Image Policy Tests (Job)", func() {
 			Expect(err).NotTo(HaveOccurred())
 		}()
 
-		_, err = e2epod.WaitForPodsWithLabelRunningReady(cs, namespace, appLabelSelector(appLabel), 1, 1*time.Minute)
+		_, err = e2epod.WaitForPodsWithLabelRunningReady(cs, namespace, appLabelSelector(appLabel), 1, waitForPodTimeout)
 		Expect(err).NotTo(HaveOccurred())
 
 		job.WaitForJobFinish(cs, namespace, jobObj.Name)
@@ -502,7 +503,7 @@ var _ = describe("Image Policy Tests (Job) (when disabled)", func() {
 			Expect(err).NotTo(HaveOccurred())
 		}()
 
-		_, err = e2epod.WaitForPodsWithLabelRunningReady(cs, namespace, appLabelSelector(appLabel), 1, 1*time.Minute)
+		_, err = e2epod.WaitForPodsWithLabelRunningReady(cs, namespace, appLabelSelector(appLabel), 1, waitForPodTimeout)
 		Expect(err).NotTo(HaveOccurred())
 
 		job.WaitForJobFinish(cs, namespace, jobObj.Name)
@@ -538,7 +539,7 @@ var _ = describe("ECR Registry Pull", func() {
 			Expect(err).NotTo(HaveOccurred())
 		}()
 
-		_, err = e2epod.WaitForPodsWithLabelRunningReady(cs, namespace, appLabelSelector(appLabel), 1, 1*time.Minute)
+		_, err = e2epod.WaitForPodsWithLabelRunningReady(cs, namespace, appLabelSelector(appLabel), 1, waitForPodTimeout)
 		Expect(err).NotTo(HaveOccurred())
 
 		job.WaitForJobFinish(cs, namespace, jobObj.Name)
@@ -565,7 +566,7 @@ var _ = describe("ECR Registry Pull", func() {
 			Expect(err).NotTo(HaveOccurred())
 		}()
 
-		_, err = e2epod.WaitForPodsWithLabelRunningReady(cs, namespace, appLabelSelector(appLabel), 1, 1*time.Minute)
+		_, err = e2epod.WaitForPodsWithLabelRunningReady(cs, namespace, appLabelSelector(appLabel), 1, waitForPodTimeout)
 		Expect(err).NotTo(HaveOccurred())
 
 		job.WaitForJobFinish(cs, namespace, jobObj.Name)


### PR DESCRIPTION
The tests checking for pods with compliant images only wait 1 minute for the pods to be running and ready. It could be that it takes longer because of a node needing to be scaled out so increase the timeout to 5 min. to reduce the likely-hood of this being an issue.