### PR TITLE
remove unused version field from manifests

### DIFF
--- a/cluster/manifests/dashboard/deployment.yaml
+++ b/cluster/manifests/dashboard/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     application: kubernetes
     component: dashboard
-    version: v2.4.0
 spec:
   replicas: 1
   selector:
@@ -18,7 +17,6 @@ spec:
         application: kubernetes
         component: dashboard
         deployment: kubernetes-dashboard
-        version: v2.4.0
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:

--- a/cluster/manifests/dashboard/scraper.yaml
+++ b/cluster/manifests/dashboard/scraper.yaml
@@ -25,7 +25,6 @@ metadata:
   labels:
     application: kubernetes
     component: dashboard-metrics-scraper
-    version: v1.0.7
 spec:
   replicas: 1
   selector:
@@ -37,7 +36,6 @@ spec:
         application: kubernetes
         component: dashboard-metrics-scraper
         deployment: dashboard-metrics-scraper
-        version: v1.0.7
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:

--- a/cluster/manifests/efs-provisioner/depl-efs-provisioner.yaml
+++ b/cluster/manifests/efs-provisioner/depl-efs-provisioner.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     application: kubernetes
     component: efs-provisioner
-    version: v2.4.0
 spec:
   strategy:
     type: Recreate
@@ -20,7 +19,6 @@ spec:
         application: kubernetes
         component: efs-provisioner
         deployment: efs-provisioner
-        version: v2.4.0
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:

--- a/cluster/manifests/kube-downscaler/deployment.yaml
+++ b/cluster/manifests/kube-downscaler/deployment.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     application: kubernetes
     component: kube-downscaler
-    version: v20.4.1
 spec:
   replicas: 1
   selector:
@@ -19,7 +18,6 @@ spec:
         deployment: kube-downscaler
         application: kubernetes
         component: kube-downscaler
-        version: v20.4.1
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:

--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     application: kubernetes
     component: kube2iam
-    version: 0.11.1
 spec:
   selector:
     matchLabels:
@@ -19,7 +18,6 @@ spec:
         daemonset: kube2iam
         application: kubernetes
         component: kube2iam
-        version: 0.11.1
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:

--- a/cluster/manifests/kubenurse/prometheus.yaml
+++ b/cluster/manifests/kubenurse/prometheus.yaml
@@ -9,7 +9,6 @@ metadata:
   labels:
     application: kubernetes
     component: kubenurse-prometheus
-    version: v2.41.0
   name: prometheus
   namespace: kubenurse
 spec:
@@ -25,7 +24,6 @@ spec:
         statefulset: kubenurse-prometheus
         application: kubernetes
         component: kubenurse-prometheus
-        version: v2.41.0
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
         prometheus.io/path: /metrics

--- a/cluster/manifests/pdb-controller/deployment.yaml
+++ b/cluster/manifests/pdb-controller/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     application: kubernetes
     component: pdb-controller
-    version: v0.0.19
 spec:
   replicas: 1
   selector:
@@ -18,7 +17,6 @@ spec:
         deployment: pdb-controller
         application: kubernetes
         component: pdb-controller
-        version: v0.0.19
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:

--- a/docs/user-guide/using-volumes.rst
+++ b/docs/user-guide/using-volumes.rst
@@ -39,7 +39,6 @@ instance.
         metadata:
           labels:
             application: redis
-            version: 3.2.5
         spec:
           containers:
           - name: redis
@@ -147,7 +146,6 @@ Modify your deployment in the following way in order to use the persistent volum
         metadata:
           labels:
             application: redis
-            version: 3.2.5
         spec:
           containers:
           - name: redis

--- a/test/e2e/loadtest/client/prom-statefulset.yaml
+++ b/test/e2e/loadtest/client/prom-statefulset.yaml
@@ -3,7 +3,6 @@ kind: StatefulSet
 metadata:
   labels:
     application: loadtest-prometheus
-    version: v2.26.0
   namespace: loadtest-e2e
   name: loadtest-prometheus
 spec:
@@ -17,7 +16,6 @@ spec:
     metadata:
       labels:
         application: loadtest-prometheus
-        version: v2.26.0
       annotations:
         prometheus.io/path: /metrics
         prometheus.io/port: "9090"


### PR DESCRIPTION
The `version` field is not used in many manifests and is often outdated. We decided to clean it up from the manifests.