### PR TITLE
redis autoscaling as default and cleanup

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -140,7 +140,6 @@ skipper_redis_pool_timeout: "250ms"
 skipper_redis_read_timeout: "25ms"
 skipper_redis_write_timeout: "25ms"
 
-skipper_ingress_redis_autoscaling: "true"
 skipper_ingress_redis_swarm_enabled: "true"
 skipper_ingress_redis_target_average_utilization_cpu: "30"
 skipper_ingress_redis_target_average_utilization_memory: "60"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -131,7 +131,8 @@ skipper_termination_grace_period: "392"
 
 # skipper redis settings
 enable_dedicate_nodepool_skipper_redis: "false"
-skipper_redis_replicas: 2
+# TODO: skipper_redis_replicas cleanup after merge
+skipper_redis_replicas: 1
 skipper_redis_cpu: "100m"
 skipper_redis_memory: "512Mi"
 skipper_redis_dial_timeout: "25ms"
@@ -139,16 +140,9 @@ skipper_redis_pool_timeout: "250ms"
 skipper_redis_read_timeout: "25ms"
 skipper_redis_write_timeout: "25ms"
 
-# "true" enable autoscaling
-# "false" remove autoscaling
-# "" do not change
-{{if eq .Cluster.Environment "test"}}
 skipper_ingress_redis_autoscaling: "true"
-{{else}}
-skipper_ingress_redis_autoscaling: ""
-{{end}}
 skipper_ingress_redis_swarm_enabled: "true"
-skipper_ingress_redis_target_average_utilization_cpu: "60"
+skipper_ingress_redis_target_average_utilization_cpu: "30"
 skipper_ingress_redis_target_average_utilization_memory: "60"
 skipper_ingress_redis_min_replicas: "1"
 skipper_ingress_redis_max_replicas: "100"

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -131,11 +131,6 @@ post_apply:
   kind: Deployment
 {{ end }}
 
-{{ if eq .ConfigItems.skipper_ingress_redis_autoscaling "false" }}
-- name: skipper-ingress-redis
-  namespace: kube-system
-  kind: HorizontalPodAutoscaler
-{{ end }}
 {{- if eq .ConfigItems.prometheus_remote_write "disabled" }}
 - name: prometheus-credentials
   kind: PlatformCredentialsSet

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -154,19 +154,14 @@ spec:
           - "-max-audit-body=0"
 {{ if eq .ConfigItems.skipper_ingress_redis_swarm_enabled "true" }}
           - "-enable-swarm"
-  {{ if and (ne .ConfigItems.skipper_redis_replicas "0") (ne .ConfigItems.skipper_ingress_redis_autoscaling "true") }}
-          - "-swarm-redis-urls={{ indexedList "skipper-ingress-redis-$.skipper-ingress-redis.kube-system.svc.cluster.local:6379" (parseInt64 .ConfigItems.skipper_redis_replicas) }}"
-  {{ end }}
           - "-swarm-redis-dial-timeout={{ .ConfigItems.skipper_redis_dial_timeout }}"
           - "-swarm-redis-pool-timeout={{ .ConfigItems.skipper_redis_pool_timeout }}"
           - "-swarm-redis-read-timeout={{ .ConfigItems.skipper_redis_read_timeout }}"
           - "-swarm-redis-write-timeout={{ .ConfigItems.skipper_redis_write_timeout }}"
           - "-cluster-ratelimit-max-group-shards={{ .ConfigItems.skipper_cluster_ratelimit_max_group_shards }}"
-  {{ if eq .ConfigItems.skipper_ingress_redis_autoscaling "true" }}
           - "-kubernetes-redis-service-namespace=kube-system"
           - "-kubernetes-redis-service-name=skipper-ingress-redis"
           - "-kubernetes-redis-service-port=6379"
-  {{ end }}
 {{ end }}
           - "-histogram-metric-buckets=.0001,.00025,.0005,.00075,.001,.0025,.005,.0075,.01,.025,.05,.075,.1,.2,.3,.4,.5,.75,1,2,3,4,5,7,10,15,20,30,60,120,300,600"
           - >-

--- a/cluster/manifests/skipper/hpa-redis.yaml
+++ b/cluster/manifests/skipper/hpa-redis.yaml
@@ -1,4 +1,3 @@
-{{ if eq .ConfigItems.skipper_ingress_redis_autoscaling "true" }}
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -11,8 +10,7 @@ spec:
     apiVersion: apps/v1
     kind: StatefulSet
     name: skipper-ingress-redis
-  minReplicas: {{ .ConfigItems.skipper_redis_replicas }}
-  #minReplicas: {{ .ConfigItems.skipper_ingress_redis_min_replicas }}
+  minReplicas: {{ .ConfigItems.skipper_ingress_redis_min_replicas }}
   maxReplicas: {{ .ConfigItems.skipper_ingress_redis_max_replicas }}
   metrics:
   - type: Resource
@@ -54,4 +52,3 @@ spec:
         value: 100
         periodSeconds: 60
       selectPolicy: Min
-{{ end }}

--- a/cluster/manifests/skipper/skipper-redis.yaml
+++ b/cluster/manifests/skipper/skipper-redis.yaml
@@ -4,16 +4,11 @@ metadata:
   labels:
     application: skipper-ingress-redis
     version: v6.2.7
-{{- if eq .ConfigItems.skipper_ingress_redis_autoscaling "true" }}
   annotations:
     zalando.org/update-using-hpa-replicas: skipper-ingress-redis
-{{- end }}
   name: skipper-ingress-redis
   namespace: kube-system
 spec:
-{{ if ne .ConfigItems.skipper_ingress_redis_autoscaling "true" }}
-  replicas: {{ .ConfigItems.skipper_redis_replicas }}
-{{ end }}
   podManagementPolicy: Parallel
   selector:
     matchLabels:


### PR DESCRIPTION
redis autoscaling as default and cleanup
No config revert required anymore and move from skipper_redis_replicas to skipper_ingress_redis_min_replicas

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>