### PR TITLE
fix: skipper-ingress-redis terminated too fast

### DIFF
--- a/cluster/manifests/skipper/skipper-redis.yaml
+++ b/cluster/manifests/skipper/skipper-redis.yaml
@@ -73,6 +73,10 @@ spec:
           limits:
             cpu: {{ .Cluster.ConfigItems.skipper_redis_cpu }}
             memory: {{ .Cluster.ConfigItems.skipper_redis_memory }}
+        lifecycle:
+          preStop:
+            exec:
+              command: ["sleep","30"]
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler


### PR DESCRIPTION
fix: skipper-ingress-redis terminated too fast to be detectable by skipper-ingress