### PR TITLE
ExternalDNS: allow to configure domain filter via config item

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -687,6 +687,8 @@ custom_dns_zone_nameservers: "" # space separated list of nameserver IP addresse
 
 # prefix prepended to ownership TXT records for external-dns
 external_dns_ownership_prefix: ""
+# domains that should be included by ExternalDNS ("" includes all hosted zones in the account. Separate multiple domains with a comma)
+external_dns_domain_filter: ""
 # domains that should be ignored by ExternalDNS
 external_dns_excluded_domains: cluster.local
 # synchronization policy between Kubernetes and AWS Route53 (default: sync, options: sync, upsert-only, create-only)

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -37,6 +37,9 @@ spec:
         - --source=service
         - --source=ingress
         - --source=skipper-routegroup
+{{- range split .ConfigItems.external_dns_domain_filter "," }}
+        - --domain-filter={{ . }}
+{{- end }}
 {{- range split .ConfigItems.external_dns_excluded_domains "," }}
         - --exclude-domains={{ . }}
 {{- end }}


### PR DESCRIPTION
Allow to configure domain filter with a config item.

The default setting results in the current behaviour so there's no change when using the default config item value (empty string).

After that we can configure, e.g.:

```yaml
external_dns_domain_filter: teapot.zalan.do,teapot-e2e.zalan.do
```

to get the flags `--domain=filter=teapot.zalan.do --domain-filter=teapot-e2e.zalan.do` which includes all zones matching either of these two suffixes.