### PR TITLE
Disable auditlog_read_access by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -664,7 +664,7 @@ auditlog_metric_dimensions: "authorization_decision"
 
 # enable auditlogging of read access to identify service accounts reading from
 # the api.
-auditlog_read_access: "true"
+auditlog_read_access: "false"
 
 # allow ssh access for internal VPC IPs only
 ssh_vpc_only: "false"


### PR DESCRIPTION
Follow up to #5542 to disable `auditlog_read_access` by default. We only want to enable it when investigating something.