### PR TITLE
skipper: cleanup skipper_ingress_opentracing_excluded_proxy_tags

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -230,7 +230,7 @@ skipper_max_tcp_listener_concurrency: "-1"
 skipper_max_tcp_listener_queue: "-1"
 
 # opentracing
-skipper_ingress_opentracing_excluded_proxy_tags: "skipper.route"
+skipper_ingress_opentracing_excluded_proxy_tags: ""
 skipper_ingress_opentracing_backend_name_tag: "true"
 skipper_opentracing_disable_filter_spans: "true"
 # lightstep


### PR DESCRIPTION
`skipper.route` tag was removed long ago, see https://github.com/zalando/skipper/pull/1907