### PR TITLE
Categorise manual, poweruser, and emergency access as exempt from APF

### DIFF
--- a/cluster/manifests/apf/manual-emergency-access.yaml
+++ b/cluster/manifests/apf/manual-emergency-access.yaml
@@ -1,0 +1,44 @@
+apiVersion: flowcontrol.apiserver.k8s.io/v1beta2
+kind: FlowSchema
+metadata:
+  name: manual-emergency-access
+spec:
+  matchingPrecedence: 3
+  priorityLevelConfiguration:
+    name: exempt
+  rules:
+    - nonResourceRules:
+      - nonResourceURLs:
+        - '*'
+        verbs:
+        - '*'
+      subjects:
+      - group:
+          name: "PowerUser"
+        kind: Group
+      - group:
+          name: "Manual"
+        kind: Group
+      - group:
+          name: "Emergency"
+        kind: Group
+    - resourceRules:
+      - apiGroups:
+        - '*'
+        clusterScope: true
+        namespaces:
+        - '*'
+        resources:
+        - '*'
+        verbs:
+        - '*'
+      subjects:
+      - group:
+          name: "PowerUser"
+        kind: Group
+      - group:
+          name: "Manual"
+        kind: Group
+      - group:
+          name: "Emergency"
+        kind: Group


### PR DESCRIPTION
Do not apply Kubernetes API Priority and Fairness limits to users of the `Manual`/`PowerUser`/`Emergency` roles. Users responding to incidents should not have their requests affected by other applications/components so they can apply mitigations within a cluster as quickly and effectively as possible.