### PR TITLE
Update skipper-ingress deployment to introduce endpointregistry component

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.17.7-602" }}
+{{ $internal_version := "v0.17.41-635" }}
 {{ $version := index (split $internal_version "-") 0 }}
 
 apiVersion: apps/v1


### PR DESCRIPTION
This skipper update introduces endpointregistry component which should simplify load shedding, fadeIn and other algorithms which should have metadata about endpoints.
See https://github.com/zalando/skipper/pull/2535