### PR TITLE
Add field for controlling traffic segment enablement.

### DIFF
--- a/cluster/manifests/deployment-service/01-config.yaml
+++ b/cluster/manifests/deployment-service/01-config.yaml
@@ -20,3 +20,4 @@ data:
   ml-experiment-deployment-role-arn: "arn:aws:iam::{{accountID .Cluster.InfrastructureAccount}}:role/{{.Cluster.LocalID}}-deployment-service-ml-experiment-deployment"
 {{- end }}
   cloudformation-enable-auto-expand: "{{.Cluster.ConfigItems.deployment_service_cf_auto_expand_enabled}}"
+  probe-for-traffic-segments: "{{.Cluster.ConfigItems.stackset_enable_traffic_segments}}"


### PR DESCRIPTION
Adds the field `probe-for-traffic-segments` in the deployment-service configuration. Both `cdp-steps` and `deployment-service` will use this field to control enabling/diasbling traffic segment probling.

We use the already existing config item that the StackSet controller uses to control this feature.