### PR TITLE
Revert "Add config item to enable/disable traffic segment probing"

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -821,9 +821,6 @@ stackset_routegroup_support_enabled: "true"
 # E.g. switching from RouteGroup to Ingress or vice versa.
 stackset_ingress_source_switch_ttl: "5m"
 
-# configure cdp-steps and deployment-service to probe for traffic segments
-enable_traffic_segments: "false"
-
 # Enable/Disable profiling for Kubernetes components
 enable_control_plane_profiling: "false"
 

--- a/cluster/manifests/deployment-service/01-config.yaml
+++ b/cluster/manifests/deployment-service/01-config.yaml
@@ -20,4 +20,3 @@ data:
   ml-experiment-deployment-role-arn: "arn:aws:iam::{{accountID .Cluster.InfrastructureAccount}}:role/{{.Cluster.LocalID}}-deployment-service-ml-experiment-deployment"
 {{- end }}
   cloudformation-enable-auto-expand: "{{.Cluster.ConfigItems.deployment_service_cf_auto_expand_enabled}}"
-  probe-for-traffic-segments: "{{.Cluster.ConfigItems.enable_traffic_segments}}"


### PR DESCRIPTION
Reverts zalando-incubator/kubernetes-on-aws#6193

We intend to use the per-Stackset annotation approach. Revert this.