### PR TITLE
skipper: add controller label to hostname credentials

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -139,7 +139,7 @@ post_apply:
 {{ with $config_hash := printf "%.32s" (.ConfigItems.skipper_oauth2_ui_login_hostnames | sha256) }}
 - kind: PlatformCredentialsSet
   namespace: kube-system
-  selector: application=skipper-ingress,component=hostname-credentials,config-hash!={{ $config_hash }}
+  selector: application=skipper-ingress,component=hostname-credentials,controller=cluster-lifecycle-manager,config-hash!={{ $config_hash }}
 {{ end }}
 
 {{ else }}
@@ -148,6 +148,7 @@ post_apply:
   labels:
     application: skipper-ingress
     component: hostname-credentials
+    controller: cluster-lifecycle-manager
 
 - kind: CronJob
   name: secret-combiner

--- a/cluster/manifests/skipper/pcs.yaml
+++ b/cluster/manifests/skipper/pcs.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     application: skipper-ingress
     component: hostname-credentials
+    controller: cluster-lifecycle-manager
     config-hash: {{ $config_hash }}
 spec:
   application: "{{ $application }}"


### PR DESCRIPTION
Label PlatformCredentialsSets created from config item with a controller label to enable cooperation with another controller that would create credentials by processing Ingresses and RouteGroups.