### PR TITLE
Remove superflous config item used for StorageClass change

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -829,9 +829,6 @@ deployment_service_enabled: "true"
 # Standard storageclass gp3 volume type
 storageclass_standard_gp3: "true"
 
-# Standard storageclass gp3 volume zones fix
-storageclass_standard_sanitized_zones: "true"
-
 # opentelemetry config
 observability_collector_endpoint: "tracing.platform-infrastructure.zalan.do"
 observability_collector_port: "8443"

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -19,11 +19,6 @@ pre_apply:
     volume-type: gp3
   kind: StorageClass
 {{ end }}
-{{ if eq .Cluster.ConfigItems.storageclass_standard_sanitized_zones "true" }}
-- labels:
-    zones-sanitized: "false"
-  kind: StorageClass
-{{ end }}
 - labels:
     application: nvidia-gpu-device-plugin
   namespace: kube-system

--- a/cluster/manifests/storageclass/storageclass.yaml
+++ b/cluster/manifests/storageclass/storageclass.yaml
@@ -7,16 +7,9 @@ metadata:
   labels:
     kubernetes.io/cluster-service: "true"
     volume-type: {{ if eq .Cluster.ConfigItems.storageclass_standard_gp3 "true" }}gp3{{else}}gp2{{end}}
-    zones-sanitized: "{{ if eq .Cluster.ConfigItems.storageclass_standard_sanitized_zones "true" }}true{{else}}false{{end}}"
 provisioner: kubernetes.io/aws-ebs
 parameters:
   type: {{ if eq .Cluster.ConfigItems.storageclass_standard_gp3 "true" }}gp3{{else}}gp2{{end}}
   # TODO: this assumes 3 zones per region
-  #
-  # The old definition of zones containing spaces doesn't work well with CSI Migration.
-{{- if eq .ConfigItems.storageclass_standard_sanitized_zones "true" }}
   zones: {{ .Cluster.Region }}a,{{ .Cluster.Region }}b,{{ .Cluster.Region }}c
-{{- else }}
-  zones: {{ .Cluster.Region }}a, {{ .Cluster.Region }}b, {{ .Cluster.Region }}c
-{{- end }}
 allowVolumeExpansion: true


### PR DESCRIPTION
This isn't needed anymore. Merge when https://github.com/zalando-incubator/kubernetes-on-aws/pull/5568 has been rolled out to stable.