### PR TITLE
logging: configure keyValue parser

### DIFF
--- a/cluster/manifests/fabric-gateway/deployment.yaml
+++ b/cluster/manifests/fabric-gateway/deployment.yaml
@@ -28,6 +28,8 @@ spec:
         version: "{{ .ConfigItems.fabric_gateway_controller_version }}"
         mode: "{{ .ConfigItems.fabric_gateway_controller_mode }}"
       annotations:
+        kubernetes-log-watcher/scalyr-parser: |
+          [{"container": "controller", "parser": "keyValue"}]
         logging/destination: "{{ .Cluster.ConfigItems.log_destination_infra }}"
         prometheus.io/path: /metrics
         prometheus.io/port: "7979"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -424,9 +424,9 @@ spec:
         version: {{ $version }}
         component: routesrv
       annotations:
-        kubernetes-log-watcher/scalyr-parser: |
-          [{"container": "routesrv", "parser": "skipper-access-log"}]
         config/hash: {{"secret.yaml" | manifestHash}}
+        kubernetes-log-watcher/scalyr-parser: |
+          [{"container": "routesrv", "parser": "keyValue"}]
         logging/destination: "{{.Cluster.ConfigItems.log_destination_local}}"
         prometheus.io/path: /metrics
         prometheus.io/port: "9990"

--- a/cluster/manifests/skipper/hostname-credentials-controller.yaml
+++ b/cluster/manifests/skipper/hostname-credentials-controller.yaml
@@ -78,6 +78,8 @@ spec:
             application: skipper-ingress
             component: hostname-credentials
           annotations:
+            kubernetes-log-watcher/scalyr-parser: |
+              [{"container": "controller", "parser": "keyValue"}]
             logging/destination: "{{ .ConfigItems.log_destination_infra }}"
         spec:
           serviceAccountName: hostname-credentials-controller


### PR DESCRIPTION
Configure built-in keyValue parser for containers using https://github.com/sirupsen/logrus that logs in the format compatible with https://pkg.go.dev/github.com/kr/logfmt