### PR TITLE
Fix wrong file name.

### DIFF
--- a/cluster/etcd/files.yaml
+++ b/cluster/etcd/files.yaml
@@ -7,7 +7,7 @@ files:
     data: "{{ .Cluster.ConfigItems.etcd_client_server_cert }}"
     permissions: 0400
     encrypted: false
-  - path: /etc/etcd/ssl/client.key.enc
+  - path: /etc/etcd/ssl/client.key
     data: "{{ .Cluster.ConfigItems.etcd_client_server_key }}"
     permissions: 0400
     encrypted: true


### PR DESCRIPTION
One of the files for the etcd AMI has a wrong extension.

Signed-off-by: rreis <rodrigo.gargravarr@gmail.com>