### PR TITLE
Add status to scaling schedules

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/01-rbac.yaml
+++ b/cluster/manifests/kube-metrics-adapter/01-rbac.yaml
@@ -96,6 +96,13 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - zalando.org
+  resources:
+  - clusterscalingschedules/status
+  - scalingschedules/status
+  verbs:
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/cluster/manifests/kube-metrics-adapter/cluster_scaling_schedules_crd.yaml
+++ b/cluster/manifests/kube-metrics-adapter/cluster_scaling_schedules_crd.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: clusterscalingschedules.zalando.org
 spec:
@@ -16,7 +15,12 @@ spec:
     singular: clusterscalingschedule
   scope: Cluster
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Whether one or more schedules are currently active.
+      jsonPath: .status.active
+      name: Active
+      type: boolean
+    name: v1
     schema:
       openAPIV3Schema:
         description: ClusterScalingSchedule describes a cluster scoped time based
@@ -56,8 +60,8 @@ spec:
                       format: date-time
                       type: string
                     durationMinutes:
-                      description: The duration in minutes that the configured value
-                        will be returned for the defined schedule.
+                      description: The duration in minutes (default 0) that the configured
+                        value will be returned for the defined schedule.
                       type: integer
                     endDate:
                       description: Defines the ending date of a OneTime schedule.
@@ -113,7 +117,6 @@ spec:
                       format: int64
                       type: integer
                   required:
-                  - durationMinutes
                   - type
                   - value
                   type: object
@@ -121,11 +124,22 @@ spec:
             required:
             - schedules
             type: object
+          status:
+            description: ScalingScheduleStatus is the status section of the ScalingSchedule.
+            properties:
+              active:
+                default: false
+                description: Active is true if at least one of the schedules defined
+                  in the scaling schedule is currently active.
+                type: boolean
+            type: object
         required:
         - spec
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: container-registry.zalando.net/teapot/kube-metrics-adapter:v0.1.19-20-g75738f1
+        image: container-registry.zalando.net/teapot/kube-metrics-adapter:v0.1.19-26-g88b7d74
         env:
         - name: AWS_REGION
           value: {{ .Region }}

--- a/cluster/manifests/kube-metrics-adapter/scaling_schedules_crd.yaml
+++ b/cluster/manifests/kube-metrics-adapter/scaling_schedules_crd.yaml
@@ -1,22 +1,28 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: scalingschedules.zalando.org
 spec:
   group: zalando.org
   names:
+    categories:
+    - all
     kind: ScalingSchedule
     listKind: ScalingScheduleList
     plural: scalingschedules
     singular: scalingschedule
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Whether one or more schedules are currently active.
+      jsonPath: .status.active
+      name: Active
+      type: boolean
+    name: v1
     schema:
       openAPIV3Schema:
         description: ScalingSchedule describes a namespaced time based metric to be
@@ -56,8 +62,8 @@ spec:
                       format: date-time
                       type: string
                     durationMinutes:
-                      description: The duration in minutes that the configured value
-                        will be returned for the defined schedule.
+                      description: The duration in minutes (default 0) that the configured
+                        value will be returned for the defined schedule.
                       type: integer
                     endDate:
                       description: Defines the ending date of a OneTime schedule.
@@ -113,7 +119,6 @@ spec:
                       format: int64
                       type: integer
                   required:
-                  - durationMinutes
                   - type
                   - value
                   type: object
@@ -121,11 +126,22 @@ spec:
             required:
             - schedules
             type: object
+          status:
+            description: ScalingScheduleStatus is the status section of the ScalingSchedule.
+            properties:
+              active:
+                default: false
+                description: Active is true if at least one of the schedules defined
+                  in the scaling schedule is currently active.
+                type: boolean
+            type: object
         required:
         - spec
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
Extends the `kube-metrics-adapter` to update the status of scheduled scaling resources based on them being active or not.

Ref: https://github.com/zalando-incubator/kube-metrics-adapter/pull/549