### PR TITLE
update AMI to move snapshot generation and drop compression

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -576,8 +576,8 @@ tracing_coredns_local_zone_traces_endpoint: ""
 # [0]: https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/8a9bd1cb2d094038a9e23e646421f8146b48886a/provisioner/template.go#L116
 kuberuntu_image_v1_22_amd64: {{ amiID "zalando-ubuntu-kubernetes-production-v1.22.17-amd64-master-243" "861068367966" }}
 kuberuntu_image_v1_22_arm64: {{ amiID "zalando-ubuntu-kubernetes-production-v1.22.17-arm64-master-243" "861068367966" }}
-kuberuntu_image_v1_23_amd64: {{ amiID "zalando-ubuntu-kubernetes-production-v1.23.17-amd64-master-255" "861068367966" }}
-kuberuntu_image_v1_23_arm64: {{ amiID "zalando-ubuntu-kubernetes-production-v1.23.17-arm64-master-255" "861068367966" }}
+kuberuntu_image_v1_23_amd64: {{ amiID "zalando-ubuntu-kubernetes-production-v1.23.17-amd64-master-256" "861068367966" }}
+kuberuntu_image_v1_23_arm64: {{ amiID "zalando-ubuntu-kubernetes-production-v1.23.17-arm64-master-256" "861068367966" }}
 
 # Feature toggle for auditing events
 audit_pod_events: "true"


### PR DESCRIPTION
This should speed up boot time for instance storage disks.