### PR TITLE
Update Etcd AMI - enable `ethtool` and `processes` on Prometheus

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -545,7 +545,7 @@ etcd_instance_type: "t3.medium"
 
 etcd_docker_image: "registry.opensource.zalan.do/teapot/etcd-cluster:3.4.16-master-10"
 etcd_scalyr_key: ""
-etcd_ami: {{ amiID "zalando-ubuntu-etcd-production-v3.4.16-amd64-main-9" "861068367966"}}
+etcd_ami: {{ amiID "zalando-ubuntu-etcd-production-v3.4.16-amd64-main-10" "861068367966"}}
 
 dynamodb_service_link_enabled: "false"
 


### PR DESCRIPTION
This etcd AMI contains the fix for enabling `ethtool` and `processes` plugins for prometheus node exporter. Fix for https://github.com/zalando-incubator/kubernetes-on-aws/pull/5490

Requires rotating etcd nodes.

Signed-off-by: rreis <rodrigo.gargravarr@gmail.com>