### PR TITLE
fix: skipper-ingress route lookup edge case with fabric and stackset 1/2

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,5 +1,5 @@
 {{ $internal_version := "v0.18.82-731" }}
-{{ $canary_internal_version := "v0.18.82-731" }}
+{{ $canary_internal_version := "v0.18.92-741" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}
 {{ $canary_args := "" }}


### PR DESCRIPTION
fix: skipper-ingress route lookup edge case with fabric and stackset

step 1 canary only

https://github.com/zalando/skipper/compare/v0.18.82...v0.18.92