### PR TITLE
Remove ServiceQuota SLR from kube-1 stack

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -2085,13 +2085,6 @@ Resources:
       Description: "AWS service role for application autoscaling DynamoDB"
     Type: "AWS::IAM::ServiceLinkedRole"
 {{- end }}
-{{- if eq .Cluster.ConfigItems.quotas_service_link_enabled "true" }}
-  ServiceLinkedRoleServiceQuotas:
-    Properties:
-      AWSServiceName: "servicequotas.amazonaws.com"
-      Description: "AWS service role for Service Quotas"
-    Type: "AWS::IAM::ServiceLinkedRole"
-{{- end }}
   RemoteFilesEncryptionKey:
     Type: "AWS::KMS::Key"
     Properties:

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -566,11 +566,8 @@ etcd_scalyr_key: ""
 etcd_ami: {{ amiID "zalando-ubuntu-etcd-production-v3.4.16-amd64-main-10" "861068367966"}}
 
 dynamodb_service_link_enabled: "false"
-{{if eq .Cluster.Environment "e2e"}}
 quotas_service_link_enabled: "false"
-{{else}}
-quotas_service_link_enabled: "true"
-{{end}}
+
 
 cluster_dns: "coredns"
 coredns_log_svc_names: "true"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -566,8 +566,6 @@ etcd_scalyr_key: ""
 etcd_ami: {{ amiID "zalando-ubuntu-etcd-production-v3.4.16-amd64-main-10" "861068367966"}}
 
 dynamodb_service_link_enabled: "false"
-quotas_service_link_enabled: "false"
-
 
 cluster_dns: "coredns"
 coredns_log_svc_names: "true"


### PR DESCRIPTION
This removes the `ServiceLinkedRole` for `ServiceQuota` service. This is the first step to migration to AILM. The second step will be to deploy the stack that creates these roles through [this PR](https://github.bus.zalan.do/Base-Infrastructure/aws-base-infrastructure/pull/1062).

Basically, since all accounts are using the default value for the config-item, changing the value to false should remove the roles. I'm keeping the config-item in case we need to roll-back, we can do so by setting the item to `true` again. Later, we should remove the item + the resource from the CF template as well, once the migration is complete.

More context: https://github.bus.zalan.do/zooport/issues/issues/3517