### PR TITLE
Fix routesrv log parser

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -402,7 +402,7 @@ spec:
         component: routesrv
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
-          [{"container": "skipper-ingress", "parser": "skipper-access-log"}]
+          [{"container": "routesrv", "parser": "skipper-access-log"}]
         config/hash: {{"secret.yaml" | manifestHash}}
         logging/destination: "{{.Cluster.ConfigItems.log_destination_local}}"
         prometheus.io/path: /metrics


### PR DESCRIPTION
Wrong container name make use of the the default log parser `json`

Signed-off-by: Mustafa Abdelrahman <mustafa.abdelrahman@zalando.de>