### PR TITLE
Disable legacy APIs by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -441,8 +441,11 @@ horizontal_pod_downscale_stabilization: "5m0s"
 # enable/disable legacy autoscaling APIs
 # Note StackSet controller still depends on autoscaling/v2beta2 in clusters
 # using horizontalPodAutoscaler field.
-autoscaling_v2beta1_enabled: "true"
-autoscaling_v2beta2_enabled: "true"
+autoscaling_v2beta1_enabled: "false"
+autoscaling_v2beta2_enabled: "false"
+
+# enable/disable legacy api versions prior to v1.25
+batch_v1beta1_enabled: "false"
 
 # Vertical pod autoscaler version for controlling roll-out, can be "current" or "legacy"
 # current => v0.11.0-internal.17

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -127,7 +127,7 @@ write_files:
           {{- end }}
           - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
           - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
-          - --runtime-config=policy/v1beta1=true,authorization.k8s.io/v1beta1=true,scheduling.k8s.io/v1alpha1=true,admissionregistration.k8s.io/v1beta1=true,autoscaling/v2beta2={{ .Cluster.ConfigItems.autoscaling_v2beta2_enabled }},autoscaling/v2beta1={{ .Cluster.ConfigItems.autoscaling_v2beta1_enabled }}
+          - --runtime-config=policy/v1beta1=true,authorization.k8s.io/v1beta1=true,scheduling.k8s.io/v1alpha1=true,admissionregistration.k8s.io/v1beta1=true,autoscaling/v2beta2={{ .Cluster.ConfigItems.autoscaling_v2beta2_enabled }},autoscaling/v2beta1={{ .Cluster.ConfigItems.autoscaling_v2beta1_enabled }},batch/v1beta1={{ .Cluster.ConfigItems.batch_v1beta1_enabled }}
           - --authentication-token-webhook-config-file=/etc/kubernetes/config/authn.yaml
           - --authentication-token-webhook-cache-ttl=10s
           - --cloud-provider=aws


### PR DESCRIPTION
This disables legacy APIs by default which will no longer be available in Kubernetes v1.25 or v1.26.

It's implemented as a config-item so we can easily enable it for some clusters still not fully migrated away from using legacy APIs.

Note: ideally we also wanted to disable `policy/v1beta1` but this is not possible as the apiserver itself uses `policy/v1beta1` for setting up watches for PDBs. So this will be disabled _with_ Kubernetes v1.25