### PR TITLE
Update deployment-service from autoscalingv2beta* to autoscalingv2

### DIFF
--- a/cluster/manifests/deployment-service/controller-statefulset.yaml
+++ b/cluster/manifests/deployment-service/controller-statefulset.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
         - name: "deployment-service-controller"
-          image: "container-registry.zalando.net/teapot/deployment-controller:master-123"
+          image: "container-registry.zalando.net/teapot/deployment-controller:master-125"
           args:
             - "--config-namespace=kube-system"
           env:

--- a/cluster/manifests/deployment-service/status-service-deployment.yaml
+++ b/cluster/manifests/deployment-service/status-service-deployment.yaml
@@ -1,5 +1,5 @@
 {{ $image   := "container-registry.zalando.net/teapot/deployment-status-service" }}
-{{ $version := "master-123" }}
+{{ $version := "master-125" }}
 
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Updates to a version of deployment service that removes support for `autoscalingv2/beta1` and replaces support for `autoscaling/v2beta2` with `autoscaling/v2`: https://github.bus.zalan.do/teapot/deployment-service/pull/144