### PR TITLE
Update deployment-service to transparently validate secret resources

### DIFF
--- a/cluster/manifests/deployment-service/controller-statefulset.yaml
+++ b/cluster/manifests/deployment-service/controller-statefulset.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
         - name: "deployment-service-controller"
-          image: "container-registry.zalando.net/teapot/deployment-controller:master-155"
+          image: "container-registry.zalando.net/teapot/deployment-controller:master-158"
           args:
             - "--config-namespace=kube-system"
           env:

--- a/cluster/manifests/deployment-service/status-service-deployment.yaml
+++ b/cluster/manifests/deployment-service/status-service-deployment.yaml
@@ -1,5 +1,5 @@
 {{ $image   := "container-registry.zalando.net/teapot/deployment-status-service" }}
-{{ $version := "master-155" }}
+{{ $version := "master-158" }}
 
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Updates the `deployment-service` to a version that don't try to decrypt secret resources for the validation endpoint.

This is an alternative to #6433 so it doesn't need additional permissions.