### PR TITLE
Enable 2k nodes by default stage [2/2]

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -603,7 +603,7 @@ kube2iam_memory: "100Mi"
 #
 # Set `enable_node_scale_out_beyond_1k_nodes: "stage2"` to apply the cluster_cidr
 # change on the kube-controller-manager,
-enable_node_scale_out_beyond_1k_nodes: "stage1"
+enable_node_scale_out_beyond_1k_nodes: "stage2"
 
 
 # CIDR configuration for nodes and pods


### PR DESCRIPTION
Roll out second(last) stage of enabling 2k nodes by default in clusters (1k in test, 2k in prod).

```
# The enable_node_scale_out_beyond_1k_nodes is feature toogle to change
# the default cluster_cidr from 10.2.0.0/16 to 10.2.0.0/15, this change
# enables the kubernetes cluster to scale out beyond 1000 nodes.
#
# Set `enable_node_scale_out_beyond_1k_nodes: "stage1"` to apply the cluster_cidr
# change first in the components flannel, coredns, and skipper.
#
# Set `enable_node_scale_out_beyond_1k_nodes: "stage2"` to apply the cluster_cidr
# change on the kube-controller-manager,
```