### PR TITLE
Control traffic segment feature in deployment-service

### DIFF
--- a/cluster/manifests/deployment-service/controller-statefulset.yaml
+++ b/cluster/manifests/deployment-service/controller-statefulset.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
         - name: "deployment-service-controller"
-          image: "container-registry.zalando.net/teapot/deployment-controller:master-162"
+          image: "container-registry.zalando.net/teapot/deployment-controller:master-163"
           args:
             - "--config-namespace=kube-system"
 {{- if ne .Cluster.ConfigItems.deployment_secret_key_managed "true" }}

--- a/cluster/manifests/deployment-service/status-service-deployment.yaml
+++ b/cluster/manifests/deployment-service/status-service-deployment.yaml
@@ -1,5 +1,5 @@
 {{ $image   := "container-registry.zalando.net/teapot/deployment-status-service" }}
-{{ $version := "master-162" }}
+{{ $version := "master-163" }}
 
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
New version allows controlling traffic segment probing through a config map field/config item, defined in https://github.com/zalando-incubator/kubernetes-on-aws/pull/6691