### PR TITLE
feature: support stackset-controller minReadyPercent

### DIFF
--- a/cluster/manifests/stackset-controller/01-stackset-crd.yaml
+++ b/cluster/manifests/stackset-controller/01-stackset-crd.yaml
@@ -103,6 +103,10 @@ spec:
                 - backendPort
                 - hosts
                 type: object
+              minReadyPercent:
+                description: minReadyPercent sets the minimum percentage of Pods expected
+                  to be Ready to consider a Stack for traffic switch
+                type: integer
               routegroup:
                 description: RouteGroup is an alternative to ingress allowing more
                   advanced routing configuration while still maintaining the ability

--- a/cluster/manifests/stackset-controller/deployment.yaml
+++ b/cluster/manifests/stackset-controller/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $version := "v1.3.62" }}
+{{ $version := "v1.3.68" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
minReadyPercent is an optional Stackset field that sets the minimum
required percentage of replicas available for starting traffic switch.
Ref: https://github.com/zalando-incubator/stackset-controller/pull/456

Signed-off-by: Katyanna Moura <amelie.kn@gmail.com>