### PR TITLE
[STABLE] Generate service_account key using aws-account-creator

### DIFF
--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -19,7 +19,6 @@ clusters:
     etcd_client_ca_key: "${ETCD_CLIENT_CA_KEY}"
     etcd_scalyr_key: "${ETCD_SCALYR_KEY}"
     docker_meta_url: https://docker-meta.stups-test.zalan.do
-    service_account_private_key: ${SERVICE_ACCOUNT_PRIVATE_KEY}
     vpa_enabled: "true"
     lightstep_token: "${LIGHTSTEP_TOKEN}"
     okta_auth_issuer_url: "${OKTA_AUTH_ISSUER_URL}"

--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -51,10 +51,6 @@ export API_SERVER_URL="https://${LOCAL_ID}.${HOSTED_ZONE}"
 export INFRASTRUCTURE_ACCOUNT="aws:${AWS_ACCOUNT}"
 export CLUSTER_ID="${INFRASTRUCTURE_ACCOUNT}:${REGION}:${LOCAL_ID}"
 
-# Generate a new key for this E2E run
-SERVICE_ACCOUNT_PRIVATE_KEY="$(openssl genrsa | base64 | tr -d '\n')"
-export SERVICE_ACCOUNT_PRIVATE_KEY
-
 # create kubeconfig
 cat >kubeconfig <<EOF
 apiVersion: v1


### PR DESCRIPTION
Hotfix #6087 to stable as it needs to be merged ahead of other changes to fix e2e.