### PR TITLE
Update deployment-service to support traffic segments

### DIFF
--- a/cluster/manifests/deployment-service/controller-statefulset.yaml
+++ b/cluster/manifests/deployment-service/controller-statefulset.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
         - name: "deployment-service-controller"
-          image: "container-registry.zalando.net/teapot/deployment-controller:master-145"
+          image: "container-registry.zalando.net/teapot/deployment-controller:master-147"
           args:
             - "--config-namespace=kube-system"
           env:

--- a/cluster/manifests/deployment-service/status-service-deployment.yaml
+++ b/cluster/manifests/deployment-service/status-service-deployment.yaml
@@ -1,5 +1,5 @@
 {{ $image   := "container-registry.zalando.net/teapot/deployment-status-service" }}
-{{ $version := "master-145" }}
+{{ $version := "master-147" }}
 
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
This enables Deployment Service to probe for legacy and new Stacksets based on cluster-wide configuration.