### PR TITLE
Build multi-arch e2e image

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -32,9 +32,8 @@ pipeline:
         exit 1
       fi
 
-      if [ "$CDP_TRIGGER_EVENT" == "pull_request" ]; then
-        VERSION="$CDP_BUILD_VERSION" make build.push
-      fi
+      IMAGE=container-registry-test.zalando.net/teapot/kubernetes-on-aws-e2e
+      IMAGE=$IMAGE VERSION=$CDP_BUILD_VERSION make build.push.multiarch
 
 - id: create-cluster
   when:
@@ -69,7 +68,7 @@ pipeline:
         restartPolicy: Never
         containers:
         - name: e2e
-          image: "pierone.stups.zalan.do/teapot/kubernetes-on-aws-e2e:#{CDP_BUILD_VERSION}"
+          image: "container-registry-test.zalando.net/teapot/kubernetes-on-aws-e2e:#{CDP_BUILD_VERSION}"
           args:
           - create-cluster
           env: &e2e_env
@@ -189,7 +188,7 @@ pipeline:
         restartPolicy: Never
         containers:
         - name: e2e
-          image: "pierone.stups.zalan.do/teapot/kubernetes-on-aws-e2e:#{CDP_BUILD_VERSION}"
+          image: "container-registry-test.zalando.net/teapot/kubernetes-on-aws-e2e:#{CDP_BUILD_VERSION}"
           args:
           - e2e
           env: *e2e_env
@@ -226,7 +225,7 @@ pipeline:
         restartPolicy: Never
         containers:
         - name: e2e
-          image: "pierone.stups.zalan.do/teapot/kubernetes-on-aws-e2e:#{CDP_BUILD_VERSION}"
+          image: "container-registry-test.zalando.net/teapot/kubernetes-on-aws-e2e:#{CDP_BUILD_VERSION}"
           args:
           - loadtest-e2e
           env: *e2e_env
@@ -263,7 +262,7 @@ pipeline:
         restartPolicy: Never
         containers:
         - name: e2e
-          image: "pierone.stups.zalan.do/teapot/kubernetes-on-aws-e2e:#{CDP_BUILD_VERSION}"
+          image: "container-registry-test.zalando.net/teapot/kubernetes-on-aws-e2e:#{CDP_BUILD_VERSION}"
           args:
           - stackset-e2e
           env: *e2e_env
@@ -302,7 +301,7 @@ pipeline:
         restartPolicy: Never
         containers:
         - name: e2e
-          image: "pierone.stups.zalan.do/teapot/kubernetes-on-aws-e2e:#{CDP_BUILD_VERSION}"
+          image: "container-registry-test.zalando.net/teapot/kubernetes-on-aws-e2e:#{CDP_BUILD_VERSION}"
           args:
           - decommission-cluster
           env: *e2e_env

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -6,7 +6,9 @@ RUN go install github.com/onsi/ginkgo/ginkgo@v1.16.5
 # final image
 # TODO get rid of python dependencies
 # * wait-for-update.py
-FROM registry.opensource.zalan.do/library/python-3.10-slim:latest
+FROM container-registry.zalando.net/library/python-3.11-slim:latest
+
+ARG TARGETARCH
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
   bc \
@@ -18,14 +20,14 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
   && pip3 install awscli --no-cache-dir
 
 ARG KUBE_VERSION
-ADD https://storage.googleapis.com/kubernetes-release/release/$KUBE_VERSION/bin/linux/amd64/kubectl /usr/bin/kubectl
+ADD https://storage.googleapis.com/kubernetes-release/release/$KUBE_VERSION/bin/linux/$TARGETARCH/kubectl /usr/bin/kubectl
 RUN chmod +x /usr/bin/kubectl
 
 COPY --from=builder /go/bin/ginkgo /usr/local/bin/ginkgo
 
 # copy CLM
-COPY --from=registry.opensource.zalan.do/teapot/cluster-lifecycle-manager:latest /clm /usr/bin/clm
-COPY --from=pierone.stups.zalan.do/teapot/aws-account-creator:latest /aws-account-creator /usr/bin/aws-account-creator
+COPY --from=container-registry.zalando.net/teapot/cluster-lifecycle-manager:latest /clm /usr/bin/clm
+COPY --from=container-registry.zalando.net/teapot/aws-account-creator:latest /aws-account-creator /usr/bin/aws-account-creator
 
 ADD . /workdir
 

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -37,11 +37,30 @@ stackset-e2e:
 
 build: e2e.test stackset-e2e
 
+build/linux/amd64/e2e.test: generate-code
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -v -c -o $@
+
+build/linux/amd64/stackset-e2e:
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -modfile stackset/go.mod -c -o $@ github.com/zalando-incubator/stackset-controller/cmd/e2e
+
+build/linux/arm64/e2e.test: generate-code
+	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go test -v -c -o $@
+
+build/linux/arm64/stackset-e2e:
+	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go test -modfile stackset/go.mod -c -o $@ github.com/zalando-incubator/stackset-controller/cmd/e2e
+
+build.linux.amd64: build/linux/amd64/e2e.test build/linux/amd64/stackset-e2e
+build.linux.arm64: build/linux/arm64/e2e.test build/linux/arm64/stackset-e2e
+
 build.docker: build
 	docker build --rm --build-arg KUBE_VERSION=$(KUBE_VERSION) -t "$(IMAGE):$(TAG)" -f $(DOCKERFILE) ../..
 
 build.push: build.docker
 	docker push "$(IMAGE):$(TAG)"
+
+build.push.multiarch: build.linux.amd64 build.linux.arm64
+	docker buildx create --config /etc/cdp-buildkitd.toml --driver-opt network=host --bootstrap --use
+	docker buildx build --rm --build-arg KUBE_VERSION=$(KUBE_VERSION) -t "$(IMAGE):$(TAG)" --platform linux/amd64,linux/arm64 --push -f $(DOCKERFILE) ../..
 
 clean:
 	rm -rf e2e.test

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -60,7 +60,8 @@ build.push: build.docker
 
 build.push.multiarch: build.linux.amd64 build.linux.arm64
 	docker buildx create --config /etc/cdp-buildkitd.toml --driver-opt network=host --bootstrap --use
-	docker buildx build --rm --build-arg KUBE_VERSION=$(KUBE_VERSION) -t "$(IMAGE):$(TAG)" --platform linux/amd64,linux/arm64 --push -f $(DOCKERFILE) ../..
+	# docker buildx build --rm --build-arg KUBE_VERSION=$(KUBE_VERSION) -t "$(IMAGE):$(TAG)" --platform linux/amd64,linux/arm64 --push -f $(DOCKERFILE) ../..
+	docker buildx build --rm --build-arg KUBE_VERSION=$(KUBE_VERSION) -t "$(IMAGE):$(TAG)" --platform linux/amd64 --push -f $(DOCKERFILE) ../..
 
 clean:
 	rm -rf e2e.test


### PR DESCRIPTION
As a follow up to https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/645 build and use a multi-arch image for running e2e.


This sets up everything for building a multi-arch image, but I limited it only to amd64 for now because otherwise it doubles the build time which we do for every PR. IMO we can merge as is and later enable arm64 if it makes sense.