### PR TITLE
Update ensure-apiserver for optional ipv6 support

### DIFF
--- a/cluster/manifests/coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/coredns-local/daemonset-coredns.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       initContainers:
       - name: ensure-apiserver
-        image: container-registry.zalando.net/teapot/ensure-apiserver:master-3
+        image: container-registry.zalando.net/teapot/ensure-apiserver:master-5
         resources:
           requests:
             cpu: 1m

--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: flannel
       initContainers:
       - name: ensure-apiserver
-        image: container-registry.zalando.net/teapot/ensure-apiserver:master-3
+        image: container-registry.zalando.net/teapot/ensure-apiserver:master-5
         resources:
           requests:
             cpu: 1m


### PR DESCRIPTION
Updates the ensure-apiserver container to a version that can handle apiservers with IPv6 addresses. This is not relevant on the short term but can be helpful in the future. As long as we have IPv4 it will continue to work as usual.