### PR TITLE
Disable Prometheus PCS when not used

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -44,7 +44,11 @@ pre_apply:
   kind: ClusterRole
 - name: system:admission-controller
   kind: ClusterRoleBinding
-
+{{- if eq .ConfigItems.prometheus_remote_write "disabled" }}
+- name: prometheus-credentials
+  kind: PlatformCredentialsSet
+  namespace: kube-system
+{{- end }}
 # everything defined under here will be deleted after applying the manifests
 post_apply:
 {{ if eq .ConfigItems.teapot_admission_controller_process_resources "true" }}

--- a/cluster/manifests/prometheus/credentialset.yaml
+++ b/cluster/manifests/prometheus/credentialset.yaml
@@ -1,10 +1,12 @@
+{{- if ne .ConfigItems.prometheus_remote_write "disabled" }}
 apiVersion: zalando.org/v1
 kind: PlatformCredentialsSet
 metadata:
   name: prometheus-credentials
   namespace: kube-system
 spec:
-  application: prometheus
+  application: kubernetes
   token_version: v2
   tokens:
     remote-write: {}
+{{- end }}


### PR DESCRIPTION
Disables the Prometheus PCS when remote write is not enabled. Also changed the application from `prometheus` to `kubernetes` which is the active application ID.