### PR TITLE
[WIP] Optional support for custom default service account

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -594,6 +594,10 @@ teapot_admission_controller_crd_role_provisioning_allowed_api_groups: "flink.k8s
 teapot_admission_controller_topology_spread: optin
 teapot_admission_controller_topology_spread_timeout: 7m
 
+# Inject custom default service account to identify client pods using default SA
+# to read from the Kubernetes API.
+teapot_admission_controller_custom_default_service_account: "false"
+
 
 # Enable and configure runtime-policy annotation
 {{if eq .Cluster.Environment "production"}}

--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -61,6 +61,10 @@ data:
   podfactory.base-image-check.namespaces: "{{ .Cluster.ConfigItems.teapot_admission_controller_validate_base_images_namespaces }}"
 {{- end }}
 
+{{- if eq .Cluster.ConfigItems.teapot_admission_controller_custom_default_service_account "true"}}
+  podfactory.custom-default-service-account.enable: "true"
+{{- end }}
+
   # This setting enables and disables the container image compliance checks
   pod.image-check.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_validate_pod_images }}"
 

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -205,7 +205,8 @@ write_files:
             limits:
               memory: {{ .Values.InstanceInfo.MemoryFraction (parseInt64 .Cluster.ConfigItems.apiserver_memory_limit_percent)}}
 {{- end }}
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-198
+        # - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-198
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/staging_namespace/teapot/admission-controller:pr-202-12
           name: admission-controller
           lifecycle:
             preStop:
@@ -273,7 +274,8 @@ write_files:
             - mountPath: /etc/kubernetes/ssl
               name: ssl-certs-kubernetes
               readOnly: true
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/k8s-authnz-webhook:master-128
+        # - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/k8s-authnz-webhook:master-128
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/staging_namespace/teapot/k8s-authnz-webhook:pr-159-4
           name: webhook
           ports:
           - containerPort: 8081


### PR DESCRIPTION
This introduces an injection of a custom default service account named after the resource in the format: `default-<kind>-<name>`. E.g. if you deploy a `Deployment` with the name `my-app` the serviceAccountName used in the pod will be `default-deployment-my-app` if you didn't specify a custom serviceAccountName already. This is done for the following kinds: `Deployment`, `StatefulSet`, `StackSet`, `Crobjob`.

The motivation for this is that we have pods running with `default` service account and reading from the Kubernetes API. This is a leftover from before RBAC was introduced and the intention is that all such use cases be replaced with a custom service account as defined here: https://cloud.docs.zalando.net/howtos/service-accounts/
The problem is that since _all_ workloads run with `default` service account by default, it's hard to identify those workloads that run with `default` AND read from the Kubernetes api. We have metrics from the audit-events: https://teapot.docs.zalando.net/application/kubernetes/#apiserver-client-visibility but the user is always `system:serviceaccounts:<namespace>:default` so it's hard to identify which deployment/statefulset/pods that actually is doing it.
By introducing a custom default service account for all main resource types we effectively give each deployment/statefulset/etc. their own identity which will make it simple to identify in the metrics.

The intention is to roll it out behind a flag and only enable it per cluster where there are a need for it because `default` service account is reading from the apiserver. There are some clusters where the `default` service account is bound to RBAC permissions. In those clusters we can't enable this because we would have to also change the bindings to not drop permissions (not entirely sure if it matters in practice, but would start by just looking into those specific cases).