### PR TITLE
etcd: move scalyr key to files.yaml

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -625,7 +625,7 @@ etcd_instance_type: "t3.medium"
 {{end}}
 
 etcd_scalyr_key: ""
-etcd_ami: {{ amiID "zalando-ubuntu-etcd-production-v3.5.9-amd64-main-21" "861068367966"}}
+etcd_ami: {{ amiID "zalando-ubuntu-etcd-production-v3.5.9-amd64-main-24" "861068367966"}}
 
 dynamodb_service_link_enabled: "false"
 

--- a/cluster/etcd/files.yaml
+++ b/cluster/etcd/files.yaml
@@ -11,3 +11,7 @@ files:
     data: "{{ .Cluster.ConfigItems.etcd_client_server_key }}"
     permissions: 0400
     encrypted: true
+  - path: /etc/scalyr-agent-2/userdata.yaml
+    data: {{ printf "scalyr_api_key: %s\ncluster_alias: %s\n" .Cluster.ConfigItems.etcd_scalyr_key .Cluster.Alias | base64 }}
+    permissions: 0400
+    encrypted: true

--- a/cluster/etcd/stack.yaml
+++ b/cluster/etcd/stack.yaml
@@ -51,11 +51,6 @@ Resources:
           Fn::Base64: !Sub |
             #cloud-config
             write_files:
-              - path: /etc/scalyr-agent-2/userdata.yaml
-                permissions: 0644
-                content: |
-                  scalyr_api_key: "{{.Values.etcd_scalyr_key}}"
-                  stack_name: ${AWS::StackName}
               - path: /etc/default/etcd
                 permissions: 0644
                 content: |
@@ -65,7 +60,7 @@ Resources:
                   ETCD_LOG_LEVEL=info
                   HOSTED_ZONE="{{.Values.hosted_zone}}"
                   S3_CERTS_BUCKET="{{ .S3GeneratedFilesPath }}"
-                  AWS_DEFAULT_REGION=eu-central-1
+                  AWS_DEFAULT_REGION="{{ .Cluster.Region }}"
             runcmd:
               - [ cfn-signal, --success, 'true', --stack, ${AWS::StackName}, --resource, AppServer, --region, ${AWS::Region} ]
               - [ complete-asg-lifecycle.py, 'etcd-server-lifecycle-hook' ]


### PR DESCRIPTION
This change fixes a bug where the userdata of the etcd launchtemplate always change when the etcd stack is rendered which causes a new launch template version leading to a need for rotating etcds more often than needed.

The issue happens because the scalyr key is encrypted and the encrypted value is stored in the userdata. The encrypted value is _always_ different although the underlying key doesn't change.

The fix is to move the scalyr config file to the files.yaml such that the encrypted value will be stored on s3 and pulled down at etcd instance startup like what happens for the certificate files. This way the userdata stays the same and launchtemplate doesn't change either.

Since we don't have easy access to the stackname in the files.yaml we remove the stack_name key from the scalyr config and instead pass `cluster_alias`. The stack is legacy from STUPS days and not very meaningful when querying in scalyr.