### PR TITLE
skipper: update version to v0.16.123

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.16.118-537" }}
+{{ $internal_version := "v0.16.123-542" }}
 {{ $version := index (split $internal_version "-") 0 }}
 
 apiVersion: apps/v1


### PR DESCRIPTION
This update reduces amount of kubenetes dataclient logs, see https://github.com/zalando/skipper/compare/v0.16.118...v0.16.123