### PR TITLE
Disable PCS for audittrail-adapter test

### DIFF
--- a/cluster/manifests/audittrail-adapter/credentials.yaml
+++ b/cluster/manifests/audittrail-adapter/credentials.yaml
@@ -1,3 +1,4 @@
+{{- if ne .Cluster.ConfigItems.audittrail_url "" }}
 apiVersion: "zalando.org/v1"
 kind: PlatformCredentialsSet
 metadata:
@@ -10,3 +11,4 @@ spec:
    tokens:
      audittrail:
        privileges: []
+{{- end }}

--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -66,7 +66,9 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 1000
+      {{- if ne .Cluster.ConfigItems.audittrail_url "" }}
       volumes:
       - name: platform-iam-credentials
         secret:
           secretName: audittrail-adapter
+      {{- end }}


### PR DESCRIPTION
Follow up to #5542 

This disables deployment of the PCS used by `audittrail-adapter` when the audittrail-api url is not set. It's only needed in production where audittrail-api URL is configured.

This should fix issues in e2e where the secret for the PCS is not created.