### PR TITLE
skipper: removes credentials path

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -226,7 +226,6 @@ spec:
           - "-oauth2-secret-file=/etc/skipper/secret/encryption-key"
           - "-oauth2-client-id-file=/etc/skipper/oauth/{{ .Cluster.Alias }}-employee-client-id"
           - "-oauth2-client-secret-file=/etc/skipper/oauth/{{ .Cluster.Alias }}-employee-client-secret"
-          - "-credentials-paths=/etc/skipper/secret,/etc/skipper/oauth"
           - "-credentials-update-interval=1m"
           - "-oauth2-token-cookie-name={{.ConfigItems.skipper_oauth2_cookie_name }}"
           - "-oauth2-callback-path={{ .ConfigItems.skipper_oauth2_redirect_url }}"


### PR DESCRIPTION
`-credentials-path` is only used by `bearerinjector` filter that is no used in the ingress setting.

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>