### PR TITLE
skipper-admission-webhook: update skipper images/apps in master nodes

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -246,7 +246,7 @@ write_files:
               name: admission-controller-kubeconfig
               readOnly: true
         - name: skipper-admission-webhook
-          image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/skipper:v0.17.1
+          image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/skipper:v0.19.32
           args:
             - webhook
             - --address=:9085
@@ -421,7 +421,7 @@ write_files:
             value: {{ .Cluster.ConfigItems.apiserver_business_partner_ids }}
 {{ end }}
         - name: skipper-proxy
-          image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/skipper:v0.16.154
+          image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/skipper:v0.19.32
           args:
           - skipper
           - -access-log-strip-query
@@ -472,7 +472,7 @@ write_files:
             name: ssl-certs-kubernetes
             readOnly: true
         - name: skipper-metrics
-          image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/skipper:v0.16.154
+          image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/skipper:v0.19.32
           args:
           - skipper
           - -access-log-strip-query


### PR DESCRIPTION
This PR specially focus on updating `skipper-admission-webhook` image to include new skipper updates, other images are a get along update.

For skipper changes see https://github.com/zalando/skipper/compare/v0.19.19...v0.19.32

Related to https://github.com/zalando-incubator/kubernetes-on-aws/pull/6831 & https://github.com/zalando-incubator/kubernetes-on-aws/pull/6832 and it's better to merge after the other 2 are deployed.