### PR TITLE
Update kube-metrics-adapter-version

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: container-registry.zalando.net/teapot/kube-metrics-adapter:v0.1.19-2-g3796948
+        image: container-registry.zalando.net/teapot/kube-metrics-adapter:v0.1.19-13-gc50d9cc
         env:
         - name: AWS_REGION
           value: {{ .Region }}


### PR DESCRIPTION
Update the kube-metrics-adapter version to include support for (cluster) scaling-schedules end date/time configuration.

Relevant Kube-Metrics-Adapter: [PR](https://github.com/zalando-incubator/kube-metrics-adapter/pull/505) (& nil pointer fix [PR](https://github.com/zalando-incubator/kube-metrics-adapter/pull/506))