### PR TITLE
Remove outdated hostname_max_length config-item

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -827,7 +827,6 @@ enable_size_memory_backed_volumes: "true"
 # Each subdomain can reach a max of 63 bytes on Route53
 # This custom value sets the subdomain max allowed length taking into consideration the 'cname-' prefix added by external-dns
 subdomain_max_length: "57"
-hostname_max_length: "57" # to be removed
 
 # Network monitoring
 network_monitoring_enabled: "false"

--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -8,7 +8,6 @@ data:
   daemonset.reserved.memory: "{{ .Cluster.ConfigItems.teapot_admission_controller_daemonset_reserved_memory }}"
 
   dns.default.subdomain-max-length: "{{ .Cluster.ConfigItems.subdomain_max_length }}"
-  dns.default.hostname-max-length: "{{ .Cluster.ConfigItems.hostname_max_length }}" # to be removed
 
   pod.container-resource-control.min-memory-request: "25Mi"
   pod.container-resource-control.default-cpu-request: "{{ .Cluster.ConfigItems.teapot_admission_controller_default_cpu_request }}"


### PR DESCRIPTION
Following up with the Admission Controller's [update](https://github.com/zalando-incubator/kubernetes-on-aws/pull/5510), that now looks
for `subdomain_max_length`, `hostname_max_length` is no longer used.