### PR TITLE
pump admission-controller version

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -202,7 +202,7 @@ write_files:
             limits:
               memory: {{ .Values.InstanceInfo.MemoryFraction (parseInt64 .Cluster.ConfigItems.apiserver_memory_limit_percent)}}
 {{- end }}
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-169
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-172
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
Update admission-controller version.
The latest version supports multiple node-lifecycle providers.
It is needed to run the karpenter and cluster autoscaler concurrently, where every scaler expects a different provide

Signed-off-by: Mahmoud Gaballah <mahmoud.gaballah@zalando.de>
has to be rolled out after #6354