### PR TITLE
Enhance audittrail adapter metrics

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -646,16 +646,24 @@ rotate_service_account_tokens: "true"
 # issue tokens with a long expiration time in order to detect applications that don't refresh tokens.
 rotate_service_account_tokens_extended_expiration: "true"
 
-# enable auditlogging metrics such that we can identify clients calling the
-# apiserver.
-{{ if eq .Cluster.Environment "test" }}
-auditlog_metrics: "true"
-{{ else }}
-auditlog_metrics: "false"
-{{ end }}
+# Comma separated list of dimensions to include in the Prometheus metrics
+# exposed by audittrail-adapter.
+# Adding more dimensions can help detect which clients are calling the
+# Kubernetes API. Examples:
+# * Detect clients not rotating service tokens: `authentication_stale_token` metric.
+# * Detect clients with high load on the API Server for certain calls.
+# * Detect client calling old api_version/api_groups for resources.
+#
+# Adding more dimensions has the negative effect that it produces more
+# Prometheus data, so it's not intended to be enabled ALL THE TIME, but can be
+# enabled when needed to answer one of the above questions or similar.
+#
+# The possible dimentions are:
+# authorization_decision,authentication_stale_token,user,user_agent,verb,code,resource,api_group,api_version
+auditlog_metric_dimensions: "authorization_decision"
 
 # enable auditlogging of read access to identify service accounts reading from
-# the api. This only has effect if auditlog_metrics=true.
+# the api.
 auditlog_read_access: "true"
 
 # allow ssh access for internal VPC IPs only

--- a/cluster/manifests/audittrail-adapter/01-rbac.yaml
+++ b/cluster/manifests/audittrail-adapter/01-rbac.yaml
@@ -1,4 +1,3 @@
-{{ if ne .Cluster.ConfigItems.audittrail_url "" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -20,4 +19,3 @@ subjects:
 - kind: ServiceAccount
   name: audittrail-adapter
   namespace: kube-system
-{{ end }}

--- a/cluster/manifests/audittrail-adapter/credentials.yaml
+++ b/cluster/manifests/audittrail-adapter/credentials.yaml
@@ -1,4 +1,3 @@
-{{ if ne .Cluster.ConfigItems.audittrail_url "" }}
 apiVersion: "zalando.org/v1"
 kind: PlatformCredentialsSet
 metadata:
@@ -11,4 +10,3 @@ spec:
    tokens:
      audittrail:
        privileges: []
-{{ end }}

--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -1,4 +1,3 @@
-{{ if ne .Cluster.ConfigItems.audittrail_url "" }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -36,7 +35,7 @@ spec:
       hostNetwork: true
       containers:
       - name: audittrail-adapter
-        image: container-registry.zalando.net/teapot/audittrail-adapter:master-30
+        image: container-registry.zalando.net/teapot/audittrail-adapter:master-35
         env:
           - name: AWS_REGION
             value: {{.Cluster.Region}}
@@ -46,6 +45,12 @@ spec:
         - --s3-bucket-name=zalando-audittrail-{{accountID .InfrastructureAccount}}-{{.LocalID}}
         - --address=:8889
         - --metrics-address=:7980
+        {{- if eq .Cluster.ConfigItems.audittrail_url "" }}
+        - --metrics-only
+        {{- end }}
+        {{- range $label := split .Cluster.ConfigItems.auditlog_metric_dimensions  "," }}
+        - --metric-labels={{ $label }}
+        {{- end }}
         volumeMounts:
         - name: platform-iam-credentials
           mountPath: /meta/credentials
@@ -65,4 +70,3 @@ spec:
       - name: platform-iam-credentials
         secret:
           secretName: audittrail-adapter
-{{ end }}

--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -127,11 +127,6 @@ data:
     - <<: *apiserver_container_metric
       job_name: "aws-encryption-provider"
       metrics_path: "/aws-encryption-provider"
-{{- if eq .Cluster.ConfigItems.auditlog_metrics "true" }}
-    - <<: *apiserver_container_metric
-      job_name: "audit-metrics"
-      metrics_path: "/audit-metrics"
-{{- end }}
     - job_name: 'kube-state-metrics'
       scheme: http
       honor_labels: true

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -147,21 +147,14 @@ write_files:
           - --service-account-jwks-uri={{ .Cluster.APIServerURL }}/openid/v1/jwks
           - --service-account-extend-token-expiration={{ .Cluster.ConfigItems.rotate_service_account_tokens_extended_expiration }}
           - --audit-policy-file=/etc/kubernetes/config/audit-policy.yaml
-          {{ if and (ne .Cluster.ConfigItems.audittrail_url "") (ne .Cluster.Environment "e2e") }}
-          - --audit-webhook-config-file=/etc/kubernetes/config/audit.yaml
-          - --audit-webhook-mode=batch
-          - --audit-webhook-version=audit.k8s.io/v1
-          {{ end }}
           {{ if eq .Cluster.Environment "e2e" }}
           - --audit-log-path=/var/log/kube-audit.log
           - --audit-log-maxage=0
           - --audit-log-maxbackup=0
-          - --audit-policy-file=/etc/kubernetes/config/audit-policy.yaml
-          {{ else if eq .Cluster.ConfigItems.auditlog_metrics "true" }}
-          - --audit-log-path=/var/log/kube-audit.log
-          - --audit-log-maxage=0
-          - --audit-log-maxbackup=1 # Limit number of rotated audit files to 1
-          - --audit-log-maxsize=100 # Limit file size to 100Mi
+          {{ else }}
+          - --audit-webhook-config-file=/etc/kubernetes/config/audit.yaml
+          - --audit-webhook-mode=batch
+          - --audit-webhook-version=audit.k8s.io/v1
           {{ end }}
           # enable aggregated apiservers
           - --client-ca-file=/etc/kubernetes/ssl/ca.pem
@@ -199,8 +192,6 @@ write_files:
             readOnly: true
           - mountPath: /var/run/kmsplugin
             name: var-run-kmsplugin
-          - mountPath: /var/log
-            name: var-log
           resources:
             requests:
               cpu: 100m
@@ -494,12 +485,6 @@ write_files:
               -> disableAccessLog()
               -> setPath("/metrics")
               -> "http://localhost:8086";
-{{- if eq .Cluster.ConfigItems.auditlog_metrics "true" }}
-            audit_metrics: Path("/audit-metrics")
-              -> disableAccessLog()
-              -> setPath("/metrics")
-              -> "http://localhost:8087";
-{{- end }}
             skipper_proxy: Path("/skipper-proxy")
               -> disableAccessLog()
               -> setPath("/metrics")
@@ -554,31 +539,6 @@ write_files:
           volumeMounts:
           - mountPath: /var/run/kmsplugin
             name: var-run-kmsplugin
-{{- if eq .Cluster.ConfigItems.auditlog_metrics "true" }}
-        - name: k8s-audit-metrics
-          image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/k8s-audit-metrics:main-2
-          command: ["/bin/sh", "-c"]
-          args:
-          - "touch /var/log/kube-audit.log && exec /k8s-audit-metrics /var/log/kube-audit.log"
-          ports:
-          - containerPort: 8087
-            protocol: TCP
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c",  " sleep 60"]
-          readinessProbe:
-            httpGet:
-              path: /healthz
-              port: 8087
-          resources:
-            requests:
-              cpu: 50m
-              memory: 50Mi
-          volumeMounts:
-          - mountPath: /var/log
-            name: var-log
-{{- end }}
         volumes:
         - hostPath:
             path: /etc/kubernetes/ssl
@@ -594,9 +554,6 @@ write_files:
             path: /etc/kubernetes/admission-controller-kubeconfig
             type: File
           name: admission-controller-kubeconfig
-        - hostPath:
-            path: /var/log
-          name: var-log
 
   - owner: root:root
     path: /etc/kubernetes/manifests/kube-controller-manager.yaml
@@ -848,7 +805,7 @@ write_files:
               resources: ["tokenreviews"]
           omitStages:
             - "RequestReceived"
-{{ if and (eq .Cluster.ConfigItems.auditlog_metrics "true") (eq .Cluster.ConfigItems.auditlog_read_access "true") }}
+{{ if eq .Cluster.ConfigItems.auditlog_read_access "true" }}
         - level: None
           verbs: ["watch", "list", "get"]
           userGroups: ["system:serviceaccounts:kube-system"]


### PR DESCRIPTION
This is an evolution of what was first introduced in #5491 

This enhances the audittrail-adapter component such that we can use the audit events and Prometheus metrics exposed to get detailed information about clients calling the Kubernetes API. This can be useful for the following cases and more:

* Detect clients not rotating service tokens: `authentication_stale_token` metric.
* Detect clients with high load on the API Server for certain calls.
* Detect client calling old api_version/api_groups for resources.

What changes is that the audittrail-adapter now can take a list of dimension to include in the event Prometheus metric exposed. This enables us to enrich the metric with information from the events.
The desired dimensions can be configured via the config-item `auditlog_metric_dimensions`. Possible values are: `authorization_decision,authentication_stale_token,user,user_agent,verb,code,resource,api_group,api_version` as also documented in the `config-defaults.yaml` file.

This change also enables `audittrail-adapter` to run in `test` clusters which was previously not the case. It runs in a mode where it only uses the events to enrich the Prometheus metrics, it doesn't forward the events anywhere so the behavior is similar to the past where audittrail-adapter was not running in `test`.

Lastly it removes the `k8s-audit-metrics` container previously introduced in #5491. This one has the same purpose as what is now implemented in `audittrail-adapter`, the new implementation is just more robust and easier to maintain being a project we own internally. 