### PR TITLE
Upgrade stackset CRD version 1.4.4 -> 1.4.11

### DIFF
--- a/cluster/manifests/stackset-controller/deployment.yaml
+++ b/cluster/manifests/stackset-controller/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $version := "v1.4.4" }}
+{{ $version := "v1.4.11" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
What changes in stackset controller?

1.4.11: Add stack weight verification for HPA reconciling

- https://github.com/zalando-incubator/stackset-controller/pull/519

1.4.10: Fix annotation for hostname rps based scaling

- https://github.com/zalando-incubator/stackset-controller/pull/512

1.4.9: Add RequestsPerSecond type to validation

- https://github.com/zalando-incubator/stackset-controller/pull/511

1.4.8: Regenerate CRD based on code

- https://github.com/zalando-incubator/stackset-controller/pull/510

1.4.7: Bump github.com/sirupsen/logrus from 1.9.2 to 1.9.3

- https://github.com/zalando-incubator/stackset-controller/pull/507

1.4.6: Bump github.com/prometheus/client_golang from 1.15.1 to 1.16.0

- https://github.com/zalando-incubator/stackset-controller/pull/508

1.4.5: Bump golang.org/x/sync from 0.2.0 to 0.3.0

- https://github.com/zalando-incubator/stackset-controller/pull/503

Why?

The main reason is to add the new HPA metric based on hostname RPS.

Is there any breaking changes?

No.