### PR TITLE
Avoid using spaces when specifying volume zones

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -823,6 +823,9 @@ deployment_service_enabled: "true"
 # Standard storageclass gp3 volume type
 storageclass_standard_gp3: "true"
 
+# Standard storageclass gp3 volume zones fix
+storageclass_standard_sanitized_zones: "false"
+
 # opentelemetry config
 observability_collector_endpoint: "tracing.platform-infrastructure.zalan.do"
 observability_collector_port: "8443"

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -19,6 +19,11 @@ pre_apply:
     volume-type: gp3
   kind: StorageClass
 {{ end }}
+{{ if eq .Cluster.ConfigItems.storageclass_standard_sanitized_zones "true" }}
+- labels:
+    zones-sanitized: "false"
+  kind: StorageClass
+{{ end }}
 - labels:
     application: nvidia-gpu-device-plugin
   namespace: kube-system

--- a/cluster/manifests/storageclass/storageclass.yaml
+++ b/cluster/manifests/storageclass/storageclass.yaml
@@ -11,5 +11,5 @@ provisioner: kubernetes.io/aws-ebs
 parameters:
   type: {{ if eq .Cluster.ConfigItems.storageclass_standard_gp3 "true" }}gp3{{else}}gp2{{end}}
   # TODO: this assumes 3 zones per region
-  zones: {{ .Cluster.Region }}a, {{ .Cluster.Region }}b, {{ .Cluster.Region }}c
+  zones: {{ .Cluster.Region }}a,{{ .Cluster.Region }}b,{{ .Cluster.Region }}c
 allowVolumeExpansion: true

--- a/cluster/manifests/storageclass/storageclass.yaml
+++ b/cluster/manifests/storageclass/storageclass.yaml
@@ -7,9 +7,16 @@ metadata:
   labels:
     kubernetes.io/cluster-service: "true"
     volume-type: {{ if eq .Cluster.ConfigItems.storageclass_standard_gp3 "true" }}gp3{{else}}gp2{{end}}
+    zones-sanitized: "{{ if eq .Cluster.ConfigItems.storageclass_standard_sanitized_zones "true" }}true{{else}}false{{end}}"
 provisioner: kubernetes.io/aws-ebs
 parameters:
   type: {{ if eq .Cluster.ConfigItems.storageclass_standard_gp3 "true" }}gp3{{else}}gp2{{end}}
   # TODO: this assumes 3 zones per region
+  #
+  # The old definition of zones containing spaces doesn't work well with CSI Migration.
+{{- if eq .ConfigItems.storageclass_standard_sanitized_zones "true" }}
   zones: {{ .Cluster.Region }}a,{{ .Cluster.Region }}b,{{ .Cluster.Region }}c
+{{- else }}
+  zones: {{ .Cluster.Region }}a, {{ .Cluster.Region }}b, {{ .Cluster.Region }}c
+{{- end }}
 allowVolumeExpansion: true


### PR DESCRIPTION
Using spaces when specifying volume zones will lead to an error when `CSIMigrationAWS` is enabled because it doesn't trim the space from the region name.

```
csi-provisioner E1205 13:43:11.085265       1 controller.go:957] error syncing claim "27ee3ab9-1f4a-490d-bd1c-a17583e4b581": failed to provision volume with StorageClass "standard": rpc error: code = Internal desc = Could not create volume "pvc-27ee3ab9-1f4a-490d-bd1c could not create volume in EC2: InvalidZone.NotFound: The zone ' eu-central-1b' does not exist.
```

While doing this I realised we could also switch to using [`allowedTopologies`](https://kubernetes.io/docs/concepts/storage/storage-classes/#allowed-topologies) because `zones` is [deprecated](https://kubernetes.io/docs/concepts/storage/storage-classes/#aws-ebs).

However, I wasn't able to identify which label to use for it to work as expected. There are the three options:
* `failure-domain.beta.kubernetes.io/zone`
* `topology.kubernetes.io/zone`
* `topology.ebs.csi.aws.com/zone`

Using the old approach allows us to defer that decision to whatever upstream does.