### PR TITLE
admission-controller: Handle CronJobs as batch/v1

### DIFF
--- a/cluster/manifests/01-admission-control/teapot.yaml
+++ b/cluster/manifests/01-admission-control/teapot.yaml
@@ -68,7 +68,7 @@ webhooks:
     rules:
       - operations: [ "CREATE", "UPDATE" ]
         apiGroups: ["batch"]
-        apiVersions: ["v1beta1", "v2alpha1"]
+        apiVersions: ["v1"]
         resources: ["cronjobs"]
   - name: job-admitter.teapot.zalan.do
     clientConfig:

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -205,7 +205,7 @@ write_files:
             limits:
               memory: {{ .Values.InstanceInfo.MemoryFraction (parseInt64 .Cluster.ConfigItems.apiserver_memory_limit_percent)}}
 {{- end }}
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-173
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-177
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
* Handle CronJob resources as the `batch/v1` api