### PR TITLE
Update skipper-ingress to deploy lock-free endpointregistry

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,5 +1,5 @@
 {{ $internal_version := "v0.18.69-718" }}
-{{ $canary_internal_version := "v0.18.69-718" }}
+{{ $canary_internal_version := "v0.18.82-731" }}
 
 {{ template "skipper-ingress" dict
   "name" "skipper-ingress"


### PR DESCRIPTION
FYI https://github.com/zalando/skipper/compare/v0.18.69...v0.18.82
