### PR TITLE
Lower default audit webhook batch max size

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -611,7 +611,7 @@ audittrail_adapter_memory: "200Mi"
 
 audittrail_adapter_timeout: "2s"
 
-audit_webhook_batch_max_size: "400"
+audit_webhook_batch_max_size: "250"
 
 kube2iam_cpu: "25m"
 kube2iam_memory: "100Mi"


### PR DESCRIPTION
Following the reduction in errors in multiple clusters after lowering the audit batch max size from the default `400` value to `250`, this change will set this value to the default in all clusters.

More information in [Teapot Issue 3436](https://github.bus.zalan.do/teapot/issues/issues/3436) ([relevant comment](https://github.bus.zalan.do/teapot/issues/issues/3436#issuecomment-4651754))