### PR TITLE
Allow to configure registry pull qps and burst

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -424,10 +424,13 @@ kubelet_system_reserved_memory: "164Mi"
 kubelet_kube_reserved_cpu: "100m"
 kubelet_kube_reserved_memory: "282Mi"
 
+# if true, uses the explicit registry pull values below, otherwise uses the defaults.
+# Once all clusters use explicit values, this switch can be removed without rolling the nodes.
+kubelet_registry_explicit_pull_config: "false"
 # limit of registry pulls per second (default: 5)
-kubelet_registry_pull_qps: 5
+kubelet_registry_pull_qps: "5"
 # temporary allowance for bursty pulls to the registry (default: 10)
-kubelet_registry_burst: 10
+kubelet_registry_burst: "10"
 
 {{if eq .Cluster.Environment "production"}}
 teapot_admission_controller_validate_application_label: "true"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -424,6 +424,11 @@ kubelet_system_reserved_memory: "164Mi"
 kubelet_kube_reserved_cpu: "100m"
 kubelet_kube_reserved_memory: "282Mi"
 
+# limit of registry pulls per second (default: 5)
+kubelet_registry_pull_qps: 5
+# temporary allowance for bursty pulls to the registry (default: 10)
+kubelet_registry_burst: 10
+
 {{if eq .Cluster.Environment "production"}}
 teapot_admission_controller_validate_application_label: "true"
 teapot_admission_controller_validate_base_images: "true"

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -46,8 +46,10 @@ write_files:
       eventBurst: 50
       kubeAPIQPS: 50
       kubeAPIBurst: 50
-      registryPullQPS:  {{ .Cluster.ConfigItems.kubelet_registry_pull_qps }}
-      registryBurst: {{ .Cluster.ConfigItems.kubelet_registry_burst }}
+{{- if eq .Cluster.ConfigItems.kubelet_registry_explicit_pull_config "true" }}
+      registryPullQPS: "{{ .Cluster.ConfigItems.kubelet_registry_pull_qps }}"
+      registryBurst: "{{ .Cluster.ConfigItems.kubelet_registry_burst }}"
+{{- end }}
       systemReserved:
         cpu: "{{ .Cluster.ConfigItems.kubelet_system_reserved_cpu }}"
         memory: "{{ .Cluster.ConfigItems.kubelet_system_reserved_memory }}"

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -46,6 +46,8 @@ write_files:
       eventBurst: 50
       kubeAPIQPS: 50
       kubeAPIBurst: 50
+      registryPullQPS:  {{ .Cluster.ConfigItems.kubelet_registry_pull_qps }}
+      registryBurst: {{ .Cluster.ConfigItems.kubelet_registry_burst }}
       systemReserved:
         cpu: "{{ .Cluster.ConfigItems.kubelet_system_reserved_cpu }}"
         memory: "{{ .Cluster.ConfigItems.kubelet_system_reserved_memory }}"

--- a/cluster/node-pools/worker-splitaz/userdata.yaml
+++ b/cluster/node-pools/worker-splitaz/userdata.yaml
@@ -86,6 +86,8 @@ write_files:
       eventBurst: 50
       kubeAPIQPS: 50
       kubeAPIBurst: 50
+      registryPullQPS:  {{ .Cluster.ConfigItems.kubelet_registry_pull_qps }}
+      registryBurst: {{ .Cluster.ConfigItems.kubelet_registry_burst }}
       systemReserved:
         cpu: "{{ .Cluster.ConfigItems.kubelet_system_reserved_cpu }}"
         memory: "{{ .Cluster.ConfigItems.kubelet_system_reserved_memory }}"

--- a/cluster/node-pools/worker-splitaz/userdata.yaml
+++ b/cluster/node-pools/worker-splitaz/userdata.yaml
@@ -86,8 +86,10 @@ write_files:
       eventBurst: 50
       kubeAPIQPS: 50
       kubeAPIBurst: 50
-      registryPullQPS:  {{ .Cluster.ConfigItems.kubelet_registry_pull_qps }}
-      registryBurst: {{ .Cluster.ConfigItems.kubelet_registry_burst }}
+{{- if eq .Cluster.ConfigItems.kubelet_registry_explicit_pull_config "true" }}
+      registryPullQPS: "{{ .Cluster.ConfigItems.kubelet_registry_pull_qps }}"
+      registryBurst: "{{ .Cluster.ConfigItems.kubelet_registry_burst }}"
+{{- end }}
       systemReserved:
         cpu: "{{ .Cluster.ConfigItems.kubelet_system_reserved_cpu }}"
         memory: "{{ .Cluster.ConfigItems.kubelet_system_reserved_memory }}"


### PR DESCRIPTION
During the load test we saw that kubelet massively rate-limited itself when pulling from the registries. According to the team managing those there's enough capacity to increase these values. Let's make them configurable so we can adjust them before the next load test.

For reference: https://github.bus.zalan.do/teapot/issues/issues/3353