### PR TITLE
update: skipper

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.16.75-494" }}
+{{ $internal_version := "v0.16.93-512" }}
 {{ $version := index (split $internal_version "-") 0 }}
 
 apiVersion: apps/v1


### PR DESCRIPTION
fix: ingress backend weights for multi color traffic switching
update: dependencies go-redis, go-metrics
optimize: no goroutine in metric updates
feature: trace ID logged in the proxy

https://github.com/zalando/skipper/compare/v0.16.75...v0.16.93