### PR TITLE
Allow status service to parse/decrypt Secret objects

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -935,6 +935,11 @@ Resources:
                   - !Sub "arn:aws:s3:::${DeploymentServiceBucket}"
                 Effect: Allow
               - Action:
+                  - kms:Decrypt
+                Resource:
+                  - !GetAtt DeploymentSecretKey.Arn
+                Effect: Allow
+              - Action:
                   - 'cloudformation:DescribeStackEvents'
                   - 'cloudformation:DescribeStackResources'
                   - 'cloudformation:DescribeStacks'


### PR DESCRIPTION
Status Service uses Controller's `Parse` function which processes Secrets. As such it also needs access to the KMS key.

This was needed to make the `/validate` API work. In theory the payload of a Secret isn't needed to fulfil this functionality. 

Therefore, as a follow up we should check if we can avoid Status Service from needing access to Secret payloads.