### PR TITLE
Fix small mistake in function comment

### DIFF
--- a/test/e2e/kube_metrics_adapter_test.go
+++ b/test/e2e/kube_metrics_adapter_test.go
@@ -264,7 +264,7 @@ func simplePodMetricDeployment(name string, replicas int32, metricName string, m
 		})
 }
 
-// podDeployment is a Deployment of an application that exposes an HTTP endpoint
+// simplePodDeployment is a Deployment of an application that exposes an HTTP endpoint
 func simplePodDeployment(name string, replicas int32) *appsv1.Deployment {
 	podSpec := corev1.PodSpec{Containers: []corev1.Container{}}
 	podSpec.Containers = append(podSpec.Containers, podContainerSpec(name))


### PR DESCRIPTION
This tiny change fixes a single word where the comment does not match the function name.

Background: I'm doing a research study on function comments that may be incorrect. You can find more info and a short and optional anonymous survey [here](https://forms.office.com/e/yHv4PRXM2i).
 
Thanks for reviewing!