### PR TITLE
Remove legacy HPA field from StackSet CRD by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -774,7 +774,20 @@ spot_allocation_strategy: "capacity-optimized"
 stackset_controller_sync_interval: "10s"
 stackset_controller_mem_min: "120Mi"
 stackset_controller_mem_max: "4Gi"
+
+# This is part of decommissioning the legacy `horizontalPodAutoscaler` field of
+# the stackset.StackTemplate and to migrate all use cases to the `autoscaler`
+# field.
+# We disable the use of the field in two stages:
+# 1. Block changes/new deployments of stacksets with the
+#    `horizontalPodAutoscaler` field via the admission-controller. The
+#    `stackset_legacy_hpa_field_enabled` config-item controls this.
+#
+# 2. Drop the `horizontalPodAutoscaler` field from the CRD spec. This will
+# remove it from any existing StackSet and prevent setting the field at all.
+# This is controlled by the `stackset_legacy_hpa_field_crd_enabled` config-item.
 stackset_legacy_hpa_field_enabled: "false"
+stackset_legacy_hpa_field_crd_enabled: "false"
 
 # EBS settings for the root volume
 ebs_master_root_volume_size: "50"

--- a/cluster/manifests/stackset-controller/01-stack-crd.yaml
+++ b/cluster/manifests/stackset-controller/01-stack-crd.yaml
@@ -307,6 +307,7 @@ spec:
                 - maxReplicas
                 - metrics
                 type: object
+{{- if eq .Cluster.ConfigItems.stackset_legacy_hpa_field_crd_enabled "true" }}
               horizontalPodAutoscaler:
                 description: HorizontalPodAutoscaler is the Autoscaling configuration
                   of a Stack.
@@ -761,6 +762,7 @@ spec:
                 required:
                 - maxReplicas
                 type: object
+{{- end }}
               ingress:
                 description: Settings for the per-stack ingresses (in case the StackSet
                   has a configured ingress)

--- a/cluster/manifests/stackset-controller/01-stackset-crd.yaml
+++ b/cluster/manifests/stackset-controller/01-stackset-crd.yaml
@@ -542,6 +542,7 @@ spec:
                         - maxReplicas
                         - metrics
                         type: object
+{{- if eq .Cluster.ConfigItems.stackset_legacy_hpa_field_crd_enabled "true" }}
                       horizontalPodAutoscaler:
                         description: HorizontalPodAutoscaler is the Autoscaling configuration
                           of a Stack.
@@ -1035,6 +1036,7 @@ spec:
                         required:
                         - maxReplicas
                         type: object
+{{- end }}
                       ingress:
                         description: Settings for the per-stack ingresses (in case
                           the StackSet has a configured ingress)

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -44,6 +44,7 @@ clusters:
     stackset_routegroup_support_enabled: "true"
     stackset_ingress_source_switch_ttl: "1m"
     stackset_legacy_hpa_field_enabled: "true"
+    stackset_legacy_hpa_field_crd_enabled: "true"
     teapot_admission_controller_daemonset_reserved_cpu: "518m"
   criticality_level: 1
   environment: e2e


### PR DESCRIPTION
This removes the legacy `horizontalPodAutoscaler` field from StackSet (and Stacks) by default. The idea of this is to gradually phase this out across clusters as usage drops.

I have set the config-item: `stackset_legacy_hpa_field_crd_enabled: true` in all clusters such that we simply drop the config-item per cluster to drop the field. This setting should only be changed after validation that no stacksets in the cluster uses the `horizontalPodAutoscaler` field.
This way it's also quick to get a list of clusters still needing migration (those with the config-item still set).