### PR TITLE
Add kubelet-summary-metrics proxy

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -336,6 +336,15 @@ cadvisor_cpu: "150m"
 cadvisor_memory: "150Mi"
 cadvisor_profiling_enabled: "false"
 
+# settings for enabling the kubelet-summary-metrics proxy and prometheus metric
+# collection.
+kubelet_summary_metrics_enabled: "true"
+kubelet_summary_metrics_cpu: "10m"
+kubelet_summary_metrics_memory: "512Mi"
+kubelet_summary_metrics_hpa_max_replicas: "10"
+kubelet_summary_metrics_hpa_cpu_target: "80"
+kubelet_summary_metrics_hpa_memory_target: "80"
+
 # node exporter settings
 node_exporter_cpu: "20m"
 node_exporter_memory: "75Mi"

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -247,3 +247,21 @@ post_apply:
 - name: business-partner-service
   kind: ClusterRoleBinding
 {{ end }}
+{{ if ne .Cluster.ConfigItems.kubelet_summary_metrics_enabled "true" }}
+- name: kubelet-summary-metrics
+  kind: ClusterRole
+- name: kubelet-summary-metrics
+  kind: ClusterRoleBinding
+- name: kubelet-summary-metrics
+  kind: ServiceAccount
+  namespace: kube-system
+- name: kubelet-summary-metrics
+  kind: Service
+  namespace: kube-system
+- name: kubelet-summary-metrics
+  kind: Deployment
+  namespace: kube-system
+- name: kubelet-summary-metrics
+  kind: HorizontalPodAutoscaler
+  namespace: kube-system
+{{ end }}

--- a/cluster/manifests/kubelet-summary-metrics/deployment.yaml
+++ b/cluster/manifests/kubelet-summary-metrics/deployment.yaml
@@ -1,0 +1,38 @@
+# {{ if eq .Cluster.ConfigItems.kubelet_summary_metrics_enabled "true" }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubelet-summary-metrics
+  namespace: kube-system
+  labels:
+    application: kubernetes
+    component: kubelet-summary-metrics
+spec:
+  selector:
+    matchLabels:
+      deployment: kubelet-summary-metrics
+  template:
+    metadata:
+      labels:
+        application: kubernetes
+        component: kubelet-summary-metrics
+        deployment: kubelet-summary-metrics
+      annotations:
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
+    spec:
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+      serviceAccountName: kubelet-summary-metrics
+      containers:
+      - name: proxy
+        image: container-registry.zalando.net/teapot/kubelet-summary-metrics:main-1
+        resources:
+          limits:
+            cpu: "{{.Cluster.ConfigItems.kubelet_summary_metrics_cpu}}"
+            memory: "{{.Cluster.ConfigItems.kubelet_summary_metrics_memory}}"
+          requests:
+            cpu: "{{.Cluster.ConfigItems.kubelet_summary_metrics_cpu}}"
+            memory: "{{.Cluster.ConfigItems.kubelet_summary_metrics_memory}}"
+# {{ end }}

--- a/cluster/manifests/kubelet-summary-metrics/hpa.yaml
+++ b/cluster/manifests/kubelet-summary-metrics/hpa.yaml
@@ -1,0 +1,30 @@
+# {{ if eq .Cluster.ConfigItems.kubelet_summary_metrics_enabled "true" }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: kubelet-summary-metrics
+  namespace: kube-system
+  labels:
+    application: kubernetes
+    component: kubelet-summary-metrics
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: kubelet-summary-metrics
+  minReplicas: 2
+  maxReplicas: {{.Cluster.ConfigItems.kubelet_summary_metrics_hpa_max_replicas}}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{.Cluster.ConfigItems.kubelet_summary_metrics_hpa_cpu_target}}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{.Cluster.ConfigItems.kubelet_summary_metrics_hpa_memory_target}}
+# {{ end }}

--- a/cluster/manifests/kubelet-summary-metrics/rbac.yaml
+++ b/cluster/manifests/kubelet-summary-metrics/rbac.yaml
@@ -1,0 +1,40 @@
+# {{ if eq .Cluster.ConfigItems.kubelet_summary_metrics_enabled "true" }}
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: kubelet-summary-metrics
+  namespace: kube-system
+  labels:
+    application: kubernetes
+    component: kubelet-summary-metrics
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubelet-summary-metrics
+  labels:
+    application: kubernetes
+    component: kubelet-summary-metrics
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes/stats
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubelet-summary-metrics
+  labels:
+    application: kubernetes
+    component: kubelet-summary-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubelet-summary-metrics
+subjects:
+- kind: ServiceAccount
+  name: kubelet-summary-metrics
+  namespace: kube-system
+# {{ end }}

--- a/cluster/manifests/kubelet-summary-metrics/service.yaml
+++ b/cluster/manifests/kubelet-summary-metrics/service.yaml
@@ -1,0 +1,18 @@
+# {{ if eq .Cluster.ConfigItems.kubelet_summary_metrics_enabled "true" }}
+kind: Service
+apiVersion: v1
+metadata:
+  name: kubelet-summary-metrics
+  namespace: kube-system
+  labels:
+    application: kubernetes
+    component: kubelet-summary-metrics
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 9090
+      protocol: TCP
+  selector:
+    deployment: kubelet-summary-metrics
+# {{ end }}

--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -401,3 +401,17 @@ data:
        - source_labels: [ __name__ ]
          regex: 'reflector.*'
          action: drop
+    # {{ if eq .Cluster.ConfigItems.kubelet_summary_metrics_enabled "true" }}
+    - job_name: "kubelet-summary"
+      kubernetes_sd_configs:
+        - role: node
+      relabel_configs:
+        - action: labelmap
+          regex: __meta_kubernetes_node_label_(.+)
+        - source_labels: [__meta_kubernetes_node_name]
+          regex: (.+)
+          target_label: __metrics_path__
+          replacement: /nodes/${1}/metrics
+        - target_label: __address__
+          replacement: kubelet-summary-metrics
+    # {{ end }}


### PR DESCRIPTION
Add a simple proxy that sits between kubelets and prometheus and translates the kubelet stats summary json into prometheus metric data.

The motivation for this is to provide per pod/container filesystem usage metrics which are not provided by cadvisor. Eventually more metric types could be provided this way and reduce the need for cadvisor (pending evaluation).

The architecture looks like this:

![image](https://github.com/zalando-incubator/kubernetes-on-aws/assets/128566/e2eea93c-d567-4c99-8c06-34f304a77a4a)

The benefit compared to cadvisor is that it runs centrally in the cluster instead of a daemonset and thereby can scale horizontally and not take up per node resources.