### PR TITLE
Update DeploymentSecretKey policy

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -738,7 +738,8 @@ Resources:
               - 'kms:Delete*'
               - 'kms:ScheduleKeyDeletion'
               - 'kms:CancelKeyDeletion'
-              - 'tag:TagResources'
+              - 'kms:TagResources'
+              - 'kms:UntagResources'
             Effect: Allow
             Principal:
               AWS: 'arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:root'


### PR DESCRIPTION
Fix the key policy with `kms:TagResources` and `kms:UntagResources` operations to allow key tagging.

Fixes the earlier issue with `tag:TagResources` operation which is not relevant for KMS keys, which was added in this PR: https://github.com/zalando-incubator/kubernetes-on-aws/pull/5362

This is to support the work for tagging CF templates: https://github.com/zalando-incubator/kubernetes-on-aws/pull/5357