### PR TITLE
Add external RPS metric support

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -35,6 +35,7 @@ spec:
         - --prometheus-server=http://prometheus.kube-system.svc.cluster.local
         - --skipper-ingress-metrics
         - --skipper-routegroup-metrics
+        - --external-rps-metrics
         - --scaling-schedule
         - --scaling-schedule-default-scaling-window={{.Cluster.ConfigItems.kube_metrics_adapter_default_scaling_window}}
         - --scaling-schedule-ramp-steps={{.Cluster.ConfigItems.kube_metrics_adapter_scaling_schedule_ramp_steps}}

--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: container-registry.zalando.net/teapot/kube-metrics-adapter:v0.2.0
+        image: container-registry.zalando.net/teapot/kube-metrics-adapter:v0.2.1
         env:
         - name: AWS_REGION
           value: {{ .Region }}

--- a/test/e2e/kube_metrics_adapter_test.go
+++ b/test/e2e/kube_metrics_adapter_test.go
@@ -134,7 +134,7 @@ var _ = describe("[HPA] Horizontal pod autoscaling (scale resource: Custom Metri
 		tc.Run()
 	})
 
-    It("should scale with external metric based on hostname RPS [CustomMetricsAutoscaling] [Zalando]", func() {
+	It("should scale with external metric based on hostname RPS [CustomMetricsAutoscaling] [Zalando]", func() {
 		hostName := fmt.Sprintf("%s-%d.%s", DeploymentName, time.Now().UTC().Unix(), E2EHostedZone())
 
 		initialReplicas := 2
@@ -164,7 +164,7 @@ var _ = describe("[HPA] Horizontal pod autoscaling (scale resource: Custom Metri
 			},
 		}
 		tc.Run()
-    })
+	})
 })
 
 type CustomMetricTestCase struct {
@@ -198,7 +198,6 @@ func (tc *CustomMetricTestCase) Run() {
 		Expect(err).NotTo(HaveOccurred())
 		// Wait for the deployment to run
 		waitForReplicas(deployment.ObjectMeta.Name, tc.framework.Namespace.ObjectMeta.Name, tc.kubeClient, 15*time.Minute, int(*(deployment.Spec.Replicas)))
-
 	}
 
 	// Check if an Ingress needs to be created
@@ -423,17 +422,15 @@ func podMetricHPA(deploymentName string, metricTargets map[string]int64) *autosc
 	}
 }
 
-
-
 func externalRPSHPA(deploymentName, host, weight string, target int64) *autoscaling.HorizontalPodAutoscaler {
 	return externalHPA(
-        deploymentName,
-        map[string]int64{"foo": target},
-        map[string]string{
-            "metric-config.foo.requests-per-second/hostnames": host,
-            "metric-config.foo.requests-per-second/weight": weight,
-        },
-    )
+		deploymentName,
+		map[string]int64{"foo": target},
+		map[string]string{
+			"metric-config.external.foo.requests-per-second/hostnames": host,
+			"metric-config.external.foo.requests-per-second/weight":    weight,
+		},
+	)
 }
 
 func externalHPA(deploymentName string, metricNameTargets map[string]int64, annotations map[string]string) *autoscaling.HorizontalPodAutoscaler {
@@ -441,30 +438,29 @@ func externalHPA(deploymentName string, metricNameTargets map[string]int64, anno
 	metrics := []autoscaling.MetricSpec{}
 	for metricName, target := range metricNameTargets {
 		metrics = append(metrics, autoscaling.MetricSpec{
-				Type: autoscaling.ExternalMetricSourceType,
-				External: &autoscaling.ExternalMetricSource{
-					Metric: autoscaling.MetricIdentifier{
-						Name: metricName,
-						Selector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{"type": "requests-per-second"},
-						},
+			Type: autoscaling.ExternalMetricSourceType,
+			External: &autoscaling.ExternalMetricSource{
+				Metric: autoscaling.MetricIdentifier{
+					Name: metricName,
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"type": "requests-per-second"},
 					},
-                    Target: autoscaling.MetricTarget{
-                        Type: autoscaling.AverageValueMetricType,
-                        AverageValue: resource.NewQuantity(target, resource.DecimalSI),
-                        
-                    },
 				},
+				Target: autoscaling.MetricTarget{
+					Type:         autoscaling.AverageValueMetricType,
+					AverageValue: resource.NewQuantity(target, resource.DecimalSI),
+				},
+			},
 		})
 	}
 
-    return &autoscaling.HorizontalPodAutoscaler{
+	return &autoscaling.HorizontalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "custom-metrics-pods-hpa",
 			Labels: map[string]string{
 				"application": deploymentName,
 			},
-            Annotations: annotations,
+			Annotations: annotations,
 		},
 		Spec: autoscaling.HorizontalPodAutoscalerSpec{
 			Metrics:     metrics,
@@ -478,7 +474,6 @@ func externalHPA(deploymentName string, metricNameTargets map[string]int64, anno
 		},
 	}
 }
-
 
 func rpsBasedHPA(deploymentName, name, apiVersion, kind string, metricTarget int64) *autoscaling.HorizontalPodAutoscaler {
 	return podHPA(deploymentName, name, apiVersion, kind, map[string]int64{"requests-per-second": metricTarget})
@@ -506,7 +501,6 @@ func podHPA(deploymentName, name, apiVersion, kind string, metricTargets map[str
 			},
 		})
 	}
-
 
 	return &autoscaling.HorizontalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/kube_metrics_adapter_test.go
+++ b/test/e2e/kube_metrics_adapter_test.go
@@ -134,7 +134,7 @@ var _ = describe("[HPA] Horizontal pod autoscaling (scale resource: Custom Metri
 		tc.Run()
 	})
 
-    It("should scale with external metric based on hostname RPS", func() {
+    It("should scale with external metric based on hostname RPS [CustomMetricsAutoscaling] [Zalando]", func() {
 		hostName := fmt.Sprintf("%s-%d.%s", DeploymentName, time.Now().UTC().Unix(), E2EHostedZone())
 
 		initialReplicas := 2


### PR DESCRIPTION
This change upgrades `kube-metrics-adapter` to version 0.2.1 to support External RPS metrics. It also adds E2E tests to ensure  External RPS metrics are working properly.