### PR TITLE
Update kube2iam to v0.11.1

### DIFF
--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     application: kubernetes
     component: kube2iam
-    version: 0.10.11
+    version: 0.11.1
 spec:
   selector:
     matchLabels:
@@ -19,7 +19,7 @@ spec:
         daemonset: kube2iam
         application: kubernetes
         component: kube2iam
-        version: 0.10.11
+        version: 0.11.1
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
@@ -36,7 +36,7 @@ spec:
         effect: NoExecute
       hostNetwork: true
       containers:
-      - image: container-registry.zalando.net/teapot/kube2iam:0.10.11-master-10
+      - image: container-registry.zalando.net/teapot/kube2iam:0.11.1-master-13
         name: kube2iam
         args:
         - --auto-discover-base-arn


### PR DESCRIPTION
Update to the latest version and make use of the original multi-arch upstream image: https://hub.docker.com/layers/jtblin/kube2iam/0.11.1/images/sha256-4a8cbf557984fc3081c120cc8d56a7059fa71f182224b6cb84481e739c982fc8?context=explore