### PR TITLE
Create deployment event on merge to channel branches

### DIFF
--- a/_deploy_event/configmap.yaml
+++ b/_deploy_event/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "kubernetes-deploy-event"
+  labels:
+    application: "kubernetes"
+    component: "deploy-event"
+data:
+  empty-event: "deployment"

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -312,3 +312,16 @@ pipeline:
             requests:
               cpu: 500m
               memory: 1Gi
+
+- id: deploy-event
+  type: deploy
+  target: stups
+  when:
+    event: push
+    branch:
+    - dev
+    - alpha
+    - beta
+    - stable
+  sources:
+    - dir: _deploy_event


### PR DESCRIPTION
This introduces a "fake" deployment event on every merge to a channel branch. The purpose is to generate a CDP deployment event which can later be shown e.g. in Sunrise. This is similar to how Linus does for AILM.

See internal ticket: teapot/issues#3528 for more context