### PR TITLE
Drop legacy external-dns version

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -669,11 +669,6 @@ external_dns_excluded_domains: cluster.local
 # synchronization policy between Kubernetes and AWS Route53 (default: sync, options: sync, upsert-only, create-only)
 external_dns_policy: sync
 
-# eternal-dns version for controlling roll-out, can be "current" or "legacy"
-# current => v0.13.2-12-ga18bf2b5-internal-master-34
-# legacy => v0.9.0-master-26
-external_dns_version: "current"
-
 # resource configuration
 external_dns_mem: "4Gi"
 

--- a/cluster/manifests/external-dns/01-rbac.yaml
+++ b/cluster/manifests/external-dns/01-rbac.yaml
@@ -22,11 +22,7 @@ rules:
 - apiGroups: [""]
   resources: ["services", "endpoints", "pods", "nodes"]
   verbs: ["list"]
-{{- if eq .Cluster.ConfigItems.external_dns_version "current" }}
 - apiGroups: ["networking.k8s.io"]
-{{- else }}
-- apiGroups: ["extensions"]
-{{- end }}
   resources: ["ingresses"]
   verbs: ["list"]
 - apiGroups: ["zalando.org"]

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -34,11 +34,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        {{- if eq .Cluster.ConfigItems.external_dns_version "current" }}
         image: container-registry.zalando.net/teapot/external-dns:v0.13.2-12-ga18bf2b5-internal-master-34
-        {{- else }}
-        image: container-registry.zalando.net/teapot/external-dns:v0.9.0-master-26
-        {{- end }}
         args:
         - --source=service
         - --source=ingress


### PR DESCRIPTION
This reverts #5383 as there is no longer a need to run the legacy version of external-dns in any clusters. 