### PR TITLE
Add Audittrail IAM Role

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -2097,6 +2097,12 @@ Resources:
         - PolicyDocument:
             Statement:
               - Action:
+                  - s3:ListBucket
+                Effect: Allow
+                Resource:
+                  - arn:aws:s3:::zalando-audittrail-central
+
+              - Action:
                   - s3:PutObject
                 Effect: Allow
                 Resource:
@@ -2104,6 +2110,7 @@ Resources:
             Version: 2012-10-17
           PolicyName: root
       RoleName: "zalando-audittrail-adapter-central"
+    Type: 'AWS::IAM::Role'
 {{- if eq .Cluster.ConfigItems.dynamodb_service_link_enabled "true" }}
   ServiceLinkedRoleAutoScalingDynamoDB:
     Properties:

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1914,75 +1914,6 @@ Resources:
         Status: Suspended
 {{ end }}
 
-  AuditTrailBucketPrimary:
-    Type: AWS::S3::Bucket
-    DeletionPolicy: Retain
-    Properties:
-      BucketName: "zalando-audittrail-primary-{{accountID .Cluster.InfrastructureAccount}}-{{.Cluster.LocalID}}"
-      LifecycleConfiguration:
-        Rules:
-          - AbortIncompleteMultipartUpload:
-              DaysAfterInitiation: 1
-            Prefix: ""
-            Status: Enabled
-      VersioningConfiguration:
-        Status: Suspended
-      Tags:
-      - Key: component
-        Value: audittrail-adapter
-  AuditTrailBucketPrimaryPolicy:
-    Type: AWS::S3::BucketPolicy
-    Properties:
-      Bucket: !Ref AuditTrailBucketPrimary
-      PolicyDocument:
-        Statement:
-          # In-cluster access
-          - Action:
-              - s3:ListBucket
-            Effect: Allow
-            Principal:
-              AWS:
-                - !GetAtt EmergencyAccessServiceIAMRole.Arn
-                - !GetAtt AudittrailAdapterIAMRole.Arn
-            Resource:
-              - !GetAtt AuditTrailBucketPrimary.Arn
-
-          - Action:
-              - s3:PutObject
-            Effect: Allow
-            Principal:
-              AWS:
-              - !GetAtt EmergencyAccessServiceIAMRole.Arn
-              - !GetAtt AudittrailAdapterIAMRole.Arn
-            Resource:
-              - !Sub
-                - "${BucketArn}/*"
-                - BucketArn: !GetAtt AuditTrailBucketPrimary.Arn
-
-{{- if ne .Cluster.ConfigItems.audittrail_root_account_role "" }}
-          # Central access
-          - Action:
-              - s3:ListBucket
-            Effect: Allow
-            Principal:
-              AWS:
-                - {{.Cluster.ConfigItems.audittrail_root_account_role}}
-            Resource:
-              - !GetAtt AuditTrailBucketPrimary.Arn
-
-          - Action:
-              - s3:GetObject
-              - s3:DeleteObject
-            Effect: Allow
-            Principal:
-              AWS:
-                - {{.Cluster.ConfigItems.audittrail_root_account_role}}
-            Resource:
-              - !Sub
-                - "${BucketArn}/*"
-                - BucketArn: !GetAtt AuditTrailBucketPrimary.Arn
-{{- end }}
-
   AuditTrailBucket:
     Type: AWS::S3::Bucket
     DeletionPolicy: Delete
@@ -2101,16 +2032,12 @@ Resources:
                   - s3:ListBucket
                 Effect: Allow
                 Resource:
-                  - !GetAtt AuditTrailBucketPrimary.Arn
                   - !GetAtt AuditTrailBucket.Arn
 
               - Action:
                   - s3:PutObject
                 Effect: Allow
                 Resource:
-                  - !Sub
-                    - "${BucketArn}/*"
-                    - BucketArn: !GetAtt AuditTrailBucketPrimary.Arn
                   - !Sub
                     - "${BucketArn}/*"
                     - BucketArn: !GetAtt AuditTrailBucket.Arn
@@ -2139,7 +2066,6 @@ Resources:
                   - s3:ListBucket
                 Effect: Allow
                 Resource:
-                  - !GetAtt AuditTrailBucketPrimary.Arn
                   - !GetAtt AuditTrailBucket.Arn
 
               - Action:
@@ -2148,14 +2074,36 @@ Resources:
                 Resource:
                   - !Sub
                     - "${BucketArn}/*"
-                    - BucketArn: !GetAtt AuditTrailBucketPrimary.Arn
-                  - !Sub
-                    - "${BucketArn}/*"
                     - BucketArn: !GetAtt AuditTrailBucket.Arn
             Version: 2012-10-17
           PolicyName: root
       RoleName: "{{.Cluster.LocalID}}-audittrail-adapter"
     Type: 'AWS::IAM::Role'
+  AudittrailAdapterCentralIAMRole:
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Federated: !Sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+            Action:
+              - 'sts:AssumeRoleWithWebIdentity'
+            Condition:
+              StringEquals:
+                "{{ .Cluster.LocalID }}.{{ .Values.hosted_zone }}:sub": "system:serviceaccount:kube-system:audittrail-adapter"
+        Version: 2012-10-17
+      Path: /
+      Policies:
+        - PolicyDocument:
+            Statement:
+              - Action:
+                  - s3:PutObject
+                Effect: Allow
+                Resource:
+                  - arn:aws:s3:::zalando-audittrail-central/*
+            Version: 2012-10-17
+          PolicyName: root
+      RoleName: "zalando-audittrail-adapter-central"
 {{- if eq .Cluster.ConfigItems.dynamodb_service_link_enabled "true" }}
   ServiceLinkedRoleAutoScalingDynamoDB:
     Properties:

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1913,7 +1913,77 @@ Resources:
       VersioningConfiguration:
         Status: Suspended
 {{ end }}
-  AuditTrailBucket:
+
+  AuditTrailBucketPrimary:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    Properties:
+      BucketName: "zalando-audittrail-primary-{{accountID .Cluster.InfrastructureAccount}}-{{.Cluster.LocalID}}"
+      LifecycleConfiguration:
+        Rules:
+          - AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 1
+            Prefix: ""
+            Status: Enabled
+      VersioningConfiguration:
+        Status: Suspended
+      Tags:
+      - Key: component
+        Value: audittrail-adapter
+  AuditTrailBucketPrimaryPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref AuditTrailBucketPrimary
+      PolicyDocument:
+        Statement:
+          # In-cluster access
+          - Action:
+              - s3:ListBucket
+            Effect: Allow
+            Principal:
+              AWS:
+                - !GetAtt EmergencyAccessServiceIAMRole.Arn
+                - !GetAtt AudittrailAdapterIAMRole.Arn
+            Resource:
+              - !GetAtt AuditTrailBucketPrimary.Arn
+
+          - Action:
+              - s3:PutObject
+            Effect: Allow
+            Principal:
+              AWS:
+              - !GetAtt EmergencyAccessServiceIAMRole.Arn
+              - !GetAtt AudittrailAdapterIAMRole.Arn
+            Resource:
+              - !Sub
+                - "${BucketArn}/*"
+                - BucketArn: !GetAtt AuditTrailBucketPrimary.Arn
+
+{{- if ne .Cluster.ConfigItems.audittrail_root_account_role "" }}
+          # Central access
+          - Action:
+              - s3:ListBucket
+            Effect: Allow
+            Principal:
+              AWS:
+                - {{.Cluster.ConfigItems.audittrail_root_account_role}}
+            Resource:
+              - !GetAtt AuditTrailBucketPrimary.Arn
+
+          - Action:
+              - s3:GetObject
+              - s3:DeleteObject
+            Effect: Allow
+            Principal:
+              AWS:
+                - {{.Cluster.ConfigItems.audittrail_root_account_role}}
+            Resource:
+              - !Sub
+                - "${BucketArn}/*"
+                - BucketArn: !GetAtt AuditTrailBucketPrimary.Arn
+{{- end }}
+
+  AuditTrailBucketFallback:
     Type: AWS::S3::Bucket
     DeletionPolicy: Delete
     Properties:
@@ -1931,10 +2001,10 @@ Resources:
       Tags:
       - Key: component
         Value: audittrail-adapter
-  AuditTrailBucketPolicy:
+  AuditTrailBucketFallbackPolicy:
     Type: AWS::S3::BucketPolicy
     Properties:
-      Bucket: !Ref AuditTrailBucket
+      Bucket: !Ref AuditTrailBucketFallback
       PolicyDocument:
         Statement:
           # In-cluster access
@@ -1946,7 +2016,7 @@ Resources:
                 - !GetAtt EmergencyAccessServiceIAMRole.Arn
                 - !GetAtt AudittrailAdapterIAMRole.Arn
             Resource:
-              - !GetAtt AuditTrailBucket.Arn
+              - !GetAtt AuditTrailBucketFallback.Arn
 
           - Action:
               - s3:PutObject
@@ -1958,7 +2028,7 @@ Resources:
             Resource:
               - !Sub
                 - "${BucketArn}/*"
-                - BucketArn: !GetAtt AuditTrailBucket.Arn
+                - BucketArn: !GetAtt AuditTrailBucketFallback.Arn
 
 {{- if ne .Cluster.ConfigItems.audittrail_root_account_role "" }}
           # Central access
@@ -1969,7 +2039,7 @@ Resources:
               AWS:
                 - {{.Cluster.ConfigItems.audittrail_root_account_role}}
             Resource:
-              - !GetAtt AuditTrailBucket.Arn
+              - !GetAtt AuditTrailBucketFallback.Arn
 
           - Action:
               - s3:GetObject
@@ -1981,7 +2051,7 @@ Resources:
             Resource:
               - !Sub
                 - "${BucketArn}/*"
-                - BucketArn: !GetAtt AuditTrailBucket.Arn
+                - BucketArn: !GetAtt AuditTrailBucketFallback.Arn
 {{- end }}
 
   AWSNodeDecommissionerIAMRole:
@@ -2031,7 +2101,8 @@ Resources:
                   - s3:ListBucket
                 Effect: Allow
                 Resource:
-                  - !GetAtt AuditTrailBucket.Arn
+                  - !GetAtt AuditTrailBucketPrimary.Arn
+                  - !GetAtt AuditTrailBucketFallback.Arn
 
               - Action:
                   - s3:PutObject
@@ -2039,7 +2110,10 @@ Resources:
                 Resource:
                   - !Sub
                     - "${BucketArn}/*"
-                    - BucketArn: !GetAtt AuditTrailBucket.Arn
+                    - BucketArn: !GetAtt AuditTrailBucketPrimary.Arn
+                  - !Sub
+                    - "${BucketArn}/*"
+                    - BucketArn: !GetAtt AuditTrailBucketFallback.Arn
             Version: 2012-10-17
           PolicyName: root
       RoleName: "{{.Cluster.LocalID}}-emergency-access-service"
@@ -2065,7 +2139,8 @@ Resources:
                   - s3:ListBucket
                 Effect: Allow
                 Resource:
-                  - !GetAtt AuditTrailBucket.Arn
+                  - !GetAtt AuditTrailBucketPrimary.Arn
+                  - !GetAtt AuditTrailBucketFallback.Arn
 
               - Action:
                   - s3:PutObject
@@ -2073,7 +2148,10 @@ Resources:
                 Resource:
                   - !Sub
                     - "${BucketArn}/*"
-                    - BucketArn: !GetAtt AuditTrailBucket.Arn
+                    - BucketArn: !GetAtt AuditTrailBucketPrimary.Arn
+                  - !Sub
+                    - "${BucketArn}/*"
+                    - BucketArn: !GetAtt AuditTrailBucketFallback.Arn
             Version: 2012-10-17
           PolicyName: root
       RoleName: "{{.Cluster.LocalID}}-audittrail-adapter"

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1983,7 +1983,7 @@ Resources:
                 - BucketArn: !GetAtt AuditTrailBucketPrimary.Arn
 {{- end }}
 
-  AuditTrailBucketFallback:
+  AuditTrailBucket:
     Type: AWS::S3::Bucket
     DeletionPolicy: Delete
     Properties:
@@ -2001,10 +2001,10 @@ Resources:
       Tags:
       - Key: component
         Value: audittrail-adapter
-  AuditTrailBucketFallbackPolicy:
+  AuditTrailBucketPolicy:
     Type: AWS::S3::BucketPolicy
     Properties:
-      Bucket: !Ref AuditTrailBucketFallback
+      Bucket: !Ref AuditTrailBucket
       PolicyDocument:
         Statement:
           # In-cluster access
@@ -2016,7 +2016,7 @@ Resources:
                 - !GetAtt EmergencyAccessServiceIAMRole.Arn
                 - !GetAtt AudittrailAdapterIAMRole.Arn
             Resource:
-              - !GetAtt AuditTrailBucketFallback.Arn
+              - !GetAtt AuditTrailBucket.Arn
 
           - Action:
               - s3:PutObject
@@ -2028,7 +2028,7 @@ Resources:
             Resource:
               - !Sub
                 - "${BucketArn}/*"
-                - BucketArn: !GetAtt AuditTrailBucketFallback.Arn
+                - BucketArn: !GetAtt AuditTrailBucket.Arn
 
 {{- if ne .Cluster.ConfigItems.audittrail_root_account_role "" }}
           # Central access
@@ -2039,7 +2039,7 @@ Resources:
               AWS:
                 - {{.Cluster.ConfigItems.audittrail_root_account_role}}
             Resource:
-              - !GetAtt AuditTrailBucketFallback.Arn
+              - !GetAtt AuditTrailBucket.Arn
 
           - Action:
               - s3:GetObject
@@ -2051,7 +2051,7 @@ Resources:
             Resource:
               - !Sub
                 - "${BucketArn}/*"
-                - BucketArn: !GetAtt AuditTrailBucketFallback.Arn
+                - BucketArn: !GetAtt AuditTrailBucket.Arn
 {{- end }}
 
   AWSNodeDecommissionerIAMRole:
@@ -2102,7 +2102,7 @@ Resources:
                 Effect: Allow
                 Resource:
                   - !GetAtt AuditTrailBucketPrimary.Arn
-                  - !GetAtt AuditTrailBucketFallback.Arn
+                  - !GetAtt AuditTrailBucket.Arn
 
               - Action:
                   - s3:PutObject
@@ -2113,7 +2113,7 @@ Resources:
                     - BucketArn: !GetAtt AuditTrailBucketPrimary.Arn
                   - !Sub
                     - "${BucketArn}/*"
-                    - BucketArn: !GetAtt AuditTrailBucketFallback.Arn
+                    - BucketArn: !GetAtt AuditTrailBucket.Arn
             Version: 2012-10-17
           PolicyName: root
       RoleName: "{{.Cluster.LocalID}}-emergency-access-service"
@@ -2140,7 +2140,7 @@ Resources:
                 Effect: Allow
                 Resource:
                   - !GetAtt AuditTrailBucketPrimary.Arn
-                  - !GetAtt AuditTrailBucketFallback.Arn
+                  - !GetAtt AuditTrailBucket.Arn
 
               - Action:
                   - s3:PutObject
@@ -2151,7 +2151,7 @@ Resources:
                     - BucketArn: !GetAtt AuditTrailBucketPrimary.Arn
                   - !Sub
                     - "${BucketArn}/*"
-                    - BucketArn: !GetAtt AuditTrailBucketFallback.Arn
+                    - BucketArn: !GetAtt AuditTrailBucket.Arn
             Version: 2012-10-17
           PolicyName: root
       RoleName: "{{.Cluster.LocalID}}-audittrail-adapter"


### PR DESCRIPTION
Due to the changes to the `audittrail-adapter` that will now send and store kubernetes events in a centralised S3 bucket, this PR adds an IAM role that will allow the adapter to sufficiently interact with the bucket via list and put actions.

[Relevant teapot issue](https://github.bus.zalan.do/teapot/issues/issues/3436)