### PR TITLE
optimize: skipper node pool memory

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -63,7 +63,7 @@ skipper_ingress_min_replicas: "3"
 skipper_ingress_min_replicas: "2"
 {{end}}
 skipper_ingress_cpu: "1000m"
-skipper_ingress_memory: "1Gi"
+skipper_ingress_memory: "1500Mi"
 # When set to true (and dedicated node pool for skipper is also true) the
 # daemonset overhead will be substracted from the cpu settings such
 # that skipper will perfectly fit on the node.


### PR DESCRIPTION
optimize: skipper node pool c6g.large has more memory than 1Gi for us