### PR TITLE
skipper: remove route-cache volume

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -328,8 +328,6 @@ spec:
           runAsNonRoot: true
           runAsUser: 1000
         volumeMounts:
-          - name: routes-cache
-            mountPath: /tmp
 {{ if eq .ConfigItems.skipper_local_tokeninfo "bridge"}}
           - name: routes
             mountPath: /etc/routes
@@ -357,8 +355,6 @@ spec:
             readOnly: true
 {{ end }}
       volumes:
-        - name: routes-cache
-          emptyDir: {}
 {{ if eq .ConfigItems.skipper_local_tokeninfo "bridge"}}
         - name: routes
           configMap:


### PR DESCRIPTION
There is no need to mount empty volume to the /tmp.

This was added by #4704 initially