### PR TITLE
Quick fix for e2e by using Debian 11 for Go build

### DIFF
--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -1,5 +1,5 @@
 # builder image
-FROM golang:1.20 as builder
+FROM golang:1.20-bullseye as builder
 
 RUN go install github.com/onsi/ginkgo/ginkgo@v1.16.5
 


### PR DESCRIPTION
This is a quick and hacky way to get e2e to work again.

It switches the go image used in the e2e image build to Debian 11 (bullseye) such that it's aligned with the Debian version in the `container-registry.zalando.net/library/python-3.11-slim:latest` base image.

This is to avoid issues like:

```
ginkgo: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by ginkgo)
ginkgo: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by ginkgo)
```