### PR TITLE
node-exporter: Disable unused collectors

### DIFF
--- a/cluster/manifests/node-monitor/daemonset.yaml
+++ b/cluster/manifests/node-monitor/daemonset.yaml
@@ -86,6 +86,9 @@ spec:
             - --path.procfs=/host/proc
             - --path.sysfs=/host/sys
             - --path.rootfs=/host
+            - --no-collector.wifi
+            - --no-collector.hwmon
+            - --no-collector.btrfs
             - --collector.filesystem.mount-points-exclude=^/(dev|proc|run|sys|host|var/lib/lxcfs|opt/podruntime/docker/.+|opt/podruntime/kubelet/.+)($|/)
             - --collector.netdev.device-exclude=^veth.*$
             - --collector.netclass.ignored-devices=^veth.*$


### PR DESCRIPTION
Disable some node-exporter collector that we don't use:

* Disabling `wifi` and `hwmon` is inspired from how it's configured in https://github.com/prometheus-operator/kube-prometheus (EC2 don't have WIFI and we don't care about hardware monitoring if it even would work)
* Disabling `btrfs` is inspired by: https://twitter.com/MetalMatze/status/1648630535214825475. Not sure if it would have a positive impact for us but we use ext4 so btrfs monitoring definitely is not needed.