### PR TITLE
Add application/component tags to NAT gateway stack

### DIFF
--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -44,6 +44,8 @@ spec:
         - "--cluster-id={{ .ID }}"
         - "--cluster-id-tag-prefix=zalando.org/cluster/"
         - "--additional-stack-tags=InfrastructureComponent=true"
+        - "--additional-stack-tags=application=kubernetes"
+        - "--additional-stack-tags=component=kube-static-egress-controller"
         env:
         - name: AWS_REGION
           value: {{ .Cluster.Region }}


### PR DESCRIPTION
Adds `application` and `component` tags to the NAT stack such that NAT gateways are tagged with an application.