### PR TITLE
Use policy/v1 for e2e PDB

### DIFF
--- a/test/e2e/apply/pdb.yaml
+++ b/test/e2e/apply/pdb.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: "{{{APPLICATION}}}-{{{COMPONENT}}}"


### PR DESCRIPTION
Use the up to date apiVersion for the pdb deployed as part of e2e.