### PR TITLE
Use autoscaling/v2 for HPAs

### DIFF
--- a/cluster/manifests/skipper/hpa-redis.yaml
+++ b/cluster/manifests/skipper/hpa-redis.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: skipper-ingress-redis

--- a/cluster/manifests/skipper/hpa-routesrv.yaml
+++ b/cluster/manifests/skipper/hpa-routesrv.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: skipper-ingress-routesrv

--- a/cluster/manifests/skipper/hpa.yaml
+++ b/cluster/manifests/skipper/hpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: skipper-ingress


### PR DESCRIPTION
With Kubernetes v1.23 the autoscaling API used for Horizontal Pod Autoscalers was promoted from `autoscaling/v2beta2` to `autoscaling/v2`.

Update it where we have HPAs