### PR TITLE
Update kube-metrics-adapter to v0.2.0

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: container-registry.zalando.net/teapot/kube-metrics-adapter:v0.1.19-26-g88b7d74
+        image: container-registry.zalando.net/teapot/kube-metrics-adapter:v0.2.0
         env:
         - name: AWS_REGION
           value: {{ .Region }}


### PR DESCRIPTION
Updates to the latest version which uses `autoscaling/v2` API which is the default in Kubernetes v1.23.

https://github.com/zalando-incubator/kube-metrics-adapter/releases/tag/v0.2.0

