### PR TITLE
Add vpa for event-logger

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -822,6 +822,8 @@ pdb_controller_max_unavailable: "1%"
 
 # Log Kubernetes events to Scalyr
 kubernetes_event_logger_enabled: "true"
+event_logger_mem_min: "100Mi"
+event_logger_cpu_min: "10m"
 
 # enable/disable routegroup support for stackset
 stackset_routegroup_support_enabled: "true"

--- a/cluster/manifests/event-logger/statefulset.yaml
+++ b/cluster/manifests/event-logger/statefulset.yaml
@@ -36,8 +36,8 @@ spec:
             - --snapshot-name=kubernetes-event-logger
         resources:
           limits:
-            cpu: 10m
+            cpu: 20m
             memory: 100Mi
           requests:
-            cpu: 10m
+            cpu: 20m
             memory: 100Mi

--- a/cluster/manifests/event-logger/statefulset.yaml
+++ b/cluster/manifests/event-logger/statefulset.yaml
@@ -36,8 +36,8 @@ spec:
             - --snapshot-name=kubernetes-event-logger
         resources:
           limits:
-            cpu: 20m
+            cpu: 10m
             memory: 100Mi
           requests:
-            cpu: 20m
+            cpu: 10m
             memory: 100Mi

--- a/cluster/manifests/event-logger/vpa.yaml
+++ b/cluster/manifests/event-logger/vpa.yaml
@@ -18,4 +18,4 @@ spec:
     - containerName: logger
       minAllowed:
         memory: {{.ConfigItems.event_logger_mem_min}}
-        cpu: {{.ConfigItems.event_logger_cpu_min}}
+        cpu: {{.Cluster.ConfigItems.event_logger_cpu_min}}

--- a/cluster/manifests/event-logger/vpa.yaml
+++ b/cluster/manifests/event-logger/vpa.yaml
@@ -1,0 +1,21 @@
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: event-logger-vpa
+  namespace: kube-system
+  labels:
+    application: kubernetes
+    component: event-logger
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: kubernetes-event-logger
+  updatePolicy:
+    updateMode: Auto
+  resourcePolicy:
+    containerPolicies:
+    - containerName: logger
+      minAllowed:
+        memory: 100Mi
+        cpu: 20m

--- a/cluster/manifests/event-logger/vpa.yaml
+++ b/cluster/manifests/event-logger/vpa.yaml
@@ -17,5 +17,5 @@ spec:
     containerPolicies:
     - containerName: logger
       minAllowed:
-        memory: 100Mi
-        cpu: 20m
+        memory: {{.ConfigItems.event_logger_mem_min}}
+        cpu: {{.ConfigItems.event_logger_cpu_min}}

--- a/cluster/manifests/event-logger/vpa.yaml
+++ b/cluster/manifests/event-logger/vpa.yaml
@@ -17,5 +17,5 @@ spec:
     containerPolicies:
     - containerName: logger
       minAllowed:
-        memory: {{.ConfigItems.event_logger_mem_min}}
+        memory: {{.Cluster.ConfigItems.event_logger_mem_min}}
         cpu: {{.Cluster.ConfigItems.event_logger_cpu_min}}


### PR DESCRIPTION
During UJLT 2023-09-13 scale-up, `customer-data-platform` cluster has `kubernetes-event-logger` statefulset pod stuck in CrashLoop because of insufficient CPU availability. 

Had to manually increase CPU requests from `10Mi` to `20Mi` in the STS object to fix the pod. Creating this PR to increase the default to avoid this problem in the future, also to persist the changes made.

A VPA was also added to the `event-logger` for easier scaling in the future.

<img width="1427" alt="Screenshot 2023-09-27 at 10 46 44" src="https://github.com/zalando-incubator/kubernetes-on-aws/assets/15079451/604cc184-4135-4928-b278-be0840720457">
