### PR TITLE
Increase max startup timeout for flannel-awaiter

### DIFF
--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -54,6 +54,8 @@ spec:
             command:
               - cat
               - /run/flannel-ready
+          failureThreshold: 30
+          periodSeconds: 10
       - name: kube-flannel
         image: container-registry.zalando.net/teapot/flannel:v0.21.3-master-13
         command:


### PR DESCRIPTION
Follow up to #5932

Increases the StartUp probe to a maximum of  `30 x 10 = 300 seconds` for the `flannel-awaiter` container. The default is `failureThreshold=3` which means `3 x 10 = 30 seconds`. That is not enough as observed by the roll out to the `stups` cluster, hence the increase.