### PR TITLE
Run master nodes in test clusters on jammy

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -595,8 +595,8 @@ tracing_coredns_local_zone_traces_endpoint: ""
 # [0]: https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/8a9bd1cb2d094038a9e23e646421f8146b48886a/provisioner/template.go#L116
 kuberuntu_image_v1_23_focal_amd64: {{ amiID "zalando-ubuntu-focal-20.04-kubernetes-production-v1.23.17-amd64-master-273" "861068367966" }}
 kuberuntu_image_v1_23_focal_arm64: {{ amiID "zalando-ubuntu-focal-20.04-kubernetes-production-v1.23.17-arm64-master-273" "861068367966" }}
-kuberuntu_image_v1_23_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.23.17-amd64-master-273" "861068367966" }}
-kuberuntu_image_v1_23_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.23.17-arm64-master-273" "861068367966" }}
+kuberuntu_image_v1_23_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.23.17-amd64-master-279" "861068367966" }}
+kuberuntu_image_v1_23_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.23.17-arm64-master-279" "861068367966" }}
 
 # Which distro from the previous config items should be used. Valid options are `focal` and `jammy`. Can be set for each node pool.
 {{if eq .Cluster.Environment "test"}}

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -599,7 +599,13 @@ kuberuntu_image_v1_23_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernet
 kuberuntu_image_v1_23_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.23.17-arm64-master-273" "861068367966" }}
 
 # Which distro from the previous config items should be used. Valid options are `focal` and `jammy`. Can be set for each node pool.
-kuberuntu_distro: "focal"
+{{if eq .Cluster.Environment "test"}}
+kuberuntu_distro_master: "jammy"
+kuberuntu_distro_worker: "focal"
+{{else}}
+kuberuntu_distro_master: "focal"
+kuberuntu_distro_worker: "focal"
+{{end}}
 
 # Feature toggle for auditing events
 audit_pod_events: "true"

--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -10,7 +10,7 @@ Mappings:
   Images:
     eu-central-1:
       # Use the node pool's architecture to construct the config item name that we're using to get the AMI name.
-      MachineImage: '{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_23_" .NodePool.ConfigItems.kuberuntu_distro "_" .Values.InstanceInfo.Architecture) }}'
+      MachineImage: '{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_23_" .NodePool.ConfigItems.kuberuntu_distro_master "_" .Values.InstanceInfo.Architecture) }}'
 
 Resources:
   AutoScalingGroup:

--- a/cluster/node-pools/worker-combined/stack.yaml
+++ b/cluster/node-pools/worker-combined/stack.yaml
@@ -10,7 +10,7 @@ Mappings:
   Images:
     eu-central-1:
       # Use the node pool's architecture to construct the config item name that we're using to get the AMI name.
-      MachineImage: '{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_23_" .NodePool.ConfigItems.kuberuntu_distro "_" .Values.InstanceInfo.Architecture) }}'
+      MachineImage: '{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_23_" .NodePool.ConfigItems.kuberuntu_distro_worker "_" .Values.InstanceInfo.Architecture) }}'
 
 Resources:
   AutoScalingGroup:

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -111,7 +111,7 @@ metadata:
 spec:
   amiFamily: Custom
   amiSelector:
-    aws-ids: "{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_23_" .NodePool.ConfigItems.kuberuntu_distro "_amd64")  }},{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_23_" .NodePool.ConfigItems.kuberuntu_distro "_arm64") }}"
+    aws-ids: "{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_23_" .NodePool.ConfigItems.kuberuntu_distro_worker "_amd64")  }},{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_23_" .NodePool.ConfigItems.kuberuntu_distro_worker "_arm64") }}"
   metadataOptions:
     httpTokens: optional
   subnetSelector:

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -10,7 +10,7 @@ Mappings:
   Images:
     eu-central-1:
       # Use the node pool's architecture to construct the config item name that we're using to get the AMI name.
-      MachineImage: '{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_23_" .NodePool.ConfigItems.kuberuntu_distro "_" .Values.InstanceInfo.Architecture) }}'
+      MachineImage: '{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_23_" .NodePool.ConfigItems.kuberuntu_distro_worker "_" .Values.InstanceInfo.Architecture) }}'
 
 Resources:
 {{ with $data := . }}

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -58,6 +58,8 @@ clusters:
     profile: master-default
     min_size: 1
     max_size: 2
+    config_items:
+      kuberuntu_distro: jammy
   - discount_strategy: none
     instance_types: ["m5.xlarge"]
     name: default-worker-splitaz

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -58,8 +58,6 @@ clusters:
     profile: master-default
     min_size: 1
     max_size: 2
-    config_items:
-      kuberuntu_distro: jammy
   - discount_strategy: none
     instance_types: ["m5.xlarge"]
     name: default-worker-splitaz


### PR DESCRIPTION
Let's switch master nodes to `jammy` in test clusters.

I picked `if eq .Cluster.Environment "test"` so that e2e tests still run with `focal` which then maps to what's actually running in production clusters. We'd see any issues in the dev channel first.