### PR TITLE
update etcd AMI with logrotate fix

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -615,7 +615,7 @@ etcd_instance_type: "t3.medium"
 {{end}}
 
 etcd_scalyr_key: ""
-etcd_ami: {{ amiID "zalando-ubuntu-etcd-production-v3.5.9-amd64-main-20" "861068367966"}}
+etcd_ami: {{ amiID "zalando-ubuntu-etcd-production-v3.5.9-amd64-main-21" "861068367966"}}
 
 dynamodb_service_link_enabled: "false"
 


### PR DESCRIPTION
Updates the etcd AMI that includes the logrotate fix.

More context: https://github.bus.zalan.do/teapot/issues/issues/3486