### PR TITLE
Fix e2e by generating service_account_key via aws-account-creator

### DIFF
--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -19,7 +19,6 @@ clusters:
     etcd_client_ca_key: "${ETCD_CLIENT_CA_KEY}"
     etcd_scalyr_key: "${ETCD_SCALYR_KEY}"
     docker_meta_url: https://docker-meta.stups-test.zalan.do
-    service_account_private_key: ${SERVICE_ACCOUNT_PRIVATE_KEY}
     vpa_enabled: "true"
     lightstep_token: "${LIGHTSTEP_TOKEN}"
     okta_auth_issuer_url: "${OKTA_AUTH_ISSUER_URL}"

--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -51,10 +51,6 @@ export API_SERVER_URL="https://${LOCAL_ID}.${HOSTED_ZONE}"
 export INFRASTRUCTURE_ACCOUNT="aws:${AWS_ACCOUNT}"
 export CLUSTER_ID="${INFRASTRUCTURE_ACCOUNT}:${REGION}:${LOCAL_ID}"
 
-# Generate a new key for this E2E run
-SERVICE_ACCOUNT_PRIVATE_KEY="$(openssl genrsa | base64 | tr -d '\n')"
-export SERVICE_ACCOUNT_PRIVATE_KEY
-
 # create kubeconfig
 cat >kubeconfig <<EOF
 apiVersion: v1


### PR DESCRIPTION
This removes the use of `openssl` to generate `service_account_private_key` as part of the e2e cluster and instead relies on `aws-account-creator` which is also used for all other certs/keys.

The motivation for this is that `openssl genrsa` changed behavior in the latest base image (`container-registry.zalando.net/library/python-3.11-slim`) and not generates a key PEM format incompatible with CLM.

We could also fix it by using `openssl genrsa -traditional` but better to not rely on `openssl` at all.

Note: This change will not work against `dev` because the e2e cluster setup depends on the `cluster_config.sh` of the target branch and this change is now incompatible. We need to merge this to `dev` and any new PR against `dev` will work.

It's validated that this change works in #6090 