### PR TITLE
Allow to specify Ubuntu distro for a node pool

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -593,10 +593,13 @@ tracing_coredns_local_zone_traces_endpoint: ""
 # AMI id given the image name and the Image AWS account owner.
 #
 # [0]: https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/8a9bd1cb2d094038a9e23e646421f8146b48886a/provisioner/template.go#L116
-kuberuntu_image_v1_22_amd64: {{ amiID "zalando-ubuntu-kubernetes-production-v1.22.17-amd64-master-243" "861068367966" }}
-kuberuntu_image_v1_22_arm64: {{ amiID "zalando-ubuntu-kubernetes-production-v1.22.17-arm64-master-243" "861068367966" }}
-kuberuntu_image_v1_23_amd64: {{ amiID "zalando-ubuntu-focal-20.04-kubernetes-production-v1.23.17-amd64-master-273" "861068367966" }}
-kuberuntu_image_v1_23_arm64: {{ amiID "zalando-ubuntu-focal-20.04-kubernetes-production-v1.23.17-arm64-master-273" "861068367966" }}
+kuberuntu_image_v1_23_focal_amd64: {{ amiID "zalando-ubuntu-focal-20.04-kubernetes-production-v1.23.17-amd64-master-273" "861068367966" }}
+kuberuntu_image_v1_23_focal_arm64: {{ amiID "zalando-ubuntu-focal-20.04-kubernetes-production-v1.23.17-arm64-master-273" "861068367966" }}
+kuberuntu_image_v1_23_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.23.17-amd64-master-273" "861068367966" }}
+kuberuntu_image_v1_23_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.23.17-arm64-master-273" "861068367966" }}
+
+# Which distro from the previous config items should be used. Valid options are `focal` and `jammy`. Can be set for each node pool.
+kuberuntu_distro: "focal"
 
 # Feature toggle for auditing events
 audit_pod_events: "true"

--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -10,7 +10,7 @@ Mappings:
   Images:
     eu-central-1:
       # Use the node pool's architecture to construct the config item name that we're using to get the AMI name.
-      MachineImage: '{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_23_" .Values.InstanceInfo.Architecture) }}'
+      MachineImage: '{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_23_" .NodePool.ConfigItems.kuberuntu_distro "_" .Values.InstanceInfo.Architecture) }}'
 
 Resources:
   AutoScalingGroup:

--- a/cluster/node-pools/worker-combined/stack.yaml
+++ b/cluster/node-pools/worker-combined/stack.yaml
@@ -10,7 +10,7 @@ Mappings:
   Images:
     eu-central-1:
       # Use the node pool's architecture to construct the config item name that we're using to get the AMI name.
-      MachineImage: '{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_23_" .Values.InstanceInfo.Architecture) }}'
+      MachineImage: '{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_23_" .NodePool.ConfigItems.kuberuntu_distro "_" .Values.InstanceInfo.Architecture) }}'
 
 Resources:
   AutoScalingGroup:

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -111,7 +111,7 @@ metadata:
 spec:
   amiFamily: Custom
   amiSelector:
-    aws-ids: "{{ .Cluster.ConfigItems.kuberuntu_image_v1_23_amd64  }},{{ .Cluster.ConfigItems.kuberuntu_image_v1_23_arm64 }}"
+    aws-ids: "{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_23_" .NodePool.ConfigItems.kuberuntu_distro "_amd64")  }},{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_23_" .NodePool.ConfigItems.kuberuntu_distro "_arm64") }}"
   metadataOptions:
     httpTokens: optional
   subnetSelector:

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -10,7 +10,7 @@ Mappings:
   Images:
     eu-central-1:
       # Use the node pool's architecture to construct the config item name that we're using to get the AMI name.
-      MachineImage: '{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_23_" .Values.InstanceInfo.Architecture) }}'
+      MachineImage: '{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_23_" .NodePool.ConfigItems.kuberuntu_distro "_" .Values.InstanceInfo.Architecture) }}'
 
 Resources:
 {{ with $data := . }}


### PR DESCRIPTION
This eases the way of running another Ubuntu distro for a node pool. Our current approach requires to specify the AMI ID directly which is tedious and gets out-of-date when the AMI is updated.

This adds the ability to set a config item on a node pool (or globally) to the desired Ubuntu distro, e.g.:

```yaml
    config_items:
      kuberuntu_distro: jammy
```