### PR TITLE
Drop stackset legacy field check from admission-controller

### DIFF
--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -8,7 +8,6 @@ data:
   daemonset.reserved.memory: "{{ .Cluster.ConfigItems.teapot_admission_controller_daemonset_reserved_memory }}"
 
   dns.default.subdomain-max-length: "{{ .Cluster.ConfigItems.subdomain_max_length }}"
-  stackset.legacy_hpa_field.enable: "false"
 
   pod.container-resource-control.min-memory-request: "25Mi"
   pod.container-resource-control.default-cpu-request: "{{ .Cluster.ConfigItems.teapot_admission_controller_default_cpu_request }}"

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -202,7 +202,7 @@ write_files:
             limits:
               memory: {{ .Values.InstanceInfo.MemoryFraction (parseInt64 .Cluster.ConfigItems.apiserver_memory_limit_percent)}}
 {{- end }}
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-172
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-173
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
Drops the legacy stackset field check from admission-controller which is no longer needed since: #6397