### PR TITLE
Update audittrail-adapter to allow unset s3 audit bucket

### DIFF
--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
       hostNetwork: true
       containers:
       - name: audittrail-adapter
-        image: container-registry.zalando.net/teapot/audittrail-adapter:master-43
+        image: container-registry.zalando.net/teapot/audittrail-adapter:master-44
         env:
           - name: AWS_REGION
             value: {{.Cluster.Region}}


### PR DESCRIPTION
Currently we are sending too many requests to AWS S3 which is leading to a large cost increase. While we implement a better solution (e.g. request batching), this change will let us easily disable the centralised S3 feature.

[Teapot issue 3436](https://github.bus.zalan.do/teapot/issues/issues/3436)