### PR TITLE
Reduce replicas of csi controller to one

### DIFF
--- a/cluster/manifests/03-ebs-csi/controller.yaml
+++ b/cluster/manifests/03-ebs-csi/controller.yaml
@@ -8,7 +8,7 @@ metadata:
     application: kubernetes
     component: ebs-csi-driver
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       deployment: ebs-csi-controller


### PR DESCRIPTION
I was contemplating how to run it. A two-replicas Deployment running on worker nodes is suggested by upstream.

For us, if we want to run it on master nodes, this either maps to a DaemonSet that scales with the number of master nodes (similar to cluster-autoscaler) or just a single replica Deployment since it's a controller (similar to CLC or ExternalDNS).

Anyways, two replicas on our single-master beta clusters is very odd. So I'm lowering it to one replica for now.

I don't expect any issues because a short downtime isn't too bad. However, two replicas also protect you from rolling out bad versions due to the readiness probe of the new replica failing.

Let me know what you think.