### PR TITLE
Move Prometheus PCS cleanup to post apply

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -44,11 +44,6 @@ pre_apply:
   kind: ClusterRole
 - name: system:admission-controller
   kind: ClusterRoleBinding
-{{- if eq .ConfigItems.prometheus_remote_write "disabled" }}
-- name: prometheus-credentials
-  kind: PlatformCredentialsSet
-  namespace: kube-system
-{{- end }}
 # everything defined under here will be deleted after applying the manifests
 post_apply:
 {{ if eq .ConfigItems.teapot_admission_controller_process_resources "true" }}
@@ -126,3 +121,8 @@ post_apply:
   namespace: kube-system
   kind: HorizontalPodAutoscaler
 {{ end }}
+{{- if eq .ConfigItems.prometheus_remote_write "disabled" }}
+- name: prometheus-credentials
+  kind: PlatformCredentialsSet
+  namespace: kube-system
+{{- end }}


### PR DESCRIPTION
Follow up to #5406 moves the cleanup to post-apply to avoid breaking new cluster/e2e setup.