### PR TITLE
Update kube-ingress-aws-controller for SAToken refresh

### DIFF
--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.13.18
+    version: v0.13.23
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.13.18
+        version: v0.13.23
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_both}}"
         prometheus.io/path: /metrics
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: kube-ingress-aws-controller
       containers:
       - name: controller
-        image: container-registry.zalando.net/teapot/kube-ingress-aws-controller:v0.13.18
+        image: container-registry.zalando.net/teapot/kube-ingress-aws-controller:v0.13.23
         args:
         - --stack-termination-protection
         - --ssl-policy={{ .ConfigItems.kube_aws_ingress_controller_ssl_policy }}

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kube-ingress-aws-controller
-    version: v0.13.14
+    version: v0.13.18
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kube-ingress-aws-controller
-        version: v0.13.14
+        version: v0.13.18
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_both}}"
         prometheus.io/path: /metrics
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: kube-ingress-aws-controller
       containers:
       - name: controller
-        image: container-registry.zalando.net/teapot/kube-ingress-aws-controller:v0.13.14
+        image: container-registry.zalando.net/teapot/kube-ingress-aws-controller:v0.13.18
         args:
         - --stack-termination-protection
         - --ssl-policy={{ .ConfigItems.kube_aws_ingress_controller_ssl_policy }}


### PR DESCRIPTION
Rolling out the update to `kube-ingress-aws-controller` for rolling out the SAToken refresh functionality from this patch: https://github.com/zalando-incubator/kube-ingress-aws-controller/pull/551

More context in this issue: https://github.com/zalando-incubator/kube-ingress-aws-controller/issues/535