### PR TITLE
Increase CPU resources for kubelet-summary-proxy

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -341,7 +341,7 @@ cadvisor_profiling_enabled: "false"
 # settings for enabling the kubelet-summary-metrics proxy and prometheus metric
 # collection.
 kubelet_summary_metrics_enabled: "true"
-kubelet_summary_metrics_cpu: "10m"
+kubelet_summary_metrics_cpu: "100m"
 kubelet_summary_metrics_memory: "512Mi"
 kubelet_summary_metrics_hpa_max_replicas: "10"
 kubelet_summary_metrics_hpa_cpu_target: "80"


### PR DESCRIPTION
I was a bit too optimistic setting `10m` as default. With `100m` only two pods are needed in a big cluster with `250` nodes, so that seems like a reasonable value.

ref: #6593 