### PR TITLE
Update Karpenter to v0.29.2

### DIFF
--- a/cluster/manifests/z-karpenter/deployment.yaml
+++ b/cluster/manifests/z-karpenter/deployment.yaml
@@ -40,7 +40,7 @@ spec:
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       containers:
         - name: controller
-          image: "container-registry.zalando.net/teapot/karpenter:networkinterfaces-experimental-main-10"
+          image: "container-registry.zalando.net/teapot/karpenter:v0.29.2-main-12.custom"
           env:
             - name: KUBERNETES_MIN_VERSION
               value: "1.22.0-0"


### PR DESCRIPTION
Updates Karpenter to be based on v0.29.2 and fixes the images to be multi-arch and work on ARM instances.