### PR TITLE
test/e2e: upgrade loadtest skipper version

### DIFF
--- a/test/e2e/loadtest/client/loadtest-deployment.yaml
+++ b/test/e2e/loadtest/client/loadtest-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         application: e2e-vegeta
     spec:
       containers:
-      - image: container-registry.zalando.net/teapot/skipper:v0.13.240
+      - image: container-registry.zalando.net/teapot/skipper:v0.17.6
         imagePullPolicy: IfNotPresent
         name: skipper
         args:


### PR DESCRIPTION
Upgrade version to prove `connect: cannot assign requested address` is caused by Skipper.

Followup on #6278 and  #6271