### PR TITLE
fix operator for affinity on karpenter deployment

### DIFF
--- a/cluster/manifests/z-karpenter/deployment.yaml
+++ b/cluster/manifests/z-karpenter/deployment.yaml
@@ -102,7 +102,7 @@ spec:
               preference:
                 matchExpressions:
                 - key: node.kubernetes.io/role
-                  operator: Equals
+                  operator: In
                   values:
                   - master
         podAntiAffinity:


### PR DESCRIPTION
The operator value `Equals` is invalid. It should be `In`.

```
operator	<string> -required-
     Represents a key's relationship to a set of values. Valid operators are In,
     NotIn, Exists, DoesNotExist. Gt, and Lt.
```