### PR TITLE
Consolidate Audittrail IAM roles

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -2067,39 +2067,6 @@ Resources:
                 Effect: Allow
                 Resource:
                   - !GetAtt AuditTrailBucket.Arn
-
-              - Action:
-                  - s3:PutObject
-                Effect: Allow
-                Resource:
-                  - !Sub
-                    - "${BucketArn}/*"
-                    - BucketArn: !GetAtt AuditTrailBucket.Arn
-            Version: 2012-10-17
-          PolicyName: root
-      RoleName: "{{.Cluster.LocalID}}-audittrail-adapter"
-    Type: 'AWS::IAM::Role'
-  AudittrailAdapterCentralIAMRole:
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-          - Effect: Allow
-            Principal:
-              Federated: !Sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
-            Action:
-              - 'sts:AssumeRoleWithWebIdentity'
-            Condition:
-              StringEquals:
-                "{{ .Cluster.LocalID }}.{{ .Values.hosted_zone }}:sub": "system:serviceaccount:kube-system:audittrail-adapter"
-        Version: 2012-10-17
-      Path: /
-      Policies:
-        - PolicyDocument:
-            Statement:
-              - Action:
-                  - s3:ListBucket
-                Effect: Allow
-                Resource:
                   - arn:aws:s3:::zalando-audittrail-central
 
               - Action:
@@ -2107,9 +2074,12 @@ Resources:
                 Effect: Allow
                 Resource:
                   - arn:aws:s3:::zalando-audittrail-central/*
+                  - !Sub
+                    - "${BucketArn}/*"
+                    - BucketArn: !GetAtt AuditTrailBucket.Arn
             Version: 2012-10-17
           PolicyName: root
-      RoleName: "zalando-audittrail-adapter-central-{{.Cluster.LocalID}}"
+      RoleName: "{{.Cluster.LocalID}}-audittrail-adapter"
     Type: 'AWS::IAM::Role'
 {{- if eq .Cluster.ConfigItems.dynamodb_service_link_enabled "true" }}
   ServiceLinkedRoleAutoScalingDynamoDB:


### PR DESCRIPTION
Follow up to https://github.com/zalando-incubator/kubernetes-on-aws/pull/6055.

After testing the setup using the recently added centralised Audittrail IAM role, it was discovered that the approach of a single, extended role would be the simpler solution. This is due to the limitations of attaching multiple IAM roles to a single Service Account and the limitations of attaching multiple Service Accounts to a Kubernetes Pod. 

With a single role setup, the configuration of the `Audittrail-Adapter`'s Service Account can remain in it's current state, with only the policy of the centralised S3 Bucket needing to be edited to allow for access from this extended role. 