### PR TITLE
whitelist pod annotations

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -865,8 +865,8 @@ observability_metrics_port: "443"
 # labels whitelisted to kube-state-metrics
 observability_metrics_pods_labels: "application,component,version,stack_name,stack_version,application_id,application_version,team"
 observability_metrics_ingresses_labels: ""
-observability_metrics_jobs_labels: ""
-observability_metrics_jobs_annotations: ""
+
+observability_metrics_pods_annotations: ""
 
 # opentelemetry collector
 observability_otel_collector_enabled: "false"

--- a/cluster/manifests/kube-state-metrics/deployment.yaml
+++ b/cluster/manifests/kube-state-metrics/deployment.yaml
@@ -30,8 +30,8 @@ spec:
         image: container-registry.zalando.net/teapot/kube-state-metrics:v2.9.2-master-22
         args:
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
-        - --metric-labels-allowlist=jobs=[{{.Cluster.ConfigItems.observability_metrics_jobs_labels}}],pods=[{{.Cluster.ConfigItems.observability_metrics_pods_labels}}],ingresses=[{{.Cluster.ConfigItems.observability_metrics_ingresses_labels}}],nodes=[topology.kubernetes.io/zone,node.kubernetes.io/instance-type,node.kubernetes.io/node-pool,node.kubernetes.io/role,dedicated]
-        - --metric-annotations-allowlist=jobs=[{{.Cluster.ConfigItems.observability_metrics_jobs_annotations}}]
+        - --metric-labels-allowlist=pods=[{{.Cluster.ConfigItems.observability_metrics_pods_labels}}],ingresses=[{{.Cluster.ConfigItems.observability_metrics_ingresses_labels}}],nodes=[topology.kubernetes.io/zone,node.kubernetes.io/instance-type,node.kubernetes.io/node-pool,node.kubernetes.io/role,dedicated]
+        - --metric-annotations-allowlist=pods=[{{.Cluster.ConfigItems.observability_metrics_pods_annotations}}]
         ports:
         - containerPort: 8080
           name: http-metrics


### PR DESCRIPTION
as it turned out having pods annotations is enough to determine if metrics storing is allowed

follow-up for https://github.com/zalando-incubator/kubernetes-on-aws/pull/6235

