### PR TITLE
[Proposal] Scale down etcd in e2e outside of working hours

### DIFF
--- a/cluster/etcd/stack.yaml
+++ b/cluster/etcd/stack.yaml
@@ -101,6 +101,24 @@ Resources:
         - Key: certificate-expiry-node
           PropagateAtLaunch: true
           Value: {{certificateExpiry (base64Decode .Cluster.ConfigItems.etcd_client_server_cert)}}
+{{- if eq .Cluster.Environment "e2e" }}
+  ScheduledActionOut: 
+    Type: AWS::AutoScaling::ScheduledAction
+    Properties:
+      AutoScalingGroupName: !Ref AppServer
+      MinSize: {{.Cluster.ConfigItems.etcd_instance_count}}
+      MaxSize: {{.Cluster.ConfigItems.etcd_instance_count}}
+      Recurrence: "0 8 * * 1-5"
+      TimeZone: "Europe/Berlin"
+  ScheduledActionIn: 
+    Type: AWS::AutoScaling::ScheduledAction
+    Properties:
+      AutoScalingGroupName: !Ref AppServer
+      MaxSize: '0'
+      MinSize: '0'
+      Recurrence: "0 20 * * 1-5"
+      TimeZone: "Europe/Berlin"
+{{- end }}
   AutoScalingLifecycleHook:
     Type: "AWS::AutoScaling::LifecycleHook"
     Properties:


### PR DESCRIPTION
Proposal on how we can scale down the etcd cluster used in e2e outside of working hours.

It uses the scheduled action feature of AWS Autoscaling Groups: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-scheduledaction.html

This has two benefits:
* We clean etcd storage every day so we don't have a build-up of data which leads to slower etcd
* We save a bit of cost outside of office hours.