### PR TITLE
Correctly clean up previous CSI resources when it's disabled

### DIFF
--- a/cluster/manifests/03-ebs-csi/01-rbac.yaml
+++ b/cluster/manifests/03-ebs-csi/01-rbac.yaml
@@ -1,3 +1,4 @@
+{{- if eq .ConfigItems.enable_csi_migration "true" }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -240,3 +241,4 @@ roleRef:
   kind: ClusterRole
   name: ebs-external-resizer-role
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -64,6 +64,29 @@ post_apply:
 - name: ebs
   kind: StorageClass
   namespace: kube-system
+- kind: CSIDriver
+  name: ebs.csi.aws.com
+- kind: ServiceAccount
+  name: ebs-csi-controller
+  namespace: kube-system
+- kind: ClusterRole
+  name: ebs-external-attacher
+- kind: ClusterRole
+  name: ebs-external-provisioner
+- kind: ClusterRoleBinding
+  name: ebs-csi-attacher-binding
+- kind: ClusterRoleBinding
+  name: ebs-csi-provisioner-binding
+- kind: ServiceAccount
+  name: ebs-csi-node
+  namespace: kube-system
+- kind: RoleBinding
+  name: ebs-csi-node-privileged-psp
+  namespace: kube-system
+- kind: ClusterRole
+  name: ebs-external-resizer-role
+- kind: ClusterRoleBinding
+  name: ebs-csi-resizer-binding
 {{ end }}
 {{ if ne .ConfigItems.prometheus_csi_ebs "true" }}
 - name: prometheus-csi


### PR DESCRIPTION
The current implementation of CSI is guarded by a feature flag. However the feature flag isn't covering the RBAC resources and they and the CSIDriver are also not part of deletions. Hence, the resources are present in all clusters although CSI isn't used. This makes problems when rolling out [the revamp](https://github.com/zalando-incubator/kubernetes-on-aws/pull/5547) because some of them are immutable.