### PR TITLE
Make autoscaler log level configurable

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -9,6 +9,10 @@ autoscaling_utilization_threshold: "1.0"
 autoscaling_max_empty_bulk_delete: "10"
 autoscaling_scale_down_unneeded_time: "2m"
 autoscaling_unremovable_node_recheck_timeout: "5m"
+# configure the log level for the autoscaler. Setting this to 4 gives enough
+# verbosity to understand why a certain node pool is not picked for scheduling a
+# pod.
+autoscaling_autoscaler_log_level: "1"
 
 # How long to wait for pod eviction when scaling down.
 {{if eq .Cluster.Environment "production"}}

--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -39,7 +39,7 @@ spec:
         image: container-registry.zalando.net/teapot/kube-cluster-autoscaler:v1.18.2-internal.39
         command:
           - ./cluster-autoscaler
-          - --v=1
+          - --v={{.Cluster.ConfigItems.autoscaling_autoscaler_log_level}}
           - --stderrthreshold=info
           - --scale-down-utilization-threshold={{.Cluster.ConfigItems.autoscaling_utilization_threshold}}
           - --cloud-provider=aws


### PR DESCRIPTION
This makes the autoscaler log level configurable per cluster so it's easier to temporally enable debug logging when trying to understand why a pod is not being scheduled on an expected instance type size.