### PR TITLE
e2e/loadtest: increase number of idle connections per host

### DIFF
--- a/test/e2e/loadtest/client/loadtest-deployment.yaml
+++ b/test/e2e/loadtest/client/loadtest-deployment.yaml
@@ -36,6 +36,7 @@ spec:
         - -metrics-flavour=prometheus
         - -histogram-metric-buckets=.0001,.00025,.0005,.00075,.001,.0025,.005,.0075,.01,.025,.05,.075,.1,.2,.3,.4,.5,.75,1,2,3,4,5,7,10,15,20,30,60,120,300,600
         - -close-idle-conns-period=20s
+        - -idle-conns-num=1000
         - -serve-host-metrics
         - -serve-method-metric=false
         - -serve-status-code-metric=true


### PR DESCRIPTION
Increase number of idle connections per host from default 64 based on https://github.com/golang/go/issues/16012#issuecomment-224948823 in attempt to mitigate `connect: cannot assign requested address` errors.

Total number of idle connections (`-max-idle-connection-backend`) is not limited by default.