### PR TITLE
Update Audittrail Adapter IAM Role to include new centralised S3 buckets 

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -2066,12 +2066,22 @@ Resources:
                 Resource:
                   - !GetAtt AuditTrailBucket.Arn
                   - arn:aws:s3:::zalando-audittrail-central
+                    {{- if .Environment "production" }}
+                  - arn:aws:s3:::zalando-kubernetes-audit
+                    {{- else }}
+                  - arn:aws:s3:::zalando-kubernetes-audit-test
+                    {{- end }}
 
               - Action:
                   - s3:PutObject
                 Effect: Allow
                 Resource:
                   - arn:aws:s3:::zalando-audittrail-central/*
+                    {{- if .Environment "production" }}
+                  - arn:aws:s3:::zalando-kubernetes-audit/*
+                    {{- else }}
+                  - arn:aws:s3:::zalando-kubernetes-audit-test/*
+                    {{- end }}
                   - !Sub
                     - "${BucketArn}/*"
                     - BucketArn: !GetAtt AuditTrailBucket.Arn

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -2066,7 +2066,7 @@ Resources:
                 Resource:
                   - !GetAtt AuditTrailBucket.Arn
                   - arn:aws:s3:::zalando-audittrail-central
-                    {{- if .Environment "production" }}
+                    {{- if eq .Cluster.Environment "production" }}
                   - arn:aws:s3:::zalando-kubernetes-audit
                     {{- else }}
                   - arn:aws:s3:::zalando-kubernetes-audit-test
@@ -2077,7 +2077,7 @@ Resources:
                 Effect: Allow
                 Resource:
                   - arn:aws:s3:::zalando-audittrail-central/*
-                    {{- if .Environment "production" }}
+                    {{- if eq .Cluster.Environment "production" }}
                   - arn:aws:s3:::zalando-kubernetes-audit/*
                     {{- else }}
                   - arn:aws:s3:::zalando-kubernetes-audit-test/*


### PR DESCRIPTION
Update the Audittrail Adapter IAM Role to include the new centralised S3 buckets. As the production and test cluster events will be separated into two buckets, also update the referenced bucket in the role accordingly.

[Teapot issue 3436](https://github.bus.zalan.do/teapot/issues/issues/3436)