### PR TITLE
Update key policies to allow tagging

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -738,6 +738,7 @@ Resources:
               - 'kms:Delete*'
               - 'kms:ScheduleKeyDeletion'
               - 'kms:CancelKeyDeletion'
+              - 'tag:TagResources'
             Effect: Allow
             Principal:
               AWS: 'arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:root'
@@ -1925,6 +1926,7 @@ Resources:
                 - "arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/Shibboleth-Administrator"
             Action:
             - "kms:*"
+            - "tag:TagResources"
             Resource: "*"
           - Sid: "Enable master and worker nodes to decrypt the remote files"
             Effect: "Allow"
@@ -1958,7 +1960,9 @@ Resources:
             Effect: "Allow"
             Principal:
               AWS: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:role/Shibboleth-Administrator"
-            Action: "kms:*"
+            Action:
+            - "kms:*"
+            - "tag:TagResources"
             Resource: "*"
           - Sid: "Enable master nodes to encrypt and decrypt secrets in etcd"
             Effect: "Allow"
@@ -1995,6 +1999,7 @@ Resources:
                 - "arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/Shibboleth-Administrator"
             Action:
             - "kms:*"
+            - "tag:TagResources"
             Resource: "*"
           - Sid: "Enable master nodes to decrypt the remote files"
             Effect: "Allow"
@@ -2030,6 +2035,7 @@ Resources:
                 - "arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/Shibboleth-Administrator"
             Action:
             - "kms:*"
+            - "tag:TagResources"
             Resource: "*"
           - Sid: "Enable worker nodes to decrypt the remote files"
             Effect: "Allow"


### PR DESCRIPTION
Updating the key policies for the following keys to add `tag:TagResources` permission as part of administration actions:
1. DecryptionSecretKey
2. WorkerFilesEncryptionKey
3. RemoteFilesEncryptionKey
4. MasterFilesEncryptionKey
5. EtcdEncryptionKey

This is done separately in the PR in order to succeed with the CF resource tagging work here: https://github.com/zalando-incubator/kubernetes-on-aws/pull/5357

This is because of the chicken and egg problem of updating the policies in the tagging PR itself, causing a race condition where the policy is never updated _before_ applying the tagging update to the CF stacks.