### PR TITLE
Reduce Karpenter CPU request

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -28,7 +28,7 @@ cluster_autoscaler_max_graceful_termination_sec: "1209600" # 2 weeks
 cluster_autoscaler_max_usnchedulable_pods_considered: "1000"
 
 # karpenter settings
-karpenter_controller_cpu: "250m"
+karpenter_controller_cpu: "240m"
 karpenter_controller_memory: "250Mi"
 
 # ALB config created by kube-aws-ingress-controller


### PR DESCRIPTION
Reduce Karpenter CPU request so it can fit on a `m6g.large` instance as we have in e2e.