### PR TITLE
Add ephemeral storage limit to etcd-backup job

### DIFF
--- a/cluster/manifests/etcd-backup/cronjob.yaml
+++ b/cluster/manifests/etcd-backup/cronjob.yaml
@@ -53,9 +53,11 @@ spec:
               limits:
                 cpu: 1m
                 memory: 384Mi
+                ephemeral-storage: 8Gi
               requests:
                 cpu: 1m
                 memory: 384Mi
+                ephemeral-storage: 8Gi
             volumeMounts:
 {{ if index .Cluster.ConfigItems "etcd_client_ca_cert" }}
             - name: etcd-ca


### PR DESCRIPTION
This adds ephemeral-storage limit/requests to the `etcd-backup` cronjob. The 8Gi is choosen based on the upper limit for etcd storage size.