### PR TITLE
Enable BoundServiceAccountTokenVolume by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -623,7 +623,7 @@ kubernetes_controller_manager_image: "zalando"
 # when set to true, service account tokens can be used from outside the cluster
 allow_external_service_accounts: "false"
 # issue service account tokens with expiration time.
-rotate_service_account_tokens: "false"
+rotate_service_account_tokens: "true"
 # issue tokens with a long expiration time in order to detect applications that don't refresh tokens.
 rotate_service_account_tokens_extended_expiration: "true"
 


### PR DESCRIPTION
This enables `BoundServiceAccountTokenVolume` by default. This is a prerequisite for Kubernetes v1.22 update where this feature must be enabled!

We can safely do this before all components are refreshing the tokens because we set the flag: `--service-account-extend-token-expiration=true` which means tokens have a 1y life-time which is plenty in our environment.

With this enabled we can track which clients are not refreshing the tokens and get the users to fix it and at the same time we can roll forward with Kubernetes v1.22.

For completely safety I have set `rotate_service_account_tokens=false` for now such that rolling this out will only enable it in test as a start. Once we're 100% sure of not issues we can manually enable it in production clusters by dropping the `rotate_service_account_tokens` config-item per cluster.