### PR TITLE
Add load balancer tags from service labels

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -205,7 +205,7 @@ write_files:
             limits:
               memory: {{ .Values.InstanceInfo.MemoryFraction (parseInt64 .Cluster.ConfigItems.apiserver_memory_limit_percent)}}
 {{- end }}
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-180
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-181
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
### Problem

Currently AWS Load balancers created from services of type LoadBalancer don't have any `application` or `component` tags which makes ownership/cost attribution hard.

This problem is also raised as a feature request from users.

### Solution

It's possible to inject tags on the AWS LoadBalancer by setting the annotation: `service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags` on the service resource: https://github.com/kubernetes/kubernetes/blob/22a9682c8fe855c321be75c5faacde343f909b04/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go#L186-L190

To avoid the need for users adding this annotation, this PR implements automatic injection of this annotation based on labels on the service. That is, if `application` and/or `component` labels are defined they will be used to set the annotation on the service. If the users already set the annotation for other labels, it will just be extended to include `application` and/or `component` tags as well.
If the users already define `application` and/or `component` tag with a different value than in the labels, then it will be treated as an error and the service resource is not admitted. (There are no existing services which have this conflict, so no issue for the roll out).