### PR TITLE
Make kube-proxy sync period configurable per cluster.

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -324,6 +324,7 @@ node_exporter_experimental_metrics: "false"
 # kube-proxy settings
 kube_proxy_cpu: "50m"
 kube_proxy_memory: "200Mi"
+kube_proxy_sync_period: "15m0s"
 
 # flannel settings
 flannel_cpu: "25m"

--- a/cluster/manifests/kube-proxy/configmap.yaml
+++ b/cluster/manifests/kube-proxy/configmap.yaml
@@ -14,7 +14,7 @@ data:
       contentType: application/vnd.kubernetes.protobuf
       qps: 5
     clusterCIDR: ""
-    configSyncPeriod: 15m0s
+    configSyncPeriod: {{ .Cluster.ConfigItems.kube_proxy_sync_period }}
     conntrack:
       maxPerCore: 131072
       min: 524288


### PR DESCRIPTION
Adds a new config item `kube_proxy_sync_period`, so that we can test the effect of reducing kube-proxy's `configSyncPeriod` in a cluster.