### PR TITLE
skipper: remove unused skipper_routegroup_enable_hostport config item

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -248,9 +248,6 @@ skipper_serve_status_code_metric: "false"
 # can be one of disabled|provisioned|enabled
 routegroups_validation: "enabled"
 
-# enable hostnames with port in host definition
-skipper_routegroup_enable_hostport: "false"
-
 # tokeninfo
 {{if eq .Cluster.Environment "production"}}
 # production|bridge|disabled

--- a/cluster/manifests/skipper/routegroup-crd.yaml
+++ b/cluster/manifests/skipper/routegroup-crd.yaml
@@ -144,12 +144,8 @@ spec:
               hosts:
                 description: List of hostnames for the RouteGroup
                 items:
-{{ if eq .ConfigItems.skipper_routegroup_enable_hostport "true"}}
-                  pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?([.][a-z0-9]([-a-z0-9]*[a-z0-9])?)*(:[0-9]+)?$"
-{{ else }}
                   pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?([.][a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
-{{ end }}
-                  minItems: 1
+                  minItems: 1 # original CRD allows empty hosts but we explicitly want it specified in our infrastructure
                   type: string
                 type: array
               routes:


### PR DESCRIPTION
Remove unused config item to simplify RouetGroup CRD updates.