### PR TITLE
replace several images with multi-arch counterparts

### DIFF
--- a/test/e2e/kube_metrics_adapter_test.go
+++ b/test/e2e/kube_metrics_adapter_test.go
@@ -299,7 +299,7 @@ func podMetricDeployment(name string, replicas int32, containers []CustomMetricC
 func podContainerSpec(name string) corev1.Container {
 	return corev1.Container{
 		Name:  name,
-		Image: "pierone.stups.zalan.do/teapot/sample-custom-metrics-autoscaling:master-13",
+		Image: "container-registry.zalando.net/teapot/sample-custom-metrics-autoscaling:master-15",
 		Ports: []corev1.ContainerPort{{ContainerPort: 8000, Protocol: "TCP"}},
 		Resources: corev1.ResourceRequirements{
 			Limits: map[corev1.ResourceName]resource.Quantity{
@@ -316,7 +316,7 @@ func podContainerSpec(name string) corev1.Container {
 func podMetricContainerSpec(container CustomMetricContainerSpec) corev1.Container {
 	return corev1.Container{
 		Name:  container.Name,
-		Image: "pierone.stups.zalan.do/teapot/sample-custom-metrics-autoscaling:master-13",
+		Image: "container-registry.zalando.net/teapot/sample-custom-metrics-autoscaling:master-15",
 		Ports: []corev1.ContainerPort{{ContainerPort: 8000, Protocol: "TCP"}},
 		Resources: corev1.ResourceRequirements{
 			Limits: map[corev1.ResourceName]resource.Quantity{

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -44,7 +44,7 @@ import (
 )
 
 const (
-	awsCliImage  = "registry.opensource.zalan.do/teapot/awscli:master-1"
+	awsCliImage  = "container-registry.zalando.net/teapot/awscli:master-2"
 	pauseImage   = "container-registry.zalando.net/teapot/pause:3.4.1-master-18"
 	appLabelName = "application"
 )
@@ -275,7 +275,7 @@ func createSkipperPodSpec(route string, port int32) corev1.PodSpec {
 		Containers: []corev1.Container{
 			{
 				Name:  "skipper",
-				Image: "registry.opensource.zalan.do/teapot/skipper:latest",
+				Image: "container-registry.zalando.net/teapot/skipper:v0.15.23",
 				Args: []string{
 					"skipper",
 					"-inline-routes",


### PR DESCRIPTION
Use multi-arch images for more components to pass e2e tests for an all-arm64 cluster.

Also aligns the skipper image on `v0.15.23` everywhere.

Part of https://github.com/zalando-incubator/kubernetes-on-aws/pull/5098