### PR TITLE
Give lower priority to rotation of spot replacement nodes

### DIFF
--- a/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         operator: Exists
       containers:
       - name: cluster-lifecycle-controller
-        image: container-registry.zalando.net/teapot/cluster-lifecycle-controller:master-30
+        image: container-registry.zalando.net/teapot/cluster-lifecycle-controller:master-31
         args:
             - --drain-grace-period={{.ConfigItems.drain_grace_period}}
             - --drain-min-pod-lifetime={{.ConfigItems.drain_min_pod_lifetime}}

--- a/cluster/manifests/spot-node-rescheduler/cronjob.yaml
+++ b/cluster/manifests/spot-node-rescheduler/cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: spot-node-rescheduler
-            image: container-registry.zalando.net/teapot/spot-node-rescheduler:main-4
+            image: container-registry.zalando.net/teapot/spot-node-rescheduler:main-5
             resources:
               limits:
                 cpu: "{{ .ConfigItems.spot_node_rescheduler_cpu }}"


### PR DESCRIPTION
The spot-node-rescheduler will now set a lower priority on the nodes that are marked for rotation such that nodes rolled as part of e.g. a Kubernetes update have higher priority.

This is done to avoid a problem where during a cluster upgrade the node rotation gets stuck because nodes rotated because of spot replacement keep being selected first by CLC.