### PR TITLE
Fix scraping of dnsmasq metrics

### DIFF
--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -234,7 +234,7 @@ data:
           names:
             - kube-system
       relabel_configs:
-      - source_labels: [__meta_kubernetes_pod_label_application, __meta_kubernetes_pod_container_port_number]
+      - source_labels: [__meta_kubernetes_pod_label_daemonset, __meta_kubernetes_pod_container_port_number]
         action: keep
         regex: coredns;9054
       - action: replace


### PR DESCRIPTION
With #5145 we consolidated the `coredns` application into the `kubernetes` application as a component. Unfortunately this broke our prometheus scraping configuration for dnsmasq relying on the `application=coredns` label on the coredns pods.

This fixes the issue by relying on the new `daemonset` label used for the matchLabel selection.