### PR TITLE
Update to node-exporter v1.7.0

### DIFF
--- a/cluster/manifests/node-monitor/daemonset.yaml
+++ b/cluster/manifests/node-monitor/daemonset.yaml
@@ -77,7 +77,7 @@ spec:
               containerPort: 9101
               hostPort: 9101
               protocol: TCP
-        - image: container-registry.zalando.net/teapot/prometheus-node-exporter:v1.6.1-master-19
+        - image: container-registry.zalando.net/teapot/prometheus-node-exporter:v1.7.0-master-20
           args:
 {{- if eq .Cluster.ConfigItems.node_exporter_experimental_metrics "true" }}
             - --collector.ethtool


### PR DESCRIPTION
Update to node-exporter v1.7.0

https://github.com/prometheus/node_exporter/releases/tag/v1.7.0