### PR TITLE
Reduce batch size to avoid blocking record updates

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -50,7 +50,11 @@ spec:
         - --registry=txt
         - --txt-owner-id={{ .Region }}:{{ .LocalID }}
         - --txt-prefix={{ .ConfigItems.external_dns_ownership_prefix }}
-        - --aws-batch-change-size=100
+        {{- if eq .Cluster.ConfigItems.external_dns_version "current" }}
+        - --aws-batch-change-size=3
+        {{- else }}
+        - --aws-batch-change-size=2
+        {{- end }}
         - --annotation-filter=external-dns.alpha.kubernetes.io/exclude notin (true)
         - --policy={{ .ConfigItems.external_dns_policy }}
         resources:

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -50,11 +50,7 @@ spec:
         - --registry=txt
         - --txt-owner-id={{ .Region }}:{{ .LocalID }}
         - --txt-prefix={{ .ConfigItems.external_dns_ownership_prefix }}
-        {{- if eq .Cluster.ConfigItems.external_dns_version "current" }}
-        - --aws-batch-change-size=3
-        {{- else }}
-        - --aws-batch-change-size=2
-        {{- end }}
+        - --aws-batch-change-size=120
         - --annotation-filter=external-dns.alpha.kubernetes.io/exclude notin (true)
         - --policy={{ .ConfigItems.external_dns_policy }}
         resources:


### PR DESCRIPTION
This is ridiculous but I want to give it a try for https://github.bus.zalan.do/teapot/issues/issues/3327

By reducing the batch size we reduce the blast radius that occurs when any record within the batch cannot be applied. We don't want to completely get rid of batching because the pair of A and TXT record(s) should be successfully created or fail in unison. This is best achieved by putting them in the same batch but could also be achieved differently.

From my observation the newer versions of ExternalDNS manage two TXT records (either by intention or bug) so the batch size is different between the versions.

This relies upon the fact that the previous stage in ExternalDNS provides the A and TXT records in an alternating order where an A and subsequent TXT forms the pair. I'm not sure if that's always the case but it certainly looks like it in old versions of ExternalDNS. The new `cname-` prefixed TXT records might break this assumption.

Choosing a non-aligned batch size, no batching at all, or if A and TXT of a pair (or triple) are not subsequent, then it doesn't matter as long as there are no errors in a batch. If there are then it could happen that a TXT record is created without the corresponding A record and vice versa, which would lead to subsequent errors.

However, it does allow records unrelated to the small failing batch to be correctly processed.

This will also drive up the API calls to AWS by 50x in the worst case. However, changes to DNS records are typically 0-5 per iteration so the increase API calls would be something like 5x in that case.