### PR TITLE
Add config item for audit webhook batch max size

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -610,6 +610,8 @@ audittrail_adapter_memory: "200Mi"
 
 audittrail_adapter_timeout: "2s"
 
+audit_webhook_batch_max_size: "400"
+
 kube2iam_cpu: "25m"
 kube2iam_memory: "100Mi"
 

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -160,6 +160,7 @@ write_files:
           {{ else }}
           - --audit-webhook-config-file=/etc/kubernetes/config/audit.yaml
           - --audit-webhook-mode=batch
+          - --audit-webhook-batch-max-size={{ .Cluster.ConfigItems.audit_webhook_batch_max_size }}
           - --audit-webhook-version=audit.k8s.io/v1
           {{ end }}
           # enable aggregated apiservers


### PR DESCRIPTION
Allow the audit webhook batch size to be configurable. We see batches of audit events timing out leading to entire batches being retried exponentially. By configuring (and specifically lowering) the batch size value from the default 400, we can ensure all events within the batch are processed within the timeout window.

[Teapot issue 3436](https://github.bus.zalan.do/teapot/issues/issues/3436)