### PR TITLE
Add audittrail adapter timeout config item and reduce timeout value

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -576,6 +576,8 @@ audittrail_root_account_role: ""
 audittrail_adapter_cpu: "50m"
 audittrail_adapter_memory: "200Mi"
 
+audittrail_adapter_timeout: "2s"
+
 kube2iam_cpu: "25m"
 kube2iam_memory: "100Mi"
 

--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -45,7 +45,7 @@ spec:
         - --s3-bucket-name=zalando-audittrail-{{accountID .InfrastructureAccount}}-{{.LocalID}}
         - --address=:8889
         - --metrics-address=:7980
-        - --audittrail_timeout={{ .Cluster.ConfigItems.audittrail_adapter_timeout }}
+        - --audittrail-timeout={{ .Cluster.ConfigItems.audittrail_adapter_timeout }}
         {{- if eq .Cluster.ConfigItems.audittrail_url "" }}
         - --metrics-only
         {{- end }}

--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -45,6 +45,7 @@ spec:
         - --s3-bucket-name=zalando-audittrail-{{accountID .InfrastructureAccount}}-{{.LocalID}}
         - --address=:8889
         - --metrics-address=:7980
+        - --audittrail_timeout={{.Cluster.ConfigItems.audittrail_adapter_timeout}}
         {{- if eq .Cluster.ConfigItems.audittrail_url "" }}
         - --metrics-only
         {{- end }}

--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -41,11 +41,11 @@ spec:
             value: {{.Cluster.Region}}
         args:
         - --cluster-id={{ .ID }}
-        - --audittrail-url={{.Cluster.ConfigItems.audittrail_url}}
+        - --audittrail-url={{ .Cluster.ConfigItems.audittrail_url }}
         - --s3-bucket-name=zalando-audittrail-{{accountID .InfrastructureAccount}}-{{.LocalID}}
         - --address=:8889
         - --metrics-address=:7980
-        - --audittrail_timeout={{.Cluster.ConfigItems.audittrail_adapter_timeout}}
+        - --audittrail_timeout={{ .Cluster.ConfigItems.audittrail_adapter_timeout }}
         {{- if eq .Cluster.ConfigItems.audittrail_url "" }}
         - --metrics-only
         {{- end }}


### PR DESCRIPTION
Add a config item for `audittrail-timeout` for the `audittrail-adapter`.

Note: the default config item value is set at 2s, which also lowers the default value from the current 5s.

---

After observing the `audittrail-adpater` being OOM killed when the `audittrail-api` is unavailable/slow, this reduction in timeout will allow the `audittrail-adapter` to fallback faster to the secondary approach of first sending events to s3 -- which will then be resent to the api once it is available. The goal of this is to reduce the load on the adapter *faster* which in turn will reduce the memory build up.

Teapot issue: 3406