### PR TITLE
Adding ClusterRole and config-items for business-partner-service controller

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -864,6 +864,9 @@ disable_zmon_appliance_worker_tracking: "true"
 # Add ClusterRole for clusters required by hyped-article-lifecycle-management controller
 hyped_article_lifecycle_management: "false"
 
+# Add ClusterRole for clusters required by business-partner controller
+business_partner_service: "false"
+
 # enable SizeMemoryBackedVolumes feature flag
 enable_size_memory_backed_volumes: "true"
 

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -253,3 +253,9 @@ post_apply:
   namespace: kube-system
   kind: VerticalPodAutoscaler
 {{ end }}
+{{ if eq .Cluster.ConfigItems.business_partner_service "false" }}
+- name: business-partner-service
+  kind: ClusterRole
+- name: business-partner-service
+  kind: ClusterRoleBinding
+{{ end }}

--- a/cluster/manifests/roles/business-partner-rbac.yaml
+++ b/cluster/manifests/roles/business-partner-rbac.yaml
@@ -1,0 +1,33 @@
+{{- if eq .Cluster.ConfigItems.business_partner_service "true" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: business-partner-service
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - business-partners-config
+  - sales-channels-config
+  verbs:
+  - get
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: business-partner-service
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: business-partner-service
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: zalando-iam:zalando:service:business-partner-service
+{{- end }}


### PR DESCRIPTION
Based on #6081 

Related Teapot Issue: [Enabling business_partner and sales_channel configmaps for application: business-partner-service](https://github.bus.zalan.do/zooport/issues/issues/3705)

> In the scope of a project, it's decided to provide a new capability to distribute business configurations via AWS S3 and ConfigMaps. The configuration that are in scope are business partners and sales-channels that are managed by `business-partner-service`. An ultimate goal is to provide the simple (compare to periodically calling the service REST API or consume-persist events) way to distribute dynamic business configurations to existing and new clients.

> In order to allow a controller to update the configmaps we need to give it access in dedicated clusters.
The controller has the application ID: `business-partner-service`

The PR introduces a ClusterRole/ClusterRoleBinding providing the business-partner-service controller access to the relevant configmaps. It also adds a config-item which will then be enabled in the specific clusters which the controller requires access to. Similar change was done in https://github.com/zalando-incubator/kubernetes-on-aws/pull/5230