### PR TITLE
Configure ExternalDNS to cache the list of hosted zones for 1 hour

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -701,6 +701,8 @@ external_dns_domain_filter: ""
 external_dns_excluded_domains: cluster.local
 # synchronization policy between Kubernetes and AWS Route53 (default: sync, options: sync, upsert-only, create-only)
 external_dns_policy: sync
+# the duration for how long to cache the list of hosted zones in memory
+external_dns_zones_cache_duration: "1h"
 
 # resource configuration
 external_dns_mem: "4Gi"

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -48,6 +48,7 @@ spec:
         - --txt-owner-id={{ .Region }}:{{ .LocalID }}
         - --txt-prefix={{ .ConfigItems.external_dns_ownership_prefix }}
         - --aws-batch-change-size=120
+        - --aws-zones-cache-duration={{ .ConfigItems.external_dns_zones_cache_duration }}
         - --annotation-filter=external-dns.alpha.kubernetes.io/exclude notin (true)
         - --policy={{ .ConfigItems.external_dns_policy }}
         resources:


### PR DESCRIPTION
This _might_ help with ExternalDNS in `cloud`.

It doesn't reduce the number of requests for a single fetch of all hosted zones with pagination but it reduces the overall number of requests by only doing it once per hour instead of every minute.

Making it the default because hosted zones change so rarely that there's really no point in doing it more than once per hour.