### PR TITLE
Restore adapter bucket to zalando-kubernetes-audit

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -628,7 +628,7 @@ audittrail_adapter_cpu: "50m"
 audittrail_adapter_memory: "200Mi"
 
 audittrail_adapter_timeout: "2s"
-audittrail_adapter_bucket: "zalando-audittrail-central"
+audittrail_adapter_bucket: "zalando-kubernetes-audit"
 
 audit_webhook_batch_max_size: "250"
 


### PR DESCRIPTION
This restores the bucket to `zalando-kubernetes-audit` which makes the rollback unnecessary, since the errors we observed were transient errors and they're gone.
 We would like to keep the setup running with the new bucket in other channels (beyond `dev`). So, "reverting" the change from #6304 before it goes further than `dev`.