### PR TITLE
Run load test after cluster has been fully updated

### DIFF
--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -119,10 +119,6 @@ if [ "$create_cluster" = true ]; then
 
         # Wait for the resources to be ready
         ./wait-for-update.py --timeout 1200
-
-        # provision and start load test
-        echo "provision and start load test"
-        ./start-load-test.sh --zone "$HOSTED_ZONE" --target "$(date +%s)" -v --timeout 900 --wait 30
     fi
 
     # generate updated clusters.yaml
@@ -148,6 +144,10 @@ if [ "$create_cluster" = true ]; then
     # Wait for the resources to be ready after the update
     # TODO: make a feature of CLM --wait-for-kube-system
     ./wait-for-update.py --timeout 1200
+
+    # provision and start load test
+    echo "provision and start load test"
+    ./start-load-test.sh --zone "$HOSTED_ZONE" --target "$(date +%s)" -v --timeout 900 --wait 30
 fi
 
 if [ "$e2e" = true ]; then


### PR DESCRIPTION
The current location of the load test script runs _after_ the initial cluster has been provisioned but _before_ the cluster that's actually being tested in the PR.

For example, let's say a PR introduces a performance regression, we would not notice that as part of the load test because what's being load tested is the previous cluster (before introducing the regression).

I believe the execution of the load test should come later.

@szuecs Can you check if that's still the behaviour that you expect?