### PR TITLE
Make it possible to setup a custom etcd stack

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -11,7 +11,7 @@ Resources:
     Properties:
       FromPort: 2379
       ToPort: 2379
-      GroupId: !ImportValue 'etcd-cluster-etcd:etcd-security-group-id'
+      GroupId: !ImportValue '{{.Cluster.ConfigItems.etcd_stack_name}}:etcd-security-group-id'
       IpProtocol: tcp
       SourceSecurityGroupId: !Ref MasterSecurityGroup
   EtcdClusterSecurityGroupTLSIngressFromMaster:
@@ -19,7 +19,7 @@ Resources:
     Properties:
       FromPort: 2479
       ToPort: 2479
-      GroupId: !ImportValue 'etcd-cluster-etcd:etcd-security-group-id'
+      GroupId: !ImportValue '{{.Cluster.ConfigItems.etcd_stack_name}}:etcd-security-group-id'
       IpProtocol: tcp
       SourceSecurityGroupId: !Ref MasterSecurityGroup
   IngressLoadBalancerSecurityGroup:

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -555,6 +555,8 @@ teapot_admission_controller_graceful_termination: "true"
 blocked_availability_zone: ""
 
 # etcd cluster
+etcd_stack_name: "etcd-cluster-etcd"
+
 {{if eq .Cluster.Environment "production"}}
 etcd_instance_count: "5"
 etcd_instance_type: "m5.large"

--- a/cluster/etcd/stack.yaml
+++ b/cluster/etcd/stack.yaml
@@ -11,12 +11,12 @@ Outputs:
     Description: "Security Group ID of the etcd cluster"
     Value: !GetAtt EtcdClusterSecurityGroup.GroupId
     Export:
-      Name: "etcd-cluster-etcd:etcd-security-group-id"
+      Name: "{{.Cluster.ConfigItems.etcd_stack_name}}:etcd-security-group-id"
   LaunchTemplateId:
     Description: "Launch template ID of the etcd nodes"
     Value: !Ref LaunchTemplate
     Export:
-      Name: "etcd-cluster-etcd:launch-template-id"
+      Name: "{{.Cluster.ConfigItems.etcd_stack_name}}:launch-template-id"
 Resources:
   AppServerInstanceProfile:
     Type: AWS::IAM::InstanceProfile
@@ -27,7 +27,7 @@ Resources:
   LaunchTemplate:
     Type: AWS::EC2::LaunchTemplate
     Properties:
-      LaunchTemplateName: 'etcd-cluster-etcd'
+      LaunchTemplateName: '{{.Cluster.ConfigItems.etcd_stack_name}}'
       LaunchTemplateData:
         NetworkInterfaces:
           - DeviceIndex: 0
@@ -87,7 +87,8 @@ Resources:
       Tags:
         - Key: Name
           PropagateAtLaunch: true
-          Value: etcd-cluster-etcd
+          Value: {{.Cluster.ConfigItems.etcd_stack_name}}
+        # TODO: used by etcd.py?
         - Key: StackName
           PropagateAtLaunch: true
           Value: etcd-cluster
@@ -198,6 +199,9 @@ Resources:
   EtcdRole:
     Type: AWS::IAM::Role
     Properties:
+      # This is a hack to make the name fit the pattern allowed by the kms key
+      # currently provisioned outside of CLM.
+      RoleName: "etcd-cluster-etcd-EtcdRole-{{.Cluster.ConfigItems.etcd_stack_name}}"
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
       AssumeRolePolicyDocument:
@@ -261,7 +265,7 @@ Resources:
             - autoscaling:CompleteLifecycleAction
             # The shitty CF doesn't allow to do something like !GetAtt AppServer.Arn
             # Ref: https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/548
-            Resource: [ "arn:aws:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/etcd-cluster-etcd-AppServer*" ]
+            Resource: [ "arn:aws:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/{{.Cluster.ConfigItems.etcd_stack_name}}-AppServer*" ]
       - PolicyName: KMSDecrypt
         PolicyDocument:
           Version: "2012-10-17"


### PR DESCRIPTION
This makes the `etcd_stack_name` configurable such that it's possible to create a custom etcd cluster if needed for testing.

Apart from setting a custom value for `etcd_stack_name` you will also need to adjust:

* `etcd_endpoints` - This needs to follow a specific naming scheme based on `etcd_stack_name`. If `etcd_stack_name` is set to `my-etcd-<username>` then the etcd_endpoints` should be `https://etcd-server.<username>.<alias>.zalan.do:2479. This is logic hardcoded in the etcd.py and would need to be adjusted to make this more flexible.
* `etcd_s3_backup_bucket` - needs to be adjusted in order to create a unique bucket for this new stack to not overlap with the existing one.