### PR TITLE
Set maxPods on karpenter provisioner

### DIFF
--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -5,6 +5,8 @@ kind: Provisioner
 metadata:
   name: "{{.NodePool.Name}}"
 spec:
+  kubeletConfiguration:
+    maxPods: {{ nodeCIDRMaxPods (parseInt64 .Cluster.ConfigItems.node_cidr_mask_size) (parseInt64 .Cluster.ConfigItems.node_max_pods_extra_capacity) }}
   {{- if index .NodePool.ConfigItems "scaling_priority"}}
   weight: {{.NodePool.ConfigItems.scaling_priority}}
   {{- end}}


### PR DESCRIPTION
This sets the `maxPods` on the karpenter provisioner to the same value as we set directly in the kubelet configuration in userdata.
This ensures that Karpenter has the right expectation about how many pods a new instance can have.

After setting this we no longer see the errors:

```
check failed, expected 234 of resource pods, but found 110 (47.0% of expected)
```

Which was previously seen an indicates karpenter was overestimating the amount of pods on a node and thereby scaling less nodes than needed.