### PR TITLE
Update CDPDeploymentTask with source information fields

### DIFF
--- a/cluster/manifests/deployment-service/00-crd.yaml
+++ b/cluster/manifests/deployment-service/00-crd.yaml
@@ -52,6 +52,27 @@ spec:
               pipelineID:
                 description: CDP pipeline ID
                 type: string
+              sourceInformation:
+                description: Information about where this deployment task and its
+                  manifests originate from
+                properties:
+                  cdpStepName:
+                    description: The CDP pipeline step
+                    type: string
+                  repositoryBase:
+                    description: The source repository's hostname
+                    type: string
+                  repositoryBranch:
+                    description: The source repository's branch being used
+                    type: string
+                  repositoryID:
+                    description: The source repository's internal ID
+                    type: string
+                  repositoryName:
+                    description: The source repository's relative name within the
+                      base
+                    type: string
+                type: object
               taskKind:
                 description: The kind of this deployment task. Currently only 'Standard'
                   and 'MLExperiment' tasks are supported. If unset, the task is considered


### PR DESCRIPTION
In preparation of rolling out source information we need to update the CRD. Tested backwards compatibility by rolling out cluster-registry to stups test while using the new CRD.