### PR TITLE
prometheus: support optional metrics version label

### DIFF
--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -275,6 +275,9 @@ data:
         source_labels: ['__meta_kubernetes_pod_label_component']
         target_label: component
       - action: replace
+        source_labels: ['__meta_kubernetes_pod_label_metrics_version']
+        target_label: version
+      - action: replace
         source_labels: ['__meta_kubernetes_pod_name']
         target_label: pod_name
       - action: replace

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         application: skipper-ingress
         version: {{ $version }}
         component: ingress
+        metrics/version: {{ $version }}
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
           [{"container": "skipper-ingress", "parser": "skipper-access-log"}]


### PR DESCRIPTION
Add version label derived from optional metrics/version pod label. A new label is used with metrics/ prefix to avoid adding version metrics label when it is not needed.