### PR TITLE
Revert "Update deployment-service to process tag changes on stacks"

### DIFF
--- a/cluster/manifests/deployment-service/controller-statefulset.yaml
+++ b/cluster/manifests/deployment-service/controller-statefulset.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
         - name: "deployment-service-controller"
-          image: "container-registry.zalando.net/teapot/deployment-controller:master-136"
+          image: "container-registry.zalando.net/teapot/deployment-controller:master-135"
           args:
             - "--config-namespace=kube-system"
           env:

--- a/cluster/manifests/deployment-service/status-service-deployment.yaml
+++ b/cluster/manifests/deployment-service/status-service-deployment.yaml
@@ -1,5 +1,5 @@
 {{ $image   := "container-registry.zalando.net/teapot/deployment-status-service" }}
-{{ $version := "master-136" }}
+{{ $version := "master-135" }}
 
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Reverts zalando-incubator/kubernetes-on-aws#6136

Reverting because users are negatively affected by this.