### PR TITLE
Drop unused volume from etcd.

### DIFF
--- a/cluster/etcd/stack.yaml
+++ b/cluster/etcd/stack.yaml
@@ -27,12 +27,6 @@ Resources:
     Properties:
       LaunchTemplateName: 'etcd-cluster-etcd'
       LaunchTemplateData:
-        BlockDeviceMappings:
-          - DeviceName: /dev/xvdb
-            Ebs:
-              VolumeSize: "32"
-              DeleteOnTermination: true
-              VolumeType: "gp3"
         NetworkInterfaces:
           - DeviceIndex: 0
             AssociatePublicIpAddress: true


### PR DESCRIPTION
This PR drops the volume `dev/xvdb`, which is not used in the new etcd cluster. 

Signed-off-by: rreis <rodrigo.gargravarr@gmail.com>