### PR TITLE
Enable ksm pod labels 

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -857,7 +857,7 @@ observability_metrics_endpoint: "ingest.lightstep.com"
 observability_metrics_port: "443"
 
 # labels whitelisted to kube-state-metrics
-observability_metrics_pods_labels: "application,component"
+observability_metrics_pods_labels: "application,component,version,stack_name,stack_version,application_id,application_version,team"
 observability_metrics_ingresses_labels: ""
 
 # opentelemetry collector


### PR DESCRIPTION
This enables KSM pod labels for Otel collector

Part of https://github.com/zalando-incubator/kubernetes-on-aws/issues/5831