### PR TITLE
Block v1beta1 CRDs by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -290,9 +290,8 @@ event_rate_limit_enable: "true"
 event_rate_limit_config_qps: "500"
 event_rate_limit_config_burst: "1000"
 
-# This parameter will be set to default 'true' when testing is in progress.
-# Will later be changed to default 'false' as a sane value.
-allow_v1beta1_crds: "true"
+# As CRD migration is almost finished (2 clusters remain), setting sane default to `false`.
+allow_v1beta1_crds: "false"
 
 # cadvisor settings
 cadvisor_cpu: "150m"


### PR DESCRIPTION
Updates the sane default of `allow_v1beta1_crds` from `true` to `false` since the CRD rollout is almost finished. This config-item will stay in place until all clusters have been rolled out to 1.22. Afterwards, it will be removed.