### PR TITLE
Improve audit-policy

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -752,12 +752,6 @@ write_files:
         # don't audit any kube-controller-manager events
         - level: None
           users: ["system:kube-controller-manager"]
-        # Don't audit events from system users in kube-system
-        - level: None
-          userGroups: ["system:serviceaccounts:kube-system"]
-        # Don't audit events from high traffic infrastructure components
-        - level: None
-          users: ["credentials-provider"]
         - level: None
           userGroups: ["system:nodes"]
           verbs: ["get"]
@@ -798,6 +792,12 @@ write_files:
           resources:
             - group: "" # core
               resources: ["events"]
+{{ if ne .Cluster.ConfigItems.auditlog_read_access "true" }}
+        # Don't audit events from system users in kube-system
+        # unless auditlog_read_access=true
+        - level: None
+          userGroups: ["system:serviceaccounts:kube-system"]
+{{ end }}
         # Secrets, ConfigMaps, and TokenReviews can contain sensitive & binary data,
         # so only log at the Metadata level.
         - level: Metadata
@@ -809,18 +809,15 @@ write_files:
           omitStages:
             - "RequestReceived"
 {{ if eq .Cluster.ConfigItems.auditlog_read_access "true" }}
-        - level: None
-          verbs: ["watch", "list", "get"]
-          userGroups: ["system:serviceaccounts:kube-system"]
         - level: Request
           verbs: ["watch", "list", "get"]
-          userGroups: ["system:serviceaccounts"]
           omitStages:
           - "RequestReceived"
-{{ end }}
+{{ else }}
         # Don't audit read-only events.
         - level: None
           verbs: ["watch", "list", "get"]
+{{ end }}
         # Default level for all other requests.
         - level: Request
           omitStages:


### PR DESCRIPTION
Improves the audit-policy to log ALL read events if `auditlog_read_access=true`. 

We previously dropped events from service account users in kube-system, but this is now enabled if `auditlog_read_access=true`.

Also drops an old config supressing the `credentials-provider` identity which is no longer used (The user is called something like: `zalando-iam:zalando:service:k8sapi_credentials-provider`).