### PR TITLE
Only tag worker node volumes when updating to jammy

### DIFF
--- a/cluster/node-pools/worker-combined/stack.yaml
+++ b/cluster/node-pools/worker-combined/stack.yaml
@@ -124,6 +124,7 @@ Resources:
     Properties:
       LaunchTemplateName: '{{.Cluster.LocalID}}-{{ .NodePool.Name }}'
       LaunchTemplateData:
+{{- if eq .Cluster.ConfigItems.kuberuntu_distro_worker "jammy" }}
         TagSpecifications:
         - ResourceType: "volume"
           Tags:
@@ -131,6 +132,7 @@ Resources:
             Value: kubernetes
           - Key: component
             Value: "shared-resource"
+{{- end }}
         BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -137,6 +137,7 @@ Resources:
     Properties:
       LaunchTemplateName: '{{ $data.Cluster.LocalID }}-{{ $data.NodePool.Name }}'
       LaunchTemplateData:
+{{- if eq .Cluster.ConfigItems.kuberuntu_distro_worker "jammy" }}
         TagSpecifications:
         - ResourceType: "volume"
           Tags:
@@ -144,6 +145,7 @@ Resources:
             Value: kubernetes
           - Key: component
             Value: "shared-resource"
+{{- end }}
         BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:


### PR DESCRIPTION
This is a follow up to #6712 to only add volume tags to worker nodes when rotating the nodes for the Ubuntu update. Otherwise the nodes will rotate because of the LaunchTemplate change which was not desired to do right now.