### PR TITLE
Use standard DNS settings as applied to all other core components

### DIFF
--- a/cluster/manifests/z-karpenter/deployment.yaml
+++ b/cluster/manifests/z-karpenter/deployment.yaml
@@ -25,6 +25,10 @@ spec:
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
       dnsPolicy: Default
       serviceAccountName: karpenter
       securityContext:


### PR DESCRIPTION
Adds the standard DNS config to the karpenter deployment to align it with what we use for other components.