### PR TITLE
Prevent k8s-audit-metrics from crashing on startup

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -557,8 +557,9 @@ write_files:
 {{- if eq .Cluster.ConfigItems.auditlog_metrics "true" }}
         - name: k8s-audit-metrics
           image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/k8s-audit-metrics:main-2
+          command: ["/bin/sh", "-c"]
           args:
-          - /var/log/kube-audit.log
+          - "touch /var/log/kube-audit.log && exec /k8s-audit-metrics /var/log/kube-audit.log"
           ports:
           - containerPort: 8087
             protocol: TCP


### PR DESCRIPTION
`k8s-audit-metrics` container can race with the kube-apiserver and will fail to start if the file `/var/log/kube-audit.log` is not already present. To avoid the noise of restarting containers in the `kube-apiserver` pod, simply ensure the file is present before starting `k8s-audit-metrics`.