### PR TITLE
Custom build of cadvisor fixing containerd metrics

### DIFF
--- a/cluster/manifests/node-monitor/daemonset.yaml
+++ b/cluster/manifests/node-monitor/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: node-monitor
       containers:
         - name: cadvisor
-          image: container-registry.zalando.net/teapot/cadvisor:v0.47.0-master-11
+          image: container-registry-test.zalando.net/teapot/cadvisor:v0.47.0-pr-17-2.custom
           args:
             - --port=9101
 {{- if eq .Cluster.ConfigItems.cadvisor_profiling_enabled "true" }}


### PR DESCRIPTION
Introduces a custom build of cadvisor which fixes the metric `container_fs_usage_bytes` when running with containerd.

The custom build is built with this patch: https://github.com/google/cadvisor/commit/f31dffa9297174bf066f11d2dc4dc09d141aa577 (rebased on v0.48.1)