### PR TITLE
Kubenurse: Allow master to master communication via overlay network

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -178,6 +178,17 @@ Resources:
           Value: owned
       ToPort: 8472
     Type: 'AWS::EC2::SecurityGroupIngress'
+  MasterSecurityGroupIngressFromMasterFlannelToMaster:
+    Properties:
+      FromPort: 8472
+      GroupId: !Ref MasterSecurityGroup
+      IpProtocol: udp
+      SourceSecurityGroupId: !Ref MasterSecurityGroup
+      Tags:
+        - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
+          Value: owned
+      ToPort: 8472
+    Type: 'AWS::EC2::SecurityGroupIngress'
   MasterSecurityGroupIngressFromMaster:
     Properties:
       FromPort: 443


### PR DESCRIPTION
kubenurse is running per node and checking connections to all other nodes to identify network issues between nodes. This works for **worker to worker** and **master to worker** communication, but it doesn't work for **master to master** as illustrated below (red path is broken)

![image](https://github.com/zalando-incubator/kubernetes-on-aws/assets/128566/6918a997-8553-4103-900e-af58223f0b91)

This leads to error log every minute in the two pods on the master nodes and leads to noise in the metrics because there are always network issues reported.

This fixes the issue by opening the port used for overlay network traffic between the master nodes. This will add one more request per minute per master node.