### PR TITLE
Enable automatic CSI migration by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -630,7 +630,7 @@ allowed_unsafe_sysctls: "net.ipv4.tcp_keepalive_time,net.ipv4.tcp_keepalive_intv
 # enable CSI Driver feature flag
 enable_csi: "true"
 # enable CSIMigration and CSIMigrationAWS feature flags (make sure to set `enable_csi: true` for this to work)
-enable_csi_migration: "false"
+enable_csi_migration: "true"
 # the maximum amount of memory for EBS CSI controller's sidecars
 ebs_csi_controller_sidecar_memory: "80Mi"
 


### PR DESCRIPTION
Let's enable CSI Migration by default in the Kubernetes 1.23 branch so that we can roll it out to stable together. 