### PR TITLE
Update PDB to policy/v1

### DIFF
--- a/cluster/manifests/kube-cluster-autoscaler/pdb.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/pdb.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:


### PR DESCRIPTION
PodDisruptionBudget must use `policy/v1` apiVersion from v1.25. Upgrade now as preparation.