### PR TITLE
Name Skipper service internal ports.

### DIFF
--- a/cluster/manifests/skipper/service-internal.yaml
+++ b/cluster/manifests/skipper/service-internal.yaml
@@ -13,10 +13,12 @@ spec:
     - port: 80
       targetPort: 9999
       protocol: TCP
+      name: main
 {{if eq .Cluster.ConfigItems.skipper_ingress_eastwest_additional_port "true"}}
     - port: 8080
       targetPort: 9999
       protocol: TCP
+      name: additional
 {{end}}
   selector:
     application: skipper-ingress


### PR DESCRIPTION
When having more than 1 port in a service, ports need to have a name. Fix for https://github.com/zalando-incubator/kubernetes-on-aws/pull/5473

Signed-off-by: rreis <rodrigo.gargravarr@gmail.com>