### PR TITLE
Drop unused apiserver flag

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -102,7 +102,6 @@ write_files:
         - name: kube-apiserver
           image: nonexistent.zalan.do/teapot/kube-apiserver:fixed
           args:
-          - --apiserver-count={{ .Values.apiserver_count }}
           - --bind-address=0.0.0.0
           - --etcd-servers={{ .NodePool.ConfigItems.etcd_endpoints }}
 {{- if index .Cluster.ConfigItems "etcd_client_ca_cert" }}


### PR DESCRIPTION
Since we run with the default `--endpoint-reconciler-type=lease`, the flag `--apiserver-count` has no effect and should be dropped.

Was found during investigation for #6441