### PR TITLE
fix: tee filter performance

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.16.15-434" }}
+{{ $internal_version := "v0.16.22-441" }}
 {{ $version := index (split $internal_version "-") 0 }}
 
 apiVersion: apps/v1


### PR DESCRIPTION
fix: tee filter performance had a bottleneck because of default http client has only 2 connections to a single host
feature: tee filter has now a client that does also httptrace introspection like the main http client.