### PR TITLE
Allow rolling back external-dns version

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -649,6 +649,11 @@ external_dns_excluded_domains: cluster.local
 # synchronization policy between Kubernetes and AWS Route53 (default: sync, options: sync, upsert-only, create-only)
 external_dns_policy: sync
 
+# eternal-dns version for controlling roll-out, can be "current" or "legacy"
+# current => v0.12.2-master-29
+# legacy => v0.9.0-master-26
+external_dns_version: "current"
+
 # select which cache to use for Cluster DNS: unbound or dnsmasq.
 dns_cache: "dnsmasq"
 

--- a/cluster/manifests/external-dns/01-rbac.yaml
+++ b/cluster/manifests/external-dns/01-rbac.yaml
@@ -22,7 +22,11 @@ rules:
 - apiGroups: [""]
   resources: ["services", "endpoints", "pods", "nodes"]
   verbs: ["list"]
+{{- if eq .Cluster.ConfigItems.external_dns_version "current" }}
 - apiGroups: ["networking.k8s.io"]
+{{- else }}
+- apiGroups: ["extensions"]
+{{- end }}
   resources: ["ingresses"]
   verbs: ["list"]
 - apiGroups: ["zalando.org"]

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -34,7 +34,11 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
+        {{- if eq .Cluster.ConfigItems.external_dns_version "current" }}
         image: container-registry.zalando.net/teapot/external-dns:v0.12.2-master-29
+        {{- else }}
+        image: container-registry.zalando.net/teapot/external-dns:v0.9.0-master-26
+        {{- end }}
         args:
         - --source=service
         - --source=ingress


### PR DESCRIPTION
We have observed issues related to the new version where we get the following errors in some clusters:

```
InvalidChangeBatch: FATAL problem: DomainLabelTooLong (Domain label is too long) encountered with 'cname
-cdp-e2e-zlawrence-f67f5f88d914191c18848b9b54e9957315a5a36c'\n\tstatus code: 400, request id: 04ab213b-74d3-4567-bebf-7bfb49b72645"
```

Allow rolling back via the config-item: `external_dns_version=legacy`

ref: #5354 