### PR TITLE
Reduce Karpenter CPU even more

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -28,7 +28,7 @@ cluster_autoscaler_max_graceful_termination_sec: "1209600" # 2 weeks
 cluster_autoscaler_max_usnchedulable_pods_considered: "1000"
 
 # karpenter settings
-karpenter_controller_cpu: "190m"
+karpenter_controller_cpu: "170m"
 karpenter_controller_memory: "250Mi"
 
 # ALB config created by kube-aws-ingress-controller


### PR DESCRIPTION
Follow up to #6268 again.

Reduce CPU on Karpenter even more so all components can fit on master nodes.