### PR TITLE
Allowing dropping read-only events before audittrail-api

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -632,6 +632,12 @@ audittrail_adapter_memory: "200Mi"
 audittrail_adapter_timeout: "2s"
 audittrail_adapter_bucket: "zalando-kubernetes-audit"
 
+# When enabled, any read-only events are added to the metrics, but are dropped
+# before being sent to audittrail-api.
+# When this is set to true, `auditlog_read_access` can safely be set true
+# without overloading audittrail-api.
+audittrail_adapter_drop_audittrail_api_read_only: "true"
+
 audit_webhook_batch_max_size: "250"
 
 kube2iam_cpu: "25m"

--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
       hostNetwork: true
       containers:
       - name: audittrail-adapter
-        image: container-registry.zalando.net/teapot/audittrail-adapter:master-44
+        image: container-registry.zalando.net/teapot/audittrail-adapter:master-46
         env:
           - name: AWS_REGION
             value: {{.Cluster.Region}}
@@ -46,6 +46,9 @@ spec:
         - --address=:8889
         - --metrics-address=:7980
         - --audittrail-timeout={{ .Cluster.ConfigItems.audittrail_adapter_timeout }}
+        {{- if eq .Cluster.ConfigItems.audittrail_adapter_drop_audittrail_api_read_only "true" }}
+        - --audittrail-drop-read-only
+        {{- end }}
         {{- if not .Cluster.ConfigItems.audittrail_url }}
         - --metrics-only
         {{- end }}


### PR DESCRIPTION
This introduces a flag `--audittrail-drop-read-only` on the audittrail-adapter which allows dropping read-only events before sending to audittrail-api. The motivation for this is that we currently drop read-only events on the audit config (apiserver) level and therefore never see them in audittrail-adapter. Since audittrail-adapter also provide metrics about clients calling the apiserver it's helpful to have the read-only events in those metrics, but we still don't want to send to audittrail-api because of the volume, which was the motivation for dropping them in the first place.

The config-item `auditlog_read_access` is still set to `false` by default meaning the events are dropped at the apiserver level. The idea is to enable it in some cluster to see the effect before enabling it everywhere.