### PR TITLE
Add RequestsPerSecond based autoscaling to StackSet

### DIFF
--- a/cluster/manifests/stackset-controller/01-stack-crd.yaml
+++ b/cluster/manifests/stackset-controller/01-stack-crd.yaml
@@ -260,6 +260,20 @@ spec:
                           - name
                           - region
                           type: object
+                        requestsPerSecond:
+                          description: MetricRequestsPerSecond specifies basic information
+                            to scale based on on external RPS metric.
+                          properties:
+                            hostnames:
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              type: string
+                          required:
+                          - hostnames
+                          - name
+                          type: object
                         scalingSchedule:
                           description: MetricsScalingSchedule specifies the ScalingSchedule
                             object which should be used for scaling.
@@ -1645,14 +1659,6 @@ spec:
                                                   and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
                                                 items:
                                                   type: string
                                                 type: array

--- a/cluster/manifests/stackset-controller/01-stackset-crd.yaml
+++ b/cluster/manifests/stackset-controller/01-stackset-crd.yaml
@@ -505,6 +505,21 @@ spec:
                                   - name
                                   - region
                                   type: object
+                                requestsPerSecond:
+                                  description: MetricRequestsPerSecond specifies basic
+                                    information to scale based on on external RPS
+                                    metric.
+                                  properties:
+                                    hostnames:
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      type: string
+                                  required:
+                                  - hostnames
+                                  - name
+                                  type: object
                                 scalingSchedule:
                                   description: MetricsScalingSchedule specifies the
                                     ScalingSchedule object which should be used for

--- a/cluster/manifests/stackset-controller/deployment.yaml
+++ b/cluster/manifests/stackset-controller/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $version := "v1.4.0" }}
+{{ $version := "v1.4.4" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/test/e2e/stackset/go.mod
+++ b/test/e2e/stackset/go.mod
@@ -2,7 +2,7 @@ module github.com/zalando-incubator/kubernetes-on-aws/test/e2e/stackset
 
 go 1.20
 
-require github.com/zalando-incubator/stackset-controller v1.4.2
+require github.com/zalando-incubator/stackset-controller v1.4.4
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/test/e2e/stackset/go.sum
+++ b/test/e2e/stackset/go.sum
@@ -414,8 +414,8 @@ github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
-github.com/zalando-incubator/stackset-controller v1.4.2 h1:n6fd2ijZ79Tz6vk/fxTaqH+fVD1raNhHfyFMGqRjdxo=
-github.com/zalando-incubator/stackset-controller v1.4.2/go.mod h1:Ln8fZCi6Ap9UYTa7j/lKBim0xpblJChs+kP7gsZRyXQ=
+github.com/zalando-incubator/stackset-controller v1.4.4 h1:RcKtkWH+Ej9aYuUzYYrYmpq+KxwMQIkGSz53mNPMX1g=
+github.com/zalando-incubator/stackset-controller v1.4.4/go.mod h1:4OfrpQpYnTBEd2TpPw3ZU9We4/wBFqwsxKvqOpfsxnM=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=


### PR DESCRIPTION
This adds a new `RequestsPerSecond` metric to the `autoscaler` field of StackSet which allows scaling based on RPS of a defined hostname.

https://github.com/zalando-incubator/stackset-controller/releases/tag/v1.4.4