### PR TITLE
Upgrade etcd cluster to v3.5.9

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -568,7 +568,11 @@ etcd_instance_type: "t3.medium"
 {{end}}
 
 etcd_scalyr_key: ""
+{{if eq .Cluster.Environment "test"}}
+etcd_ami: {{ amiID "zalando-ubuntu-etcd-production-v3.5.9-amd64-main-15" "861068367966"}}
+{{else}}
 etcd_ami: {{ amiID "zalando-ubuntu-etcd-production-v3.4.16-amd64-main-10" "861068367966"}}
+{{end}}
 
 dynamodb_service_link_enabled: "false"
 

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -567,7 +567,6 @@ etcd_instance_count: "3"
 etcd_instance_type: "t3.medium"
 {{end}}
 
-etcd_docker_image: "registry.opensource.zalan.do/teapot/etcd-cluster:3.4.16-master-10"
 etcd_scalyr_key: ""
 etcd_ami: {{ amiID "zalando-ubuntu-etcd-production-v3.4.16-amd64-main-10" "861068367966"}}
 


### PR DESCRIPTION
![image](https://github.com/zalando-incubator/kubernetes-on-aws/assets/36162/23e00500-26cc-4502-a132-57909645c392)

https://kubernetes.io/docs/tasks/administer-cluster/configure-upgrade-etcd/#prerequisites

We currently run `v3.4.16` so it's slightly outdated. Kubernetes 1.24 already [uses etcd 3.5 in its code base](https://github.com/kubernetes/kubernetes/pull/113099). Although I don't know the significance of this, it's not a bad practice to keep it aligned with what's actually running on the server side.

This updates the etcd Stack to `v3.5.9` in test clusters first. After rollout we also need to run `etcd-upgrade` to roll the nodes.