### PR TITLE
clean up renamed karpenter logging config map

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -146,6 +146,9 @@ post_apply:
 - kind: ClusterRoleBinding
   name: kubenurse-prometheus
 {{- end }}
+- name: karpenter-logging-config
+  kind: ConfigMap
+  namespace: kube-system
 {{ if eq .Cluster.ConfigItems.karpenter_pools_enabled "false" }}
 - name: karpenter
   namespace: kube-system


### PR DESCRIPTION
clean up resources that was left by the rename in the PR #6345