### PR TITLE
Collect ethtool metrics in prometheus

### DIFF
--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -293,7 +293,7 @@ data:
         target_label: uid
       - source_labels: [__name__]
         action: keep
-        regex: '(container_cpu_cfs_throttled_seconds_total|container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_memory_rss|container_memory_cache|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_fs_usage_bytes|container_fs_limit_bytes|container_fs_reads_bytes_total|container_fs_writes_bytes_total|container_threads|container_threads_max|container_file_descriptors)'
+        regex: '(container_cpu_cfs_throttled_seconds_total|container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_memory_rss|container_memory_cache|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_fs_usage_bytes|container_fs_limit_bytes|container_fs_reads_bytes_total|container_fs_writes_bytes_total|container_threads|container_threads_max|container_file_descriptors{{ if eq .Cluster.ConfigItems.node_exporter_experimental_metrics "true" }}|ethtool{{end}})'
     - job_name: 'node-exporter'
       scheme: http
       honor_labels: true


### PR DESCRIPTION
Follow up to #4590 to collect the `ethtool` metrics in prometheus if the collector is enabled.