### PR TITLE
Update deployment-service to return empty response if no errors

### DIFF
--- a/cluster/manifests/deployment-service/controller-statefulset.yaml
+++ b/cluster/manifests/deployment-service/controller-statefulset.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
         - name: "deployment-service-controller"
-          image: "container-registry.zalando.net/teapot/deployment-controller:master-130"
+          image: "container-registry.zalando.net/teapot/deployment-controller:master-131"
           args:
             - "--config-namespace=kube-system"
           env:

--- a/cluster/manifests/deployment-service/status-service-deployment.yaml
+++ b/cluster/manifests/deployment-service/status-service-deployment.yaml
@@ -1,5 +1,5 @@
 {{ $image   := "container-registry.zalando.net/teapot/deployment-status-service" }}
-{{ $version := "master-130" }}
+{{ $version := "master-131" }}
 
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
If resources have no errors and warnings they won't be displayed at all in the response.