### PR TITLE
kube-janitor: extend pull request cleanup rule

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -772,8 +772,11 @@ enable_indexed_jobs: "false"
 # to ensure all secrets are encrypted/decrypted all secrets need to be rewritten after masters have been rolled
 enable_encryption: "true"
 
-# default ttl for kube janitor for resources build from PRs in namespaces matching .*-pr-.*
+# default ttl for kube janitor for resources build from PRs
 kube_janitor_default_pr_ttl: "1w"  # 1 week
+# enable cleanup of pr resources other than namespaces
+kube_janitor_cleanup_pr_resources: "false"
+
 # opt-in deletion of unused PVCs
 kube_janitor_default_unused_pvc_ttl: "forever"
 

--- a/cluster/manifests/kube-janitor/deployment.yaml
+++ b/cluster/manifests/kube-janitor/deployment.yaml
@@ -1,4 +1,6 @@
-{{ if ne .Environment "production" }}
+# {{ if ne .Environment "production" }}
+# {{ $internal_version := "22.7.2-master-17" }}
+# {{ $version := index (split $internal_version "-") 0 }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -7,7 +9,7 @@ metadata:
   labels:
     application: kubernetes
     component: kube-janitor
-    version: v20.4.1
+    version: "{{ $version }}"
 spec:
   replicas: 1
   selector:
@@ -19,8 +21,9 @@ spec:
         deployment: kube-janitor
         application: kubernetes
         component: kube-janitor
-        version: v20.4.1
+        version: "{{ $version }}"
       annotations:
+        config/hash: '{{"rules-config.yaml" | manifestHash}}'
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
       dnsConfig:
@@ -29,33 +32,33 @@ spec:
             value: "1"
       serviceAccountName: kube-janitor
       containers:
-      - name: janitor
-        # see https://github.com/hjacobs/kube-janitor/releases
-        image: container-registry.zalando.net/teapot/kube-janitor:22.7.2-master-17
-        args:
-          # run every minute
-          - --interval=60
-          # do not touch system/infra namespaces
-          - --exclude-namespaces=kube-system,visibility
-          - --rules-file=/config/rules.yaml
-          - --deployment-time-annotation=deployment-time
-        resources:
-          limits:
-            cpu: 5m
-            memory: 4Gi
-          requests:
-            # this is a background app ==> low priority, low CPU requests
-            cpu: 5m
-            memory: 4Gi
-        securityContext:
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          runAsUser: 1000
-        volumeMounts:
-          - name: config-volume
-            mountPath: /config
+        - name: janitor
+          # see https://github.com/hjacobs/kube-janitor/releases
+          image: container-registry.zalando.net/teapot/kube-janitor:{{ $internal_version }}
+          args:
+            # run every minute
+            - --interval=60
+            # do not touch system/infra namespaces
+            - --exclude-namespaces=kube-system,visibility
+            - --rules-file=/config/rules.yaml
+            - --deployment-time-annotation=deployment-time
+          resources:
+            limits:
+              cpu: 5m
+              memory: 4Gi
+            requests:
+              # this is a background app ==> low priority, low CPU requests
+              cpu: 5m
+              memory: 4Gi
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+          volumeMounts:
+            - name: config-volume
+              mountPath: /config
       volumes:
-      - name: config-volume
-        configMap:
-          name: kube-janitor
-{{ end }}
+        - name: config-volume
+          configMap:
+            name: kube-janitor
+# {{ end }}

--- a/cluster/manifests/kube-janitor/rules-config.yaml
+++ b/cluster/manifests/kube-janitor/rules-config.yaml
@@ -1,9 +1,12 @@
-{{ if ne .Environment "production" }}
+# {{ if ne .Environment "production" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kube-janitor
   namespace: kube-system
+  labels:
+    application: kubernetes
+    component: kube-janitor
 data:
   rules.yaml: |-
     # example rules configuration to set TTL for arbitrary objects
@@ -39,8 +42,8 @@ data:
         # see http://jmespath.org/specification.html#starts-with
         jmespath: "starts_with(metadata.name, 'd-')"
         ttl: 24h
-      - id: cleanup-resources-from-pull-requests
-        # Delete all resources in namespaces matching .*-pr-.* after configured period:
+      - id: cleanup-namespaces-from-pull-requests
+        # Delete namespaces matching .*-pr-.* after configured period:
         # This allows to put resources build from pull requests into a
         # namespace like my-project-pr-123 . They won't mess up the cluster
         # anymore, see #2930.
@@ -48,6 +51,36 @@ data:
           - namespaces
         jmespath: "contains(metadata.name, '-pr-')"
         ttl: "{{ .Cluster.ConfigItems.kube_janitor_default_pr_ttl }}"
+
+      {{ if eq .ConfigItems.kube_janitor_cleanup_pr_resources "true" }}
+      - id: cleanup-resources-from-pull-requests
+        # Delete resources matching .*-pr-[0-9] after configured period.
+        # Note that jmespath does not support regexps, see https://github.com/jmespath/jmespath.jep/issues/23
+        # TODO: merge namespaces rule here after rollout
+        resources:
+          - stacksets
+          - deployments
+          - statefulsets
+          - cronjobs
+          - services
+          - ingresses
+          - routegroups
+          {{ if eq .ConfigItems.fabric_gateway_crd_v1_enabled "true" }}- fabricgateways{{ end }}
+          - platformcredentialssets
+        jmespath: >-
+          contains(metadata.name, '-pr-0') ||
+          contains(metadata.name, '-pr-1') ||
+          contains(metadata.name, '-pr-2') ||
+          contains(metadata.name, '-pr-3') ||
+          contains(metadata.name, '-pr-4') ||
+          contains(metadata.name, '-pr-5') ||
+          contains(metadata.name, '-pr-6') ||
+          contains(metadata.name, '-pr-7') ||
+          contains(metadata.name, '-pr-8') ||
+          contains(metadata.name, '-pr-9')
+        ttl: "{{ .Cluster.ConfigItems.kube_janitor_default_pr_ttl }}"
+      {{ end }}
+
       - id: cleanup-unused-pvcs
         # Delete all unused PersistentVolumeClaims (PVCs) and their EBS volumes
         # to save costs ($0.119/GiB per month)
@@ -55,4 +88,5 @@ data:
           - persistentvolumeclaims
         jmespath: "_context.pvc_is_not_mounted && _context.pvc_is_not_referenced"
         ttl: "{{ .Cluster.ConfigItems.kube_janitor_default_unused_pvc_ttl }}"
-{{ end }}
+
+# {{ end }}


### PR DESCRIPTION
Existing pull request cleanup rule added by https://github.com/zalando-incubator/kubernetes-on-aws/pull/2975
only cleans up namespaces matching `-pr-` pattern.

This change:

* adds a rule to cleanup other than namespace resources with name matching `-pr-[0-9]` pattern
* adds config/hash to enable dynamic configuration update
* fixes deployment version label
* moves template actions into yaml comments to make files valid yamls