### PR TITLE
Correctly disable old ingress api Versions

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -124,7 +124,7 @@ write_files:
           {{- end }}
           - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
           - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
-          - --runtime-config=extensions/v1beta1/networkpolicies=true,policy/v1beta1=true,authorization.k8s.io/v1beta1=true,scheduling.k8s.io/v1alpha1=true,admissionregistration.k8s.io/v1beta1=true,apiextensions.k8s.io/v1beta1={{ .Cluster.ConfigItems.allow_v1beta1_crds }},extensions/v1beta1/ingress={{ .Cluster.ConfigItems.allow_v1beta1_ingresses }},networking.k8s.io/v1beta1/ingress={{ .Cluster.ConfigItems.allow_v1beta1_ingresses }}
+          - --runtime-config=extensions/v1beta1/networkpolicies=true,policy/v1beta1=true,authorization.k8s.io/v1beta1=true,scheduling.k8s.io/v1alpha1=true,admissionregistration.k8s.io/v1beta1=true,apiextensions.k8s.io/v1beta1={{ .Cluster.ConfigItems.allow_v1beta1_crds }},extensions/v1beta1/ingresses={{ .Cluster.ConfigItems.allow_v1beta1_ingresses }},networking.k8s.io/v1beta1/ingresses={{ .Cluster.ConfigItems.allow_v1beta1_ingresses }}
           - --authentication-token-webhook-config-file=/etc/kubernetes/config/authn.yaml
           - --authentication-token-webhook-cache-ttl=10s
           - --cloud-provider=aws


### PR DESCRIPTION
Fixes disabling old ingress api versions when `allow_v1beta1_ingresses=false`. Right now the setting is just ignored and the old API versions continue to work.