### PR TITLE
Update Audittrail Adapter version

### DIFF
--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: audittrail-adapter
-    version: master-41
+    version: master-42
 spec:
   selector:
     matchLabels:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         application: audittrail-adapter
-        version: master-41
+        version: master-42
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
         prometheus.io/path: /metrics
@@ -35,7 +35,7 @@ spec:
       hostNetwork: true
       containers:
       - name: audittrail-adapter
-        image: container-registry.zalando.net/teapot/audittrail-adapter:master-41
+        image: container-registry.zalando.net/teapot/audittrail-adapter:master-42
         env:
           - name: AWS_REGION
             value: {{.Cluster.Region}}


### PR DESCRIPTION
Update the Audittrail Adapter to add a new application ID header.

[Audittrail Adapter PR](https://github.bus.zalan.do/teapot/audittrail-adapter/pull/45)