### PR TITLE
Make master node shutdown graceful

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -914,6 +914,9 @@ apiserver_max_requests_inflight: "400"
 # specify if control plane nodes should rely on ASG Lifecycle Hook or not
 control_plane_asg_lifecycle_hook: "true"
 
+# enable graceful shutdown on the control_plane nodes
+control_plane_graceful_shutdown: "true"
+
 # This allows setting custom sysctl settings. The config-item is intended to be
 # used on node-pools rather being set globally.
 #

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -70,6 +70,10 @@ write_files:
           cacheAuthorizedTTL: "5m"
           cacheUnauthorizedTTL: "30s"
       protectKernelDefaults: true
+{{- if eq .Cluster.ConfigItems.control_plane_graceful_shutdown "true" }}
+      shutdownGracePeriod: "120s"
+      shutdownGracePeriodCriticalPods: "80s"
+{{- end }}
 
   - owner: root:root
     path: /etc/kubernetes/manifests/kube-apiserver.yaml


### PR DESCRIPTION
With the switch from docker to containerd the shutdown behavior of a master node seem to have changed.

With docker the `docker.service` would be stopped during shutdown and that would trigger SIGTERM to all the container processes. When `kube-apiserver` gets a SIGTERM it removes itself from the list of endpoints in the `kubernetes` service such that clients are moved to other apiserver endpoints somewhat graceful.

With containerd the behavior is different because stopping the `containerd.service` does NOT terminate the container processes which means the stopping of those likely happen later and less graceful in the shutdown procedure leading to the apiserver not being gracefully removed from the `kubernetes` service endpoint.

### Solution

To address this, we introduce the GracefulShutdown behavior which ensures the following shutdown steps:

1. A master node is picked by CLC for decommissioning
2. CLC drains all "normal" pods from the node
3. CLC triggers instance termination via EC2 AutoscalingGroup api
4. The instance goes into "draining" status in the NLB, this means new connections are not forwarded to the instance and ongoing, shortlived connections have time to finish. We set the draining period to 60s, but it seems to be longer than that in reality
5. After draining is done, the instance is terminated by the autoscaling group via a termination signal (EC2 level). This triggers a clean shutdown of Linux
6. During shutdown systemd detect the hook from kubelet (described in the link above) and gracefully terminates the pods respecting the pod termination rules.
7. kube-apiserver gets SIGTERM and removes its endpoint from the `kubernetes` service
8. kube-apiserver waits 60s (`--shutdown-delay`) before existing
9. Linux is stopped/instance is terminated.

Step 6-8 is what is new and more graceful than before. This should allow most clients to gracefully fade over to another apiserver and let kube-proxy update the `kubernetes` service endpoints list before the kube-apiserver container is gracefully terminated.

### Roll out strategy

The feature is enabled by default which means as soon as we merge master nodes will roll and there is a risk that current masters are rotated and shutdown in a non-graceful way because they don't yet have the fix. To address this the roll out is planned like this:

1. Disable the feature in all clusters via config-item (this allows us to enable it later per cluster in a more controlled way than for a whole channel when merging the PR)
2. Before enabling, run a script against all old master nodes and add the configuration + restart kubelet, this will effectively enable it on existing instances.
3. Enable the feature for the cluster to start rotation.
4. After rotation the problem should be mitigated for future rotations.