### PR TITLE
Add VPA version config-item

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -379,6 +379,9 @@ horizontal_pod_autoscaler_sync_period: "30s"
 horizontal_pod_autoscaler_tolerance: "0.1"
 horizontal_pod_downscale_stabilization: "5m0s"
 
+# Vertical pod autoscaler version config for controlling roll-out
+vertical_pod_autoscaler_version: "v0.11.0-internal.17"
+
 # Cluster update settings
 {{if eq .Cluster.Environment "production"}}
 drain_grace_period: "6h"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -379,8 +379,10 @@ horizontal_pod_autoscaler_sync_period: "30s"
 horizontal_pod_autoscaler_tolerance: "0.1"
 horizontal_pod_downscale_stabilization: "5m0s"
 
-# Vertical pod autoscaler version config for controlling roll-out
-vertical_pod_autoscaler_version: "v0.11.0-internal.17"
+# Vertical pod autoscaler version for controlling roll-out, can be "current" or "legacy"
+# current => v0.11.0-internal.17
+# legacy => v0.6.1-internal.16
+vertical_pod_autoscaler_version: "current"
 
 # Cluster update settings
 {{if eq .Cluster.Environment "production"}}

--- a/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
@@ -27,6 +27,9 @@ spec:
       serviceAccountName: vpa-admission-controller
       containers:
       - name: admission-controller
+        {{if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "current"}}
+        image: container-registry.zalando.net/teapot/vpa-admission-controller:v0.11.0-internal.17
+        {{else if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "legacy"}}
         image: container-registry.zalando.net/teapot/vpa-admission-controller:v0.6.1-internal.16
         command:
           - /admission-controller

--- a/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
@@ -31,6 +31,7 @@ spec:
         image: container-registry.zalando.net/teapot/vpa-admission-controller:v0.11.0-internal.17
         {{else if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "legacy"}}
         image: container-registry.zalando.net/teapot/vpa-admission-controller:v0.6.1-internal.16
+        {{end}}
         command:
           - /admission-controller
         args:

--- a/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
@@ -25,6 +25,9 @@ spec:
       serviceAccountName: vpa-recommender
       containers:
       - name: recommender
+        {{if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "current"}}
+        image: container-registry.zalando.net/teapot/vpa-recommender:v0.11.0-internal.17
+        {{else if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "legacy"}}
         image: container-registry.zalando.net/teapot/vpa-recommender:v0.6.1-internal.16
         args:
         - --logtostderr

--- a/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
@@ -29,6 +29,7 @@ spec:
         image: container-registry.zalando.net/teapot/vpa-recommender:v0.11.0-internal.17
         {{else if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "legacy"}}
         image: container-registry.zalando.net/teapot/vpa-recommender:v0.6.1-internal.16
+        {{end}}
         args:
         - --logtostderr
         - --v=1

--- a/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
@@ -25,7 +25,10 @@ spec:
       serviceAccountName: vpa-updater
       containers:
       - name: updater
-        image: container-registry.zalando.net/teapot/vpa-updater:{{.Cluster.ConfigItems.vertical_pod_autoscaler_version}}
+        {{if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "current"}}
+        image: container-registry.zalando.net/teapot/vpa-updater:v0.11.0-internal.17
+        {{else if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "legacy"}}
+        image: container-registry.zalando.net/teapot/vpa-updater:v0.6.1-internal.16
         command:
           - ./updater
         args:

--- a/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: vpa-updater
       containers:
       - name: updater
-        image: container-registry.zalando.net/teapot/vpa-updater:v0.6.1-internal.16
+        image: container-registry.zalando.net/teapot/vpa-updater:{{.Cluster.ConfigItems.vertical_pod_autoscaler_version}}
         command:
           - ./updater
         args:

--- a/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
@@ -36,7 +36,6 @@ spec:
           - --v=1
           - --logtostderr
           - --min-replicas=1
-          - --pod-lifetime-update-threshold=12h
           - --evict-after-oom-threshold=12h
         resources:
           limits:

--- a/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
@@ -29,6 +29,7 @@ spec:
         image: container-registry.zalando.net/teapot/vpa-updater:v0.11.0-internal.17
         {{else if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "legacy"}}
         image: container-registry.zalando.net/teapot/vpa-updater:v0.6.1-internal.16
+        {{end}}
         command:
           - ./updater
         args:


### PR DESCRIPTION
In order to safely roll-out the latest version of the `vertical-pod-autoscaler` (rebase on latest upstream), this config-item is introduced as a flag to be able to restore to the legacy version in case of running into any issues.

More information in this issue: https://github.bus.zalan.do/teapot/issues/issues/3328