### PR TITLE
Revert "Only run kube2iam on worker nodes"

### DIFF
--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -23,8 +23,6 @@ spec:
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
-      nodeSelector:
-        node.kubernetes.io/role: worker
       dnsConfig:
         options:
           - name: ndots


### PR DESCRIPTION
Reverts zalando-incubator/kubernetes-on-aws#6668

Does not work because karpenter and kube-node-ready currently depend on EC2 metadata service endpoint