### PR TITLE
Give deployment-status-service the required permission to read CloudFormation templates

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -938,6 +938,7 @@ Resources:
                   - 'cloudformation:DescribeStackEvents'
                   - 'cloudformation:DescribeStackResources'
                   - 'cloudformation:DescribeStacks'
+                  - 'cloudformation:GetTemplate'
                 Effect: Allow
                 Resource: '*'
   ExternalDNSIAMRole:


### PR DESCRIPTION
This adds the required permissions in the per-cluster configuration of deployment-service's status-service. Originally from here: https://github.bus.zalan.do/teapot/deployment-service/pull/170/files#diff-35010792c4dfbbf482b8a9ac13669df5ced738a388ac95b3510d07c4e6910c31