### PR TITLE
Update admission-controller with configmap protection feature

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -569,6 +569,9 @@ teapot_admission_controller_log4j_format_msg_no_lookups: "true"
 
 teapot_admission_controller_graceful_termination: "true"
 
+# toggle that prevents active configmaps from being deleted
+teapot_admission_controller_configmap_deletion_protection_enabled: "true"
+
 # Prevent the use of a particular AZ as much as possible
 blocked_availability_zone: ""
 

--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -4,6 +4,8 @@ metadata:
   name: teapot-admission-controller
   namespace: kube-system
 data:
+  configmap.deletion-protection.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_configmap_deletion_protection_enabled }}"
+
   daemonset.reserved.cpu: "{{ .Cluster.ConfigItems.teapot_admission_controller_daemonset_reserved_cpu }}"
   daemonset.reserved.memory: "{{ .Cluster.ConfigItems.teapot_admission_controller_daemonset_reserved_memory }}"
 

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -205,7 +205,7 @@ write_files:
             limits:
               memory: {{ .Values.InstanceInfo.MemoryFraction (parseInt64 .Cluster.ConfigItems.apiserver_memory_limit_percent)}}
 {{- end }}
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-178
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-179
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
Update admission controller including [this feature](https://github.bus.zalan.do/teapot/admission-controller/pull/204) and enable it by default.