### PR TITLE
Fix VPA update permissions

### DIFF
--- a/cluster/manifests/01-vertical-pod-autoscaler/rbac.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/rbac.yaml
@@ -284,7 +284,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: system:admission-controller
+  name: system:vpa-admission-controller
   labels:
     application: kubernetes
     component: vpa-admission-controller
@@ -325,19 +325,56 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - create
+      - update
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: system:admission-controller
+  name: system:vpa-admission-controller
   labels:
     application: kubernetes
     component: vpa-admission-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:admission-controller
+  name: system:vpa-admission-controller
 subjects:
   - kind: ServiceAccount
     name: vpa-admission-controller
     namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:vpa-status-reader
+rules:
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:vpa-status-reader-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:vpa-status-reader
+subjects:
+- kind: ServiceAccount
+  name: vpa-updater
+  namespace: kube-system

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -39,6 +39,11 @@ pre_apply:
     component: metrics-scraper
   namespace: kube-system
   kind: Deployment
+# cleanup old vpa related roles
+- name: system:admission-controller
+  kind: ClusterRole
+- name: system:admission-controller
+  kind: ClusterRoleBinding
 
 # everything defined under here will be deleted after applying the manifests
 post_apply:


### PR DESCRIPTION
Follow up to #5361 adding missing permissions

Without this we get the following errors for `vpa-admission-controller` and `vpa-updater`.

```
Status update by vpa-admission-controller-65cf6c86db-9wzbk failed: leases.coordination.k8s.io "vpa-admission-controller" is forbidden: User "system:serviceaccount:kube-system:vpa-admission-controller" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system": access undecided system:serviceaccount:kube-system:vpa-admission-controller/[system:serviceaccounts system:serviceaccounts:kube-system system:authenticated]
```