### PR TITLE
Update admission-controller to support StatefulSets with PVCs

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -205,7 +205,7 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-154
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-158
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
This allows to process the `zalando.org/topology-spread` annotation on StatefulSets.