### PR TITLE
Disable old Ingress API by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -292,7 +292,7 @@ allow_v1beta1_crds: "false"
 
 # This parameter is set to default `true` while we migrate ingresses to v1.
 # Later, will be changed to default to `false` and after migration is done, will be removed.
-allow_v1beta1_ingresses: "true"
+allow_v1beta1_ingresses: "false"
 
 # cadvisor settings
 cadvisor_cpu: "150m"


### PR DESCRIPTION
This disables the old Ingress API versions by default. `allow_v1beta1_ingresses` is set to `true` in the clusters which still have not fully migrated away from the old API versions.

Once this is rolled out it will start to block deployments of ingresses still defining the old api versions, but the teams have automated PRs with the needed update so they can merge those to fix the deployments.