### PR TITLE
Update audittrail-adapter to fix user_group metric label

### DIFF
--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
       hostNetwork: true
       containers:
       - name: audittrail-adapter
-        image: container-registry.zalando.net/teapot/audittrail-adapter:master-46
+        image: container-registry.zalando.net/teapot/audittrail-adapter:master-47
         env:
           - name: AWS_REGION
             value: {{.Cluster.Region}}


### PR DESCRIPTION
Fixes a bug in audittrail-adapter where it didn't group nodes under a single `user` `system:node` which was the whole point of the `user_group` label.