### PR TITLE
set client.uid tag to caller uid

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -101,6 +101,7 @@ skipper_validate_query: "true"
 skipper_validate_query_log: "false"
 
 skipper_default_filters: 'disableAccessLog(2,3,404,429) -> fifo(2000,20,"1s")'
+skipper_default_filters_append: 'stateBagToTag("auth-user", "client.uid")'
 skipper_disabled_filters: "lua,static,bearerinjector"
 skipper_edit_route_placeholders: ""
 skipper_ingress_inline_routes: ""

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -247,6 +247,7 @@ spec:
           - "-disabled-filters={{ .Cluster.ConfigItems.skipper_disabled_filters }}"
 {{ if ne .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
           - '-default-filters-prepend={{ .Cluster.ConfigItems.skipper_default_filters }}'
+          - '-default-filters-append={{ .Cluster.ConfigItems.skipper_default_filters_append }}'
   {{ if .Cluster.ConfigItems.skipper_edit_route_placeholders }}
           {{ range $placeholder := split .Cluster.ConfigItems.skipper_edit_route_placeholders "[cf724afc]" }}
           - '-edit-route={{ $placeholder }}'
@@ -529,6 +530,7 @@ spec:
           - "-reverse-source-predicate"
           - "-default-filters-dir=/etc/config/default-filters"
           - '-default-filters-prepend={{ .Cluster.ConfigItems.skipper_default_filters }}'
+          - '-default-filters-append={{ .Cluster.ConfigItems.skipper_default_filters_append }}'
 {{ if eq .Cluster.ConfigItems.skipper_ingress_redis_swarm_enabled "true" }}
           - "-enable-swarm"
           - "-kubernetes-redis-service-namespace=kube-system"


### PR DESCRIPTION
set client.uid tag to caller uid

- in case statebag entry exists it will set client.uid to uid of the statebag entry 
- if it does not exit in statebag the tag will not be created.

In case we need to rollback this change without rolling back the PR as incident mitigation:
Override the config-item  `skipper_default_filters_append` with value `dropResponseHeader("does-not-exist")`