### PR TITLE
fix: safely reconfigure skipper_cluster_ratelimit_max_group_shards

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.14.11-340" }}
+{{ $internal_version := "v0.14.19-349" }}
 {{ $version := index (split $internal_version "-") 0 }}
 
 apiVersion: apps/v1


### PR DESCRIPTION
fix: safely reconfigure skipper_cluster_ratelimit_max_group_shards
fix: goroutine and channel leaks which were likely not relevant, but we create less garbage for the GC to collect
log: add authuser/sub into access logs
feature: expose tokeninfo metrics

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>