### PR TITLE
Upgrade autoscaling API version in e2e tests to v2

### DIFF
--- a/test/e2e/kube_metrics_adapter_test.go
+++ b/test/e2e/kube_metrics_adapter_test.go
@@ -402,17 +402,17 @@ func podHPA(deploymentName, name, apiVersion, kind string, metricTargets map[str
 		metrics = append(metrics, autoscaling.MetricSpec{
 			Type: autoscaling.ObjectMetricSourceType,
 			Object: &autoscaling.ObjectMetricSource{
+				DescribedObject: autoscaling.CrossVersionObjectReference{
+					APIVersion: apiVersion,
+					Kind:       kind,
+					Name:       name,
+				},
 				Metric: autoscaling.MetricIdentifier{
 					Name: metric,
 				},
 				Target: autoscaling.MetricTarget{
 					Type:         autoscaling.AverageValueMetricType,
 					AverageValue: resource.NewQuantity(target, resource.DecimalSI),
-				},
-				DescribedObject: autoscaling.CrossVersionObjectReference{
-					APIVersion: apiVersion,
-					Kind:       kind,
-					Name:       name,
 				},
 			},
 		})

--- a/test/e2e/kube_metrics_adapter_test.go
+++ b/test/e2e/kube_metrics_adapter_test.go
@@ -12,7 +12,7 @@ import (
 	rgclient "github.com/szuecs/routegroup-client"
 	rgv1 "github.com/szuecs/routegroup-client/apis/zalando.org/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscaling "k8s.io/api/autoscaling/v2beta1"
+	autoscaling "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -199,7 +199,7 @@ func (tc *CustomMetricTestCase) Run() {
 	}
 
 	// Autoscale the deployment
-	_, err = tc.kubeClient.AutoscalingV2beta1().HorizontalPodAutoscalers(ns).Create(context.TODO(), tc.hpa, metav1.CreateOptions{})
+	_, err = tc.kubeClient.AutoscalingV2().HorizontalPodAutoscalers(ns).Create(context.TODO(), tc.hpa, metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred())
 
 	waitForReplicas(tc.deployment.ObjectMeta.Name, tc.framework.Namespace.ObjectMeta.Name, tc.kubeClient, 15*time.Minute, tc.scaledReplicas)
@@ -355,8 +355,12 @@ func podMetricHPA(deploymentName string, metricTargets map[string]int64) *autosc
 		metrics = append(metrics, autoscaling.MetricSpec{
 			Type: autoscaling.PodsMetricSourceType,
 			Pods: &autoscaling.PodsMetricSource{
-				MetricName:         metric,
-				TargetAverageValue: *resource.NewQuantity(target, resource.DecimalSI),
+				Metric: autoscaling.MetricIdentifier{
+					Name: metric,
+				},
+				Target: autoscaling.MetricTarget{
+					AverageValue: resource.NewQuantity(target, resource.DecimalSI),
+				},
 			},
 		})
 		metricName = metric
@@ -397,14 +401,18 @@ func podHPA(deploymentName, name, apiVersion, kind string, metricTargets map[str
 		metrics = append(metrics, autoscaling.MetricSpec{
 			Type: autoscaling.ObjectMetricSourceType,
 			Object: &autoscaling.ObjectMetricSource{
-				MetricName: metric,
-				Target: autoscaling.CrossVersionObjectReference{
+				Metric: autoscaling.MetricIdentifier{
+					Name: metric,
+				},
+				Target: autoscaling.MetricTarget{
+					Value:        resource.NewQuantity(target, resource.DecimalSI),
+					AverageValue: resource.NewQuantity(target, resource.DecimalSI),
+				},
+				DescribedObject: autoscaling.CrossVersionObjectReference{
 					APIVersion: apiVersion,
 					Kind:       kind,
 					Name:       name,
 				},
-				TargetValue:  *resource.NewQuantity(target, resource.DecimalSI),
-				AverageValue: resource.NewQuantity(target, resource.DecimalSI),
 			},
 		})
 	}

--- a/test/e2e/kube_metrics_adapter_test.go
+++ b/test/e2e/kube_metrics_adapter_test.go
@@ -359,6 +359,7 @@ func podMetricHPA(deploymentName string, metricTargets map[string]int64) *autosc
 					Name: metric,
 				},
 				Target: autoscaling.MetricTarget{
+					Type:         autoscaling.AverageValueMetricType,
 					AverageValue: resource.NewQuantity(target, resource.DecimalSI),
 				},
 			},
@@ -405,7 +406,7 @@ func podHPA(deploymentName, name, apiVersion, kind string, metricTargets map[str
 					Name: metric,
 				},
 				Target: autoscaling.MetricTarget{
-					Value:        resource.NewQuantity(target, resource.DecimalSI),
+					Type:         autoscaling.AverageValueMetricType,
 					AverageValue: resource.NewQuantity(target, resource.DecimalSI),
 				},
 				DescribedObject: autoscaling.CrossVersionObjectReference{


### PR DESCRIPTION
What?

kube-metrics-adapter e2e tests were previously using version v2beta1, this commit ugrades it to version v2.

Why?

From kubernetes 1.26 onwards v2beta1 will be deprecated and it will not be possible to keep using it. Also, recently kube-metrics-adapter started to use autoscaling/v2 so even though there is some backward compatibility there is no reason to keep using v2beta1.

...

Is there any breaking changes?

No.

-----

Related issues:

- https://github.com/zalando-incubator/kubernetes-on-aws/issues/6052

Reference links:

- https://github.com/zalando-incubator/kube-metrics-adapter/pull/551