### PR TITLE
Update external-dns to multi-arch image

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: container-registry.zalando.net/teapot/external-dns:v0.13.2-12-ga18bf2b5-internal-master-34
+        image: container-registry.zalando.net/teapot/external-dns:v0.13.2-12-ga18bf2b5-internal-master-35
         args:
         - --source=service
         - --source=ingress


### PR DESCRIPTION
Update external-dns to multi-arch image in preparation for all-arm64 clusters.