### PR TITLE
Configure etcd v3.5 for production clusters

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -564,11 +564,7 @@ etcd_instance_type: "t3.medium"
 {{end}}
 
 etcd_scalyr_key: ""
-{{if eq .Cluster.Environment "test"}}
 etcd_ami: {{ amiID "zalando-ubuntu-etcd-production-v3.5.9-amd64-main-15" "861068367966"}}
-{{else}}
-etcd_ami: {{ amiID "zalando-ubuntu-etcd-production-v3.4.16-amd64-main-10" "861068367966"}}
-{{end}}
 
 dynamodb_service_link_enabled: "false"
 


### PR DESCRIPTION
Follow up from https://github.com/zalando-incubator/kubernetes-on-aws/pull/6276

Configure etcd v3.5 for production clusters as well.