### PR TITLE
Fix RBAC for metrics-server

### DIFF
--- a/cluster/manifests/metrics-server/rbac.yaml
+++ b/cluster/manifests/metrics-server/rbac.yaml
@@ -14,11 +14,16 @@ rules:
   resources:
   - pods
   - nodes
-  - nodes/stats
   verbs:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes/metrics
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
#5826 failed to update the RBAC permissions according to: https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.6.0

![image](https://user-images.githubusercontent.com/128566/225373944-a863c398-7732-4d76-88bc-3876a6aa531f.png)


This means it stopped working with errors like this:

```
E0315 16:17:55.001069       1 scraper.go:140] "Failed to scrape node" err="request failed, status: \"403 Forbidden\"" node="ip-172-31-9-93.eu-central-1.compute.internal"
```

This fixes the RBAC permissions.

