### PR TITLE
Only run ebs-csi-node on worker nodes

### DIFF
--- a/cluster/manifests/03-ebs-csi/node.yaml
+++ b/cluster/manifests/03-ebs-csi/node.yaml
@@ -21,6 +21,8 @@ spec:
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
+      nodeSelector:
+        node.kubernetes.io/role: worker
       serviceAccountName: ebs-csi-node-sa
       priorityClassName: system-node-critical
       tolerations:


### PR DESCRIPTION
Similar to #6668 we don't need volumes on master nodes, so only run ebs-csi-node daemonset on worker nodes to save some CPU resources on small master nodes. 