### PR TITLE
skipper-ingress: enable OAuth grant flow by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -268,14 +268,9 @@ skipper_tokeninfo_cache_ttl: "30s"
 skipper_oauth2_ui_login: "false"
 skipper_ingress_encryption_key: ""
 {{else}}
-skipper_oauth2_ui_login: "false"
+skipper_oauth2_ui_login: "true"
 {{end}}
 
-# Comma-separated list of <hostname>=<application> pairs.
-# E.g. to configure "foo.example.org" and "foo.example.com" hostnames for application "foo" and
-# "bar.example.net" for "bar" set
-# skipper_oauth2_ui_login_hostnames: "foo.example.org=foo,foo.example.com=foo,bar.example.net=bar"
-skipper_oauth2_ui_login_hostnames: ""
 # Comma-separated list of tokeninfo keys to retain
 skipper_oauth2_ui_login_tokeninfo_keys: ""
 


### PR DESCRIPTION
* remove unused `skipper_oauth2_ui_login_hostnames` (followup on https://github.com/zalando-incubator/kubernetes-on-aws/pull/5901)