### PR TITLE
Update audittrail-adapter user group metric

### DIFF
--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: kube-system
   labels:
     application: audittrail-adapter
-    version: master-42
 spec:
   selector:
     matchLabels:
@@ -16,7 +15,6 @@ spec:
     metadata:
       labels:
         application: audittrail-adapter
-        version: master-42
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
         prometheus.io/path: /metrics
@@ -35,7 +33,7 @@ spec:
       hostNetwork: true
       containers:
       - name: audittrail-adapter
-        image: container-registry.zalando.net/teapot/audittrail-adapter:master-42
+        image: container-registry.zalando.net/teapot/audittrail-adapter:master-43
         env:
           - name: AWS_REGION
             value: {{.Cluster.Region}}


### PR DESCRIPTION
Adds a `user_group` dimension to the metrics. It's similar to `user` but groups nodes under one name `system:node` to reduce carnality. Could potentially do the same for other clients in the future if it makes sense.

This illustrates the problem that it solves:

All the individual node users would be treated as a single one reducing the number of time-series significantly.

![image](https://github.com/zalando-incubator/kubernetes-on-aws/assets/128566/66350531-ce9d-4db1-8501-1a493d4a0dc4)
