### PR TITLE
Revert "Update Audittrail to allow Nakadi functionality"

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -685,7 +685,6 @@ audittrail_url: "https://audittrail.cloud.zalando.com"
 {{else}}
 audittrail_url: ""
 {{end}}
-audittrail_nakadi_url: ""
 audittrail_root_account_role: ""
 
 audittrail_adapter_cpu: "50m"

--- a/cluster/manifests/audittrail-adapter/credentials.yaml
+++ b/cluster/manifests/audittrail-adapter/credentials.yaml
@@ -1,4 +1,4 @@
-{{- if or .Cluster.ConfigItems.audittrail_url .Cluster.ConfigItems.audittrail_nakadi_url }}
+{{- if .Cluster.ConfigItems.audittrail_url }}
 apiVersion: "zalando.org/v1"
 kind: PlatformCredentialsSet
 metadata:
@@ -8,15 +8,7 @@ metadata:
      application: "audittrail-adapter"
 spec:
    application: "audittrail-adapter"
-   token_version: v2
    tokens:
-{{- end }}
-{{- if .Cluster.ConfigItems.audittrail_url }}
      audittrail:
        privileges: []
-{{- end }}
-{{- if .Cluster.ConfigItems.audittrail_nakadi_url }}
-     nakadi:
-       privileges:
-       - com.zalando::nakadi.event_stream.write
 {{- end }}

--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
       hostNetwork: true
       containers:
       - name: audittrail-adapter
-        image: container-registry.zalando.net/teapot/audittrail-adapter:master-51
+        image: container-registry.zalando.net/teapot/audittrail-adapter:master-49
         env:
           - name: AWS_REGION
             value: "{{ .Cluster.Region }}"
@@ -41,8 +41,7 @@ spec:
         - --cluster-id={{ .Cluster.ID }}
         - --cluster-alias={{ .Cluster.Alias }}
         - --audittrail-url={{ .Cluster.ConfigItems.audittrail_url }}
-        - --s3-fallback-bucket-name=zalando-audittrail-{{ accountID .Cluster.InfrastructureAccount }}-{{ .Cluster.LocalID }}
-        - --nakadi-url={{ .Cluster.ConfigItems.audittrail_nakadi_url }}
+        - --s3-fallback-bucket-name=zalando-audittrail-{{accountID .Cluster.InfrastructureAccount}}-{{ .Cluster.LocalID }}
         - --address=:8889
         - --metrics-address=:7980
         - --audittrail-timeout={{ .Cluster.ConfigItems.audittrail_adapter_timeout }}


### PR DESCRIPTION
Reverts zalando-incubator/kubernetes-on-aws#6747 due to permission errors from audittrail-adpater -> audittrail-api