### PR TITLE
Enable CSI Migration which handles current PVCs through CSI

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -623,7 +623,7 @@ allowed_unsafe_sysctls: "net.ipv4.tcp_keepalive_time,net.ipv4.tcp_keepalive_intv
 # enable CSI Driver feature flag
 enable_csi: "true"
 # enable CSIMigration and CSIMigrationAWS feature flags (make sure to set `enable_csi: true` for this to work)
-enable_csi_migration: "false"
+enable_csi_migration: "true"
 # the maximum amount of memory for EBS CSI controller's sidecars
 ebs_csi_controller_sidecar_memory: "80Mi"
 


### PR DESCRIPTION
Switch the flip to enable CSI migration (default in 1.23). This will process all current and future EBS PVCs via the CSI driver. There's no need for users to change anything.