### PR TITLE
Disable arm build for e2e image

### DIFF
--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -58,7 +58,7 @@ build.docker: build
 build.push: build.docker
 	docker push "$(IMAGE):$(TAG)"
 
-build.push.multiarch: build.linux.amd64 build.linux.arm64
+build.push.multiarch: build.linux.amd64 #build.linux.arm64
 	docker buildx create --config /etc/cdp-buildkitd.toml --driver-opt network=host --bootstrap --use
 	# docker buildx build --rm --build-arg KUBE_VERSION=$(KUBE_VERSION) -t "$(IMAGE):$(TAG)" --platform linux/amd64,linux/arm64 --push -f $(DOCKERFILE) ../..
 	docker buildx build --rm --build-arg KUBE_VERSION=$(KUBE_VERSION) -t "$(IMAGE):$(TAG)" --platform linux/amd64 --push -f $(DOCKERFILE) ../..


### PR DESCRIPTION
#5284 introduced a setup for multi-arch build but limited the container image build for now to amd64 as it takes much longer to build for both architectures.

However, it didn't actually disable the Go build of arm64 so we built for BOTH archs but only create an image for amd64. This disables the arm64 build to speed it up.