### PR TITLE
Fix reference to deploy key

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -876,11 +876,14 @@ Resources:
               - Action:
                   - kms:Decrypt
                 Effect: Allow
-                Resource:
 {{- if eq .Cluster.ConfigItems.deployment_secret_key_managed "true" }}
+                Resource:
                   - !GetAtt DeploymentSecretKey.Arn
 {{- else }}
-                  - !ImportValue "DeploymentKeyArn"
+                Resource: "*"
+                Condition:
+                  StringLike:
+                    "kms:RequestAlias": "alias/deployment-secret"
 {{- end }}
               - Action:
                   - 'sts:AssumeRole'

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -875,9 +875,13 @@ Resources:
                 Effect: Allow
               - Action:
                   - kms:Decrypt
-                Resource:
-                  - !GetAtt DeploymentSecretKey.Arn
                 Effect: Allow
+                Resource:
+{{- if eq .Cluster.ConfigItems.deployment_secret_key_managed "true" }}
+                  - !GetAtt DeploymentSecretKey.Arn
+{{- else }}
+                  - !ImportValue "DeploymentKeyArn"
+{{- end }}
               - Action:
                   - 'sts:AssumeRole'
                 Effect: Allow

--- a/cluster/manifests/deployment-service/controller-statefulset.yaml
+++ b/cluster/manifests/deployment-service/controller-statefulset.yaml
@@ -29,9 +29,10 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
         - name: "deployment-service-controller"
-          image: "container-registry.zalando.net/teapot/deployment-controller:master-159"
+          image: "container-registry.zalando.net/teapot/deployment-controller:master-162"
           args:
             - "--config-namespace=kube-system"
+            - "--decrypt-kms-alias-arn=arn:aws:kms:{{ .Cluster.Region }}:{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:alias/deployment-secret"
           env:
             - name: AWS_REGION
               value: "{{.Cluster.Region}}"

--- a/cluster/manifests/deployment-service/status-service-deployment.yaml
+++ b/cluster/manifests/deployment-service/status-service-deployment.yaml
@@ -1,5 +1,5 @@
 {{ $image   := "container-registry.zalando.net/teapot/deployment-status-service" }}
-{{ $version := "master-159" }}
+{{ $version := "master-162" }}
 
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Follow up to #6641 and #6642 remove reference to cluster managed key if the key is not managed in cluster.yaml

When the key is managed account wide we give deployment-service access based on alias: https://docs.aws.amazon.com/kms/latest/developerguide/alias-authorization.html