### PR TITLE
External dns mem config hotfix

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -670,6 +670,9 @@ external_dns_policy: sync
 # legacy => v0.9.0-master-26
 external_dns_version: "current"
 
+# resource configuration
+external_dns_mem: "4Gi"
+
 # select which cache to use for Cluster DNS: unbound or dnsmasq.
 dns_cache: "dnsmasq"
 

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -56,10 +56,10 @@ spec:
         resources:
           requests:
             cpu: 50m
-            memory: 4Gi
+            memory: {{ .ConfigItems.external_dns_mem }}
           limits:
             cpu: 50m
-            memory: 4Gi
+            memory: {{ .ConfigItems.external_dns_mem }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/cluster/manifests/external-dns/vpa.yaml
+++ b/cluster/manifests/external-dns/vpa.yaml
@@ -17,4 +17,4 @@ spec:
     containerPolicies:
     - containerName: external-dns
       maxAllowed:
-        memory: 4Gi
+        memory: {{ .ConfigItems.external_dns_mem }}


### PR DESCRIPTION
a hot fix PR to avoid merging features on beta channel to stable

This enables increasing resources for external-dns in big clusters.

ref: #5530