### PR TITLE
Update Audittrail Adapter version

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1964,23 +1964,11 @@ Resources:
                 Effect: Allow
                 Resource:
                   - !GetAtt AuditTrailBucket.Arn
-                  - arn:aws:s3:::zalando-audittrail-central
-                    {{- if eq .Cluster.Environment "production" }}
-                  - arn:aws:s3:::zalando-kubernetes-audit
-                    {{- else }}
-                  - arn:aws:s3:::zalando-kubernetes-audit-test
-                    {{- end }}
 
               - Action:
                   - s3:PutObject
                 Effect: Allow
                 Resource:
-                  - arn:aws:s3:::zalando-audittrail-central/*
-                    {{- if eq .Cluster.Environment "production" }}
-                  - arn:aws:s3:::zalando-kubernetes-audit/*
-                    {{- else }}
-                  - arn:aws:s3:::zalando-kubernetes-audit-test/*
-                    {{- end }}
                   - !Sub
                     - "${BucketArn}/*"
                     - BucketArn: !GetAtt AuditTrailBucket.Arn

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -667,7 +667,6 @@ audittrail_adapter_cpu: "50m"
 audittrail_adapter_memory: "200Mi"
 
 audittrail_adapter_timeout: "2s"
-audittrail_adapter_bucket: "zalando-kubernetes-audit"
 
 # When enabled, any read-only events are added to the metrics, but are dropped
 # before being sent to audittrail-api.

--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
       hostNetwork: true
       containers:
       - name: audittrail-adapter
-        image: container-registry.zalando.net/teapot/audittrail-adapter:master-48
+        image: container-registry.zalando.net/teapot/audittrail-adapter:master-49
         env:
           - name: AWS_REGION
             value: {{.Cluster.Region}}
@@ -41,7 +41,6 @@ spec:
         - --cluster-id={{ .ID }}
         - --cluster-alias={{ .Cluster.Alias }}
         - --audittrail-url={{ .Cluster.ConfigItems.audittrail_url }}
-        - --s3-audit-bucket-name={{ .Cluster.ConfigItems.audittrail_adapter_bucket }}
         - --s3-fallback-bucket-name=zalando-audittrail-{{accountID .InfrastructureAccount}}-{{.LocalID}}
         - --address=:8889
         - --metrics-address=:7980


### PR DESCRIPTION
This version refactors how Audittrail sends events to auditing backends:
- Sending events directly to S3 as a primary backend will be disabled (S3 as a fallback will remain)
- Sending events to auditing backends (e.g. audittrail-api) will now be done concurrently

Additionally:
- Update Audittrail IAM policy to reflect changes
- Remove now-unused config-item