### PR TITLE
skipper: add application label to the synthetic-probe RouteGroup

### DIFF
--- a/cluster/manifests/skipper/routegroup-probe.yaml
+++ b/cluster/manifests/skipper/routegroup-probe.yaml
@@ -3,6 +3,9 @@ kind: RouteGroup
 metadata:
   name: synthetic-probe
   namespace: kube-system
+  labels:
+    application: skipper-ingress
+    component: ingress
 spec:
   backends:
   - name: simulation


### PR DESCRIPTION
#0