### PR TITLE
Improve GPU e2e test by not restarting the pod

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -216,7 +216,7 @@ Follow up code, that waits for creations to be happen:
   S3_AWS_IAM_BUCKET=zalando-e2e-aws-iam-test-12345678912-kube-1 \
   AWS_IAM_ROLE=kube-1-e2e-aws-iam-test \
   ginkgo -nodes=25 -flakeAttempts=2 -focus="\[Zalando\]" \
-  e2e.test -- -non-blocking-taints=node.kubernetes.io/role,nvidia.com/gpu
+  e2e.test -- -non-blocking-taints=node.kubernetes.io/role,nvidia.com/gpu,dedicated
   ```
 
 * **Why is the go modules such a mess?**

--- a/test/e2e/gpu.go
+++ b/test/e2e/gpu.go
@@ -46,7 +46,7 @@ var _ = describe("GPU job processing", func() {
 		pod := createVectorPod(nameprefix, ns, labels)
 		_, err := cs.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "Could not create POD %s", pod.Name)
-		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, pod.Name, pod.Namespace))
+		framework.ExpectNoError(e2epod.WaitForPodSuccessInNamespace(f.ClientSet, pod.Name, pod.Namespace))
 		for {
 			p, err := cs.CoreV1().Pods(ns).Get(context.TODO(), pod.Name, metav1.GetOptions{})
 			if err != nil {

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -929,6 +929,7 @@ func createVectorPod(nameprefix, namespace string, labels map[string]string) *v1
 			Labels:    labels,
 		},
 		Spec: v1.PodSpec{
+			RestartPolicy: v1.RestartPolicyNever,
 			Containers: []v1.Container{
 				{
 					Name:  "cuda-vector-add",


### PR DESCRIPTION
The GPU e2e tests essentially works by running a single pod with the image `k8s.gcr.io/cuda-vector-add:v0.1` and checking that the container exists with status code 0 which indicates it successfully tested GPU capabilities on the node.

Because pods by default have the [`restartPolicy: Always`](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy), exiting with 0 means that the pod is automatically restarted again and again leading to the pod getting into a `CrashLoopBackOff` state.

I believe this can make the test flaky because it tries to read the logs after the pod has exited with 0 and if it's contentiously restarted the logs will change and the check could be wrong.

Avoid this by setting `restartPolicy: Never`