### PR TITLE
Update to cadvisor v0.47.0

### DIFF
--- a/cluster/manifests/node-monitor/daemonset.yaml
+++ b/cluster/manifests/node-monitor/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: node-monitor
       containers:
         - name: cadvisor
-          image: container-registry.zalando.net/teapot/cadvisor:v0.38.8-master-9
+          image: container-registry.zalando.net/teapot/cadvisor:v0.47.0-master-11
           args:
             - --port=9101
 {{- if eq .Cluster.ConfigItems.cadvisor_profiling_enabled "true" }}


### PR DESCRIPTION
https://github.com/google/cadvisor/releases/tag/v0.47.0

In the past we ran v0.44.0 but downgraded to v0.38.0 to support ARM. Now we can upgrade to the latest version also running on ARM.