### PR TITLE
skipper: update grant cookie configuration

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -255,7 +255,7 @@ skipper_tokeninfo_cache_ttl: "30s"
 skipper_oauth2_ui_login: "false"
 skipper_ingress_encryption_key: ""
 {{else}}
-skipper_oauth2_ui_login: "true"
+skipper_oauth2_ui_login: "false"
 {{end}}
 
 # ClusterScalingSchedules

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.15.6-380" }}
+{{ $internal_version := "v0.15.10-383" }}
 {{ $version := index (split $internal_version "-") 0 }}
 
 apiVersion: apps/v1
@@ -225,6 +225,8 @@ spec:
           - "-oauth2-client-secret-file=/etc/skipper/oauth/{{ .Cluster.Alias }}-employee-client-secret"
           - "-credentials-update-interval=1m"
           - "-oauth2-token-cookie-name={{ .ConfigItems.skipper_oauth2_cookie_name }}"
+          - "-oauth2-token-cookie-remove-subdomains=0"
+          - "-oauth2-callback-path={{ .ConfigItems.skipper_oauth2_redirect_uri_path }}"
           - "-oauth2-auth-url-parameters=redirect_uri=https://{{ .ConfigItems.skipper_oauth2_redirect_uri_host }}{{ .ConfigItems.skipper_oauth2_redirect_uri_path }}"
 {{ end }}
 {{ if or (eq .ConfigItems.nlb_switch "pre") (eq .ConfigItems.nlb_switch "exec") }}
@@ -427,6 +429,7 @@ spec:
           - '-default-filters-prepend={{ .ConfigItems.skipper_default_filters }}'
 {{ if eq .ConfigItems.skipper_oauth2_ui_login "true" }}
           - "-enable-oauth2-grant-flow"
+          - "-oauth2-callback-path={{ .ConfigItems.skipper_oauth2_redirect_uri_path }}"
 {{ end }}
 {{ if ne .ConfigItems.skipper_edit_route_placeholders "" }}
           {{ range $placeholder := split .ConfigItems.skipper_edit_route_placeholders "[cf724afc]" }}


### PR DESCRIPTION
Updated configuration ensures token cookie to be issued for the initial request domain when initial request host is different from the `redirect_uri` host.

See https://github.com/zalando/skipper/compare/v0.15.6...v0.15.10

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>