### PR TITLE
Remove superflous env variable KUBE_MAX_PD_VOLS

### DIFF
--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -71,7 +71,5 @@ spec:
         env:
           - name: AWS_REGION
             value: {{ .Region }}
-          - name: KUBE_MAX_PD_VOLS
-            value: "26"
       nodeSelector:
         node.kubernetes.io/role: master

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -675,9 +675,6 @@ write_files:
           - --leader-elect=true
           - --feature-gates=NonPreemptingPriority=true
           - --profiling={{ .Cluster.ConfigItems.enable_control_plane_profiling }}
-          env:
-          - name: KUBE_MAX_PD_VOLS
-            value: "26"
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
the problem described below has been fixed with the introduction of ClusterAutoscaler based on version v1.23 #6123. This also made the environment variable `KUBE_MAX_PD_VOLS ` superfluous. Let's remove it.

---

[OLD DESCRIPTION]

Set a global limit of `22` attachable volumes for every single node type across our clusters.

This global reduction of 4 storage slots will mean that nodes that are currently successfully holding 23 to 26 PVCs will need an additional node to run the same amount of pods with volumes, therefore increasing cost. In practice, this should happen rarely as 20+ is already quite a large amount of volumes to be attached for normal nodes. Pods rarely have multiple volumes, so you need twenty-something Pods to run on the node (while still be within CPU and memory limits) to exceed that threshold. This should only happen on very big instance types given typical Pod requirements.

The advantage is that a limit of 22 will also cover all `d` instance types with up to 4 local storage disks (the maximum, e.g. `m5.24xlarge`) which each take up a slot themselves (since Nitro). That means that users of `d` types with lots of volumes will not run into situations where the scheduler _thinks_ it can attach yet another volume only to get blocked by AWS later which currently results in forever-Pending Pods.

~~Note, that the reduction to the previous value should be `-4` but this PR only reduces it by `3`. I noticed that the previous value of `26` will result in an effective value of `25` in the cluster, possibly because Kubernetes already "reserves" one for itself. Hence, the value should specify the actual maximum number of possible attachments which is `27` on most instance types and `23` on the biggest `d` instance types. The new value should result in a maximum number of available slots for PVCs of `22` on the biggest `d` instance types which is then equal to what you get when using CSI directly.~~

I couldn't confirm the above and my experiments yielded the correct results when using 22.

This will also fix the limit for 6th generation instance types which are currently completely off with a number of 39 due to using legacy code that was written before they existed.

After all this env doesn't solve the problem entirely and there will be a [follow-up PR](https://github.com/zalando-incubator/autoscaler/pull/102) in ClusterAutoscaler. But for consistency it's good to set these values here as well.