### PR TITLE
Add support for scaling on Nakadi metrics

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -203,6 +203,8 @@ kube_metrics_adapter_default_scaling_window: "10m"
 kube_metrics_adapter_scaling_schedule_ramp_steps: "5"
 ## ZMON KairosDB URL
 zmon_kairosdb_url: "https://data-service.zmon.zalan.do/kairosdb-proxy"
+## Nakadi URL (for the stats API)
+nakadi_url: ""
 
 # skipper east-west feature - deprecated configuration
 # enable_skipper_eastwest is the legacy feature gate for the automatic

--- a/cluster/manifests/kube-metrics-adapter/credentials.yaml
+++ b/cluster/manifests/kube-metrics-adapter/credentials.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Environment "production" }}
+{{- if or (eq .Environment "production") (ne .Cluster.ConfigItems.nakadi_url "") }}
 apiVersion: zalando.org/v1
 kind: PlatformCredentialsSet
 metadata:
@@ -10,6 +10,12 @@ metadata:
 spec:
   application: kubernetes
   tokens:
+    {{- if and (eq .Environment "production") (ne .Cluster.ConfigItems.zmon_kairosdb_url "") }}
     zmon:
       privileges: []
-{{ end }}
+    {{- end }}
+    {{- if ne .Cluster.ConfigItems.nakadi_url ""}}
+    nakadi:
+      privileges: []
+    {{- end }}
+{{- end }}

--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: container-registry.zalando.net/teapot/kube-metrics-adapter:v0.2.1-18-g85f1c3e
+        image: container-registry.zalando.net/teapot/kube-metrics-adapter:v0.2.2
         env:
         - name: AWS_REGION
           value: {{ .Region }}
@@ -46,12 +46,15 @@ spec:
         {{ if eq .Environment "production" }}
         - --zmon-kariosdb-endpoint={{.Cluster.ConfigItems.zmon_kairosdb_url}}
         {{ end }}
+        {{- if ne .Cluster.ConfigItems.nakadi_url "" }}
+        - --nakadi-endpoint={{.Cluster.ConfigItems.nakadi_url}}
+        {{- end }}
         volumeMounts:
-        {{ if eq .Environment "production" }}
+        {{- if or (eq .Environment "production") (ne .Cluster.ConfigItems.nakadi_url "") }}
         - name: credentials
           mountPath: /meta/credentials
           readOnly: true
-        {{ end }}
+        {{- end }}
         resources:
           limits:
             cpu: 10m
@@ -60,8 +63,8 @@ spec:
             cpu: 10m
             memory: 4Gi
       volumes:
-      {{ if eq .Environment "production" }}
+      {{- if or (eq .Environment "production") (ne .Cluster.ConfigItems.nakadi_url "") }}
       - name: credentials
         secret:
           secretName: "kube-metrics-adapter"
-      {{ end }}
+      {{- end }}


### PR DESCRIPTION
This updates the kube-metrics-adapter to a version that supports scaling based on Nakadi metrics as documented in: https://github.com/zalando-incubator/kube-metrics-adapter?tab=readme-ov-file#nakadi-collector

Ref: https://github.com/zalando-incubator/kube-metrics-adapter/pull/636