### PR TITLE
Widen status-service's permissions to readonly on all safe resources

### DIFF
--- a/cluster/manifests/deployment-service/status-service-rbac.yaml
+++ b/cluster/manifests/deployment-service/status-service-rbac.yaml
@@ -27,6 +27,12 @@ rules:
     resources:
       - secrets
     verbs: ["get", "list", "watch"]
+  - apiGroups:
+      - zalando.org
+    resources:
+      - fabricgateways
+      - fabriceventstreams
+    verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cluster/manifests/deployment-service/status-service-rbac.yaml
+++ b/cluster/manifests/deployment-service/status-service-rbac.yaml
@@ -22,61 +22,6 @@ rules:
     resources:
       - cdpdeploymenttasks
     verbs: ["get", "list", "watch"]
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - events
-      - services
-      - persistentvolumeclaims
-    verbs: ["get", "list", "watch"]
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
-    resourceNames:
-      - deployment-config
-    verbs: ["get", "list", "watch"]
-  - apiGroups:
-      - apps
-    resources:
-      - deployments
-      - statefulsets
-      - replicasets
-    verbs: ["get", "list", "watch"]
-  - apiGroups:
-      - batch
-    resources:
-      - cronjobs
-      - jobs
-    verbs: ["get", "list", "watch"]
-  - apiGroups:
-      - networking.k8s.io
-    resources:
-      - ingresses
-    verbs: ["get", "list", "watch"]
-  - apiGroups:
-      - autoscaling
-    resources:
-      - horizontalpodautoscalers
-    verbs: ["get", "list", "watch"]
-  - apiGroups:
-      - zalando.org
-    resources:
-      - stacksets
-      - stacks
-      - platformcredentialssets
-      - routegroups
-      - fabricgateways
-      - fabriceventstreams
-    verbs: ["get", "list", "watch"]
-  - apiGroups:
-      - nakadi.zalan.do
-    resources:
-      - eventtypes
-      - eventtypesubscriptions
-      - nakadisqlqueries
-    verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -93,3 +38,19 @@ roleRef:
   kind: ClusterRole
   name: "deployment-service-status-service"
   apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "deployment-service-status-service-readonly"
+  labels:
+    application: "deployment-service"
+    component: "status-service"
+roleRef:
+  kind: ClusterRole
+  name: readonly
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: "deployment-service-status-service"
+    namespace: "kube-system"

--- a/cluster/manifests/deployment-service/status-service-rbac.yaml
+++ b/cluster/manifests/deployment-service/status-service-rbac.yaml
@@ -23,15 +23,26 @@ rules:
       - cdpdeploymenttasks
     verbs: ["get", "list", "watch"]
   - apiGroups:
+      - zalando.org
+    resources:
+      - stacksets
+      - stacks
+      - platformcredentialssets
+      - routegroups
+      - fabricgateways
+      - fabriceventstreams
+    verbs: ["get", "list", "watch"]
+  - apiGroups:
+      - nakadi.zalan.do
+    resources:
+      - eventtypes
+      - eventtypesubscriptions
+      - nakadisqlqueries
+    verbs: ["get", "list", "watch"]
+  - apiGroups:
       - ""
     resources:
       - secrets
-    verbs: ["get", "list", "watch"]
-  - apiGroups:
-      - zalando.org
-    resources:
-      - fabricgateways
-      - fabriceventstreams
     verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRoleBinding

--- a/cluster/manifests/deployment-service/status-service-rbac.yaml
+++ b/cluster/manifests/deployment-service/status-service-rbac.yaml
@@ -22,6 +22,11 @@ rules:
     resources:
       - cdpdeploymenttasks
     verbs: ["get", "list", "watch"]
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
`status-service`'s `/validate` endpoint needs to retrieve annotations of existing resources in the cluster. Since users can currently deploy most resources directly we need to widen `status-service`'s read-only access to these resources. The easiest and straight forward way is to give it the generic `readonly` cluster-wide role.

~Note, that it still can't and shouldn't have access to `Secret`s. There's currently no way to allow to read metadata, such as annotations, without also allowing read access to the secret data itself, hence we need to block it. This means that overwrite protection cannot be done for `Secret`s in the current implementation even after this PR.~

In addition to `readonly` it also requires access to Secret's which is added separately.

I removed the redundant read-only permissions of `status-service`'s specific role.