### PR TITLE
Update deployment-service to include validate api

### DIFF
--- a/cluster/manifests/deployment-service/controller-statefulset.yaml
+++ b/cluster/manifests/deployment-service/controller-statefulset.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
         - name: "deployment-service-controller"
-          image: "container-registry.zalando.net/teapot/deployment-controller:master-125"
+          image: "container-registry.zalando.net/teapot/deployment-controller:master-127"
           args:
             - "--config-namespace=kube-system"
           env:

--- a/cluster/manifests/deployment-service/status-service-deployment.yaml
+++ b/cluster/manifests/deployment-service/status-service-deployment.yaml
@@ -1,5 +1,5 @@
 {{ $image   := "container-registry.zalando.net/teapot/deployment-status-service" }}
-{{ $version := "master-125" }}
+{{ $version := "master-127" }}
 
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
This adds the `/validate` endpoint to each cluster's local deployment-status service.