### PR TITLE
Address e2e test flakyness for complient image job tests

### DIFF
--- a/test/e2e/apiserver.go
+++ b/test/e2e/apiserver.go
@@ -462,10 +462,7 @@ var _ = describe("Image Policy Tests (Job)", func() {
 			Expect(err).NotTo(HaveOccurred())
 		}()
 
-		_, err = e2epod.WaitForPodsWithLabelRunningReady(cs, namespace, appLabelSelector(appLabel), 1, waitForPodTimeout)
-		Expect(err).NotTo(HaveOccurred())
-
-		job.WaitForJobFinish(cs, namespace, jobObj.Name)
+		job.WaitForJobComplete(cs, namespace, jobObj.Name, 1)
 	})
 
 	It("Should not create Job using non-compliant image [Image-Policy] [Non-Compliant] [Zalando]", func() {
@@ -518,10 +515,7 @@ var _ = describe("Image Policy Tests (Job) (when disabled)", func() {
 			Expect(err).NotTo(HaveOccurred())
 		}()
 
-		_, err = e2epod.WaitForPodsWithLabelRunningReady(cs, namespace, appLabelSelector(appLabel), 1, waitForPodTimeout)
-		Expect(err).NotTo(HaveOccurred())
-
-		job.WaitForJobFinish(cs, namespace, jobObj.Name)
+		job.WaitForJobComplete(cs, namespace, jobObj.Name, 1)
 	})
 })
 


### PR DESCRIPTION
This aims to address the flakyness of the tests:

* **Should create Job using non-compliant image [Image-Policy] [Non-Compliant] [Zalando]**
* **Should create Job with compliant image [Image-Policy] [Compliant] [Zalando]**

This is done by removing the step to wait for job pods to be running and ready as this step can be flaky if a pod finishes in between the check interval and thus is never detected to be running.
Instead we check for Job Completion which indirectly validates that the job container must have successfully run.