### PR TITLE
skipper: disable catchall routes by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -299,7 +299,7 @@ skipper_ingress_backend_traffic_algorithm: "traffic-segment-predicate"
 # TODO: after a while we can remove this and hardcode (2023-06-30)
 skipper_ingress_default_lb_algorithm: "powerOfRandomNChoices"
 
-skipper_ingress_disable_catchall_routes: "false"
+skipper_ingress_disable_catchall_routes: "true"
 
 # Set defaults values that would enable Open Policy Agent in a skipper filter
 skipper_open_policy_agent_enabled: "false"


### PR DESCRIPTION
Catchall routes are already disabled in cluster registry.

Followup on #6537