### PR TITLE
Update cronjob-fixer to v1.24

### DIFF
--- a/cluster/manifests/cronjob-fixer/deployment.yaml
+++ b/cluster/manifests/cronjob-fixer/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: cronjob-fixer
       containers:
         - name: cronjob-fixer
-          image: "container-registry.zalando.net/teapot/cronjob-fixer:master-11"
+          image: "container-registry.zalando.net/teapot/cronjob-fixer:master-13"
           resources:
             limits:
               cpu: 5m


### PR DESCRIPTION
Updates to Kubernetes v1.24, uses batch/v1 instead of `batch/v1beta1`.