### PR TITLE
Update admission-controller using non-blocking image cache

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -201,7 +201,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-153
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-154
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
Updates to the latest version of admission-controller that doesn't fail startup in large clusters.