### PR TITLE
visibility: skipper expose redisclient number of shards

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.15.23-396" }}
+{{ $internal_version := "v0.15.35-409" }}
 {{ $version := index (split $internal_version "-") 0 }}
 
 apiVersion: apps/v1


### PR DESCRIPTION
https://github.com/zalando/skipper/compare/v0.15.23...v0.15.35

- [secrets: log updates only when content changes](https://github.com/zalando/skipper/commit/d8a65781619a475dcc21dac53770702cde40e06c)
- [refactor: proxy error response](https://github.com/zalando/skipper/commit/c7cbca56817d8bb3f88178a6e70b4f2d6107071b)
- [filters: add wrapContent](https://github.com/zalando/skipper/commit/b9ea0c5c7e0702621de5217a63cbd3d4aeb9dd82)
- [RouteSRV: Expose redis shards endpoints](https://github.com/zalando/skipper/commit/a1d359cf7bc4f9bd3aa916002a40d21aa6d8392b)
- [filters/diag: add repeatContentHex and wrapContentHex](https://github.com/zalando/skipper/commit/36ed5db206c1d9c3397abf6c1e2de066c40d35e5)
- [feature: expose number of known redis shards ](https://github.com/zalando/skipper/commit/5d44e5a125b91f9ce8dbf7a9ff6048eca8ea456e)