### PR TITLE
Update to flannel v0.22.3

### DIFF
--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -57,7 +57,7 @@ spec:
           failureThreshold: 30
           periodSeconds: 10
       - name: kube-flannel
-        image: container-registry.zalando.net/teapot/flannel:v0.22.2-master-17
+        image: container-registry.zalando.net/teapot/flannel:v0.22.3-master-18
         command:
         - /opt/bin/flanneld
         args:


### PR DESCRIPTION
https://github.com/flannel-io/flannel/releases/tag/v0.22.3

-> fix: goroutine leak during watch leases (kube) by @iiiceoo in https://github.com/flannel-io/flannel/pull/1799