### PR TITLE
Update aws-encryption-provider to latest version

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -530,7 +530,7 @@ write_files:
             runAsNonRoot: true
             runAsUser: 1000
         - name: aws-encryption-provider
-          image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/aws-encryption-provider:master-3
+          image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/aws-encryption-provider:2d868b88c45572a5986dfe2820add60c8f858f06-main-2.custom
           command:
           - /aws-encryption-provider
           - --key=arn:aws:kms:{{ .Cluster.Region }}:{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:key/{{ .Values.ClusterStackOutputs.EtcdEncryptionKey }}


### PR DESCRIPTION
Updates the aws-encryption-provider to the latest version.

This is to make it work with #6669 