### PR TITLE
Update metrics-server to v0.6.2

### DIFF
--- a/cluster/manifests/metrics-server/deployment.yaml
+++ b/cluster/manifests/metrics-server/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     application: kubernetes
     component: metrics-server
-    version: v0.5.0
 spec:
   replicas: 1
   selector:
@@ -19,7 +18,6 @@ spec:
         application: kubernetes
         component: metrics-server
         deployment: metrics-server
-        version: v0.5.0
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
@@ -30,7 +28,7 @@ spec:
       serviceAccountName: metrics-server
       containers:
       - name: metrics-server
-        image: container-registry.zalando.net/teapot/metrics-server:v0.5.0-master-12
+        image: container-registry.zalando.net/teapot/metrics-server:v0.6.2-master-13
         args:
         - --cert-dir=/tmp
         - --secure-port=4443


### PR DESCRIPTION
https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.6.0 https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.6.2

* Additionally drops the `version` label as we often forgot to update it and it's in the image already!