### PR TITLE
Update skipper version to introduce logBody() filter and normalize routing.Route host, step 2/2

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.18.94-743" }}
+{{ $internal_version := "v0.18.99-748" }}
 {{ $canary_internal_version := "v0.18.99-748" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}


### PR DESCRIPTION
FYI https://github.com/zalando/skipper/compare/v0.18.94...v0.18.99

Merge only after https://github.com/zalando-incubator/kubernetes-on-aws/pull/6752