### PR TITLE
Fix cronjob indentation

### DIFF
--- a/cluster/manifests/spot-node-rescheduler/cronjob.yaml
+++ b/cluster/manifests/spot-node-rescheduler/cronjob.yaml
@@ -26,10 +26,10 @@ spec:
           - name: node-spot-rescheduler
             image: container-registry.zalando.net/teapot/spot-node-rescheduler:main-1
             resources:
-            limits:
-              cpu: "{{ .ConfigItems.spot_node_rescheduler_cpu }}"
-              memory: "{{ .ConfigItems.spot_node_rescheduler_memory }}"
-            requests:
-              cpu: "{{ .ConfigItems.spot_node_rescheduler_cpu }}"
-              memory: "{{ .ConfigItems.spot_node_rescheduler_memory }}"
+              limits:
+                cpu: "{{ .ConfigItems.spot_node_rescheduler_cpu }}"
+                memory: "{{ .ConfigItems.spot_node_rescheduler_memory }}"
+              requests:
+                cpu: "{{ .ConfigItems.spot_node_rescheduler_cpu }}"
+                memory: "{{ .ConfigItems.spot_node_rescheduler_memory }}"
 {{ end }}


### PR DESCRIPTION
Add missing indentation on `resources` section.