### PR TITLE
Drop teapot_admission_controller_node_lifecycle_provider config-item

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -523,8 +523,6 @@ teapot_admission_controller_crd_role_provisioning_allowed_api_groups: "flink.k8s
 teapot_admission_controller_topology_spread: optin
 teapot_admission_controller_topology_spread_timeout: 7m
 
-# keep legacy configs during rollout Supported providers: 'zalando', `karpenter`
-teapot_admission_controller_node_lifecycle_provider: "zalando"
 
 # Enable and configure runtime-policy annotation
 {{if eq .Cluster.Environment "production"}}

--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -113,8 +113,6 @@ data:
   node.node-not-ready-taint.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_node_not_ready_taint }}"
   node.extended-node-restriction.enable: "true"
 
-  # keep legacy configs during rollouts
-  pod.node-lifecycle.provider: "{{ .Cluster.ConfigItems.teapot_admission_controller_node_lifecycle_provider }}"
 {{- range $group, $provider := nodeLifeCycleProviderPerNodePoolGroup .Cluster.NodePools }}
   pod.node-lifecycle.provider.{{ $group }}: "{{ $provider }}"
 {{- end}}


### PR DESCRIPTION
This config-item is no longer needed after the `admission-controller` patch made [here](https://github.bus.zalan.do/teapot/admission-controller/pull/194) which allows configuring `provider` per node-pool, which is the desired configuration for the `karpenter` rollout. So, a configuration per cluster is no longer needed.

This is also necessary since we wish to support both providers (cluster-autoscaler and karpenter) during the rollout phase.
