### PR TITLE
Mark nodes for decommissioning if not ready in time

### DIFF
--- a/cluster/manifests/kube-node-ready-controller/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready-controller/daemonset.yaml
@@ -36,7 +36,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: controller
-        image: container-registry.zalando.net/teapot/kube-node-ready-controller:master-19
+        image: container-registry.zalando.net/teapot/kube-node-ready-controller:master-20
         resources:
           requests:
             cpu: {{.Cluster.ConfigItems.kube_node_ready_controller_cpu}}


### PR DESCRIPTION
With Cluster Autoscaler nodes that don't get ready in time are treated as empty nodes and will be replaced. This solves the problem of getting a bad node and automatically having it replaced.

With Karpenter this does _not_ happen because Karpenter keeps waiting for the not-ready taint to be removed so a node can be stuck for ever and Karpenter does not spin up any other nodes in this time leading to pods pending forever.

This PR updates kube-node-ready-controller to a version that implements marking a node for decommissioning if it's not getting ready within 10 min. after creation.