### PR TITLE
fix schema on node affinity

### DIFF
--- a/cluster/manifests/z-karpenter/deployment.yaml
+++ b/cluster/manifests/z-karpenter/deployment.yaml
@@ -103,7 +103,8 @@ spec:
                 matchExpressions:
                 - key: node.kubernetes.io/role
                   operator: Equals
-                  value: master
+                  values:
+                  - master
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:


### PR DESCRIPTION
Fixes the node affinity schema to fix validation error in the karpenter deployment. It expects `values` as a `[]string`.

```
time="2023-07-27T17:53:47Z" level=error msg="error: error validating \"STDIN\": error validating data: ValidationError(Deployment.spec.template.spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[1].preference.matchExpressions[0]): unknown field \"value\" in io.k8s.api.core.v1.NodeSelectorRequirement; if you choose to ignore these errors, turn validation off with --validate=false" cluster=teapot module=main/z-karpenter worker=95

```