### PR TITLE
Update to flannel v0.19.2

### DIFF
--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -6,10 +6,10 @@ metadata:
   labels:
     application: kubernetes
     component: flannel
-    version: v0.18.1
+    version: v0.19.2
 spec:
   updateStrategy:
-    type: OnDelete
+    type: RollingUpdate
   selector:
     matchLabels:
       daemonset: kube-flannel
@@ -19,9 +19,10 @@ spec:
         daemonset: kube-flannel
         application: kubernetes
         component: flannel
-        version: v0.18.1
+        version: v0.19.2
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
+        config/hash: {{"configmap.yaml" | manifestHash}}
     spec:
       priorityClassName: system-node-critical
       serviceAccountName: flannel
@@ -61,7 +62,7 @@ spec:
             cpu: 25m
             memory: 50Mi
       - name: kube-flannel
-        image: container-registry.zalando.net/teapot/flannel:v0.18.1-master-9
+        image: container-registry.zalando.net/teapot/flannel:v0.19.2-master-11
         command:
         - /opt/bin/flanneld
         args:


### PR DESCRIPTION
https://github.com/flannel-io/flannel/releases/tag/v0.19.2
https://github.com/flannel-io/flannel/releases/tag/v0.19.1
https://github.com/flannel-io/flannel/releases/tag/v0.19.0

This also changes the update strategy from `OnDelete` to `RollingUpdate`. This is done since the motivation for `OnDelete` has not been relevant since: https://github.com/zalando-incubator/kubernetes-on-aws/pull/1188 and #1253