### PR TITLE
Add updated CRD files for kube-metrics-adapter

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/cluster_scaling_schedules_crd.yaml
+++ b/cluster/manifests/kube-metrics-adapter/cluster_scaling_schedules_crd.yaml
@@ -59,6 +59,11 @@ spec:
                       description: The duration in minutes that the configured value
                         will be returned for the defined schedule.
                       type: integer
+                    endDate:
+                      description: Defines the ending date of a OneTime schedule.
+                        It must be a RFC3339 formated date.
+                      format: date-time
+                      type: string
                     period:
                       description: Defines the details of a Repeating schedule.
                       properties:
@@ -77,6 +82,10 @@ spec:
                             - Sat
                             type: string
                           type: array
+                        endTime:
+                          description: The endTime has the format HH:MM
+                          pattern: (([0-1][0-9])|([2][0-3])):([0-5][0-9])
+                          type: string
                         startTime:
                           description: The startTime has the format HH:MM
                           pattern: (([0-1][0-9])|([2][0-3])):([0-5][0-9])

--- a/cluster/manifests/kube-metrics-adapter/scaling_schedules_crd.yaml
+++ b/cluster/manifests/kube-metrics-adapter/scaling_schedules_crd.yaml
@@ -59,6 +59,11 @@ spec:
                       description: The duration in minutes that the configured value
                         will be returned for the defined schedule.
                       type: integer
+                    endDate:
+                      description: Defines the ending date of a OneTime schedule.
+                        It must be a RFC3339 formated date.
+                      format: date-time
+                      type: string
                     period:
                       description: Defines the details of a Repeating schedule.
                       properties:
@@ -77,6 +82,10 @@ spec:
                             - Sat
                             type: string
                           type: array
+                        endTime:
+                          description: The endTime has the format HH:MM
+                          pattern: (([0-1][0-9])|([2][0-3])):([0-5][0-9])
+                          type: string
                         startTime:
                           description: The startTime has the format HH:MM
                           pattern: (([0-1][0-9])|([2][0-3])):([0-5][0-9])


### PR DESCRIPTION
Follow up to https://github.com/zalando-incubator/kubernetes-on-aws/pull/5624.

This PR updates the scaling schedules and cluster scaling schedules CRD files to add the `endDate` and `endTime` field.