### PR TITLE
allow gerry to call priority and fairness debug endpoints

### DIFF
--- a/cluster/manifests/roles/zmon-external-check-rbac.yaml
+++ b/cluster/manifests/roles/zmon-external-check-rbac.yaml
@@ -6,14 +6,18 @@ kind: ClusterRole
 metadata:
   name: zmon-external-check
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - endpoints
-  resourceNames:
-  - coredns
-  verbs:
-  - get
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    resourceNames:
+      - coredns
+    verbs:
+      - get
+  - nonResourceURLs:
+      - "/debug/api_priority_and_fairness/*"
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -24,6 +28,6 @@ roleRef:
   kind: ClusterRole
   name: zmon-external-check
 subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: User
-  name: zalando-iam:zalando:service:stups_gerry
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: zalando-iam:zalando:service:stups_gerry


### PR DESCRIPTION
# Prolog
This is a change to a critical component and therefore falls under the [BUILD Deployment Strategy](https://docs.google.com/document/d/1nsOJy-p-kvzKbj8ue0As0mCgI13JHNjuyP78eSQmKc8/edit). In order to reduce the risk of a service degradation caused by the change, the below requested information must be provided, respectively listed measures are taken.

# Change Description
granting zmon worker permissions to read the debug endpoints of kubernetes priority and fairness feature.
this will be used to build 24x7 alerts in case the api server started queuing requests
the zmon [check](https://zmon.zalando.net/#/check-definitions/view/13749) and the in progress [alert](https://zmon.zalando.net/#/alert-details/1431114)

# Deployment Rationale / Business Reason
enhancing the visibility over k8s control plane ([ticket](https://zenhub.dc.zalan.do/workspaces/teapot-582ad81d72162adf1ea147b4/issues/teapot/issues/3455))
we want 24x7 responders to quickly see the queued requests for the api server, the output will look like:

```
PriorityLevelName, FlowSchemaName, QueueIndex, RequestIndexInQueue, FlowDistingsher,       ArriveTime,                     UserName,              Verb,   APIPath,                                                     Namespace, Name,   APIVersion, Resource, SubResource,
system,            system-nodes,   12,         0,                   system:node:127.0.0.1, 2020-07-23T15:31:03.583823404Z, system:node:127.0.0.1, create, /api/v1/namespaces/scaletest/configmaps,
system,            system-nodes,   12,         1,                   system:node:127.0.0.1, 2020-07-23T15:31:03.594555947Z, system:node:127.0.0.1, create, /api/v1/namespaces/scaletest/configmaps,
```
this will show if most of the queued requests belong to a certain usecase and whether or not should we intervene and adjust the configurations to prioritise such usecase

for example:
Requests from manual access users if they are queued for long times, then we need to quickly intervene by configuring manual access users to exempt bucket or to a higher priority

# Preflight Checklist / Actions until go-live
<!-- Detailed steps and checkpoints for the go-live, end-to-end. Are all measures taken to uncover unknown unknowns? Talk to domain experts? Any automation on infra level that can potentially interfere with this? -->

# Review 
- [ ] 6 Eyes Review has been implemented:
  - [x] Sign-off by @myaser 
  - [ ] Sign-off by $name-2
  - [ ] Sign-off by $name-3
- [x] Sign-off by Application Owner - @nctram 
- [ ] Sign-off by Senior Principal - @Jan-M 
- [ ] Changes will be rolled out gradually

# Deployment Pre Conditions
- [ ] The merge has happened before 4pm
- [ ] At least one member of the service owning team is available and able to act fast to issues.

 Once all above steps have been completed, you can proceed with the deployment.

# Deployment Post Conditions
- [ ] The deployer has actively monitored the rollout and validated the change


