### PR TITLE
Update authnz webhook to the latest version

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -273,7 +273,7 @@ write_files:
               name: ssl-certs-kubernetes
               readOnly: true
 {{- end}}
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/k8s-authnz-webhook:master-122
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/k8s-authnz-webhook:master-123
           name: webhook
           ports:
           - containerPort: 8081


### PR DESCRIPTION
Updates the webhook to Go1.20 and other dependency updates. Let's merge together with https://github.com/zalando-incubator/kubernetes-on-aws/pull/5745 to reduce the master rolls.