### PR TITLE
Only run kube2iam on worker nodes

### DIFF
--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -23,6 +23,8 @@ spec:
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
+      nodeSelector:
+        node.kubernetes.io/role: worker
       dnsConfig:
         options:
           - name: ndots


### PR DESCRIPTION
Run kube2iam only on worker nodes. This is motivated by two things:

1. Reduce the resources overhead on master nodes, relevant for very small master nodes in test clusters
2. There is no components depending on kube2iam on master nodes, so no reason to run it there.