### PR TITLE
Drop ZMON based scaling for skipper-ingress

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -258,13 +258,6 @@ skipper_ingress_encryption_key: ""
 skipper_oauth2_ui_login: "true"
 {{end}}
 
-# Skipper Time based scaling
-#
-# This section contains the config items related to time based scaling
-# for skipper
-# kube-zmon-scaling
-skipper_time_based_scaling_check_id: ""
-skipper_time_based_scaling_target: "1"
 # ClusterScalingSchedules
 # One or multiple cluster scaling schedules can be configured as a
 # comma-separated list of <cluster schedule name>=<target value> pairs.

--- a/cluster/manifests/skipper/hpa.yaml
+++ b/cluster/manifests/skipper/hpa.yaml
@@ -25,22 +25,6 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ .ConfigItems.skipper_ingress_target_average_utilization_memory }}
-{{ if ne .ConfigItems.skipper_time_based_scaling_check_id "" }}
-  - type: External
-    external:
-      target:
-        averageValue: {{ .ConfigItems.skipper_time_based_scaling_target }}
-        type: AverageValue
-      metric:
-        name: zmon-check
-        selector:
-          matchLabels:
-            type: "zmon"
-            check-id: "{{ .ConfigItems.skipper_time_based_scaling_check_id }}"
-            key: ""
-            tag-application: "skipper-ingress"
-            aggregators: last
-{{ end }}
 {{ if ne .ConfigItems.skipper_cluster_scaling_schedules "" }}
   {{ range split .ConfigItems.skipper_cluster_scaling_schedules "," }}
   {{ $name_target := split . "=" }}


### PR DESCRIPTION
This feature is no longer used and thus we can remove the configuration.

## TODO

* [x] Remove usage from the last cluster.