### PR TITLE
Updated skipper version to use endpointregistry in the hotpath, step 2/2

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.18.99-748" }}
+{{ $internal_version := "v0.19.1-752" }}
 {{ $canary_internal_version := "v0.19.1-752" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}


### PR DESCRIPTION
FYI https://github.com/zalando/skipper/compare/v0.18.99...v0.19.1

Merge https://github.com/zalando-incubator/kubernetes-on-aws/pull/6772 first (merged up to stable, it works fine).