### PR TITLE
Run one arm64 pool in e2e

### DIFF
--- a/cluster/manifests/e2e-resources/pool-reserve.yaml
+++ b/cluster/manifests/e2e-resources/pool-reserve.yaml
@@ -1,5 +1,5 @@
 {{ if eq .Environment "e2e" }}
-{{ range $pool := split "default-worker-splitaz,worker-limit-az,worker-combined,worker-instance-storage,worker-node-tests,worker-karpenter" "," }}
+{{ range $pool := split "default-worker-splitaz,worker-limit-az,worker-combined,worker-instance-storage,worker-node-tests,worker-karpenter,worker-arm64" "," }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -37,6 +37,11 @@ spec:
         - effect: NoSchedule
           key: dedicated
           value: worker-karpenter
+      {{ end }}
+      {{ if eq $pool "worker-arm64" }}
+        - effect: NoSchedule
+          key: dedicated
+          value: worker-arm64
       {{ end }}
       terminationGracePeriodSeconds: 0
       containers:

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -149,6 +149,15 @@ clusters:
     config_items:
       labels: dedicated=worker-karpenter
       taints: dedicated=worker-karpenter:NoSchedule
+  - discount_strategy: none
+    instance_types: ["m6g.large"]
+    min_size: 0
+    max_size: 3
+    profile: worker-splitaz
+    name: worker-arm64
+    config_items:
+      labels: dedicated=worker-arm64
+      taints: dedicated=worker-arm64:NoSchedule
   provider: zalando-aws
   region: ${REGION}
   owner: '${OWNER}'


### PR DESCRIPTION
Based on https://github.com/zalando-incubator/kubernetes-on-aws/pull/6250 and in order to get rid of https://github.com/zalando-incubator/kubernetes-on-aws/pull/5098 run one arm64-only container on an arm64 worker pool to test that this works.