### PR TITLE
audittrail-adapter: Condition volume mount in all places

### DIFF
--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -51,10 +51,12 @@ spec:
         {{- range $label := split .Cluster.ConfigItems.auditlog_metric_dimensions  "," }}
         - --metric-labels={{ $label }}
         {{- end }}
+        {{- if ne .Cluster.ConfigItems.audittrail_url "" }}
         volumeMounts:
         - name: platform-iam-credentials
           mountPath: /meta/credentials
           readOnly: true
+        {{- end }}
         resources:
           limits:
             cpu: 50m


### PR DESCRIPTION
Follow up to #5552 

Add the condition in all places so the manifest is valid.