### PR TITLE
Update deployment-service to correctly log namespace for cloudformation

### DIFF
--- a/cluster/manifests/deployment-service/controller-statefulset.yaml
+++ b/cluster/manifests/deployment-service/controller-statefulset.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
         - name: "deployment-service-controller"
-          image: "container-registry.zalando.net/teapot/deployment-controller:master-115"
+          image: "container-registry.zalando.net/teapot/deployment-controller:master-118"
           args:
             - "--config-namespace=kube-system"
           env:

--- a/cluster/manifests/deployment-service/status-service-deployment.yaml
+++ b/cluster/manifests/deployment-service/status-service-deployment.yaml
@@ -1,5 +1,5 @@
 {{ $image   := "container-registry.zalando.net/teapot/deployment-status-service" }}
-{{ $version := "master-115" }}
+{{ $version := "master-118" }}
 
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Correctly log `default` as the namespace for any CloudFormation Stacks being deployed.