### PR TITLE
Expose more metrics via kubelet-summary-metrics

### DIFF
--- a/cluster/manifests/kubelet-summary-metrics/deployment.yaml
+++ b/cluster/manifests/kubelet-summary-metrics/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: kubelet-summary-metrics
       containers:
       - name: proxy
-        image: container-registry.zalando.net/teapot/kubelet-summary-metrics:main-2
+        image: container-registry.zalando.net/teapot/kubelet-summary-metrics:main-3
         resources:
           limits:
             cpu: "{{.Cluster.ConfigItems.kubelet_summary_metrics_cpu}}"


### PR DESCRIPTION
Extends the proxy to expose the following additional metric types:

* CPU
* Memory
* Network