### PR TITLE
webhook: update `RouteGroup` validation image

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -243,7 +243,7 @@ write_files:
               readOnly: true
 {{- if or (eq .Cluster.ConfigItems.routegroups_validation "provisioned") (eq .Cluster.ConfigItems.routegroups_validation "enabled") }}
         - name: routegroups-admission-webhook
-          image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/skipper:v0.16.154
+          image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/skipper:v0.16.167
           args:
             - webhook
             - --address=:9085


### PR DESCRIPTION
We introduced some changes to RouteGroup's `ValidationWebhook` to validate eskip grammer for both filters & predicates.

https://github.com/zalando/skipper/pull/2484 & https://github.com/zalando/skipper/pull/2492