### PR TITLE
Reduce apiserver container CPU requests to fit all in e2e

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -262,7 +262,7 @@ write_files:
             timeoutSeconds: 5
           resources:
             requests:
-              cpu: 50m
+              cpu: 30m
               memory: 100Mi
           ports:
             - containerPort: 9085
@@ -293,7 +293,7 @@ write_files:
             timeoutSeconds: 5
           resources:
             requests:
-              cpu: 50m
+              cpu: 40m
               memory: 50Mi
           args:
             - --node-auth-cluster-id={{.Cluster.ID}}


### PR DESCRIPTION
Reduce apiserver container CPU requests to fit all in e2e

This reduces the CPU request of containers which are never utilized this much in production clusters.