### PR TITLE
Allow disabling deployment secret key management in cluster stack

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -714,6 +714,7 @@ Resources:
         - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-AllowPowerUser"
       RoleName: "{{.Cluster.LocalID}}-deployment"
     Type: 'AWS::IAM::Role'
+{{- if eq .Cluster.ConfigItems.deployment_secret_key_managed "true" }}
   DeploymentSecretKey:
     Properties:
       Description: Key used by deployment pipeline for secret encryption/decryption
@@ -769,6 +770,7 @@ Resources:
     Type: 'AWS::KMS::Alias'
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
+{{- end }}
   DeploymentServiceBucket:
     Type: AWS::S3::Bucket
     DeletionPolicy: Delete

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -994,3 +994,8 @@ min_domains_in_pod_topology_spread_enabled: "true"
 # enable CronJobTimeZone
 # https://v1-24.docs.kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones
 cronjob_time_zone_enabled: "true"
+
+# flag to control if the deployment secret key is managed by the cluster stack
+# or not. When set to a value != "true" the key will be removed from the stack.
+# TODO: remove after migrating out of all cluster stacks.
+deployment_secret_key_managed: "true"


### PR DESCRIPTION
Related to #6641 this allows removing the Deployment Secret key from the cluster stack via a config-item: `deployment_secret_key_managed`.

This will allow us to slowly migrate the KMS key to central management cluster by cluster.

To be 100% safe, this should only be merged once #6641 is fully rolled out.