### PR TITLE
Remove plural from key policy

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -738,8 +738,8 @@ Resources:
               - 'kms:Delete*'
               - 'kms:ScheduleKeyDeletion'
               - 'kms:CancelKeyDeletion'
-              - 'kms:TagResources'
-              - 'kms:UntagResources'
+              - 'kms:TagResource'
+              - 'kms:UntagResource'
             Effect: Allow
             Principal:
               AWS: 'arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:root'


### PR DESCRIPTION
This PR removes the plural term from the key-policy for `DeploymentSecretKey`. This is to assist the CF Template tagging work in this PR: https://github.com/zalando-incubator/kubernetes-on-aws/pull/5357

