### PR TITLE
Update Audittrail Adapter version and flags

### DIFF
--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: audittrail-adapter
-    version: master-36
+    version: master-41
 spec:
   selector:
     matchLabels:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: audittrail-adapter
-        version: master-36
+        version: master-41
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
         prometheus.io/path: /metrics
@@ -35,14 +35,16 @@ spec:
       hostNetwork: true
       containers:
       - name: audittrail-adapter
-        image: container-registry.zalando.net/teapot/audittrail-adapter:master-36
+        image: container-registry.zalando.net/teapot/audittrail-adapter:master-41
         env:
           - name: AWS_REGION
             value: {{.Cluster.Region}}
         args:
         - --cluster-id={{ .ID }}
+        - --cluster-alias={{ .Cluster.Alias }}
         - --audittrail-url={{ .Cluster.ConfigItems.audittrail_url }}
-        - --s3-bucket-name=zalando-audittrail-{{accountID .InfrastructureAccount}}-{{.LocalID}}
+        - --s3-audit-bucket-name=zalando-audittrail-central
+        - --s3-fallback-bucket-name=zalando-audittrail-{{accountID .InfrastructureAccount}}-{{.LocalID}}
         - --address=:8889
         - --metrics-address=:7980
         - --audittrail-timeout={{ .Cluster.ConfigItems.audittrail_adapter_timeout }}


### PR DESCRIPTION
Update the Audittrail Adapter to use the latest version.

With the addition of the centralised S3 bucket storing audit events, the `--s3-bucket-name` flag has been split into two -- separating the central bucket target from the fallback bucket target.

`--cluster-alias` (added [here](https://github.bus.zalan.do/teapot/audittrail-adapter/pull/42)) will be used as part of the Bucket path for the centralised Bucket.

[Relevant Teapot issue](https://github.bus.zalan.do/teapot/issues/issues/3436)