### PR TITLE
Drop prevent downscale from e2e

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -63,7 +63,6 @@ pipeline:
           component: e2e
         annotations:
           zalando.org/runtime-policy: require-on-demand
-          zalando.org/prevent-scale-down: "true"
       spec:
         serviceAccountName: kubernetes-e2e
         restartPolicy: Never
@@ -184,7 +183,6 @@ pipeline:
           component: e2e
         annotations:
           zalando.org/runtime-policy: require-on-demand
-          zalando.org/prevent-scale-down: "true"
       spec:
         serviceAccountName: kubernetes-e2e
         restartPolicy: Never
@@ -222,7 +220,6 @@ pipeline:
           component: e2e
         annotations:
           zalando.org/runtime-policy: require-on-demand
-          zalando.org/prevent-scale-down: "true"
       spec:
         serviceAccountName: kubernetes-e2e
         restartPolicy: Never
@@ -260,7 +257,6 @@ pipeline:
           component: e2e
         annotations:
           zalando.org/runtime-policy: require-on-demand
-          zalando.org/prevent-scale-down: "true"
       spec:
         serviceAccountName: kubernetes-e2e
         restartPolicy: Never
@@ -300,7 +296,6 @@ pipeline:
           component: e2e
         annotations:
           zalando.org/runtime-policy: require-on-demand
-          zalando.org/prevent-scale-down: "true"
       spec:
         serviceAccountName: kubernetes-e2e
         restartPolicy: Never


### PR DESCRIPTION
Reverts #6284 which is no longer needed as the admission-controller will correctly handle this as of #6293