### PR TITLE
external-dns: try experimental version that doesn't fail entire batch

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -683,7 +683,7 @@ external_dns_excluded_domains: cluster.local
 external_dns_policy: sync
 
 # eternal-dns version for controlling roll-out, can be "current" or "legacy"
-# current => v0.12.2-master-29
+# current => v0.13.1-internal
 # legacy => v0.9.0-master-26
 external_dns_version: "current"
 

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -35,7 +35,7 @@ spec:
       containers:
       - name: external-dns
         {{- if eq .Cluster.ConfigItems.external_dns_version "current" }}
-        image: container-registry.zalando.net/teapot/external-dns:v0.12.2-master-29
+        image: container-registry.zalando.net/teapot/external-dns:v0.13.1-internal-master-32
         {{- else }}
         image: container-registry.zalando.net/teapot/external-dns:v0.9.0-master-26
         {{- end }}


### PR DESCRIPTION
This is https://github.com/kubernetes-sigs/external-dns/pull/1209 rebased on `v0.13.1` aka `v0.13.1-internal-*`.

Let's see if this version passes all tests.

If not:
* make sure that vanilla `v0.13.1` even passes (we used v0.12.2 so far)

If yes:
* add an e2e test containing a broken DNS record that would normally break everything, then check if this PR fixes it.