### PR TITLE
enable otel-collector by default, aligh pod labels

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -872,13 +872,14 @@ observability_metrics_endpoint: "ingest.lightstep.com"
 observability_metrics_port: "443"
 
 # labels whitelisted to kube-state-metrics
-observability_metrics_pods_labels: "application,component,version,stack_name,stack_version,application_id,application_version,team"
+observability_metrics_pods_labels: "application,component,version,environment,stack_name,stack_version,application_id,application_version,team,job-name"
+
 observability_metrics_ingresses_labels: ""
 
-observability_metrics_pods_annotations: ""
+observability_metrics_pods_annotations: "zalando.org/zmon-job-metric-stored"
 
 # opentelemetry collector
-observability_otel_collector_enabled: "false"
+observability_otel_collector_enabled: "true"
 
 # list of comma separated buckets which are accessible by zmon
 zmon_accessible_s3_buckets: ""


### PR DESCRIPTION
This PR:
- enables Otel Collectors by default
- alignes scraped pod labels and annotations