### PR TITLE
Update ExternalDNS to v0.13.5

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -32,7 +32,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: container-registry.zalando.net/teapot/external-dns:v0.13.4-master-36
+        image: container-registry.zalando.net/teapot/external-dns:v0.13.5-master-37
         args:
         - --source=service
         - --source=ingress


### PR DESCRIPTION
Update ExternalDNS to the latest version: https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.13.5