### PR TITLE
Add config-item for Audittrail target S3 Bucket

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -628,6 +628,7 @@ audittrail_adapter_cpu: "50m"
 audittrail_adapter_memory: "200Mi"
 
 audittrail_adapter_timeout: "2s"
+audittrail_adapter_bucket: "zalando-audittrail-central"
 
 audit_webhook_batch_max_size: "250"
 

--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -43,7 +43,7 @@ spec:
         - --cluster-id={{ .ID }}
         - --cluster-alias={{ .Cluster.Alias }}
         - --audittrail-url={{ .Cluster.ConfigItems.audittrail_url }}
-        - --s3-audit-bucket-name=zalando-kubernetes-audit
+        - --s3-audit-bucket-name={{ .Cluster.ConfigItems.audittrail_adapter_bucket }}
         - --s3-fallback-bucket-name=zalando-audittrail-{{accountID .InfrastructureAccount}}-{{.LocalID}}
         - --address=:8889
         - --metrics-address=:7980


### PR DESCRIPTION
This PR makes the `audittrail-adapter` target S3 Bucket configurable via a config item. The default is set to the central S3 Bucket located in the `stups` cluster.