### PR TITLE
Use component name kube-metrics-adapter

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/credentials.yaml
+++ b/cluster/manifests/kube-metrics-adapter/credentials.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kubernetes
-    component: metrics-adapter
+    component: kube-metrics-adapter
 spec:
   application: kubernetes
   tokens:

--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   labels:
     application: kubernetes
-    component: metrics-adapter
+    component: kube-metrics-adapter
   name: kube-metrics-adapter
   namespace: kube-system
 spec:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         application: kubernetes
-        component: metrics-adapter
+        component: kube-metrics-adapter
         deployment: kube-metrics-adapter
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"

--- a/cluster/manifests/kube-metrics-adapter/service.yaml
+++ b/cluster/manifests/kube-metrics-adapter/service.yaml
@@ -3,6 +3,9 @@ kind: Service
 metadata:
   name: kube-metrics-adapter
   namespace: kube-system
+  labels:
+    application: kubernetes
+    component: kube-metrics-adapter
 spec:
   ports:
   - port: 443
@@ -10,4 +13,4 @@ spec:
     protocol: TCP
   selector:
     application: kubernetes
-    component: metrics-adapter
+    component: kube-metrics-adapter

--- a/cluster/manifests/kube-metrics-adapter/vpa.yaml
+++ b/cluster/manifests/kube-metrics-adapter/vpa.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     application: kubernetes
-    component: metrics-adapter
+    component: kube-metrics-adapter
 spec:
   targetRef:
     apiVersion: apps/v1


### PR DESCRIPTION
It's confusing that the component name is `metrics-adapter` when the project is `kube-metrics-adapter`. Align the naming.