### PR TITLE
change: default fifo max queue

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -90,7 +90,7 @@ skipper_suppress_route_update_logs: "true"
 skipper_validate_query: "true"
 skipper_validate_query_log: "false"
 
-skipper_default_filters: 'disableAccessLog(2,3,404,429) -> fifo(2000,20000,"3s")'
+skipper_default_filters: 'disableAccessLog(2,3,404,429) -> fifo(2000,20,"3s")'
 skipper_disabled_filters: "lua"
 skipper_edit_route_placeholders: ""
 skipper_ingress_inline_routes: ""
@@ -99,6 +99,8 @@ skipper_ingress_refuse_payload: ""
 skipper_compress_encodings: "gzip,deflate,br"
 
 # skipper profiling settings, 0 keeps default, <0 disable, >0 enable with value
+# https://pkg.go.dev/runtime@master#SetBlockProfileRate
+# https://pkg.go.dev/runtime@master#SetMutexProfileFraction
 skipper_block_profile_rate: 0
 skipper_mutex_profile_fraction: 0
 skipper_memory_profile_rate: 0


### PR DESCRIPTION
change: default fifo max queue. In order to tune MTTR for the good we drop out early in case we would queue up requests that would timeout anyways.