### PR TITLE
Add hyped article ClusterRole and ClusterRoleBinding deletions

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -253,6 +253,12 @@ post_apply:
   namespace: kube-system
   kind: VerticalPodAutoscaler
 {{ end }}
+{{ if eq .Cluster.ConfigItems.hyped_article_lifecycle_management "false" }}
+- name: hyped-articles-lifecycle-management
+  kind: ClusterRole
+- name: hyped-articles-lifecycle-management
+  kind: ClusterRoleBinding
+{{ end }}
 {{ if eq .Cluster.ConfigItems.business_partner_service "false" }}
 - name: business-partner-service
   kind: ClusterRole


### PR DESCRIPTION
Update the cluster deletions to remove the `hyped_articles_lifecycle_management` ClusterRole and ClusterRoleBindings when the `hyped_article_lifecycle_management` config item is false.