### PR TITLE
Add cloudformation definition for etcd key.

### DIFF
--- a/cluster/etcd/pre-stack.yaml
+++ b/cluster/etcd/pre-stack.yaml
@@ -1,0 +1,56 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Etcd Pre-stack resources
+Metadata:
+  Tags:
+    InfrastructureComponent: "true"
+    application: "kubernetes"
+Outputs:
+  EtcdKeyArn:
+    Description: "Key used to encrypt and decrypt Etcd bootstrap secrets."
+    Value: !GetAtt EtcdFilesEncryptionKey.Arn
+    Export:
+      Name: "etcd-cluster-preapply-etcd:etcd-kms-key-arn"
+Resources:
+  EtcdFilesEncryptionKey:
+    Type: "AWS::KMS::Key"
+    DeletionPolicy: "Retain"
+    Properties:
+      Description: Key used by the etcd cluster nodes
+      EnableKeyRotation: false
+      KeyPolicy:
+        Version: "2012-10-17"
+        Id: "etcd-files-key-policy"
+        Statement:
+          - Sid: "Full access for Key Administrators"
+            Effect: "Allow"
+            Principal:
+              AWS:
+                - !Sub "arn:aws:iam::${AWS::AccountId}:role/cluster-lifecycle-manager-entrypoint"
+                - !Sub "arn:aws:iam::${AWS::AccountId}:role/Shibboleth-Administrator"
+            Action:
+            - "kms:*"
+            Resource: "*"
+          - Sid: "Allow describe for everyone"
+            Effect: "Allow"
+            Principal:
+              AWS:
+                - !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action:
+            - "kms:DescribeKey"
+            Resource: "*"
+          - Sid: "Allow etcd nodes to decrypt the remote files"
+            Effect: "Allow"
+            Principal:
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action:
+            - "kms:Decrypt"
+            Resource: "*"
+            Condition:
+              ArnLike:
+                "aws:PrincipalArn": !Sub "arn:aws:iam::${AWS::AccountId}:role/etcd-cluster-etcd-EtcdRole-*"
+  EtcdFilesSecretKeyAlias:
+    Type: 'AWS::KMS::Alias'
+    DeletionPolicy: "Retain"
+    Properties:
+      AliasName: "alias/etcd-cluster"
+      TargetKeyId: !Ref EtcdFilesEncryptionKey


### PR DESCRIPTION
This Pull Request adds the CloudFormation (CF) definition for the key used by CLM and etcd to exchange secrets on bootstrap of etcd.

For now CLM won't apply this CF definition. First we need to import the existing keys to CF.

The file name is prefixed with `pre`, to imply that CLM will apply it before the main stack.

Signed-off-by: rreis <rodrigo.gargravarr@gmail.com>