### PR TITLE
Remove unused explicit csi-based replacement prometheus

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -349,8 +349,6 @@ prometheus_mem_min: "2Gi"
 prometheus_cpu_min: "0"
 prometheus_retention_size: "49GB" # one GB less than prometheus' PVC
 prometheus_retention_time: "1d"
-# Deploy a replacement Prometheus that uses the CSI-based EBS-backed StorageClass directly, mostly for testing
-prometheus_csi_ebs: "false"
 
 # Upstream defaults are too aggressive:
 # https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -71,27 +71,6 @@ post_apply:
   namespace: kube-system
   kind: VerticalPodAutoscaler
 {{ end }}
-{{ if ne .ConfigItems.prometheus_csi_ebs "true" }}
-- name: prometheus-csi
-  namespace: kube-system
-  kind: StatefulSet
-- name: prometheus-storage-volume-prometheus-csi-0
-  kind: PersistentVolumeClaim
-  namespace: kube-system
-- name: prometheus-storage-volume-prometheus-csi-1
-  kind: PersistentVolumeClaim
-  namespace: kube-system
-{{ else }}
-- name: prometheus
-  namespace: kube-system
-  kind: StatefulSet
-- name: prometheus-storage-volume-prometheus-0
-  kind: PersistentVolumeClaim
-  namespace: kube-system
-- name: prometheus-storage-volume-prometheus-1
-  kind: PersistentVolumeClaim
-  namespace: kube-system
-{{ end }}
 {{ if ne .ConfigItems.downscaler_enabled "true" }}
 - name: kube-downscaler
   namespace: kube-system

--- a/cluster/manifests/prometheus/prometheus-vpa.yaml
+++ b/cluster/manifests/prometheus/prometheus-vpa.yaml
@@ -10,11 +10,7 @@ spec:
   targetRef:
     apiVersion: apps/v1
     kind: StatefulSet
-{{ if ne .ConfigItems.prometheus_csi_ebs "true" }}
     name: prometheus
-{{ else }}
-    name: prometheus-csi
-{{ end }}
   updatePolicy:
     updateMode: Auto
   resourcePolicy:

--- a/cluster/manifests/prometheus/statefulset.yaml
+++ b/cluster/manifests/prometheus/statefulset.yaml
@@ -6,11 +6,7 @@ metadata:
   labels:
     application: kubernetes
     component: prometheus
-{{- if ne .ConfigItems.prometheus_csi_ebs "true" }}
   name: prometheus
-{{- else }}
-  name: prometheus-csi
-{{- end }}
   namespace: kube-system
 spec:
   replicas: 2
@@ -119,11 +115,7 @@ spec:
   - metadata:
       name: prometheus-storage-volume
     spec:
-{{- if ne .ConfigItems.prometheus_csi_ebs "true" }}
       storageClassName: standard
-{{- else }}
-      storageClassName: ebs-sc
-{{- end }}
       accessModes:
       - "ReadWriteOnce"
       resources:


### PR DESCRIPTION
Remove obsolete CSI based replacement Prometheus to simplify the config.

Since `CSIMigration` the default storage class is automatically handled by CSI and we don't need to explicitly specify it. This makes the replacement Prometheus obsolete for testing CSI.