### PR TITLE
Introduce a problematic DNS and ExternalDNS version with the fix

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -683,7 +683,7 @@ external_dns_excluded_domains: cluster.local
 external_dns_policy: sync
 
 # eternal-dns version for controlling roll-out, can be "current" or "legacy"
-# current => v0.13.1-internal-master-32
+# current => v0.13.2-12-ga18bf2b5-internal-master-34
 # legacy => v0.9.0-master-26
 external_dns_version: "current"
 

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -683,7 +683,7 @@ external_dns_excluded_domains: cluster.local
 external_dns_policy: sync
 
 # eternal-dns version for controlling roll-out, can be "current" or "legacy"
-# current => v0.13.1-master-32
+# current => v0.13.1-internal-master-32
 # legacy => v0.9.0-master-26
 external_dns_version: "current"
 

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -35,7 +35,7 @@ spec:
       containers:
       - name: external-dns
         {{- if eq .Cluster.ConfigItems.external_dns_version "current" }}
-        image: container-registry.zalando.net/teapot/external-dns:v0.13.1-master-32
+        image: container-registry.zalando.net/teapot/external-dns:v0.13.1-internal-master-32
         {{- else }}
         image: container-registry.zalando.net/teapot/external-dns:v0.9.0-master-26
         {{- end }}

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -35,7 +35,7 @@ spec:
       containers:
       - name: external-dns
         {{- if eq .Cluster.ConfigItems.external_dns_version "current" }}
-        image: container-registry.zalando.net/teapot/external-dns:v0.13.1-internal-master-32
+        image: container-registry.zalando.net/teapot/external-dns:v0.13.2-12-ga18bf2b5-internal-master-34
         {{- else }}
         image: container-registry.zalando.net/teapot/external-dns:v0.9.0-master-26
         {{- end }}

--- a/test/e2e/broken-dns-record.yaml
+++ b/test/e2e/broken-dns-record.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: broken-dns-record
+  annotations:
+    # specifying the apex domain name breaks ExternalDNS
+    external-dns.alpha.kubernetes.io/hostname: .teapot-e2e.zalan.do
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 80
+    targetPort: 8080

--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -195,6 +195,9 @@ if [ "$e2e" = true ]; then
     #   https://github.com/kubernetes/kubernetes/blob/v1.21.5/test/e2e/network/hostport.go#L61
     set +e
 
+    # introduce a broken DNS record to mess with ExternalDNS
+    cat broken-dns-record.yaml | kubectl apply -f -
+
     mkdir -p junit_reports
     ginkgo -nodes=25 -flakeAttempts=2 \
         -focus="(\[Conformance\]|\[StatefulSetBasic\]|\[Feature:StatefulSet\]\s\[Slow\].*mysql|\[Zalando\])" \


### PR DESCRIPTION
Let's add a Service of `Type: LoadBalancer` giving it a DNS name that ExternalDNS has problems with (as of `v0.13.1`, it might be fixed in later versions)

The idea is that DNS should be pretty broken when running e2e tests. Then we can see if introducing https://github.com/zalando-incubator/kubernetes-on-aws/pull/5602 makes sure to ignore the bad record.