### PR TITLE
log: change default access logs

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -86,7 +86,7 @@ skipper_suppress_route_update_logs: "true"
 skipper_validate_query: "true"
 skipper_validate_query_log: "false"
 
-skipper_default_filters: 'enableAccessLog(4,5) -> fifo(2000,20000,"3s")'
+skipper_default_filters: 'disableAccessLog(2,3,404,429) -> fifo(2000,20000,"3s")'
 skipper_disabled_filters: ""
 skipper_edit_route_placeholders: ""
 skipper_ingress_inline_routes: ""


### PR DESCRIPTION
log: change default access logs: disable 404 which is often the case by scanners and just produce log volume and 429 which is covered by metrics.
Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>