### PR TITLE
Build ginkgo with cgo disabled

### DIFF
--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -1,7 +1,7 @@
 # builder image
 FROM golang:1.20 as builder
 
-RUN go install github.com/onsi/ginkgo/ginkgo@v1.16.5
+RUN CGO_ENABLED=0 go install github.com/onsi/ginkgo/ginkgo@v1.16.5
 
 # final image
 # TODO get rid of python dependencies


### PR DESCRIPTION
Currently the e2e image fails to run because of this error:

```
ginkgo: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by ginkgo)
ginkgo: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by ginkgo)
```

This is happening because right now the `golang:1.20` image is based on Debian 12 and the base image: `container-registry.zalando.net/library/python-3.11-slim:latest` based on Debian 11 and we build the `ginkgo` binary in the first and run it in the second against a different libc which doesn't work.

Proper fix is to build `ginkgo` with `CGO_ENABLED=0` so it's just a static binary.