### PR TITLE
Add config-item enable_node_scale_out_beyond_1k_nodes

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -189,8 +189,6 @@ zmon_kairosdb_url: "https://data-service.zmon.zalan.do/kairosdb-proxy"
 enable_skipper_eastwest_dns: "true"
 enable_skipper_eastwest: "false"
 
-# Configure skipper-internal ClusterIP to Coredns query
-skipper_internal_cluster_ip: "10.5.99.99"
 
 # enable temporay logging of ingress.cluster.local names
 # used to find services for which it's being used.
@@ -547,11 +545,6 @@ coredns_log_forward: "false"
 # clusters and prevent CoreDNS from running out of memory in case of spikes.
 coredns_max_upstream_concurrency: 2000 # 0 means there is no concurrency limits
 
-# Coredns clusterIP.
-coredns_cluster_ip_1: 10.5.0.11
-# Coredns reverse lookup of kubernetes addresses
-coredns_cluster_cidr_local_zone: "2.10.in-addr.arpa."
-coredns_service_cluster_local_zone: "5.10.in-addr.arpa."
 
 tracing_coredns_route_traces_to_local_zone: "false"
 tracing_coredns_global_traces_endpoint: ""
@@ -574,12 +567,17 @@ audittrail_url: ""
 {{end}}
 audittrail_root_account_role: ""
 
-# A CIDR notation IP range from which to assign service cluster IPs.
-# This must not overlap with any IP ranges assigned to nodes or pods.
-service_cluster_ip_range: "10.5.0.0/16"
+# The enable_node_scale_out_beyond_1k_nodes is feature toogle to change
+# the default cluster_cidr from 10.2.0.0/16 to 10.2.0.0/15, this change
+# enables the kubernetes cluster to scale out beyond 1000 nodes.
+#
+# Set `enable_node_scale_out_beyond_1k_nodes: "stage1"` to apply the cluster_cidr
+# change first in the components flannel, coredns, and skipper.
+#
+# Set `enable_node_scale_out_beyond_1k_nodes: "stage2"` to apply the cluster_cidr
+# change on the kube-controller-manager,
+enable_node_scale_out_beyond_1k_nodes: ""
 
-# CIDR Range for Pods in cluster
-cluster_cidr: "10.2.0.0/16"
 
 # CIDR configuration for nodes and pods
 # Changing this will change the number of nodes and pods we can schedule in the

--- a/cluster/manifests/coredns-local/configmap-local.yaml
+++ b/cluster/manifests/coredns-local/configmap-local.yaml
@@ -29,8 +29,13 @@ data:
       minimal-responses: yes
       extended-statistics: yes
       # support reverse lookup of kubernetes addresses
-      local-zone: "{{ .ConfigItems.coredns_cluster_cidr_local_zone }}" transparent
-      local-zone: "{{ .ConfigItems.coredns_service_cluster_local_zone }}" transparent
+{{ if or (eq .ConfigItems.enable_node_scale_out_beyond_1k_nodes "stage1") (eq .ConfigItems.enable_node_scale_out_beyond_1k_nodes "stage2") }}
+      local-zone: "2.10.in-addr.arpa." transparent
+      local-zone: "3.10.in-addr.arpa." transparent
+{{ else }}
+      local-zone: "2.10.in-addr.arpa." transparent
+{{ end }}
+      local-zone: "5.10.in-addr.arpa." transparent
       # make metrics available for the unbound-telemetry container (127.0.0.1:9054)
       remote-control:
         control-enable: yes
@@ -38,11 +43,20 @@ data:
     forward-zone:
       name: "."
       forward-addr: 127.0.0.1@9254 # coredns
+{{ if or (eq .ConfigItems.enable_node_scale_out_beyond_1k_nodes "stage1") (eq .ConfigItems.enable_node_scale_out_beyond_1k_nodes "stage2") }}
     forward-zone:
-      name: "{{ .ConfigItems.coredns_cluster_cidr_local_zone }}"
+      name: "2.10.in-addr.arpa."
       forward-addr: 127.0.0.1@9254 # coredns
     forward-zone:
-      name: "{{ .ConfigItems.coredns_service_cluster_local_zone }}"
+      name: "3.10.in-addr.arpa."
+      forward-addr: 127.0.0.1@9254 # coredns
+{{ else }}
+    forward-zone:
+      name: "2.10.in-addr.arpa."
+      forward-addr: 127.0.0.1@9254 # coredns
+{{ end }}
+    forward-zone:
+      name: "5.10.in-addr.arpa."
       forward-addr: 127.0.0.1@9254 # coredns
   Corefile: |
 {{ if and (ne .ConfigItems.custom_dns_zone "") (ne .ConfigItems.custom_dns_zone_nameservers "") }}
@@ -68,7 +82,7 @@ data:
 {{ end }}
         template IN A {
             match "^.*[.]ingress[.]cluster[.]local"
-            answer "{{"{{"}} .Name {{"}}"}} 60 IN A {{ .ConfigItems.skipper_internal_cluster_ip }}"
+            answer "{{"{{"}} .Name {{"}}"}} 60 IN A 10.5.99.99"
             fallthrough
         }
         template IN AAAA {
@@ -81,7 +95,7 @@ data:
 
     # Defines that this server is authority for reverse
     # lookups for these ranges.
-    cluster.local:9254 {{ .ConfigItems.cluster_cidr }}:9254 {{ .ConfigItems.service_cluster_ip_range }}:9254 {{ if eq .ConfigItems.tracing_coredns_route_traces_to_local_zone "true"}}{{ range $src := split .ConfigItems.tracing_coredns_global_traces_endpoint  "," }}{{ $src }}:9254 {{ end }} {{ end }} {
+    cluster.local:9254 {{ if or (eq .ConfigItems.enable_node_scale_out_beyond_1k_nodes "stage1") (eq .ConfigItems.enable_node_scale_out_beyond_1k_nodes "stage2") }}10.2.0.0/15:9254{{ else }}10.2.0.0/16:9254{{ end }} 10.5.0.0/16:9254 {{ if eq .ConfigItems.tracing_coredns_route_traces_to_local_zone "true"}}{{ range $src := split .ConfigItems.tracing_coredns_global_traces_endpoint  "," }}{{ $src }}:9254 {{ end }} {{ end }} {
         errors
         {{ if eq .ConfigItems.tracing_coredns_route_traces_to_local_zone "true"}}
           {{- with $cluster := .Cluster }}

--- a/cluster/manifests/coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/coredns-local/daemonset-coredns.yaml
@@ -122,7 +122,7 @@ spec:
         - --neg-ttl=60
         # send requests to the last server first, only fallback to the previous ones if it's unreachable
         - --strict-order
-        - --server={{ .Cluster.ConfigItems.coredns_cluster_ip_1 }}#53
+        - --server=10.5.0.11#53
         - --server=127.0.0.1#9254
         ports:
         - containerPort: 53

--- a/cluster/manifests/coredns-local/service-coredns.yaml
+++ b/cluster/manifests/coredns-local/service-coredns.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   selector:
     component: coredns
-  clusterIP: {{ .Cluster.ConfigItems.coredns_cluster_ip_1 }}
+  clusterIP: 10.5.0.11
   ports:
   - name: dns
     port: 53

--- a/cluster/manifests/flannel/configmap.yaml
+++ b/cluster/manifests/flannel/configmap.yaml
@@ -23,7 +23,11 @@ data:
     }
   net-conf.json: |
     {
-      "Network": "{{ .ConfigItems.cluster_cidr }}",
+{{ if or (eq .ConfigItems.enable_node_scale_out_beyond_1k_nodes "stage1") (eq .ConfigItems.enable_node_scale_out_beyond_1k_nodes "stage2") }}
+      "Network": "10.2.0.0/15",
+{{ else }}
+      "Network": "10.2.0.0/16",
+{{ end }}
       "Backend": {
         "Type": "vxlan"
       }

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -114,7 +114,10 @@ spec:
 {{ end }}
 {{ if ne .ConfigItems.skipper_routesrv_enabled "exec" }}
           - "-kubernetes-east-west-range-domains=ingress.cluster.local"
-          - "-kubernetes-east-west-range-predicates=ClientIP(\"{{ .Cluster.ConfigItems.cluster_cidr }}\", \"{{ .Values.vpc_ipv4_cidr }}\")"
+{{ else if or (eq .ConfigItems.enable_node_scale_out_beyond_1k_nodes "stage1") (eq .ConfigItems.enable_node_scale_out_beyond_1k_nodes "stage2") }}
+          - "-kubernetes-east-west-range-predicates=ClientIP(\"10.2.0.0/15\", \"{{ .Values.vpc_ipv4_cidr }}\")"
+{{ else }}
+          - "-kubernetes-east-west-range-predicates=ClientIP(\"10.2.0.0/16\", \"{{ .Values.vpc_ipv4_cidr }}\")"
 {{ end }}
           - "-proxy-preserve-host"
           - "-compress-encodings={{ .ConfigItems.skipper_compress_encodings }}"
@@ -225,7 +228,10 @@ spec:
 {{ end }}
 {{ if or (eq .ConfigItems.nlb_switch "pre") (eq .ConfigItems.nlb_switch "exec") }}
           - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
-          - "-forwarded-headers-exclude-cidrs={{ .Cluster.ConfigItems.cluster_cidr }},{{ .Values.vpc_ipv4_cidr}}"
+{{ else if or (eq .ConfigItems.enable_node_scale_out_beyond_1k_nodes "stage1") (eq .ConfigItems.enable_node_scale_out_beyond_1k_nodes "stage2") }}
+          - "-forwarded-headers-exclude-cidrs=10.2.0.0/15,{{ .Values.vpc_ipv4_cidr}}"
+{{ else }}
+          - "-forwarded-headers-exclude-cidrs=10.2.0.0/16,{{ .Values.vpc_ipv4_cidr}}"
 {{ end }}
 {{ if ne .ConfigItems.skipper_ingress_inline_routes "" }}
           - "-inline-routes={{ .ConfigItems.skipper_ingress_inline_routes }}"
@@ -411,7 +417,11 @@ spec:
           - "-kubernetes-east-west-domain=.ingress.cluster.local"
 {{ end }}
           - "-kubernetes-east-west-range-domains=ingress.cluster.local"
-          - "-kubernetes-east-west-range-predicates=ClientIP(\"{{ .Cluster.ConfigItems.cluster_cidr }}\", \"{{ .Values.vpc_ipv4_cidr }}\")"
+{{ if or (eq .ConfigItems.enable_node_scale_out_beyond_1k_nodes "stage1") (eq .ConfigItems.enable_node_scale_out_beyond_1k_nodes "stage2") }}
+          - "-kubernetes-east-west-range-predicates=ClientIP(\"10.2.0.0/15\", \"{{ .Values.vpc_ipv4_cidr }}\")"
+{{ else }}
+          - "-kubernetes-east-west-range-predicates=ClientIP(\"10.2.0.0/16\", \"{{ .Values.vpc_ipv4_cidr }}\")"
+{{ end }}
           - "-reverse-source-predicate"
           - "-enable-api-usage-monitoring"
           - "-api-usage-monitoring-realm-keys=https://identity.zalando.com/realm"
@@ -420,7 +430,10 @@ spec:
           - "-default-filters-dir=/etc/config/default-filters"
 {{ if or (eq .ConfigItems.nlb_switch "pre") (eq .ConfigItems.nlb_switch "exec") }}
           - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
-          - "-forwarded-headers-exclude-cidrs={{ .Cluster.ConfigItems.cluster_cidr }},{{ .Values.vpc_ipv4_cidr}}"
+{{ else if or (eq .ConfigItems.enable_node_scale_out_beyond_1k_nodes "stage1") (eq .ConfigItems.enable_node_scale_out_beyond_1k_nodes "stage2") }}
+          - "-forwarded-headers-exclude-cidrs=10.2.0.0/15,{{ .Values.vpc_ipv4_cidr}}"
+{{ else }}
+          - "-forwarded-headers-exclude-cidrs=10.2.0.0/16,{{ .Values.vpc_ipv4_cidr}}"
 {{ end }}
         resources:
           limits:

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -114,10 +114,11 @@ spec:
 {{ end }}
 {{ if ne .ConfigItems.skipper_routesrv_enabled "exec" }}
           - "-kubernetes-east-west-range-domains=ingress.cluster.local"
-{{ else if or (eq .ConfigItems.enable_node_scale_out_beyond_1k_nodes "stage1") (eq .ConfigItems.enable_node_scale_out_beyond_1k_nodes "stage2") }}
+{{ if or (eq .Cluster.ConfigItems.enable_node_scale_out_beyond_1k_nodes "stage1") (eq .Cluster.ConfigItems.enable_node_scale_out_beyond_1k_nodes "stage2") }}
           - "-kubernetes-east-west-range-predicates=ClientIP(\"10.2.0.0/15\", \"{{ .Values.vpc_ipv4_cidr }}\")"
 {{ else }}
           - "-kubernetes-east-west-range-predicates=ClientIP(\"10.2.0.0/16\", \"{{ .Values.vpc_ipv4_cidr }}\")"
+{{ end }}
 {{ end }}
           - "-proxy-preserve-host"
           - "-compress-encodings={{ .ConfigItems.skipper_compress_encodings }}"
@@ -228,10 +229,11 @@ spec:
 {{ end }}
 {{ if or (eq .ConfigItems.nlb_switch "pre") (eq .ConfigItems.nlb_switch "exec") }}
           - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
-{{ else if or (eq .ConfigItems.enable_node_scale_out_beyond_1k_nodes "stage1") (eq .ConfigItems.enable_node_scale_out_beyond_1k_nodes "stage2") }}
+{{ if or (eq .ConfigItems.enable_node_scale_out_beyond_1k_nodes "stage1") (eq .ConfigItems.enable_node_scale_out_beyond_1k_nodes "stage2") }}
           - "-forwarded-headers-exclude-cidrs=10.2.0.0/15,{{ .Values.vpc_ipv4_cidr}}"
 {{ else }}
           - "-forwarded-headers-exclude-cidrs=10.2.0.0/16,{{ .Values.vpc_ipv4_cidr}}"
+{{ end }}
 {{ end }}
 {{ if ne .ConfigItems.skipper_ingress_inline_routes "" }}
           - "-inline-routes={{ .ConfigItems.skipper_ingress_inline_routes }}"
@@ -430,10 +432,11 @@ spec:
           - "-default-filters-dir=/etc/config/default-filters"
 {{ if or (eq .ConfigItems.nlb_switch "pre") (eq .ConfigItems.nlb_switch "exec") }}
           - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
-{{ else if or (eq .ConfigItems.enable_node_scale_out_beyond_1k_nodes "stage1") (eq .ConfigItems.enable_node_scale_out_beyond_1k_nodes "stage2") }}
+{{ if or (eq .ConfigItems.enable_node_scale_out_beyond_1k_nodes "stage1") (eq .ConfigItems.enable_node_scale_out_beyond_1k_nodes "stage2") }}
           - "-forwarded-headers-exclude-cidrs=10.2.0.0/15,{{ .Values.vpc_ipv4_cidr}}"
 {{ else }}
           - "-forwarded-headers-exclude-cidrs=10.2.0.0/16,{{ .Values.vpc_ipv4_cidr}}"
+{{ end }}
 {{ end }}
         resources:
           limits:

--- a/cluster/manifests/skipper/service-internal.yaml
+++ b/cluster/manifests/skipper/service-internal.yaml
@@ -8,7 +8,7 @@ metadata:
     component: ingress
 spec:
   type: ClusterIP
-  clusterIP: {{ .ConfigItems.skipper_internal_cluster_ip }}
+  clusterIP: 10.5.99.99
   ports:
     - port: 80
       targetPort: 9999

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -115,7 +115,7 @@ write_files:
           - --storage-media-type=application/vnd.kubernetes.protobuf
           - --encryption-provider-config=/etc/kubernetes/config/encryption-config.yaml
           - --allow-privileged=true
-          - --service-cluster-ip-range={{.Cluster.ConfigItems.service_cluster_ip_range}}
+          - --service-cluster-ip-range=10.5.0.0/16
           - --secure-port=443
           - --enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,ExtendedResourceToleration,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota,StorageObjectInUseProtection,PodSecurityPolicy,Priority,NodeRestriction
           - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
@@ -594,7 +594,11 @@ write_files:
           - --use-service-account-credentials=true
           - --configure-cloud-routes=false
           - --allocate-node-cidrs=true
-          - --cluster-cidr={{ .Cluster.ConfigItems.cluster_cidr}}
+{{ if eq .ConfigItems.enable_node_scale_out_beyond_1k_nodes "stage2" }}
+          - --cluster-cidr=10.2.0.0/15
+{{ else }}
+          - --cluster-cidr=10.2.0.0/16
+{{ end }}
           - --node-cidr-mask-size={{ .Cluster.ConfigItems.node_cidr_mask_size }}
           - --kube-api-qps=50
           - --terminated-pod-gc-threshold=500


### PR DESCRIPTION
This commit adds the config-item `enable_node_scale_out_beyond_1k_nodes` to enable Kubernetes to scale out beyond 1000 nodes by changing the cluster_cidr range from `10.2.0.0/16 `to `10.2.0.0/15`

## How to use the config-item?

- First, set `enable_node_scale_out_beyond_1k_nodes: "stage1"` to CLM update flannel, coredns, and skipper. After CLM finishes the update, rotate all the `flannel` and `coredns` pods to reload the new configuration. i.e:

```sh
zkubectl --context <CLUSTER> delete pod -l component=flannel -n kube-system
```

- Then, set `enable_node_scale_out_beyond_1k_nodes: "stage2"` to CLM update the `kube-controller-manager` to use the cluster_cidr 10.2.0.0/15.

It also removes config-items prior created to support the Service CIDR migration and hard code it back in the manifest files.