### PR TITLE
Move RouteSRV to `exec` mode in test clusters

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -162,7 +162,7 @@ skipper_routesrv_replicas: 3
 skipper_routesrv_cpu: "1000m"
 skipper_routesrv_memory: "1Gi"
 {{else}}
-skipper_routesrv_enabled: "pre"
+skipper_routesrv_enabled: "exec"
 skipper_routesrv_replicas: 3
 skipper_routesrv_cpu: "100m"
 skipper_routesrv_memory: "1Gi"


### PR DESCRIPTION
Move RouteSRV to exec mode in test clusters

Signed-off-by: Mustafa Abdelrahman <mustafa.abdelrahman@zalando.de>