### PR TITLE
Revert faulty etcd AMI on dev.

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -642,11 +642,7 @@ etcd_instance_type: "t3.medium"
 
 etcd_scalyr_key: ""
 
-{{if eq .Cluster.Channel "dev"}}
-etcd_ami: {{ amiID "zalando-ubuntu-etcd-production-v3.5.9-amd64-main-27" "861068367966"}}
-{{else}}
 etcd_ami: {{ amiID "zalando-ubuntu-etcd-production-v3.5.9-amd64-main-24" "861068367966"}}
-{{end}}
 
 cluster_dns: "coredns"
 coredns_log_svc_names: "true"


### PR DESCRIPTION
We already know that the AMI with ID "zalando-ubuntu-etcd-production-v3.5.9-amd64-main-27" fails when creating the ETCD cluster. Let's revert this change to `dev` as well, so `playground` gets created.