### PR TITLE
Skipper: do not enforce topology spread after pending for 7m

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -33,6 +33,9 @@ spec:
         prometheus.io/path: /metrics
         prometheus.io/port: "9911"
         prometheus.io/scrape: "true"
+{{- if eq .ConfigItems.skipper_topology_spread_enabled "true" }}
+        zalando.org/topology-spread-timeout: 7m
+{{- end }}
     spec:
 {{- if eq .ConfigItems.skipper_topology_spread_enabled "true" }}
       topologySpreadConstraints:
@@ -388,6 +391,9 @@ spec:
         prometheus.io/path: /metrics
         prometheus.io/port: "9990"
         prometheus.io/scrape: "true"
+{{- if eq .ConfigItems.skipper_topology_spread_enabled "true" }}
+        zalando.org/topology-spread-timeout: 7m
+{{- end }}
     spec:
 {{- if eq .ConfigItems.skipper_topology_spread_enabled "true" }}
       topologySpreadConstraints:

--- a/cluster/manifests/skipper/skipper-redis.yaml
+++ b/cluster/manifests/skipper/skipper-redis.yaml
@@ -28,6 +28,9 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
+{{- if eq .ConfigItems.skipper_topology_spread_enabled "true" }}
+        zalando.org/topology-spread-timeout: 7m
+{{- end }}
     spec:
 {{- if eq .ConfigItems.skipper_topology_spread_enabled "true" }}
       topologySpreadConstraints:


### PR DESCRIPTION
We cannot use the [Automatic Topology Spread annotation ](https://cloud.docs.zalando.net/howtos/topology-spread/#ensure-pods-are-evenly-spread-across-availability-zones) for skipper-redis because it has custom `affinities` in which case we [don't inject automatically](https://github.bus.zalan.do/teapot/admission-controller/blob/902713033465f03f378c23d79f890f989992b3d2/pkg/admitters/pod/admit_pod.go#L830-L832).

Since the affinity used here (prevent two pods from landing on the same node) is compatible with topology spread across zones we've added it manually. To fully mimic what the automatic injection would do, we also need to inject the timeout annotation with the default value.

The timeout annotation instructs the autoscaler to ignore topology spread constraints if the pod has been Pending for 7m or more. This prevents deployments from being stuck in case there's a shortage of nodes in a zone.