### PR TITLE
skipper: update main to v0.18.92-741

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.18.82-731" }}
+{{ $internal_version := "v0.18.92-741" }}
 {{ $canary_internal_version := "v0.18.92-741" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}


### PR DESCRIPTION
https://github.com/zalando/skipper/compare/v0.18.82...v0.18.92

dataclients/kubernetes: partially create RouteGroup routes on missing service https://github.com/zalando/skipper/pull/2796

Followup on https://github.com/zalando-incubator/kubernetes-on-aws/pull/6723