### PR TITLE
Flip on default storage class zone sanitization

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -823,7 +823,7 @@ deployment_service_enabled: "true"
 storageclass_standard_gp3: "true"
 
 # Standard storageclass gp3 volume zones fix
-storageclass_standard_sanitized_zones: "false"
+storageclass_standard_sanitized_zones: "true"
 
 # opentelemetry config
 observability_collector_endpoint: "tracing.platform-infrastructure.zalan.do"


### PR DESCRIPTION
Sanitizes the zone specification in the default storage class for `CSIMigrationAWS` to work without issue.

Merge after https://github.com/zalando-incubator/kubernetes-on-aws/pull/5554 is in stable.