### PR TITLE
Update ingress-controller to v0.13.14

### DIFF
--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.13.4
+    version: v0.13.14
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.13.4
+        version: v0.13.14
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_both}}"
         prometheus.io/path: /metrics
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: kube-ingress-aws-controller
       containers:
       - name: controller
-        image: container-registry.zalando.net/teapot/kube-ingress-aws-controller:v0.13.4
+        image: container-registry.zalando.net/teapot/kube-ingress-aws-controller:v0.13.14
         args:
         - --stack-termination-protection
         - --ssl-policy={{ .ConfigItems.kube_aws_ingress_controller_ssl_policy }}


### PR DESCRIPTION
Updates the ingress controller with prevents creating a new ALB if WAF, SecurityGroup or TLS settings are changed on an owned ALB. See more context here: https://github.com/zalando-incubator/kube-ingress-aws-controller/pull/533