### PR TITLE
Allow to run containerd AMIs in existing clusters

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -20,6 +20,11 @@ write_files:
       # https://github.com/kubernetes/kubernetes/blob/v1.13.6/staging/src/k8s.io/kubelet/config/v1beta1/types.go
       apiVersion: kubelet.config.k8s.io/v1beta1
       kind: KubeletConfiguration
+{{- if index .NodePool.ConfigItems "support_containerd" }}
+      cgroupDriver: systemd
+      containerLogMaxSize: "50Mi"
+      containerLogMaxFiles: 2
+{{- end }}
       staticPodPath: "/etc/kubernetes/manifests"
       clusterDomain: cluster.local
 {{- if not (index .Cluster.ConfigItems "enable_cfs_quota") }}

--- a/cluster/node-pools/worker-splitaz/userdata.yaml
+++ b/cluster/node-pools/worker-splitaz/userdata.yaml
@@ -59,6 +59,11 @@ write_files:
       # https://github.com/kubernetes/kubernetes/blob/v1.13.6/staging/src/k8s.io/kubelet/config/v1beta1/types.go
       apiVersion: kubelet.config.k8s.io/v1beta1
       kind: KubeletConfiguration
+{{- if index .NodePool.ConfigItems "support_containerd" }}
+      cgroupDriver: systemd
+      containerLogMaxSize: "50Mi"
+      containerLogMaxFiles: 2
+{{- end }}
       clusterDomain: cluster.local
       cpuCFSQuota: false
       featureGates:


### PR DESCRIPTION
We currently configure a single node pool in `teapot` that runs `containerd`. However, this doesn't work out of the box without also switching to the systemd cgroup driver. For a limited time, this config item can be set alongside the AMI to make this work and it should not lead to any node rotations for existing clusters.

This config item is short-lived and should be removed as soon as possible.

The intention is to configure a node pool, e.g. in teapot, like so:

```yaml
- config_items:
    kuberuntu_image_v1_23_amd64: ami-123456789 # AMI that runs containerd
    kuberuntu_image_v1_23_arm64: ami-987654321 # AMI that runs containerd
    support_containerd: "true"
  discount_strategy: none
  instance_type: m5.xlarge
  instance_types:
  - m5.xlarge
  max_size: 300
  min_size: 0
  name: containerd-node-pool
  profile: worker-splitaz
```