### PR TITLE
remove ETCD_CLIENT_TLS_ENABLED from etcd env

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -615,7 +615,7 @@ etcd_instance_type: "t3.medium"
 {{end}}
 
 etcd_scalyr_key: ""
-etcd_ami: {{ amiID "zalando-ubuntu-etcd-production-v3.5.9-amd64-main-15" "861068367966"}}
+etcd_ami: {{ amiID "zalando-ubuntu-etcd-production-v3.5.9-amd64-main-20" "861068367966"}}
 
 dynamodb_service_link_enabled: "false"
 

--- a/cluster/etcd/stack.yaml
+++ b/cluster/etcd/stack.yaml
@@ -62,7 +62,6 @@ Resources:
                   ETCD_CERT_FILE=/etc/etcd/ssl/client.cert
                   ETCD_KEY_FILE=/etc/etcd/ssl/client.key
                   ETCD_TRUSTED_CA_FILE=/etc/etcd/ssl/ca.cert
-                  ETCD_CLIENT_TLS_ENABLED='true'
                   ETCD_LOG_LEVEL=info
                   HOSTED_ZONE="{{.Values.hosted_zone}}"
                   S3_CERTS_BUCKET="{{ .S3GeneratedFilesPath }}"


### PR DESCRIPTION
Removes the flag as we've decided to enable TLS by default.

More context: https://github.bus.zalan.do/teapot/issues/issues/3520