### PR TITLE
Grant `list`, `get` and `watch` for `EndpointSlice` resources for `readonly` role.

### DIFF
--- a/cluster/manifests/roles/readonly-role.yaml
+++ b/cluster/manifests/roles/readonly-role.yaml
@@ -169,6 +169,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - extensions
   - networking.k8s.io
   resources:


### PR DESCRIPTION
This is to enable the mentioned role to inspect `EndpointSlice` K8s resources for troubleshooting.
Some information about `EndpointSlice` K8s resource: https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/.