### PR TITLE
reconfigure node-lifecycle.provider per node-pool

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -518,7 +518,7 @@ teapot_admission_controller_crd_role_provisioning_allowed_api_groups: "flink.k8s
 teapot_admission_controller_topology_spread: optin
 teapot_admission_controller_topology_spread_timeout: 7m
 
-# Supported providers: 'zalando', `karpenter`
+# keep legacy configs during rollout Supported providers: 'zalando', `karpenter`
 teapot_admission_controller_node_lifecycle_provider: "zalando"
 
 # Enable and configure runtime-policy annotation

--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -117,7 +117,7 @@ data:
   # keep legacy configs during rollouts
   pod.node-lifecycle.provider: "{{ .Cluster.ConfigItems.teapot_admission_controller_node_lifecycle_provider }}"
 {{- range $group, $provider := nodeLifeCycleProviderPerNodePoolGroup .Cluster.NodePools }}
-  pod.node-lifecycle.provider.{{ group }}: "{{ provider }}"
+  pod.node-lifecycle.provider.{{ $group }}: "{{ $provider }}"
 {{- end}}
 
   pod.runtime-policy.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_runtime_policy_enabled }}"

--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -114,7 +114,11 @@ data:
   node.node-not-ready-taint.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_node_not_ready_taint }}"
   node.extended-node-restriction.enable: "true"
 
+  # keep legacy configs during rollouts
   pod.node-lifecycle.provider: "{{ .Cluster.ConfigItems.teapot_admission_controller_node_lifecycle_provider }}"
+{{- range $group, $provider := nodeLifeCycleProviderPerNodePoolGroup .Cluster.NodePools }}
+  pod.node-lifecycle.provider.{{ group }}: "{{ provider }}"
+{{- end}}
 
   pod.runtime-policy.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_runtime_policy_enabled }}"
   pod.runtime-policy.default: "{{ .Cluster.ConfigItems.teapot_admission_controller_runtime_policy_default }}"


### PR DESCRIPTION
during karpenter rollout, clusters will run karpenter provisioners and CA pools at the same time
both scalers require different controls for the pod evection and for spot/on-demand scheduling

for pod evection:
- CA uses the annotation `cluster-autoscaler.kubernetes.io/safe-to-evict`
- karpenter uses the annotation `karpenter.sh/do-not-evict`

for the spot/on-demand scheduling
- CA uses this label `aws.amazon.com/spot` as node selector or affinity constraint
- karpneter uses this lable `karpenter.sh/capacity-type` as node selector or affinity constraint

in order to run both scalers in parallel, we need:
1.  to know the correct provider for each node-pool (karpenter vs Zalando). this is provided as configuration
2. to map the pod to the node-pool that it will land on. this is "guessed" by reading the "dedicated" toleration of the label

then we are able to inject the right controls

this PR configures the providers for each node-pool

to be merged after https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/692