### PR TITLE
Revert "Default to jammy distribution in dev channel"

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -599,10 +599,7 @@ kuberuntu_image_v1_23_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernet
 kuberuntu_image_v1_23_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.23.17-arm64-master-279" "861068367966" }}
 
 # Which distro from the previous config items should be used. Valid options are `focal` and `jammy`. Can be set for each node pool.
-{{if eq .Cluster.Channel "dev"}}
-kuberuntu_distro_master: "jammy"
-kuberuntu_distro_worker: "jammy"
-{{else if eq .Cluster.Environment "test"}}
+{{if eq .Cluster.Environment "test"}}
 kuberuntu_distro_master: "jammy"
 kuberuntu_distro_worker: "focal"
 {{else}}


### PR DESCRIPTION
Reverts https://github.com/zalando-incubator/kubernetes-on-aws/pull/6395

Let's not do this. Let's just the config items directly. The `dev` channel is also `kube-1.24` at the moment and who knows what it's next.