### PR TITLE
drop support for docker AMI

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -596,19 +596,14 @@ tracing_coredns_local_zone_traces_endpoint: ""
 # AMI id given the image name and the Image AWS account owner.
 #
 # [0]: https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/8a9bd1cb2d094038a9e23e646421f8146b48886a/provisioner/template.go#L116
-kuberuntu_image_v1_23_focal_docker_amd64: {{ amiID "zalando-ubuntu-kubernetes-production-v1.23.17-amd64-master-256" "861068367966" }}
-kuberuntu_image_v1_23_focal_docker_arm64: {{ amiID "zalando-ubuntu-kubernetes-production-v1.23.17-arm64-master-256" "861068367966" }}
-
-kuberuntu_image_v1_23_focal_containerd_amd64: {{ amiID "zalando-ubuntu-focal-20.04-kubernetes-production-v1.23.17-amd64-master-273" "861068367966" }}
-kuberuntu_image_v1_23_focal_containerd_arm64: {{ amiID "zalando-ubuntu-focal-20.04-kubernetes-production-v1.23.17-arm64-master-273" "861068367966" }}
-kuberuntu_image_v1_23_jammy_containerd_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.23.17-amd64-master-279" "861068367966" }}
-kuberuntu_image_v1_23_jammy_containerd_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.23.17-arm64-master-279" "861068367966" }}
-kuberuntu_image_v1_24_focal_containerd_amd64: {{ amiID "zalando-ubuntu-focal-20.04-kubernetes-production-v1.24.16-amd64-master-281" "861068367966" }}
-kuberuntu_image_v1_24_focal_containerd_arm64: {{ amiID "zalando-ubuntu-focal-20.04-kubernetes-production-v1.24.16-arm64-master-281" "861068367966" }}
-kuberuntu_image_v1_24_jammy_containerd_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.24.16-amd64-master-281" "861068367966" }}
-kuberuntu_image_v1_24_jammy_containerd_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.24.16-arm64-master-281" "861068367966" }}
-
-container_runtime: "containerd"
+kuberuntu_image_v1_23_focal_amd64: {{ amiID "zalando-ubuntu-focal-20.04-kubernetes-production-v1.23.17-amd64-master-273" "861068367966" }}
+kuberuntu_image_v1_23_focal_arm64: {{ amiID "zalando-ubuntu-focal-20.04-kubernetes-production-v1.23.17-arm64-master-273" "861068367966" }}
+kuberuntu_image_v1_23_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.23.17-amd64-master-279" "861068367966" }}
+kuberuntu_image_v1_23_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.23.17-arm64-master-279" "861068367966" }}
+kuberuntu_image_v1_24_focal_amd64: {{ amiID "zalando-ubuntu-focal-20.04-kubernetes-production-v1.24.16-amd64-master-281" "861068367966" }}
+kuberuntu_image_v1_24_focal_arm64: {{ amiID "zalando-ubuntu-focal-20.04-kubernetes-production-v1.24.16-arm64-master-281" "861068367966" }}
+kuberuntu_image_v1_24_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.24.16-amd64-master-281" "861068367966" }}
+kuberuntu_image_v1_24_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.24.16-arm64-master-281" "861068367966" }}
 
 # Which distro from the previous config items should be used. Valid options are `focal` and `jammy`. Can be set for each node pool.
 {{if eq .Cluster.Environment "test"}}

--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -10,7 +10,7 @@ Mappings:
   Images:
     eu-central-1:
       # Use the node pool's architecture to construct the config item name that we're using to get the AMI name.
-      MachineImage: '{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_24_" .NodePool.ConfigItems.kuberuntu_distro_master "_containerd_" .Values.InstanceInfo.Architecture) }}'
+      MachineImage: '{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_24_" .NodePool.ConfigItems.kuberuntu_distro_master "_" .Values.InstanceInfo.Architecture) }}'
 
 Resources:
   AutoScalingGroup:

--- a/cluster/node-pools/worker-combined/stack.yaml
+++ b/cluster/node-pools/worker-combined/stack.yaml
@@ -10,7 +10,7 @@ Mappings:
   Images:
     eu-central-1:
       # Use the node pool's architecture to construct the config item name that we're using to get the AMI name.
-      MachineImage: '{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_24_" .NodePool.ConfigItems.kuberuntu_distro_worker "_" .NodePool.ConfigItems.container_runtime "_" .Values.InstanceInfo.Architecture) }}'
+      MachineImage: '{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_24_" .NodePool.ConfigItems.kuberuntu_distro_worker "_" .Values.InstanceInfo.Architecture) }}'
 
 Resources:
   AutoScalingGroup:

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -111,7 +111,7 @@ metadata:
 spec:
   amiFamily: Custom
   amiSelector:
-    aws-ids: "{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_24_" .NodePool.ConfigItems.kuberuntu_distro_worker "_" .NodePool.ConfigItems.container_runtime "_amd64")  }},{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_24_" .NodePool.ConfigItems.kuberuntu_distro_worker "_" .NodePool.ConfigItems.container_runtime "_arm64") }}"
+    aws-ids: "{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_24_" .NodePool.ConfigItems.kuberuntu_distro_worker "_amd64")  }},{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_24_" .NodePool.ConfigItems.kuberuntu_distro_worker "_arm64") }}"
   metadataOptions:
     httpTokens: optional
   subnetSelector:

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -10,7 +10,7 @@ Mappings:
   Images:
     eu-central-1:
       # Use the node pool's architecture to construct the config item name that we're using to get the AMI name.
-      MachineImage: '{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_24_" .NodePool.ConfigItems.kuberuntu_distro_worker "_" .NodePool.ConfigItems.container_runtime "_" .Values.InstanceInfo.Architecture) }}'
+      MachineImage: '{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_24_" .NodePool.ConfigItems.kuberuntu_distro_worker "_" .Values.InstanceInfo.Architecture) }}'
 
 Resources:
 {{ with $data := . }}

--- a/cluster/node-pools/worker-splitaz/userdata.yaml
+++ b/cluster/node-pools/worker-splitaz/userdata.yaml
@@ -59,11 +59,9 @@ write_files:
       # https://github.com/kubernetes/kubernetes/blob/v1.13.6/staging/src/k8s.io/kubelet/config/v1beta1/types.go
       apiVersion: kubelet.config.k8s.io/v1beta1
       kind: KubeletConfiguration
-{{- if eq .NodePool.ConfigItems.container_runtime "containerd" }}
       cgroupDriver: systemd
       containerLogMaxSize: "50Mi"
       containerLogMaxFiles: 2
-{{- end }}
       clusterDomain: cluster.local
       cpuCFSQuota: false
       featureGates:


### PR DESCRIPTION
Reverts #6287, #6285 for Kubernetes v1.24 as docker is not supported anyway.