### PR TITLE
Allow changing kube-proxy verbose level

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -325,6 +325,7 @@ node_exporter_experimental_metrics: "false"
 kube_proxy_cpu: "50m"
 kube_proxy_memory: "200Mi"
 kube_proxy_sync_period: "15m0s"
+kube_proxy_verbose_level: "2"
 
 # flannel settings
 flannel_cpu: "25m"

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -37,7 +37,7 @@ spec:
         args:
         - --hostname-override=$(HOSTNAME_OVERRIDE)
         - --config=/config/kube-proxy.yaml
-        - --v=2
+        - --v={{ .Cluster.ConfigItems.kube_proxy_verbose_level }}
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"


### PR DESCRIPTION
Allow setting kube-proxy verbose level via config-item to get a better understanding of kube-proxy updates during master node rotation.