### PR TITLE
ingress-controller: add application stack tag

### DIFF
--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -44,7 +44,8 @@ spec:
             # {{ end }}
             - --cluster-local-domain=cluster.local
             - --deny-internal-domains
-            - "--additional-stack-tags=InfrastructureComponent=true"
+            - --additional-stack-tags=InfrastructureComponent=true
+            - --additional-stack-tags=application=kube-ingress-aws-controller
             # {{ if or (eq .Cluster.ConfigItems.nlb_switch "pre") (eq .Cluster.ConfigItems.nlb_switch "exec") }}
             - --nlb-http-enabled
             - --nlb-http-target-port=9998


### PR DESCRIPTION
Controller propagates stack tags to loadbalancers and target groups.
Update of loadbalancer and target group tags requires no interruption,
see
* https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-tags
* https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-loadbalancer.html#cfn-elasticloadbalancingv2-loadbalancer-tags
