### PR TITLE
add missing RBAC for karpenter v0.30.0

### DIFF
--- a/cluster/manifests/z-karpenter/01-rbac.yaml
+++ b/cluster/manifests/z-karpenter/01-rbac.yaml
@@ -40,8 +40,11 @@ rules:
     verbs: [ "get", "list", "watch" ]
   # Write
   - apiGroups: ["karpenter.sh"]
-    resources: ["provisioners/status", "machines", "machines/status"]
-    verbs: ["create", "delete", "patch"]
+    resources: ["machines", "machines/status"]
+    verbs: ["create", "delete", "update", "patch"]
+  - apiGroups: ["karpenter.sh"]
+    resources: ["provisioners", "provisioners/status"]
+    verbs: ["update", "patch"]
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
@@ -55,10 +58,7 @@ rules:
     resources: ["validatingwebhookconfigurations"]
     verbs: ["update"]
     resourceNames: ["validation.webhook.karpenter.sh", "validation.webhook.config.karpenter.sh"]
-  - apiGroups: ["admissionregistration.k8s.io"]
-    resources: ["mutatingwebhookconfigurations"]
-    verbs: ["update"]
-    resourceNames: ["defaulting.webhook.karpenter.sh"]
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -98,7 +98,7 @@ rules:
     resourceNames: ["defaulting.webhook.karpenter.k8s.aws"]
   # Write
   - apiGroups: ["karpenter.k8s.aws"]
-    resources: ["awsnodetemplates/status"]
+    resources: ["awsnodetemplates", "awsnodetemplates/status"]
     verbs: ["patch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -213,6 +213,41 @@ subjects:
     namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: karpenter-lease
+  namespace: kube-node-lease
+  labels:
+    application: kubernetes
+    component: karpenter
+rules:
+  # Read
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch"]
+  # Write
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: karpenter-lease
+  namespace: kube-node-lease
+  labels:
+    application: kubernetes
+    component: karpenter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: karpenter-lease
+subjects:
+  - kind: ServiceAccount
+    name: karpenter
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: karpenter-admin
@@ -227,5 +262,4 @@ rules:
   - apiGroups: [ "karpenter.k8s.aws" ]
     resources: [ "awsnodetemplates" ]
     verbs: [ "get", "list", "watch" ]
-
 {{ end }}


### PR DESCRIPTION
Karpenter with the new version `v0.30.0` that was rolled to `kube-1.24` caused `karpenter` to crash in `stups-test` and `teapot` with the error:

```
2023-09-05T14:18:05.502Z	ERROR	controller	pkg/mod/k8s.io/client-go@v0.26.6/tools/cache/reflector.go:169: Failed to watch *v1.Lease: failed to list *v1.Lease: leases.coordination.k8s.io is forbidden: User "system:serviceaccount:kube-system:karpenter" cannot list resource "leases" in API group "coordination.k8s.io" in the namespace "kube-node-lease": access undecided system:serviceaccount:kube-system:karpenter/[system:serviceaccounts system:serviceaccounts:kube-system system:authenticated]
```

This was traced to be coming from missing RBAC in the new version that was added upstream in [this PR](https://github.com/aws/karpenter/pull/4453/files). 

While, we wait for the new release, we can just patch the RBAC for now to not block karpenter rollout. This patch was done manually and it fixed the problem, so now providing a permanent fix in the PR.

Ref: Karpenter update to `v0.30.0` in [this PR](https://github.com/zalando-incubator/kubernetes-on-aws/commit/8a4772d974275b12b8b7e38f8bc54d5273675a7d).