### PR TITLE
Fix application association for deploy-event

### DIFF
--- a/_deploy_event/configmap.yaml
+++ b/_deploy_event/configmap.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: "{{{APPLICATION}}}-{{{COMPONENT}}}-{{{CDP_TARGET_BRANCH}}}"
-  labels:
-    application: "{{{APPLICATION}}}"
-    component: "{{{COMPONENT}}}"
-data:
-  empty-event: "deployment"

--- a/_deploy_event/stack.yaml
+++ b/_deploy_event/stack.yaml
@@ -1,0 +1,17 @@
+Metadata:
+  StackName: "kubernetes-on-aws-deploy-event-{{{CDP_TARGET_BRANCH}}}"
+  Tags:
+    application: "kubernetes"
+    component: "deploy-event"
+
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "Empty stack to emit deploy event"
+
+Conditions:
+  Never:
+    !Equals [ "A", "B" ]
+
+Resources:
+  NonResource:
+    Type: Custom::NonResource
+    Condition: Never

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -325,6 +325,3 @@ pipeline:
     - stable
   sources:
     - dir: _deploy_event
-      template_vars:
-        APPLICATION: kubernetes
-        COMPONENT: deploy-event


### PR DESCRIPTION
Follow up to #6664 and #6629

The other PRs did not work because CDP could not associate an application with the deployment. This is because the application is derived from labels/tags on the resources and configmap is not supported for deriving application.

This changes to use a CF stack instead of configmap which is supported.