### PR TITLE
Synchronize annotation feature for StackSet.

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -888,8 +888,13 @@ stackset_configmap_support_enabled: "false"
 {{end}}
 
 # enable/disable traffic segment support for stackset
+{{if eq .Cluster.Environment "e2e"}}
+stackset_enable_traffic_segments: "true"
+stackset_annotated_traffic_segments: "true"
+{{else}}
 stackset_enable_traffic_segments: "false"
 stackset_annotated_traffic_segments: "false"
+{{end}}
 
 # Enable/Disable profiling for Kubernetes components
 enable_control_plane_profiling: "false"

--- a/cluster/manifests/stackset-controller/deployment.yaml
+++ b/cluster/manifests/stackset-controller/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $version := "v1.4.23" }}
+{{ $version := "v1.4.26" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -46,6 +46,20 @@ spec:
 {{- if eq .Cluster.ConfigItems.stackset_annotated_traffic_segments "true" }}
         - "--annotated-traffic-segments"
 {{- end }}
+{{if eq .Cluster.Environment "e2e"}}
+        - "--sync-ingress-annotation=example.org/i-haz-synchronize"
+        - "--sync-ingress-annotation=teapot.org/the-best"
+{{else}}
+        - "--sync-ingress-annotation=alb.ingress.kubernetes.io/ip-address-type"
+        - "--sync-ingress-annotation=zalando.org/aws-load-balancer-ssl-cert"
+        - "--sync-ingress-annotation=zalando.org/aws-load-balancer-scheme"
+        - "--sync-ingress-annotation=zalando.org/aws-load-balancer-security-group"
+        - "--sync-ingress-annotation=zalando.org/aws-load-balancer-ssl-policy"
+        - "--sync-ingress-annotation=zalando.org/aws-load-balancer-type"
+        - "--sync-ingress-annotation=zalando.org/aws-load-balancer-http2"
+        - "--sync-ingress-annotation=zalando.org/aws-waf-web-acl-id"
+        - "--sync-ingress-annotation=kubernetes.io/ingress.class"
+{{end}}
         - "--cluster-domain={{ .Values.hosted_zone }}"
         - "--cluster-domain=ingress.cluster.local"
         resources:

--- a/cluster/manifests/stackset-controller/deployment.yaml
+++ b/cluster/manifests/stackset-controller/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $version := "v1.4.23" }}
+{{ $version := "v1.4.26" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -46,6 +46,15 @@ spec:
 {{- if eq .Cluster.ConfigItems.stackset_annotated_traffic_segments "true" }}
         - "--annotated-traffic-segments"
 {{- end }}
+        - "--sync-ingress-annotation=alb.ingress.kubernetes.io/ip-address-type"
+        - "--sync-ingress-annotation=zalando.org/aws-load-balancer-ssl-cert"
+        - "--sync-ingress-annotation=zalando.org/aws-load-balancer-scheme"
+        - "--sync-ingress-annotation=zalando.org/aws-load-balancer-security-group"
+        - "--sync-ingress-annotation=zalando.org/aws-load-balancer-ssl-policy"
+        - "--sync-ingress-annotation=zalando.org/aws-load-balancer-type"
+        - "--sync-ingress-annotation=zalando.org/aws-load-balancer-http2"
+        - "--sync-ingress-annotation=zalando.org/aws-waf-web-acl-id"
+        - "--sync-ingress-annotation=kubernetes.io/ingress.class"
         - "--cluster-domain={{ .Values.hosted_zone }}"
         - "--cluster-domain=ingress.cluster.local"
         resources:

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -44,8 +44,6 @@ clusters:
     stackset_ingress_source_switch_ttl: "1m"
     teapot_admission_controller_daemonset_reserved_cpu: "518m"
     karpenter_pools_enabled: "true"
-    stackset_enable_traffic_segments: "true"
-    stackset_annotated_traffic_segments: "true"
   criticality_level: 1
   environment: e2e
   id: ${CLUSTER_ID}

--- a/test/e2e/stackset/go.mod
+++ b/test/e2e/stackset/go.mod
@@ -2,7 +2,7 @@ module github.com/zalando-incubator/kubernetes-on-aws/test/e2e/stackset
 
 go 1.21
 
-require github.com/zalando-incubator/stackset-controller v1.4.25
+require github.com/zalando-incubator/stackset-controller v1.4.26
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/test/e2e/stackset/go.sum
+++ b/test/e2e/stackset/go.sum
@@ -438,8 +438,8 @@ github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
-github.com/zalando-incubator/stackset-controller v1.4.25 h1:iKZa4028gcNcgMsKEvIuLL3VFLU73zTM3gDnNQQFJ8M=
-github.com/zalando-incubator/stackset-controller v1.4.25/go.mod h1:9sGmpa7ABBiAI/uBUPEkyzN+P+hNlOIVc+naGh6m1ro=
+github.com/zalando-incubator/stackset-controller v1.4.26 h1:BdxjU2Nn6HJov7Stec4jNuA+a/XFR0jSBuFm5oo8loA=
+github.com/zalando-incubator/stackset-controller v1.4.26/go.mod h1:9sGmpa7ABBiAI/uBUPEkyzN+P+hNlOIVc+naGh6m1ro=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=


### PR DESCRIPTION
This Pull Request updates the Stackset Controller to a [new version](https://github.com/zalando-incubator/stackset-controller/releases/tag/v1.4.26), supporting ingress annotation synchronization among Ingress and/or RouteGroup segments.

The update configures the StackSet Controller to synchronize almost all annotations from [kube-ingress-aws-controller](https://github.com/zalando-incubator/kube-ingress-aws-controller/tree/master?tab=readme-ov-file#annotations). I opted to not synchronize `zalando.org/aws-load-balancer-shared`, because:
* When set to `true`, kube-ingress-aws-controller would create dedicated Load Balancers for _all_ stacks, which is a waste of resources. We also observed during testing that the Load Balancer where the requests go would be non-deterministic.
* Without synchronizing, the StackSet will use the Load Balancer from the oldest stack, which anyway won't break access to the application.    

This feature is only relevant when we enable traffic segments: flags `--enable-traffic-segments` and `--annotated-traffic-segments`.

Additionally, I moved the configuration for end-2-end testing to config.defaults file, which is easier to find.