### PR TITLE
skipper: remove skipper_ingress_canary_args config item

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -74,10 +74,6 @@ skipper_ingress_memory: "1500Mi"
 # Enables deployment of canary version
 skipper_ingress_canary_enabled: "false"
 
-# Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g.:
-# skipper_ingress_canary_args: "-foo=has a whitespace[cf724afc]-baz=qux"
-skipper_ingress_canary_args: ""
-
 # When set to true (and dedicated node pool for skipper is also true) the
 # daemonset overhead will be subtracted from the cpu settings such
 # that skipper will perfectly fit on the node.

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,6 +1,9 @@
 {{ $internal_version := "v0.18.42-691" }}
 {{ $canary_internal_version := "v0.18.42-691" }}
 
+{{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}
+{{ $canary_args := "" }}
+
 {{ template "skipper-ingress" dict
   "name" "skipper-ingress"
   "internal_version" $internal_version
@@ -14,7 +17,7 @@
   "name" "skipper-ingress-canary"
   "internal_version" $canary_internal_version
   "replicas" 1
-  "args" (index .Cluster.ConfigItems "skipper_ingress_canary_args")
+  "args" $canary_args
 
   "Cluster" .Cluster
   "Values" .Values


### PR DESCRIPTION
As we decided to not have a config item for canary version value it also does not make sense to have an item for canary args.

This change uses template variable for canary args to keep canary version and args close together.

Followup on #6592