### PR TITLE
Process routes once if RouteSRV in `exec` mode

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -193,12 +193,14 @@ spec:
           - "-idle-timeout-server={{ .ConfigItems.skipper_idle_timeout_server }}"
           - "-read-timeout-server={{ .ConfigItems.skipper_read_timeout_server }}"
           - "-write-timeout-server={{ .ConfigItems.skipper_write_timeout_server }}"
-          - '-default-filters-prepend={{ .ConfigItems.skipper_default_filters }}'
           - "-disabled-filters={{ .ConfigItems.skipper_disabled_filters }}"
-{{ if ne .ConfigItems.skipper_edit_route_placeholders "" }}
+{{ if ne .ConfigItems.skipper_routesrv_enabled "exec" }}
+          - '-default-filters-prepend={{ .ConfigItems.skipper_default_filters }}'
+  {{ if ne .ConfigItems.skipper_edit_route_placeholders "" }}
           {{ range $placeholder := split .ConfigItems.skipper_edit_route_placeholders "[cf724afc]" }}
           - '-edit-route={{ $placeholder }}'
           {{ end }}
+  {{ end }}
 {{ end }}
           - "-suppress-route-update-logs={{ .ConfigItems.skipper_suppress_route_update_logs }}"
 {{ if eq .ConfigItems.skipper_enable_tcp_queue "true" }}


### PR DESCRIPTION
In `exec` mode both RouteSRV and Skipper process routes which lead to duplicate filters

Signed-off-by: Mustafa Abdelrahman <mustafa.abdelrahman@zalando.de>