### PR TITLE
Remove BoundSATokenVolume flag from kube-proxy-config

### DIFF
--- a/cluster/manifests/kube-proxy/configmap.yaml
+++ b/cluster/manifests/kube-proxy/configmap.yaml
@@ -22,7 +22,6 @@ data:
       tcpEstablishedTimeout: 24h0m0s
     enableProfiling: false
     featureGates:
-      BoundServiceAccountTokenVolume: {{ .Cluster.ConfigItems.rotate_service_account_tokens }}
       EndpointSliceProxying: {{ .Cluster.ConfigItems.enable_endpointsliceproxying }}
       SizeMemoryBackedVolumes: {{ .Cluster.ConfigItems.enable_size_memory_backed_volumes }}
     healthzBindAddress: 127.0.0.1:10256


### PR DESCRIPTION
Removing the `BoundServiceAccountTokenVolume` feature flag from the `kube-proxy` configmap in order to move forward with the v1.22 upgrade. 

This flag causes a race condition where it never gets updated during an upgrade rollout and the old value causes the control-plane provisioning to fail. 

See [here](https://github.com/zalando-incubator/kubernetes-on-aws/pull/5269#issuecomment-1245329930) for reference.