### PR TITLE
Set apiserver memory limit based on instance-type

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -846,3 +846,9 @@ network_monitoring_check_neighborhood: "true"
 network_monitoring_check_unschedulable_nodes: "true"
 network_monitoring_check_interval: "1m"
 network_monitoring_separate_prometheus: "false"
+
+# Percent of master node instance memory to allocate to the kube-apiserver
+# container. If this value is non-zero it will set the memory limit for the
+# kube-apiserver container in the kube-apiserver pod.
+# Must be a whole number between 0-100.
+apiserver_memory_limit_percent: "80"

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -199,6 +199,10 @@ write_files:
             requests:
               cpu: 100m
               memory: 200Mi
+{{- if ne .Cluster.ConfigItems.apiserver_memory_limit_percent "0" }}
+            limits:
+              memory: {{ .Values.InstanceInfo.MemoryFraction (parseInt64 .Cluster.ConfigItems.apiserver_memory_limit_percent)}}
+{{- end }}
         - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-158
           name: admission-controller
           lifecycle:


### PR DESCRIPTION
This introduces a way to set the apiserver memory with a limit based on instance-type size such that we don't run apiserver without memory limits.

The motivation for this is that we have multiple times observed how an overrun apiserver instance becomes completely unresponsive. The theory is that if we have a memory limit set on the container then it will kill the process before it can use up all the memory of the instance and prevent it from dying completely.

This is set to 80% of the instance memory by default based on testing and the understanding that the kube-apiserver is the main process on the node using memory.
It can be disabled per cluster via the config-item: `apiserver_memory_limit_percent=0`


