### PR TITLE
update etcd.py to v3 API

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -625,7 +625,7 @@ etcd_instance_type: "t3.medium"
 {{end}}
 
 etcd_scalyr_key: ""
-etcd_ami: {{ amiID "zalando-ubuntu-etcd-production-v3.5.9-amd64-main-24" "861068367966"}}
+etcd_ami: {{ amiID "zalando-ubuntu-etcd-production-v3.5.9-amd64-main-27" "861068367966"}}
 
 dynamodb_service_link_enabled: "false"
 


### PR DESCRIPTION
Our lifecycle hook script `etcd.py` in the etcd AMI still relies on the long deprecated `v2` API for etcd. This updates the AMI to fully remove `v2` dependencies.

`v2` support has been enabled for now (`--enable-v2` flag) for backwards compatibility and will be removed in another rollout. 

PR in etcd AMI with more details: https://github.bus.zalan.do/teapot/etcd-on-ubuntu/pull/30
Related upstream issue with more details: https://github.bus.zalan.do/teapot/issues/issues/3553