### PR TITLE
Reduce required CPU resources to run etcd backup job

### DIFF
--- a/cluster/manifests/etcd-backup/cronjob.yaml
+++ b/cluster/manifests/etcd-backup/cronjob.yaml
@@ -51,10 +51,10 @@ spec:
 {{ end }}
             resources:
               limits:
-                cpu: 50m
+                cpu: 1m
                 memory: 384Mi
               requests:
-                cpu: 50m
+                cpu: 1m
                 memory: 384Mi
             volumeMounts:
 {{ if index .Cluster.ConfigItems "etcd_client_ca_cert" }}


### PR DESCRIPTION
Given our etcd setup, it's essential that etcd-backup runs at least once a day (retention time).

Since we don't implement CPU limits anyway, we only use them for making scheduling decisions. However, for etcd-backup there's really no decision to make since it already limits itself to run on master nodes.

[EDIT] This is very hacky. Looking for feedback on this.