### PR TITLE
Cleanup some obsolete config items

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -795,9 +795,6 @@ deployment_service_cf_auto_expand_enabled: "false"
 # Will be dropped after the migration
 deployment_service_enabled: "true"
 
-# Standard storageclass gp3 volume type
-storageclass_standard_gp3: "true"
-
 # opentelemetry config
 observability_collector_endpoint: "tracing.platform-infrastructure.zalan.do"
 observability_collector_port: "8443"

--- a/cluster/manifests/dashboard/rbac.yaml
+++ b/cluster/manifests/dashboard/rbac.yaml
@@ -61,7 +61,7 @@ metadata:
   name: kubernetes-dashboard
   namespace: kube-system
   labels:
-    application: kubernetes-dashboard
+    application: kubernetes
     component: dashboard
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -79,7 +79,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kubernetes-dashboard-internal
   labels:
-    application: kubernetes-dashboard
+    application: kubernetes
     component: dashboard
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -97,7 +97,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kubernetes-dashboard-readonly
   labels:
-    application: kubernetes-dashboard
+    application: kubernetes
     component: dashboard
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -4,46 +4,6 @@ pre_apply:
 - name: "routegroup-admitter.teapot.zalan.do"
   kind: ValidatingWebhookConfiguration
 {{ end }}
-{{ if eq .Cluster.Environment "e2e" }}
-- name: pool-reserve-default-worker
-  namespace: default
-  kind: Deployment
-{{ end }}
-
-{{ if eq .Cluster.ConfigItems.storageclass_standard_gp3 "true" }}
-- labels:
-    volume-type: gp2
-  kind: StorageClass
-{{ else }}
-- labels:
-    volume-type: gp3
-  kind: StorageClass
-{{ end }}
-- labels:
-    application: nvidia-gpu-device-plugin
-  namespace: kube-system
-  kind: DaemonSet
-- labels:
-    application: external-dns
-  namespace: kube-system
-  kind: Deployment
-- labels:
-    application: stackset-controller
-  namespace: kube-system
-  kind: Deployment
-- labels:
-    application: kubernetes-dashboard
-  namespace: kube-system
-  kind: Deployment
-- labels:
-    component: metrics-scraper
-  namespace: kube-system
-  kind: Deployment
-# cleanup old vpa related roles
-- name: system:admission-controller
-  kind: ClusterRole
-- name: system:admission-controller
-  kind: ClusterRoleBinding
 
 # everything defined under here will be deleted after applying the manifests
 post_apply:
@@ -146,10 +106,6 @@ post_apply:
 - name: spot-node-rescheduler
   kind: ClusterRoleBinding
 {{ end }}
-- labels:
-    application: external-dns
-  namespace: kube-system
-  kind: Pod
 {{- if ne .Cluster.ConfigItems.okta_auth_enabled "true" }}
 - name: cluster-admin-okta
   kind: ClusterRoleBinding

--- a/cluster/manifests/storageclass/storageclass.yaml
+++ b/cluster/manifests/storageclass/storageclass.yaml
@@ -6,10 +6,10 @@ metadata:
     storageclass.kubernetes.io/is-default-class: "true"
   labels:
     kubernetes.io/cluster-service: "true"
-    volume-type: {{ if eq .Cluster.ConfigItems.storageclass_standard_gp3 "true" }}gp3{{else}}gp2{{end}}
+    volume-type: gp3
 provisioner: kubernetes.io/aws-ebs
 parameters:
-  type: {{ if eq .Cluster.ConfigItems.storageclass_standard_gp3 "true" }}gp3{{else}}gp2{{end}}
+  type: gp3
   # TODO: this assumes 3 zones per region
   zones: {{ .Cluster.Region }}a,{{ .Cluster.Region }}b,{{ .Cluster.Region }}c
 allowVolumeExpansion: true


### PR DESCRIPTION
Some of these are not needed anymore can be deleted:
* `storageclass_standard_gp3`: always true, remove all the ifs
* `application: nvidia-gpu-device-plugin` etc. don't exist anymore after consolidation under `application: kubernetes`