### PR TITLE
Prevent scaling down orphaned or job pods with Karpenter

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -522,7 +522,7 @@ teapot_admission_controller_crd_role_provisioning_allowed_api_groups: "flink.k8s
 teapot_admission_controller_topology_spread: optin
 teapot_admission_controller_topology_spread_timeout: 7m
 
-# Supported providers: 'zalando'
+# Supported providers: 'zalando', `karpenter`
 teapot_admission_controller_node_lifecycle_provider: "zalando"
 
 # Enable and configure runtime-policy annotation

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -201,7 +201,7 @@ write_files:
             limits:
               memory: {{ .Values.InstanceInfo.MemoryFraction (parseInt64 .Cluster.ConfigItems.apiserver_memory_limit_percent)}}
 {{- end }}
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-168
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-169
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
This adds "prevent-scale-down" injection for pods that are from a Job or doesn't have a parent resource, when the provider is `karpenter`.

The motivation for this is to have the same behavior with karpenter as Cluster Autoscaler where those type of pods are handled in a special way and are not evicted when a node _could_ be scaled down.

In CA we implemented it directly: https://github.com/zalando-incubator/autoscaler/pull/29/files to avoid needing to implement this in Karpenter we can simply inject the respective prevent-scale-down annotation on those pods which Karpenter would respect.

Once rolled out it will allow to revert #6284