### PR TITLE
Set DeletionPolicy to retain for deplyoment secret kms key

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -760,11 +760,13 @@ Resources:
         Version: 2012-10-17
       KeyUsage: ENCRYPT_DECRYPT
     Type: 'AWS::KMS::Key'
+    DeletionPolicy: Retain
   DeploymentSecretKeyAlias:
     Properties:
       AliasName: "alias/{{.Cluster.LocalID}}-deployment-secret"
       TargetKeyId: !Ref DeploymentSecretKey
     Type: 'AWS::KMS::Alias'
+    DeletionPolicy: Retain
   DeploymentServiceBucket:
     Type: AWS::S3::Bucket
     DeletionPolicy: Delete

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -761,12 +761,14 @@ Resources:
       KeyUsage: ENCRYPT_DECRYPT
     Type: 'AWS::KMS::Key'
     DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
   DeploymentSecretKeyAlias:
     Properties:
       AliasName: "alias/{{.Cluster.LocalID}}-deployment-secret"
       TargetKeyId: !Ref DeploymentSecretKey
     Type: 'AWS::KMS::Alias'
     DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
   DeploymentServiceBucket:
     Type: AWS::S3::Bucket
     DeletionPolicy: Delete


### PR DESCRIPTION
Preparation to move kms key/alias creation to AILM

This will allow us to remove the resources from the cluster.yaml stack while retaining them and importing in AILM config later on.

#6642 will enable the actual deletion from stack per cluster.

Opened as a local branch in favor of #6640 