### PR TITLE
Update admission-controller to Kubernetes v1.23

### DIFF
--- a/cluster/manifests/01-admission-control/teapot.yaml
+++ b/cluster/manifests/01-admission-control/teapot.yaml
@@ -157,7 +157,7 @@ webhooks:
     rules:
       - operations: [ "CREATE", "UPDATE" ]
         apiGroups: ["autoscaling"]
-        apiVersions: ["v2beta2"]
+        apiVersions: ["v2"]
         resources: ["horizontalpodautoscalers"]
   - name: serviceaccount-admitter.teapot.zalan.do
     clientConfig:

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -201,7 +201,7 @@ write_files:
             limits:
               memory: {{ .Values.InstanceInfo.MemoryFraction (parseInt64 .Cluster.ConfigItems.apiserver_memory_limit_percent)}}
 {{- end }}
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-162
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-163
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
Updates the admission-controller to Kubernetes v1.23 version of client-go and friend + updates to use `autoscaling/v2` for HPA resources.