### PR TITLE
Tell prometheus to scrape kube-proxy metrics

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -200,16 +200,16 @@ Resources:
           Value: owned
       ToPort: 443
     Type: 'AWS::EC2::SecurityGroupIngress'
-  MasterSecurityGroupIngressFromWorkerToMasterKubelet:
+  MasterSecurityGroupIngressFromWorkerToMasterKubeletAndKubeProxy:
     Properties:
-      FromPort: 10250
+      FromPort: 10249 # KubeProxy
       GroupId: !Ref MasterSecurityGroup
       IpProtocol: tcp
       SourceSecurityGroupId: !Ref WorkerSecurityGroup
       Tags:
         - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
           Value: owned
-      ToPort: 10250
+      ToPort: 10250 # Kubelet
     Type: 'AWS::EC2::SecurityGroupIngress'
   MasterSecurityGroupIngressFromWorkerToNodeMonitor:
     Properties:
@@ -335,16 +335,16 @@ Resources:
           Value: owned
       ToPort: 8472
     Type: 'AWS::EC2::SecurityGroupIngress'
-  WorkerSecurityGroupIngressFromWorkerToWorkerKubelet:
+  WorkerSecurityGroupIngressFromWorkerToWorkerKubeletAndKubeProxy:
     Properties:
-      FromPort: 10250
+      FromPort: 10249 # KubeProxy
       GroupId: !Ref WorkerSecurityGroup
       IpProtocol: tcp
       SourceSecurityGroupId: !Ref WorkerSecurityGroup
       Tags:
         - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
           Value: owned
-      ToPort: 10250
+      ToPort: 10250 # Kubelet
     Type: 'AWS::EC2::SecurityGroupIngress'
   WorkerSecurityGroupIngressFromWorkerToWorkerSkipperMetrics:
     Properties:

--- a/cluster/manifests/kube-proxy/configmap.yaml
+++ b/cluster/manifests/kube-proxy/configmap.yaml
@@ -36,7 +36,7 @@ data:
       scheduler: ""
       syncPeriod: 30s
     kind: KubeProxyConfiguration
-    metricsBindAddress: 127.0.0.1:10249
+    metricsBindAddress: 0.0.0.0:10249
     mode: iptables
     oomScoreAdj: -999
     portRange: ""

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -22,6 +22,9 @@ spec:
       annotations:
         config/hash: {{"configmap.yaml" | manifestHash}}
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "10249"
+        prometheus.io/scrape: "true"
     spec:
       priorityClassName: system-node-critical
       serviceAccountName: kube-proxy


### PR DESCRIPTION
Add kube-proxy to Prometheus' scraping targets. Kube-proxy doesn't use Pod IPs, but rather node IPs. An update to the firewall rules is needed for that.