### PR TITLE
Calculate max nodes considering pod CIDR size

### DIFF
--- a/cluster/manifests/infrastructure-configs/cluster-config.yaml
+++ b/cluster/manifests/infrastructure-configs/cluster-config.yaml
@@ -5,4 +5,8 @@ metadata:
   namespace: kube-system
 data:
   cluster-alias: "{{.Cluster.Alias}}"
-  max-nodes: "{{ nodeCIDRMaxNodes (parseInt64 .Cluster.ConfigItems.node_cidr_mask_size) (parseInt64 .Cluster.ConfigItems.reserved_nodes) }}"
+{{ $pod_cidr_size := "16" }}
+{{- if eq .Cluster.ConfigItems.enable_node_scale_out_beyond_1k_nodes "stage2" }}
+{{ $pod_cidr_size = "15" }}
+{{- end }}
+  max-nodes: "{{ nodeCIDRMaxNodesPodCIDR (parseInt64 $pod_cidr_size) (parseInt64 .Cluster.ConfigItems.node_cidr_mask_size) (parseInt64 .Cluster.ConfigItems.reserved_nodes) }}"

--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -51,7 +51,11 @@ spec:
           - --expander=highest-priority
           - --balance-similar-node-groups
           - --max-node-provision-time=7m
-          - --max-nodes-total={{ nodeCIDRMaxNodes (parseInt64 .Cluster.ConfigItems.node_cidr_mask_size) (parseInt64 .Cluster.ConfigItems.reserved_nodes) }}
+          {{ $pod_cidr_size := "16" }}
+          {{- if eq .Cluster.ConfigItems.enable_node_scale_out_beyond_1k_nodes "stage2" }}
+          {{ $pod_cidr_size = "15" }}
+          {{- end }}
+          - --max-nodes-total={{ nodeCIDRMaxNodesPodCIDR (parseInt64 $pod_cidr_size) (parseInt64 .Cluster.ConfigItems.node_cidr_mask_size) (parseInt64 .Cluster.ConfigItems.reserved_nodes) }}
           - --scale-down-enabled={{ .Cluster.ConfigItems.autoscaling_scale_down_enabled }}
           - --max-empty-bulk-delete={{ .Cluster.ConfigItems.autoscaling_max_empty_bulk_delete }}
           - --scale-down-unneeded-time={{ .Cluster.ConfigItems.autoscaling_scale_down_unneeded_time }}


### PR DESCRIPTION
Related to https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/618

This includes the pod CIDR size when calculating the max number of nodes.