### PR TITLE
Update skipper image to avoid using endpointregistry in the hotpath

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.18.24-671" }}
+{{ $internal_version := "v0.18.32-681" }}
 {{ $version := index (split $internal_version "-") 0 }}
 
 apiVersion: apps/v1


### PR DESCRIPTION
This is needed because endpointregistry seems to show not so good performance when it is under lock contention.

FYI https://github.com/zalando/skipper/compare/v0.18.24...v0.18.32