### PR TITLE
Make auditrail role unique

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -2109,7 +2109,7 @@ Resources:
                   - arn:aws:s3:::zalando-audittrail-central/*
             Version: 2012-10-17
           PolicyName: root
-      RoleName: "zalando-audittrail-adapter-central"
+      RoleName: "zalando-audittrail-adapter-central-{{.Cluster.LocalID}}"
     Type: 'AWS::IAM::Role'
 {{- if eq .Cluster.ConfigItems.dynamodb_service_link_enabled "true" }}
   ServiceLinkedRoleAutoScalingDynamoDB:


### PR DESCRIPTION
Follow up to #6055 to make the role unique when there are multiple clusters per account (e.g. in e2e tests).