### PR TITLE
End support for autoscaling/v2beta2 on Admission Controller

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -201,7 +201,7 @@ write_files:
             limits:
               memory: {{ .Values.InstanceInfo.MemoryFraction (parseInt64 .Cluster.ConfigItems.apiserver_memory_limit_percent)}}
 {{- end }}
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-163
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-164
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
The Admission Controller only handles HPAs in `autoscaling/v2` version now.