### PR TITLE
mount efs with the additional noresvport option

### DIFF
--- a/cluster/manifests/efs-provisioner/sc-aws-efs.yaml
+++ b/cluster/manifests/efs-provisioner/sc-aws-efs.yaml
@@ -4,4 +4,7 @@ kind: StorageClass
 metadata:
   name: aws-efs
 provisioner: external-storage.alpha.kubernetes.io/aws-efs
+mountOptions:
+- vers=4.1
+- noresvport
 {{ end }}


### PR DESCRIPTION
For Zooport ticket https://github.bus.zalan.do/zooport/issues/issues/3965

This adds the recommended `noresvport` mount option. `vers=4.1` is default when nothing is specified, so we have to list that as well.

Note, this only applies to **new** EFS based PVCs.