### PR TITLE
kube-state-metrics: whitelist job labels

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -866,6 +866,7 @@ observability_metrics_port: "443"
 # labels whitelisted to kube-state-metrics
 observability_metrics_pods_labels: "application,component,version,stack_name,stack_version,application_id,application_version,team"
 observability_metrics_ingresses_labels: ""
+observability_metrics_jobs_labels: ""
 
 # opentelemetry collector
 observability_otel_collector_enabled: "false"

--- a/cluster/manifests/kube-state-metrics/deployment.yaml
+++ b/cluster/manifests/kube-state-metrics/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         image: container-registry.zalando.net/teapot/kube-state-metrics:v2.9.2-master-22
         args:
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
-        - --metric-labels-allowlist=pods=[{{.Cluster.ConfigItems.observability_metrics_pods_labels}}],ingresses=[{{.Cluster.ConfigItems.observability_metrics_ingresses_labels}}],nodes=[topology.kubernetes.io/zone,node.kubernetes.io/instance-type,node.kubernetes.io/node-pool,node.kubernetes.io/role,dedicated]
+        - --metric-labels-allowlist=jobs=[{{.Cluster.ConfigItems.observability_metrics_jobs_labels}}],pods=[{{.Cluster.ConfigItems.observability_metrics_pods_labels}}],ingresses=[{{.Cluster.ConfigItems.observability_metrics_ingresses_labels}}],nodes=[topology.kubernetes.io/zone,node.kubernetes.io/instance-type,node.kubernetes.io/node-pool,node.kubernetes.io/role,dedicated]
         ports:
         - containerPort: 8080
           name: http-metrics


### PR DESCRIPTION
Added option to whitelist jobs labels to appear in `kube-job-labels` and `kube_job_annotations` to filter out system metrics of pods owned by cronjobs which are not explicitly whitelisted to ship metrics.

