### PR TITLE
kube-janitor: comment template actions

### DIFF
--- a/cluster/manifests/kube-janitor/deployment.yaml
+++ b/cluster/manifests/kube-janitor/deployment.yaml
@@ -1,6 +1,6 @@
-{{ if ne .Environment "production" }}
-{{ $internal_version := "22.7.2-master-17" }}
-{{ $version := index (split $internal_version "-") 0 }}
+# {{ if ne .Environment "production" }}
+# {{ $internal_version := "22.7.2-master-17" }}
+# {{ $version := index (split $internal_version "-") 0 }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -61,4 +61,4 @@ spec:
         - name: config-volume
           configMap:
             name: kube-janitor
-{{ end }}
+# {{ end }}

--- a/cluster/manifests/kube-janitor/rules-config.yaml
+++ b/cluster/manifests/kube-janitor/rules-config.yaml
@@ -1,4 +1,4 @@
-{{ if ne .Environment "production" }}
+# {{ if ne .Environment "production" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -91,4 +91,4 @@ data:
         jmespath: "_context.pvc_is_not_mounted && _context.pvc_is_not_referenced"
         ttl: "{{ .Cluster.ConfigItems.kube_janitor_default_unused_pvc_ttl }}"
 
-{{ end }}
+# {{ end }}


### PR DESCRIPTION
This reverts #6478 since CLM empty manifest detection was improved by https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/701