### PR TITLE
test/e2e: downgrade loadtest skipper version

### DIFF
--- a/test/e2e/loadtest/client/loadtest-deployment.yaml
+++ b/test/e2e/loadtest/client/loadtest-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         application: e2e-vegeta
     spec:
       containers:
-      - image: container-registry.zalando.net/teapot/skipper:v0.16.154
+      - image: container-registry.zalando.net/teapot/skipper:v0.13.240
         imagePullPolicy: IfNotPresent
         name: skipper
         args:


### PR DESCRIPTION
Partially reverts #6203 to debug `connect: cannot assign requested address` and see whether it is caused by Skipper or something else.

Followup on #6271