### PR TITLE
test: require IMDSv2 for default-karpenter nodetemplate

### DIFF
--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -121,7 +121,8 @@ spec:
   amiSelector:
     aws-ids: "{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_24_" .NodePool.ConfigItems.kuberuntu_distro_worker "_amd64")  }},{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_24_" .NodePool.ConfigItems.kuberuntu_distro_worker "_arm64") }}"
   metadataOptions:
-    httpTokens: optional
+    httpTokens: required
+    httpPutResponseHopLimit: 2
   subnetSelector:
     kubernetes.io/role/karpenter: "enabled"
   securityGroupSelector:


### PR DESCRIPTION
test result:
- new EC2 nodes come up with  `.MetadataOptions.HttpTokens == "required"`
- Kubernetes does not see them, because kubelet is not started
- EC2 node is accessible via SSH/SSM, but user template is not available.