### PR TITLE
Fix node priority for decommissioning

### DIFF
--- a/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         operator: Exists
       containers:
       - name: cluster-lifecycle-controller
-        image: container-registry.zalando.net/teapot/cluster-lifecycle-controller:master-31
+        image: container-registry.zalando.net/teapot/cluster-lifecycle-controller:master-32
         args:
             - --drain-grace-period={{.ConfigItems.drain_grace_period}}
             - --drain-min-pod-lifetime={{.ConfigItems.drain_min_pod_lifetime}}

--- a/cluster/manifests/spot-node-rescheduler/cronjob.yaml
+++ b/cluster/manifests/spot-node-rescheduler/cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: spot-node-rescheduler
-            image: container-registry.zalando.net/teapot/spot-node-rescheduler:main-5
+            image: container-registry.zalando.net/teapot/spot-node-rescheduler:main-6
             resources:
               limits:
                 cpu: "{{ .ConfigItems.spot_node_rescheduler_cpu }}"


### PR DESCRIPTION
This is a follow up to #5943

It changes the node priority such that the default is `100` and the priority for spot rescheduled nodes is `90`. Before it was `0` and `-10` respectively, but setting `-10` did not work because of:

```
Node \"ip-10-14-7-186.eu-central-1.compute.internal\" is invalid: metadata.labels: Invalid value: \"-10\": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
```