### PR TITLE
Add config-item for disabling HPA field via flag

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -757,7 +757,7 @@ spot_allocation_strategy: "capacity-optimized"
 stackset_controller_sync_interval: "10s"
 stackset_controller_mem_min: "120Mi"
 stackset_controller_mem_max: "4Gi"
-stackset_hpa_field_enabled: "true"
+stackset_legacy_hpa_field_enabled: "false"
 
 # EBS settings for the root volume
 ebs_master_root_volume_size: "50"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -757,6 +757,7 @@ spot_allocation_strategy: "capacity-optimized"
 stackset_controller_sync_interval: "10s"
 stackset_controller_mem_min: "120Mi"
 stackset_controller_mem_max: "4Gi"
+stackset_hpa_field_enabled: "true"
 
 # EBS settings for the root volume
 ebs_master_root_volume_size: "50"

--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -8,7 +8,7 @@ data:
   daemonset.reserved.memory: "{{ .Cluster.ConfigItems.teapot_admission_controller_daemonset_reserved_memory }}"
 
   dns.default.subdomain-max-length: "{{ .Cluster.ConfigItems.subdomain_max_length }}"
-  stackset.legacy_hpa_field.enable: "{{ .Cluster.ConfigItems.stackset_hpa_field_enabled }}"
+  stackset.legacy_hpa_field.enable: "{{ .Cluster.ConfigItems.stackset_legacy_hpa_field_enabled }}"
 
   pod.container-resource-control.min-memory-request: "25Mi"
   pod.container-resource-control.default-cpu-request: "{{ .Cluster.ConfigItems.teapot_admission_controller_default_cpu_request }}"

--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -8,6 +8,7 @@ data:
   daemonset.reserved.memory: "{{ .Cluster.ConfigItems.teapot_admission_controller_daemonset_reserved_memory }}"
 
   dns.default.subdomain-max-length: "{{ .Cluster.ConfigItems.subdomain_max_length }}"
+  stackset.legacy_hpa_field.enable: "{{ .Cluster.ConfigItems.stackset_hpa_field_enabled }}"
 
   pod.container-resource-control.min-memory-request: "25Mi"
   pod.container-resource-control.default-cpu-request: "{{ .Cluster.ConfigItems.teapot_admission_controller_default_cpu_request }}"

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -201,7 +201,7 @@ write_files:
             limits:
               memory: {{ .Values.InstanceInfo.MemoryFraction (parseInt64 .Cluster.ConfigItems.apiserver_memory_limit_percent)}}
 {{- end }}
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-161
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-162
           name: admission-controller
           lifecycle:
             preStop:

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -43,6 +43,7 @@ clusters:
     routegroups_validation: "enabled"
     stackset_routegroup_support_enabled: "true"
     stackset_ingress_source_switch_ttl: "1m"
+    stackset_legacy_hpa_field_enabled: "true"
     teapot_admission_controller_daemonset_reserved_cpu: "518m"
   criticality_level: 1
   environment: e2e


### PR DESCRIPTION
To split the rollout of the deprecation of the `horizontalPodAutoscaler` field on Stackset definitions for test and production clusters, the Admission Controller will validate Stacksets based on the `stackset_hpa_field_enabled` config-item.