### PR TITLE
skipper admission: re-enable ingress validation

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -251,7 +251,7 @@ skipper_serve_status_code_metric: "false"
 routegroups_validation: "enabled"
 
 # disabled|enabled ingress validation via skipper webhook
-ingresses_validation: "disabled"
+ingresses_validation: "enabled"
 
 # tokeninfo
 {{if eq .Cluster.Environment "production"}}

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -6,9 +6,6 @@ pre_apply:
 
 # everything defined under here will be deleted after applying the manifests
 post_apply:
-# TODO: remove later
-- name: "routegroup-admitter.teapot.zalan.do"
-  kind: ValidatingWebhookConfiguration
 - name: cronjob-monitor
   namespace: kube-system
   kind: VerticalPodAutoscaler


### PR DESCRIPTION
After some cleaning this shouldn't create problems as it did last time and we can work with people to fix their configuration or disable on demand.