### PR TITLE
Deploy CSI-related components by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -606,7 +606,7 @@ cpu_manager_policy: "none"
 allowed_unsafe_sysctls: "net.ipv4.tcp_keepalive_time,net.ipv4.tcp_keepalive_intvl,net.ipv4.tcp_keepalive_probes,net.ipv4.tcp_syn_retries,net.ipv4.tcp_retries2"
 
 # enable CSI Driver feature flag
-enable_csi: "false"
+enable_csi: "true"
 # enable CSIMigration and CSIMigrationAWS feature flags (make sure to set `enable_csi: true` for this to work)
 enable_csi_migration: "false"
 


### PR DESCRIPTION
Flips the switch and turns on CSI by default. Without `enable_csi_migration: true` as well it would be entirely opt-in for users by using a different StorageClass.

- [x] Based on https://github.com/zalando-incubator/kubernetes-on-aws/pull/5547 and must be merged after.

Precondition for enabling `CSIMigrationAWS` (i.e. `enable_csi_migration: true`) which requires a running CSI Driver (enabled by default in this PR).

Checklist:
- [x] This adds a DaemonSet to all clusters, so we need to increase DaemonSet reservations