### PR TITLE
skipper: enable manual canary deployment

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -70,6 +70,14 @@ skipper_ingress_min_replicas: "2"
 {{end}}
 skipper_ingress_cpu: "1000m"
 skipper_ingress_memory: "1500Mi"
+
+# Enables deployment of canary version
+skipper_ingress_canary_enabled: "false"
+
+# Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g.:
+# skipper_ingress_canary_args: "-foo=has a whitespace[cf724afc]-baz=qux"
+skipper_ingress_canary_args: ""
+
 # When set to true (and dedicated node pool for skipper is also true) the
 # daemonset overhead will be subtracted from the cpu settings such
 # that skipper will perfectly fit on the node.

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -59,6 +59,12 @@ post_apply:
   kind: ClusterRoleBinding
 {{- end }}
 
+{{ if ne .Cluster.ConfigItems.skipper_ingress_canary_enabled "true" }}
+- name: skipper-ingress-canary
+  namespace: kube-system
+  kind: Deployment
+{{ end }}
+
 {{ if eq .Cluster.ConfigItems.skipper_routesrv_enabled "false" }}
 - name: skipper-ingress-routesrv
   namespace: kube-system

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,27 +1,53 @@
 {{ $internal_version := "v0.18.42-691" }}
-{{ $version := index (split $internal_version "-") 0 }}
+{{ $canary_internal_version := "v0.18.42-691" }}
 
+{{ template "skipper-ingress" dict
+  "name" "skipper-ingress"
+  "internal_version" $internal_version
+
+  "Cluster" .Cluster
+  "Values" .Values
+}}
+
+{{ if eq .Cluster.ConfigItems.skipper_ingress_canary_enabled "true" }}
+{{ template "skipper-ingress" dict
+  "name" "skipper-ingress-canary"
+  "internal_version" $canary_internal_version
+  "replicas" 1
+  "args" (index .Cluster.ConfigItems "skipper_ingress_canary_args")
+
+  "Cluster" .Cluster
+  "Values" .Values
+}}
+{{ end }}
+
+{{ define "skipper-ingress" }}
+{{ $version := index (split .internal_version "-") 0 }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: skipper-ingress
+  name: "{{ .name }}"
   namespace: kube-system
   labels:
     application: skipper-ingress
     version: {{ $version }}
     component: ingress
 spec:
+{{ if index . "replicas" }}
+  replicas: {{ .replicas }}
+{{ end }}
   strategy:
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 0
   selector:
     matchLabels:
-      deployment: skipper-ingress
+      deployment: "{{ .name }}"
   template:
     metadata:
       labels:
-        deployment: skipper-ingress
+        deployment: "{{ .name }}"
         application: skipper-ingress
         version: {{ $version }}
         component: ingress
@@ -30,15 +56,15 @@ spec:
         kubernetes-log-watcher/scalyr-parser: |
           [{"container": "skipper-ingress", "parser": "skipper-access-log"}]
         config/hash: {{"secret.yaml" | manifestHash}}
-        logging/destination: "{{.Cluster.ConfigItems.log_destination_local}}"
+        logging/destination: "{{ .Cluster.ConfigItems.log_destination_local }}"
         prometheus.io/path: /metrics
         prometheus.io/port: "9911"
         prometheus.io/scrape: "true"
-{{- if eq .ConfigItems.skipper_topology_spread_enabled "true" }}
+{{- if eq .Cluster.ConfigItems.skipper_topology_spread_enabled "true" }}
         zalando.org/topology-spread-timeout: 7m
 {{- end }}
     spec:
-{{- if eq .ConfigItems.skipper_topology_spread_enabled "true" }}
+{{- if eq .Cluster.ConfigItems.skipper_topology_spread_enabled "true" }}
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone
@@ -56,13 +82,13 @@ spec:
       hostNetwork: true
       containers:
       - name: skipper-ingress
-        image: container-registry.zalando.net/teapot/skipper-internal:{{ $internal_version }}
+        image: container-registry.zalando.net/teapot/skipper-internal:{{ .internal_version }}
         ports:
         - name: ingress-port
           containerPort: 9999
           hostPort: 9999
           protocol: TCP
-{{ if or (eq .ConfigItems.nlb_switch "pre") (eq .ConfigItems.nlb_switch "exec") }}
+{{ if or (eq .Cluster.ConfigItems.nlb_switch "pre") (eq .Cluster.ConfigItems.nlb_switch "exec") }}
         - name: http-redirect
           containerPort: 9998
           hostPort: 9998
@@ -74,7 +100,7 @@ spec:
             secretKeyRef:
               name: skipper-ingress
               key: lightstep-token
-{{ if or (eq .ConfigItems.skipper_local_tokeninfo "production") (eq .ConfigItems.skipper_local_tokeninfo "bridge") }}
+{{ if or (eq .Cluster.ConfigItems.skipper_local_tokeninfo "production") (eq .Cluster.ConfigItems.skipper_local_tokeninfo "bridge") }}
         - name: LOCAL_TOKENINFO
           value: "true"
         - name: ENABLE_OPENTRACING
@@ -87,15 +113,15 @@ spec:
               name: skipper-ingress
               key: lightstep-token
 {{ end }}
-{{ if eq .ConfigItems.skipper_local_tokeninfo "bridge" }}
+{{ if eq .Cluster.ConfigItems.skipper_local_tokeninfo "bridge" }}
         - name: LOCAL_TOKENINFO_SANDBOX
           value: "true"
 {{ end }}
-{{ if or (eq .ConfigItems.nlb_switch "pre") (eq .ConfigItems.nlb_switch "exec") }}
+{{ if or (eq .Cluster.ConfigItems.nlb_switch "pre") (eq .Cluster.ConfigItems.nlb_switch "exec") }}
         - name: HTTP_REDIRECT
           value: "true"
 {{ end }}
-{{ if eq .ConfigItems.skipper_lua_scripts_enabled "true" }}
+{{ if eq .Cluster.ConfigItems.skipper_lua_scripts_enabled "true" }}
         - name: LUA_PATH
           value: /etc/skipper/lua/?.lua
         - name: DATADOME_API_KEY
@@ -104,7 +130,7 @@ spec:
               name: skipper-ingress
               key: datadome-api-key
 {{ end }}
-{{ if eq .ConfigItems.skipper_open_policy_agent_enabled "true" }}
+{{ if eq .Cluster.ConfigItems.skipper_open_policy_agent_enabled "true" }}
         - name: STYRA_TOKEN
           valueFrom:
             secretKeyRef:
@@ -114,43 +140,43 @@ spec:
         args:
           - "run.sh"
           - "skipper"
-          - "-validate-query={{ .ConfigItems.skipper_validate_query }}"
+          - "-validate-query={{ .Cluster.ConfigItems.skipper_validate_query }}"
           - "-validate-query-log={{ .Cluster.ConfigItems.skipper_validate_query_log }}"
-{{ if eq .ConfigItems.skipper_routesrv_enabled "exec" }}
+{{ if eq .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
           - "-routes-urls=http://skipper-ingress-routesrv.kube-system.svc.cluster.local/routes"
           - "-normalize-host"
 {{ else }}
           - "-kubernetes"
           - "-kubernetes-in-cluster"
           - "-kubernetes-path-mode=path-prefix"
-          - "-kubernetes-backend-traffic-algorithm={{ .ConfigItems.skipper_ingress_backend_traffic_algorithm }}"
-          - "-kubernetes-default-lb-algorithm={{ .ConfigItems.skipper_ingress_default_lb_algorithm }}"
-          - "-kubernetes-disable-catchall-routes={{ .ConfigItems.skipper_ingress_disable_catchall_routes }}"
-          - "-enable-kubernetes-endpointslices={{ .ConfigItems.skipper_endpointslices_enabled }}"
+          - "-kubernetes-backend-traffic-algorithm={{ .Cluster.ConfigItems.skipper_ingress_backend_traffic_algorithm }}"
+          - "-kubernetes-default-lb-algorithm={{ .Cluster.ConfigItems.skipper_ingress_default_lb_algorithm }}"
+          - "-kubernetes-disable-catchall-routes={{ .Cluster.ConfigItems.skipper_ingress_disable_catchall_routes }}"
+          - "-enable-kubernetes-endpointslices={{ .Cluster.ConfigItems.skipper_endpointslices_enabled }}"
 {{ end }}
           - "-address=:9999"
           - "-wait-first-route-load"
           - "-wait-for-healthcheck-interval={{ .Cluster.ConfigItems.skipper_wait_for_healthcheck_interval }}"
-{{ if and (ne .ConfigItems.skipper_routesrv_enabled "exec") (eq .ConfigItems.enable_skipper_eastwest "true")}}
+{{ if and (ne .Cluster.ConfigItems.skipper_routesrv_enabled "exec") (eq .Cluster.ConfigItems.enable_skipper_eastwest "true")}}
           - "-enable-kubernetes-east-west"
           - "-kubernetes-east-west-domain=.ingress.cluster.local"
 {{ end }}
-{{ if ne .ConfigItems.skipper_routesrv_enabled "exec" }}
+{{ if ne .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
           - "-kubernetes-east-west-range-domains=ingress.cluster.local"
           - "-kubernetes-east-west-range-predicates=ClientIP(\"10.2.0.0/15\", \"{{ .Values.vpc_ipv4_cidr }}\")"
           - "-reverse-source-predicate"
 {{ end }}
           - "-proxy-preserve-host"
-          - "-compress-encodings={{ .ConfigItems.skipper_compress_encodings }}"
+          - "-compress-encodings={{ .Cluster.ConfigItems.skipper_compress_encodings }}"
           - "-serve-host-metrics"
-          - "-serve-method-metric={{ .ConfigItems.skipper_serve_method_metric }}"
-          - "-serve-status-code-metric={{ .ConfigItems.skipper_serve_status_code_metric }}"
+          - "-serve-method-metric={{ .Cluster.ConfigItems.skipper_serve_method_metric }}"
+          - "-serve-status-code-metric={{ .Cluster.ConfigItems.skipper_serve_status_code_metric }}"
           - "-serve-host-counter"
           - "-disable-metrics-compat"
           - "-enable-profile"
-          - "-memory-profile-rate={{ .ConfigItems.skipper_memory_profile_rate }}"
-          - "-block-profile-rate={{ .ConfigItems.skipper_block_profile_rate }}"
-          - "-mutex-profile-fraction={{ .ConfigItems.skipper_mutex_profile_fraction }}"
+          - "-memory-profile-rate={{ .Cluster.ConfigItems.skipper_memory_profile_rate }}"
+          - "-block-profile-rate={{ .Cluster.ConfigItems.skipper_block_profile_rate }}"
+          - "-mutex-profile-fraction={{ .Cluster.ConfigItems.skipper_mutex_profile_fraction }}"
           - "-debug-listener=:9922"
           - "-enable-ratelimits"
           - "-experimental-upgrade"
@@ -164,18 +190,18 @@ spec:
           - "-api-usage-monitoring-realm-keys=https://identity.zalando.com/realm"
           - "-api-usage-monitoring-client-keys=https://identity.zalando.com/managed-id,sub"
           - "-api-usage-monitoring-default-client-tracking-pattern=services[.].*"
-{{ if ne .ConfigItems.skipper_routesrv_enabled "exec" }}
+{{ if ne .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
           - "-default-filters-dir=/etc/config/default-filters"
 {{ end }}
           - "-max-audit-body=0"
-{{ if eq .ConfigItems.skipper_ingress_redis_swarm_enabled "true" }}
+{{ if eq .Cluster.ConfigItems.skipper_ingress_redis_swarm_enabled "true" }}
           - "-enable-swarm"
-          - "-swarm-redis-dial-timeout={{ .ConfigItems.skipper_redis_dial_timeout }}"
-          - "-swarm-redis-pool-timeout={{ .ConfigItems.skipper_redis_pool_timeout }}"
-          - "-swarm-redis-read-timeout={{ .ConfigItems.skipper_redis_read_timeout }}"
-          - "-swarm-redis-write-timeout={{ .ConfigItems.skipper_redis_write_timeout }}"
-          - "-cluster-ratelimit-max-group-shards={{ .ConfigItems.skipper_cluster_ratelimit_max_group_shards }}"
-{{ if eq .ConfigItems.skipper_routesrv_enabled "exec" }}
+          - "-swarm-redis-dial-timeout={{ .Cluster.ConfigItems.skipper_redis_dial_timeout }}"
+          - "-swarm-redis-pool-timeout={{ .Cluster.ConfigItems.skipper_redis_pool_timeout }}"
+          - "-swarm-redis-read-timeout={{ .Cluster.ConfigItems.skipper_redis_read_timeout }}"
+          - "-swarm-redis-write-timeout={{ .Cluster.ConfigItems.skipper_redis_write_timeout }}"
+          - "-cluster-ratelimit-max-group-shards={{ .Cluster.ConfigItems.skipper_cluster_ratelimit_max_group_shards }}"
+{{ if eq .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
           - "-swarm-redis-remote=http://skipper-ingress-routesrv.kube-system.svc.cluster.local/swarm/redis/shards"
 {{ else }}
           - "-kubernetes-redis-service-namespace=kube-system"
@@ -193,122 +219,127 @@ spec:
             tag=application=skipper-ingress
             tag=account={{ .Cluster.Alias }}
             tag=cluster={{ .Cluster.Alias }}
-            tag=artifact=container-registry.zalando.net/teapot/skipper-internal:{{ $internal_version }}
-            max-buffered-spans={{ .ConfigItems.skipper_ingress_tracing_buffer }}
-            grpc-max-msg-size={{ .ConfigItems.skipper_ingress_lightstep_grpc_max_msg_size }}
-            max-period={{ .ConfigItems.skipper_ingress_lightstep_max_period }}
-            min-period={{ .ConfigItems.skipper_ingress_lightstep_min_period }}
-            max-log-key-len={{ .ConfigItems.skipper_ingress_lightstep_max_log_key_len }}
-            max-log-value-len={{ .ConfigItems.skipper_ingress_lightstep_max_log_value_len }}
-            max-logs-per-span={{ .ConfigItems.skipper_ingress_lightstep_max_logs_per_span }}
-            propagators={{ .ConfigItems.skipper_ingress_lightstep_propagators }}
+            tag=artifact=container-registry.zalando.net/teapot/skipper-internal:{{ .internal_version }}
+            max-buffered-spans={{ .Cluster.ConfigItems.skipper_ingress_tracing_buffer }}
+            grpc-max-msg-size={{ .Cluster.ConfigItems.skipper_ingress_lightstep_grpc_max_msg_size }}
+            max-period={{ .Cluster.ConfigItems.skipper_ingress_lightstep_max_period }}
+            min-period={{ .Cluster.ConfigItems.skipper_ingress_lightstep_min_period }}
+            max-log-key-len={{ .Cluster.ConfigItems.skipper_ingress_lightstep_max_log_key_len }}
+            max-log-value-len={{ .Cluster.ConfigItems.skipper_ingress_lightstep_max_log_value_len }}
+            max-logs-per-span={{ .Cluster.ConfigItems.skipper_ingress_lightstep_max_logs_per_span }}
+            propagators={{ .Cluster.ConfigItems.skipper_ingress_lightstep_propagators }}
             {{ .Cluster.ConfigItems.skipper_ingress_lightstep_log_events }}
-          - "-opentracing-excluded-proxy-tags={{ .ConfigItems.skipper_ingress_opentracing_excluded_proxy_tags }}"
-{{ if eq .ConfigItems.skipper_ingress_opentracing_backend_name_tag "true" }}
+          - "-opentracing-excluded-proxy-tags={{ .Cluster.ConfigItems.skipper_ingress_opentracing_excluded_proxy_tags }}"
+{{ if eq .Cluster.ConfigItems.skipper_ingress_opentracing_backend_name_tag "true" }}
           - "-opentracing-backend-name-tag"
 {{ end }}
-          - "-opentracing-disable-filter-spans={{ .ConfigItems.skipper_opentracing_disable_filter_spans }}"
-          - "-expect-continue-timeout-backend={{ .ConfigItems.skipper_expect_continue_timeout_backend }}"
-          - "-keepalive-backend={{ .ConfigItems.skipper_keepalive_backend }}"
-          - "-max-idle-connection-backend={{ .ConfigItems.skipper_max_idle_connection_backend }}"
-          - "-response-header-timeout-backend={{ .ConfigItems.skipper_response_header_timeout_backend }}"
-          - "-timeout-backend={{ .ConfigItems.skipper_timeout_backend }}"
-          - "-tls-timeout-backend={{ .ConfigItems.skipper_tls_timeout_backend }}"
-          - "-close-idle-conns-period={{ .ConfigItems.skipper_close_idle_conns_period }}"
-          - "-idle-timeout-server={{ .ConfigItems.skipper_idle_timeout_server }}"
-          - "-read-timeout-server={{ .ConfigItems.skipper_read_timeout_server }}"
-          - "-write-timeout-server={{ .ConfigItems.skipper_write_timeout_server }}"
-          - "-disabled-filters={{ .ConfigItems.skipper_disabled_filters }}"
-{{ if ne .ConfigItems.skipper_routesrv_enabled "exec" }}
-          - '-default-filters-prepend={{ .ConfigItems.skipper_default_filters }}'
-  {{ if .ConfigItems.skipper_edit_route_placeholders }}
-          {{ range $placeholder := split .ConfigItems.skipper_edit_route_placeholders "[cf724afc]" }}
+          - "-opentracing-disable-filter-spans={{ .Cluster.ConfigItems.skipper_opentracing_disable_filter_spans }}"
+          - "-expect-continue-timeout-backend={{ .Cluster.ConfigItems.skipper_expect_continue_timeout_backend }}"
+          - "-keepalive-backend={{ .Cluster.ConfigItems.skipper_keepalive_backend }}"
+          - "-max-idle-connection-backend={{ .Cluster.ConfigItems.skipper_max_idle_connection_backend }}"
+          - "-response-header-timeout-backend={{ .Cluster.ConfigItems.skipper_response_header_timeout_backend }}"
+          - "-timeout-backend={{ .Cluster.ConfigItems.skipper_timeout_backend }}"
+          - "-tls-timeout-backend={{ .Cluster.ConfigItems.skipper_tls_timeout_backend }}"
+          - "-close-idle-conns-period={{ .Cluster.ConfigItems.skipper_close_idle_conns_period }}"
+          - "-idle-timeout-server={{ .Cluster.ConfigItems.skipper_idle_timeout_server }}"
+          - "-read-timeout-server={{ .Cluster.ConfigItems.skipper_read_timeout_server }}"
+          - "-write-timeout-server={{ .Cluster.ConfigItems.skipper_write_timeout_server }}"
+          - "-disabled-filters={{ .Cluster.ConfigItems.skipper_disabled_filters }}"
+{{ if ne .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
+          - '-default-filters-prepend={{ .Cluster.ConfigItems.skipper_default_filters }}'
+  {{ if .Cluster.ConfigItems.skipper_edit_route_placeholders }}
+          {{ range $placeholder := split .Cluster.ConfigItems.skipper_edit_route_placeholders "[cf724afc]" }}
           - '-edit-route={{ $placeholder }}'
           {{ end }}
   {{ end }}
 {{ end }}
-          - "-suppress-route-update-logs={{ .ConfigItems.skipper_suppress_route_update_logs }}"
-{{ if eq .ConfigItems.skipper_enable_tcp_queue "true" }}
+          - "-suppress-route-update-logs={{ .Cluster.ConfigItems.skipper_suppress_route_update_logs }}"
+{{ if eq .Cluster.ConfigItems.skipper_enable_tcp_queue "true" }}
           - "-enable-tcp-queue"
-          - "-expected-bytes-per-request={{ .ConfigItems.skipper_expected_bytes_per_request }}"
-          - "-max-tcp-listener-concurrency={{ .ConfigItems.skipper_max_tcp_listener_concurrency }}"
-          - "-max-tcp-listener-queue={{ .ConfigItems.skipper_max_tcp_listener_queue }}"
+          - "-expected-bytes-per-request={{ .Cluster.ConfigItems.skipper_expected_bytes_per_request }}"
+          - "-max-tcp-listener-concurrency={{ .Cluster.ConfigItems.skipper_max_tcp_listener_concurrency }}"
+          - "-max-tcp-listener-queue={{ .Cluster.ConfigItems.skipper_max_tcp_listener_queue }}"
 {{ end }}
-{{ if eq .ConfigItems.skipper_local_tokeninfo "bridge" }}
+{{ if eq .Cluster.ConfigItems.skipper_local_tokeninfo "bridge" }}
           - "-oauth2-tokeninfo-url=http://127.0.0.1:9000/oauth2/tokeninfo"
           - "-status-checks=http://127.0.0.1:9021/health,http://127.0.0.1:9121/health,http://127.0.0.1:9000/healthz"
-{{ else if eq .ConfigItems.skipper_local_tokeninfo "production" }}
+{{ else if eq .Cluster.ConfigItems.skipper_local_tokeninfo "production" }}
           - "-oauth2-tokeninfo-url=http://127.0.0.1:9021/oauth2/tokeninfo"
           - "-status-checks=http://127.0.0.1:9021/health"
 {{ end }}
-          - "-oauth2-tokeninfo-cache-size={{ .ConfigItems.skipper_tokeninfo_cache_size }}"
-          - "-oauth2-tokeninfo-cache-ttl={{ .ConfigItems.skipper_tokeninfo_cache_ttl }}"
-{{ if eq .ConfigItems.skipper_oauth2_ui_login "true" }}
+          - "-oauth2-tokeninfo-cache-size={{ .Cluster.ConfigItems.skipper_tokeninfo_cache_size }}"
+          - "-oauth2-tokeninfo-cache-ttl={{ .Cluster.ConfigItems.skipper_tokeninfo_cache_ttl }}"
+{{ if eq .Cluster.ConfigItems.skipper_oauth2_ui_login "true" }}
           - "-enable-oauth2-grant-flow"
-          - "-oauth2-auth-url={{ .ConfigItems.skipper_oauth2_auth_url }}"
-          - "-oauth2-token-url={{ .ConfigItems.skipper_oauth2_token_url }}"
+          - "-oauth2-auth-url={{ .Cluster.ConfigItems.skipper_oauth2_auth_url }}"
+          - "-oauth2-token-url={{ .Cluster.ConfigItems.skipper_oauth2_token_url }}"
           - "-oauth2-secret-file=/etc/skipper/secret/encryption-key"
           - "-oauth2-client-id-file=/etc/skipper/hostname-credentials/{host}-grant-credentials-employee-client-id"
           - "-oauth2-client-secret-file=/etc/skipper/hostname-credentials/{host}-grant-credentials-employee-client-secret"
           - "-credentials-update-interval=1m"
-          - "-oauth2-token-cookie-name={{ .ConfigItems.skipper_oauth2_cookie_name }}"
+          - "-oauth2-token-cookie-name={{ .Cluster.ConfigItems.skipper_oauth2_cookie_name }}"
           - "-oauth2-token-cookie-remove-subdomains=0"
-          - "-oauth2-callback-path={{ .ConfigItems.skipper_oauth2_redirect_uri_path }}"
-          - "-oauth2-grant-tokeninfo-keys={{ .ConfigItems.skipper_oauth2_ui_login_tokeninfo_keys }}"
+          - "-oauth2-callback-path={{ .Cluster.ConfigItems.skipper_oauth2_redirect_uri_path }}"
+          - "-oauth2-grant-tokeninfo-keys={{ .Cluster.ConfigItems.skipper_oauth2_ui_login_tokeninfo_keys }}"
 {{ end }}
-{{ if eq .ConfigItems.skipper_open_policy_agent_enabled "true" }}
+{{ if eq .Cluster.ConfigItems.skipper_open_policy_agent_enabled "true" }}
           - "-enable-open-policy-agent"
           - "-open-policy-agent-config-template=/etc/skipper/open-policy-agent/opaconfig.yaml"
           - "-open-policy-agent-envoy-metadata=/etc/skipper/open-policy-agent/envoymetadata.json"
 {{ end }}
-{{ if or (eq .ConfigItems.nlb_switch "pre") (eq .ConfigItems.nlb_switch "exec") }}
+{{ if or (eq .Cluster.ConfigItems.nlb_switch "pre") (eq .Cluster.ConfigItems.nlb_switch "exec") }}
           - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
           - "-forwarded-headers-exclude-cidrs=10.2.0.0/15,{{ .Values.vpc_ipv4_cidr}}"
 {{ end }}
-{{ if .ConfigItems.skipper_ingress_inline_routes }}
-          - "-inline-routes={{ .ConfigItems.skipper_ingress_inline_routes }}"
+{{ if .Cluster.ConfigItems.skipper_ingress_inline_routes }}
+          - "-inline-routes={{ .Cluster.ConfigItems.skipper_ingress_inline_routes }}"
 {{ end }}
-{{ if .ConfigItems.skipper_ingress_refuse_payload }}
-          {{ range $pattern := split .ConfigItems.skipper_ingress_refuse_payload "[cf724afc]" }}
+{{ if .Cluster.ConfigItems.skipper_ingress_refuse_payload }}
+          {{ range $pattern := split .Cluster.ConfigItems.skipper_ingress_refuse_payload "[cf724afc]" }}
           - "-refuse-payload={{ $pattern }}"
+          {{ end }}
+{{ end }}
+{{ if index . "args" }}
+          {{ range $arg := split .args "[cf724afc]" }}
+          - "{{ $arg }}"
           {{ end }}
 {{ end }}
         resources:
 {{ if and (eq .Cluster.ConfigItems.enable_dedicate_nodepool_skipper "true") (eq .Cluster.ConfigItems.skipper_ingress_binpack "true") }}
-{{ $cpu_requests := sumQuantities .Cluster.ConfigItems.skipper_ingress_cpu (printf "-%s"  .Cluster.ConfigItems.teapot_admission_controller_daemonset_reserved_cpu) (printf "-%s" .Cluster.ConfigItems.kubelet_system_reserved_cpu) (printf "-%s" .Cluster.ConfigItems.kubelet_kube_reserved_cpu) }}
+{{ $cpu_requests := sumQuantities .Cluster.ConfigItems.skipper_ingress_cpu (printf "-%s" .Cluster.ConfigItems.teapot_admission_controller_daemonset_reserved_cpu) (printf "-%s" .Cluster.ConfigItems.kubelet_system_reserved_cpu) (printf "-%s" .Cluster.ConfigItems.kubelet_kube_reserved_cpu) }}
           limits:
             cpu: "{{ $cpu_requests }}"
-            memory: "{{ .ConfigItems.skipper_ingress_memory }}"
+            memory: "{{ .Cluster.ConfigItems.skipper_ingress_memory }}"
           requests:
             cpu: "{{ $cpu_requests }}"
-            memory: "{{ .ConfigItems.skipper_ingress_memory }}"
+            memory: "{{ .Cluster.ConfigItems.skipper_ingress_memory }}"
 {{ else }}
           limits:
-            cpu: "{{ .ConfigItems.skipper_ingress_cpu }}"
-            memory: "{{ .ConfigItems.skipper_ingress_memory }}"
+            cpu: "{{ .Cluster.ConfigItems.skipper_ingress_cpu }}"
+            memory: "{{ .Cluster.ConfigItems.skipper_ingress_memory }}"
           requests:
-            cpu: "{{ .ConfigItems.skipper_ingress_cpu }}"
-            memory: "{{ .ConfigItems.skipper_ingress_memory }}"
+            cpu: "{{ .Cluster.ConfigItems.skipper_ingress_cpu }}"
+            memory: "{{ .Cluster.ConfigItems.skipper_ingress_memory }}"
 {{ end }}
         readinessProbe:
           httpGet:
             path: /kube-system/healthz
             port: 9999
-          initialDelaySeconds: {{ .ConfigItems.skipper_readiness_init_delay_seconds }}
+          initialDelaySeconds: {{ .Cluster.ConfigItems.skipper_readiness_init_delay_seconds }}
           timeoutSeconds: 5
-{{ if eq .ConfigItems.skipper_local_tokeninfo "production" }}
+{{ if eq .Cluster.ConfigItems.skipper_local_tokeninfo "production" }}
         livenessProbe:
           httpGet:
             path: /health
             port: 9021
             host: 127.0.0.1
             scheme: HTTP
-          initialDelaySeconds: {{ .ConfigItems.skipper_liveness_init_delay_seconds }}
+          initialDelaySeconds: {{ .Cluster.ConfigItems.skipper_liveness_init_delay_seconds }}
           periodSeconds: 10
           timeoutSeconds: 5
           successThreshold: 1
           failureThreshold: 5
-{{ else if eq .ConfigItems.skipper_local_tokeninfo "bridge" }}
+{{ else if eq .Cluster.ConfigItems.skipper_local_tokeninfo "bridge" }}
         livenessProbe:
           exec:
             command:
@@ -318,7 +349,7 @@ spec:
             # wget will exit with non-zero status code if the HTTP code is no 2xx.
             # production tokeninfo, sandbox tokeninfo, bridge
             - "wget -T 1 -q -O /dev/null http://127.0.0.1:9021/health; wget -T 1 -q -O /dev/null http://127.0.0.1:9121/health; wget -T 1 -q -O /dev/null http://127.0.0.1:9000/healthz"
-          initialDelaySeconds: {{ .ConfigItems.skipper_liveness_init_delay_seconds }}
+          initialDelaySeconds: {{ .Cluster.ConfigItems.skipper_liveness_init_delay_seconds }}
           periodSeconds: 10
           timeoutSeconds: 5
           successThreshold: 1
@@ -331,20 +362,20 @@ spec:
         volumeMounts:
           - name: routes-cache
             mountPath: /tmp
-{{ if eq .ConfigItems.skipper_local_tokeninfo "bridge"}}
+{{ if eq .Cluster.ConfigItems.skipper_local_tokeninfo "bridge"}}
           - name: routes
             mountPath: /etc/routes
 {{ end }}
-{{ if ne .ConfigItems.skipper_routesrv_enabled "exec" }}
+{{ if ne .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
           - name: filters
             mountPath: /etc/config/default-filters
 {{ end }}
-{{ if eq .ConfigItems.skipper_lua_scripts_enabled "true" }}
+{{ if eq .Cluster.ConfigItems.skipper_lua_scripts_enabled "true" }}
           - name: lua
             mountPath: /etc/skipper/lua
             readOnly: true
 {{ end }}
-{{ if eq .ConfigItems.skipper_oauth2_ui_login "true"}}
+{{ if eq .Cluster.ConfigItems.skipper_oauth2_ui_login "true"}}
           - name: hostname-credentials
             mountPath: /etc/skipper/hostname-credentials
             readOnly: true
@@ -352,7 +383,7 @@ spec:
             mountPath: /etc/skipper/secret
             readOnly: true
 {{ end }}
-{{ if eq .ConfigItems.skipper_open_policy_agent_enabled "true" }}
+{{ if eq .Cluster.ConfigItems.skipper_open_policy_agent_enabled "true" }}
           - name: open-policy-agent-config
             mountPath: /etc/skipper/open-policy-agent
             readOnly: true
@@ -360,24 +391,24 @@ spec:
       volumes:
         - name: routes-cache
           emptyDir: {}
-{{ if eq .ConfigItems.skipper_local_tokeninfo "bridge"}}
+{{ if eq .Cluster.ConfigItems.skipper_local_tokeninfo "bridge"}}
         - name: routes
           configMap:
             name: sandbox-tokeninfo-bridge-conf
 {{ end }}
-{{ if ne .ConfigItems.skipper_routesrv_enabled "exec" }}
+{{ if ne .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
         - name: filters
           configMap:
             name: skipper-default-filters
             optional: true
 {{ end }}
-{{ if eq .ConfigItems.skipper_lua_scripts_enabled "true" }}
+{{ if eq .Cluster.ConfigItems.skipper_lua_scripts_enabled "true" }}
         - name: lua
           configMap:
             name: skipper-ingress-lua
             optional: true
 {{ end }}
-{{ if eq .ConfigItems.skipper_oauth2_ui_login "true"}}
+{{ if eq .Cluster.ConfigItems.skipper_oauth2_ui_login "true"}}
         - name: hostname-credentials
           secret:
             secretName: hostname-credentials
@@ -385,12 +416,12 @@ spec:
           secret:
             secretName: skipper-ingress
 {{ end }}
-{{ if eq .ConfigItems.skipper_open_policy_agent_enabled "true" }}
+{{ if eq .Cluster.ConfigItems.skipper_open_policy_agent_enabled "true" }}
         - name: open-policy-agent-config
           configMap:
             name: open-policy-agent-config
 {{ end }}
-{{ if eq .ConfigItems.enable_dedicate_nodepool_skipper "true"}}
+{{ if eq .Cluster.ConfigItems.enable_dedicate_nodepool_skipper "true"}}
       nodeSelector:
         dedicated: skipper-ingress
       tolerations:
@@ -398,8 +429,10 @@ spec:
         key: dedicated
         value: skipper-ingress
 {{ end }}
+{{ end }}
 
-{{ if ne .ConfigItems.skipper_routesrv_enabled "false" }}
+{{ if ne .Cluster.ConfigItems.skipper_routesrv_enabled "false" }}
+{{ $version := index (split $internal_version "-") 0 }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -430,15 +463,15 @@ spec:
         config/hash: {{"secret.yaml" | manifestHash}}
         kubernetes-log-watcher/scalyr-parser: |
           [{"container": "routesrv", "parser": "keyValue"}]
-        logging/destination: "{{.Cluster.ConfigItems.log_destination_local}}"
+        logging/destination: "{{ .Cluster.ConfigItems.log_destination_local }}"
         prometheus.io/path: /metrics
         prometheus.io/port: "9990"
         prometheus.io/scrape: "true"
-{{- if eq .ConfigItems.skipper_topology_spread_enabled "true" }}
+{{- if eq .Cluster.ConfigItems.skipper_topology_spread_enabled "true" }}
         zalando.org/topology-spread-timeout: 7m
 {{- end }}
     spec:
-{{- if eq .ConfigItems.skipper_topology_spread_enabled "true" }}
+{{- if eq .Cluster.ConfigItems.skipper_topology_spread_enabled "true" }}
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone
@@ -452,7 +485,7 @@ spec:
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       serviceAccountName: skipper-ingress
       terminationGracePeriodSeconds: {{ .Cluster.ConfigItems.skipper_termination_grace_period }}
-{{- if eq .ConfigItems.skipper_routesrv_node_affinity_enabled "true" }}
+{{- if eq .Cluster.ConfigItems.skipper_routesrv_node_affinity_enabled "true" }}
       affinity:
        podAntiAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
@@ -477,17 +510,17 @@ spec:
           protocol: TCP
         args:
           - "routesrv"
-          - "-application-log-level={{ .ConfigItems.skipper_routesrv_log_level }}"
+          - "-application-log-level={{ .Cluster.ConfigItems.skipper_routesrv_log_level }}"
           - "-kubernetes"
           - "-kubernetes-in-cluster"
           - "-kubernetes-path-mode=path-prefix"
-          - "-kubernetes-backend-traffic-algorithm={{ .ConfigItems.skipper_ingress_backend_traffic_algorithm }}"
-          - "-kubernetes-default-lb-algorithm={{ .ConfigItems.skipper_ingress_default_lb_algorithm }}"
-          - "-kubernetes-disable-catchall-routes={{ .ConfigItems.skipper_ingress_disable_catchall_routes }}"
-          - "-enable-kubernetes-endpointslices={{ .ConfigItems.skipper_endpointslices_enabled }}"
+          - "-kubernetes-backend-traffic-algorithm={{ .Cluster.ConfigItems.skipper_ingress_backend_traffic_algorithm }}"
+          - "-kubernetes-default-lb-algorithm={{ .Cluster.ConfigItems.skipper_ingress_default_lb_algorithm }}"
+          - "-kubernetes-disable-catchall-routes={{ .Cluster.ConfigItems.skipper_ingress_disable_catchall_routes }}"
+          - "-enable-kubernetes-endpointslices={{ .Cluster.ConfigItems.skipper_endpointslices_enabled }}"
           - "-address=:9990"
           - "-wait-for-healthcheck-interval={{ .Cluster.ConfigItems.skipper_wait_for_healthcheck_interval }}"
-{{ if eq .ConfigItems.enable_skipper_eastwest "true"}}
+{{ if eq .Cluster.ConfigItems.enable_skipper_eastwest "true"}}
           - "-enable-kubernetes-east-west"
           - "-kubernetes-east-west-domain=.ingress.cluster.local"
 {{ end }}
@@ -495,22 +528,22 @@ spec:
           - "-kubernetes-east-west-range-predicates=ClientIP(\"10.2.0.0/15\", \"{{ .Values.vpc_ipv4_cidr }}\")"
           - "-reverse-source-predicate"
           - "-default-filters-dir=/etc/config/default-filters"
-          - '-default-filters-prepend={{ .ConfigItems.skipper_default_filters }}'
-{{ if eq .ConfigItems.skipper_ingress_redis_swarm_enabled "true" }}
+          - '-default-filters-prepend={{ .Cluster.ConfigItems.skipper_default_filters }}'
+{{ if eq .Cluster.ConfigItems.skipper_ingress_redis_swarm_enabled "true" }}
           - "-enable-swarm"
           - "-kubernetes-redis-service-namespace=kube-system"
           - "-kubernetes-redis-service-name=skipper-ingress-redis"
 {{ end }}
-{{ if eq .ConfigItems.skipper_oauth2_ui_login "true" }}
+{{ if eq .Cluster.ConfigItems.skipper_oauth2_ui_login "true" }}
           - "-enable-oauth2-grant-flow"
-          - "-oauth2-callback-path={{ .ConfigItems.skipper_oauth2_redirect_uri_path }}"
+          - "-oauth2-callback-path={{ .Cluster.ConfigItems.skipper_oauth2_redirect_uri_path }}"
 {{ end }}
-{{ if .ConfigItems.skipper_edit_route_placeholders }}
-          {{ range $placeholder := split .ConfigItems.skipper_edit_route_placeholders "[cf724afc]" }}
+{{ if .Cluster.ConfigItems.skipper_edit_route_placeholders }}
+          {{ range $placeholder := split .Cluster.ConfigItems.skipper_edit_route_placeholders "[cf724afc]" }}
           - '-edit-route={{ $placeholder }}'
           {{ end }}
 {{ end }}
-{{ if or (eq .ConfigItems.nlb_switch "pre") (eq .ConfigItems.nlb_switch "exec") }}
+{{ if or (eq .Cluster.ConfigItems.nlb_switch "pre") (eq .Cluster.ConfigItems.nlb_switch "exec") }}
           - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
           - "-forwarded-headers-exclude-cidrs=10.2.0.0/15,{{ .Values.vpc_ipv4_cidr}}"
 {{ end }}
@@ -525,14 +558,14 @@ spec:
             tag=account={{ .Cluster.Alias }}
             tag=cluster={{ .Cluster.Alias }}
             tag=artifact=container-registry.zalando.net/teapot/skipper:{{ $version }}
-            max-buffered-spans={{ .ConfigItems.skipper_ingress_tracing_buffer }}
-            grpc-max-msg-size={{ .ConfigItems.skipper_ingress_lightstep_grpc_max_msg_size }}
+            max-buffered-spans={{ .Cluster.ConfigItems.skipper_ingress_tracing_buffer }}
+            grpc-max-msg-size={{ .Cluster.ConfigItems.skipper_ingress_lightstep_grpc_max_msg_size }}
             max-period=2500ms
             min-period=500ms
-            max-log-key-len={{ .ConfigItems.skipper_ingress_lightstep_max_log_key_len }}
-            max-log-value-len={{ .ConfigItems.skipper_ingress_lightstep_max_log_value_len }}
-            max-logs-per-span={{ .ConfigItems.skipper_ingress_lightstep_max_logs_per_span }}
-            propagators={{ .ConfigItems.skipper_ingress_lightstep_propagators }}
+            max-log-key-len={{ .Cluster.ConfigItems.skipper_ingress_lightstep_max_log_key_len }}
+            max-log-value-len={{ .Cluster.ConfigItems.skipper_ingress_lightstep_max_log_value_len }}
+            max-logs-per-span={{ .Cluster.ConfigItems.skipper_ingress_lightstep_max_logs_per_span }}
+            propagators={{ .Cluster.ConfigItems.skipper_ingress_lightstep_propagators }}
             {{ .Cluster.ConfigItems.skipper_ingress_lightstep_log_events }}
         env:
         - name: LIGHTSTEP_TOKEN
@@ -542,11 +575,11 @@ spec:
               key: lightstep-token
         resources:
           limits:
-            cpu: "{{ .ConfigItems.skipper_routesrv_cpu }}"
-            memory: "{{ .ConfigItems.skipper_routesrv_memory }}"
+            cpu: "{{ .Cluster.ConfigItems.skipper_routesrv_cpu }}"
+            memory: "{{ .Cluster.ConfigItems.skipper_routesrv_memory }}"
           requests:
-            cpu: "{{ .ConfigItems.skipper_routesrv_cpu }}"
-            memory: "{{ .ConfigItems.skipper_routesrv_memory }}"
+            cpu: "{{ .Cluster.ConfigItems.skipper_routesrv_cpu }}"
+            memory: "{{ .Cluster.ConfigItems.skipper_routesrv_memory }}"
         readinessProbe:
           httpGet:
             path: /health

--- a/cluster/manifests/skipper/hpa.yaml
+++ b/cluster/manifests/skipper/hpa.yaml
@@ -1,3 +1,11 @@
+{{ $min_replicas := .Cluster.ConfigItems.skipper_ingress_min_replicas }}
+{{ if and
+  (eq .Cluster.ConfigItems.skipper_ingress_canary_enabled "true")
+  (ne .Cluster.ConfigItems.skipper_ingress_min_replicas "0")
+  (ne .Cluster.ConfigItems.skipper_ingress_min_replicas "1") }}
+{{ $min_replicas = sumQuantities .Cluster.ConfigItems.skipper_ingress_min_replicas "-1" }}
+{{ end }}
+
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -5,28 +13,29 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
+    component: ingress
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
     name: skipper-ingress
-  minReplicas: {{ .ConfigItems.skipper_ingress_min_replicas }}
-  maxReplicas: {{ .ConfigItems.skipper_ingress_max_replicas }}
+  minReplicas: {{ $min_replicas }}
+  maxReplicas: {{ .Cluster.ConfigItems.skipper_ingress_max_replicas }}
   metrics:
   - type: Resource
     resource:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: {{ .ConfigItems.skipper_ingress_target_average_utilization_cpu }}
+        averageUtilization: {{ .Cluster.ConfigItems.skipper_ingress_target_average_utilization_cpu }}
   - type: Resource
     resource:
       name: memory
       target:
         type: Utilization
-        averageUtilization: {{ .ConfigItems.skipper_ingress_target_average_utilization_memory }}
-{{ if .ConfigItems.skipper_cluster_scaling_schedules }}
-  {{ range split .ConfigItems.skipper_cluster_scaling_schedules "," }}
+        averageUtilization: {{ .Cluster.ConfigItems.skipper_ingress_target_average_utilization_memory }}
+{{ if .Cluster.ConfigItems.skipper_cluster_scaling_schedules }}
+  {{ range split .Cluster.ConfigItems.skipper_cluster_scaling_schedules "," }}
   {{ $name_target := split . "=" }}
   - type: Object
     object:
@@ -43,7 +52,7 @@ spec:
 {{ end }}
   behavior:
     scaleDown:
-      stabilizationWindowSeconds: {{ .ConfigItems.skipper_ingress_hpa_scale_down_wait }}
+      stabilizationWindowSeconds: {{ .Cluster.ConfigItems.skipper_ingress_hpa_scale_down_wait }}
       policies:
       - type: Pods
         value: 10
@@ -59,6 +68,6 @@ spec:
         value: 4
       - periodSeconds: 15
         type: Percent
-        value:  {{ .ConfigItems.skipper_ingress_hpa_scale_up_max_perc }}
+        value: {{ .Cluster.ConfigItems.skipper_ingress_hpa_scale_up_max_perc }}
       selectPolicy: Max
       stabilizationWindowSeconds: 0


### PR DESCRIPTION
The change introduces parameterized `skipper-ingress` deployment template.
This template is used to define `main` and `canary` deployments.
A single replica `canary` deployment is enabled by a new `skipper_ingress_canary_enabled` config item.
When `canary` deployment is enabled number of `main` HPA min replicas is reduced by one.

To deploy a canary version update `$canary_internal_version` and set `skipper_ingress_canary_enabled`.
After checking that canary behaves as expected set `$internal_version` equal to `$canary_internal_version`.

I.e. in the cluster where canary is enabled there is always one canary
instance whose version is either above or equal to the main deployment version.

All config items are accessed through `.Cluster.ConfigItems` for clarity.

https://github.com/zalando-incubator/kubernetes-on-aws/labels/architectural