### PR TITLE
Give poweruser permission to manage endpointslices

### DIFF
--- a/cluster/manifests/roles/poweruser-role.yaml
+++ b/cluster/manifests/roles/poweruser-role.yaml
@@ -166,6 +166,16 @@ rules:
   - patch
   - update
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
   - extensions
   - networking.k8s.io
   resources:


### PR DESCRIPTION
Add manage permissions for `endpointslices` for the poweruser role. This is consistent with `endpoints` (poweruser can manage them) and avoids any difference between the two, since `endpointslices` is the successor of `endpoints`. `endpointslices` has already been added to the readonly role in a previous change.

This should allow users to deploy (namespaced) roles and bindings targeting `endpointslices`.

This came out of https://github.bus.zalan.do/zooport/issues/issues/4070