### PR TITLE
fix: admissionControl filter in distributed call chains

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.16.166-587" }}
+{{ $internal_version := "v0.17.7-602" }}
 {{ $version := index (split $internal_version "-") 0 }}
 
 apiVersion: apps/v1


### PR DESCRIPTION
fix: admissionControl filter in distributed call chains are not counting load shedding responses as errors, otherwise intermidiate services will shedd load because of leaf services that shedd load
feature: deletion of response Cookie is possible

https://github.com/zalando/skipper/compare/v0.16.166...v0.17.7