### PR TITLE
deploy: use test cluster for deploy-event

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -315,7 +315,7 @@ pipeline:
 
 - id: deploy-event
   type: deploy
-  target: stups
+  target: stups-test
   when:
     event: push
     branch:
@@ -324,4 +324,4 @@ pipeline:
     - beta
     - stable
   sources:
-    - dir: _deploy_event
+  - dir: _deploy_event


### PR DESCRIPTION
Use test cluster to avoid Access denied error during deploy-event step.

Followup on #6629