### PR TITLE
Tag instance root volumes with application/component

### DIFF
--- a/cluster/etcd/stack.yaml
+++ b/cluster/etcd/stack.yaml
@@ -29,6 +29,13 @@ Resources:
     Properties:
       LaunchTemplateName: '{{.Cluster.ConfigItems.etcd_stack_name}}'
       LaunchTemplateData:
+        TagSpecifications:
+        - ResourceType: "volume"
+          Tags:
+          - Key: application
+            Value: kubernetes
+          - Key: component
+            Value: etcd-cluster
         NetworkInterfaces:
           - DeviceIndex: 0
             AssociatePublicIpAddress: true

--- a/cluster/manifests/z-karpenter/configmap.yaml
+++ b/cluster/manifests/z-karpenter/configmap.yaml
@@ -19,7 +19,7 @@ data:
   "aws.nodeNameConvention": "ip-name"
   "aws.vmMemoryOverheadPercent": "0.075"
   #The global tags to use on all AWS infrastructure resources (launch templates, instances, etc.) across node templates
-  "aws.tags": '{"InfrastructureComponent":"true","application":"kubernetes","component":"worker","environment":"{{ .Cluster.Environment }}"}'
+  "aws.tags": '{"InfrastructureComponent":"true","application":"kubernetes","component":"shared-resource","environment":"{{ .Cluster.Environment }}"}'
   "featureGates.driftEnabled": "false"
   "batchIdleDuration": "1s"
   "batchMaxDuration": "10s"

--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -49,6 +49,13 @@ Resources:
     Properties:
       LaunchTemplateName: '{{.Cluster.LocalID}}-{{ .NodePool.Name }}'
       LaunchTemplateData:
+        TagSpecifications:
+        - ResourceType: "volume"
+          Tags:
+          - Key: application
+            Value: kubernetes
+          - Key: component
+            Value: control-plane
 {{ if .Values.supports_t2_unlimited }}
         CreditSpecification:
           CpuCredits: unlimited

--- a/cluster/node-pools/worker-combined/stack.yaml
+++ b/cluster/node-pools/worker-combined/stack.yaml
@@ -124,6 +124,13 @@ Resources:
     Properties:
       LaunchTemplateName: '{{.Cluster.LocalID}}-{{ .NodePool.Name }}'
       LaunchTemplateData:
+        TagSpecifications:
+        - ResourceType: "volume"
+          Tags:
+          - Key: application
+            Value: kubernetes
+          - Key: component
+            Value: "shared-resource"
         BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -137,6 +137,13 @@ Resources:
     Properties:
       LaunchTemplateName: '{{ $data.Cluster.LocalID }}-{{ $data.NodePool.Name }}'
       LaunchTemplateData:
+        TagSpecifications:
+        - ResourceType: "volume"
+          Tags:
+          - Key: application
+            Value: kubernetes
+          - Key: component
+            Value: "shared-resource"
         BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:


### PR DESCRIPTION
Add application/component tag to root volumes when instances are launched. This enables better allocation of cost for volumes.

## TODO:

* [x] Tags for karpenter instances.