### PR TITLE
Run tests against arm64 master nodes

### DIFF
--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -52,7 +52,7 @@ clusters:
   local_id: ${LOCAL_ID}
   node_pools:
   - discount_strategy: none
-    instance_types: ["m5a.large"]
+    instance_types: ["m6g.large"]
     name: default-master
     profile: master-default
     min_size: 1


### PR DESCRIPTION
Pretty much all clusters run with arm64-based master nodes because they are reported as being the cheapest by master node autoscaler.

Let's have our e2e tests use a similar configuration.

Besides being cheaper, this is intended to replace https://github.com/zalando-incubator/kubernetes-on-aws/pull/5098 but I think we might still want it to test arm64-based worker pools.