### PR TITLE
Include mandatory tags in AppServer.

### DIFF
--- a/cluster/etcd/stack.yaml
+++ b/cluster/etcd/stack.yaml
@@ -103,6 +103,15 @@ Resources:
         - Key: certificate-expiry-node
           PropagateAtLaunch: true
           Value: {{certificateExpiry (base64Decode .Cluster.ConfigItems.etcd_client_server_cert)}}
+        - Key: InfrastructureComponent
+          PropagateAtLaunch: true
+          Value: true
+        - Key: application
+          PropagateAtLaunch: true
+          Value: kubernetes
+        - Key: component
+          PropagateAtLaunch: true
+          Value: etcd-cluster
 {{- if eq .Cluster.Environment "e2e" }}
   ScheduledActionOut:
     Type: AWS::AutoScaling::ScheduledAction


### PR DESCRIPTION
When launching an isolated etcd based on our current stack definitiion, not all tags were present in the EC2 instances. This PR adds the missing tags to the `AppServer` definition.

Signed-off-by: rreis <rodrigo.gargravarr@gmail.com>