### PR TITLE
Revert "Update audittrail S3 bucket"

### DIFF
--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -43,7 +43,7 @@ spec:
         - --cluster-id={{ .ID }}
         - --cluster-alias={{ .Cluster.Alias }}
         - --audittrail-url={{ .Cluster.ConfigItems.audittrail_url }}
-        - --s3-audit-bucket-name=zalando-kubernetes-audit
+        - --s3-audit-bucket-name=zalando-audittrail-central
         - --s3-fallback-bucket-name=zalando-audittrail-{{accountID .InfrastructureAccount}}-{{.LocalID}}
         - --address=:8889
         - --metrics-address=:7980


### PR DESCRIPTION
Reverts zalando-incubator/kubernetes-on-aws#6291

After the change in bucket name we observed many audittrail-adapter OOM crashes and kube-apiserver audit plugin webhook timeouts.