### PR TITLE
Don't create metrics with zero timestamp

### DIFF
--- a/cluster/manifests/kubelet-summary-metrics/deployment.yaml
+++ b/cluster/manifests/kubelet-summary-metrics/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: kubelet-summary-metrics
       containers:
       - name: proxy
-        image: container-registry.zalando.net/teapot/kubelet-summary-metrics:main-1
+        image: container-registry.zalando.net/teapot/kubelet-summary-metrics:main-2
         resources:
           limits:
             cpu: "{{.Cluster.ConfigItems.kubelet_summary_metrics_cpu}}"


### PR DESCRIPTION
Fixes a bug in kubelet-summary-metrics where it would expose metrics with zero timestamps which is not valid in systems consuming the metrics.