### PR TITLE
Update ExternalDNS to the latest version (v0.13.1)

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -683,7 +683,7 @@ external_dns_excluded_domains: cluster.local
 external_dns_policy: sync
 
 # eternal-dns version for controlling roll-out, can be "current" or "legacy"
-# current => v0.12.2-master-29
+# current => v0.13.1-master-32
 # legacy => v0.9.0-master-26
 external_dns_version: "current"
 

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -35,7 +35,7 @@ spec:
       containers:
       - name: external-dns
         {{- if eq .Cluster.ConfigItems.external_dns_version "current" }}
-        image: container-registry.zalando.net/teapot/external-dns:v0.12.2-master-29
+        image: container-registry.zalando.net/teapot/external-dns:v0.13.1-master-32
         {{- else }}
         image: container-registry.zalando.net/teapot/external-dns:v0.9.0-master-26
         {{- end }}


### PR DESCRIPTION
Just a regular update of ExternalDNS. Changelog: https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.13.1