### PR TITLE
Make external-dns memory configurable

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -670,6 +670,9 @@ external_dns_policy: sync
 # legacy => v0.9.0-master-26
 external_dns_version: "current"
 
+# resource configuration
+external_dns_mem: "4Gi"
+
 # select which cache to use for Cluster DNS: unbound or dnsmasq.
 dns_cache: "dnsmasq"
 

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -56,10 +56,10 @@ spec:
         resources:
           requests:
             cpu: 50m
-            memory: 4Gi
+            memory: {{ .ConfigItems.external_dns_mem }}
           limits:
             cpu: 50m
-            memory: 4Gi
+            memory: {{ .ConfigItems.external_dns_mem }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/cluster/manifests/external-dns/vpa.yaml
+++ b/cluster/manifests/external-dns/vpa.yaml
@@ -17,4 +17,4 @@ spec:
     containerPolicies:
     - containerName: external-dns
       maxAllowed:
-        memory: 4Gi
+        memory: {{ .ConfigItems.external_dns_mem }}


### PR DESCRIPTION
It was observed that for larger clusters like `fashion-store` external-dns can be OOM killed due to processing too much information (it has pod, node, endpoint informers enabled for our use case). Currently, the memory limit is not configurable.

This patch makes it possible to increase memory limit for external-dns.