### PR TITLE
Shorten expiration of etcd backup objects.

### DIFF
--- a/cluster/etcd/stack.yaml
+++ b/cluster/etcd/stack.yaml
@@ -104,7 +104,7 @@ Resources:
           PropagateAtLaunch: true
           Value: {{certificateExpiry (base64Decode .Cluster.ConfigItems.etcd_client_server_cert)}}
 {{- if eq .Cluster.Environment "e2e" }}
-  ScheduledActionOut: 
+  ScheduledActionOut:
     Type: AWS::AutoScaling::ScheduledAction
     Properties:
       AutoScalingGroupName: !Ref AppServer
@@ -112,7 +112,7 @@ Resources:
       MaxSize: {{.Cluster.ConfigItems.etcd_instance_count}}
       Recurrence: "0 8 * * 1-5"
       TimeZone: "Europe/Berlin"
-  ScheduledActionIn: 
+  ScheduledActionIn:
     Type: AWS::AutoScaling::ScheduledAction
     Properties:
       AutoScalingGroupName: !Ref AppServer
@@ -180,7 +180,7 @@ Resources:
         Rules:
           - AbortIncompleteMultipartUpload:
               DaysAfterInitiation: 1
-            ExpirationInDays: 2
+            ExpirationInDays: 1
             NoncurrentVersionExpirationInDays: 1
             Prefix: ""
             Status: Enabled


### PR DESCRIPTION
The etcd S3 bucket contains backups taken from etcd clusters every minute. We use these backups when we need to recover an etcd cluster after an event that compromises the current data.

When recovering an etcd cluster, we normally use the most recent backup, reflecting the last known state of etcd. Therefore having the current bucket object expiration policy set to 2 days does not makes sense and incur in unnecessary S3 storage costs.

This pull request reduces the object expiration policy to 1 day, hopefully reducing by more or less half the size of the etcd bucket. Ideally we could have an expiration policy of 1 or 2 hours, but unfortunately the S3 lifecycle configuration only allows to specify the number of days for the expiration time.
 
Signed-off-by: rreis <rodrigo.gargravarr@gmail.com>