### PR TITLE
fix: external-dns being redirected to virginia

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -64,3 +64,6 @@ spec:
           runAsUser: 65534
           capabilities:
             drop: ["ALL"]
+        env:
+        - name: AWS_REGION
+          value: {{ .Region }}


### PR DESCRIPTION
fix: external-dns being redirected to virginia as we observed on 2023-06-13 22:20-22:50 CEST
      to mitigate this we use the `AWS_REGION` env var to stay in the same region