### PR TITLE
enable metrics scraping for karpenter

### DIFF
--- a/cluster/manifests/z-karpenter/deployment.yaml
+++ b/cluster/manifests/z-karpenter/deployment.yaml
@@ -24,6 +24,10 @@ spec:
         component: karpenter
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
+        prometheus.io/port: "8000"
+        prometheus.io/path: "/metrics"
+        prometheus.io/scheme: "http"
+        prometheus.io/scrape: "true"
     spec:
       dnsConfig:
         options:


### PR DESCRIPTION
Enable metrics scraping for `karpenter` pods in order to leverage metrics. 