### PR TITLE
Update skipper-ingress to deploy lock-free endpointregistry step2

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.18.69-718" }}
+{{ $internal_version := "v0.18.82-731" }}
 {{ $canary_internal_version := "v0.18.82-731" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}


### PR DESCRIPTION
step2 from https://github.com/zalando-incubator/kubernetes-on-aws/pull/6705