### PR TITLE
Include StackSet ingress/routegroup definition in stack definition

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -812,7 +812,7 @@ stackset_legacy_hpa_field_enabled: "false"
 stackset_legacy_hpa_field_crd_enabled: "false"
 
 # Flag to include the stackset ingress in the stack definition
-stackset_ingress_in_stack_crd: "true"
+stackset_ingress_in_stack_crd: "false"
 
 # EBS settings for the root volume
 ebs_master_root_volume_size: "50"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -810,6 +810,9 @@ stackset_controller_mem_max: "4Gi"
 stackset_legacy_hpa_field_enabled: "false"
 stackset_legacy_hpa_field_crd_enabled: "false"
 
+# Flag to include the stackset ingress in the stack definition
+stackset_ingress_in_stack_crd: "true"
+
 # EBS settings for the root volume
 ebs_master_root_volume_size: "50"
 ebs_root_volume_size: "50"

--- a/cluster/manifests/stackset-controller/01-stack-crd.yaml
+++ b/cluster/manifests/stackset-controller/01-stack-crd.yaml
@@ -837,6 +837,7 @@ spec:
                 type: object
 # {{ end }}
               ingress:
+# {{ if eq .Cluster.ConfigItems.stackset_ingress_in_stack_crd "true" }}
                 description: Stack specific Ingress, based on the parent StackSet
                   at creation time.
                 properties:
@@ -870,6 +871,40 @@ spec:
                 - backendPort
                 - hosts
                 type: object
+# {{ else }}
+                description: Settings for the per-stack ingresses (in case the StackSet
+                  has a configured ingress)
+                properties:
+                  enabled:
+                    description: Whether to enable per-stack ingresses or routegroups.
+                      Defaults to enabled if unset.
+                    type: boolean
+                  hosts:
+                    description: Hostnames to use for the per-stack ingresses (or
+                      route groups). These must contain the special $(STACK_NAME)
+                      token, which will be replaced with the stack's name. Would be
+                      automatically generated based on the hosts in the ingress/routegroup
+                      entry if unset.
+                    items:
+                      type: string
+                    type: array
+                  metadata:
+                    description: EmbeddedObjectMetaWithAnnotations defines the metadata
+                      which can be attached to a resource. It's a slimmed down version
+                      of metav1.ObjectMeta only containing annotations.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                    type: object
+                type: object
+# {{ end }}
               minReadySeconds:
                 description: Minimum number of seconds for which a newly created pod
                   should be ready without any of its container crashing, for it to
@@ -7654,6 +7689,7 @@ spec:
                 format: int32
                 type: integer
               routegroup:
+# {{ if eq .Cluster.ConfigItems.stackset_ingress_in_stack_crd "true" }}
                 description: Stack specific RouteGroup, based on the parent StackSet
                   at creation time.
                 properties:
@@ -7807,6 +7843,40 @@ spec:
                 - hosts
                 - routes
                 type: object
+# {{ else }}
+                description: Settings for the per-stack route groups (in case the
+                  StackSet has a configured RouteGroup)
+                properties:
+                  enabled:
+                    description: Whether to enable per-stack ingresses or routegroups.
+                      Defaults to enabled if unset.
+                    type: boolean
+                  hosts:
+                    description: Hostnames to use for the per-stack ingresses (or
+                      route groups). These must contain the special $(STACK_NAME)
+                      token, which will be replaced with the stack's name. Would be
+                      automatically generated based on the hosts in the ingress/routegroup
+                      entry if unset.
+                    items:
+                      type: string
+                    type: array
+                  metadata:
+                    description: EmbeddedObjectMetaWithAnnotations defines the metadata
+                      which can be attached to a resource. It's a slimmed down version
+                      of metav1.ObjectMeta only containing annotations.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                    type: object
+                type: object
+# {{ end }}
               service:
                 description: Service can be used to configure a custom service, if
                   not set stackset-controller will generate a service based on container

--- a/cluster/manifests/stackset-controller/01-stack-crd.yaml
+++ b/cluster/manifests/stackset-controller/01-stack-crd.yaml
@@ -1,5 +1,3 @@
-# This is an adjusted copy of https://github.com/zalando-incubator/stackset-controller/blob/master/docs/stack_crd.yaml
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -66,7 +64,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: StackSpec is the spec part of the Stack.
+            description: StackSpecInternal is the spec part of the Stack, including
+              `ingress` and `routegroup` specs inherited from the parent StackSet.
             properties:
               autoscaler:
                 description: Autoscaler is the autoscaling definition for a stack
@@ -348,7 +347,6 @@ spec:
                 - maxReplicas
                 - metrics
                 type: object
-# {{ if eq .Cluster.ConfigItems.stackset_legacy_hpa_field_crd_enabled "true" }}
               horizontalPodAutoscaler:
                 description: HorizontalPodAutoscaler is the Autoscaling configuration
                   of a Stack. If defined an HPA will be created for the Stack.
@@ -834,21 +832,16 @@ spec:
                 required:
                 - maxReplicas
                 type: object
-# {{ end }}
               ingress:
-                description: Settings for the per-stack ingresses (in case the StackSet
-                  has a configured ingress)
+                description: Stack specific Ingress, based on the parent StackSet
+                  at creation time.
                 properties:
-                  enabled:
-                    description: Whether to enable per-stack ingresses or routegroups.
-                      Defaults to enabled if unset.
-                    type: boolean
+                  backendPort:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    x-kubernetes-int-or-string: true
                   hosts:
-                    description: Hostnames to use for the per-stack ingresses (or
-                      route groups). These must contain the special $(STACK_NAME)
-                      token, which will be replaced with the stack's name. Would be
-                      automatically generated based on the hosts in the ingress/routegroup
-                      entry if unset.
                     items:
                       type: string
                     type: array
@@ -867,6 +860,11 @@ spec:
                           http://kubernetes.io/docs/user-guide/annotations'
                         type: object
                     type: object
+                  path:
+                    type: string
+                required:
+                - backendPort
+                - hosts
                 type: object
               minReadySeconds:
                 description: Minimum number of seconds for which a newly created pod
@@ -954,10 +952,6 @@ spec:
                                                   selector applies to.
                                                 type: string
                                               operator:
-                                                description: Represents a key's relationship
-                                                  to a set of values. Valid operators
-                                                  are In, NotIn, Exists, DoesNotExist.
-                                                  Gt, and Lt.
                                                 type: string
                                               values:
                                                 items:
@@ -982,10 +976,6 @@ spec:
                                                   selector applies to.
                                                 type: string
                                               operator:
-                                                description: Represents a key's relationship
-                                                  to a set of values. Valid operators
-                                                  are In, NotIn, Exists, DoesNotExist.
-                                                  Gt, and Lt.
                                                 type: string
                                               values:
                                                 items:
@@ -1040,10 +1030,6 @@ spec:
                                                   selector applies to.
                                                 type: string
                                               operator:
-                                                description: Represents a key's relationship
-                                                  to a set of values. Valid operators
-                                                  are In, NotIn, Exists, DoesNotExist.
-                                                  Gt, and Lt.
                                                 type: string
                                               values:
                                                 items:
@@ -1068,10 +1054,6 @@ spec:
                                                   selector applies to.
                                                 type: string
                                               operator:
-                                                description: Represents a key's relationship
-                                                  to a set of values. Valid operators
-                                                  are In, NotIn, Exists, DoesNotExist.
-                                                  Gt, and Lt.
                                                 type: string
                                               values:
                                                 items:
@@ -1125,10 +1107,6 @@ spec:
                                                 of label selector requirements. The
                                                 requirements are ANDed.
                                               items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
                                                 properties:
                                                   key:
                                                     type: string
@@ -1174,10 +1152,6 @@ spec:
                                                 of label selector requirements. The
                                                 requirements are ANDed.
                                               items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
                                                 properties:
                                                   key:
                                                     type: string
@@ -1281,20 +1255,8 @@ spec:
                                                   that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1340,10 +1302,6 @@ spec:
                                                   that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
                                                 type: string
                                               values:
                                                 items:
@@ -1428,10 +1386,6 @@ spec:
                                                 of label selector requirements. The
                                                 requirements are ANDed.
                                               items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
                                                 properties:
                                                   key:
                                                     type: string
@@ -1477,10 +1431,6 @@ spec:
                                                 of label selector requirements. The
                                                 requirements are ANDed.
                                               items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
                                                 properties:
                                                   key:
                                                     type: string
@@ -1584,20 +1534,8 @@ spec:
                                                   that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1643,20 +1581,8 @@ spec:
                                                   that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -6820,10 +6746,6 @@ spec:
                                                 of label selector requirements. The
                                                 requirements are ANDed.
                                               items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
                                                 properties:
                                                   key:
                                                     type: string
@@ -7728,22 +7650,72 @@ spec:
                 format: int32
                 type: integer
               routegroup:
-                description: Settings for the per-stack route groups (in case the
-                  StackSet has a configured RouteGroup)
+                description: Stack specific RouteGroup, based on the parent StackSet
+                  at creation time.
                 properties:
-                  enabled:
-                    description: Whether to enable per-stack ingresses or routegroups.
-                      Defaults to enabled if unset.
-                    type: boolean
+                  additionalBackends:
+                    description: AdditionalBackends is the list of additional backends
+                      to use for routing.
+                    items:
+                      properties:
+                        address:
+                          description: Address is required for Type network
+                          type: string
+                        algorithm:
+                          description: Algorithm is required for Type lb
+                          enum:
+                          - roundRobin
+                          - random
+                          - consistentHash
+                          - powerOfRandomNChoices
+                          type: string
+                        endpoints:
+                          description: Endpoints is required for Type lb
+                          items:
+                            type: string
+                          minItems: 1
+                          type: array
+                        name:
+                          description: Name is the BackendName that can be referenced
+                            as RouteGroupBackendReference
+                          type: string
+                        serviceName:
+                          description: ServiceName is required for Type service
+                          type: string
+                        servicePort:
+                          description: ServicePort is required for Type service
+                          type: integer
+                        type:
+                          description: Type is one of "service|shunt|loopback|dynamic|lb|network"
+                          enum:
+                          - service
+                          - shunt
+                          - loopback
+                          - dynamic
+                          - lb
+                          - network
+                          type: string
+                      required:
+                      - name
+                      - type
+                      type: object
+                    type: array
+                  backendPort:
+                    type: integer
                   hosts:
-                    description: Hostnames to use for the per-stack ingresses (or
-                      route groups). These must contain the special $(STACK_NAME)
-                      token, which will be replaced with the stack's name. Would be
-                      automatically generated based on the hosts in the ingress/routegroup
-                      entry if unset.
+                    description: Hosts is the list of hostnames to add to the routegroup.
                     items:
                       type: string
                     type: array
+                  lbAlgorithm:
+                    description: The load balancing algorithm used for the generated
+                      per stack backends.
+                    enum:
+                    - roundRobin
+                    - random
+                    - consistentHash
+                    - powerOfRandomNChoices
+                    type: string
                   metadata:
                     description: EmbeddedObjectMetaWithAnnotations defines the metadata
                       which can be attached to a resource. It's a slimmed down version
@@ -7759,6 +7731,77 @@ spec:
                           http://kubernetes.io/docs/user-guide/annotations'
                         type: object
                     type: object
+                  routes:
+                    description: Routes is the list of routes to be applied to the
+                      routegroup.
+                    items:
+                      properties:
+                        backends:
+                          description: RouteGroupBackendReference specifies the list
+                            of backendReference that should be applied to override
+                            the defaultBackends
+                          items:
+                            properties:
+                              backendName:
+                                description: BackendName references the skipperBackend
+                                  by name
+                                type: string
+                              weight:
+                                description: Weight defines the traffic weight, if
+                                  there are 2 or more default backends
+                                minimum: 0
+                                type: integer
+                            required:
+                            - backendName
+                            type: object
+                          type: array
+                        filters:
+                          description: Filters specifies the list of filters applied
+                            to the routeSpec
+                          items:
+                            type: string
+                          type: array
+                        methods:
+                          description: Methods defines valid HTTP methods for the
+                            specified routeSpec
+                          items:
+                            description: HTTPMethod is a valid HTTP method in uppercase.
+                            enum:
+                            - GET
+                            - HEAD
+                            - POST
+                            - PUT
+                            - PATCH
+                            - DELETE
+                            - CONNECT
+                            - OPTIONS
+                            - TRACE
+                            type: string
+                          type: array
+                        path:
+                          description: Path specifies Path predicate, only one of
+                            Path or PathSubtree is allowed
+                          type: string
+                        pathRegexp:
+                          description: PathRegexp can be added additionally
+                          type: string
+                        pathSubtree:
+                          description: PathSubtree specifies PathSubtree predicate,
+                            only one of Path or PathSubtree is allowed
+                          type: string
+                        predicates:
+                          description: Predicates specifies the list of predicates
+                            applied to the routeSpec
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    minItems: 1
+                    type: array
+                required:
+                - backendPort
+                - hosts
+                - routes
                 type: object
               service:
                 description: Service can be used to configure a custom service, if

--- a/cluster/manifests/stackset-controller/01-stack-crd.yaml
+++ b/cluster/manifests/stackset-controller/01-stack-crd.yaml
@@ -1,3 +1,5 @@
+# This is an adjusted copy of https://github.com/zalando-incubator/stackset-controller/blob/master/docs/stack_crd.yaml
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -347,6 +349,7 @@ spec:
                 - maxReplicas
                 - metrics
                 type: object
+# {{ if eq .Cluster.ConfigItems.stackset_legacy_hpa_field_crd_enabled "true" }}
               horizontalPodAutoscaler:
                 description: HorizontalPodAutoscaler is the Autoscaling configuration
                   of a Stack. If defined an HPA will be created for the Stack.
@@ -832,6 +835,7 @@ spec:
                 required:
                 - maxReplicas
                 type: object
+# {{ end }}
               ingress:
                 description: Stack specific Ingress, based on the parent StackSet
                   at creation time.

--- a/cluster/manifests/stackset-controller/01-stackset-crd.yaml
+++ b/cluster/manifests/stackset-controller/01-stackset-crd.yaml
@@ -1,3 +1,5 @@
+# This is an adjusted copy of https://github.com/zalando-incubator/stackset-controller/blob/master/docs/stackset_crd.yaml
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -594,6 +596,7 @@ spec:
                         - maxReplicas
                         - metrics
                         type: object
+# {{ if eq .Cluster.ConfigItems.stackset_legacy_hpa_field_crd_enabled "true" }}
                       horizontalPodAutoscaler:
                         description: HorizontalPodAutoscaler is the Autoscaling configuration
                           of a Stack. If defined an HPA will be created for the Stack.
@@ -1119,6 +1122,7 @@ spec:
                         required:
                         - maxReplicas
                         type: object
+# {{ end }}
                       minReadySeconds:
                         description: Minimum number of seconds for which a newly created
                           pod should be ready without any of its container crashing,

--- a/cluster/manifests/stackset-controller/01-stackset-crd.yaml
+++ b/cluster/manifests/stackset-controller/01-stackset-crd.yaml
@@ -1398,10 +1398,6 @@ spec:
                                                     pods.
                                                   properties:
                                                     matchExpressions:
-                                                      description: matchExpressions
-                                                        is a list of label selector
-                                                        requirements. The requirements
-                                                        are ANDed.
                                                       items:
                                                         properties:
                                                           key:
@@ -1420,16 +1416,6 @@ spec:
                                                     matchLabels:
                                                       additionalProperties:
                                                         type: string
-                                                      description: matchLabels is
-                                                        a map of {key,value} pairs.
-                                                        A single {key,value} in the
-                                                        matchLabels map is equivalent
-                                                        to an element of matchExpressions,
-                                                        whose key field is "key",
-                                                        the operator is "In", and
-                                                        the values array contains
-                                                        only "value". The requirements
-                                                        are ANDed.
                                                       type: object
                                                   type: object
                                                 namespaceSelector:
@@ -1448,10 +1434,6 @@ spec:
                                                     feature is enabled.
                                                   properties:
                                                     matchExpressions:
-                                                      description: matchExpressions
-                                                        is a list of label selector
-                                                        requirements. The requirements
-                                                        are ANDed.
                                                       items:
                                                         properties:
                                                           key:
@@ -1696,10 +1678,6 @@ spec:
                                                     pods.
                                                   properties:
                                                     matchExpressions:
-                                                      description: matchExpressions
-                                                        is a list of label selector
-                                                        requirements. The requirements
-                                                        are ANDed.
                                                       items:
                                                         properties:
                                                           key:
@@ -1736,10 +1714,6 @@ spec:
                                                     feature is enabled.
                                                   properties:
                                                     matchExpressions:
-                                                      description: matchExpressions
-                                                        is a list of label selector
-                                                        requirements. The requirements
-                                                        are ANDed.
                                                       items:
                                                         properties:
                                                           key:
@@ -7453,21 +7427,10 @@ spec:
                                                     as the DataSourceRef field.'
                                                   properties:
                                                     apiGroup:
-                                                      description: APIGroup is the
-                                                        group for the resource being
-                                                        referenced. If APIGroup is
-                                                        not specified, the specified
-                                                        Kind must be in the core API
-                                                        group. For any other third-party
-                                                        types, APIGroup is required.
                                                       type: string
                                                     kind:
-                                                      description: Kind is the type
-                                                        of resource being referenced
                                                       type: string
                                                     name:
-                                                      description: Name is the name
-                                                        of resource being referenced
                                                       type: string
                                                   required:
                                                   - kind
@@ -7509,21 +7472,10 @@ spec:
                                                     feature gate to be enabled.'
                                                   properties:
                                                     apiGroup:
-                                                      description: APIGroup is the
-                                                        group for the resource being
-                                                        referenced. If APIGroup is
-                                                        not specified, the specified
-                                                        Kind must be in the core API
-                                                        group. For any other third-party
-                                                        types, APIGroup is required.
                                                       type: string
                                                     kind:
-                                                      description: Kind is the type
-                                                        of resource being referenced
                                                       type: string
                                                     name:
-                                                      description: Name is the name
-                                                        of resource being referenced
                                                       type: string
                                                   required:
                                                   - kind
@@ -7548,10 +7500,6 @@ spec:
                                                         - type: string
                                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                         x-kubernetes-int-or-string: true
-                                                      description: 'Limits describes
-                                                        the maximum amount of compute
-                                                        resources allowed. More info:
-                                                        https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                       type: object
                                                     requests:
                                                       additionalProperties:
@@ -7567,10 +7515,6 @@ spec:
                                                     volumes to consider for binding.
                                                   properties:
                                                     matchExpressions:
-                                                      description: matchExpressions
-                                                        is a list of label selector
-                                                        requirements. The requirements
-                                                        are ANDed.
                                                       items:
                                                         properties:
                                                           key:
@@ -7589,16 +7533,6 @@ spec:
                                                     matchLabels:
                                                       additionalProperties:
                                                         type: string
-                                                      description: matchLabels is
-                                                        a map of {key,value} pairs.
-                                                        A single {key,value} in the
-                                                        matchLabels map is equivalent
-                                                        to an element of matchExpressions,
-                                                        whose key field is "key",
-                                                        the operator is "In", and
-                                                        the values array contains
-                                                        only "value". The requirements
-                                                        are ANDed.
                                                       type: object
                                                   type: object
                                                 storageClassName:
@@ -8035,26 +7969,7 @@ spec:
                                                   configMap data to project
                                                 properties:
                                                   items:
-                                                    description: If unspecified, each
-                                                      key-value pair in the Data field
-                                                      of the referenced ConfigMap
-                                                      will be projected into the volume
-                                                      as a file whose name is the
-                                                      key and content is the value.
-                                                      If specified, the listed keys
-                                                      will be projected into the specified
-                                                      paths, and unlisted keys will
-                                                      not be present. If a key is
-                                                      specified which is not present
-                                                      in the ConfigMap, the volume
-                                                      setup will error unless it is
-                                                      marked optional. Paths must
-                                                      be relative and may not contain
-                                                      the '..' path or start with
-                                                      '..'.
                                                     items:
-                                                      description: Maps a string key
-                                                        to a path within a volume.
                                                       properties:
                                                         key:
                                                           type: string
@@ -8088,10 +8003,6 @@ spec:
                                                     description: Items is a list of
                                                       DownwardAPIVolume file
                                                     items:
-                                                      description: DownwardAPIVolumeFile
-                                                        represents information to
-                                                        create the file containing
-                                                        the pod field
                                                       properties:
                                                         fieldRef:
                                                           properties:
@@ -8149,8 +8060,6 @@ spec:
                                                       and may not contain the '..'
                                                       path or start with '..'.
                                                     items:
-                                                      description: Maps a string key
-                                                        to a path within a volume.
                                                       properties:
                                                         key:
                                                           type: string

--- a/cluster/manifests/stackset-controller/01-stackset-crd.yaml
+++ b/cluster/manifests/stackset-controller/01-stackset-crd.yaml
@@ -1,5 +1,3 @@
-# This is an adjusted copy of https://github.com/zalando-incubator/stackset-controller/blob/master/docs/stackset_crd.yaml
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -596,7 +594,6 @@ spec:
                         - maxReplicas
                         - metrics
                         type: object
-# {{ if eq .Cluster.ConfigItems.stackset_legacy_hpa_field_crd_enabled "true" }}
                       horizontalPodAutoscaler:
                         description: HorizontalPodAutoscaler is the Autoscaling configuration
                           of a Stack. If defined an HPA will be created for the Stack.
@@ -1122,41 +1119,6 @@ spec:
                         required:
                         - maxReplicas
                         type: object
-# {{ end }}
-                      ingress:
-                        description: Settings for the per-stack ingresses (in case
-                          the StackSet has a configured ingress)
-                        properties:
-                          enabled:
-                            description: Whether to enable per-stack ingresses or
-                              routegroups. Defaults to enabled if unset.
-                            type: boolean
-                          hosts:
-                            description: Hostnames to use for the per-stack ingresses
-                              (or route groups). These must contain the special $(STACK_NAME)
-                              token, which will be replaced with the stack's name.
-                              Would be automatically generated based on the hosts
-                              in the ingress/routegroup entry if unset.
-                            items:
-                              type: string
-                            type: array
-                          metadata:
-                            description: EmbeddedObjectMetaWithAnnotations defines
-                              the metadata which can be attached to a resource. It's
-                              a slimmed down version of metav1.ObjectMeta only containing
-                              annotations.
-                            properties:
-                              annotations:
-                                additionalProperties:
-                                  type: string
-                                description: 'Annotations is an unstructured key value
-                                  map stored with a resource that may be set by external
-                                  tools to store and retrieve arbitrary metadata.
-                                  They are not queryable and should be preserved when
-                                  modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
-                                type: object
-                            type: object
-                        type: object
                       minReadySeconds:
                         description: Minimum number of seconds for which a newly created
                           pod should be ready without any of its container crashing,
@@ -1396,6 +1358,10 @@ spec:
                                                     pods.
                                                   properties:
                                                     matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
                                                       items:
                                                         properties:
                                                           key:
@@ -1414,6 +1380,16 @@ spec:
                                                     matchLabels:
                                                       additionalProperties:
                                                         type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
                                                       type: object
                                                   type: object
                                                 namespaceSelector:
@@ -1432,6 +1408,10 @@ spec:
                                                     feature is enabled.
                                                   properties:
                                                     matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
                                                       items:
                                                         properties:
                                                           key:
@@ -1676,6 +1656,10 @@ spec:
                                                     pods.
                                                   properties:
                                                     matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
                                                       items:
                                                         properties:
                                                           key:
@@ -1712,6 +1696,10 @@ spec:
                                                     feature is enabled.
                                                   properties:
                                                     matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
                                                       items:
                                                         properties:
                                                           key:
@@ -7425,10 +7413,21 @@ spec:
                                                     as the DataSourceRef field.'
                                                   properties:
                                                     apiGroup:
+                                                      description: APIGroup is the
+                                                        group for the resource being
+                                                        referenced. If APIGroup is
+                                                        not specified, the specified
+                                                        Kind must be in the core API
+                                                        group. For any other third-party
+                                                        types, APIGroup is required.
                                                       type: string
                                                     kind:
+                                                      description: Kind is the type
+                                                        of resource being referenced
                                                       type: string
                                                     name:
+                                                      description: Name is the name
+                                                        of resource being referenced
                                                       type: string
                                                   required:
                                                   - kind
@@ -7470,10 +7469,21 @@ spec:
                                                     feature gate to be enabled.'
                                                   properties:
                                                     apiGroup:
+                                                      description: APIGroup is the
+                                                        group for the resource being
+                                                        referenced. If APIGroup is
+                                                        not specified, the specified
+                                                        Kind must be in the core API
+                                                        group. For any other third-party
+                                                        types, APIGroup is required.
                                                       type: string
                                                     kind:
+                                                      description: Kind is the type
+                                                        of resource being referenced
                                                       type: string
                                                     name:
+                                                      description: Name is the name
+                                                        of resource being referenced
                                                       type: string
                                                   required:
                                                   - kind
@@ -7498,6 +7508,10 @@ spec:
                                                         - type: string
                                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                         x-kubernetes-int-or-string: true
+                                                      description: 'Limits describes
+                                                        the maximum amount of compute
+                                                        resources allowed. More info:
+                                                        https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                       type: object
                                                     requests:
                                                       additionalProperties:
@@ -7513,6 +7527,10 @@ spec:
                                                     volumes to consider for binding.
                                                   properties:
                                                     matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
                                                       items:
                                                         properties:
                                                           key:
@@ -7531,6 +7549,16 @@ spec:
                                                     matchLabels:
                                                       additionalProperties:
                                                         type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
                                                       type: object
                                                   type: object
                                                 storageClassName:
@@ -7967,7 +7995,26 @@ spec:
                                                   configMap data to project
                                                 properties:
                                                   items:
+                                                    description: If unspecified, each
+                                                      key-value pair in the Data field
+                                                      of the referenced ConfigMap
+                                                      will be projected into the volume
+                                                      as a file whose name is the
+                                                      key and content is the value.
+                                                      If specified, the listed keys
+                                                      will be projected into the specified
+                                                      paths, and unlisted keys will
+                                                      not be present. If a key is
+                                                      specified which is not present
+                                                      in the ConfigMap, the volume
+                                                      setup will error unless it is
+                                                      marked optional. Paths must
+                                                      be relative and may not contain
+                                                      the '..' path or start with
+                                                      '..'.
                                                     items:
+                                                      description: Maps a string key
+                                                        to a path within a volume.
                                                       properties:
                                                         key:
                                                           type: string
@@ -8001,6 +8048,10 @@ spec:
                                                     description: Items is a list of
                                                       DownwardAPIVolume file
                                                     items:
+                                                      description: DownwardAPIVolumeFile
+                                                        represents information to
+                                                        create the file containing
+                                                        the pod field
                                                       properties:
                                                         fieldRef:
                                                           properties:
@@ -8058,6 +8109,8 @@ spec:
                                                       and may not contain the '..'
                                                       path or start with '..'.
                                                     items:
+                                                      description: Maps a string key
+                                                        to a path within a volume.
                                                       properties:
                                                         key:
                                                           type: string
@@ -8454,40 +8507,6 @@ spec:
                           to 1.
                         format: int32
                         type: integer
-                      routegroup:
-                        description: Settings for the per-stack route groups (in case
-                          the StackSet has a configured RouteGroup)
-                        properties:
-                          enabled:
-                            description: Whether to enable per-stack ingresses or
-                              routegroups. Defaults to enabled if unset.
-                            type: boolean
-                          hosts:
-                            description: Hostnames to use for the per-stack ingresses
-                              (or route groups). These must contain the special $(STACK_NAME)
-                              token, which will be replaced with the stack's name.
-                              Would be automatically generated based on the hosts
-                              in the ingress/routegroup entry if unset.
-                            items:
-                              type: string
-                            type: array
-                          metadata:
-                            description: EmbeddedObjectMetaWithAnnotations defines
-                              the metadata which can be attached to a resource. It's
-                              a slimmed down version of metav1.ObjectMeta only containing
-                              annotations.
-                            properties:
-                              annotations:
-                                additionalProperties:
-                                  type: string
-                                description: 'Annotations is an unstructured key value
-                                  map stored with a resource that may be set by external
-                                  tools to store and retrieve arbitrary metadata.
-                                  They are not queryable and should be preserved when
-                                  modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
-                                type: object
-                            type: object
-                        type: object
                       service:
                         description: Service can be used to configure a custom service,
                           if not set stackset-controller will generate a service based

--- a/cluster/manifests/stackset-controller/01-stackset-crd.yaml
+++ b/cluster/manifests/stackset-controller/01-stackset-crd.yaml
@@ -1123,6 +1123,42 @@ spec:
                         - maxReplicas
                         type: object
 # {{ end }}
+# {{ if ne .Cluster.ConfigItems.stackset_ingress_in_stack_crd "true" }}
+                      ingress:
+                        description: Settings for the per-stack ingresses (in case
+                          the StackSet has a configured ingress)
+                        properties:
+                          enabled:
+                            description: Whether to enable per-stack ingresses or
+                              routegroups. Defaults to enabled if unset.
+                            type: boolean
+                          hosts:
+                            description: Hostnames to use for the per-stack ingresses
+                              (or route groups). These must contain the special $(STACK_NAME)
+                              token, which will be replaced with the stack's name.
+                              Would be automatically generated based on the hosts
+                              in the ingress/routegroup entry if unset.
+                            items:
+                              type: string
+                            type: array
+                          metadata:
+                            description: EmbeddedObjectMetaWithAnnotations defines
+                              the metadata which can be attached to a resource. It's
+                              a slimmed down version of metav1.ObjectMeta only containing
+                              annotations.
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: 'Annotations is an unstructured key value
+                                  map stored with a resource that may be set by external
+                                  tools to store and retrieve arbitrary metadata.
+                                  They are not queryable and should be preserved when
+                                  modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                                type: object
+                            type: object
+                        type: object
+# {{ end }}
                       minReadySeconds:
                         description: Minimum number of seconds for which a newly created
                           pod should be ready without any of its container crashing,
@@ -8511,6 +8547,42 @@ spec:
                           to 1.
                         format: int32
                         type: integer
+# {{ if ne .Cluster.ConfigItems.stackset_ingress_in_stack_crd "true" }}
+                      routegroup:
+                        description: Settings for the per-stack route groups (in case
+                          the StackSet has a configured RouteGroup)
+                        properties:
+                          enabled:
+                            description: Whether to enable per-stack ingresses or
+                              routegroups. Defaults to enabled if unset.
+                            type: boolean
+                          hosts:
+                            description: Hostnames to use for the per-stack ingresses
+                              (or route groups). These must contain the special $(STACK_NAME)
+                              token, which will be replaced with the stack's name.
+                              Would be automatically generated based on the hosts
+                              in the ingress/routegroup entry if unset.
+                            items:
+                              type: string
+                            type: array
+                          metadata:
+                            description: EmbeddedObjectMetaWithAnnotations defines
+                              the metadata which can be attached to a resource. It's
+                              a slimmed down version of metav1.ObjectMeta only containing
+                              annotations.
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: 'Annotations is an unstructured key value
+                                  map stored with a resource that may be set by external
+                                  tools to store and retrieve arbitrary metadata.
+                                  They are not queryable and should be preserved when
+                                  modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                                type: object
+                            type: object
+                        type: object
+# {{ end }}
                       service:
                         description: Service can be used to configure a custom service,
                           if not set stackset-controller will generate a service based


### PR DESCRIPTION
This Pull Request updates both StackSet and Stack CRD to include the Ingress and RouteGroup definition in the Stack.

With the Ingress/Routegroup included in the Stack definition, we can implement in the StackSet controller to base creation of the pre-stack and segment ingresses/routegroups directly from the Stack, and re-create a specific stacks' Ingress/RouteGroup in case of accidental deletion.

I put this feature behind a config item `stackset_ingress_in_stack_crd`, in case we need to rollback for a cluster.