### PR TITLE
Add support for PostgresAdmin

### DIFF
--- a/cluster/manifests/roles/k8s-authnz-webhook-rbac.yaml
+++ b/cluster/manifests/roles/k8s-authnz-webhook-rbac.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: k8s-authnz-webhook
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k8s-authnz-webhook
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8s-authnz-webhook
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: k8s-authnz-webhook

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -276,7 +276,7 @@ write_files:
               name: ssl-certs-kubernetes
               readOnly: true
 {{- end}}
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/k8s-authnz-webhook:master-125
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/k8s-authnz-webhook:master-126
           name: webhook
           ports:
           - containerPort: 8081
@@ -319,6 +319,7 @@ write_files:
 {{- if eq .Cluster.ConfigItems.collaborator_administrator_access "true"}}
             - --role-mapping=Administrator=cn=Contributor,ou=collaborators,ou=Kubernetes,ou=apps,dc=zalando,dc=net
 {{- end}}
+            - --role-mapping=CollaboratorPostgresAdmin=cn=Postgres Admin,ou=collaborators,ou=Kubernetes,ou=apps,dc=zalando,dc=net
 
             # Member roles
             - --role-mapping=Administrator=cn=Administrator,ou={{.Cluster.ID}},ou=Kubernetes,ou=apps,dc=zalando,dc=net
@@ -340,6 +341,8 @@ write_files:
             - --system-users=system:serviceaccount:api-infrastructure:api-monitoring-controller
             - --collaborator-app-users=zalando-iam:zalando:service:stups_scalyr-key-rotation
           env:
+            - name: KUBECONFIG
+              value: /etc/kubernetes/k8s-authnz-webhook-kubeconfig
             - name: TEAMS_API_URL
               value: https://teams.auth.zalando.com
             - name: TOKENINFO_URLS
@@ -347,8 +350,14 @@ write_files:
             - name: USER_GROUPS
               value: stups_cluster-lifecycle-manager=system:masters{{if eq .Cluster.Environment "e2e"}},stups_kubernetes-on-aws-e2e=system:masters,stups_kubernetes=system:masters{{end}}
           volumeMounts:
+          - mountPath: /etc/kubernetes/ssl
+            name: ssl-certs-kubernetes
+            readOnly: true
           - mountPath: /etc/kubernetes/config
             name: kubernetes-configs
+            readOnly: true
+          - mountPath: /etc/kubernetes/k8s-authnz-webhook-kubeconfig
+            name: k8s-authnz-webhook-kubeconfig
             readOnly: true
         - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/foundation/platform-iam-tokeninfo:master-55
           name: tokeninfo
@@ -564,6 +573,10 @@ write_files:
             path: /etc/kubernetes/admission-controller-kubeconfig
             type: File
           name: admission-controller-kubeconfig
+        - hostPath:
+            path: /etc/kubernetes/k8s-authnz-webhook-kubeconfig
+            type: File
+          name: k8s-authnz-webhook-kubeconfig
 
   - owner: root:root
     path: /etc/kubernetes/manifests/kube-controller-manager.yaml


### PR DESCRIPTION
This introduces support for a special `PostgresAdmin` role which in the `k8s-authnz-webhook` is configured to be allowed to `exec` to pods with `application: spilo` label and every other role is prevented from doing it.