### PR TITLE
stackset-contoller: update CRDs

### DIFF
--- a/cluster/manifests/stackset-controller/01-stack-crd.yaml
+++ b/cluster/manifests/stackset-controller/01-stack-crd.yaml
@@ -1,4 +1,4 @@
-
+# This is an adjusted copy of https://github.com/zalando-incubator/stackset-controller/blob/master/docs/stack_crd.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -50,15 +50,18 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: Stack defines one version of an application.
+        description: Stack defines one version of an application. It is possible to
+          switch traffic between multiple versions of an application.
         properties:
           apiVersion:
-            description: APIVersion defines the versioned schema of this representation
-              of an object.
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: Kind is a string value representing the REST resource this
-              object represents.
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -71,14 +74,21 @@ spec:
                   behavior:
                     description: behavior configures the scaling behavior of the target
                       in both Up and Down directions (scaleUp and scaleDown fields
-                      respectively).
+                      respectively). If not set, the default HPAScalingRules for scale
+                      up and scale down are used.
                     properties:
                       scaleDown:
                         description: scaleDown is scaling policy for scaling Down.
+                          If not set, the default value is to allow to scale down
+                          to minReplicas pods, with a 300 second stabilization window
+                          (i.e., the highest recommendation for the last 300sec is
+                          used).
                         properties:
                           policies:
                             description: policies is a list of potential scaling polices
-                              which can be used during scaling.
+                              which can be used during scaling. At least one policy
+                              must be specified, otherwise the HPAScalingRules will
+                              be discarded as invalid
                             items:
                               description: HPAScalingPolicy is a single policy which
                                 must hold true for a specified past interval.
@@ -109,21 +119,32 @@ spec:
                             x-kubernetes-list-type: atomic
                           selectPolicy:
                             description: selectPolicy is used to specify which policy
-                              should be used.
+                              should be used. If not set, the default value Max is
+                              used.
                             type: string
                           stabilizationWindowSeconds:
-                            description: StabilizationWindowSeconds is the number
+                            description: 'StabilizationWindowSeconds is the number
                               of seconds for which past recommendations should be
-                              considered while scaling up or scaling down.
+                              considered while scaling up or scaling down. StabilizationWindowSeconds
+                              must be greater than or equal to zero and less than
+                              or equal to 3600 (one hour). If not set, use the default
+                              values: - For scale up: 0 (i.e. no stabilization is
+                              done). - For scale down: 300 (i.e. the stabilization
+                              window is 300 seconds long).'
                             format: int32
                             type: integer
                         type: object
                       scaleUp:
-                        description: scaleUp is scaling policy for scaling Up.
+                        description: 'scaleUp is scaling policy for scaling Up. If
+                          not set, the default value is the higher of: * increase
+                          no more than 4 pods per 60 seconds * double the number of
+                          pods per 60 seconds No stabilization is used.'
                         properties:
                           policies:
                             description: policies is a list of potential scaling polices
-                              which can be used during scaling.
+                              which can be used during scaling. At least one policy
+                              must be specified, otherwise the HPAScalingRules will
+                              be discarded as invalid
                             items:
                               description: HPAScalingPolicy is a single policy which
                                 must hold true for a specified past interval.
@@ -154,19 +175,26 @@ spec:
                             x-kubernetes-list-type: atomic
                           selectPolicy:
                             description: selectPolicy is used to specify which policy
-                              should be used.
+                              should be used. If not set, the default value Max is
+                              used.
                             type: string
                           stabilizationWindowSeconds:
-                            description: StabilizationWindowSeconds is the number
+                            description: 'StabilizationWindowSeconds is the number
                               of seconds for which past recommendations should be
-                              considered while scaling up or scaling down.
+                              considered while scaling up or scaling down. StabilizationWindowSeconds
+                              must be greater than or equal to zero and less than
+                              or equal to 3600 (one hour). If not set, use the default
+                              values: - For scale up: 0 (i.e. no stabilization is
+                              done). - For scale down: 300 (i.e. the stabilization
+                              window is 300 seconds long).'
                             format: int32
                             type: integer
                         type: object
                     type: object
                   maxReplicas:
                     description: maxReplicas is the upper limit for the number of
-                      replicas to which the autoscaler can scale up.
+                      replicas to which the autoscaler can scale up. It cannot be
+                      less that minReplicas.
                     format: int32
                     type: integer
                   metrics:
@@ -300,29 +328,37 @@ spec:
                     type: array
                   minReplicas:
                     description: minReplicas is the lower limit for the number of
-                      replicas to which the autoscaler can scale down.
+                      replicas to which the autoscaler can scale down. It defaults
+                      to 1 pod.
                     format: int32
                     type: integer
                 required:
                 - maxReplicas
                 - metrics
                 type: object
-{{- if eq .Cluster.ConfigItems.stackset_legacy_hpa_field_crd_enabled "true" }}
+# {{ if eq .Cluster.ConfigItems.stackset_legacy_hpa_field_crd_enabled "true" }}
               horizontalPodAutoscaler:
                 description: HorizontalPodAutoscaler is the Autoscaling configuration
-                  of a Stack.
+                  of a Stack. If defined an HPA will be created for the Stack.
                 properties:
                   behavior:
                     description: behavior configures the scaling behavior of the target
                       in both Up and Down directions (scaleUp and scaleDown fields
-                      respectively).
+                      respectively). If not set, the default HPAScalingRules for scale
+                      up and scale down are used.
                     properties:
                       scaleDown:
                         description: scaleDown is scaling policy for scaling Down.
+                          If not set, the default value is to allow to scale down
+                          to minReplicas pods, with a 300 second stabilization window
+                          (i.e., the highest recommendation for the last 300sec is
+                          used).
                         properties:
                           policies:
                             description: policies is a list of potential scaling polices
-                              which can be used during scaling.
+                              which can be used during scaling. At least one policy
+                              must be specified, otherwise the HPAScalingRules will
+                              be discarded as invalid
                             items:
                               description: HPAScalingPolicy is a single policy which
                                 must hold true for a specified past interval.
@@ -353,21 +389,32 @@ spec:
                             x-kubernetes-list-type: atomic
                           selectPolicy:
                             description: selectPolicy is used to specify which policy
-                              should be used.
+                              should be used. If not set, the default value Max is
+                              used.
                             type: string
                           stabilizationWindowSeconds:
-                            description: StabilizationWindowSeconds is the number
+                            description: 'StabilizationWindowSeconds is the number
                               of seconds for which past recommendations should be
-                              considered while scaling up or scaling down.
+                              considered while scaling up or scaling down. StabilizationWindowSeconds
+                              must be greater than or equal to zero and less than
+                              or equal to 3600 (one hour). If not set, use the default
+                              values: - For scale up: 0 (i.e. no stabilization is
+                              done). - For scale down: 300 (i.e. the stabilization
+                              window is 300 seconds long).'
                             format: int32
                             type: integer
                         type: object
                       scaleUp:
-                        description: scaleUp is scaling policy for scaling Up.
+                        description: 'scaleUp is scaling policy for scaling Up. If
+                          not set, the default value is the higher of: * increase
+                          no more than 4 pods per 60 seconds * double the number of
+                          pods per 60 seconds No stabilization is used.'
                         properties:
                           policies:
                             description: policies is a list of potential scaling polices
-                              which can be used during scaling.
+                              which can be used during scaling. At least one policy
+                              must be specified, otherwise the HPAScalingRules will
+                              be discarded as invalid
                             items:
                               description: HPAScalingPolicy is a single policy which
                                 must hold true for a specified past interval.
@@ -398,25 +445,37 @@ spec:
                             x-kubernetes-list-type: atomic
                           selectPolicy:
                             description: selectPolicy is used to specify which policy
-                              should be used.
+                              should be used. If not set, the default value Max is
+                              used.
                             type: string
                           stabilizationWindowSeconds:
-                            description: StabilizationWindowSeconds is the number
+                            description: 'StabilizationWindowSeconds is the number
                               of seconds for which past recommendations should be
-                              considered while scaling up or scaling down.
+                              considered while scaling up or scaling down. StabilizationWindowSeconds
+                              must be greater than or equal to zero and less than
+                              or equal to 3600 (one hour). If not set, use the default
+                              values: - For scale up: 0 (i.e. no stabilization is
+                              done). - For scale down: 300 (i.e. the stabilization
+                              window is 300 seconds long).'
                             format: int32
                             type: integer
                         type: object
                     type: object
                   maxReplicas:
                     description: maxReplicas is the upper limit for the number of
-                      replicas to which the autoscaler can scale up.
+                      replicas to which the autoscaler can scale up. It cannot be
+                      less that minReplicas.
                     format: int32
                     type: integer
                   metrics:
                     description: metrics contains the specifications for which to
                       use to calculate the desired replica count (the maximum replica
-                      count across all metrics will be used).
+                      count across all metrics will be used).  The desired replica
+                      count is calculated multiplying the ratio between the target
+                      value and the current value by the current number of pods.  Ergo,
+                      metrics used must decrease as the pod count is increased, and
+                      vice-versa.  See the individual metric source types for more
+                      information about how each type of metric must respond.
                     items:
                       description: MetricSpec specifies how to scale based on a single
                         metric (only `type` and one other matching field should be
@@ -756,13 +815,14 @@ spec:
                     type: array
                   minReplicas:
                     description: minReplicas is the lower limit for the number of
-                      replicas to which the autoscaler can scale down.
+                      replicas to which the autoscaler can scale down. It defaults
+                      to 1 pod.
                     format: int32
                     type: integer
                 required:
                 - maxReplicas
                 type: object
-{{- end }}
+# {{ end }}
               ingress:
                 description: Settings for the per-stack ingresses (in case the StackSet
                   has a configured ingress)
@@ -773,27 +833,34 @@ spec:
                     type: boolean
                   hosts:
                     description: Hostnames to use for the per-stack ingresses (or
-                      route groups).
+                      route groups). These must contain the special $(STACK_NAME)
+                      token, which will be replaced with the stack's name. Would be
+                      automatically generated based on the hosts in the ingress/routegroup
+                      entry if unset.
                     items:
                       type: string
                     type: array
                   metadata:
                     description: EmbeddedObjectMetaWithAnnotations defines the metadata
-                      which can be attached to a resource.
+                      which can be attached to a resource. It's a slimmed down version
+                      of metav1.ObjectMeta only containing annotations.
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations is an unstructured key value map
+                        description: 'Annotations is an unstructured key value map
                           stored with a resource that may be set by external tools
-                          to store and retrieve arbitrary metadata.
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
                         type: object
                     type: object
                 type: object
               minReadySeconds:
                 description: Minimum number of seconds for which a newly created pod
                   should be ready without any of its container crashing, for it to
-                  be considered available.
+                  be considered available. Defaults to 0 (pod will be considered available
+                  as soon as it is ready)
                 format: int32
                 type: integer
               podTemplate:
@@ -805,24 +872,30 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations is an unstructured key value map
+                        description: 'Annotations is an unstructured key value map
                           stored with a resource that may be set by external tools
-                          to store and retrieve arbitrary metadata.
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Map of string keys and values that can be used
-                          to organize and categorize (scope and select) objects.
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
                         type: object
                     type: object
                   spec:
-                    description: Specification of the desired behavior of the pod.
+                    description: 'Specification of the desired behavior of the pod.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
                     properties:
                       activeDeadlineSeconds:
                         description: Optional duration in seconds the pod may be active
                           on the node relative to StartTime before the system will
                           actively try to mark it failed and kill associated containers.
+                          Value must be a positive integer.
                         format: int64
                         type: integer
                       affinity:
@@ -836,7 +909,15 @@ spec:
                                 description: The scheduler will prefer to schedule
                                   pods to nodes that satisfy the affinity expressions
                                   specified by this field, but it may choose a node
-                                  that violates one or more of the expressions.
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node matches the corresponding matchExpressions;
+                                  the node(s) with the highest sum are the most preferred.
                                 items:
                                   description: An empty preferred scheduling term
                                     matches all objects with implicit weight 0 (i.e.
@@ -867,16 +948,6 @@ spec:
                                                   Gt, and Lt.
                                                 type: string
                                               values:
-                                                description: An array of string values.
-                                                  If the operator is In or NotIn,
-                                                  the values array must be non-empty.
-                                                  If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty.
-                                                  If the operator is Gt or Lt, the
-                                                  values array must have a single
-                                                  element, which will be interpreted
-                                                  as an integer. This array is replaced
-                                                  during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -905,16 +976,6 @@ spec:
                                                   Gt, and Lt.
                                                 type: string
                                               values:
-                                                description: An array of string values.
-                                                  If the operator is In or NotIn,
-                                                  the values array must be non-empty.
-                                                  If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty.
-                                                  If the operator is Gt or Lt, the
-                                                  values array must have a single
-                                                  element, which will be interpreted
-                                                  as an integer. This array is replaced
-                                                  during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -938,7 +999,11 @@ spec:
                               requiredDuringSchedulingIgnoredDuringExecution:
                                 description: If the affinity requirements specified
                                   by this field are not met at scheduling time, the
-                                  pod will not be scheduled onto the node.
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to an update), the system may or may not try
+                                  to eventually evict the pod from its node.
                                 properties:
                                   nodeSelectorTerms:
                                     description: Required. A list of node selector
@@ -969,16 +1034,6 @@ spec:
                                                   Gt, and Lt.
                                                 type: string
                                               values:
-                                                description: An array of string values.
-                                                  If the operator is In or NotIn,
-                                                  the values array must be non-empty.
-                                                  If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty.
-                                                  If the operator is Gt or Lt, the
-                                                  values array must have a single
-                                                  element, which will be interpreted
-                                                  as an integer. This array is replaced
-                                                  during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1007,16 +1062,6 @@ spec:
                                                   Gt, and Lt.
                                                 type: string
                                               values:
-                                                description: An array of string values.
-                                                  If the operator is In or NotIn,
-                                                  the values array must be non-empty.
-                                                  If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty.
-                                                  If the operator is Gt or Lt, the
-                                                  values array must have a single
-                                                  element, which will be interpreted
-                                                  as an integer. This array is replaced
-                                                  during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1032,13 +1077,24 @@ spec:
                                 type: object
                             type: object
                           podAffinity:
-                            description: Describes pod affinity scheduling rules (e.
+                            description: Describes pod affinity scheduling rules (e.g.
+                              co-locate this pod in the same node, zone, etc. as some
+                              other pod(s)).
                             properties:
                               preferredDuringSchedulingIgnoredDuringExecution:
                                 description: The scheduler will prefer to schedule
                                   pods to nodes that satisfy the affinity expressions
                                   specified by this field, but it may choose a node
-                                  that violates one or more of the expressions.
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
                                 items:
                                   description: The weights of all of the matched WeightedPodAffinityTerm
                                     fields are added per-node to find the most preferred
@@ -1063,25 +1119,10 @@ spec:
                                                   the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label
-                                                      key that the selector applies
-                                                      to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -1127,25 +1168,10 @@ spec:
                                                   the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label
-                                                      key that the selector applies
-                                                      to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -1206,7 +1232,14 @@ spec:
                               requiredDuringSchedulingIgnoredDuringExecution:
                                 description: If the affinity requirements specified
                                   by this field are not met at scheduling time, the
-                                  pod will not be scheduled onto the node.
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to a pod label update), the system may or may
+                                  not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes
+                                  corresponding to each podAffinityTerm are intersected,
+                                  i.e. all terms must be satisfied.
                                 items:
                                   description: Defines a set of pods (namely those
                                     matching the labelSelector relative to the given
@@ -1356,13 +1389,23 @@ spec:
                             type: object
                           podAntiAffinity:
                             description: Describes pod anti-affinity scheduling rules
-                              (e.
+                              (e.g. avoid putting this pod in the same node, zone,
+                              etc. as some other pod(s)).
                             properties:
                               preferredDuringSchedulingIgnoredDuringExecution:
                                 description: The scheduler will prefer to schedule
                                   pods to nodes that satisfy the anti-affinity expressions
                                   specified by this field, but it may choose a node
-                                  that violates one or more of the expressions.
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity
+                                  expressions, etc.), compute a sum by iterating through
+                                  the elements of this field and adding "weight" to
+                                  the sum if the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
                                 items:
                                   description: The weights of all of the matched WeightedPodAffinityTerm
                                     fields are added per-node to find the most preferred
@@ -1387,25 +1430,10 @@ spec:
                                                   the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label
-                                                      key that the selector applies
-                                                      to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -1451,25 +1479,10 @@ spec:
                                                   the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label
-                                                      key that the selector applies
-                                                      to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -1530,7 +1543,14 @@ spec:
                               requiredDuringSchedulingIgnoredDuringExecution:
                                 description: If the anti-affinity requirements specified
                                   by this field are not met at scheduling time, the
-                                  pod will not be scheduled onto the node.
+                                  pod will not be scheduled onto the node. If the
+                                  anti-affinity requirements specified by this field
+                                  cease to be met at some point during pod execution
+                                  (e.g. due to a pod label update), the system may
+                                  or may not try to eventually evict the pod from
+                                  its node. When there are multiple elements, the
+                                  lists of nodes corresponding to each podAffinityTerm
+                                  are intersected, i.e. all terms must be satisfied.
                                 items:
                                   description: Defines a set of pods (namely those
                                     matching the labelSelector relative to the given
@@ -1684,7 +1704,9 @@ spec:
                           a service account token should be automatically mounted.
                         type: boolean
                       containers:
-                        description: List of containers belonging to the pod.
+                        description: List of containers belonging to the pod. Containers
+                          cannot currently be added or removed. There must be at least
+                          one container in a Pod. Cannot be updated.
                         items:
                           description: A single application container that you want
                             to run within a pod.
@@ -2143,11 +2165,11 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service\
-                                        \ to place in the gRPC HealthCheckRequest\
-                                        \ (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\
-                                        \ \n If this is not specified, the default\
-                                        \ behavior is defined by gRPC."
+                                      description: "Service is the name of the service
+                                        to place in the gRPC HealthCheckRequest (see
+                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                        \n If this is not specified, the default behavior
+                                        is defined by gRPC."
                                       type: string
                                   required:
                                   - port
@@ -2355,11 +2377,11 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service\
-                                        \ to place in the gRPC HealthCheckRequest\
-                                        \ (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\
-                                        \ \n If this is not specified, the default\
-                                        \ behavior is defined by gRPC."
+                                      description: "Service is the name of the service
+                                        to place in the gRPC HealthCheckRequest (see
+                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                        \n If this is not specified, the default behavior
+                                        is defined by gRPC."
                                       type: string
                                   required:
                                   - port
@@ -2633,13 +2655,13 @@ spec:
                                         location. Must only be set if type is "Localhost".
                                       type: string
                                     type:
-                                      description: "type indicates which kind of seccomp\
-                                        \ profile will be applied. Valid options are:\
-                                        \ \n Localhost - a profile defined in a file\
-                                        \ on the node should be used. RuntimeDefault\
-                                        \ - the container runtime default profile\
-                                        \ should be used. Unconfined - no profile\
-                                        \ should be applied."
+                                      description: "type indicates which kind of seccomp
+                                        profile will be applied. Valid options are:
+                                        \n Localhost - a profile defined in a file
+                                        on the node should be used. RuntimeDefault
+                                        - the container runtime default profile should
+                                        be used. Unconfined - no profile should be
+                                        applied."
                                       type: string
                                   required:
                                   - type
@@ -2733,11 +2755,11 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service\
-                                        \ to place in the gRPC HealthCheckRequest\
-                                        \ (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\
-                                        \ \n If this is not specified, the default\
-                                        \ behavior is defined by gRPC."
+                                      description: "Service is the name of the service
+                                        to place in the gRPC HealthCheckRequest (see
+                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                        \n If this is not specified, the default behavior
+                                        is defined by gRPC."
                                       type: string
                                   required:
                                   - port
@@ -2974,15 +2996,23 @@ spec:
                           type: object
                         type: array
                       dnsConfig:
-                        description: Specifies the DNS parameters of a pod.
+                        description: Specifies the DNS parameters of a pod. Parameters
+                          specified here will be merged to the generated DNS configuration
+                          based on DNSPolicy.
                         properties:
                           nameservers:
-                            description: A list of DNS name server IP addresses.
+                            description: A list of DNS name server IP addresses. This
+                              will be appended to the base nameservers generated from
+                              DNSPolicy. Duplicated nameservers will be removed.
                             items:
                               type: string
                             type: array
                           options:
-                            description: A list of DNS resolver options.
+                            description: A list of DNS resolver options. This will
+                              be merged with the base options generated from DNSPolicy.
+                              Duplicated entries will be removed. Resolution options
+                              given in Options will override those that appear in
+                              the base DNSPolicy.
                             items:
                               description: PodDNSConfigOption defines DNS resolver
                                 options of a pod.
@@ -2996,34 +3026,49 @@ spec:
                             type: array
                           searches:
                             description: A list of DNS search domains for host-name
-                              lookup.
+                              lookup. This will be appended to the base search paths
+                              generated from DNSPolicy. Duplicated search paths will
+                              be removed.
                             items:
                               type: string
                             type: array
                         type: object
                       dnsPolicy:
-                        description: Set DNS policy for the pod.
+                        description: Set DNS policy for the pod. Defaults to "ClusterFirst".
+                          Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst',
+                          'Default' or 'None'. DNS parameters given in DNSConfig will
+                          be merged with the policy selected with DNSPolicy. To have
+                          DNS options set along with hostNetwork, you have to specify
+                          DNS policy explicitly to 'ClusterFirstWithHostNet'.
                         type: string
                       enableServiceLinks:
-                        description: EnableServiceLinks indicates whether information
-                          about services should be injected into pod's environment
-                          variables, matching the syntax of Docker links.
+                        description: 'EnableServiceLinks indicates whether information
+                          about services should be injected into pod''s environment
+                          variables, matching the syntax of Docker links. Optional:
+                          Defaults to true.'
                         type: boolean
                       ephemeralContainers:
                         description: List of ephemeral containers run in this pod.
+                          Ephemeral containers may be run in an existing pod to perform
+                          user-initiated actions such as debugging. This list cannot
+                          be specified when creating a pod, and it cannot be modified
+                          by updating the pod spec. In order to add an ephemeral container
+                          to an existing pod, use the pod's ephemeralcontainers subresource.
+                          This field is beta-level and available on clusters that
+                          haven't disabled the EphemeralContainers feature gate.
                         items:
-                          description: "An EphemeralContainer is a temporary container\
-                            \ that you may add to an existing Pod for user-initiated\
-                            \ activities such as debugging. Ephemeral containers have\
-                            \ no resource or scheduling guarantees, and they will\
-                            \ not be restarted when they exit or when a Pod is removed\
-                            \ or restarted. The kubelet may evict a Pod if an ephemeral\
-                            \ container causes the Pod to exceed its resource allocation.\
-                            \ \n To add an ephemeral container, use the ephemeralcontainers\
-                            \ subresource of an existing Pod. Ephemeral containers\
-                            \ may not be removed or restarted. \n This is a beta feature\
-                            \ available on clusters that haven't disabled the EphemeralContainers\
-                            \ feature gate."
+                          description: "An EphemeralContainer is a temporary container
+                            that you may add to an existing Pod for user-initiated
+                            activities such as debugging. Ephemeral containers have
+                            no resource or scheduling guarantees, and they will not
+                            be restarted when they exit or when a Pod is removed or
+                            restarted. The kubelet may evict a Pod if an ephemeral
+                            container causes the Pod to exceed its resource allocation.
+                            \n To add an ephemeral container, use the ephemeralcontainers
+                            subresource of an existing Pod. Ephemeral containers may
+                            not be removed or restarted. \n This is a beta feature
+                            available on clusters that haven't disabled the EphemeralContainers
+                            feature gate."
                           properties:
                             args:
                               description: 'Arguments to the entrypoint. The docker
@@ -3473,11 +3518,11 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service\
-                                        \ to place in the gRPC HealthCheckRequest\
-                                        \ (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\
-                                        \ \n If this is not specified, the default\
-                                        \ behavior is defined by gRPC."
+                                      description: "Service is the name of the service
+                                        to place in the gRPC HealthCheckRequest (see
+                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                        \n If this is not specified, the default behavior
+                                        is defined by gRPC."
                                       type: string
                                   required:
                                   - port
@@ -3676,11 +3721,11 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service\
-                                        \ to place in the gRPC HealthCheckRequest\
-                                        \ (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\
-                                        \ \n If this is not specified, the default\
-                                        \ behavior is defined by gRPC."
+                                      description: "Service is the name of the service
+                                        to place in the gRPC HealthCheckRequest (see
+                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                        \n If this is not specified, the default behavior
+                                        is defined by gRPC."
                                       type: string
                                   required:
                                   - port
@@ -3955,13 +4000,13 @@ spec:
                                         location. Must only be set if type is "Localhost".
                                       type: string
                                     type:
-                                      description: "type indicates which kind of seccomp\
-                                        \ profile will be applied. Valid options are:\
-                                        \ \n Localhost - a profile defined in a file\
-                                        \ on the node should be used. RuntimeDefault\
-                                        \ - the container runtime default profile\
-                                        \ should be used. Unconfined - no profile\
-                                        \ should be applied."
+                                      description: "type indicates which kind of seccomp
+                                        profile will be applied. Valid options are:
+                                        \n Localhost - a profile defined in a file
+                                        on the node should be used. RuntimeDefault
+                                        - the container runtime default profile should
+                                        be used. Unconfined - no profile should be
+                                        applied."
                                       type: string
                                   required:
                                   - type
@@ -4047,11 +4092,11 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service\
-                                        \ to place in the gRPC HealthCheckRequest\
-                                        \ (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\
-                                        \ \n If this is not specified, the default\
-                                        \ behavior is defined by gRPC."
+                                      description: "Service is the name of the service
+                                        to place in the gRPC HealthCheckRequest (see
+                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                        \n If this is not specified, the default behavior
+                                        is defined by gRPC."
                                       type: string
                                   required:
                                   - port
@@ -4185,15 +4230,15 @@ spec:
                                 will never receive an EOF. Default is false
                               type: boolean
                             targetContainerName:
-                              description: "If set, the name of the container from\
-                                \ PodSpec that this ephemeral container targets. The\
-                                \ ephemeral container will be run in the namespaces\
-                                \ (IPC, PID, etc) of this container. If not set then\
-                                \ the ephemeral container uses the namespaces configured\
-                                \ in the Pod spec. \n The container runtime must implement\
-                                \ support for this feature. If the runtime does not\
-                                \ support namespace targeting then the result of setting\
-                                \ this field is undefined."
+                              description: "If set, the name of the container from
+                                PodSpec that this ephemeral container targets. The
+                                ephemeral container will be run in the namespaces
+                                (IPC, PID, etc) of this container. If not set then
+                                the ephemeral container uses the namespaces configured
+                                in the Pod spec. \n The container runtime must implement
+                                support for this feature. If the runtime does not
+                                support namespace targeting then the result of setting
+                                this field is undefined."
                               type: string
                             terminationMessagePath:
                               description: 'Optional: Path at which the file to which
@@ -4302,6 +4347,7 @@ spec:
                       hostAliases:
                         description: HostAliases is an optional list of hosts and
                           IPs that will be injected into the pod's hosts file if specified.
+                          This is only valid for non-hostNetwork pods.
                         items:
                           description: HostAlias holds the mapping between IP and
                             hostnames that will be injected as an entry in the pod's
@@ -4322,7 +4368,9 @@ spec:
                           to false.'
                         type: boolean
                       hostNetwork:
-                        description: Host networking requested for this pod.
+                        description: Host networking requested for this pod. Use the
+                          host's network namespace. If this option is set, the ports
+                          that will be used must be specified. Default to false.
                         type: boolean
                       hostPID:
                         description: 'Use the host''s pid namespace. Optional: Default
@@ -4333,9 +4381,12 @@ spec:
                           the pod's hostname will be set to a system-defined value.
                         type: string
                       imagePullSecrets:
-                        description: ImagePullSecrets is an optional list of references
+                        description: 'ImagePullSecrets is an optional list of references
                           to secrets in the same namespace to use for pulling any
-                          of the images used by this PodSpec.
+                          of the images used by this PodSpec. If specified, these
+                          secrets will be passed to individual puller implementations
+                          for them to use. For example, in the case of docker, only
+                          DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                         items:
                           description: LocalObjectReference contains enough information
                             to let you locate the referenced object inside the same
@@ -4348,8 +4399,20 @@ spec:
                           type: object
                         type: array
                       initContainers:
-                        description: List of initialization containers belonging to
-                          the pod.
+                        description: 'List of initialization containers belonging
+                          to the pod. Init containers are executed in order prior
+                          to containers being started. If any init container fails,
+                          the pod is considered to have failed and is handled according
+                          to its restartPolicy. The name for an init container or
+                          normal container must be unique among all containers. Init
+                          containers may not have Lifecycle actions, Readiness probes,
+                          Liveness probes, or Startup probes. The resourceRequirements
+                          of an init container are taken into account during scheduling
+                          by finding the highest request/limit for each resource type,
+                          and then using the max of of that value or the sum of the
+                          normal containers. Limits are applied to init containers
+                          in a similar fashion. Init containers cannot currently be
+                          added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
                         items:
                           description: A single application container that you want
                             to run within a pod.
@@ -4808,11 +4871,11 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service\
-                                        \ to place in the gRPC HealthCheckRequest\
-                                        \ (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\
-                                        \ \n If this is not specified, the default\
-                                        \ behavior is defined by gRPC."
+                                      description: "Service is the name of the service
+                                        to place in the gRPC HealthCheckRequest (see
+                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                        \n If this is not specified, the default behavior
+                                        is defined by gRPC."
                                       type: string
                                   required:
                                   - port
@@ -5020,11 +5083,11 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service\
-                                        \ to place in the gRPC HealthCheckRequest\
-                                        \ (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\
-                                        \ \n If this is not specified, the default\
-                                        \ behavior is defined by gRPC."
+                                      description: "Service is the name of the service
+                                        to place in the gRPC HealthCheckRequest (see
+                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                        \n If this is not specified, the default behavior
+                                        is defined by gRPC."
                                       type: string
                                   required:
                                   - port
@@ -5298,13 +5361,13 @@ spec:
                                         location. Must only be set if type is "Localhost".
                                       type: string
                                     type:
-                                      description: "type indicates which kind of seccomp\
-                                        \ profile will be applied. Valid options are:\
-                                        \ \n Localhost - a profile defined in a file\
-                                        \ on the node should be used. RuntimeDefault\
-                                        \ - the container runtime default profile\
-                                        \ should be used. Unconfined - no profile\
-                                        \ should be applied."
+                                      description: "type indicates which kind of seccomp
+                                        profile will be applied. Valid options are:
+                                        \n Localhost - a profile defined in a file
+                                        on the node should be used. RuntimeDefault
+                                        - the container runtime default profile should
+                                        be used. Unconfined - no profile should be
+                                        applied."
                                       type: string
                                   required:
                                   - type
@@ -5398,11 +5461,11 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service\
-                                        \ to place in the gRPC HealthCheckRequest\
-                                        \ (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\
-                                        \ \n If this is not specified, the default\
-                                        \ behavior is defined by gRPC."
+                                      description: "Service is the name of the service
+                                        to place in the gRPC HealthCheckRequest (see
+                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                        \n If this is not specified, the default behavior
+                                        is defined by gRPC."
                                       type: string
                                   required:
                                   - port
@@ -5640,23 +5703,44 @@ spec:
                         type: array
                       nodeName:
                         description: NodeName is a request to schedule this pod onto
-                          a specific node.
+                          a specific node. If it is non-empty, the scheduler simply
+                          schedules this pod onto that node, assuming that it fits
+                          resource requirements.
                         type: string
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: NodeSelector is a selector which must be true
-                          for the pod to fit on a node.
+                        description: 'NodeSelector is a selector which must be true
+                          for the pod to fit on a node. Selector which must match
+                          a node''s labels for the pod to be scheduled on that node.
+                          More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                         type: object
                         x-kubernetes-map-type: atomic
                       os:
-                        description: "Specifies the OS of the containers in the pod.\n\
-                          \ If the OS field is set to linux, the following fields\
-                          \ must be unset: -securityContext.\n If the OS field is\
-                          \ set to windows, following fields must be unset: - spec."
+                        description: "Specifies the OS of the containers in the pod.
+                          Some pod and container fields are restricted if this is
+                          set. \n If the OS field is set to linux, the following fields
+                          must be unset: -securityContext.windowsOptions \n If the
+                          OS field is set to windows, following fields must be unset:
+                          - spec.hostPID - spec.hostIPC - spec.securityContext.seLinuxOptions
+                          - spec.securityContext.seccompProfile - spec.securityContext.fsGroup
+                          - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls
+                          - spec.shareProcessNamespace - spec.securityContext.runAsUser
+                          - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups
+                          - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile
+                          - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem
+                          - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation
+                          - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser
+                          - spec.containers[*].securityContext.runAsGroup This is
+                          an alpha field and requires the IdentifyPodOS feature"
                         properties:
                           name:
-                            description: Name is the name of the operating system.
+                            description: 'Name is the name of the operating system.
+                              The currently supported values are linux and windows.
+                              Additional value may be defined in future and can be
+                              one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                              Clients should expect to handle additional values and
+                              treat unrecognized values in this field as os: null'
                             type: string
                         required:
                         - name
@@ -5668,23 +5752,49 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: Overhead represents the resource overhead associated
-                          with running a pod for a given RuntimeClass.
+                        description: 'Overhead represents the resource overhead associated
+                          with running a pod for a given RuntimeClass. This field
+                          will be autopopulated at admission time by the RuntimeClass
+                          admission controller. If the RuntimeClass admission controller
+                          is enabled, overhead must not be set in Pod create requests.
+                          The RuntimeClass admission controller will reject Pod create
+                          requests which have the overhead already set. If RuntimeClass
+                          is configured and selected in the PodSpec, Overhead will
+                          be set to the value defined in the corresponding RuntimeClass,
+                          otherwise it will remain unset and treated as zero. More
+                          info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md
+                          This field is beta-level as of Kubernetes v1.18, and is
+                          only honored by servers that enable the PodOverhead feature.'
                         type: object
                       preemptionPolicy:
                         description: PreemptionPolicy is the Policy for preempting
-                          pods with lower priority.
+                          pods with lower priority. One of Never, PreemptLowerPriority.
+                          Defaults to PreemptLowerPriority if unset. This field is
+                          beta-level, gated by the NonPreemptingPriority feature-gate.
                         type: string
                       priority:
-                        description: The priority value.
+                        description: The priority value. Various system components
+                          use this field to find the priority of the pod. When Priority
+                          Admission Controller is enabled, it prevents users from
+                          setting this field. The admission controller populates this
+                          field from PriorityClassName. The higher the value, the
+                          higher the priority.
                         format: int32
                         type: integer
                       priorityClassName:
-                        description: If specified, indicates the pod's priority.
+                        description: If specified, indicates the pod's priority. "system-node-critical"
+                          and "system-cluster-critical" are two special keywords which
+                          indicate the highest priorities with the former being the
+                          highest priority. Any other name must be defined by creating
+                          a PriorityClass object with that name. If not specified,
+                          the pod priority will be default or zero if there is no
+                          default.
                         type: string
                       readinessGates:
-                        description: If specified, all readiness gates will be evaluated
-                          for pod readiness.
+                        description: 'If specified, all readiness gates will be evaluated
+                          for pod readiness. A pod is ready when all its containers
+                          are ready AND all conditions specified in the readiness
+                          gates have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
                         items:
                           description: PodReadinessGate contains the reference to
                             a pod condition
@@ -5698,50 +5808,91 @@ spec:
                           type: object
                         type: array
                       restartPolicy:
-                        description: Restart policy for all containers within the
-                          pod.
+                        description: 'Restart policy for all containers within the
+                          pod. One of Always, OnFailure, Never. Default to Always.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                         type: string
                       runtimeClassName:
-                        description: RuntimeClassName refers to a RuntimeClass object
-                          in the node.
+                        description: 'RuntimeClassName refers to a RuntimeClass object
+                          in the node.k8s.io group, which should be used to run this
+                          pod.  If no RuntimeClass resource matches the named class,
+                          the pod will not be run. If unset or empty, the "legacy"
+                          RuntimeClass will be used, which is an implicit class with
+                          an empty definition that uses the default runtime handler.
+                          More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class
+                          This is a beta feature as of Kubernetes v1.14.'
                         type: string
                       schedulerName:
                         description: If specified, the pod will be dispatched by specified
-                          scheduler.
+                          scheduler. If not specified, the pod will be dispatched
+                          by default scheduler.
                         type: string
                       securityContext:
-                        description: SecurityContext holds pod-level security attributes
-                          and common container settings.
+                        description: 'SecurityContext holds pod-level security attributes
+                          and common container settings. Optional: Defaults to empty.  See
+                          type description for default values of each field.'
                         properties:
                           fsGroup:
-                            description: "A special supplemental group that applies\
-                              \ to all containers in a pod.\n 1.\n If unset, the Kubelet\
-                              \ will not modify the ownership and permissions of any\
-                              \ volume."
+                            description: "A special supplemental group that applies
+                              to all containers in a pod. Some volume types allow
+                              the Kubelet to change the ownership of that volume to
+                              be owned by the pod: \n 1. The owning GID will be the
+                              FSGroup 2. The setgid bit is set (new files created
+                              in the volume will be owned by FSGroup) 3. The permission
+                              bits are OR'd with rw-rw---- \n If unset, the Kubelet
+                              will not modify the ownership and permissions of any
+                              volume. Note that this field cannot be set when spec.os.name
+                              is windows."
                             format: int64
                             type: integer
                           fsGroupChangePolicy:
-                            description: fsGroupChangePolicy defines behavior of changing
-                              ownership and permission of the volume before being
-                              exposed inside Pod.
+                            description: 'fsGroupChangePolicy defines behavior of
+                              changing ownership and permission of the volume before
+                              being exposed inside Pod. This field will only apply
+                              to volume types which support fsGroup based ownership(and
+                              permissions). It will have no effect on ephemeral volume
+                              types such as: secret, configmaps and emptydir. Valid
+                              values are "OnRootMismatch" and "Always". If not specified,
+                              "Always" is used. Note that this field cannot be set
+                              when spec.os.name is windows.'
                             type: string
                           runAsGroup:
                             description: The GID to run the entrypoint of the container
-                              process.
+                              process. Uses runtime default if unset. May also be
+                              set in SecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence for that container. Note that this
+                              field cannot be set when spec.os.name is windows.
                             format: int64
                             type: integer
                           runAsNonRoot:
                             description: Indicates that the container must run as
-                              a non-root user.
+                              a non-root user. If true, the Kubelet will validate
+                              the image at runtime to ensure that it does not run
+                              as UID 0 (root) and fail to start the container if it
+                              does. If unset or false, no such validation will be
+                              performed. May also be set in SecurityContext.  If set
+                              in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
                             type: boolean
                           runAsUser:
                             description: The UID to run the entrypoint of the container
-                              process.
+                              process. Defaults to user specified in image metadata
+                              if unspecified. May also be set in SecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence
+                              for that container. Note that this field cannot be set
+                              when spec.os.name is windows.
                             format: int64
                             type: integer
                           seLinuxOptions:
                             description: The SELinux context to be applied to all
-                              containers.
+                              containers. If unspecified, the container runtime will
+                              allocate a random SELinux context for each container.  May
+                              also be set in SecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence for that container. Note that this
+                              field cannot be set when spec.os.name is windows.
                             properties:
                               level:
                                 description: Level is SELinux level label that applies
@@ -5762,16 +5913,24 @@ spec:
                             type: object
                           seccompProfile:
                             description: The seccomp options to use by the containers
-                              in this pod.
+                              in this pod. Note that this field cannot be set when
+                              spec.os.name is windows.
                             properties:
                               localhostProfile:
                                 description: localhostProfile indicates a profile
-                                  defined in a file on the node should be used.
+                                  defined in a file on the node should be used. The
+                                  profile must be preconfigured on the node to work.
+                                  Must be a descending path, relative to the kubelet's
+                                  configured seccomp profile location. Must only be
+                                  set if type is "Localhost".
                                 type: string
                               type:
-                                description: "type indicates which kind of seccomp\
-                                  \ profile will be applied.\n Localhost - a profile\
-                                  \ defined in a file on the node should be used."
+                                description: "type indicates which kind of seccomp
+                                  profile will be applied. Valid options are: \n Localhost
+                                  - a profile defined in a file on the node should
+                                  be used. RuntimeDefault - the container runtime
+                                  default profile should be used. Unconfined - no
+                                  profile should be applied."
                                 type: string
                             required:
                             - type
@@ -5779,14 +5938,18 @@ spec:
                           supplementalGroups:
                             description: A list of groups applied to the first process
                               run in each container, in addition to the container's
-                              primary GID.
+                              primary GID.  If unspecified, no groups will be added
+                              to any container. Note that this field cannot be set
+                              when spec.os.name is windows.
                             items:
                               format: int64
                               type: integer
                             type: array
                           sysctls:
                             description: Sysctls hold a list of namespaced sysctls
-                              used for the pod.
+                              used for the pod. Pods with unsupported sysctls (by
+                              the container runtime) might fail to launch. Note that
+                              this field cannot be set when spec.os.name is windows.
                             items:
                               description: Sysctl defines a kernel parameter to be
                                 set
@@ -5804,11 +5967,17 @@ spec:
                             type: array
                           windowsOptions:
                             description: The Windows specific settings applied to
-                              all containers.
+                              all containers. If unspecified, the options within a
+                              container's SecurityContext will be used. If set in
+                              both SecurityContext and PodSecurityContext, the value
+                              specified in SecurityContext takes precedence. Note
+                              that this field cannot be set when spec.os.name is linux.
                             properties:
                               gmsaCredentialSpec:
                                 description: GMSACredentialSpec is where the GMSA
-                                  admission webhook (https://github.
+                                  admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                  inlines the contents of the GMSA credential spec
+                                  named by the GMSACredentialSpecName field.
                                 type: string
                               gmsaCredentialSpecName:
                                 description: GMSACredentialSpecName is the name of
@@ -5816,37 +5985,72 @@ spec:
                                 type: string
                               hostProcess:
                                 description: HostProcess determines if a container
-                                  should be run as a 'Host Process' container.
+                                  should be run as a 'Host Process' container. This
+                                  field is alpha-level and will only be honored by
+                                  components that enable the WindowsHostProcessContainers
+                                  feature flag. Setting this field without the feature
+                                  flag will result in errors when validating the Pod.
+                                  All of a Pod's containers must have the same effective
+                                  HostProcess value (it is not allowed to have a mix
+                                  of HostProcess containers and non-HostProcess containers).  In
+                                  addition, if HostProcess is true then HostNetwork
+                                  must also be set to true.
                                 type: boolean
                               runAsUserName:
                                 description: The UserName in Windows to run the entrypoint
-                                  of the container process.
+                                  of the container process. Defaults to the user specified
+                                  in image metadata if unspecified. May also be set
+                                  in PodSecurityContext. If set in both SecurityContext
+                                  and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
                                 type: string
                             type: object
                         type: object
                       serviceAccount:
-                        description: DeprecatedServiceAccount is a depreciated alias
-                          for ServiceAccountName.
+                        description: 'DeprecatedServiceAccount is a depreciated alias
+                          for ServiceAccountName. Deprecated: Use serviceAccountName
+                          instead.'
                         type: string
                       serviceAccountName:
-                        description: ServiceAccountName is the name of the ServiceAccount
-                          to use to run this pod.
+                        description: 'ServiceAccountName is the name of the ServiceAccount
+                          to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                         type: string
                       setHostnameAsFQDN:
                         description: If true the pod's hostname will be configured
                           as the pod's FQDN, rather than the leaf name (the default).
+                          In Linux containers, this means setting the FQDN in the
+                          hostname field of the kernel (the nodename field of struct
+                          utsname). In Windows containers, this means setting the
+                          registry value of hostname for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters
+                          to FQDN. If a pod does not have FQDN, this has no effect.
+                          Default to false.
                         type: boolean
                       shareProcessNamespace:
-                        description: Share a single process namespace between all
-                          of the containers in a pod.
+                        description: 'Share a single process namespace between all
+                          of the containers in a pod. When this is set containers
+                          will be able to view and signal processes from other containers
+                          in the same pod, and the first process in each container
+                          will not be assigned PID 1. HostPID and ShareProcessNamespace
+                          cannot both be set. Optional: Default to false.'
                         type: boolean
                       subdomain:
                         description: If specified, the fully qualified Pod hostname
-                          will be "<hostname>.
+                          will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
+                          domain>". If not specified, the pod will not have a domainname
+                          at all.
                         type: string
                       terminationGracePeriodSeconds:
                         description: Optional duration in seconds the pod needs to
-                          terminate gracefully.
+                          terminate gracefully. May be decreased in delete request.
+                          Value must be non-negative integer. The value zero indicates
+                          stop immediately via the kill signal (no opportunity to
+                          shut down). If this value is nil, the default grace period
+                          will be used instead. The grace period is the duration in
+                          seconds after the processes running in the pod are sent
+                          a termination signal and the time when the processes are
+                          forcibly halted with a kill signal. Set this value longer
+                          than the expected cleanup time for your process. Defaults
+                          to 30 seconds.
                         format: int64
                         type: integer
                       tolerations:
@@ -5893,7 +6097,9 @@ spec:
                         type: array
                       topologySpreadConstraints:
                         description: TopologySpreadConstraints describes how a group
-                          of pods ought to spread across topology domains.
+                          of pods ought to spread across topology domains. Scheduler
+                          will schedule pods in a way which abides by the constraints.
+                          All topologySpreadConstraints are ANDed.
                         items:
                           description: TopologySpreadConstraint specifies how to spread
                             matching pods among the given topology.
@@ -6004,8 +6210,8 @@ spec:
                         - whenUnsatisfiable
                         x-kubernetes-list-type: map
                       volumes:
-                        description: List of volumes that can be mounted by containers
-                          belonging to the pod.
+                        description: 'List of volumes that can be mounted by containers
+                          belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
                         items:
                           description: Volume represents a named volume in a pod that
                             may be accessed by any container in the pod.
@@ -6414,51 +6620,50 @@ spec:
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: "Ephemeral represents a volume that is\
-                                \ handled by a cluster storage driver. The volume's\
-                                \ lifecycle is tied to the pod that defines it - it\
-                                \ will be created before the pod starts, and deleted\
-                                \ when the pod is removed. \n Use this if: a) the\
-                                \ volume is only needed while the pod runs, b) features\
-                                \ of normal volumes like restoring from snapshot or\
-                                \ capacity tracking are needed, c) the storage driver\
-                                \ is specified through a storage class, and d) the\
-                                \ storage driver supports dynamic volume provisioning\
-                                \ through a PersistentVolumeClaim (see EphemeralVolumeSource\
-                                \ for more information on the connection between this\
-                                \ volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim\
-                                \ or one of the vendor-specific APIs for volumes that\
-                                \ persist for longer than the lifecycle of an individual\
-                                \ pod. \n Use CSI for light-weight local ephemeral\
-                                \ volumes if the CSI driver is meant to be used that\
-                                \ way - see the documentation of the driver for more\
-                                \ information. \n A pod can use both types of ephemeral\
-                                \ volumes and persistent volumes at the same time."
+                              description: "Ephemeral represents a volume that is
+                                handled by a cluster storage driver. The volume's
+                                lifecycle is tied to the pod that defines it - it
+                                will be created before the pod starts, and deleted
+                                when the pod is removed. \n Use this if: a) the volume
+                                is only needed while the pod runs, b) features of
+                                normal volumes like restoring from snapshot or capacity
+                                tracking are needed, c) the storage driver is specified
+                                through a storage class, and d) the storage driver
+                                supports dynamic volume provisioning through a PersistentVolumeClaim
+                                (see EphemeralVolumeSource for more information on
+                                the connection between this volume type and PersistentVolumeClaim).
+                                \n Use PersistentVolumeClaim or one of the vendor-specific
+                                APIs for volumes that persist for longer than the
+                                lifecycle of an individual pod. \n Use CSI for light-weight
+                                local ephemeral volumes if the CSI driver is meant
+                                to be used that way - see the documentation of the
+                                driver for more information. \n A pod can use both
+                                types of ephemeral volumes and persistent volumes
+                                at the same time."
                               properties:
                                 volumeClaimTemplate:
-                                  description: "Will be used to create a stand-alone\
-                                    \ PVC to provision the volume. The pod in which\
-                                    \ this EphemeralVolumeSource is embedded will\
-                                    \ be the owner of the PVC, i.e. the PVC will be\
-                                    \ deleted together with the pod.  The name of\
-                                    \ the PVC will be `<pod name>-<volume name>` where\
-                                    \ `<volume name>` is the name from the `PodSpec.Volumes`\
-                                    \ array entry. Pod validation will reject the\
-                                    \ pod if the concatenated name is not valid for\
-                                    \ a PVC (for example, too long). \n An existing\
-                                    \ PVC with that name that is not owned by the\
-                                    \ pod will *not* be used for the pod to avoid\
-                                    \ using an unrelated volume by mistake. Starting\
-                                    \ the pod is then blocked until the unrelated\
-                                    \ PVC is removed. If such a pre-created PVC is\
-                                    \ meant to be used by the pod, the PVC has to\
-                                    \ updated with an owner reference to the pod once\
-                                    \ the pod exists. Normally this should not be\
-                                    \ necessary, but it may be useful when manually\
-                                    \ reconstructing a broken cluster. \n This field\
-                                    \ is read-only and no changes will be made by\
-                                    \ Kubernetes to the PVC after it has been created.\
-                                    \ \n Required, must not be nil."
+                                  description: "Will be used to create a stand-alone
+                                    PVC to provision the volume. The pod in which
+                                    this EphemeralVolumeSource is embedded will be
+                                    the owner of the PVC, i.e. the PVC will be deleted
+                                    together with the pod.  The name of the PVC will
+                                    be `<pod name>-<volume name>` where `<volume name>`
+                                    is the name from the `PodSpec.Volumes` array entry.
+                                    Pod validation will reject the pod if the concatenated
+                                    name is not valid for a PVC (for example, too
+                                    long). \n An existing PVC with that name that
+                                    is not owned by the pod will *not* be used for
+                                    the pod to avoid using an unrelated volume by
+                                    mistake. Starting the pod is then blocked until
+                                    the unrelated PVC is removed. If such a pre-created
+                                    PVC is meant to be used by the pod, the PVC has
+                                    to updated with an owner reference to the pod
+                                    once the pod exists. Normally this should not
+                                    be necessary, but it may be useful when manually
+                                    reconstructing a broken cluster. \n This field
+                                    is read-only and no changes will be made by Kubernetes
+                                    to the PVC after it has been created. \n Required,
+                                    must not be nil."
                                   properties:
                                     metadata:
                                       description: May contain labels and annotations
@@ -6617,25 +6822,10 @@ spec:
                                                   the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label
-                                                      key that the selector applies
-                                                      to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -7076,32 +7266,11 @@ spec:
                                                 path within a volume.
                                               properties:
                                                 key:
-                                                  description: The key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'Optional: mode bits
-                                                    used to set permissions on this
-                                                    file. Must be an octal value between
-                                                    0000 and 0777 or a decimal value
-                                                    between 0 and 511. YAML accepts
-                                                    both octal and decimal values,
-                                                    JSON requires decimal values for
-                                                    mode bits. If not specified, the
-                                                    volume defaultMode will be used.
-                                                    This might be in conflict with
-                                                    other options that affect the
-                                                    file mode, like fsGroup, and the
-                                                    result can be other mode bits
-                                                    set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: The relative path of
-                                                    the file to map the key to. May
-                                                    not be an absolute path. May not
-                                                    contain the path element '..'.
-                                                    May not start with the string
-                                                    '..'.
                                                   type: string
                                               required:
                                               - key
@@ -7132,75 +7301,30 @@ spec:
                                                 the pod field
                                               properties:
                                                 fieldRef:
-                                                  description: 'Required: Selects
-                                                    a field of the pod: only annotations,
-                                                    labels, name and namespace are
-                                                    supported.'
                                                   properties:
                                                     apiVersion:
-                                                      description: Version of the
-                                                        schema the FieldPath is written
-                                                        in terms of, defaults to "v1".
                                                       type: string
                                                     fieldPath:
-                                                      description: Path of the field
-                                                        to select in the specified
-                                                        API version.
                                                       type: string
                                                   required:
                                                   - fieldPath
                                                   type: object
                                                 mode:
-                                                  description: 'Optional: mode bits
-                                                    used to set permissions on this
-                                                    file, must be an octal value between
-                                                    0000 and 0777 or a decimal value
-                                                    between 0 and 511. YAML accepts
-                                                    both octal and decimal values,
-                                                    JSON requires decimal values for
-                                                    mode bits. If not specified, the
-                                                    volume defaultMode will be used.
-                                                    This might be in conflict with
-                                                    other options that affect the
-                                                    file mode, like fsGroup, and the
-                                                    result can be other mode bits
-                                                    set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: 'Required: Path is  the
-                                                    relative path name of the file
-                                                    to be created. Must not be absolute
-                                                    or contain the ''..'' path. Must
-                                                    be utf-8 encoded. The first item
-                                                    of the relative path must not
-                                                    start with ''..'''
                                                   type: string
                                                 resourceFieldRef:
-                                                  description: 'Selects a resource
-                                                    of the container: only resources
-                                                    limits and requests (limits.cpu,
-                                                    limits.memory, requests.cpu and
-                                                    requests.memory) are currently
-                                                    supported.'
                                                   properties:
                                                     containerName:
-                                                      description: 'Container name:
-                                                        required for volumes, optional
-                                                        for env vars'
                                                       type: string
                                                     divisor:
                                                       anyOf:
                                                       - type: integer
                                                       - type: string
-                                                      description: Specifies the output
-                                                        format of the exposed resources,
-                                                        defaults to "1"
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
-                                                      description: 'Required: resource
-                                                        to select'
                                                       type: string
                                                   required:
                                                   - resource
@@ -7233,32 +7357,11 @@ spec:
                                                 path within a volume.
                                               properties:
                                                 key:
-                                                  description: The key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'Optional: mode bits
-                                                    used to set permissions on this
-                                                    file. Must be an octal value between
-                                                    0000 and 0777 or a decimal value
-                                                    between 0 and 511. YAML accepts
-                                                    both octal and decimal values,
-                                                    JSON requires decimal values for
-                                                    mode bits. If not specified, the
-                                                    volume defaultMode will be used.
-                                                    This might be in conflict with
-                                                    other options that affect the
-                                                    file mode, like fsGroup, and the
-                                                    result can be other mode bits
-                                                    set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: The relative path of
-                                                    the file to map the key to. May
-                                                    not be an absolute path. May not
-                                                    contain the path element '..'.
-                                                    May not start with the string
-                                                    '..'.
                                                   type: string
                                               required:
                                               - key
@@ -7616,7 +7719,8 @@ spec:
                     type: object
                 type: object
               replicas:
-                description: Number of desired pods.
+                description: Number of desired pods. This is a pointer to distinguish
+                  between explicit zero and not specified. Defaults to 1.
                 format: int32
                 type: integer
               routegroup:
@@ -7629,20 +7733,26 @@ spec:
                     type: boolean
                   hosts:
                     description: Hostnames to use for the per-stack ingresses (or
-                      route groups).
+                      route groups). These must contain the special $(STACK_NAME)
+                      token, which will be replaced with the stack's name. Would be
+                      automatically generated based on the hosts in the ingress/routegroup
+                      entry if unset.
                     items:
                       type: string
                     type: array
                   metadata:
                     description: EmbeddedObjectMetaWithAnnotations defines the metadata
-                      which can be attached to a resource.
+                      which can be attached to a resource. It's a slimmed down version
+                      of metav1.ObjectMeta only containing annotations.
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations is an unstructured key value map
+                        description: 'Annotations is an unstructured key value map
                           stored with a resource that may be set by external tools
-                          to store and retrieve arbitrary metadata.
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
                         type: object
                     type: object
                 type: object
@@ -7653,18 +7763,22 @@ spec:
                 properties:
                   metadata:
                     description: EmbeddedObjectMetaWithAnnotations defines the metadata
-                      which can be attached to a resource.
+                      which can be attached to a resource. It's a slimmed down version
+                      of metav1.ObjectMeta only containing annotations.
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations is an unstructured key value map
+                        description: 'Annotations is an unstructured key value map
                           stored with a resource that may be set by external tools
-                          to store and retrieve arbitrary metadata.
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
                         type: object
                     type: object
                   ports:
-                    description: The list of ports that are exposed by this service.
+                    description: 'The list of ports that are exposed by this service.
+                      More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
                     items:
                       description: ServicePort contains information on service's port.
                       properties:
@@ -7729,21 +7843,42 @@ spec:
                   deployment
                 properties:
                   rollingUpdate:
-                    description: Rolling update config params.
+                    description: 'Rolling update config params. Present only if DeploymentStrategyType
+                      = RollingUpdate. --- TODO: Update this to follow our convention
+                      for oneOf, whatever we decide it to be.'
                     properties:
                       maxSurge:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: The maximum number of pods that can be scheduled
-                          above the desired number of pods.
+                        description: 'The maximum number of pods that can be scheduled
+                          above the desired number of pods. Value can be an absolute
+                          number (ex: 5) or a percentage of desired pods (ex: 10%).
+                          This can not be 0 if MaxUnavailable is 0. Absolute number
+                          is calculated from percentage by rounding up. Defaults to
+                          25%. Example: when this is set to 30%, the new ReplicaSet
+                          can be scaled up immediately when the rolling update starts,
+                          such that the total number of old and new pods do not exceed
+                          130% of desired pods. Once old pods have been killed, new
+                          ReplicaSet can be scaled up further, ensuring that total
+                          number of pods running at any time during the update is
+                          at most 130% of desired pods.'
                         x-kubernetes-int-or-string: true
                       maxUnavailable:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: The maximum number of pods that can be unavailable
-                          during the update.
+                        description: 'The maximum number of pods that can be unavailable
+                          during the update. Value can be an absolute number (ex:
+                          5) or a percentage of desired pods (ex: 10%). Absolute number
+                          is calculated from percentage by rounding down. This can
+                          not be 0 if MaxSurge is 0. Defaults to 25%. Example: when
+                          this is set to 30%, the old ReplicaSet can be scaled down
+                          to 70% of desired pods immediately when the rolling update
+                          starts. Once new pods are ready, old ReplicaSet can be scaled
+                          down further, followed by scaling up the new ReplicaSet,
+                          ensuring that the total number of pods available at all
+                          times during the update is at least 70% of desired pods.'
                         x-kubernetes-int-or-string: true
                     type: object
                   type:
@@ -7758,8 +7893,9 @@ spec:
             description: StackStatus is the status part of the Stack.
             properties:
               actualTrafficWeight:
-                description: ActualTrafficWeight is the actual amount of traffic currently
-                  routed to the stack.
+                description: 'ActualTrafficWeight is the actual amount of traffic
+                  currently routed to the stack. TODO: should we be using floats in
+                  the API?'
                 format: float
                 type: number
               desiredReplicas:
@@ -7831,7 +7967,7 @@ spec:
       status: {}
 status:
   acceptedNames:
-    kind: ''
-    plural: ''
+    kind: ""
+    plural: ""
   conditions: []
   storedVersions: []

--- a/cluster/manifests/stackset-controller/01-stackset-crd.yaml
+++ b/cluster/manifests/stackset-controller/01-stackset-crd.yaml
@@ -1,4 +1,4 @@
-
+# This is an adjusted copy of https://github.com/zalando-incubator/stackset-controller/blob/master/docs/stackset_crd.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -41,12 +41,14 @@ spec:
         description: StackSet describes an application resource.
         properties:
           apiVersion:
-            description: APIVersion defines the versioned schema of this representation
-              of an object.
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: Kind is a string value representing the REST resource this
-              object represents.
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -67,7 +69,9 @@ spec:
                 type: object
               ingress:
                 description: Ingress is the information we need to create ingress
-                  and service.
+                  and service. Ingress is optional, because other controller might
+                  create ingress objects, but stackset owns the traffic switch. In
+                  this case we would only have a Traffic, but no ingress.
                 properties:
                   backendPort:
                     anyOf:
@@ -80,14 +84,17 @@ spec:
                     type: array
                   metadata:
                     description: EmbeddedObjectMetaWithAnnotations defines the metadata
-                      which can be attached to a resource.
+                      which can be attached to a resource. It's a slimmed down version
+                      of metav1.ObjectMeta only containing annotations.
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations is an unstructured key value map
+                        description: 'Annotations is an unstructured key value map
                           stored with a resource that may be set by external tools
-                          to store and retrieve arbitrary metadata.
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
                         type: object
                     type: object
                   path:
@@ -103,7 +110,8 @@ spec:
               routegroup:
                 description: RouteGroup is an alternative to ingress allowing more
                   advanced routing configuration while still maintaining the ability
-                  to switch traffic to stacks.
+                  to switch traffic to stacks. Use this if you need skipper filters
+                  or predicates.
                 properties:
                   additionalBackends:
                     description: AdditionalBackends is the list of additional backends
@@ -170,14 +178,17 @@ spec:
                     type: string
                   metadata:
                     description: EmbeddedObjectMetaWithAnnotations defines the metadata
-                      which can be attached to a resource.
+                      which can be attached to a resource. It's a slimmed down version
+                      of metav1.ObjectMeta only containing annotations.
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations is an unstructured key value map
+                        description: 'Annotations is an unstructured key value map
                           stored with a resource that may be set by external tools
-                          to store and retrieve arbitrary metadata.
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
                         type: object
                     type: object
                   routes:
@@ -257,14 +268,15 @@ spec:
                 properties:
                   limit:
                     description: Limit defines the maximum number of Stacks to keep
-                      around.
+                      around. If the number of Stacks exceeds the limit then the oldest
+                      stacks which are not getting traffic are deleted.
                     format: int32
                     minimum: 1
                     type: integer
                   scaledownTTLSeconds:
                     description: ScaledownTTLSeconds is the ttl in seconds for when
                       Stacks of a StackSet should be scaled down to 0 replicas in
-                      case they are not getting traffic.
+                      case they are not getting traffic. Defaults to 300 seconds.
                     format: int64
                     type: integer
                 type: object
@@ -274,14 +286,17 @@ spec:
                 properties:
                   metadata:
                     description: EmbeddedObjectMetaWithAnnotations defines the metadata
-                      which can be attached to a resource.
+                      which can be attached to a resource. It's a slimmed down version
+                      of metav1.ObjectMeta only containing annotations.
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations is an unstructured key value map
+                        description: 'Annotations is an unstructured key value map
                           stored with a resource that may be set by external tools
-                          to store and retrieve arbitrary metadata.
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
                         type: object
                     type: object
                   spec:
@@ -294,15 +309,22 @@ spec:
                           behavior:
                             description: behavior configures the scaling behavior
                               of the target in both Up and Down directions (scaleUp
-                              and scaleDown fields respectively).
+                              and scaleDown fields respectively). If not set, the
+                              default HPAScalingRules for scale up and scale down
+                              are used.
                             properties:
                               scaleDown:
                                 description: scaleDown is scaling policy for scaling
-                                  Down.
+                                  Down. If not set, the default value is to allow
+                                  to scale down to minReplicas pods, with a 300 second
+                                  stabilization window (i.e., the highest recommendation
+                                  for the last 300sec is used).
                                 properties:
                                   policies:
                                     description: policies is a list of potential scaling
-                                      polices which can be used during scaling.
+                                      polices which can be used during scaling. At
+                                      least one policy must be specified, otherwise
+                                      the HPAScalingRules will be discarded as invalid
                                     items:
                                       description: HPAScalingPolicy is a single policy
                                         which must hold true for a specified past
@@ -335,23 +357,34 @@ spec:
                                     x-kubernetes-list-type: atomic
                                   selectPolicy:
                                     description: selectPolicy is used to specify which
-                                      policy should be used.
+                                      policy should be used. If not set, the default
+                                      value Max is used.
                                     type: string
                                   stabilizationWindowSeconds:
-                                    description: StabilizationWindowSeconds is the
+                                    description: 'StabilizationWindowSeconds is the
                                       number of seconds for which past recommendations
                                       should be considered while scaling up or scaling
-                                      down.
+                                      down. StabilizationWindowSeconds must be greater
+                                      than or equal to zero and less than or equal
+                                      to 3600 (one hour). If not set, use the default
+                                      values: - For scale up: 0 (i.e. no stabilization
+                                      is done). - For scale down: 300 (i.e. the stabilization
+                                      window is 300 seconds long).'
                                     format: int32
                                     type: integer
                                 type: object
                               scaleUp:
-                                description: scaleUp is scaling policy for scaling
-                                  Up.
+                                description: 'scaleUp is scaling policy for scaling
+                                  Up. If not set, the default value is the higher
+                                  of: * increase no more than 4 pods per 60 seconds
+                                  * double the number of pods per 60 seconds No stabilization
+                                  is used.'
                                 properties:
                                   policies:
                                     description: policies is a list of potential scaling
-                                      polices which can be used during scaling.
+                                      polices which can be used during scaling. At
+                                      least one policy must be specified, otherwise
+                                      the HPAScalingRules will be discarded as invalid
                                     items:
                                       description: HPAScalingPolicy is a single policy
                                         which must hold true for a specified past
@@ -384,20 +417,27 @@ spec:
                                     x-kubernetes-list-type: atomic
                                   selectPolicy:
                                     description: selectPolicy is used to specify which
-                                      policy should be used.
+                                      policy should be used. If not set, the default
+                                      value Max is used.
                                     type: string
                                   stabilizationWindowSeconds:
-                                    description: StabilizationWindowSeconds is the
+                                    description: 'StabilizationWindowSeconds is the
                                       number of seconds for which past recommendations
                                       should be considered while scaling up or scaling
-                                      down.
+                                      down. StabilizationWindowSeconds must be greater
+                                      than or equal to zero and less than or equal
+                                      to 3600 (one hour). If not set, use the default
+                                      values: - For scale up: 0 (i.e. no stabilization
+                                      is done). - For scale down: 300 (i.e. the stabilization
+                                      window is 300 seconds long).'
                                     format: int32
                                     type: integer
                                 type: object
                             type: object
                           maxReplicas:
                             description: maxReplicas is the upper limit for the number
-                              of replicas to which the autoscaler can scale up.
+                              of replicas to which the autoscaler can scale up. It
+                              cannot be less that minReplicas.
                             format: int32
                             type: integer
                           metrics:
@@ -536,29 +576,37 @@ spec:
                           minReplicas:
                             description: minReplicas is the lower limit for the number
                               of replicas to which the autoscaler can scale down.
+                              It defaults to 1 pod.
                             format: int32
                             type: integer
                         required:
                         - maxReplicas
                         - metrics
                         type: object
-{{- if eq .Cluster.ConfigItems.stackset_legacy_hpa_field_crd_enabled "true" }}
+# {{ if eq .Cluster.ConfigItems.stackset_legacy_hpa_field_crd_enabled "true" }}
                       horizontalPodAutoscaler:
                         description: HorizontalPodAutoscaler is the Autoscaling configuration
-                          of a Stack.
+                          of a Stack. If defined an HPA will be created for the Stack.
                         properties:
                           behavior:
                             description: behavior configures the scaling behavior
                               of the target in both Up and Down directions (scaleUp
-                              and scaleDown fields respectively).
+                              and scaleDown fields respectively). If not set, the
+                              default HPAScalingRules for scale up and scale down
+                              are used.
                             properties:
                               scaleDown:
                                 description: scaleDown is scaling policy for scaling
-                                  Down.
+                                  Down. If not set, the default value is to allow
+                                  to scale down to minReplicas pods, with a 300 second
+                                  stabilization window (i.e., the highest recommendation
+                                  for the last 300sec is used).
                                 properties:
                                   policies:
                                     description: policies is a list of potential scaling
-                                      polices which can be used during scaling.
+                                      polices which can be used during scaling. At
+                                      least one policy must be specified, otherwise
+                                      the HPAScalingRules will be discarded as invalid
                                     items:
                                       description: HPAScalingPolicy is a single policy
                                         which must hold true for a specified past
@@ -591,23 +639,34 @@ spec:
                                     x-kubernetes-list-type: atomic
                                   selectPolicy:
                                     description: selectPolicy is used to specify which
-                                      policy should be used.
+                                      policy should be used. If not set, the default
+                                      value Max is used.
                                     type: string
                                   stabilizationWindowSeconds:
-                                    description: StabilizationWindowSeconds is the
+                                    description: 'StabilizationWindowSeconds is the
                                       number of seconds for which past recommendations
                                       should be considered while scaling up or scaling
-                                      down.
+                                      down. StabilizationWindowSeconds must be greater
+                                      than or equal to zero and less than or equal
+                                      to 3600 (one hour). If not set, use the default
+                                      values: - For scale up: 0 (i.e. no stabilization
+                                      is done). - For scale down: 300 (i.e. the stabilization
+                                      window is 300 seconds long).'
                                     format: int32
                                     type: integer
                                 type: object
                               scaleUp:
-                                description: scaleUp is scaling policy for scaling
-                                  Up.
+                                description: 'scaleUp is scaling policy for scaling
+                                  Up. If not set, the default value is the higher
+                                  of: * increase no more than 4 pods per 60 seconds
+                                  * double the number of pods per 60 seconds No stabilization
+                                  is used.'
                                 properties:
                                   policies:
                                     description: policies is a list of potential scaling
-                                      polices which can be used during scaling.
+                                      polices which can be used during scaling. At
+                                      least one policy must be specified, otherwise
+                                      the HPAScalingRules will be discarded as invalid
                                     items:
                                       description: HPAScalingPolicy is a single policy
                                         which must hold true for a specified past
@@ -640,26 +699,39 @@ spec:
                                     x-kubernetes-list-type: atomic
                                   selectPolicy:
                                     description: selectPolicy is used to specify which
-                                      policy should be used.
+                                      policy should be used. If not set, the default
+                                      value Max is used.
                                     type: string
                                   stabilizationWindowSeconds:
-                                    description: StabilizationWindowSeconds is the
+                                    description: 'StabilizationWindowSeconds is the
                                       number of seconds for which past recommendations
                                       should be considered while scaling up or scaling
-                                      down.
+                                      down. StabilizationWindowSeconds must be greater
+                                      than or equal to zero and less than or equal
+                                      to 3600 (one hour). If not set, use the default
+                                      values: - For scale up: 0 (i.e. no stabilization
+                                      is done). - For scale down: 300 (i.e. the stabilization
+                                      window is 300 seconds long).'
                                     format: int32
                                     type: integer
                                 type: object
                             type: object
                           maxReplicas:
                             description: maxReplicas is the upper limit for the number
-                              of replicas to which the autoscaler can scale up.
+                              of replicas to which the autoscaler can scale up. It
+                              cannot be less that minReplicas.
                             format: int32
                             type: integer
                           metrics:
                             description: metrics contains the specifications for which
                               to use to calculate the desired replica count (the maximum
-                              replica count across all metrics will be used).
+                              replica count across all metrics will be used).  The
+                              desired replica count is calculated multiplying the
+                              ratio between the target value and the current value
+                              by the current number of pods.  Ergo, metrics used must
+                              decrease as the pod count is increased, and vice-versa.  See
+                              the individual metric source types for more information
+                              about how each type of metric must respond.
                             items:
                               description: MetricSpec specifies how to scale based
                                 on a single metric (only `type` and one other matching
@@ -1031,12 +1103,13 @@ spec:
                           minReplicas:
                             description: minReplicas is the lower limit for the number
                               of replicas to which the autoscaler can scale down.
+                              It defaults to 1 pod.
                             format: int32
                             type: integer
                         required:
                         - maxReplicas
                         type: object
-{{- end }}
+# {{ end }}
                       ingress:
                         description: Settings for the per-stack ingresses (in case
                           the StackSet has a configured ingress)
@@ -1047,27 +1120,35 @@ spec:
                             type: boolean
                           hosts:
                             description: Hostnames to use for the per-stack ingresses
-                              (or route groups).
+                              (or route groups). These must contain the special $(STACK_NAME)
+                              token, which will be replaced with the stack's name.
+                              Would be automatically generated based on the hosts
+                              in the ingress/routegroup entry if unset.
                             items:
                               type: string
                             type: array
                           metadata:
                             description: EmbeddedObjectMetaWithAnnotations defines
-                              the metadata which can be attached to a resource.
+                              the metadata which can be attached to a resource. It's
+                              a slimmed down version of metav1.ObjectMeta only containing
+                              annotations.
                             properties:
                               annotations:
                                 additionalProperties:
                                   type: string
-                                description: Annotations is an unstructured key value
+                                description: 'Annotations is an unstructured key value
                                   map stored with a resource that may be set by external
                                   tools to store and retrieve arbitrary metadata.
+                                  They are not queryable and should be preserved when
+                                  modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
                                 type: object
                             type: object
                         type: object
                       minReadySeconds:
                         description: Minimum number of seconds for which a newly created
                           pod should be ready without any of its container crashing,
-                          for it to be considered available.
+                          for it to be considered available. Defaults to 0 (pod will
+                          be considered available as soon as it is ready)
                         format: int32
                         type: integer
                       podTemplate:
@@ -1079,27 +1160,31 @@ spec:
                               annotations:
                                 additionalProperties:
                                   type: string
-                                description: Annotations is an unstructured key value
+                                description: 'Annotations is an unstructured key value
                                   map stored with a resource that may be set by external
                                   tools to store and retrieve arbitrary metadata.
+                                  They are not queryable and should be preserved when
+                                  modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
                                 type: object
                               labels:
                                 additionalProperties:
                                   type: string
-                                description: Map of string keys and values that can
+                                description: 'Map of string keys and values that can
                                   be used to organize and categorize (scope and select)
-                                  objects.
+                                  objects. May match selectors of replication controllers
+                                  and services. More info: http://kubernetes.io/docs/user-guide/labels'
                                 type: object
                             type: object
                           spec:
-                            description: Specification of the desired behavior of
-                              the pod.
+                            description: 'Specification of the desired behavior of
+                              the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
                             properties:
                               activeDeadlineSeconds:
                                 description: Optional duration in seconds the pod
                                   may be active on the node relative to StartTime
                                   before the system will actively try to mark it failed
-                                  and kill associated containers.
+                                  and kill associated containers. Value must be a
+                                  positive integer.
                                 format: int64
                                 type: integer
                               affinity:
@@ -1114,7 +1199,17 @@ spec:
                                           schedule pods to nodes that satisfy the
                                           affinity expressions specified by this field,
                                           but it may choose a node that violates one
-                                          or more of the expressions.
+                                          or more of the expressions. The node that
+                                          is most preferred is the one with the greatest
+                                          sum of weights, i.e. for each node that
+                                          meets all of the scheduling requirements
+                                          (resource request, requiredDuringScheduling
+                                          affinity expressions, etc.), compute a sum
+                                          by iterating through the elements of this
+                                          field and adding "weight" to the sum if
+                                          the node matches the corresponding matchExpressions;
+                                          the node(s) with the highest sum are the
+                                          most preferred.
                                         items:
                                           description: An empty preferred scheduling
                                             term matches all objects with implicit
@@ -1136,32 +1231,10 @@ spec:
                                                       that relates the key and values.
                                                     properties:
                                                       key:
-                                                        description: The label key
-                                                          that the selector applies
-                                                          to.
                                                         type: string
                                                       operator:
-                                                        description: Represents a
-                                                          key's relationship to a
-                                                          set of values. Valid operators
-                                                          are In, NotIn, Exists, DoesNotExist.
-                                                          Gt, and Lt.
                                                         type: string
                                                       values:
-                                                        description: An array of string
-                                                          values. If the operator
-                                                          is In or NotIn, the values
-                                                          array must be non-empty.
-                                                          If the operator is Exists
-                                                          or DoesNotExist, the values
-                                                          array must be empty. If
-                                                          the operator is Gt or Lt,
-                                                          the values array must have
-                                                          a single element, which
-                                                          will be interpreted as an
-                                                          integer. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -1180,32 +1253,10 @@ spec:
                                                       that relates the key and values.
                                                     properties:
                                                       key:
-                                                        description: The label key
-                                                          that the selector applies
-                                                          to.
                                                         type: string
                                                       operator:
-                                                        description: Represents a
-                                                          key's relationship to a
-                                                          set of values. Valid operators
-                                                          are In, NotIn, Exists, DoesNotExist.
-                                                          Gt, and Lt.
                                                         type: string
                                                       values:
-                                                        description: An array of string
-                                                          values. If the operator
-                                                          is In or NotIn, the values
-                                                          array must be non-empty.
-                                                          If the operator is Exists
-                                                          or DoesNotExist, the values
-                                                          array must be empty. If
-                                                          the operator is Gt or Lt,
-                                                          the values array must have
-                                                          a single element, which
-                                                          will be interpreted as an
-                                                          integer. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -1230,7 +1281,11 @@ spec:
                                         description: If the affinity requirements
                                           specified by this field are not met at scheduling
                                           time, the pod will not be scheduled onto
-                                          the node.
+                                          the node. If the affinity requirements specified
+                                          by this field cease to be met at some point
+                                          during pod execution (e.g. due to an update),
+                                          the system may or may not try to eventually
+                                          evict the pod from its node.
                                         properties:
                                           nodeSelectorTerms:
                                             description: Required. A list of node
@@ -1251,32 +1306,10 @@ spec:
                                                       that relates the key and values.
                                                     properties:
                                                       key:
-                                                        description: The label key
-                                                          that the selector applies
-                                                          to.
                                                         type: string
                                                       operator:
-                                                        description: Represents a
-                                                          key's relationship to a
-                                                          set of values. Valid operators
-                                                          are In, NotIn, Exists, DoesNotExist.
-                                                          Gt, and Lt.
                                                         type: string
                                                       values:
-                                                        description: An array of string
-                                                          values. If the operator
-                                                          is In or NotIn, the values
-                                                          array must be non-empty.
-                                                          If the operator is Exists
-                                                          or DoesNotExist, the values
-                                                          array must be empty. If
-                                                          the operator is Gt or Lt,
-                                                          the values array must have
-                                                          a single element, which
-                                                          will be interpreted as an
-                                                          integer. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -1295,32 +1328,10 @@ spec:
                                                       that relates the key and values.
                                                     properties:
                                                       key:
-                                                        description: The label key
-                                                          that the selector applies
-                                                          to.
                                                         type: string
                                                       operator:
-                                                        description: Represents a
-                                                          key's relationship to a
-                                                          set of values. Valid operators
-                                                          are In, NotIn, Exists, DoesNotExist.
-                                                          Gt, and Lt.
                                                         type: string
                                                       values:
-                                                        description: An array of string
-                                                          values. If the operator
-                                                          is In or NotIn, the values
-                                                          array must be non-empty.
-                                                          If the operator is Exists
-                                                          or DoesNotExist, the values
-                                                          array must be empty. If
-                                                          the operator is Gt or Lt,
-                                                          the values array must have
-                                                          a single element, which
-                                                          will be interpreted as an
-                                                          integer. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -1337,14 +1348,25 @@ spec:
                                     type: object
                                   podAffinity:
                                     description: Describes pod affinity scheduling
-                                      rules (e.
+                                      rules (e.g. co-locate this pod in the same node,
+                                      zone, etc. as some other pod(s)).
                                     properties:
                                       preferredDuringSchedulingIgnoredDuringExecution:
                                         description: The scheduler will prefer to
                                           schedule pods to nodes that satisfy the
                                           affinity expressions specified by this field,
                                           but it may choose a node that violates one
-                                          or more of the expressions.
+                                          or more of the expressions. The node that
+                                          is most preferred is the one with the greatest
+                                          sum of weights, i.e. for each node that
+                                          meets all of the scheduling requirements
+                                          (resource request, requiredDuringScheduling
+                                          affinity expressions, etc.), compute a sum
+                                          by iterating through the elements of this
+                                          field and adding "weight" to the sum if
+                                          the node has pods which matches the corresponding
+                                          podAffinityTerm; the node(s) with the highest
+                                          sum are the most preferred.
                                         items:
                                           description: The weights of all of the matched
                                             WeightedPodAffinityTerm fields are added
@@ -1361,42 +1383,13 @@ spec:
                                                     pods.
                                                   properties:
                                                     matchExpressions:
-                                                      description: matchExpressions
-                                                        is a list of label selector
-                                                        requirements. The requirements
-                                                        are ANDed.
                                                       items:
-                                                        description: A label selector
-                                                          requirement is a selector
-                                                          that contains values, a
-                                                          key, and an operator that
-                                                          relates the key and values.
                                                         properties:
                                                           key:
-                                                            description: key is the
-                                                              label key that the selector
-                                                              applies to.
                                                             type: string
                                                           operator:
-                                                            description: operator
-                                                              represents a key's relationship
-                                                              to a set of values.
-                                                              Valid operators are
-                                                              In, NotIn, Exists and
-                                                              DoesNotExist.
                                                             type: string
                                                           values:
-                                                            description: values is
-                                                              an array of string values.
-                                                              If the operator is In
-                                                              or NotIn, the values
-                                                              array must be non-empty.
-                                                              If the operator is Exists
-                                                              or DoesNotExist, the
-                                                              values array must be
-                                                              empty. This array is
-                                                              replaced during a strategic
-                                                              merge patch.
                                                             items:
                                                               type: string
                                                             type: array
@@ -1408,16 +1401,6 @@ spec:
                                                     matchLabels:
                                                       additionalProperties:
                                                         type: string
-                                                      description: matchLabels is
-                                                        a map of {key,value} pairs.
-                                                        A single {key,value} in the
-                                                        matchLabels map is equivalent
-                                                        to an element of matchExpressions,
-                                                        whose key field is "key",
-                                                        the operator is "In", and
-                                                        the values array contains
-                                                        only "value". The requirements
-                                                        are ANDed.
                                                       type: object
                                                   type: object
                                                 namespaceSelector:
@@ -1436,42 +1419,13 @@ spec:
                                                     feature is enabled.
                                                   properties:
                                                     matchExpressions:
-                                                      description: matchExpressions
-                                                        is a list of label selector
-                                                        requirements. The requirements
-                                                        are ANDed.
                                                       items:
-                                                        description: A label selector
-                                                          requirement is a selector
-                                                          that contains values, a
-                                                          key, and an operator that
-                                                          relates the key and values.
                                                         properties:
                                                           key:
-                                                            description: key is the
-                                                              label key that the selector
-                                                              applies to.
                                                             type: string
                                                           operator:
-                                                            description: operator
-                                                              represents a key's relationship
-                                                              to a set of values.
-                                                              Valid operators are
-                                                              In, NotIn, Exists and
-                                                              DoesNotExist.
                                                             type: string
                                                           values:
-                                                            description: values is
-                                                              an array of string values.
-                                                              If the operator is In
-                                                              or NotIn, the values
-                                                              array must be non-empty.
-                                                              If the operator is Exists
-                                                              or DoesNotExist, the
-                                                              values array must be
-                                                              empty. This array is
-                                                              replaced during a strategic
-                                                              merge patch.
                                                             items:
                                                               type: string
                                                             type: array
@@ -1483,16 +1437,6 @@ spec:
                                                     matchLabels:
                                                       additionalProperties:
                                                         type: string
-                                                      description: matchLabels is
-                                                        a map of {key,value} pairs.
-                                                        A single {key,value} in the
-                                                        matchLabels map is equivalent
-                                                        to an element of matchExpressions,
-                                                        whose key field is "key",
-                                                        the operator is "In", and
-                                                        the values array contains
-                                                        only "value". The requirements
-                                                        are ANDed.
                                                       type: object
                                                   type: object
                                                 namespaces:
@@ -1539,7 +1483,15 @@ spec:
                                         description: If the affinity requirements
                                           specified by this field are not met at scheduling
                                           time, the pod will not be scheduled onto
-                                          the node.
+                                          the node. If the affinity requirements specified
+                                          by this field cease to be met at some point
+                                          during pod execution (e.g. due to a pod
+                                          label update), the system may or may not
+                                          try to eventually evict the pod from its
+                                          node. When there are multiple elements,
+                                          the lists of nodes corresponding to each
+                                          podAffinityTerm are intersected, i.e. all
+                                          terms must be satisfied.
                                         items:
                                           description: Defines a set of pods (namely
                                             those matching the labelSelector relative
@@ -1567,28 +1519,10 @@ spec:
                                                       key and values.
                                                     properties:
                                                       key:
-                                                        description: key is the label
-                                                          key that the selector applies
-                                                          to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents
-                                                          a key's relationship to
-                                                          a set of values. Valid operators
-                                                          are In, NotIn, Exists and
-                                                          DoesNotExist.
                                                         type: string
                                                       values:
-                                                        description: values is an
-                                                          array of string values.
-                                                          If the operator is In or
-                                                          NotIn, the values array
-                                                          must be non-empty. If the
-                                                          operator is Exists or DoesNotExist,
-                                                          the values array must be
-                                                          empty. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -1637,28 +1571,10 @@ spec:
                                                       key and values.
                                                     properties:
                                                       key:
-                                                        description: key is the label
-                                                          key that the selector applies
-                                                          to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents
-                                                          a key's relationship to
-                                                          a set of values. Valid operators
-                                                          are In, NotIn, Exists and
-                                                          DoesNotExist.
                                                         type: string
                                                       values:
-                                                        description: values is an
-                                                          array of string values.
-                                                          If the operator is In or
-                                                          NotIn, the values array
-                                                          must be non-empty. If the
-                                                          operator is Exists or DoesNotExist,
-                                                          the values array must be
-                                                          empty. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -1712,14 +1628,25 @@ spec:
                                     type: object
                                   podAntiAffinity:
                                     description: Describes pod anti-affinity scheduling
-                                      rules (e.
+                                      rules (e.g. avoid putting this pod in the same
+                                      node, zone, etc. as some other pod(s)).
                                     properties:
                                       preferredDuringSchedulingIgnoredDuringExecution:
                                         description: The scheduler will prefer to
                                           schedule pods to nodes that satisfy the
                                           anti-affinity expressions specified by this
                                           field, but it may choose a node that violates
-                                          one or more of the expressions.
+                                          one or more of the expressions. The node
+                                          that is most preferred is the one with the
+                                          greatest sum of weights, i.e. for each node
+                                          that meets all of the scheduling requirements
+                                          (resource request, requiredDuringScheduling
+                                          anti-affinity expressions, etc.), compute
+                                          a sum by iterating through the elements
+                                          of this field and adding "weight" to the
+                                          sum if the node has pods which matches the
+                                          corresponding podAffinityTerm; the node(s)
+                                          with the highest sum are the most preferred.
                                         items:
                                           description: The weights of all of the matched
                                             WeightedPodAffinityTerm fields are added
@@ -1736,42 +1663,13 @@ spec:
                                                     pods.
                                                   properties:
                                                     matchExpressions:
-                                                      description: matchExpressions
-                                                        is a list of label selector
-                                                        requirements. The requirements
-                                                        are ANDed.
                                                       items:
-                                                        description: A label selector
-                                                          requirement is a selector
-                                                          that contains values, a
-                                                          key, and an operator that
-                                                          relates the key and values.
                                                         properties:
                                                           key:
-                                                            description: key is the
-                                                              label key that the selector
-                                                              applies to.
                                                             type: string
                                                           operator:
-                                                            description: operator
-                                                              represents a key's relationship
-                                                              to a set of values.
-                                                              Valid operators are
-                                                              In, NotIn, Exists and
-                                                              DoesNotExist.
                                                             type: string
                                                           values:
-                                                            description: values is
-                                                              an array of string values.
-                                                              If the operator is In
-                                                              or NotIn, the values
-                                                              array must be non-empty.
-                                                              If the operator is Exists
-                                                              or DoesNotExist, the
-                                                              values array must be
-                                                              empty. This array is
-                                                              replaced during a strategic
-                                                              merge patch.
                                                             items:
                                                               type: string
                                                             type: array
@@ -1783,16 +1681,6 @@ spec:
                                                     matchLabels:
                                                       additionalProperties:
                                                         type: string
-                                                      description: matchLabels is
-                                                        a map of {key,value} pairs.
-                                                        A single {key,value} in the
-                                                        matchLabels map is equivalent
-                                                        to an element of matchExpressions,
-                                                        whose key field is "key",
-                                                        the operator is "In", and
-                                                        the values array contains
-                                                        only "value". The requirements
-                                                        are ANDed.
                                                       type: object
                                                   type: object
                                                 namespaceSelector:
@@ -1811,42 +1699,13 @@ spec:
                                                     feature is enabled.
                                                   properties:
                                                     matchExpressions:
-                                                      description: matchExpressions
-                                                        is a list of label selector
-                                                        requirements. The requirements
-                                                        are ANDed.
                                                       items:
-                                                        description: A label selector
-                                                          requirement is a selector
-                                                          that contains values, a
-                                                          key, and an operator that
-                                                          relates the key and values.
                                                         properties:
                                                           key:
-                                                            description: key is the
-                                                              label key that the selector
-                                                              applies to.
                                                             type: string
                                                           operator:
-                                                            description: operator
-                                                              represents a key's relationship
-                                                              to a set of values.
-                                                              Valid operators are
-                                                              In, NotIn, Exists and
-                                                              DoesNotExist.
                                                             type: string
                                                           values:
-                                                            description: values is
-                                                              an array of string values.
-                                                              If the operator is In
-                                                              or NotIn, the values
-                                                              array must be non-empty.
-                                                              If the operator is Exists
-                                                              or DoesNotExist, the
-                                                              values array must be
-                                                              empty. This array is
-                                                              replaced during a strategic
-                                                              merge patch.
                                                             items:
                                                               type: string
                                                             type: array
@@ -1858,16 +1717,6 @@ spec:
                                                     matchLabels:
                                                       additionalProperties:
                                                         type: string
-                                                      description: matchLabels is
-                                                        a map of {key,value} pairs.
-                                                        A single {key,value} in the
-                                                        matchLabels map is equivalent
-                                                        to an element of matchExpressions,
-                                                        whose key field is "key",
-                                                        the operator is "In", and
-                                                        the values array contains
-                                                        only "value". The requirements
-                                                        are ANDed.
                                                       type: object
                                                   type: object
                                                 namespaces:
@@ -1914,7 +1763,15 @@ spec:
                                         description: If the anti-affinity requirements
                                           specified by this field are not met at scheduling
                                           time, the pod will not be scheduled onto
-                                          the node.
+                                          the node. If the anti-affinity requirements
+                                          specified by this field cease to be met
+                                          at some point during pod execution (e.g.
+                                          due to a pod label update), the system may
+                                          or may not try to eventually evict the pod
+                                          from its node. When there are multiple elements,
+                                          the lists of nodes corresponding to each
+                                          podAffinityTerm are intersected, i.e. all
+                                          terms must be satisfied.
                                         items:
                                           description: Defines a set of pods (namely
                                             those matching the labelSelector relative
@@ -1942,28 +1799,10 @@ spec:
                                                       key and values.
                                                     properties:
                                                       key:
-                                                        description: key is the label
-                                                          key that the selector applies
-                                                          to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents
-                                                          a key's relationship to
-                                                          a set of values. Valid operators
-                                                          are In, NotIn, Exists and
-                                                          DoesNotExist.
                                                         type: string
                                                       values:
-                                                        description: values is an
-                                                          array of string values.
-                                                          If the operator is In or
-                                                          NotIn, the values array
-                                                          must be non-empty. If the
-                                                          operator is Exists or DoesNotExist,
-                                                          the values array must be
-                                                          empty. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -2012,28 +1851,10 @@ spec:
                                                       key and values.
                                                     properties:
                                                       key:
-                                                        description: key is the label
-                                                          key that the selector applies
-                                                          to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents
-                                                          a key's relationship to
-                                                          a set of values. Valid operators
-                                                          are In, NotIn, Exists and
-                                                          DoesNotExist.
                                                         type: string
                                                       values:
-                                                        description: values is an
-                                                          array of string values.
-                                                          If the operator is In or
-                                                          NotIn, the values array
-                                                          must be non-empty. If the
-                                                          operator is Exists or DoesNotExist,
-                                                          the values array must be
-                                                          empty. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -2093,6 +1914,9 @@ spec:
                                 type: boolean
                               containers:
                                 description: List of containers belonging to the pod.
+                                  Containers cannot currently be added or removed.
+                                  There must be at least one container in a Pod. Cannot
+                                  be updated.
                                 items:
                                   description: A single application container that
                                     you want to run within a pod.
@@ -2376,12 +2200,8 @@ spec:
                                                       HTTP probes
                                                     properties:
                                                       name:
-                                                        description: The header field
-                                                          name
                                                         type: string
                                                       value:
-                                                        description: The header field
-                                                          value
                                                         type: string
                                                     required:
                                                     - name
@@ -2494,12 +2314,8 @@ spec:
                                                       HTTP probes
                                                     properties:
                                                       name:
-                                                        description: The header field
-                                                          name
                                                         type: string
                                                       value:
-                                                        description: The header field
-                                                          value
                                                         type: string
                                                     required:
                                                     - name
@@ -2598,11 +2414,11 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
-                                              description: "Service is the name of\
-                                                \ the service to place in the gRPC\
-                                                \ HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\
-                                                \ \n If this is not specified, the\
-                                                \ default behavior is defined by gRPC."
+                                              description: "Service is the name of
+                                                the service to place in the gRPC HealthCheckRequest
+                                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                                \n If this is not specified, the default
+                                                behavior is defined by gRPC."
                                               type: string
                                           required:
                                           - port
@@ -2834,11 +2650,11 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
-                                              description: "Service is the name of\
-                                                \ the service to place in the gRPC\
-                                                \ HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\
-                                                \ \n If this is not specified, the\
-                                                \ default behavior is defined by gRPC."
+                                              description: "Service is the name of
+                                                the service to place in the gRPC HealthCheckRequest
+                                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                                \n If this is not specified, the default
+                                                behavior is defined by gRPC."
                                               type: string
                                           required:
                                           - port
@@ -3141,14 +2957,14 @@ spec:
                                                 if type is "Localhost".
                                               type: string
                                             type:
-                                              description: "type indicates which kind\
-                                                \ of seccomp profile will be applied.\
-                                                \ Valid options are: \n Localhost\
-                                                \ - a profile defined in a file on\
-                                                \ the node should be used. RuntimeDefault\
-                                                \ - the container runtime default\
-                                                \ profile should be used. Unconfined\
-                                                \ - no profile should be applied."
+                                              description: "type indicates which kind
+                                                of seccomp profile will be applied.
+                                                Valid options are: \n Localhost -
+                                                a profile defined in a file on the
+                                                node should be used. RuntimeDefault
+                                                - the container runtime default profile
+                                                should be used. Unconfined - no profile
+                                                should be applied."
                                               type: string
                                           required:
                                           - type
@@ -3256,11 +3072,11 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
-                                              description: "Service is the name of\
-                                                \ the service to place in the gRPC\
-                                                \ HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\
-                                                \ \n If this is not specified, the\
-                                                \ default behavior is defined by gRPC."
+                                              description: "Service is the name of
+                                                the service to place in the gRPC HealthCheckRequest
+                                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                                \n If this is not specified, the default
+                                                behavior is defined by gRPC."
                                               type: string
                                           required:
                                           - port
@@ -3519,14 +3335,23 @@ spec:
                                 type: array
                               dnsConfig:
                                 description: Specifies the DNS parameters of a pod.
+                                  Parameters specified here will be merged to the
+                                  generated DNS configuration based on DNSPolicy.
                                 properties:
                                   nameservers:
                                     description: A list of DNS name server IP addresses.
+                                      This will be appended to the base nameservers
+                                      generated from DNSPolicy. Duplicated nameservers
+                                      will be removed.
                                     items:
                                       type: string
                                     type: array
                                   options:
-                                    description: A list of DNS resolver options.
+                                    description: A list of DNS resolver options. This
+                                      will be merged with the base options generated
+                                      from DNSPolicy. Duplicated entries will be removed.
+                                      Resolution options given in Options will override
+                                      those that appear in the base DNSPolicy.
                                     items:
                                       description: PodDNSConfigOption defines DNS
                                         resolver options of a pod.
@@ -3540,38 +3365,53 @@ spec:
                                     type: array
                                   searches:
                                     description: A list of DNS search domains for
-                                      host-name lookup.
+                                      host-name lookup. This will be appended to the
+                                      base search paths generated from DNSPolicy.
+                                      Duplicated search paths will be removed.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               dnsPolicy:
-                                description: Set DNS policy for the pod.
+                                description: Set DNS policy for the pod. Defaults
+                                  to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet',
+                                  'ClusterFirst', 'Default' or 'None'. DNS parameters
+                                  given in DNSConfig will be merged with the policy
+                                  selected with DNSPolicy. To have DNS options set
+                                  along with hostNetwork, you have to specify DNS
+                                  policy explicitly to 'ClusterFirstWithHostNet'.
                                 type: string
                               enableServiceLinks:
-                                description: EnableServiceLinks indicates whether
+                                description: 'EnableServiceLinks indicates whether
                                   information about services should be injected into
-                                  pod's environment variables, matching the syntax
-                                  of Docker links.
+                                  pod''s environment variables, matching the syntax
+                                  of Docker links. Optional: Defaults to true.'
                                 type: boolean
                               ephemeralContainers:
                                 description: List of ephemeral containers run in this
-                                  pod.
+                                  pod. Ephemeral containers may be run in an existing
+                                  pod to perform user-initiated actions such as debugging.
+                                  This list cannot be specified when creating a pod,
+                                  and it cannot be modified by updating the pod spec.
+                                  In order to add an ephemeral container to an existing
+                                  pod, use the pod's ephemeralcontainers subresource.
+                                  This field is beta-level and available on clusters
+                                  that haven't disabled the EphemeralContainers feature
+                                  gate.
                                 items:
-                                  description: "An EphemeralContainer is a temporary\
-                                    \ container that you may add to an existing Pod\
-                                    \ for user-initiated activities such as debugging.\
-                                    \ Ephemeral containers have no resource or scheduling\
-                                    \ guarantees, and they will not be restarted when\
-                                    \ they exit or when a Pod is removed or restarted.\
-                                    \ The kubelet may evict a Pod if an ephemeral\
-                                    \ container causes the Pod to exceed its resource\
-                                    \ allocation. \n To add an ephemeral container,\
-                                    \ use the ephemeralcontainers subresource of an\
-                                    \ existing Pod. Ephemeral containers may not be\
-                                    \ removed or restarted. \n This is a beta feature\
-                                    \ available on clusters that haven't disabled\
-                                    \ the EphemeralContainers feature gate."
+                                  description: "An EphemeralContainer is a temporary
+                                    container that you may add to an existing Pod
+                                    for user-initiated activities such as debugging.
+                                    Ephemeral containers have no resource or scheduling
+                                    guarantees, and they will not be restarted when
+                                    they exit or when a Pod is removed or restarted.
+                                    The kubelet may evict a Pod if an ephemeral container
+                                    causes the Pod to exceed its resource allocation.
+                                    \n To add an ephemeral container, use the ephemeralcontainers
+                                    subresource of an existing Pod. Ephemeral containers
+                                    may not be removed or restarted. \n This is a
+                                    beta feature available on clusters that haven't
+                                    disabled the EphemeralContainers feature gate."
                                   properties:
                                     args:
                                       description: 'Arguments to the entrypoint. The
@@ -3847,12 +3687,8 @@ spec:
                                                       HTTP probes
                                                     properties:
                                                       name:
-                                                        description: The header field
-                                                          name
                                                         type: string
                                                       value:
-                                                        description: The header field
-                                                          value
                                                         type: string
                                                     required:
                                                     - name
@@ -3965,12 +3801,8 @@ spec:
                                                       HTTP probes
                                                     properties:
                                                       name:
-                                                        description: The header field
-                                                          name
                                                         type: string
                                                       value:
-                                                        description: The header field
-                                                          value
                                                         type: string
                                                     required:
                                                     - name
@@ -4068,11 +3900,11 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
-                                              description: "Service is the name of\
-                                                \ the service to place in the gRPC\
-                                                \ HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\
-                                                \ \n If this is not specified, the\
-                                                \ default behavior is defined by gRPC."
+                                              description: "Service is the name of
+                                                the service to place in the gRPC HealthCheckRequest
+                                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                                \n If this is not specified, the default
+                                                behavior is defined by gRPC."
                                               type: string
                                           required:
                                           - port
@@ -4294,11 +4126,11 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
-                                              description: "Service is the name of\
-                                                \ the service to place in the gRPC\
-                                                \ HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\
-                                                \ \n If this is not specified, the\
-                                                \ default behavior is defined by gRPC."
+                                              description: "Service is the name of
+                                                the service to place in the gRPC HealthCheckRequest
+                                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                                \n If this is not specified, the default
+                                                behavior is defined by gRPC."
                                               type: string
                                           required:
                                           - port
@@ -4601,14 +4433,14 @@ spec:
                                                 if type is "Localhost".
                                               type: string
                                             type:
-                                              description: "type indicates which kind\
-                                                \ of seccomp profile will be applied.\
-                                                \ Valid options are: \n Localhost\
-                                                \ - a profile defined in a file on\
-                                                \ the node should be used. RuntimeDefault\
-                                                \ - the container runtime default\
-                                                \ profile should be used. Unconfined\
-                                                \ - no profile should be applied."
+                                              description: "type indicates which kind
+                                                of seccomp profile will be applied.
+                                                Valid options are: \n Localhost -
+                                                a profile defined in a file on the
+                                                node should be used. RuntimeDefault
+                                                - the container runtime default profile
+                                                should be used. Unconfined - no profile
+                                                should be applied."
                                               type: string
                                           required:
                                           - type
@@ -4707,11 +4539,11 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
-                                              description: "Service is the name of\
-                                                \ the service to place in the gRPC\
-                                                \ HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\
-                                                \ \n If this is not specified, the\
-                                                \ default behavior is defined by gRPC."
+                                              description: "Service is the name of
+                                                the service to place in the gRPC HealthCheckRequest
+                                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                                \n If this is not specified, the default
+                                                behavior is defined by gRPC."
                                               type: string
                                           required:
                                           - port
@@ -4860,17 +4692,16 @@ spec:
                                         receive an EOF. Default is false
                                       type: boolean
                                     targetContainerName:
-                                      description: "If set, the name of the container\
-                                        \ from PodSpec that this ephemeral container\
-                                        \ targets. The ephemeral container will be\
-                                        \ run in the namespaces (IPC, PID, etc) of\
-                                        \ this container. If not set then the ephemeral\
-                                        \ container uses the namespaces configured\
-                                        \ in the Pod spec. \n The container runtime\
-                                        \ must implement support for this feature.\
-                                        \ If the runtime does not support namespace\
-                                        \ targeting then the result of setting this\
-                                        \ field is undefined."
+                                      description: "If set, the name of the container
+                                        from PodSpec that this ephemeral container
+                                        targets. The ephemeral container will be run
+                                        in the namespaces (IPC, PID, etc) of this
+                                        container. If not set then the ephemeral container
+                                        uses the namespaces configured in the Pod
+                                        spec. \n The container runtime must implement
+                                        support for this feature. If the runtime does
+                                        not support namespace targeting then the result
+                                        of setting this field is undefined."
                                       type: string
                                     terminationMessagePath:
                                       description: 'Optional: Path at which the file
@@ -4985,7 +4816,8 @@ spec:
                               hostAliases:
                                 description: HostAliases is an optional list of hosts
                                   and IPs that will be injected into the pod's hosts
-                                  file if specified.
+                                  file if specified. This is only valid for non-hostNetwork
+                                  pods.
                                 items:
                                   description: HostAlias holds the mapping between
                                     IP and hostnames that will be injected as an entry
@@ -5007,6 +4839,9 @@ spec:
                                 type: boolean
                               hostNetwork:
                                 description: Host networking requested for this pod.
+                                  Use the host's network namespace. If this option
+                                  is set, the ports that will be used must be specified.
+                                  Default to false.
                                 type: boolean
                               hostPID:
                                 description: 'Use the host''s pid namespace. Optional:
@@ -5018,9 +4853,13 @@ spec:
                                   a system-defined value.
                                 type: string
                               imagePullSecrets:
-                                description: ImagePullSecrets is an optional list
+                                description: 'ImagePullSecrets is an optional list
                                   of references to secrets in the same namespace to
                                   use for pulling any of the images used by this PodSpec.
+                                  If specified, these secrets will be passed to individual
+                                  puller implementations for them to use. For example,
+                                  in the case of docker, only DockerConfig type secrets
+                                  are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                                 items:
                                   description: LocalObjectReference contains enough
                                     information to let you locate the referenced object
@@ -5035,8 +4874,22 @@ spec:
                                   type: object
                                 type: array
                               initContainers:
-                                description: List of initialization containers belonging
-                                  to the pod.
+                                description: 'List of initialization containers belonging
+                                  to the pod. Init containers are executed in order
+                                  prior to containers being started. If any init container
+                                  fails, the pod is considered to have failed and
+                                  is handled according to its restartPolicy. The name
+                                  for an init container or normal container must be
+                                  unique among all containers. Init containers may
+                                  not have Lifecycle actions, Readiness probes, Liveness
+                                  probes, or Startup probes. The resourceRequirements
+                                  of an init container are taken into account during
+                                  scheduling by finding the highest request/limit
+                                  for each resource type, and then using the max of
+                                  of that value or the sum of the normal containers.
+                                  Limits are applied to init containers in a similar
+                                  fashion. Init containers cannot currently be added
+                                  or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
                                 items:
                                   description: A single application container that
                                     you want to run within a pod.
@@ -5320,12 +5173,8 @@ spec:
                                                       HTTP probes
                                                     properties:
                                                       name:
-                                                        description: The header field
-                                                          name
                                                         type: string
                                                       value:
-                                                        description: The header field
-                                                          value
                                                         type: string
                                                     required:
                                                     - name
@@ -5438,12 +5287,8 @@ spec:
                                                       HTTP probes
                                                     properties:
                                                       name:
-                                                        description: The header field
-                                                          name
                                                         type: string
                                                       value:
-                                                        description: The header field
-                                                          value
                                                         type: string
                                                     required:
                                                     - name
@@ -5542,11 +5387,11 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
-                                              description: "Service is the name of\
-                                                \ the service to place in the gRPC\
-                                                \ HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\
-                                                \ \n If this is not specified, the\
-                                                \ default behavior is defined by gRPC."
+                                              description: "Service is the name of
+                                                the service to place in the gRPC HealthCheckRequest
+                                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                                \n If this is not specified, the default
+                                                behavior is defined by gRPC."
                                               type: string
                                           required:
                                           - port
@@ -5778,11 +5623,11 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
-                                              description: "Service is the name of\
-                                                \ the service to place in the gRPC\
-                                                \ HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\
-                                                \ \n If this is not specified, the\
-                                                \ default behavior is defined by gRPC."
+                                              description: "Service is the name of
+                                                the service to place in the gRPC HealthCheckRequest
+                                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                                \n If this is not specified, the default
+                                                behavior is defined by gRPC."
                                               type: string
                                           required:
                                           - port
@@ -6085,14 +5930,14 @@ spec:
                                                 if type is "Localhost".
                                               type: string
                                             type:
-                                              description: "type indicates which kind\
-                                                \ of seccomp profile will be applied.\
-                                                \ Valid options are: \n Localhost\
-                                                \ - a profile defined in a file on\
-                                                \ the node should be used. RuntimeDefault\
-                                                \ - the container runtime default\
-                                                \ profile should be used. Unconfined\
-                                                \ - no profile should be applied."
+                                              description: "type indicates which kind
+                                                of seccomp profile will be applied.
+                                                Valid options are: \n Localhost -
+                                                a profile defined in a file on the
+                                                node should be used. RuntimeDefault
+                                                - the container runtime default profile
+                                                should be used. Unconfined - no profile
+                                                should be applied."
                                               type: string
                                           required:
                                           - type
@@ -6200,11 +6045,11 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
-                                              description: "Service is the name of\
-                                                \ the service to place in the gRPC\
-                                                \ HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\
-                                                \ \n If this is not specified, the\
-                                                \ default behavior is defined by gRPC."
+                                              description: "Service is the name of
+                                                the service to place in the gRPC HealthCheckRequest
+                                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                                \n If this is not specified, the default
+                                                behavior is defined by gRPC."
                                               type: string
                                           required:
                                           - port
@@ -6463,25 +6308,49 @@ spec:
                                 type: array
                               nodeName:
                                 description: NodeName is a request to schedule this
-                                  pod onto a specific node.
+                                  pod onto a specific node. If it is non-empty, the
+                                  scheduler simply schedules this pod onto that node,
+                                  assuming that it fits resource requirements.
                                 type: string
                               nodeSelector:
                                 additionalProperties:
                                   type: string
-                                description: NodeSelector is a selector which must
-                                  be true for the pod to fit on a node.
+                                description: 'NodeSelector is a selector which must
+                                  be true for the pod to fit on a node. Selector which
+                                  must match a node''s labels for the pod to be scheduled
+                                  on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                                 type: object
                                 x-kubernetes-map-type: atomic
                               os:
-                                description: "Specifies the OS of the containers in\
-                                  \ the pod.\n If the OS field is set to linux, the\
-                                  \ following fields must be unset: -securityContext.\n\
-                                  \ If the OS field is set to windows, following fields\
-                                  \ must be unset: - spec."
+                                description: "Specifies the OS of the containers in
+                                  the pod. Some pod and container fields are restricted
+                                  if this is set. \n If the OS field is set to linux,
+                                  the following fields must be unset: -securityContext.windowsOptions
+                                  \n If the OS field is set to windows, following
+                                  fields must be unset: - spec.hostPID - spec.hostIPC
+                                  - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile
+                                  - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy
+                                  - spec.securityContext.sysctls - spec.shareProcessNamespace
+                                  - spec.securityContext.runAsUser - spec.securityContext.runAsGroup
+                                  - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions
+                                  - spec.containers[*].securityContext.seccompProfile
+                                  - spec.containers[*].securityContext.capabilities
+                                  - spec.containers[*].securityContext.readOnlyRootFilesystem
+                                  - spec.containers[*].securityContext.privileged
+                                  - spec.containers[*].securityContext.allowPrivilegeEscalation
+                                  - spec.containers[*].securityContext.procMount -
+                                  spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup
+                                  This is an alpha field and requires the IdentifyPodOS
+                                  feature"
                                 properties:
                                   name:
-                                    description: Name is the name of the operating
-                                      system.
+                                    description: 'Name is the name of the operating
+                                      system. The currently supported values are linux
+                                      and windows. Additional value may be defined
+                                      in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                                      Clients should expect to handle additional values
+                                      and treat unrecognized values in this field
+                                      as os: null'
                                     type: string
                                 required:
                                 - name
@@ -6493,23 +6362,54 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: Overhead represents the resource overhead
+                                description: 'Overhead represents the resource overhead
                                   associated with running a pod for a given RuntimeClass.
+                                  This field will be autopopulated at admission time
+                                  by the RuntimeClass admission controller. If the
+                                  RuntimeClass admission controller is enabled, overhead
+                                  must not be set in Pod create requests. The RuntimeClass
+                                  admission controller will reject Pod create requests
+                                  which have the overhead already set. If RuntimeClass
+                                  is configured and selected in the PodSpec, Overhead
+                                  will be set to the value defined in the corresponding
+                                  RuntimeClass, otherwise it will remain unset and
+                                  treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md
+                                  This field is beta-level as of Kubernetes v1.18,
+                                  and is only honored by servers that enable the PodOverhead
+                                  feature.'
                                 type: object
                               preemptionPolicy:
                                 description: PreemptionPolicy is the Policy for preempting
-                                  pods with lower priority.
+                                  pods with lower priority. One of Never, PreemptLowerPriority.
+                                  Defaults to PreemptLowerPriority if unset. This
+                                  field is beta-level, gated by the NonPreemptingPriority
+                                  feature-gate.
                                 type: string
                               priority:
-                                description: The priority value.
+                                description: The priority value. Various system components
+                                  use this field to find the priority of the pod.
+                                  When Priority Admission Controller is enabled, it
+                                  prevents users from setting this field. The admission
+                                  controller populates this field from PriorityClassName.
+                                  The higher the value, the higher the priority.
                                 format: int32
                                 type: integer
                               priorityClassName:
                                 description: If specified, indicates the pod's priority.
+                                  "system-node-critical" and "system-cluster-critical"
+                                  are two special keywords which indicate the highest
+                                  priorities with the former being the highest priority.
+                                  Any other name must be defined by creating a PriorityClass
+                                  object with that name. If not specified, the pod
+                                  priority will be default or zero if there is no
+                                  default.
                                 type: string
                               readinessGates:
-                                description: If specified, all readiness gates will
-                                  be evaluated for pod readiness.
+                                description: 'If specified, all readiness gates will
+                                  be evaluated for pod readiness. A pod is ready when
+                                  all its containers are ready AND all conditions
+                                  specified in the readiness gates have status equal
+                                  to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
                                 items:
                                   description: PodReadinessGate contains the reference
                                     to a pod condition
@@ -6524,50 +6424,100 @@ spec:
                                   type: object
                                 type: array
                               restartPolicy:
-                                description: Restart policy for all containers within
-                                  the pod.
+                                description: 'Restart policy for all containers within
+                                  the pod. One of Always, OnFailure, Never. Default
+                                  to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                                 type: string
                               runtimeClassName:
-                                description: RuntimeClassName refers to a RuntimeClass
-                                  object in the node.
+                                description: 'RuntimeClassName refers to a RuntimeClass
+                                  object in the node.k8s.io group, which should be
+                                  used to run this pod.  If no RuntimeClass resource
+                                  matches the named class, the pod will not be run.
+                                  If unset or empty, the "legacy" RuntimeClass will
+                                  be used, which is an implicit class with an empty
+                                  definition that uses the default runtime handler.
+                                  More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class
+                                  This is a beta feature as of Kubernetes v1.14.'
                                 type: string
                               schedulerName:
                                 description: If specified, the pod will be dispatched
-                                  by specified scheduler.
+                                  by specified scheduler. If not specified, the pod
+                                  will be dispatched by default scheduler.
                                 type: string
                               securityContext:
-                                description: SecurityContext holds pod-level security
-                                  attributes and common container settings.
+                                description: 'SecurityContext holds pod-level security
+                                  attributes and common container settings. Optional:
+                                  Defaults to empty.  See type description for default
+                                  values of each field.'
                                 properties:
                                   fsGroup:
-                                    description: "A special supplemental group that\
-                                      \ applies to all containers in a pod.\n 1.\n\
-                                      \ If unset, the Kubelet will not modify the\
-                                      \ ownership and permissions of any volume."
+                                    description: "A special supplemental group that
+                                      applies to all containers in a pod. Some volume
+                                      types allow the Kubelet to change the ownership
+                                      of that volume to be owned by the pod: \n 1.
+                                      The owning GID will be the FSGroup 2. The setgid
+                                      bit is set (new files created in the volume
+                                      will be owned by FSGroup) 3. The permission
+                                      bits are OR'd with rw-rw---- \n If unset, the
+                                      Kubelet will not modify the ownership and permissions
+                                      of any volume. Note that this field cannot be
+                                      set when spec.os.name is windows."
                                     format: int64
                                     type: integer
                                   fsGroupChangePolicy:
-                                    description: fsGroupChangePolicy defines behavior
+                                    description: 'fsGroupChangePolicy defines behavior
                                       of changing ownership and permission of the
-                                      volume before being exposed inside Pod.
+                                      volume before being exposed inside Pod. This
+                                      field will only apply to volume types which
+                                      support fsGroup based ownership(and permissions).
+                                      It will have no effect on ephemeral volume types
+                                      such as: secret, configmaps and emptydir. Valid
+                                      values are "OnRootMismatch" and "Always". If
+                                      not specified, "Always" is used. Note that this
+                                      field cannot be set when spec.os.name is windows.'
                                     type: string
                                   runAsGroup:
                                     description: The GID to run the entrypoint of
-                                      the container process.
+                                      the container process. Uses runtime default
+                                      if unset. May also be set in SecurityContext.  If
+                                      set in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence for that container. Note that this
+                                      field cannot be set when spec.os.name is windows.
                                     format: int64
                                     type: integer
                                   runAsNonRoot:
                                     description: Indicates that the container must
-                                      run as a non-root user.
+                                      run as a non-root user. If true, the Kubelet
+                                      will validate the image at runtime to ensure
+                                      that it does not run as UID 0 (root) and fail
+                                      to start the container if it does. If unset
+                                      or false, no such validation will be performed.
+                                      May also be set in SecurityContext.  If set
+                                      in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence.
                                     type: boolean
                                   runAsUser:
                                     description: The UID to run the entrypoint of
-                                      the container process.
+                                      the container process. Defaults to user specified
+                                      in image metadata if unspecified. May also be
+                                      set in SecurityContext.  If set in both SecurityContext
+                                      and PodSecurityContext, the value specified
+                                      in SecurityContext takes precedence for that
+                                      container. Note that this field cannot be set
+                                      when spec.os.name is windows.
                                     format: int64
                                     type: integer
                                   seLinuxOptions:
                                     description: The SELinux context to be applied
-                                      to all containers.
+                                      to all containers. If unspecified, the container
+                                      runtime will allocate a random SELinux context
+                                      for each container.  May also be set in SecurityContext.  If
+                                      set in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence for that container. Note that this
+                                      field cannot be set when spec.os.name is windows.
                                     properties:
                                       level:
                                         description: Level is SELinux level label
@@ -6588,18 +6538,26 @@ spec:
                                     type: object
                                   seccompProfile:
                                     description: The seccomp options to use by the
-                                      containers in this pod.
+                                      containers in this pod. Note that this field
+                                      cannot be set when spec.os.name is windows.
                                     properties:
                                       localhostProfile:
                                         description: localhostProfile indicates a
                                           profile defined in a file on the node should
-                                          be used.
+                                          be used. The profile must be preconfigured
+                                          on the node to work. Must be a descending
+                                          path, relative to the kubelet's configured
+                                          seccomp profile location. Must only be set
+                                          if type is "Localhost".
                                         type: string
                                       type:
-                                        description: "type indicates which kind of\
-                                          \ seccomp profile will be applied.\n Localhost\
-                                          \ - a profile defined in a file on the node\
-                                          \ should be used."
+                                        description: "type indicates which kind of
+                                          seccomp profile will be applied. Valid options
+                                          are: \n Localhost - a profile defined in
+                                          a file on the node should be used. RuntimeDefault
+                                          - the container runtime default profile
+                                          should be used. Unconfined - no profile
+                                          should be applied."
                                         type: string
                                     required:
                                     - type
@@ -6607,14 +6565,20 @@ spec:
                                   supplementalGroups:
                                     description: A list of groups applied to the first
                                       process run in each container, in addition to
-                                      the container's primary GID.
+                                      the container's primary GID.  If unspecified,
+                                      no groups will be added to any container. Note
+                                      that this field cannot be set when spec.os.name
+                                      is windows.
                                     items:
                                       format: int64
                                       type: integer
                                     type: array
                                   sysctls:
                                     description: Sysctls hold a list of namespaced
-                                      sysctls used for the pod.
+                                      sysctls used for the pod. Pods with unsupported
+                                      sysctls (by the container runtime) might fail
+                                      to launch. Note that this field cannot be set
+                                      when spec.os.name is windows.
                                     items:
                                       description: Sysctl defines a kernel parameter
                                         to be set
@@ -6632,11 +6596,19 @@ spec:
                                     type: array
                                   windowsOptions:
                                     description: The Windows specific settings applied
-                                      to all containers.
+                                      to all containers. If unspecified, the options
+                                      within a container's SecurityContext will be
+                                      used. If set in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence. Note that this field cannot be set
+                                      when spec.os.name is linux.
                                     properties:
                                       gmsaCredentialSpec:
                                         description: GMSACredentialSpec is where the
-                                          GMSA admission webhook (https://github.
+                                          GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                          inlines the contents of the GMSA credential
+                                          spec named by the GMSACredentialSpecName
+                                          field.
                                         type: string
                                       gmsaCredentialSpecName:
                                         description: GMSACredentialSpecName is the
@@ -6645,37 +6617,78 @@ spec:
                                       hostProcess:
                                         description: HostProcess determines if a container
                                           should be run as a 'Host Process' container.
+                                          This field is alpha-level and will only
+                                          be honored by components that enable the
+                                          WindowsHostProcessContainers feature flag.
+                                          Setting this field without the feature flag
+                                          will result in errors when validating the
+                                          Pod. All of a Pod's containers must have
+                                          the same effective HostProcess value (it
+                                          is not allowed to have a mix of HostProcess
+                                          containers and non-HostProcess containers).  In
+                                          addition, if HostProcess is true then HostNetwork
+                                          must also be set to true.
                                         type: boolean
                                       runAsUserName:
                                         description: The UserName in Windows to run
                                           the entrypoint of the container process.
+                                          Defaults to the user specified in image
+                                          metadata if unspecified. May also be set
+                                          in PodSecurityContext. If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence.
                                         type: string
                                     type: object
                                 type: object
                               serviceAccount:
-                                description: DeprecatedServiceAccount is a depreciated
-                                  alias for ServiceAccountName.
+                                description: 'DeprecatedServiceAccount is a depreciated
+                                  alias for ServiceAccountName. Deprecated: Use serviceAccountName
+                                  instead.'
                                 type: string
                               serviceAccountName:
-                                description: ServiceAccountName is the name of the
-                                  ServiceAccount to use to run this pod.
+                                description: 'ServiceAccountName is the name of the
+                                  ServiceAccount to use to run this pod. More info:
+                                  https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                                 type: string
                               setHostnameAsFQDN:
                                 description: If true the pod's hostname will be configured
                                   as the pod's FQDN, rather than the leaf name (the
-                                  default).
+                                  default). In Linux containers, this means setting
+                                  the FQDN in the hostname field of the kernel (the
+                                  nodename field of struct utsname). In Windows containers,
+                                  this means setting the registry value of hostname
+                                  for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters
+                                  to FQDN. If a pod does not have FQDN, this has no
+                                  effect. Default to false.
                                 type: boolean
                               shareProcessNamespace:
-                                description: Share a single process namespace between
-                                  all of the containers in a pod.
+                                description: 'Share a single process namespace between
+                                  all of the containers in a pod. When this is set
+                                  containers will be able to view and signal processes
+                                  from other containers in the same pod, and the first
+                                  process in each container will not be assigned PID
+                                  1. HostPID and ShareProcessNamespace cannot both
+                                  be set. Optional: Default to false.'
                                 type: boolean
                               subdomain:
                                 description: If specified, the fully qualified Pod
-                                  hostname will be "<hostname>.
+                                  hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
+                                  domain>". If not specified, the pod will not have
+                                  a domainname at all.
                                 type: string
                               terminationGracePeriodSeconds:
                                 description: Optional duration in seconds the pod
-                                  needs to terminate gracefully.
+                                  needs to terminate gracefully. May be decreased
+                                  in delete request. Value must be non-negative integer.
+                                  The value zero indicates stop immediately via the
+                                  kill signal (no opportunity to shut down). If this
+                                  value is nil, the default grace period will be used
+                                  instead. The grace period is the duration in seconds
+                                  after the processes running in the pod are sent
+                                  a termination signal and the time when the processes
+                                  are forcibly halted with a kill signal. Set this
+                                  value longer than the expected cleanup time for
+                                  your process. Defaults to 30 seconds.
                                 format: int64
                                 type: integer
                               tolerations:
@@ -6728,7 +6741,9 @@ spec:
                               topologySpreadConstraints:
                                 description: TopologySpreadConstraints describes how
                                   a group of pods ought to spread across topology
-                                  domains.
+                                  domains. Scheduler will schedule pods in a way which
+                                  abides by the constraints. All topologySpreadConstraints
+                                  are ANDed.
                                 items:
                                   description: TopologySpreadConstraint specifies
                                     how to spread matching pods among the given topology.
@@ -6851,8 +6866,8 @@ spec:
                                 - whenUnsatisfiable
                                 x-kubernetes-list-type: map
                               volumes:
-                                description: List of volumes that can be mounted by
-                                  containers belonging to the pod.
+                                description: 'List of volumes that can be mounted
+                                  by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
                                 items:
                                   description: Volume represents a named volume in
                                     a pod that may be accessed by any container in
@@ -7307,57 +7322,57 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     ephemeral:
-                                      description: "Ephemeral represents a volume\
-                                        \ that is handled by a cluster storage driver.\
-                                        \ The volume's lifecycle is tied to the pod\
-                                        \ that defines it - it will be created before\
-                                        \ the pod starts, and deleted when the pod\
-                                        \ is removed. \n Use this if: a) the volume\
-                                        \ is only needed while the pod runs, b) features\
-                                        \ of normal volumes like restoring from snapshot\
-                                        \ or capacity tracking are needed, c) the\
-                                        \ storage driver is specified through a storage\
-                                        \ class, and d) the storage driver supports\
-                                        \ dynamic volume provisioning through a PersistentVolumeClaim\
-                                        \ (see EphemeralVolumeSource for more information\
-                                        \ on the connection between this volume type\
-                                        \ and PersistentVolumeClaim). \n Use PersistentVolumeClaim\
-                                        \ or one of the vendor-specific APIs for volumes\
-                                        \ that persist for longer than the lifecycle\
-                                        \ of an individual pod. \n Use CSI for light-weight\
-                                        \ local ephemeral volumes if the CSI driver\
-                                        \ is meant to be used that way - see the documentation\
-                                        \ of the driver for more information. \n A\
-                                        \ pod can use both types of ephemeral volumes\
-                                        \ and persistent volumes at the same time."
+                                      description: "Ephemeral represents a volume
+                                        that is handled by a cluster storage driver.
+                                        The volume's lifecycle is tied to the pod
+                                        that defines it - it will be created before
+                                        the pod starts, and deleted when the pod is
+                                        removed. \n Use this if: a) the volume is
+                                        only needed while the pod runs, b) features
+                                        of normal volumes like restoring from snapshot
+                                        or capacity tracking are needed, c) the storage
+                                        driver is specified through a storage class,
+                                        and d) the storage driver supports dynamic
+                                        volume provisioning through a PersistentVolumeClaim
+                                        (see EphemeralVolumeSource for more information
+                                        on the connection between this volume type
+                                        and PersistentVolumeClaim). \n Use PersistentVolumeClaim
+                                        or one of the vendor-specific APIs for volumes
+                                        that persist for longer than the lifecycle
+                                        of an individual pod. \n Use CSI for light-weight
+                                        local ephemeral volumes if the CSI driver
+                                        is meant to be used that way - see the documentation
+                                        of the driver for more information. \n A pod
+                                        can use both types of ephemeral volumes and
+                                        persistent volumes at the same time."
                                       properties:
                                         volumeClaimTemplate:
-                                          description: "Will be used to create a stand-alone\
-                                            \ PVC to provision the volume. The pod\
-                                            \ in which this EphemeralVolumeSource\
-                                            \ is embedded will be the owner of the\
-                                            \ PVC, i.e. the PVC will be deleted together\
-                                            \ with the pod.  The name of the PVC will\
-                                            \ be `<pod name>-<volume name>` where\
-                                            \ `<volume name>` is the name from the\
-                                            \ `PodSpec.Volumes` array entry. Pod validation\
-                                            \ will reject the pod if the concatenated\
-                                            \ name is not valid for a PVC (for example,\
-                                            \ too long). \n An existing PVC with that\
-                                            \ name that is not owned by the pod will\
-                                            \ *not* be used for the pod to avoid using\
-                                            \ an unrelated volume by mistake. Starting\
-                                            \ the pod is then blocked until the unrelated\
-                                            \ PVC is removed. If such a pre-created\
-                                            \ PVC is meant to be used by the pod,\
-                                            \ the PVC has to updated with an owner\
-                                            \ reference to the pod once the pod exists.\
-                                            \ Normally this should not be necessary,\
-                                            \ but it may be useful when manually reconstructing\
-                                            \ a broken cluster. \n This field is read-only\
-                                            \ and no changes will be made by Kubernetes\
-                                            \ to the PVC after it has been created.\
-                                            \ \n Required, must not be nil."
+                                          description: "Will be used to create a stand-alone
+                                            PVC to provision the volume. The pod in
+                                            which this EphemeralVolumeSource is embedded
+                                            will be the owner of the PVC, i.e. the
+                                            PVC will be deleted together with the
+                                            pod.  The name of the PVC will be `<pod
+                                            name>-<volume name>` where `<volume name>`
+                                            is the name from the `PodSpec.Volumes`
+                                            array entry. Pod validation will reject
+                                            the pod if the concatenated name is not
+                                            valid for a PVC (for example, too long).
+                                            \n An existing PVC with that name that
+                                            is not owned by the pod will *not* be
+                                            used for the pod to avoid using an unrelated
+                                            volume by mistake. Starting the pod is
+                                            then blocked until the unrelated PVC is
+                                            removed. If such a pre-created PVC is
+                                            meant to be used by the pod, the PVC has
+                                            to updated with an owner reference to
+                                            the pod once the pod exists. Normally
+                                            this should not be necessary, but it may
+                                            be useful when manually reconstructing
+                                            a broken cluster. \n This field is read-only
+                                            and no changes will be made by Kubernetes
+                                            to the PVC after it has been created.
+                                            \n Required, must not be nil."
                                           properties:
                                             metadata:
                                               description: May contain labels and
@@ -7397,21 +7412,10 @@ spec:
                                                     as the DataSourceRef field.'
                                                   properties:
                                                     apiGroup:
-                                                      description: APIGroup is the
-                                                        group for the resource being
-                                                        referenced. If APIGroup is
-                                                        not specified, the specified
-                                                        Kind must be in the core API
-                                                        group. For any other third-party
-                                                        types, APIGroup is required.
                                                       type: string
                                                     kind:
-                                                      description: Kind is the type
-                                                        of resource being referenced
                                                       type: string
                                                     name:
-                                                      description: Name is the name
-                                                        of resource being referenced
                                                       type: string
                                                   required:
                                                   - kind
@@ -7453,21 +7457,10 @@ spec:
                                                     feature gate to be enabled.'
                                                   properties:
                                                     apiGroup:
-                                                      description: APIGroup is the
-                                                        group for the resource being
-                                                        referenced. If APIGroup is
-                                                        not specified, the specified
-                                                        Kind must be in the core API
-                                                        group. For any other third-party
-                                                        types, APIGroup is required.
                                                       type: string
                                                     kind:
-                                                      description: Kind is the type
-                                                        of resource being referenced
                                                       type: string
                                                     name:
-                                                      description: Name is the name
-                                                        of resource being referenced
                                                       type: string
                                                   required:
                                                   - kind
@@ -7492,10 +7485,6 @@ spec:
                                                         - type: string
                                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                         x-kubernetes-int-or-string: true
-                                                      description: 'Limits describes
-                                                        the maximum amount of compute
-                                                        resources allowed. More info:
-                                                        https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                       type: object
                                                     requests:
                                                       additionalProperties:
@@ -7504,14 +7493,6 @@ spec:
                                                         - type: string
                                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                         x-kubernetes-int-or-string: true
-                                                      description: 'Requests describes
-                                                        the minimum amount of compute
-                                                        resources required. If Requests
-                                                        is omitted for a container,
-                                                        it defaults to Limits if that
-                                                        is explicitly specified, otherwise
-                                                        to an implementation-defined
-                                                        value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                       type: object
                                                   type: object
                                                 selector:
@@ -7519,42 +7500,13 @@ spec:
                                                     volumes to consider for binding.
                                                   properties:
                                                     matchExpressions:
-                                                      description: matchExpressions
-                                                        is a list of label selector
-                                                        requirements. The requirements
-                                                        are ANDed.
                                                       items:
-                                                        description: A label selector
-                                                          requirement is a selector
-                                                          that contains values, a
-                                                          key, and an operator that
-                                                          relates the key and values.
                                                         properties:
                                                           key:
-                                                            description: key is the
-                                                              label key that the selector
-                                                              applies to.
                                                             type: string
                                                           operator:
-                                                            description: operator
-                                                              represents a key's relationship
-                                                              to a set of values.
-                                                              Valid operators are
-                                                              In, NotIn, Exists and
-                                                              DoesNotExist.
                                                             type: string
                                                           values:
-                                                            description: values is
-                                                              an array of string values.
-                                                              If the operator is In
-                                                              or NotIn, the values
-                                                              array must be non-empty.
-                                                              If the operator is Exists
-                                                              or DoesNotExist, the
-                                                              values array must be
-                                                              empty. This array is
-                                                              replaced during a strategic
-                                                              merge patch.
                                                             items:
                                                               type: string
                                                             type: array
@@ -7566,16 +7518,6 @@ spec:
                                                     matchLabels:
                                                       additionalProperties:
                                                         type: string
-                                                      description: matchLabels is
-                                                        a map of {key,value} pairs.
-                                                        A single {key,value} in the
-                                                        matchLabels map is equivalent
-                                                        to an element of matchExpressions,
-                                                        whose key field is "key",
-                                                        the operator is "In", and
-                                                        the values array contains
-                                                        only "value". The requirements
-                                                        are ANDed.
                                                       type: object
                                                   type: object
                                                 storageClassName:
@@ -8012,60 +7954,14 @@ spec:
                                                   configMap data to project
                                                 properties:
                                                   items:
-                                                    description: If unspecified, each
-                                                      key-value pair in the Data field
-                                                      of the referenced ConfigMap
-                                                      will be projected into the volume
-                                                      as a file whose name is the
-                                                      key and content is the value.
-                                                      If specified, the listed keys
-                                                      will be projected into the specified
-                                                      paths, and unlisted keys will
-                                                      not be present. If a key is
-                                                      specified which is not present
-                                                      in the ConfigMap, the volume
-                                                      setup will error unless it is
-                                                      marked optional. Paths must
-                                                      be relative and may not contain
-                                                      the '..' path or start with
-                                                      '..'.
                                                     items:
-                                                      description: Maps a string key
-                                                        to a path within a volume.
                                                       properties:
                                                         key:
-                                                          description: The key to
-                                                            project.
                                                           type: string
                                                         mode:
-                                                          description: 'Optional:
-                                                            mode bits used to set
-                                                            permissions on this file.
-                                                            Must be an octal value
-                                                            between 0000 and 0777
-                                                            or a decimal value between
-                                                            0 and 511. YAML accepts
-                                                            both octal and decimal
-                                                            values, JSON requires
-                                                            decimal values for mode
-                                                            bits. If not specified,
-                                                            the volume defaultMode
-                                                            will be used. This might
-                                                            be in conflict with other
-                                                            options that affect the
-                                                            file mode, like fsGroup,
-                                                            and the result can be
-                                                            other mode bits set.'
                                                           format: int32
                                                           type: integer
                                                         path:
-                                                          description: The relative
-                                                            path of the file to map
-                                                            the key to. May not be
-                                                            an absolute path. May
-                                                            not contain the path element
-                                                            '..'. May not start with
-                                                            the string '..'.
                                                           type: string
                                                       required:
                                                       - key
@@ -8092,95 +7988,32 @@ spec:
                                                     description: Items is a list of
                                                       DownwardAPIVolume file
                                                     items:
-                                                      description: DownwardAPIVolumeFile
-                                                        represents information to
-                                                        create the file containing
-                                                        the pod field
                                                       properties:
                                                         fieldRef:
-                                                          description: 'Required:
-                                                            Selects a field of the
-                                                            pod: only annotations,
-                                                            labels, name and namespace
-                                                            are supported.'
                                                           properties:
                                                             apiVersion:
-                                                              description: Version
-                                                                of the schema the
-                                                                FieldPath is written
-                                                                in terms of, defaults
-                                                                to "v1".
                                                               type: string
                                                             fieldPath:
-                                                              description: Path of
-                                                                the field to select
-                                                                in the specified API
-                                                                version.
                                                               type: string
                                                           required:
                                                           - fieldPath
                                                           type: object
                                                         mode:
-                                                          description: 'Optional:
-                                                            mode bits used to set
-                                                            permissions on this file,
-                                                            must be an octal value
-                                                            between 0000 and 0777
-                                                            or a decimal value between
-                                                            0 and 511. YAML accepts
-                                                            both octal and decimal
-                                                            values, JSON requires
-                                                            decimal values for mode
-                                                            bits. If not specified,
-                                                            the volume defaultMode
-                                                            will be used. This might
-                                                            be in conflict with other
-                                                            options that affect the
-                                                            file mode, like fsGroup,
-                                                            and the result can be
-                                                            other mode bits set.'
                                                           format: int32
                                                           type: integer
                                                         path:
-                                                          description: 'Required:
-                                                            Path is  the relative
-                                                            path name of the file
-                                                            to be created. Must not
-                                                            be absolute or contain
-                                                            the ''..'' path. Must
-                                                            be utf-8 encoded. The
-                                                            first item of the relative
-                                                            path must not start with
-                                                            ''..'''
                                                           type: string
                                                         resourceFieldRef:
-                                                          description: 'Selects a
-                                                            resource of the container:
-                                                            only resources limits
-                                                            and requests (limits.cpu,
-                                                            limits.memory, requests.cpu
-                                                            and requests.memory) are
-                                                            currently supported.'
                                                           properties:
                                                             containerName:
-                                                              description: 'Container
-                                                                name: required for
-                                                                volumes, optional
-                                                                for env vars'
                                                               type: string
                                                             divisor:
                                                               anyOf:
                                                               - type: integer
                                                               - type: string
-                                                              description: Specifies
-                                                                the output format
-                                                                of the exposed resources,
-                                                                defaults to "1"
                                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                               x-kubernetes-int-or-string: true
                                                             resource:
-                                                              description: 'Required:
-                                                                resource to select'
                                                               type: string
                                                           required:
                                                           - resource
@@ -8212,42 +8045,13 @@ spec:
                                                       and may not contain the '..'
                                                       path or start with '..'.
                                                     items:
-                                                      description: Maps a string key
-                                                        to a path within a volume.
                                                       properties:
                                                         key:
-                                                          description: The key to
-                                                            project.
                                                           type: string
                                                         mode:
-                                                          description: 'Optional:
-                                                            mode bits used to set
-                                                            permissions on this file.
-                                                            Must be an octal value
-                                                            between 0000 and 0777
-                                                            or a decimal value between
-                                                            0 and 511. YAML accepts
-                                                            both octal and decimal
-                                                            values, JSON requires
-                                                            decimal values for mode
-                                                            bits. If not specified,
-                                                            the volume defaultMode
-                                                            will be used. This might
-                                                            be in conflict with other
-                                                            options that affect the
-                                                            file mode, like fsGroup,
-                                                            and the result can be
-                                                            other mode bits set.'
                                                           format: int32
                                                           type: integer
                                                         path:
-                                                          description: The relative
-                                                            path of the file to map
-                                                            the key to. May not be
-                                                            an absolute path. May
-                                                            not contain the path element
-                                                            '..'. May not start with
-                                                            the string '..'.
                                                           type: string
                                                       required:
                                                       - key
@@ -8632,7 +8436,9 @@ spec:
                             type: object
                         type: object
                       replicas:
-                        description: Number of desired pods.
+                        description: Number of desired pods. This is a pointer to
+                          distinguish between explicit zero and not specified. Defaults
+                          to 1.
                         format: int32
                         type: integer
                       routegroup:
@@ -8645,20 +8451,27 @@ spec:
                             type: boolean
                           hosts:
                             description: Hostnames to use for the per-stack ingresses
-                              (or route groups).
+                              (or route groups). These must contain the special $(STACK_NAME)
+                              token, which will be replaced with the stack's name.
+                              Would be automatically generated based on the hosts
+                              in the ingress/routegroup entry if unset.
                             items:
                               type: string
                             type: array
                           metadata:
                             description: EmbeddedObjectMetaWithAnnotations defines
-                              the metadata which can be attached to a resource.
+                              the metadata which can be attached to a resource. It's
+                              a slimmed down version of metav1.ObjectMeta only containing
+                              annotations.
                             properties:
                               annotations:
                                 additionalProperties:
                                   type: string
-                                description: Annotations is an unstructured key value
+                                description: 'Annotations is an unstructured key value
                                   map stored with a resource that may be set by external
                                   tools to store and retrieve arbitrary metadata.
+                                  They are not queryable and should be preserved when
+                                  modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
                                 type: object
                             type: object
                         type: object
@@ -8669,19 +8482,23 @@ spec:
                         properties:
                           metadata:
                             description: EmbeddedObjectMetaWithAnnotations defines
-                              the metadata which can be attached to a resource.
+                              the metadata which can be attached to a resource. It's
+                              a slimmed down version of metav1.ObjectMeta only containing
+                              annotations.
                             properties:
                               annotations:
                                 additionalProperties:
                                   type: string
-                                description: Annotations is an unstructured key value
+                                description: 'Annotations is an unstructured key value
                                   map stored with a resource that may be set by external
                                   tools to store and retrieve arbitrary metadata.
+                                  They are not queryable and should be preserved when
+                                  modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
                                 type: object
                             type: object
                           ports:
-                            description: The list of ports that are exposed by this
-                              service.
+                            description: 'The list of ports that are exposed by this
+                              service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
                             items:
                               description: ServicePort contains information on service's
                                 port.
@@ -8751,21 +8568,47 @@ spec:
                           underlying deployment
                         properties:
                           rollingUpdate:
-                            description: Rolling update config params.
+                            description: 'Rolling update config params. Present only
+                              if DeploymentStrategyType = RollingUpdate. --- TODO:
+                              Update this to follow our convention for oneOf, whatever
+                              we decide it to be.'
                             properties:
                               maxSurge:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: The maximum number of pods that can be
-                                  scheduled above the desired number of pods.
+                                description: 'The maximum number of pods that can
+                                  be scheduled above the desired number of pods. Value
+                                  can be an absolute number (ex: 5) or a percentage
+                                  of desired pods (ex: 10%). This can not be 0 if
+                                  MaxUnavailable is 0. Absolute number is calculated
+                                  from percentage by rounding up. Defaults to 25%.
+                                  Example: when this is set to 30%, the new ReplicaSet
+                                  can be scaled up immediately when the rolling update
+                                  starts, such that the total number of old and new
+                                  pods do not exceed 130% of desired pods. Once old
+                                  pods have been killed, new ReplicaSet can be scaled
+                                  up further, ensuring that total number of pods running
+                                  at any time during the update is at most 130% of
+                                  desired pods.'
                                 x-kubernetes-int-or-string: true
                               maxUnavailable:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: The maximum number of pods that can be
-                                  unavailable during the update.
+                                description: 'The maximum number of pods that can
+                                  be unavailable during the update. Value can be an
+                                  absolute number (ex: 5) or a percentage of desired
+                                  pods (ex: 10%). Absolute number is calculated from
+                                  percentage by rounding down. This can not be 0 if
+                                  MaxSurge is 0. Defaults to 25%. Example: when this
+                                  is set to 30%, the old ReplicaSet can be scaled
+                                  down to 70% of desired pods immediately when the
+                                  rolling update starts. Once new pods are ready,
+                                  old ReplicaSet can be scaled down further, followed
+                                  by scaling up the new ReplicaSet, ensuring that
+                                  the total number of pods available at all times
+                                  during the update is at least 70% of desired pods.'
                                 x-kubernetes-int-or-string: true
                             type: object
                           type:
@@ -8785,7 +8628,8 @@ spec:
                 type: object
               traffic:
                 description: Traffic is the mapping from a stackset to stack with
-                  weights.
+                  weights. It defines the desired traffic. Clients that orchestrate
+                  traffic switching should write this part.
                 items:
                   description: DesiredTraffic is the desired traffic setting to direct
                     traffic to a stack. This is meant to use by clients to orchestrate
@@ -8809,12 +8653,14 @@ spec:
             description: StackSetStatus is the status section of the StackSet resource.
             properties:
               observedStackVersion:
-                description: ObservedStackVersion is the version of Stack generated
-                  from the current StackSet definition.
+                description: 'ObservedStackVersion is the version of Stack generated
+                  from the current StackSet definition. TODO: add a more detailed
+                  comment'
                 type: string
               readyStacks:
-                description: ReadyStacks is the number of stacks managed by the StackSet
-                  which are considered ready.
+                description: 'ReadyStacks is the number of stacks managed by the StackSet
+                  which are considered ready. a Stack is considered ready if: replicas
+                  == readyReplicas == updatedReplicas.'
                 format: int32
                 type: integer
               stacks:
@@ -8863,7 +8709,7 @@ spec:
       status: {}
 status:
   acceptedNames:
-    kind: ''
-    plural: ''
+    kind: ""
+    plural: ""
   conditions: []
   storedVersions: []


### PR DESCRIPTION
Stack and StackSet CRDs were updated to not exceed annotation size limit, see https://github.com/zalando-incubator/stackset-controller/pull/498

Note that CRDs are not verbatim copies but contain conditional blocks (see https://github.com/zalando-incubator/kubernetes-on-aws/pull/5992). Templates were commented to make CRDs valid yaml.

Followup on https://github.com/zalando-incubator/kubernetes-on-aws/pull/5980