### PR TITLE
ExternalDNS: Use batch size that's divisible by both two and three

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -50,7 +50,7 @@ spec:
         - --registry=txt
         - --txt-owner-id={{ .Region }}:{{ .LocalID }}
         - --txt-prefix={{ .ConfigItems.external_dns_ownership_prefix }}
-        - --aws-batch-change-size=100
+        - --aws-batch-change-size=120
         - --annotation-filter=external-dns.alpha.kubernetes.io/exclude notin (true)
         - --policy={{ .ConfigItems.external_dns_policy }}
         resources:


### PR DESCRIPTION
The latest version of ExternalDNS uses one more TXT record for a total of three records for each main record. This can lead to issues when hitting the maximum batch size of 100 where the group of three records could be separated into two batches (because 100 is not divisible by three) which is not desirable.

Since we're still running the old ExternalDNS version in some clusters we need to support the old behaviour as well. The easiest way to do this is to pick a slightly different batch size that is divisible by both two and three so it supports both versions at the same time.