### PR TITLE
Add mandatory pull request labels

### DIFF
--- a/.zappr.yaml
+++ b/.zappr.yaml
@@ -24,4 +24,16 @@ approvals:
           - MustafaSaber
           - lucastt
 
+# mandatory pull request labels
+pull-request:
+  labels:
+    additional: true
+    oneOf:
+      - architectural
+      - major
+      - minor
+      - bugfix
+      - documentation
+      - dependencies
+
 X-Zalando-Team: "teapot"


### PR DESCRIPTION
This adds mandatory PR labels which has been enabled for internal repos automatically. Here we need to do it manually.