### PR TITLE
Prevent karpenter from scaling down e2e pod

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -63,6 +63,7 @@ pipeline:
           component: e2e
         annotations:
           zalando.org/runtime-policy: require-on-demand
+          zalando.org/prevent-scale-down: "true"
       spec:
         serviceAccountName: kubernetes-e2e
         restartPolicy: Never
@@ -183,6 +184,7 @@ pipeline:
           component: e2e
         annotations:
           zalando.org/runtime-policy: require-on-demand
+          zalando.org/prevent-scale-down: "true"
       spec:
         serviceAccountName: kubernetes-e2e
         restartPolicy: Never
@@ -220,6 +222,7 @@ pipeline:
           component: e2e
         annotations:
           zalando.org/runtime-policy: require-on-demand
+          zalando.org/prevent-scale-down: "true"
       spec:
         serviceAccountName: kubernetes-e2e
         restartPolicy: Never
@@ -257,6 +260,7 @@ pipeline:
           component: e2e
         annotations:
           zalando.org/runtime-policy: require-on-demand
+          zalando.org/prevent-scale-down: "true"
       spec:
         serviceAccountName: kubernetes-e2e
         restartPolicy: Never
@@ -296,6 +300,7 @@ pipeline:
           component: e2e
         annotations:
           zalando.org/runtime-policy: require-on-demand
+          zalando.org/prevent-scale-down: "true"
       spec:
         serviceAccountName: kubernetes-e2e
         restartPolicy: Never


### PR DESCRIPTION
This is a quick-fix to prevent karpenter from scaling down e2e pods. Ideally it should not touch pods without a parent in the first place, that is to be understood in karpenter.