### PR TITLE
update skipper from v0.16.93 to v0.16.111

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.16.93-512" }}
+{{ $internal_version := "v0.16.111-530" }}
 {{ $version := index (split $internal_version "-") 0 }}
 
 apiVersion: apps/v1


### PR DESCRIPTION
update skipper from v0.16.93 to v0.16.111 to optimize tcp accept handler max concurrency based on available memory limit increase form 1G to 4G.

https://github.com/zalando/skipper/compare/v0.16.93...v0.16.111