### PR TITLE
Make cpu/memory configurable for audittrail/kube2iam ds

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -581,6 +581,12 @@ audittrail_url: ""
 {{end}}
 audittrail_root_account_role: ""
 
+audittrail_adapter_cpu: "50m"
+audittrail_adapter_memory: "200Mi"
+
+kube2iam_cpu: "25m"
+kube2iam_memory: "100Mi"
+
 # The enable_node_scale_out_beyond_1k_nodes is feature toogle to change
 # the default cluster_cidr from 10.2.0.0/16 to 10.2.0.0/15, this change
 # enables the kubernetes cluster to scale out beyond 1000 nodes.

--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -59,11 +59,11 @@ spec:
         {{- end }}
         resources:
           limits:
-            cpu: 50m
-            memory: 200Mi
+            cpu: {{ .Cluster.ConfigItems.audittrail_adapter_cpu }}
+            memory: {{ .Cluster.ConfigItems.audittrail_adapter_memory }}
           requests:
-            cpu: 50m
-            memory: 200Mi
+            cpu: {{ .Cluster.ConfigItems.audittrail_adapter_cpu }}
+            memory: {{ .Cluster.ConfigItems.audittrail_adapter_memory }}
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true

--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -61,9 +61,9 @@ spec:
           timeoutSeconds: 3
         resources:
           requests:
-            cpu: 25m
-            memory: 100Mi
+            cpu: {{ .Cluster.ConfigItems.kube2iam_cpu }}
+            memory: {{ .Cluster.ConfigItems.kube2iam_memory }}
             ephemeral-storage: 256Mi
           limits:
-            cpu: 25m
-            memory: 100Mi
+            cpu: {{ .Cluster.ConfigItems.kube2iam_cpu }}
+            memory: {{ .Cluster.ConfigItems.kube2iam_memory }}


### PR DESCRIPTION
Makes cpu/memory configurable per cluster for `audittrail-adapter` and `kube2iam` daemonsets.

This enables reducing the resource reservation in low usage clusters like playground.