### PR TITLE
Vertically scale EBS CSI controller's memory

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -609,6 +609,8 @@ allowed_unsafe_sysctls: "net.ipv4.tcp_keepalive_time,net.ipv4.tcp_keepalive_intv
 enable_csi: "false"
 # enable CSIMigration and CSIMigrationAWS feature flags (make sure to set `enable_csi: true` for this to work)
 enable_csi_migration: "false"
+# specify the maximum amount of memory for each container of the EBS CSI controller pod
+ebs_csi_controller_sidecar_memory: "40Mi"
 
 # pull images in parallel
 serialize_image_pulls: "false"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -609,8 +609,8 @@ allowed_unsafe_sysctls: "net.ipv4.tcp_keepalive_time,net.ipv4.tcp_keepalive_intv
 enable_csi: "false"
 # enable CSIMigration and CSIMigrationAWS feature flags (make sure to set `enable_csi: true` for this to work)
 enable_csi_migration: "false"
-# specify the maximum amount of memory for each container of the EBS CSI controller pod
-ebs_csi_controller_sidecar_memory: "40Mi"
+# the maximum amount of memory for EBS CSI controller's sidecars
+ebs_csi_controller_sidecar_memory: "80Mi"
 
 # pull images in parallel
 serialize_image_pulls: "false"

--- a/cluster/manifests/03-ebs-csi/controller.yaml
+++ b/cluster/manifests/03-ebs-csi/controller.yaml
@@ -53,10 +53,10 @@ spec:
           resources:
             requests:
               cpu: 10m
-              memory: {{ .ConfigItems.ebs_csi_controller_sidecar_memory }}
+              memory: 40Mi
             limits:
               cpu: 10m
-              memory: {{ .ConfigItems.ebs_csi_controller_sidecar_memory }}
+              memory: 40Mi
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -159,10 +159,10 @@ spec:
           resources:
             requests:
               cpu: 10m
-              memory: {{ .ConfigItems.ebs_csi_controller_sidecar_memory }}
+              memory: 40Mi
             limits:
               cpu: 10m
-              memory: {{ .ConfigItems.ebs_csi_controller_sidecar_memory }}
+              memory: 40Mi
           volumeMounts:
             - name: socket-dir
               mountPath: /csi

--- a/cluster/manifests/03-ebs-csi/controller.yaml
+++ b/cluster/manifests/03-ebs-csi/controller.yaml
@@ -53,10 +53,10 @@ spec:
           resources:
             requests:
               cpu: 10m
-              memory: 40Mi
+              memory: {{ .ConfigItems.ebs_csi_controller_sidecar_memory }}
             limits:
               cpu: 10m
-              memory: 40Mi
+              memory: {{ .ConfigItems.ebs_csi_controller_sidecar_memory }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -98,10 +98,10 @@ spec:
           resources:
             requests:
               cpu: 10m
-              memory: 40Mi
+              memory: {{ .ConfigItems.ebs_csi_controller_sidecar_memory }}
             limits:
               cpu: 10m
-              memory: 40Mi
+              memory: {{ .ConfigItems.ebs_csi_controller_sidecar_memory }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -120,10 +120,10 @@ spec:
           resources:
             requests:
               cpu: 10m
-              memory: 40Mi
+              memory: {{ .ConfigItems.ebs_csi_controller_sidecar_memory }}
             limits:
               cpu: 10m
-              memory: 40Mi
+              memory: {{ .ConfigItems.ebs_csi_controller_sidecar_memory }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -142,10 +142,10 @@ spec:
           resources:
             requests:
               cpu: 10m
-              memory: 40Mi
+              memory: {{ .ConfigItems.ebs_csi_controller_sidecar_memory }}
             limits:
               cpu: 10m
-              memory: 40Mi
+              memory: {{ .ConfigItems.ebs_csi_controller_sidecar_memory }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -159,10 +159,10 @@ spec:
           resources:
             requests:
               cpu: 10m
-              memory: 40Mi
+              memory: {{ .ConfigItems.ebs_csi_controller_sidecar_memory }}
             limits:
               cpu: 10m
-              memory: 40Mi
+              memory: {{ .ConfigItems.ebs_csi_controller_sidecar_memory }}
           volumeMounts:
             - name: socket-dir
               mountPath: /csi

--- a/cluster/manifests/03-ebs-csi/vpa.yaml
+++ b/cluster/manifests/03-ebs-csi/vpa.yaml
@@ -1,0 +1,34 @@
+{{- if eq .Cluster.ConfigItems.enable_csi "true" }}
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: ebs-csi-controller
+  namespace: kube-system
+  labels:
+    application: kubernetes
+    component: ebs-csi-driver
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: ebs-csi-controller
+  updatePolicy:
+    updateMode: Auto
+  resourcePolicy:
+    containerPolicies:
+    - containerName: ebs-plugin
+      maxAllowed:
+        memory: {{ .ConfigItems.ebs_csi_controller_sidecar_memory }}
+    - containerName: csi-provisioner
+      maxAllowed:
+        memory: {{ .ConfigItems.ebs_csi_controller_sidecar_memory }}
+    - containerName: csi-attacher
+      maxAllowed:
+        memory: {{ .ConfigItems.ebs_csi_controller_sidecar_memory }}
+    - containerName: csi-resizer
+      maxAllowed:
+        memory: {{ .ConfigItems.ebs_csi_controller_sidecar_memory }}
+    - containerName: liveness-probe
+      maxAllowed:
+        memory: {{ .ConfigItems.ebs_csi_controller_sidecar_memory }}
+{{- end }}

--- a/cluster/manifests/03-ebs-csi/vpa.yaml
+++ b/cluster/manifests/03-ebs-csi/vpa.yaml
@@ -16,9 +16,6 @@ spec:
     updateMode: Auto
   resourcePolicy:
     containerPolicies:
-    - containerName: ebs-plugin
-      maxAllowed:
-        memory: {{ .ConfigItems.ebs_csi_controller_sidecar_memory }}
     - containerName: csi-provisioner
       maxAllowed:
         memory: {{ .ConfigItems.ebs_csi_controller_sidecar_memory }}
@@ -26,9 +23,6 @@ spec:
       maxAllowed:
         memory: {{ .ConfigItems.ebs_csi_controller_sidecar_memory }}
     - containerName: csi-resizer
-      maxAllowed:
-        memory: {{ .ConfigItems.ebs_csi_controller_sidecar_memory }}
-    - containerName: liveness-probe
       maxAllowed:
         memory: {{ .ConfigItems.ebs_csi_controller_sidecar_memory }}
 {{- end }}

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -54,6 +54,9 @@ post_apply:
   kind: ServiceAccount
 - name: ebs-sc
   kind: StorageClass
+- name: ebs-csi-controller
+  namespace: kube-system
+  kind: VerticalPodAutoscaler
 {{ end }}
 {{ if ne .ConfigItems.prometheus_csi_ebs "true" }}
 - name: prometheus-csi


### PR DESCRIPTION
In two clusters CSI controller reached its maximum limit for one sidecar (provisioner). Let's use a VPA and a config item to be able to configure proper values quickly.

I left out the containers for the plugin-driver and the liveness probe in order to keep them consistent with the same values in the daemonset part. The issues we saw was only with provisioner so far, so this PR only deals with the "active" parts: provisioner, attacher, resizer and bumps it by 2x to 80Mi by default.