### PR TITLE
Allow deployment service role to decrypt any secret.

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -883,7 +883,7 @@ Resources:
                 Resource: "*"
                 Condition:
                   StringLike:
-                    "kms:RequestAlias": "alias/deployment-secret"
+                    "kms:RequestAlias": "alias/{{.Cluster.LocalID}}-deployment-secret"
 {{- end }}
               - Action:
                   - 'sts:AssumeRole'

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -881,9 +881,11 @@ Resources:
                   - !GetAtt DeploymentSecretKey.Arn
 {{- else }}
                 Resource: "*"
+{{- if and (eq .Cluster.ConfigItems.deployment_secret_decrypt_any "false") (ne .Cluster.Environment "e2e") }}
                 Condition:
                   StringLike:
-                    "kms:RequestAlias": "alias/{{.Cluster.LocalID}}-deployment-secret"
+                    "kms:RequestAlias": "alias/deployment-secret"
+{{- end }}
 {{- end }}
               - Action:
                   - 'sts:AssumeRole'

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1036,3 +1036,4 @@ cronjob_time_zone_enabled: "true"
 # or not. When set to a value != "true" the key will be removed from the stack.
 # TODO: remove after migrating out of all cluster stacks.
 deployment_secret_key_managed: "true"
+deployment_secret_decrypt_any: "true"

--- a/cluster/manifests/deployment-service/controller-statefulset.yaml
+++ b/cluster/manifests/deployment-service/controller-statefulset.yaml
@@ -32,7 +32,7 @@ spec:
           image: "container-registry.zalando.net/teapot/deployment-controller:master-163"
           args:
             - "--config-namespace=kube-system"
-{{- if ne .Cluster.ConfigItems.deployment_secret_key_managed "true" }}
+{{- if eq .Cluster.ConfigItems.deployment_secret_decrypt_any "false" }}
             - "--decrypt-kms-alias-arn=arn:aws:kms:{{ .Cluster.Region }}:{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:alias/deployment-secret"
 {{- end }}
           env:


### PR DESCRIPTION
Allows the deployment service to decrypt any secret. The Pull Request puts this capability behind a feature flag, enabled by default. We will disable per cluster after AILM finishes apply the new deployment key. 