### PR TITLE
Include externalIngress port in stack definition.

### DIFF
--- a/cluster/manifests/stackset-controller/01-stack-crd.yaml
+++ b/cluster/manifests/stackset-controller/01-stack-crd.yaml
@@ -349,6 +349,18 @@ spec:
                 - maxReplicas
                 - metrics
                 type: object
+              externalIngress:
+                description: Stack specific ExternalIngress, based on the parent StackSet
+                  at creation time.
+                properties:
+                  backendPort:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    x-kubernetes-int-or-string: true
+                required:
+                - backendPort
+                type: object
 # {{ if eq .Cluster.ConfigItems.stackset_legacy_hpa_field_crd_enabled "true" }}
               horizontalPodAutoscaler:
                 description: HorizontalPodAutoscaler is the Autoscaling configuration
@@ -1290,8 +1302,6 @@ spec:
                                               the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key
-                                                  that the selector applies to.
                                                 type: string
                                               operator:
                                                 type: string
@@ -1337,8 +1347,6 @@ spec:
                                               the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key
-                                                  that the selector applies to.
                                                 type: string
                                               operator:
                                                 type: string
@@ -1569,8 +1577,6 @@ spec:
                                               the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key
-                                                  that the selector applies to.
                                                 type: string
                                               operator:
                                                 type: string
@@ -1616,8 +1622,6 @@ spec:
                                               the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key
-                                                  that the selector applies to.
                                                 type: string
                                               operator:
                                                 type: string

--- a/cluster/manifests/stackset-controller/01-stack-crd.yaml
+++ b/cluster/manifests/stackset-controller/01-stack-crd.yaml
@@ -349,6 +349,7 @@ spec:
                 - maxReplicas
                 - metrics
                 type: object
+# {{ if eq .Cluster.ConfigItems.stackset_ingress_in_stack_crd "true" }}
               externalIngress:
                 description: Stack specific ExternalIngress, based on the parent StackSet
                   at creation time.
@@ -361,6 +362,7 @@ spec:
                 required:
                 - backendPort
                 type: object
+# {{ end }}
 # {{ if eq .Cluster.ConfigItems.stackset_legacy_hpa_field_crd_enabled "true" }}
               horizontalPodAutoscaler:
                 description: HorizontalPodAutoscaler is the Autoscaling configuration


### PR DESCRIPTION
Updates the Stack CRD in to include the `externalIngress` port. This field comes from the parent StackSet. Based from the generated CRD from [here](https://github.com/zalando-incubator/stackset-controller/blob/crd-stack-ingressrg/docs/stack_crd.yaml#L350-L361).