### PR TITLE
[STABLE] Graceful node shutdown for master nodes

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -913,6 +913,9 @@ apiserver_max_requests_inflight: "400"
 # specify if control plane nodes should rely on ASG Lifecycle Hook or not
 control_plane_asg_lifecycle_hook: "true"
 
+# enable graceful shutdown on the control_plane nodes
+control_plane_graceful_shutdown: "true"
+
 # This allows setting custom sysctl settings. The config-item is intended to be
 # used on node-pools rather being set globally.
 #

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -70,6 +70,10 @@ write_files:
           cacheAuthorizedTTL: "5m"
           cacheUnauthorizedTTL: "30s"
       protectKernelDefaults: true
+{{- if eq .Cluster.ConfigItems.control_plane_graceful_shutdown "true" }}
+      shutdownGracePeriod: "120s"
+      shutdownGracePeriodCriticalPods: "80s"
+{{- end }}
 
   - owner: root:root
     path: /etc/kubernetes/manifests/kube-apiserver.yaml


### PR DESCRIPTION
Rolling out #6441 in stable.

**Note**: This does not rotate masters, because we set `control_plane_graceful_shutdown=false` in all clusters. After merging we will change to `control_plane_graceful_shutdown=true` to do the rotation as described in #6441