### PR TITLE
Avoid evicting kube-cluster-autoscaler on minimal disk usage

### DIFF
--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -68,6 +68,7 @@ spec:
           requests:
             cpu: {{.Cluster.ConfigItems.cluster_autoscaler_cpu}}
             memory: {{.Cluster.ConfigItems.cluster_autoscaler_memory}}
+            ephemeral-storage: 256Mi
         env:
           - name: AWS_REGION
             value: {{ .Region }}


### PR DESCRIPTION
If the master node comes under disk pressure the kube-cluster-autoscaler is one of the first pods to be kicked out because it uses a few KB of disk but doesn't request any. Request 256Mi to ensure it doesn't get kicked out right away.