### PR TITLE
Make kube-node-ready opt-in rather than opt-out

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -847,3 +847,6 @@ network_monitoring_check_kubenurse_ingress: "false"
 network_monitoring_check_neighborhood: "true"
 network_monitoring_check_unschedulable_nodes: "true"
 network_monitoring_check_interval: "1m"
+
+# specify if control plane nodes should rely on ASG Lifecycle Hook or not
+control_plane_asg_lifecycle_hook: "true"

--- a/cluster/manifests/kube-node-ready/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready/daemonset.yaml
@@ -25,6 +25,9 @@ spec:
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
+      # only schedule on nodes which require ASG lifecycle hook to trigger
+      nodeSelector:
+        asg-lifecycle-hook: "true"
       serviceAccountName: kube-node-ready
       dnsConfig:
         options:

--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -81,6 +81,7 @@ Resources:
       Roles:
       - !ImportValue '{{ .Cluster.ID }}:master-iam-role'
     Type: 'AWS::IAM::InstanceProfile'
+{{- if eq .Cluster.ConfigItems.control_plane_asg_lifecycle_hook "true" }}
   AutoscalingLifecycleHook:
     Properties:
       AutoScalingGroupName: !Ref AutoScalingGroup
@@ -89,3 +90,4 @@ Resources:
       HeartbeatTimeout: '600'
       LifecycleTransition: 'autoscaling:EC2_INSTANCE_LAUNCHING'
     Type: 'AWS::AutoScaling::LifecycleHook'
+{{- end }}

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -4,7 +4,7 @@ write_files:
     path: /etc/kubernetes/secrets.env
     content: |
       NODEPOOL_TAINTS=node.kubernetes.io/role=master:NoSchedule{{if index .NodePool.ConfigItems "taints"}},{{.NodePool.ConfigItems.taints}}{{end}}
-      NODE_LABELS=master=true,node.kubernetes.io/exclude-from-external-load-balancers,node.kubernetes.io/distro=ubuntu,cluster-lifecycle-controller.zalan.do/decommission-priority=999,{{ .Values.node_labels }}{{if index .NodePool.ConfigItems "labels"}},{{.NodePool.ConfigItems.labels}}{{end}}
+      NODE_LABELS=master=true,node.kubernetes.io/exclude-from-external-load-balancers,node.kubernetes.io/distro=ubuntu,cluster-lifecycle-controller.zalan.do/decommission-priority=999,{{ .Values.node_labels }}{{if index .NodePool.ConfigItems "labels"}},{{.NodePool.ConfigItems.labels}}{{end}}{{if eq .Cluster.ConfigItems.control_plane_asg_lifecycle_hook "true" }},asg-lifecycle-hook=true{{end}}
       NODEPOOL_NAME={{ .NodePool.Name }}
       KUBELET_ROLE=master
 

--- a/cluster/node-pools/worker-splitaz/userdata.yaml
+++ b/cluster/node-pools/worker-splitaz/userdata.yaml
@@ -8,7 +8,7 @@ write_files:
     path: /etc/kubernetes/secrets.env
     content: |
       NODEPOOL_TAINTS={{if index .NodePool.ConfigItems "taints"}}{{.NodePool.ConfigItems.taints}}{{end}}
-      NODE_LABELS={{ .Values.node_labels }},node.kubernetes.io/distro=ubuntu{{if index .NodePool.ConfigItems "labels"}},{{.NodePool.ConfigItems.labels}}{{end}}
+      NODE_LABELS={{ .Values.node_labels }},node.kubernetes.io/distro=ubuntu{{if index .NodePool.ConfigItems "labels"}},{{.NodePool.ConfigItems.labels}}{{end}}{{if or (eq .NodePool.Profile "worker-splitaz") (eq .NodePool.Profile "worker-combined")}},asg-lifecycle-hook=true{{end}}
       NODEPOOL_NAME={{ .NodePool.Name }}
       KUBELET_ROLE=worker
       ON_DEMAND_WORKER_REPLACEMENT_STRATEGY={{ .Cluster.ConfigItems.on_demand_worker_replacement_strategy }}


### PR DESCRIPTION
By default `kube-node-ready` run on ALL nodes. This is fine when all nodes are managed by Autoscaling Groups (ASG) but is a problem if they are not like Karpenter #5136 where we would need to opt-out.

This PR does three things:

1. Adds a label `asg-lifecycle-hook=true` to worker nodes which has a profile based on ASGs.
2. Adds a node selector for `asg-lifecycle-hook=true` on `kube-node-ready` daemonset such that it only gets scheduled on nodes which indicate the nodes are managed by an ASG.
3. Makes the ASG Lifecycle Hook and label optional on control plane nodes. This way we can experiment turning it off for control plane nodes which is an idea to reduce time to recover the control plane nodes getting overloaded. It's still enabled by default.

Because this sets a label on worker nodes it will roll all nodes but could be combined with other changes.