### PR TITLE
Adding ClusterRole and config-items for config-provider-service controller

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -930,8 +930,9 @@ disable_zmon_appliance_worker_tracking: "true"
 # Add ClusterRole for clusters required by hyped-article-lifecycle-management controller
 hyped_article_lifecycle_management: "false"
 
-# Add ClusterRole for clusters required by business-partner controller
+# Add ClusterRole for clusters required by business-partner and config-provider controller
 business_partner_service: "false"
+config_provider_service: "false"
 
 # enable SizeMemoryBackedVolumes feature flag
 enable_size_memory_backed_volumes: "true"

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -247,6 +247,12 @@ post_apply:
 - name: business-partner-service
   kind: ClusterRoleBinding
 {{ end }}
+{{ if eq .Cluster.ConfigItems.config_provider_service "false" }}
+- name: config-provider-service
+  kind: ClusterRole
+- name: config-provider-service
+  kind: ClusterRoleBinding
+{{ end }}
 {{ if ne .Cluster.ConfigItems.kubelet_summary_metrics_enabled "true" }}
 - name: kubelet-summary-metrics
   kind: ClusterRole

--- a/cluster/manifests/roles/config-provider-rbac.yaml
+++ b/cluster/manifests/roles/config-provider-rbac.yaml
@@ -1,0 +1,33 @@
+{{- if eq .Cluster.ConfigItems.config_provider_service "true" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: config-provider-service
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - business-partners-config
+  - sales-channels-config
+  verbs:
+  - get
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: config-provider-service
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: config-provider-service
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: zalando-iam:zalando:service:stups_config-provider-service
+{{- end }}


### PR DESCRIPTION
Related Teapot Issue: [Enabling business_partners and sales_channels configmaps for application: config-provider-service](https://github.bus.zalan.do/zooport/issues/issues/4290)

The PR introduces a ClusterRole/ClusterRoleBinding providing the config-provider-service controller access to the relevant configmaps. It also adds a config-item which will then be enabled in the specific clusters which the controller requires access to. Similar change was done in https://github.com/zalando-incubator/kubernetes-on-aws/pull/6084