### PR TITLE
Revert "Update Audittrail Adapter version and flags"

### DIFF
--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: audittrail-adapter
-    version: master-41
+    version: master-36
 spec:
   selector:
     matchLabels:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: audittrail-adapter
-        version: master-41
+        version: master-36
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
         prometheus.io/path: /metrics
@@ -35,16 +35,14 @@ spec:
       hostNetwork: true
       containers:
       - name: audittrail-adapter
-        image: container-registry.zalando.net/teapot/audittrail-adapter:master-41
+        image: container-registry.zalando.net/teapot/audittrail-adapter:master-36
         env:
           - name: AWS_REGION
             value: {{.Cluster.Region}}
         args:
         - --cluster-id={{ .ID }}
-        - --cluster-alias={{ .Cluster.Alias }}
         - --audittrail-url={{ .Cluster.ConfigItems.audittrail_url }}
-        - --s3-audit-bucket-name=zalando-audittrail-central
-        - --s3-fallback-bucket-name=zalando-audittrail-{{accountID .InfrastructureAccount}}-{{.LocalID}}
+        - --s3-bucket-name=zalando-audittrail-{{accountID .InfrastructureAccount}}-{{.LocalID}}
         - --address=:8889
         - --metrics-address=:7980
         - --audittrail-timeout={{ .Cluster.ConfigItems.audittrail_adapter_timeout }}


### PR DESCRIPTION
This reverts #6161 as it started causing issues and sending sporadic spikes of events to the audit-api causing issues.