### PR TITLE
fix: skipper routegroup was not recognized by default lb-algorithm change

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.18.0-648" }}
+{{ $internal_version := "v0.18.4-652" }}
 {{ $version := index (split $internal_version "-") 0 }}
 
 apiVersion: apps/v1


### PR DESCRIPTION
https://github.com/zalando/skipper/compare/v0.18.0...v0.18.4
- fix: skipper routegroup was not recognized by default lb-algorithm change
- feature: new filter tracingTagFromResponse()
- feature: opa filters can now set response headers
- routesrv: log diff and etag