### PR TITLE
skipper: require hosts in RouteGroup CRD

### DIFF
--- a/cluster/manifests/skipper/routegroup-crd.yaml
+++ b/cluster/manifests/skipper/routegroup-crd.yaml
@@ -145,9 +145,9 @@ spec:
                 description: List of hostnames for the RouteGroup
                 items:
                   pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?([.][a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
-                  minItems: 1 # original CRD allows empty hosts but we explicitly want it specified in our infrastructure
                   type: string
                 type: array
+                minItems: 1 # original CRD allows empty hosts but we explicitly want it specified in our infrastructure
               routes:
                 description: Routes describe how a matching HTTP request is handled
                   and where it is forwarded to
@@ -218,6 +218,7 @@ spec:
                 type: array
             required:
             - backends
+            - hosts # original CRD does not require hosts but we explicitly want it specified in our infrastructure
             type: object
           status:
             properties:


### PR DESCRIPTION
It was required and was broken by #3912