### PR TITLE
register configmap deletion events with admission webhook

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -579,7 +579,13 @@ teapot_admission_controller_log4j_format_msg_no_lookups: "true"
 teapot_admission_controller_graceful_termination: "true"
 
 # toggle that prevents active configmaps from being deleted
+{{if eq .Cluster.Environment "e2e"}}
+# allow deletion of active configmaps in e2e clusters because some tests rely on it
+teapot_admission_controller_configmap_deletion_protection_enabled: "false"
+{{else}}
+# prevent deletion of active configmaps in all test and production clusters
 teapot_admission_controller_configmap_deletion_protection_enabled: "true"
+{{end}}
 
 # Prevent the use of a particular AZ as much as possible
 blocked_availability_zone: ""

--- a/cluster/manifests/01-admission-control/teapot.yaml
+++ b/cluster/manifests/01-admission-control/teapot.yaml
@@ -58,6 +58,19 @@ webhooks:
         apiGroups: [""]
         apiVersions: ["v1"]
         resources: ["nodes"]
+  - name: configmap-admitter.teapot.zalan.do
+    clientConfig:
+      url: "https://localhost:8085/configmap"
+      caBundle: "{{ .ConfigItems.ca_cert_decompressed }}"
+    admissionReviewVersions: ["v1beta1"]
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    sideEffects: "NoneOnDryRun"
+    rules:
+      - operations: [ "DELETE" ]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["configmaps"]
   - name: cronjob-admitter.teapot.zalan.do
     clientConfig:
       url: "https://localhost:8085/cronjob"


### PR DESCRIPTION
We need to register the tracked event, otherwise nothing will happen.

Follow up from: https://github.com/zalando-incubator/kubernetes-on-aws/pull/6606