### PR TITLE
Enable StatefulSetAutoDeletePVC feature gate

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -844,6 +844,10 @@ hyped_article_lifecycle_management: "false"
 # enable SizeMemoryBackedVolumes feature flag
 enable_size_memory_backed_volumes: "true"
 
+# enable StatefulSetAutoDeletePVC feature flag
+# https://kubernetes.io/blog/2021/12/16/kubernetes-1-23-statefulset-pvc-auto-deletion/
+enable_statefulset_autodelete_pvc: "true"
+
 # Each subdomain can reach a max of 63 bytes on Route53
 # This custom value sets the subdomain max allowed length taking into consideration the 'cname-' prefix added by external-dns
 subdomain_max_length: "57"

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -141,7 +141,7 @@ write_files:
           - --oidc-groups-claim=groups
           - "--oidc-groups-prefix=okta:"
 {{- end }}
-          - --feature-gates=HPAScaleToZero={{ .Cluster.ConfigItems.enable_hpa_scale_to_zero }},CSIMigration={{ .Cluster.ConfigItems.enable_csi_migration }}{{- if eq .Cluster.ConfigItems.enable_csi_migration "true" }},CSIMigrationAWS=true{{- end }},EphemeralContainers={{ .Cluster.ConfigItems.enable_ephemeral_containers }},HPAContainerMetrics={{ .Cluster.ConfigItems.enable_hpa_container_metrics }},IndexedJob={{ .Cluster.ConfigItems.enable_indexed_jobs }}
+          - --feature-gates=HPAScaleToZero={{ .Cluster.ConfigItems.enable_hpa_scale_to_zero }},CSIMigration={{ .Cluster.ConfigItems.enable_csi_migration }}{{- if eq .Cluster.ConfigItems.enable_csi_migration "true" }},CSIMigrationAWS=true{{- end }},EphemeralContainers={{ .Cluster.ConfigItems.enable_ephemeral_containers }},HPAContainerMetrics={{ .Cluster.ConfigItems.enable_hpa_container_metrics }},IndexedJob={{ .Cluster.ConfigItems.enable_indexed_jobs }},StatefulSetAutoDeletePVC={{ .Cluster.ConfigItems.enable_statefulset_autodelete_pvc }}
           - --service-account-key-file=/etc/kubernetes/ssl/service-account-public-key.pem
           - --service-account-signing-key-file=/etc/kubernetes/ssl/service-account-private-key.pem
           - --service-account-issuer={{ .Cluster.APIServerURL }}
@@ -589,7 +589,7 @@ write_files:
           - --root-ca-file=/etc/kubernetes/ssl/ca.pem
           - --cloud-provider=aws
           - --cloud-config=/etc/kubernetes/cloud-config.ini
-          - --feature-gates=CSIMigration={{ .Cluster.ConfigItems.enable_csi_migration }}{{- if eq .Cluster.ConfigItems.enable_csi_migration "true" }},CSIMigrationAWS=true{{- end }},IndexedJob={{ .Cluster.ConfigItems.enable_indexed_jobs }}
+          - --feature-gates=CSIMigration={{ .Cluster.ConfigItems.enable_csi_migration }}{{- if eq .Cluster.ConfigItems.enable_csi_migration "true" }},CSIMigrationAWS=true{{- end }},IndexedJob={{ .Cluster.ConfigItems.enable_indexed_jobs }},StatefulSetAutoDeletePVC={{ .Cluster.ConfigItems.enable_statefulset_autodelete_pvc }}
           - --use-service-account-credentials=true
           - --configure-cloud-routes=false
           - --allocate-node-cidrs=true


### PR DESCRIPTION
[**`StatefulSetAutoDeletePVC`**](https://kubernetes.io/blog/2021/12/16/kubernetes-1-23-statefulset-pvc-auto-deletion/) is a feature gate made available on Kubernetes v1.23
that allows the usage of field `.spec.persistentVolumeClaimRetentionPolicy` to
manage if and how PVCs are deleted during the lifecycle of a StatefulSet.

This commit enables this feature by default.