### PR TITLE
Update Admission Controller domain length config

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -823,3 +823,4 @@ enable_size_memory_backed_volumes: "true"
 # Each subdomain can reach a max of 63 bytes on Route53
 # This custom value sets the subdomain max allowed length taking into consideration the 'cname-' prefix added by external-dns
 subdomain_max_length: "57"
+hostname_max_length: "57" # to be removed

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -820,5 +820,6 @@ hyped_article_lifecycle_management: "false"
 # enable SizeMemoryBackedVolumes feature flag
 enable_size_memory_backed_volumes: "true"
 
-# specify hostname max allowed length
-hostname_max_length: "57"
+# Each subdomain can reach a max of 63 bytes on Route53
+# This custom value sets the subdomain max allowed length taking into consideration the 'cname-' prefix added by external-dns
+subdomain_max_length: "57"

--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -7,7 +7,7 @@ data:
   daemonset.reserved.cpu: "{{ .Cluster.ConfigItems.teapot_admission_controller_daemonset_reserved_cpu }}"
   daemonset.reserved.memory: "{{ .Cluster.ConfigItems.teapot_admission_controller_daemonset_reserved_memory }}"
 
-  dns.default.hostname-max-length: "{{ .Cluster.ConfigItems.hostname_max_length }}"
+  dns.default.subdomain-max-length: "{{ .Cluster.ConfigItems.subdomain_max_length }}"
 
   pod.container-resource-control.min-memory-request: "25Mi"
   pod.container-resource-control.default-cpu-request: "{{ .Cluster.ConfigItems.teapot_admission_controller_default_cpu_request }}"

--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -8,6 +8,7 @@ data:
   daemonset.reserved.memory: "{{ .Cluster.ConfigItems.teapot_admission_controller_daemonset_reserved_memory }}"
 
   dns.default.subdomain-max-length: "{{ .Cluster.ConfigItems.subdomain_max_length }}"
+  dns.default.hostname-max-length: "{{ .Cluster.ConfigItems.hostname_max_length }}" # to be removed
 
   pod.container-resource-control.min-memory-request: "25Mi"
   pod.container-resource-control.default-cpu-request: "{{ .Cluster.ConfigItems.teapot_admission_controller_default_cpu_request }}"

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -205,7 +205,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-157
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-158
           name: admission-controller
           lifecycle:
             preStop:

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -205,7 +205,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-155
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-157
           name: admission-controller
           lifecycle:
             preStop:

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -205,7 +205,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-154
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-155
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
- Allow `kubernurse` daemonset
- For clearer naming, rename `hostname_max_length` as
`subdomain_max_length`.