### PR TITLE
skipper-ingress: downgrade version to v0.17.40

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.17.41-635" }}
+{{ $internal_version := "v0.17.40-634" }}
 {{ $version := index (split $internal_version "-") 0 }}
 
 apiVersion: apps/v1


### PR DESCRIPTION
Downgrade skipper version to not rollout endpoint registry.

https://github.com/zalando/skipper/compare/v0.17.40...v0.17.41

Followup on #6440