### PR TITLE
Add missing fields description in the FabricGateway CRD

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -315,7 +315,7 @@ skipper_open_policy_agent_styra_token: ""
 #   - production: runs the controller
 #
 fabric_gateway_controller_mode: "disabled"
-fabric_gateway_controller_version: "master-229"
+fabric_gateway_controller_version: "master-231"
 fabric_gateway_controller_cpu: "50m"
 fabric_gateway_controller_memory: "150Mi"
 fabric_gateway_crd_v1_enabled: "false"

--- a/cluster/manifests/fabric-gateway/fabricgateway_crd.yaml
+++ b/cluster/manifests/fabric-gateway/fabricgateway_crd.yaml
@@ -40,6 +40,8 @@ spec:
           metadata:
             type: object
           spec:
+            description: 'Spec is the desired state of the FabricGateway. More info:
+              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'''
             properties:
               paths:
                 additionalProperties:
@@ -69,6 +71,10 @@ spec:
                             type: array
                         type: object
                       x-fabric-custom-routes:
+                        description: Additional routes for the same method and path
+                          to be used instead of the main route when some additional
+                          conditions apply. Properties of custom route are not inherited
+                          from the main route by default
                         items:
                           description: The additional route which is generated for
                             the same method and path but is applied only to requests
@@ -183,6 +189,9 @@ spec:
                               - default-rate
                               type: object
                             x-fabric-request-ratelimits:
+                              description: The list of request rate limits used to
+                                limit amount of requests from the single client to
+                                avoid underlying service overload
                               items:
                                 description: FabricGatewayRequestRateLimit is used
                                   to limit requests per specified period for particular
@@ -346,6 +355,9 @@ spec:
                         - default-rate
                         type: object
                       x-fabric-request-ratelimits:
+                        description: The list of request rate limits used to limit
+                          amount of requests from the single client to avoid underlying
+                          service overload
                         items:
                           description: FabricGatewayRequestRateLimit is used to limit
                             requests per specified period for particular users creating
@@ -444,13 +456,21 @@ spec:
                 minProperties: 1
                 type: object
               x-external-service-provider:
+                description: Makes the specified StackSet from the same namespace
+                  available on the specified host names. The spec.externalIngress
+                  field in the corresponding StackSet should be set together with
+                  this field
                 properties:
                   hosts:
+                    description: Host names which FabricGateway should make StackSet
+                      available on
                     items:
                       type: string
                     minItems: 1
                     type: array
                   stackSetName:
+                    description: The name of the StackSet resource in the same namespace
+                      which should be handling requests coming through FabricGateway
                     type: string
                 required:
                 - hosts
@@ -537,6 +557,8 @@ spec:
                     type: array
                 type: object
               x-fabric-service:
+                description: Makes the specified service from the same namespace available
+                  on the specified host name
                 items:
                   properties:
                     host:
@@ -574,21 +596,39 @@ spec:
             - paths
             type: object
           status:
+            description: 'Status is the current state of the FabricGateway. More info:
+              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
             properties:
               num_owned_ingress:
+                description: 'Number of ingresses which this FabricGateway object
+                  owns. Deprecated: up-to-date fabric-gateway-controller creates RouteGroups
+                  instead of ingresses'
                 type: integer
               observedGeneration:
+                description: Represents the .metadata.generation that the condition
+                  was set based upon. For instance, if .metadata.generation is currently
+                  12, but the .status.observedGeneration is 9, the condition is out
+                  of date with respect to the current state of the instance.
                 format: int64
                 type: integer
               owned_ingress_names:
+                description: 'Names of ingresses which this FabricGateway object owns.
+                  All of them reside in the same namespace as FabricGateway does.
+                  Deprecated: up-to-date fabric-gateway-controller creates RouteGroups
+                  instead of ingresses'
                 items:
                   type: string
                 type: array
               owned_routegroup_names:
+                description: Names of RouteGroups which this FabricGateway object
+                  owns. All of them reside in the same namespace as FabricGateway
+                  does
                 items:
                   type: string
                 type: array
               problems:
+                description: The problems fabric-gateway-controller has encountered
+                  while creating the object related to this FabricGateway resource
                 items:
                   type: string
                 type: array


### PR DESCRIPTION
This change is needed to fill up output of `kubectl explain ...` missing fields, for example `kubectl explain fg.spec.x-fabric-service`:

Before:
```
$ kubectl explain fg.spec.x-fabric-service | head -7
KIND:     FabricGateway
VERSION:  zalando.org/v1

RESOURCE: x-fabric-service <[]Object>

DESCRIPTION:
     <empty>
$
```

After:
```
$ kubectl explain fg.spec.x-fabric-service | head -9
KIND:     FabricGateway
VERSION:  zalando.org/v1

RESOURCE: x-fabric-service <[]Object>

DESCRIPTION:
     Makes the specified service from the same namespace available on the
     specified host name

$
```