### PR TITLE
Fix nil pointer crash in k8s-audit-metric

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -556,7 +556,7 @@ write_files:
             name: var-run-kmsplugin
 {{- if eq .Cluster.ConfigItems.auditlog_metrics "true" }}
         - name: k8s-audit-metrics
-          image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/k8s-audit-metrics:main-1
+          image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/k8s-audit-metrics:main-2
           args:
           - /var/log/kube-audit.log
           ports:


### PR DESCRIPTION
Follow up to #5491

Fixes a `invalid memory address or nil pointer dereference` that made it crash.