### PR TITLE
Stop managing service link role for quotas in e2e account

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1947,11 +1947,13 @@ Resources:
       Description: "AWS service role for application autoscaling DynamoDB"
     Type: "AWS::IAM::ServiceLinkedRole"
 {{- end }}
+{{- if eq .Cluster.ConfigItems.quotas_service_link_enabled "true" }}
   ServiceLinkedRoleServiceQuotas:
     Properties:
       AWSServiceName: "servicequotas.amazonaws.com"
       Description: "AWS service role for Service Quotas"
     Type: "AWS::IAM::ServiceLinkedRole"
+{{- end }}
   RemoteFilesEncryptionKey:
     Type: "AWS::KMS::Key"
     Properties:

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -548,6 +548,11 @@ etcd_scalyr_key: ""
 etcd_ami: {{ amiID "zalando-ubuntu-etcd-production-v3.4.16-amd64-main-10" "861068367966"}}
 
 dynamodb_service_link_enabled: "false"
+{{if eq .Cluster.Environment "e2e"}}
+quotas_service_link_enabled: "false"
+{{else}}
+quotas_service_link_enabled: "true"
+{{end}}
 
 cluster_dns: "coredns"
 coredns_log_svc_names: "true"


### PR DESCRIPTION
Let's not make the ServiceLink role for Quotas part of the Stack in e2e, so that multiple clusters/stacks don't conflict with each other.