### PR TITLE
Update deployment service to support batch/v1 for CronJobs

### DIFF
--- a/cluster/manifests/deployment-service/controller-statefulset.yaml
+++ b/cluster/manifests/deployment-service/controller-statefulset.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
         - name: "deployment-service-controller"
-          image: "container-registry.zalando.net/teapot/deployment-controller:master-131"
+          image: "container-registry.zalando.net/teapot/deployment-controller:master-135"
           args:
             - "--config-namespace=kube-system"
           env:

--- a/cluster/manifests/deployment-service/status-service-deployment.yaml
+++ b/cluster/manifests/deployment-service/status-service-deployment.yaml
@@ -1,5 +1,5 @@
 {{ $image   := "container-registry.zalando.net/teapot/deployment-status-service" }}
-{{ $version := "master-131" }}
+{{ $version := "master-135" }}
 
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
This updates the deployment-service to use `batch/v1` for CronJobs instead of `batch/v1beta1` which will not be available in Kubernetes v1.25.