### PR TITLE
Make skipper-proxy wait longer than apiserver during shutdown

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -439,7 +439,7 @@ write_files:
           # wait-for-healthcheck-interval delays termination, since it's
           # integrated with the health endpoint, using that instead of a
           # preStop hook.
-          - -wait-for-healthcheck-interval=60s
+          - -wait-for-healthcheck-interval=70s
           - -inline-routes
           - |
             s: JWTPayloadAllKV("iss", "kubernetes/serviceaccount")


### PR DESCRIPTION
This is related to #6441 

This is an experiment which doesn't make things worse, but may also not improve anything.

This is an attempt to improve the network path in red shown in the diagram below:

![image](https://github.com/zalando-incubator/kubernetes-on-aws/assets/128566/21569c2d-989c-4f3b-bb87-e00be437a393)

The idea is that watches from e.g. kube-proxy going through the `NLB -> skipper-proxy -> kube-apiserver` can get stale during shutdown/rotation of a master node. By increasing the shutdown timeout of skipper-proxy, kube-apiserver which have a shutdown delay of 60s (10s less) is able to close the connection when it's still going through skipper-proxy and thereby allow for a more graceful closing of the connection.