### PR TITLE
Update some skipper images

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -249,7 +249,7 @@ write_files:
               readOnly: true
 {{- if or (eq .Cluster.ConfigItems.routegroups_validation "provisioned") (eq .Cluster.ConfigItems.routegroups_validation "enabled") }}
         - name: routegroups-admission-webhook
-          image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/skipper:v0.13.240
+          image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/skipper:v0.16.154
           args:
             - webhook
             - --address=:9085
@@ -476,7 +476,7 @@ write_files:
             name: ssl-certs-kubernetes
             readOnly: true
         - name: skipper-metrics
-          image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/skipper:v0.13.240
+          image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/skipper:v0.16.154
           args:
           - skipper
           - -access-log-strip-query

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -425,7 +425,7 @@ write_files:
             value: {{ .Cluster.ConfigItems.apiserver_business_partner_ids }}
 {{ end }}
         - name: skipper-proxy
-          image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/skipper:v0.13.240
+          image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/skipper:v0.16.154
           args:
           - skipper
           - -access-log-strip-query

--- a/test/e2e/loadtest/client/loadtest-deployment.yaml
+++ b/test/e2e/loadtest/client/loadtest-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         application: e2e-vegeta
     spec:
       containers:
-      - image: container-registry.zalando.net/teapot/skipper:v0.13.240
+      - image: container-registry.zalando.net/teapot/skipper:v0.16.154
         imagePullPolicy: IfNotPresent
         name: skipper
         args:

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -275,7 +275,7 @@ func createSkipperPodSpec(route string, port int32) corev1.PodSpec {
 		Containers: []corev1.Container{
 			{
 				Name:  "skipper",
-				Image: "container-registry.zalando.net/teapot/skipper:v0.15.23",
+				Image: "container-registry.zalando.net/teapot/skipper:latest",
 				Args: []string{
 					"skipper",
 					"-inline-routes",

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -275,7 +275,7 @@ func createSkipperPodSpec(route string, port int32) corev1.PodSpec {
 		Containers: []corev1.Container{
 			{
 				Name:  "skipper",
-				Image: "container-registry.zalando.net/teapot/skipper:latest",
+				Image: "container-registry.zalando.net/teapot/skipper:v0.16.154",
 				Args: []string{
 					"skipper",
 					"-inline-routes",


### PR DESCRIPTION
Some of skipper images are outdated, and we also introduced some changes to routegroup admission webhook at https://github.com/zalando/skipper/pull/2431

I think the update is good anyway since we mitigated some CVE's in skipper, if you agree I can add it to the rest of skipper images here (I think only 1 left).

I changed `skipper-metrics` one because we also introduced couple of new metrics so I thought it makes sense to include here. 