### PR TITLE
Use a common name for the deployment secret across all clusters

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -749,6 +749,13 @@ Resources:
         Version: 2012-10-17
       KeyUsage: ENCRYPT_DECRYPT
     Type: 'AWS::KMS::Key'
+{{- if ne .Cluster.Environment "e2e" }}
+  DeploymentSecretKeyCommonAlias:
+    Properties:
+      AliasName: "alias/deployment-secret"
+      TargetKeyId: !Ref DeploymentSecretKey
+    Type: 'AWS::KMS::Alias'
+{{- end }}
   DeploymentSecretKeyAlias:
     Properties:
       AliasName: "alias/{{.Cluster.LocalID}}-deployment-secret"


### PR DESCRIPTION
In order to have a predictable reference name to the KMS key used to encrypt/decrypt secrets, let's create a new alias for it that doesn't include the local id. This way the KMS alias can always be referenced via `alias/deployment-secret` in every account.

The local ID was prepended to allow for multiple clusters to share the same AWS account. In practice, this is only the case in teapot and teapot-e2e where we could special case it.

Note, this doesn't solve the problem for teapot at the moment.