### PR TITLE
Run cronjob-monitor cleanup in post-apply

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -6,13 +6,13 @@ pre_apply:
 {{ end }}
 - name: cronjob-monitor
   namespace: kube-system
-  kind: VerticalPodAutoscaler
-- name: cronjob-monitor
-  namespace: kube-system
   kind: Deployment
 
 # everything defined under here will be deleted after applying the manifests
 post_apply:
+- name: cronjob-monitor
+  namespace: kube-system
+  kind: VerticalPodAutoscaler
 - name: cronjob-monitor
   kind: ClusterRole
 - name: cronjob-monitor


### PR DESCRIPTION
Trying to delete a `VerticalPodAutoscaler` resource in `pre_apply` breaks e2e because the `VerticalPodAutoscaler` resource type will not be available the very first time a cluster is set up. Therefore move it to `post_apply` to avoid this problem.

Follow up to #5851 