### PR TITLE
skipper: hpa scaling possible to configure by cluster

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -51,6 +51,8 @@ nlb_switch: "exec"
 skipper_ingress_target_average_utilization_cpu: "60"
 skipper_ingress_target_average_utilization_memory: "80"
 skipper_ingress_max_replicas: "50"
+skipper_ingress_hpa_scale_down_wait: "600"
+skipper_ingress_hpa_scale_up_max_perc: "100"
 {{if eq .Cluster.Environment "production"}}
 skipper_ingress_min_replicas: "3"
 {{else}}

--- a/cluster/manifests/skipper/hpa.yaml
+++ b/cluster/manifests/skipper/hpa.yaml
@@ -59,7 +59,7 @@ spec:
 {{ end }}
   behavior:
     scaleDown:
-      stabilizationWindowSeconds: 600
+      stabilizationWindowSeconds: {{ .ConfigItems.skipper_ingress_hpa_scale_down_wait }}
       policies:
       - type: Pods
         value: 10
@@ -68,3 +68,13 @@ spec:
         value: 100
         periodSeconds: 60
       selectPolicy: Min
+    scaleUp:
+      policies:
+      - periodSeconds: 15
+        type: Pods
+        value: 4
+      - periodSeconds: 15
+        type: Percent
+        value:  {{ .ConfigItems.skipper_ingress_hpa_scale_up_max_perc }}
+      selectPolicy: Max
+      stabilizationWindowSeconds: 0


### PR DESCRIPTION
skipper: hpa scaling possible to configure by cluster, defaults are the same

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>