### PR TITLE
Update Skipper build to print traceIDs for filters' logs

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.16.5-423" }}
+{{ $internal_version := "v0.16.15-434" }}
 {{ $version := index (split $internal_version "-") 0 }}
 
 apiVersion: apps/v1


### PR DESCRIPTION
Update Skipper build to print traceIDs for filters' logs