### PR TITLE
Add support for k8s-audit-metrics

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -639,13 +639,17 @@ rotate_service_account_tokens: "true"
 # issue tokens with a long expiration time in order to detect applications that don't refresh tokens.
 rotate_service_account_tokens_extended_expiration: "true"
 
-# enable auditlogging for read access such that we can identified clients using
-# the default service account to read from the API server.
+# enable auditlogging metrics such that we can identify clients calling the
+# apiserver.
 {{ if eq .Cluster.Environment "test" }}
-auditlog_read_access: "true"
+auditlog_metrics: "true"
 {{ else }}
-auditlog_read_access: "false"
+auditlog_metrics: "false"
 {{ end }}
+
+# enable auditlogging of read access to identify service accounts reading from
+# the api. This only has effect if auditlog_metrics=true.
+auditlog_read_access: "true"
 
 # allow ssh access for internal VPC IPs only
 ssh_vpc_only: "false"

--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -127,6 +127,11 @@ data:
     - <<: *apiserver_container_metric
       job_name: "aws-encryption-provider"
       metrics_path: "/aws-encryption-provider"
+{{- if eq .Cluster.ConfigItems.auditlog_metrics "true" }}
+    - <<: *apiserver_container_metric
+      job_name: "audit-metrics"
+      metrics_path: "/audit-metrics"
+{{- end }}
     - job_name: 'kube-state-metrics'
       scheme: http
       honor_labels: true

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -146,24 +146,22 @@ write_files:
           - --service-account-issuer={{ .Cluster.APIServerURL }}
           - --service-account-jwks-uri={{ .Cluster.APIServerURL }}/openid/v1/jwks
           - --service-account-extend-token-expiration={{ .Cluster.ConfigItems.rotate_service_account_tokens_extended_expiration }}
+          - --audit-policy-file=/etc/kubernetes/config/audit-policy.yaml
           {{ if and (ne .Cluster.ConfigItems.audittrail_url "") (ne .Cluster.Environment "e2e") }}
           - --audit-webhook-config-file=/etc/kubernetes/config/audit.yaml
           - --audit-webhook-mode=batch
           - --audit-webhook-version=audit.k8s.io/v1
-          - --audit-policy-file=/etc/kubernetes/config/audit-policy.yaml
           {{ end }}
           {{ if eq .Cluster.Environment "e2e" }}
           - --audit-log-path=/var/log/kube-audit.log
           - --audit-log-maxage=0
           - --audit-log-maxbackup=0
           - --audit-policy-file=/etc/kubernetes/config/audit-policy.yaml
-          {{ else if and (eq .Cluster.ConfigItems.enable_default_sa "true") (eq .Cluster.ConfigItems.auditlog_read_access "true") }}
-          - --audit-log-path=/dev/stdout
+          {{ else if eq .Cluster.ConfigItems.auditlog_metrics "true" }}
+          - --audit-log-path=/var/log/kube-audit.log
           - --audit-log-maxage=0
-          - --audit-log-maxbackup=0
-          {{ if eq .Cluster.ConfigItems.audittrail_url "" }}
-          - --audit-policy-file=/etc/kubernetes/config/audit-policy-ro.yaml
-          {{ end }}
+          - --audit-log-maxbackup=1 # Limit number of rotated audit files to 1
+          - --audit-log-maxsize=100 # Limit file size to 100Mi
           {{ end }}
           # enable aggregated apiservers
           - --client-ca-file=/etc/kubernetes/ssl/ca.pem
@@ -201,6 +199,8 @@ write_files:
             readOnly: true
           - mountPath: /var/run/kmsplugin
             name: var-run-kmsplugin
+          - mountPath: /var/log
+            name: var-log
           resources:
             requests:
               cpu: 100m
@@ -494,6 +494,12 @@ write_files:
               -> disableAccessLog()
               -> setPath("/metrics")
               -> "http://localhost:8086";
+{{- if eq .Cluster.ConfigItems.auditlog_metrics "true" }}
+            audit_metrics: Path("/audit-metrics")
+              -> disableAccessLog()
+              -> setPath("/metrics")
+              -> "http://localhost:8087";
+{{- end }}
             skipper_proxy: Path("/skipper-proxy")
               -> disableAccessLog()
               -> setPath("/metrics")
@@ -548,6 +554,30 @@ write_files:
           volumeMounts:
           - mountPath: /var/run/kmsplugin
             name: var-run-kmsplugin
+{{- if eq .Cluster.ConfigItems.auditlog_metrics "true" }}
+        - name: k8s-audit-metrics
+          image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/k8s-audit-metrics:main-1
+          args:
+          - /var/log/kube-audit.log
+          ports:
+          - containerPort: 8087
+            protocol: TCP
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c",  " sleep 60"]
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8087
+          resources:
+            requests:
+              cpu: 50m
+              memory: 50Mi
+          volumeMounts:
+          - mountPath: /var/log
+            name: var-log
+{{- end }}
         volumes:
         - hostPath:
             path: /etc/kubernetes/ssl
@@ -563,6 +593,9 @@ write_files:
             path: /etc/kubernetes/admission-controller-kubeconfig
             type: File
           name: admission-controller-kubeconfig
+        - hostPath:
+            path: /var/log
+          name: var-log
 
   - owner: root:root
     path: /etc/kubernetes/manifests/kube-controller-manager.yaml
@@ -814,7 +847,7 @@ write_files:
               resources: ["tokenreviews"]
           omitStages:
             - "RequestReceived"
-{{ if and (eq .Cluster.ConfigItems.enable_default_sa "true") (eq .Cluster.ConfigItems.auditlog_read_access "true") }}
+{{ if and (eq .Cluster.ConfigItems.auditlog_metrics "true") (eq .Cluster.ConfigItems.auditlog_read_access "true") }}
         - level: None
           verbs: ["watch", "list", "get"]
           userGroups: ["system:serviceaccounts:kube-system"]
@@ -831,22 +864,6 @@ write_files:
         - level: Request
           omitStages:
             - "RequestReceived"
-
-{{ if and (eq .Cluster.ConfigItems.enable_default_sa "true") (eq .Cluster.ConfigItems.auditlog_read_access "true") }}
-  - owner: root:root
-    path: /etc/kubernetes/config/audit-policy-ro.yaml
-    content: |
-      apiVersion: audit.k8s.io/v1beta1
-      kind: Policy
-      rules:
-      - level: None
-        userGroups: ["system:serviceaccounts:kube-system"]
-      - level: Request
-        verbs: ["watch", "list", "get"]
-        userGroups: ["system:serviceaccounts"]
-        omitStages:
-        - "RequestReceived"
-{{ end }}
 
   - owner: root:root
     path: /etc/kubernetes/config/encryption-config.yaml


### PR DESCRIPTION
Introduce optional support for enabling https://github.com/giantswarm/k8s-audit-metrics such that we can expose metrics about clients connecting to the apiserver. This is helpful to understand where load is coming from and for finding misbehaving clients.

This is enabled with the config item: `auditlog_metrics` which is false by default in production.

This PR also cleans up a bit of the audit-policy configuration which we had from the past where we wanted to identify different things for migrations. It is now a bit more simplified keeping the same functionality.

One challenge we have is that we don't log many read events because we don't want to overload our internal audit-trail system. This however also means that we won't count those events in the k8s-audit-metrics. Read access events for services accounts not in `kube-system` can optionally be enabled via `auditlog_read_access` config item.