### PR TITLE
Allow setting custom sysctl settings

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -907,3 +907,20 @@ apiserver_memory_limit_percent: "80"
 
 # specify if control plane nodes should rely on ASG Lifecycle Hook or not
 control_plane_asg_lifecycle_hook: "true"
+
+# This allows setting custom sysctl settings. The config-item is intended to be
+# used on node-pools rather being set globally.
+#
+# The value is a comma seprated configuration of `sysctl_setting=value` as
+# illustrated in the example below.
+#
+# Example:
+#
+#   sysctl_settings: "fs.aio-max-nr=8388608,fs.inotify.max_user_watches=100000"
+#
+# Which translates to a file on the node:
+#
+#  cat /etc/sysctl.d/99-custom-sysctl-settings.conf
+#  fs.aio-max-nr = 8388608
+#  fs.inotify.max_user_watches = 100000
+sysctl_settings: ""

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -880,6 +880,15 @@ write_files:
           qps: {{ .Cluster.ConfigItems.event_rate_limit_config_qps }}
           burst: {{ .Cluster.ConfigItems.event_rate_limit_config_burst }}
 {{ end }}
+{{- if ne .NodePool.ConfigItems.sysctl_settings ""}}
+  - owner: root:root
+    path: /etc/sysctl.d/99-custom-sysctl-settings.conf
+    content: |
+      {{- range $i, $cfgs := split .NodePool.ConfigItems.sysctl_settings ","}}
+      {{- $cfg := split $cfgs "="}}
+      {{index $cfg 0}} = {{index $cfg 1}}
+      {{- end}}
+{{- end}}
 
   - owner: root:root
     path: /etc/kubernetes/cni/net.d/10-flannel.conflist

--- a/cluster/node-pools/worker-splitaz/userdata.yaml
+++ b/cluster/node-pools/worker-splitaz/userdata.yaml
@@ -124,6 +124,15 @@ write_files:
       vm.dirty_background_bytes = {{ .Cluster.ConfigItems.vm_dirty_background_bytes }}
       vm.dirty_bytes = {{ .Cluster.ConfigItems.vm_dirty_bytes }}
 {{- end}}
+{{- if ne .NodePool.ConfigItems.sysctl_settings ""}}
+  - owner: root:root
+    path: /etc/sysctl.d/99-custom-sysctl-settings.conf
+    content: |
+      {{- range $i, $cfgs := split .NodePool.ConfigItems.sysctl_settings ","}}
+      {{- $cfg := split $cfgs "="}}
+      {{index $cfg 0}} = {{index $cfg 1}}
+      {{- end}}
+{{- end}}
 
   - owner: root:root
     path: /etc/kubernetes/cni/net.d/10-flannel.conflist


### PR DESCRIPTION
This introduces a feature to allow setting custom `sysctl` settings per node pool. The motivation for this request is that we sometime need custom `sysctl` settings because of vendor tool requirements or simply because we want to test other settings. Having to make changes to the AMI is a lot of effort so it's useful to be able to set it per node pool so we can test it before making changes across all nodes.

To illustrate how this works we can look at changing [`aio-max-nr`](https://sort.veritas.com/public/documents/HSO/2.0/linux/productguides/html/hfo_admin_ubuntu/ch04s03.htm#:~:text=The%20aio%2Dmax%2Dnr%20parameter,wide%20number%20of%20asynchronous%20requests.) which is a concrete example from a vendor requirement.

On a node without a custom setting the value is this:

```sh
sudo cat /proc/sys/fs/aio-max-nr
65536
```

By setting the `sysctl_settings` config item we can change the value:

```yaml
- discount_strategy: spot
  instance_types:
  - m5.xlarge
  - m5.2xlarge
  - m5.4xlarge
  max_size: 99
  min_size: 0
  name: worker-with-aio-max-nr
  profile: worker-splitaz
  config_items:
    sysctl_settings: "fs.aio-max-nr=8388608"
```

Which results in the setting being set on a node of the pool:

```sh
sudo cat /proc/sys/fs/aio-max-nr
8388608
```

