### PR TITLE
Default to jammy distribution in dev channel

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -599,7 +599,10 @@ kuberuntu_image_v1_23_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernet
 kuberuntu_image_v1_23_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.23.17-arm64-master-279" "861068367966" }}
 
 # Which distro from the previous config items should be used. Valid options are `focal` and `jammy`. Can be set for each node pool.
-{{if eq .Cluster.Environment "test"}}
+{{if eq .Cluster.Channel "dev"}}
+kuberuntu_distro_master: "jammy"
+kuberuntu_distro_worker: "jammy"
+{{else if eq .Cluster.Environment "test"}}
 kuberuntu_distro_master: "jammy"
 kuberuntu_distro_worker: "focal"
 {{else}}


### PR DESCRIPTION
This makes `jammy` the default distribution for all node pools in the `dev` channel.

The condition is a little complicated and it's not good practice to switch on the channel like that (we don't do it anywhere else as far as I can see). It's only for easing the rollout, to not need to set the config item per cluster. The entire if clause and config items will be removed eventually.