### PR TITLE
Enable spot node rescheduling via CronJob

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -506,6 +506,10 @@ teapot_admission_controller_runtime_policy_default: "allow-spot"
 teapot_admission_controller_runtime_policy_enforced: ""
 # Enable hard spot assignment. Only relevant when node_lifecycle_provider=zalando
 teapot_admission_controller_runtime_policy_spot_hard_assignment: "false"
+# Enable experimental rescheduling of spot nodes after spot decommission
+spot_node_rescheduler: "false"
+spot_node_rescheduler_memory: "348Mi"
+spot_node_rescheduler_cpu: "50m"
 
 # Enable and configure prevent scale down annotation
 teapot_admission_controller_prevent_scale_down_enabled: "true"

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -102,6 +102,18 @@ post_apply:
   namespace: kube-system
   kind: VerticalPodAutoscaler
 {{ end }}
+{{ if ne .ConfigItems.spot_node_rescheduler "true" }}
+- name: spot-node-rescheduler
+  namespace: kube-system
+  kind: CronJob
+- name: spot-node-rescheduler
+  namespace: kube-system
+  kind: ServiceAccount
+- name: spot-node-rescheduler
+  kind: ClusterRole
+- name: spot-node-rescheduler
+  kind: ClusterRoleBinding
+{{ end }}
 - labels:
     application: external-dns
   namespace: kube-system

--- a/cluster/manifests/spot-node-rescheduler/cronjob.yaml
+++ b/cluster/manifests/spot-node-rescheduler/cronjob.yaml
@@ -1,0 +1,35 @@
+{{ if eq .ConfigItems.spot_node_rescheduler "true" }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: node-spot-rescheduler
+  namespace: kube-system
+  labels:
+    application: kubernetes
+    component: node-spot-rescheduler
+spec:
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 1800
+      backoffLimit: 1
+      template:
+        metadata:
+          labels:
+            application: kubernetes
+            component: node-spot-rescheduler
+        spec:
+          serviceAccountName: node-spot-rescheduler
+          restartPolicy: Never
+          containers:
+          - name: node-spot-rescheduler
+            image: container-registry.zalando.net/teapot/spot-node-rescheduler:main-1
+            resources:
+            limits:
+              cpu: "{{ .ConfigItems.spot_node_rescheduler_cpu }}"
+              memory: "{{ .ConfigItems.spot_node_rescheduler_memory }}"
+            requests:
+              cpu: "{{ .ConfigItems.spot_node_rescheduler_cpu }}"
+              memory: "{{ .ConfigItems.spot_node_rescheduler_memory }}"
+{{ end }}

--- a/cluster/manifests/spot-node-rescheduler/rbac.yaml
+++ b/cluster/manifests/spot-node-rescheduler/rbac.yaml
@@ -1,0 +1,33 @@
+{{ if eq .ConfigItems.spot_node_rescheduler "true" }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: spot-node-rescheduler
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: spot-node-rescheduler
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["list"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["list", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: spot-node-rescheduler
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: spot-node-rescheduler
+subjects:
+- kind: ServiceAccount
+  name: spot-node-rescheduler
+  namespace: kube-system
+{{ end }}


### PR DESCRIPTION
Currently once a spot node dies, the pods fall to on-demand and can only go back to spot when the nodes are eventually rolled out. This PR adds a CronJob that every 5 minutes checks for spot availability and reintroduces spot nodes as soon as possible. To enable the behaviour the `spot_node_rescheduler` flag must be set to `true`.