### PR TITLE
Update unbound to 1.18.0

### DIFF
--- a/cluster/manifests/coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/coredns-local/daemonset-coredns.yaml
@@ -43,7 +43,7 @@ spec:
       containers:
 {{ if eq .Cluster.ConfigItems.dns_cache "unbound" }}
       - name: unbound
-        image: container-registry.zalando.net/teapot/unbound:1.16.0-master-4
+        image: container-registry.zalando.net/teapot/unbound:1.18.0-master-6
         args:
         - -d
         - -c


### PR DESCRIPTION
This updates `unbound` to 1.18.0.

Note: this is still not being actively used as we had issues with `unbound` as DNS cache in the past. This allows us to test with the latest version.

https://nlnetlabs.nl/projects/unbound/download/#unbound-1-18-0