### PR TITLE
Fix names on spot-node-rescheduler Cronjob

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -102,6 +102,9 @@ post_apply:
   kind: VerticalPodAutoscaler
 {{ end }}
 {{ if ne .ConfigItems.spot_node_rescheduler "true" }}
+- name: node-spot-rescheduler
+  namespace: kube-system
+  kind: CronJob
 - name: spot-node-rescheduler
   namespace: kube-system
   kind: CronJob

--- a/cluster/manifests/spot-node-rescheduler/cronjob.yaml
+++ b/cluster/manifests/spot-node-rescheduler/cronjob.yaml
@@ -2,11 +2,11 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: node-spot-rescheduler
+  name: spot-node-rescheduler
   namespace: kube-system
   labels:
     application: kubernetes
-    component: node-spot-rescheduler
+    component: spot-node-rescheduler
 spec:
   schedule: "*/5 * * * *"
   concurrencyPolicy: Forbid
@@ -18,12 +18,12 @@ spec:
         metadata:
           labels:
             application: kubernetes
-            component: node-spot-rescheduler
+            component: spot-node-rescheduler
         spec:
-          serviceAccountName: node-spot-rescheduler
+          serviceAccountName: spot-node-rescheduler
           restartPolicy: Never
           containers:
-          - name: node-spot-rescheduler
+          - name: spot-node-rescheduler
             image: container-registry.zalando.net/teapot/spot-node-rescheduler:main-1
             resources:
               limits:


### PR DESCRIPTION
Rename all `node-spot-rescheduler` occurrences on the cronjob for
`spot-node-rescheduler`, both fixing the RBAC relation and improving
name consistency.
