### PR TITLE
[STABLE] Update skipper-ingress from v0.18.13 to v0.18.32

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -292,7 +292,6 @@ skipper_ingress_backend_traffic_algorithm: "traffic-segment-predicate"
 # TODO: after a while we can remove this and hardcode (2023-06-30)
 skipper_ingress_default_lb_algorithm: "powerOfRandomNChoices"
 
-# TODO: add skipper flag
 skipper_ingress_disable_catchall_routes: "false"
 
 # Set defaults values that would enable Open Policy Agent in a skipper filter

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.18.13-661" }}
+{{ $internal_version := "v0.18.24-671" }}
 {{ $version := index (split $internal_version "-") 0 }}
 
 apiVersion: apps/v1
@@ -124,6 +124,7 @@ spec:
           - "-kubernetes-path-mode=path-prefix"
           - "-kubernetes-backend-traffic-algorithm={{ .ConfigItems.skipper_ingress_backend_traffic_algorithm }}"
           - "-kubernetes-default-lb-algorithm={{ .ConfigItems.skipper_ingress_default_lb_algorithm }}"
+          - "-kubernetes-disable-catchall-routes={{ .ConfigItems.skipper_ingress_disable_catchall_routes }}"
           - "-enable-kubernetes-endpointslices={{ .ConfigItems.skipper_endpointslices_enabled }}"
 {{ end }}
           - "-address=:9999"
@@ -481,6 +482,7 @@ spec:
           - "-kubernetes-path-mode=path-prefix"
           - "-kubernetes-backend-traffic-algorithm={{ .ConfigItems.skipper_ingress_backend_traffic_algorithm }}"
           - "-kubernetes-default-lb-algorithm={{ .ConfigItems.skipper_ingress_default_lb_algorithm }}"
+          - "-kubernetes-disable-catchall-routes={{ .ConfigItems.skipper_ingress_disable_catchall_routes }}"
           - "-enable-kubernetes-endpointslices={{ .ConfigItems.skipper_endpointslices_enabled }}"
           - "-address=:9990"
           - "-wait-for-healthcheck-interval={{ .Cluster.ConfigItems.skipper_wait_for_healthcheck_interval }}"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.18.24-671" }}
+{{ $internal_version := "v0.18.32-681" }}
 {{ $version := index (split $internal_version "-") 0 }}
 
 apiVersion: apps/v1


### PR DESCRIPTION
* Reverts the hotfix of rolling back skipper-ingress only applied in stable (#6550)
* Updates skipper-ingress to v0.18.32 (#6549)

In the end it simply updates skipper-ingress from v0.18.13 to v0.18.32

This is done with a custom PR to ensure we align stable and beta after this.