### PR TITLE
Update k8s-authnz-webhook

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -277,7 +277,7 @@ write_files:
               name: ssl-certs-kubernetes
               readOnly: true
 {{- end}}
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/k8s-authnz-webhook:master-126
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/k8s-authnz-webhook:master-127
           name: webhook
           ports:
           - containerPort: 8081


### PR DESCRIPTION
Follow up to #5844 fixing a bug that prevent the postgres-operator from exec'ing to postgres pods and doing operations it needs to do.