### PR TITLE
skipper: do not create HTTPS redirect routes when behind NLB

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -248,6 +248,7 @@ spec:
 {{ if or (eq .ConfigItems.nlb_switch "pre") (eq .ConfigItems.nlb_switch "exec") }}
           - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
           - "-forwarded-headers-exclude-cidrs=10.2.0.0/15,{{ .Values.vpc_ipv4_cidr}}"
+          - "-kubernetes-https-redirect=false"
 {{ end }}
 {{ if ne .ConfigItems.skipper_ingress_inline_routes "" }}
           - "-inline-routes={{ .ConfigItems.skipper_ingress_inline_routes }}"
@@ -483,6 +484,7 @@ spec:
 {{ if or (eq .ConfigItems.nlb_switch "pre") (eq .ConfigItems.nlb_switch "exec") }}
           - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
           - "-forwarded-headers-exclude-cidrs=10.2.0.0/15,{{ .Values.vpc_ipv4_cidr}}"
+          - "-kubernetes-https-redirect=false"
 {{ end }}
         resources:
           limits:


### PR DESCRIPTION
When Skipper runs behind AWS Network Load Balancer (NLB) it has a dedicated handler for HTTP traffic and therefore HTTPS redirect routes could be omitted to reduce routing table size.

See related https://github.com/zalando/skipper/issues/1914