### PR TITLE
Update etcd AMI.

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -545,7 +545,7 @@ etcd_instance_type: "t3.medium"
 
 etcd_docker_image: "registry.opensource.zalan.do/teapot/etcd-cluster:3.4.16-master-10"
 etcd_scalyr_key: ""
-etcd_ami: {{ amiID "zalando-ubuntu-etcd-production-v3.4.16-amd64-main-8" "861068367966"}}
+etcd_ami: {{ amiID "zalando-ubuntu-etcd-production-v3.4.16-amd64-main-9" "861068367966"}}
 
 dynamodb_service_link_enabled: "false"
 


### PR DESCRIPTION
New etcd AMI adds 2 collectors to prometheus node exporter: `ethtool` and `processes`. This way we can collect e.g. ENA metrics.

Will only have effect after rotating etcds.

Signed-off-by: rreis <rodrigo.gargravarr@gmail.com>