### PR TITLE
Update Admission Controller

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -811,4 +811,4 @@ hyped_article_lifecycle_management: "false"
 enable_size_memory_backed_volumes: "true"
 
 # specify hostname max allowed length
-hostname-max-length: 57
+hostname_max_length: 57

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -809,3 +809,6 @@ hyped_article_lifecycle_management: "false"
 
 # enable SizeMemoryBackedVolumes feature flag
 enable_size_memory_backed_volumes: "true"
+
+# specify hostname max allowed length
+hostname-max-length: 57

--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -7,6 +7,8 @@ data:
   daemonset.reserved.cpu: "{{ .Cluster.ConfigItems.teapot_admission_controller_daemonset_reserved_cpu }}"
   daemonset.reserved.memory: "{{ .Cluster.ConfigItems.teapot_admission_controller_daemonset_reserved_memory }}"
 
+  dns.default.hostname-max-length: "{{ .Cluster.ConfigItems.hostname_max_length }}"
+
   pod.container-resource-control.min-memory-request: "25Mi"
   pod.container-resource-control.default-cpu-request: "{{ .Cluster.ConfigItems.teapot_admission_controller_default_cpu_request }}"
   pod.container-resource-control.default-memory-request: "{{ .Cluster.ConfigItems.teapot_admission_controller_default_memory_request }}"

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -201,7 +201,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-151
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-153
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
Validate hostname length on Ingresses, RouteGroups, and Services
with the external-dns annotation, by ensuring that the hostname
length is still in accordance with _Route53_ limit after _external-dns_
`cname-` prefix addition on _v0.12.2_.