### PR TITLE
Avoid overwrite for deployment event resource

### DIFF
--- a/_deploy_event/configmap.yaml
+++ b/_deploy_event/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "kubernetes-deploy-event"
+  name: "kubernetes-deploy-event-{{{CDP_TARGET_BRANCH}}}"
   labels:
     application: "kubernetes"
     component: "deploy-event"


### PR DESCRIPTION
Follow up to #6629 which adds the branch name to the resource to avoid overwrite warnings on all PRs like this:

![image](https://github.com/zalando-incubator/kubernetes-on-aws/assets/128566/27131563-a762-4533-9ec6-18efd368b514)
