### PR TITLE
fabric: drop unused header

### DIFF
--- a/cluster/manifests/fabric-gateway/deployment.yaml
+++ b/cluster/manifests/fabric-gateway/deployment.yaml
@@ -49,7 +49,6 @@ spec:
             - -update-fabric-gateway-status=false
 {{ end }}
             - -versioned-hosts-base-domain={{ .Values.hosted_zone }}
-            - -filters=setRequestHeader("X-Route-Controller", "fabric-gateway-controller")
             - -log-level=info
           resources:
             requests:


### PR DESCRIPTION
The `X-Route-Controller` was added to distingush between routes of old and new controller and is not used anymore.

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>