### PR TITLE
remove dynamodb autoscaling slr

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1979,13 +1979,6 @@ Resources:
           PolicyName: root
       RoleName: "{{.Cluster.LocalID}}-audittrail-adapter"
     Type: 'AWS::IAM::Role'
-{{- if eq .Cluster.ConfigItems.dynamodb_service_link_enabled "true" }}
-  ServiceLinkedRoleAutoScalingDynamoDB:
-    Properties:
-      AWSServiceName: "dynamodb.application-autoscaling.amazonaws.com"
-      Description: "AWS service role for application autoscaling DynamoDB"
-    Type: "AWS::IAM::ServiceLinkedRole"
-{{- end }}
   RemoteFilesEncryptionKey:
     Type: "AWS::KMS::Key"
     Properties:

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -632,8 +632,6 @@ etcd_ami: {{ amiID "zalando-ubuntu-etcd-production-v3.5.9-amd64-main-27" "861068
 etcd_ami: {{ amiID "zalando-ubuntu-etcd-production-v3.5.9-amd64-main-24" "861068367966"}}
 {{end}}
 
-dynamodb_service_link_enabled: "false"
-
 cluster_dns: "coredns"
 coredns_log_svc_names: "true"
 coredns_log_forward: "false"

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -29,7 +29,6 @@ clusters:
     zmon_worker_replicas: '0'
     node_pool_feature_enabled: "true"
     enable_rbac: "true"
-    dynamodb_service_link_enabled: "false"
     skipper_ingress_refuse_payload: "refused-pattern-1[cf724afc]refused-pattern-2"
     efs_id: ${EFS_ID}
     webhook_id: ${INFRASTRUCTURE_ACCOUNT}:${REGION}:kube-aws-test


### PR DESCRIPTION
The DynamoDB Autoscaling SLR has been migrated to AILM and removed from the CLM repository kubernetes-on-aws.

Reference: https://github.bus.zalan.do/zooport/issues/issues/3517
Migration PR: https://github.bus.zalan.do/Base-Infrastructure/aws-base-infrastructure/pull/1197