### PR TITLE
Update skipper image to fix consistent hash load balancing

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.16.161-582" }}
+{{ $internal_version := "v0.16.166-587" }}
 {{ $version := index (split $internal_version "-") 0 }}
 
 apiVersion: apps/v1


### PR DESCRIPTION
There was a bug in binary search function used for this algorithm. This update fixes this issue.

FYI
https://github.com/zalando/skipper/pull/2460
https://github.com/zalando/skipper/compare/v0.16.161...v0.16.166