### PR TITLE
Update kube-janitor to latest version

### DIFF
--- a/cluster/manifests/kube-janitor/deployment.yaml
+++ b/cluster/manifests/kube-janitor/deployment.yaml
@@ -1,5 +1,5 @@
 # {{ if ne .Environment "production" }}
-# {{ $internal_version := "22.7.2-master-17" }}
+# {{ $internal_version := "23.7.0-main-2" }}
 # {{ $version := index (split $internal_version "-") 0 }}
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Updates kube-janitor to the latest version which support `batch/v1`. The previous version was failing with errors like:

```
Traceback (most recent call last):
  File "/kube_janitor/main.py", line 72, in run_loop
    clean_up(
  File "/kube_janitor/janitor.py", line 396, in clean_up
    handle_resource_on_ttl(
  File "/kube_janitor/janitor.py", line 195, in handle_resource_on_ttl
    context = get_resource_context(resource, resource_context_hook, cache)
  File "/kube_janitor/resource_context.py", line 113, in get_resource_context
    context.update(get_persistent_volume_claim_context(resource, cache))
  File "/kube_janitor/resource_context.py", line 64, in get_persistent_volume_claim_context
    for obj in get_objects_in_namespace(clazz, pvc.api, pvc.namespace, cache):
  File "/kube_janitor/resource_context.py", line 37, in get_objects_in_namespace
    objects = list(clazz.objects(api, namespace=namespace))
  File "/usr/local/lib/python3.10/site-packages/pykube/query.py", line 195, in __iter__
    return iter(self.query_cache["objects"])
  File "/usr/local/lib/python3.10/site-packages/pykube/query.py", line 185, in query_cache
    cache["response"] = self.execute().json()
  File "/usr/local/lib/python3.10/site-packages/pykube/query.py", line 160, in execute
    r.raise_for_status()
  File "/usr/local/lib/python3.10/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://10.5.0.1:443/apis/batch/v1beta1/namespaces/default/cronjobs
```

After we disabled `batch/v1beta1`.