### PR TITLE
skipper: add config to enable ingress validation webhook

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -242,9 +242,12 @@ skipper_serve_method_metric: "false"
 # of the skipper_serve_host_duration_seconds_bucket metric.
 skipper_serve_status_code_metric: "false"
 
-# disabled|provisioned|enabled routegroup validation ( skipper webhook )
+# disabled|provisioned|enabled routegroup validation via skipper webhook
 # can be one of disabled|provisioned|enabled
 routegroups_validation: "enabled"
+
+# disabled|enabled ingress validation via skipper webhook
+ingresses_validation: "disabled"
 
 # tokeninfo
 {{if eq .Cluster.Environment "production"}}

--- a/cluster/manifests/01-admission-control/skipper-webhook.yaml
+++ b/cluster/manifests/01-admission-control/skipper-webhook.yaml
@@ -6,7 +6,7 @@ metadata:
     application: skipper-ingress
     component: webhook
 webhooks:
-{{ if eq .Cluster.ConfigItems.routegroups_validation "enabled" }}
+  # {{ if eq .Cluster.ConfigItems.routegroups_validation "enabled" }}
   - name: "routegroup-admitter.teapot.zalan.do"
     rules:
       - operations: ["CREATE", "UPDATE"]
@@ -19,7 +19,8 @@ webhooks:
     admissionReviewVersions: ["v1"]
     sideEffects: None
     timeoutSeconds: 5
-{{ end }}
+  # {{ end }}
+  # {{ if eq .Cluster.ConfigItems.ingresses_validation "enabled" }}
   - name: "ingress-admitter.teapot.zalan.do"
     rules:
       - operations: ["CREATE", "UPDATE"]
@@ -31,4 +32,5 @@ webhooks:
       caBundle: "{{ .ConfigItems.ca_cert_decompressed }}"
     admissionReviewVersions: ["v1"]
     sideEffects: None
-    timeoutSeconds: 5 
+    timeoutSeconds: 5
+  # {{ end }}


### PR DESCRIPTION
Similar to existing routegroups_validation (hence plural).

Renamed manifest from routegroups-webhook.yaml to skipper-webhook.yaml.

Tested that it works also when both are disabled:
```
~$ kubectl get ValidatingWebhookConfiguration skipper-admitter.teapot.zalan.do
NAME                               WEBHOOKS   AGE
skipper-admitter.teapot.zalan.do   0          27h
```

Followup on #6341