### PR TITLE
Allow configuring max-requests-inflight

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -919,6 +919,8 @@ network_monitoring_separate_prometheus: "false"
 # Must be a whole number between 0-100.
 apiserver_memory_limit_percent: "80"
 
+apiserver_max_requests_inflight: "400"
+
 # specify if control plane nodes should rely on ASG Lifecycle Hook or not
 control_plane_asg_lifecycle_hook: "true"
 

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -172,6 +172,7 @@ write_files:
           - --kubelet-client-key=/etc/kubernetes/ssl/kubelet-client-key.pem
           - --shutdown-delay-duration=60s
           - --profiling={{ .Cluster.ConfigItems.enable_control_plane_profiling }}
+          - --max-requests-inflight={{ .Cluster.ConfigItems.apiserver_max_requests_inflight }}
           readinessProbe:
             httpGet:
               scheme: HTTPS


### PR DESCRIPTION
This enables tweaking the `--max-requests-inflight` setting of the `kube-apiserver` which controls the control the concurrency limit of the [API Priority and Fairness](https://kubernetes.io/docs/concepts/cluster-administration/flow-control/) feature.

This is done to be able to test different settings as it's likely that the default settings are too restrictive when scaling master nodes vertically.

The default is the same as the Kubernetes default for now.