### PR TITLE
all: add .Cluster prefix

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -374,7 +374,7 @@ journald_reader_cpu: "1m"
 journald_reader_memory: "30Mi"
 
 # Logging settings
-logging_s3_bucket: "zalando-logging-{{.InfrastructureAccount | getAWSAccountID}}-{{.Region}}"
+logging_s3_bucket: "zalando-logging-{{ .Cluster.InfrastructureAccount | getAWSAccountID}}-{{ .Cluster.Region }}"
 scalyr_team_token: ""
 log_destination_infra: "scalyr/stups"
 log_destination_both: "scalyr/main+stups"

--- a/cluster/manifests/03-ebs-csi/serviceaccount-csi-controller.yaml
+++ b/cluster/manifests/03-ebs-csi/serviceaccount-csi-controller.yaml
@@ -7,4 +7,4 @@ metadata:
     application: kubernetes
     component: ebs-csi-driver
   annotations:
-    iam.amazonaws.com/role: "{{ .LocalID }}-ebs-csi-controller"
+    iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-ebs-csi-controller"

--- a/cluster/manifests/audittrail-adapter/01-rbac.yaml
+++ b/cluster/manifests/audittrail-adapter/01-rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: audittrail-adapter
   namespace: kube-system
   annotations:
-    iam.amazonaws.com/role: "{{ .LocalID }}-audittrail-adapter"
+    iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-audittrail-adapter"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -36,12 +36,12 @@ spec:
         image: container-registry.zalando.net/teapot/audittrail-adapter:master-49
         env:
           - name: AWS_REGION
-            value: {{.Cluster.Region}}
+            value: "{{ .Cluster.Region }}"
         args:
-        - --cluster-id={{ .ID }}
+        - --cluster-id={{ .Cluster.ID }}
         - --cluster-alias={{ .Cluster.Alias }}
         - --audittrail-url={{ .Cluster.ConfigItems.audittrail_url }}
-        - --s3-fallback-bucket-name=zalando-audittrail-{{accountID .InfrastructureAccount}}-{{.LocalID}}
+        - --s3-fallback-bucket-name=zalando-audittrail-{{accountID .Cluster.InfrastructureAccount}}-{{ .Cluster.LocalID }}
         - --address=:8889
         - --metrics-address=:7980
         - --audittrail-timeout={{ .Cluster.ConfigItems.audittrail_adapter_timeout }}

--- a/cluster/manifests/aws-node-decommissioner/01-rbac.yaml
+++ b/cluster/manifests/aws-node-decommissioner/01-rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     application: kubernetes
     component: aws-node-decommissioner
-    iam.amazonaws.com/role: "{{.LocalID}}-aws-node-decommissioner"
+    iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-aws-node-decommissioner"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/cluster/manifests/cluster-lifecycle-controller/01-rbac.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/01-rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cluster-lifecycle-controller
   namespace: kube-system
   annotations:
-    iam.amazonaws.com/role: "{{ .LocalID }}-cluster-lifecycle-controller"
+    iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-cluster-lifecycle-controller"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
@@ -51,6 +51,6 @@ spec:
             memory: 250Mi
         env:
         - name: AWS_REGION
-          value: {{ .Region }}
+          value: "{{ .Cluster.Region }}"
       nodeSelector:
         node.kubernetes.io/role: master

--- a/cluster/manifests/e2e-resources/pool-reserve.yaml
+++ b/cluster/manifests/e2e-resources/pool-reserve.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Environment "e2e" }}
+{{ if eq .Cluster.Environment "e2e" }}
 {{ range $pool := split "default-worker-splitaz,worker-limit-az,worker-combined,worker-instance-storage,worker-node-tests,worker-karpenter,worker-arm64" "," }}
 apiVersion: apps/v1
 kind: Deployment

--- a/cluster/manifests/efs-provisioner/cm-efs-provisioner.yaml
+++ b/cluster/manifests/efs-provisioner/cm-efs-provisioner.yaml
@@ -6,6 +6,6 @@ metadata:
   namespace: kube-system
 data:
   file.system.id: "{{ .ConfigItems.efs_id }}"
-  aws.region: "{{ .Region }}"
+  aws.region: "{{ .Cluster.Region }}"
   provisioner.name: external-storage.alpha.kubernetes.io/aws-efs
 {{ end }}

--- a/cluster/manifests/efs-provisioner/depl-efs-provisioner.yaml
+++ b/cluster/manifests/efs-provisioner/depl-efs-provisioner.yaml
@@ -56,6 +56,6 @@ spec:
       volumes:
         - name: pv-volume
           nfs:
-            server: "{{ .ConfigItems.efs_id }}.efs.{{ .Region }}.amazonaws.com"
+            server: "{{ .ConfigItems.efs_id }}.efs.{{ .Cluster.Region }}.amazonaws.com"
             path: /
 {{ end }}

--- a/cluster/manifests/emergency-access-service/01-rbac.yaml
+++ b/cluster/manifests/emergency-access-service/01-rbac.yaml
@@ -1,11 +1,11 @@
-{{ if eq .Environment "production" }}
+{{ if eq .Cluster.Environment "production" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: emergency-access-service
   namespace: kube-system
   annotations:
-    iam.amazonaws.com/role: "{{ .LocalID }}-emergency-access-service"
+    iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-emergency-access-service"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/cluster/manifests/emergency-access-service/credentials.yaml
+++ b/cluster/manifests/emergency-access-service/credentials.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Environment "production" }}
+{{ if eq .Cluster.Environment "production" }}
 apiVersion: "zalando.org/v1"
 kind: PlatformCredentialsSet
 metadata:

--- a/cluster/manifests/emergency-access-service/deployment.yaml
+++ b/cluster/manifests/emergency-access-service/deployment.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Environment "production" }}
+{{ if eq .Cluster.Environment "production" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -45,16 +45,16 @@ spec:
         image: "container-registry.zalando.net/teapot/emergency-access-service:master-88"
         args:
         - --insecure-http
-        - --community={{ .Owner }}
-        - --cluster-id={{ .ID }}
+        - --community={{ .Cluster.Owner }}
+        - --cluster-id={{ .Cluster.ID }}
         - --teams-api-url=https://teams.auth.zalando.com
         # TODO(mlarsen): Rename this flag to tokeninfo-url to reflect that it's
         # not the OAuth2 token URL.
         - --token-url=https://info.services.auth.zalando.com/oauth2/tokeninfo
         # enable audittrail reporting
         - --audittrail-url=https://audittrail.cloud.zalando.com
-        - --environment={{ .Environment }}
-        - --s3-bucket-name=zalando-audittrail-{{accountID .InfrastructureAccount}}-{{.LocalID}}
+        - --environment={{ .Cluster.Environment }}
+        - --s3-bucket-name=zalando-audittrail-{{accountID .Cluster.InfrastructureAccount}}-{{ .Cluster.LocalID }}
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: "127.0.0.1"
@@ -70,7 +70,7 @@ spec:
               name: emergency-access-service-secrets
               key: opsgenie-api-key
         - name: AWS_REGION
-          value: {{.Region}}
+          value: "{{ .Cluster.Region }}"
         - name: OPENTRACING_LIGHTSTEP_ACCESS_TOKEN
           valueFrom:
             secretKeyRef:

--- a/cluster/manifests/emergency-access-service/ingress.yaml
+++ b/cluster/manifests/emergency-access-service/ingress.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Environment "production" }}
+{{ if eq .Cluster.Environment "production" }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/cluster/manifests/emergency-access-service/secret.yaml
+++ b/cluster/manifests/emergency-access-service/secret.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Environment "production" }}
+{{ if eq .Cluster.Environment "production" }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/cluster/manifests/emergency-access-service/service.yaml
+++ b/cluster/manifests/emergency-access-service/service.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Environment "production" }}
+{{ if eq .Cluster.Environment "production" }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/cluster/manifests/external-dns/01-rbac.yaml
+++ b/cluster/manifests/external-dns/01-rbac.yaml
@@ -8,7 +8,7 @@ metadata:
     application: kubernetes
     component: external-dns
   annotations:
-    iam.amazonaws.com/role: "{{ .LocalID }}-app-external-dns"
+    iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-app-external-dns"
 ---
 # allows to list services and ingresses
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -45,7 +45,7 @@ spec:
 {{- end }}
         - --provider=aws
         - --registry=txt
-        - --txt-owner-id={{ .Region }}:{{ .LocalID }}
+        - --txt-owner-id={{ .Cluster.Region }}:{{ .Cluster.LocalID }}
         - --txt-prefix={{ .ConfigItems.external_dns_ownership_prefix }}
         - --aws-batch-change-size=120
         - --aws-zones-cache-duration={{ .ConfigItems.external_dns_zones_cache_duration }}
@@ -70,4 +70,4 @@ spec:
             drop: ["ALL"]
         env:
         - name: AWS_REGION
-          value: {{ .Region }}
+          value: "{{ .Cluster.Region }}"

--- a/cluster/manifests/kube-cluster-autoscaler/01-rbac.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/01-rbac.yaml
@@ -7,7 +7,7 @@ metadata:
     application: kubernetes
     component: kube-cluster-autoscaler
   annotations:
-    iam.amazonaws.com/role: "{{ .LocalID }}-app-autoscaler"
+    iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-app-autoscaler"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -43,7 +43,7 @@ spec:
           - --stderrthreshold=info
           - --scale-down-utilization-threshold={{.Cluster.ConfigItems.autoscaling_utilization_threshold}}
           - --cloud-provider=aws
-          - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,zalando.de/cluster-local-id/{{ .LocalID }}
+          - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,zalando.de/cluster-local-id/{{ .Cluster.LocalID }}
           - --expendable-pods-priority-cutoff=-1000000
           - --skip-nodes-with-system-pods=false
           - --skip-nodes-with-local-storage=false
@@ -71,6 +71,6 @@ spec:
             ephemeral-storage: 256Mi
         env:
           - name: AWS_REGION
-            value: {{ .Region }}
+            value: "{{ .Cluster.Region }}"
       nodeSelector:
         node.kubernetes.io/role: master

--- a/cluster/manifests/kube-janitor/deployment.yaml
+++ b/cluster/manifests/kube-janitor/deployment.yaml
@@ -1,4 +1,4 @@
-# {{ if ne .Environment "production" }}
+# {{ if ne .Cluster.Environment "production" }}
 # {{ $internal_version := "23.7.0-main-2" }}
 # {{ $version := index (split $internal_version "-") 0 }}
 apiVersion: apps/v1

--- a/cluster/manifests/kube-janitor/rbac.yaml
+++ b/cluster/manifests/kube-janitor/rbac.yaml
@@ -1,4 +1,4 @@
-{{ if ne .Environment "production" }}
+{{ if ne .Cluster.Environment "production" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/cluster/manifests/kube-janitor/rules-config.yaml
+++ b/cluster/manifests/kube-janitor/rules-config.yaml
@@ -1,4 +1,4 @@
-# {{ if ne .Environment "production" }}
+# {{ if ne .Cluster.Environment "production" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cluster/manifests/kube-janitor/vpa.yaml
+++ b/cluster/manifests/kube-janitor/vpa.yaml
@@ -1,4 +1,4 @@
-{{ if ne .Environment "production" }}
+{{ if ne .Cluster.Environment "production" }}
 apiVersion: autoscaling.k8s.io/v1beta2
 kind: VerticalPodAutoscaler
 metadata:

--- a/cluster/manifests/kube-metrics-adapter/credentials.yaml
+++ b/cluster/manifests/kube-metrics-adapter/credentials.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Environment "production") (ne .Cluster.ConfigItems.nakadi_url "") }}
+{{- if or (eq .Cluster.Environment "production") (ne .Cluster.ConfigItems.nakadi_url "") }}
 apiVersion: zalando.org/v1
 kind: PlatformCredentialsSet
 metadata:
@@ -10,7 +10,7 @@ metadata:
 spec:
   application: kubernetes
   tokens:
-    {{- if and (eq .Environment "production") (ne .Cluster.ConfigItems.zmon_kairosdb_url "") }}
+    {{- if and (eq .Cluster.Environment "production") (ne .Cluster.ConfigItems.zmon_kairosdb_url "") }}
     zmon:
       privileges: []
     {{- end }}

--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -43,14 +43,14 @@ spec:
         - --aws-region=eu-central-1
         - --aws-region=eu-west-1
         - --skipper-backends-annotation=zalando.org/backend-weights
-        {{ if eq .Environment "production" }}
+        {{ if eq .Cluster.Environment "production" }}
         - --zmon-kariosdb-endpoint={{.Cluster.ConfigItems.zmon_kairosdb_url}}
         {{ end }}
         {{- if ne .Cluster.ConfigItems.nakadi_url "" }}
         - --nakadi-endpoint={{.Cluster.ConfigItems.nakadi_url}}
         {{- end }}
         volumeMounts:
-        {{- if or (eq .Environment "production") (ne .Cluster.ConfigItems.nakadi_url "") }}
+        {{- if or (eq .Cluster.Environment "production") (ne .Cluster.ConfigItems.nakadi_url "") }}
         - name: credentials
           mountPath: /meta/credentials
           readOnly: true
@@ -63,7 +63,7 @@ spec:
             cpu: 10m
             memory: 4Gi
       volumes:
-      {{- if or (eq .Environment "production") (ne .Cluster.ConfigItems.nakadi_url "") }}
+      {{- if or (eq .Cluster.Environment "production") (ne .Cluster.ConfigItems.nakadi_url "") }}
       - name: credentials
         secret:
           secretName: "kube-metrics-adapter"

--- a/cluster/manifests/kube-static-egress-controller/01-rbac.yaml
+++ b/cluster/manifests/kube-static-egress-controller/01-rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kube-static-egress-controller
   namespace: kube-system
   annotations:
-    iam.amazonaws.com/role: "{{ .LocalID }}-static-egress-controller"
+    iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-static-egress-controller"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -41,7 +41,7 @@ spec:
         - "--aws-az={{ $zone }}"
 {{ end }}
         - "--stack-termination-protection"
-        - "--cluster-id={{ .ID }}"
+        - "--cluster-id={{ .Cluster.ID }}"
         - "--cluster-id-tag-prefix=zalando.org/cluster/"
         - "--additional-stack-tags=InfrastructureComponent=true"
         - "--additional-stack-tags=application=kubernetes"

--- a/cluster/manifests/skipper/rbac.yaml
+++ b/cluster/manifests/skipper/rbac.yaml
@@ -8,7 +8,7 @@ metadata:
 {{ if eq .ConfigItems.skipper_open_policy_agent_enabled "true" }}
   # Note: if the role extends beyond OPA use, this condition can be removed
   annotations:
-    iam.amazonaws.com/role: "{{ .LocalID }}-app-skipper-ingress"
+    iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-app-skipper-ingress"
 {{ end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cluster/manifests/z-karpenter/01-rbac.yaml
+++ b/cluster/manifests/z-karpenter/01-rbac.yaml
@@ -9,7 +9,7 @@ metadata:
     application: kubernetes
     component: karpenter
   annotations:
-    iam.amazonaws.com/role: "{{ .LocalID }}-app-karpenter"
+    iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-app-karpenter"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
Update all templates to use .Cluster prefix to access cluster properties except ConfigItems.

ConfigItems will be addressed by a separate change to simplify review.