### PR TITLE
Update audittrail-adapter version

### DIFF
--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
       hostNetwork: true
       containers:
       - name: audittrail-adapter
-        image: container-registry.zalando.net/teapot/audittrail-adapter:master-47
+        image: container-registry.zalando.net/teapot/audittrail-adapter:master-48
         env:
           - name: AWS_REGION
             value: {{.Cluster.Region}}


### PR DESCRIPTION
Update the Audittrail Adapter version. This version restructures how Prometheus metrics are collected within the Adapter as preparation for integrating Nakadi functionality.