### PR TITLE
Add allow_v1beta1_ingresses config-item

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -293,6 +293,10 @@ event_rate_limit_config_burst: "1000"
 # As CRD migration is almost finished (2 clusters remain), setting sane default to `false`.
 allow_v1beta1_crds: "false"
 
+# This parameter is set to default `true` while we migrate ingresses to v1.
+# Later, will be changed to default to `false` and after migration is done, will be removed.
+allow_v1beta1_ingresses: "true"
+
 # cadvisor settings
 cadvisor_cpu: "150m"
 cadvisor_memory: "150Mi"

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -124,7 +124,7 @@ write_files:
           {{- end }}
           - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
           - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
-          - --runtime-config=extensions/v1beta1/networkpolicies=true,policy/v1beta1=true,authorization.k8s.io/v1beta1=true,scheduling.k8s.io/v1alpha1=true,admissionregistration.k8s.io/v1beta1=true,apiextensions.k8s.io/v1beta1={{ .Cluster.ConfigItems.allow_v1beta1_crds }}
+          - --runtime-config=extensions/v1beta1/networkpolicies=true,policy/v1beta1=true,authorization.k8s.io/v1beta1=true,scheduling.k8s.io/v1alpha1=true,admissionregistration.k8s.io/v1beta1=true,apiextensions.k8s.io/v1beta1={{ .Cluster.ConfigItems.allow_v1beta1_crds }},extensions/v1beta1/ingress={{ .Cluster.ConfigItems.allow_v1beta1_ingresses }},networking.k8s.io/v1beta1/ingress={{ .Cluster.ConfigItems.allow_v1beta1_ingresses }}
           - --authentication-token-webhook-config-file=/etc/kubernetes/config/authn.yaml
           - --authentication-token-webhook-cache-ttl=10s
           - --cloud-provider=aws


### PR DESCRIPTION
This makes `v1beta1` version of `Ingress` configurable. This config-item will be used to plan the migration of `Ingress` to `v1`.

Reference: https://github.bus.zalan.do/teapot/issues/issues/3255#issuecomment-4153561