### PR TITLE
Pass region to karpenter

### DIFF
--- a/cluster/manifests/z-karpenter/deployment.yaml
+++ b/cluster/manifests/z-karpenter/deployment.yaml
@@ -42,6 +42,8 @@ spec:
         - name: controller
           image: "container-registry.zalando.net/teapot/karpenter:v0.31.3-main-16.custom"
           env:
+            - name: AWS_REGION
+              value: "{{ .Cluster.Region }}"
             - name: KUBERNETES_MIN_VERSION
               value: "1.22.0-0"
             - name: KARPENTER_SERVICE


### PR DESCRIPTION
Pass region to Karpenter to avoid karpenter needing to call the ec2 instance metadata endpoint which we intend to block in the future.

Related to #6669 