### PR TITLE
Add new okta based Administrator role to KMS keys

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -815,6 +815,7 @@ Resources:
 {{- end }}
                   - !Sub "arn:aws:iam::${AWS::AccountId}:role/cluster-lifecycle-manager-entrypoint"
                   - !Sub "arn:aws:iam::${AWS::AccountId}:role/Shibboleth-Administrator"
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/Administrator"
   DeploymentControllerRole:
     Type: AWS::IAM::Role
     Properties:
@@ -1992,6 +1993,7 @@ Resources:
               AWS:
                 - !Sub "arn:aws:iam::${AWS::AccountId}:role/cluster-lifecycle-manager-entrypoint"
                 - !Sub "arn:aws:iam::${AWS::AccountId}:role/Shibboleth-Administrator"
+                - !Sub "arn:aws:iam::${AWS::AccountId}:role/Administrator"
             Action:
             - "kms:*"
             - "tag:TagResources"
@@ -2027,7 +2029,9 @@ Resources:
           - Sid: "Allow Administrator to manage and use this key"
             Effect: "Allow"
             Principal:
-              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:role/Shibboleth-Administrator"
+              AWS:
+              - !Sub "arn:aws:iam::${AWS::AccountId}:role/Shibboleth-Administrator"
+              - !Sub "arn:aws:iam::${AWS::AccountId}:role/Administrator"
             Action:
             - "kms:*"
             - "tag:TagResources"
@@ -2065,6 +2069,7 @@ Resources:
               AWS:
                 - !Sub "arn:aws:iam::${AWS::AccountId}:role/cluster-lifecycle-manager-entrypoint"
                 - !Sub "arn:aws:iam::${AWS::AccountId}:role/Shibboleth-Administrator"
+                - !Sub "arn:aws:iam::${AWS::AccountId}:role/Administrator"
             Action:
             - "kms:*"
             - "tag:TagResources"
@@ -2101,6 +2106,7 @@ Resources:
               AWS:
                 - !Sub "arn:aws:iam::${AWS::AccountId}:role/cluster-lifecycle-manager-entrypoint"
                 - !Sub "arn:aws:iam::${AWS::AccountId}:role/Shibboleth-Administrator"
+                - !Sub "arn:aws:iam::${AWS::AccountId}:role/Administrator"
             Action:
             - "kms:*"
             - "tag:TagResources"


### PR DESCRIPTION
With the switch to Okta based login we also switch the AWS role granted to Admin users. Therefore we need to also add that role to the respective kms keys/policies to continue to be able to manage those resources manually if needed in an emergency.