### PR TITLE
Make nvidia device plugin ds run on Karpenter nodes

### DIFF
--- a/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
+++ b/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
@@ -10,7 +10,6 @@ metadata:
   labels:
     application: kubernetes
     component: nvidia-gpu-device-plugin
-    version: v0.10.0
 spec:
   updateStrategy:
     type: RollingUpdate
@@ -23,7 +22,6 @@ spec:
         daemonset: nvidia-gpu-device-plugin
         application: kubernetes
         component: nvidia-gpu-device-plugin
-        version: v0.10.0
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
@@ -40,6 +38,11 @@ spec:
             - matchExpressions:
               - key: zalando.org/nvidia-gpu
                 operator: Exists
+            - matchExpressions:
+              - key: karpenter.k8s.aws/instance-gpu-manufacturer
+                operator: In
+                values:
+                - nvidia
       priorityClassName: system-node-critical
       volumes:
       - name: device-plugin
@@ -47,7 +50,7 @@ spec:
           path: /var/lib/kubelet/device-plugins
       containers:
       - name: nvidia-gpu-device-plugin
-        image: container-registry.zalando.net/teapot/nvidia-gpu-device-plugin:v0.13.0-master-7
+        image: container-registry.zalando.net/teapot/nvidia-gpu-device-plugin:v0.14.3-master-8
         args:
         - --fail-on-init-error=false
         - --pass-device-specs


### PR DESCRIPTION
* Adjusts the nodeAffinity so the nvidia device will also be scheduled on karpenter managed nvidia nodes
* Updates the nvidia device plugin to latest version
* This also removes the `version` label which was outdated and not used anyway.

### TODO:

* [x] Check if this is the best way to schedule on karpenter nodes
* [x] Update nvidia container

