### PR TITLE
Update vpa to v0.12.0

### DIFF
--- a/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     application: kubernetes
     component: vpa-admission-controller
-    version: v0.6.1-internal.12
 spec:
   replicas: 1
   selector:
@@ -18,7 +17,6 @@ spec:
         deployment: vpa-admission-controller
         application: kubernetes
         component: vpa-admission-controller
-        version: v0.6.1-internal.12
       annotations:
         config/hash: {{"02-secret.yaml" | manifestHash}}
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
@@ -28,9 +26,9 @@ spec:
       containers:
       - name: admission-controller
         {{if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "current"}}
-        image: container-registry.zalando.net/teapot/vpa-admission-controller:v0.11.0-internal.17
+        image: container-registry.zalando.net/teapot/vpa-admission-controller:v0.12.0-internal.19
         {{else if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "legacy"}}
-        image: container-registry.zalando.net/teapot/vpa-admission-controller:v0.6.1-internal.16
+        image: container-registry.zalando.net/teapot/vpa-admission-controller:v0.11.0-internal.17
         {{end}}
         command:
           - /admission-controller

--- a/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     application: kubernetes
     component: recommender
-    version: v0.6.1-internal.12
 spec:
   replicas: 1
   selector:
@@ -18,7 +17,6 @@ spec:
         deployment: vpa-recommender
         application: kubernetes
         component: vpa-recommender
-        version: v0.6.1-internal.12
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
@@ -26,9 +24,9 @@ spec:
       containers:
       - name: recommender
         {{if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "current"}}
-        image: container-registry.zalando.net/teapot/vpa-recommender:v0.11.0-internal.17
+        image: container-registry.zalando.net/teapot/vpa-recommender:v0.12.0-internal.19
         {{else if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "legacy"}}
-        image: container-registry.zalando.net/teapot/vpa-recommender:v0.6.1-internal.16
+        image: container-registry.zalando.net/teapot/vpa-recommender:v0.11.0-internal.17
         {{end}}
         args:
         - --logtostderr

--- a/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     application: kubernetes
     component: vpa-updater
-    version: v0.6.1-internal.12
 spec:
   replicas: 1
   selector:
@@ -18,7 +17,6 @@ spec:
         deployment: vpa-updater
         application: kubernetes
         component: vpa-updater
-        version: v0.6.1-internal.12
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
@@ -26,9 +24,9 @@ spec:
       containers:
       - name: updater
         {{if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "current"}}
-        image: container-registry.zalando.net/teapot/vpa-updater:v0.11.0-internal.17
+        image: container-registry.zalando.net/teapot/vpa-updater:v0.12.0-internal.19
         {{else if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "legacy"}}
-        image: container-registry.zalando.net/teapot/vpa-updater:v0.6.1-internal.16
+        image: container-registry.zalando.net/teapot/vpa-updater:v0.11.0-internal.17
         {{end}}
         command:
           - ./updater


### PR DESCRIPTION
This updates the VPA to v0.12.0 since the change is hard to test without running in a real cluster we keep the setup of `current|legacy` version. This allows us to quickly switch back to the previous version if the new VPA version doesn't behave as expected.

This is similar to what we did in #5361

The motivation for updating is to be compatible with Kubernetes v1.25 in the future.

ref: https://github.com/zalando-incubator/autoscaler/pull/101