### PR TITLE
Use account ID pseudo parameter instead of template function.

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -414,7 +414,7 @@ Resources:
             Principal:
               AWS: !Join
                 - ''
-                - - 'arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/'
+                - - !Sub 'arn:aws:iam::${AWS::AccountId}:role/'
                   - !Ref MasterIAMRole
         Version: 2012-10-17
       Path: /
@@ -488,7 +488,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Federated: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+              Federated: !Sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
             Condition:
@@ -700,7 +700,7 @@ Resources:
             Principal:
               AWS: !Join
                 - ''
-                - - 'arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/'
+                - - !Sub 'arn:aws:iam::${AWS::AccountId}:role/'
                   - !Ref WorkerIAMRole
         Version: 2012-10-17
       Path: /
@@ -739,7 +739,7 @@ Resources:
               - 'kms:UntagResource'
             Effect: Allow
             Principal:
-              AWS: 'arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:root'
+              AWS: !Sub 'arn:aws:iam::§{AWS::AccountId}:root'
             Resource: '*'
             Sid: Allow access for Key Administrators
           - Action:
@@ -832,7 +832,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Federated: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+              Federated: !Sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
             Condition:
@@ -915,7 +915,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Federated: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+              Federated: !Sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
             Condition:
@@ -954,7 +954,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Federated: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+              Federated: !Sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
             Condition:
@@ -978,7 +978,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Federated: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:oidc-provider/{{.Cluster.LocalID}}.{{ .Values.hosted_zone }}"
+              Federated: !Sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/{{.Cluster.LocalID}}.{{ .Values.hosted_zone }}"
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
             Condition:
@@ -1086,7 +1086,7 @@ Resources:
         Statement:
         - Effect: Allow
           Principal:
-            Federated: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+            Federated: !Sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
           Action:
             - 'sts:AssumeRoleWithWebIdentity'
           Condition:
@@ -1140,7 +1140,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Federated: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+              Federated: !sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
             Condition:
@@ -1152,7 +1152,7 @@ Resources:
             Principal:
               AWS: !Join
                 - ''
-                - - 'arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/'
+                - - !Sub 'arn:aws:iam::${AWS::AccountId}:role/'
                   - !Ref MasterIAMRole
         Version: 2012-10-17
       Path: /
@@ -1247,7 +1247,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Federated: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+              Federated: !Sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
             Condition:
@@ -1259,7 +1259,7 @@ Resources:
             Principal:
               AWS: !Join
                 - ''
-                - - 'arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/'
+                - - !Sub 'arn:aws:iam::§{AWS::AccountId}:role/'
                   - !Ref MasterIAMRole
         Version: 2012-10-17
       Path: /
@@ -1290,7 +1290,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Federated: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+              Federated: !Sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
             Condition:
@@ -1384,7 +1384,7 @@ Resources:
             Principal:
               AWS: !Join
                 - ''
-                - - 'arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/'
+                - - !Sub 'arn:aws:iam::§{AWS::AccountId}:role/'
                   - !Ref WorkerIAMRole
           - Action:
               - 'sts:AssumeRole'
@@ -1523,18 +1523,18 @@ Resources:
             Principal:
               AWS: !Join
                 - ''
-                - - 'arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/'
+                - - !Sub 'arn:aws:iam::§{AWS::AccountId}:role/'
                   - !Ref WorkerIAMRole
           - Action: ["sts:AssumeRole"]
             Effect: Allow
             Principal:
               AWS: !Join
                 - ''
-                - - 'arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/'
+                - - !Sub 'arn:aws:iam::§{AWS::AccountId}:role/'
                   - !Ref MasterIAMRole
           - Effect: Allow
             Principal:
-              Federated: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+              Federated: !Sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
             Condition:
@@ -1573,7 +1573,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Federated: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+              Federated: !Sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
             Condition:
@@ -1607,7 +1607,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Federated: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+              Federated: !Sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
             Condition:
@@ -1625,7 +1625,7 @@ Resources:
             Principal:
               AWS: !Join
                 - ''
-                - - 'arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/'
+                - - !Sub 'arn:aws:iam::§{AWS::AccountId}:role/'
                   - !Ref MasterIAMRole
           - Action:
               - 'sts:AssumeRole'
@@ -1633,7 +1633,7 @@ Resources:
             Principal:
               AWS: !Join
                 - ''
-                - - 'arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/'
+                - - !Sub 'arn:aws:iam::§{AWS::AccountId}:role/'
                   - !Ref WorkerIAMRole
         Version: 2012-10-17
       Path: /
@@ -1680,7 +1680,7 @@ Resources:
           Principal:
             AWS: !Join
               - ''
-              - - 'arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/'
+              - - !Sub 'arn:aws:iam::§{AWS::AccountId}:role/'
                 - !Ref WorkerIAMRole
         Version: 2012-10-17
       Path: /
@@ -1801,7 +1801,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Federated: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+              Federated: !Sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
             Condition:
@@ -1824,7 +1824,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Federated: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+              Federated: !Sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
             Condition:
@@ -1858,7 +1858,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Federated: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+              Federated: !Sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
             Condition:
@@ -1910,7 +1910,7 @@ Resources:
           - Sid: "Enable IAM User Permissions"
             Effect: "Allow"
             Principal:
-              AWS: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:root"
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
             Action:
             - "kms:DescribeKey"
             Resource: "*"
@@ -1918,8 +1918,8 @@ Resources:
             Effect: "Allow"
             Principal:
               AWS:
-                - "arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/cluster-lifecycle-manager-entrypoint"
-                - "arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/Shibboleth-Administrator"
+                - !Sub "arn:aws:iam::${AWS::AccountId}:role/cluster-lifecycle-manager-entrypoint"
+                - !Sub "arn:aws:iam::${AWS::AccountId}:role/Shibboleth-Administrator"
             Action:
             - "kms:*"
             - "tag:TagResources"
@@ -1949,13 +1949,13 @@ Resources:
           - Sid: "Allow CLM to manage this key"
             Effect: "Allow"
             Principal:
-              AWS: "arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/cluster-lifecycle-manager-entrypoint"
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:role/cluster-lifecycle-manager-entrypoint"
             Action: "kms:*"
             Resource: "*"
           - Sid: "Allow Administrator to manage and use this key"
             Effect: "Allow"
             Principal:
-              AWS: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:role/Shibboleth-Administrator"
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:role/Shibboleth-Administrator"
             Action:
             - "kms:*"
             - "tag:TagResources"
@@ -1983,7 +1983,7 @@ Resources:
           - Sid: "Enable IAM User Permissions"
             Effect: "Allow"
             Principal:
-              AWS: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:root"
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
             Action:
             - "kms:DescribeKey"
             Resource: "*"
@@ -1991,8 +1991,8 @@ Resources:
             Effect: "Allow"
             Principal:
               AWS:
-                - "arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/cluster-lifecycle-manager-entrypoint"
-                - "arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/Shibboleth-Administrator"
+                - !Sub "arn:aws:iam::${AWS::AccountId}:role/cluster-lifecycle-manager-entrypoint"
+                - !Sub "arn:aws:iam::${AWS::AccountId}:role/Shibboleth-Administrator"
             Action:
             - "kms:*"
             - "tag:TagResources"
@@ -2019,7 +2019,7 @@ Resources:
           - Sid: "Enable IAM User Permissions"
             Effect: "Allow"
             Principal:
-              AWS: "arn:aws:iam::{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:root"
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
             Action:
             - "kms:DescribeKey"
             Resource: "*"
@@ -2027,8 +2027,8 @@ Resources:
             Effect: "Allow"
             Principal:
               AWS:
-                - "arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/cluster-lifecycle-manager-entrypoint"
-                - "arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/Shibboleth-Administrator"
+                - !Sub "arn:aws:iam::${AWS::AccountId}:role/cluster-lifecycle-manager-entrypoint"
+                - !Sub "arn:aws:iam::${AWS::AccountId}:role/Shibboleth-Administrator"
             Action:
             - "kms:*"
             - "tag:TagResources"

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -739,7 +739,7 @@ Resources:
               - 'kms:UntagResource'
             Effect: Allow
             Principal:
-              AWS: !Sub 'arn:aws:iam::§{AWS::AccountId}:root'
+              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
             Resource: '*'
             Sid: Allow access for Key Administrators
           - Action:
@@ -1259,7 +1259,7 @@ Resources:
             Principal:
               AWS: !Join
                 - ''
-                - - !Sub 'arn:aws:iam::§{AWS::AccountId}:role/'
+                - - !Sub 'arn:aws:iam::${AWS::AccountId}:role/'
                   - !Ref MasterIAMRole
         Version: 2012-10-17
       Path: /
@@ -1384,7 +1384,7 @@ Resources:
             Principal:
               AWS: !Join
                 - ''
-                - - !Sub 'arn:aws:iam::§{AWS::AccountId}:role/'
+                - - !Sub 'arn:aws:iam::${AWS::AccountId}:role/'
                   - !Ref WorkerIAMRole
           - Action:
               - 'sts:AssumeRole'
@@ -1523,14 +1523,14 @@ Resources:
             Principal:
               AWS: !Join
                 - ''
-                - - !Sub 'arn:aws:iam::§{AWS::AccountId}:role/'
+                - - !Sub 'arn:aws:iam::${AWS::AccountId}:role/'
                   - !Ref WorkerIAMRole
           - Action: ["sts:AssumeRole"]
             Effect: Allow
             Principal:
               AWS: !Join
                 - ''
-                - - !Sub 'arn:aws:iam::§{AWS::AccountId}:role/'
+                - - !Sub 'arn:aws:iam::${AWS::AccountId}:role/'
                   - !Ref MasterIAMRole
           - Effect: Allow
             Principal:
@@ -1625,7 +1625,7 @@ Resources:
             Principal:
               AWS: !Join
                 - ''
-                - - !Sub 'arn:aws:iam::§{AWS::AccountId}:role/'
+                - - !Sub 'arn:aws:iam::${AWS::AccountId}:role/'
                   - !Ref MasterIAMRole
           - Action:
               - 'sts:AssumeRole'
@@ -1633,7 +1633,7 @@ Resources:
             Principal:
               AWS: !Join
                 - ''
-                - - !Sub 'arn:aws:iam::§{AWS::AccountId}:role/'
+                - - !Sub 'arn:aws:iam::${AWS::AccountId}:role/'
                   - !Ref WorkerIAMRole
         Version: 2012-10-17
       Path: /
@@ -1680,7 +1680,7 @@ Resources:
           Principal:
             AWS: !Join
               - ''
-              - - !Sub 'arn:aws:iam::§{AWS::AccountId}:role/'
+              - - !Sub 'arn:aws:iam::${AWS::AccountId}:role/'
                 - !Ref WorkerIAMRole
         Version: 2012-10-17
       Path: /

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1140,7 +1140,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Federated: !sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+              Federated: !Sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
             Condition:

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -532,7 +532,7 @@ write_files:
           image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/aws-encryption-provider:master-3
           command:
           - /aws-encryption-provider
-          - --key=arn:aws:kms:{{ .Cluster.Region }}:{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:key/{{ .Values.ClusterStackOutputs.EtcdEncryptionKey }}
+          - --key=arn:aws:kms:{{ .Cluster.Region }}:${AWS::AccountId}:key/{{ .Values.ClusterStackOutputs.EtcdEncryptionKey }}
           - --region={{ .Cluster.Region }}
           - --listen=/var/run/kmsplugin/socket.sock
           - --health-port=:8086

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -532,7 +532,7 @@ write_files:
           image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/aws-encryption-provider:master-3
           command:
           - /aws-encryption-provider
-          - --key=arn:aws:kms:{{ .Cluster.Region }}:${AWS::AccountId}:key/{{ .Values.ClusterStackOutputs.EtcdEncryptionKey }}
+          - --key=arn:aws:kms:{{ .Cluster.Region }}:{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:key/{{ .Values.ClusterStackOutputs.EtcdEncryptionKey }}
           - --region={{ .Cluster.Region }}
           - --listen=/var/run/kmsplugin/socket.sock
           - --health-port=:8086


### PR DESCRIPTION
This Pull Request updates the CloudFormation manifests to use a pseudo parameter instead of a Go Template function to determine the Account Id. AWS CloudFormation provides the Account ID as a [pseudo parameter](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html).

Signed-off-by: rreis <rodrigo.gargravarr@gmail.com>