### PR TITLE
Use endpointslice discovery for prometheus

### DIFF
--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -153,14 +153,14 @@ data:
       scheme: http
       honor_labels: true
       kubernetes_sd_configs:
-      - role: endpoints
+      - role: endpointslice
         namespaces:
           names:
             - kube-system
       relabel_configs:
-      - source_labels: [__meta_kubernetes_endpoints_name]
+      - source_labels: [__meta_kubernetes_endpointslice_name]
         action: keep
-        regex: kube-state-metrics
+        regex: "kube-state-metrics-.*"
       metric_relabel_configs:
 {{- if eq .Cluster.ConfigItems.disable_zmon_appliance_worker_tracking "true" }}
       - action: drop
@@ -310,15 +310,15 @@ data:
       scheme: http
       honor_labels: true
       kubernetes_sd_configs:
-      - role: endpoints
+      - role: endpointslice
         namespaces:
           names:
             - kube-system
       relabel_configs:
-      - source_labels: [__meta_kubernetes_endpoints_name]
+      - source_labels: [__meta_kubernetes_endpointslice_name]
         action: keep
-        regex: node-monitor
-      - source_labels: [__meta_kubernetes_endpoint_port_name]
+        regex: "node-monitor-.*"
+      - source_labels: [__meta_kubernetes_endpointslice_port_name]
         action: keep
         regex: cadvisor
       - action: replace
@@ -352,15 +352,15 @@ data:
       scheme: http
       honor_labels: true
       kubernetes_sd_configs:
-      - role: endpoints
+      - role: endpointslice
         namespaces:
           names:
             - kube-system
       relabel_configs:
-        - source_labels: [__meta_kubernetes_endpoints_name]
+        - source_labels: [__meta_kubernetes_endpointslice_name]
           action: keep
-          regex: node-monitor
-        - source_labels: [__meta_kubernetes_endpoint_port_name]
+          regex: "node-monitor-.*"
+        - source_labels: [__meta_kubernetes_endpointslice_port_name]
           action: keep
           regex: node-exporter
         - action: replace

--- a/cluster/manifests/prometheus/rbac.yaml
+++ b/cluster/manifests/prometheus/rbac.yaml
@@ -20,6 +20,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+    - discovery.k8s.io
+  resources:
+    - endpointslices
+  verbs:
+    - get
+    - list
+    - watch
 - nonResourceURLs:
   - /metrics
   verbs:


### PR DESCRIPTION
Using `endpoints` discovery for Prometheus scaling is limited to 1000 endpoints. When running with more than 1000 nodes we only get metrics for 1000 of them for cadvisor and node-exporter.

The fix is to use `endpointslice` discovery which this PR introduces.

https://github.com/prometheus/prometheus/blob/ffa74eb12db3d46c98033cea42cfdb347e7d1e75/discovery/kubernetes/endpoints.go#L360