### PR TITLE
all: update kubectl cluster-info output

### DIFF
--- a/cluster/manifests/coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/coredns-local/daemonset-coredns.yaml
@@ -7,8 +7,6 @@ metadata:
     application: kubernetes
     component: coredns
     version: v1.9.3
-    kubernetes.io/cluster-service: "true"
-    kubernetes.io/name: "CoreDNS"
 spec:
   updateStrategy:
     type: OnDelete

--- a/cluster/manifests/coredns-local/service-coredns.yaml
+++ b/cluster/manifests/coredns-local/service-coredns.yaml
@@ -6,8 +6,6 @@ metadata:
   labels:
     application: kubernetes
     component: coredns
-    kubernetes.io/cluster-service: "true"
-    kubernetes.io/name: "CoreDNS"
 spec:
   selector:
     component: coredns

--- a/cluster/manifests/dashboard/deployment.yaml
+++ b/cluster/manifests/dashboard/deployment.yaml
@@ -7,7 +7,6 @@ metadata:
     application: kubernetes
     component: dashboard
     version: v2.4.0
-    kubernetes.io/cluster-service: "true"
 spec:
   replicas: 1
   selector:
@@ -20,7 +19,6 @@ spec:
         component: dashboard
         deployment: kubernetes-dashboard
         version: v2.4.0
-        kubernetes.io/cluster-service: "true"
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -66,6 +66,9 @@ post_apply:
 - name: skipper-ingress-routesrv
   namespace: kube-system
   kind: Deployment
+- name: skipper-ingress-routesrv
+  namespace: kube-system
+  kind: Service
 {{ end }}
 
 {{- if ne .ConfigItems.skipper_oauth2_ui_login "true" }}

--- a/cluster/manifests/kube-node-ready/service.yaml
+++ b/cluster/manifests/kube-node-ready/service.yaml
@@ -6,8 +6,6 @@ metadata:
   labels:
     application: kubernetes
     component: kube-node-ready
-    kubernetes.io/cluster-service: "true"
-    kubernetes.io/name: "kube-node-ready"
 spec:
   type: NodePort
   externalTrafficPolicy: Local

--- a/cluster/manifests/metrics-server/service.yaml
+++ b/cluster/manifests/metrics-server/service.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     application: kubernetes
     component: metrics-server
-    kubernetes.io/name: "Metrics-server"
 spec:
   selector:
     application: kubernetes

--- a/cluster/manifests/skipper/routesrv-service.yaml
+++ b/cluster/manifests/skipper/routesrv-service.yaml
@@ -1,18 +1,20 @@
-kind: Service
+# {{ if ne .ConfigItems.skipper_routesrv_enabled "false" }}
 apiVersion: v1
+kind: Service
 metadata:
   name: skipper-ingress-routesrv
   namespace: kube-system
   labels:
     application: skipper-ingress
     component: routesrv
+    kubernetes.io/cluster-service: "true"
 spec:
   type: ClusterIP
   ports:
-  - name: http
-    port: 80
-    targetPort: 9990
-    protocol: TCP
+    - port: 80
+      targetPort: 9990
+      protocol: TCP
   selector:
     application: skipper-ingress
     component: routesrv
+# {{ end }}

--- a/cluster/manifests/storageclass/storageclass.yaml
+++ b/cluster/manifests/storageclass/storageclass.yaml
@@ -5,7 +5,6 @@ metadata:
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
   labels:
-    kubernetes.io/cluster-service: "true"
     volume-type: gp3
 provisioner: kubernetes.io/aws-ebs
 parameters:


### PR DESCRIPTION
kubectl cluster-info displays addresses of the control plane and services with label kubernetes.io/cluster-service=true. It also uses kubernetes.io/name to name services but since label value must be a DNS name it can not be used to provide human readable name.

This change:
* removes kubernetes.io/cluster-service and kubernetes.io/name from resources not relevant for proxy access by cluster users
* adds kubernetes.io/cluster-service to skipper-ingress-routesrv service
* removes port name from routesrv service (also makes it consistent with kubernetes dashboard service)
* adds missing routesrv Service deletion

From https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster-services/#manually-constructing-apiserver-proxy-urls
> If you haven't specified a name for your port, you don't have to specify port_name in the URL.
> You can also use the port number in place of the port_name for both named and unnamed ports.

I.e. with named routesrv port proxy url would unnecessary need to be either /api/v1/namespaces/kube-system/services/skipper-ingress-routesrv:http/proxy/routes or /api/v1/namespaces/kube-system/services/skipper-ingress-routesrv:80/proxy/routes