### PR TITLE
Update Cluster Autoscaler to Kubernetes v1.23.17

### DIFF
--- a/cluster/manifests/kube-cluster-autoscaler/01-rbac.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/01-rbac.yaml
@@ -37,6 +37,7 @@ rules:
   resources:
   - "pods"
   - "services"
+  - "namespaces"
   - "replicationcontrollers"
   - "persistentvolumeclaims"
   - "persistentvolumes"
@@ -51,7 +52,7 @@ rules:
   resources: ["statefulsets", "replicasets", "daemonsets"]
   verbs: ["watch", "list", "get"]
 - apiGroups: ["storage.k8s.io"]
-  resources: ["storageclasses", "csinodes"]
+  resources: ["storageclasses", "csinodes", "csidrivers", "csistoragecapacities"]
   verbs: ["watch", "list", "get"]
 - apiGroups: ["batch", "extensions"]
   resources: ["jobs"]

--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -36,7 +36,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cluster-autoscaler
-        image: container-registry.zalando.net/teapot/kube-cluster-autoscaler:v1.18.2-internal.39
+        image: container-registry.zalando.net/teapot/kube-cluster-autoscaler:v1.18.2-internal.43
         command:
           - ./cluster-autoscaler
           - --v={{.Cluster.ConfigItems.autoscaling_autoscaler_log_level}}


### PR DESCRIPTION
This updates our fork of the cluster-autoscaler to a version using Kubernetes v1.23.17. The purpose is to use `policy/v1` api for PodDisruptionBudgets to ensure that it will work with Kubernetes v1.25 where the `policy/v1beta1` API is no longer available.

Ref: https://github.com/zalando-incubator/autoscaler/pull/103

It also gives the autoscaler permissions to read namespaces. This is done because the scheduler code in v1.23.17 now needs this to check namespace labels: https://github.com/kubernetes/kubernetes/blob/v1.23.17/pkg/scheduler/framework/plugins/interpodaffinity/plugin.go#L130-L140

lastly it gives the autoscaler permission to read `csidrivers` and `csistoragecapacities` which have also been introduced in the scheduler in v1.23.17