### PR TITLE
Scale down empty nodes faster

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -7,7 +7,7 @@ cluster_autoscaler_cpu: "100m"
 cluster_autoscaler_memory: "300Mi"
 autoscaling_utilization_threshold: "1.0"
 autoscaling_max_empty_bulk_delete: "10"
-autoscaling_scale_down_unneeded_time: "10m"
+autoscaling_scale_down_unneeded_time: "2m"
 autoscaling_unremovable_node_recheck_timeout: "5m"
 
 # How long to wait for pod eviction when scaling down.


### PR DESCRIPTION
Instead of waiting 10m before scaling down an empty node, scale down faster to save a bit of cost. It's unclear exactly how much we can safe but there is no need to run empty nodes for 10m.

We have been running with this reduced setting in a couple of clusters. Enable it everywhere as we don't see any negative effects of reducing this.