### PR TITLE
Improve spot node e2e test to be less flaky

### DIFF
--- a/test/e2e/node_test.go
+++ b/test/e2e/node_test.go
@@ -94,9 +94,8 @@ var _ = describe("Node tests", func() {
 				RestartPolicy: corev1.RestartPolicyNever,
 			},
 		}
-		terminationTriggerPod, err := cs.CoreV1().Pods(ns).Create(context.Background(), terminationTriggerPodTemplate, metav1.CreateOptions{})
+		_, err = cs.CoreV1().Pods(ns).Create(context.Background(), terminationTriggerPodTemplate, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "Could not create a termination trigger pod")
-		framework.ExpectNoError(e2epod.WaitForPodSuccessInNamespace(f.ClientSet, terminationTriggerPod.Name, terminationTriggerPod.Namespace))
 
 		By("Ensuring that pods are deleted from the node")
 		framework.ExpectNoError(e2epod.WaitForPodToDisappear(f.ClientSet, pausePod.Namespace, pausePod.Name, labels.Everything(), framework.Poll, framework.PodDeleteTimeout))


### PR DESCRIPTION
The test **Should react to spot termination notices [Slow] [Zalando] [Spot]** is one of the most flaky/failing tests in our setup leading to regular e2e runs failing and needing to be re-run.

This aims to improve the test reliability by removing a potentially racy check:

* Don't check that the termination pod is successfully created. This is racy because it can be the pod is cleaned up after being ready between the check interval, leading to the pod not being found and thus the check fails.

We don't really care about the termination pod being created because it's job is simply to trigger the node termination. What we care about is the effect the termination trigger has which is that other pods are removed from the node and that we see the expected delete event. This we are still checking here.