### PR TITLE
skipper: change default connect timeouts for TCP to 1s and TLS to 3s

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -104,8 +104,8 @@ skipper_expect_continue_timeout_backend: "30s"
 skipper_keepalive_backend: "30s"
 skipper_max_idle_connection_backend: "0"
 skipper_response_header_timeout_backend: "1m"
-skipper_timeout_backend: "1m"
-skipper_tls_timeout_backend: "1m"
+skipper_timeout_backend: "1s"
+skipper_tls_timeout_backend: "3s"
 skipper_close_idle_conns_period: "20s"
 
 # skipper server timeout defaults


### PR DESCRIPTION
Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>