### PR TITLE
Update Audittrail version with Nakadi functionality

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -685,6 +685,7 @@ audittrail_url: "https://audittrail.cloud.zalando.com"
 {{else}}
 audittrail_url: ""
 {{end}}
+audittrail_nakadi_url: ""
 audittrail_root_account_role: ""
 
 audittrail_adapter_cpu: "50m"

--- a/cluster/manifests/audittrail-adapter/credentials.yaml
+++ b/cluster/manifests/audittrail-adapter/credentials.yaml
@@ -12,3 +12,20 @@ spec:
      audittrail:
        privileges: []
 {{- end }}
+{{- if .Cluster.ConfigItems.audittrail_nakadi_url }}
+---
+apiVersion: "zalando.org/v1"
+kind: PlatformCredentialsSet
+metadata:
+   name: "audittrail-adapter-nakadi"
+   namespace: kube-system
+   labels:
+     application: "audittrail-adapter"
+spec:
+   application: "audittrail-adapter"
+   token_version: v2
+   tokens:
+     nakadi:
+       privileges:
+       - com.zalando::nakadi.event_stream.write
+{{- end }}

--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -33,13 +33,14 @@ spec:
       hostNetwork: true
       containers:
       - name: audittrail-adapter
-        image: container-registry.zalando.net/teapot/audittrail-adapter:master-49
+        image: container-registry.zalando.net/teapot/audittrail-adapter:master-52
         env:
           - name: AWS_REGION
             value: "{{ .Cluster.Region }}"
         args:
         - --cluster-id={{ .Cluster.ID }}
         - --cluster-alias={{ .Cluster.Alias }}
+        - --nakadi-url={{ .Cluster.ConfigItems.audittrail_nakadi_url }}
         - --audittrail-url={{ .Cluster.ConfigItems.audittrail_url }}
         - --s3-fallback-bucket-name=zalando-audittrail-{{accountID .Cluster.InfrastructureAccount}}-{{ .Cluster.LocalID }}
         - --address=:8889
@@ -54,10 +55,17 @@ spec:
         {{- range $label := split .Cluster.ConfigItems.auditlog_metric_dimensions  "," }}
         - --metric-labels={{ $label }}
         {{- end }}
-        {{- if .Cluster.ConfigItems.audittrail_url }}
+        {{- if or .Cluster.ConfigItems.audittrail_url .Cluster.ConfigItems.audittrail_nakadi_url }}
         volumeMounts:
-        - name: platform-iam-credentials
-          mountPath: /meta/credentials
+        {{- end }}
+        {{- if .Cluster.ConfigItems.audittrail_url }}
+        - name: platform-iam-credentials-audittrail
+          mountPath: /meta/credentials/audittrail
+          readOnly: true
+        {{- end }}
+        {{- if .Cluster.ConfigItems.audittrail_nakadi_url }}
+        - name: platform-iam-credentials-nakadi
+          mountPath: /meta/credentials/nakadi
           readOnly: true
         {{- end }}
         resources:
@@ -71,9 +79,16 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 1000
-      {{- if .Cluster.ConfigItems.audittrail_url }}
+      {{- if or .Cluster.ConfigItems.audittrail_url .Cluster.ConfigItems.audittrail_nakadi_url }}
       volumes:
-      - name: platform-iam-credentials
+      {{- end }}
+      {{- if .Cluster.ConfigItems.audittrail_url }}
+      - name: platform-iam-credentials-audittrail
         secret:
           secretName: audittrail-adapter
+      {{- end }}
+      {{- if .Cluster.ConfigItems.audittrail_nakadi_url }}
+      - name: platform-iam-credentials-nakadi
+        secret:
+          secretName: audittrail-adapter-nakadi
       {{- end }}

--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -49,7 +49,7 @@ spec:
         {{- if eq .Cluster.ConfigItems.audittrail_adapter_drop_audittrail_api_read_only "true" }}
         - --audittrail-drop-read-only
         {{- end }}
-        {{- if not .Cluster.ConfigItems.audittrail_url }}
+        {{- if not (or .Cluster.ConfigItems.audittrail_url .Cluster.ConfigItems.audittrail_nakadi_url) }}
         - --metrics-only
         {{- end }}
         {{- range $label := split .Cluster.ConfigItems.auditlog_metric_dimensions  "," }}

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -277,3 +277,8 @@ post_apply:
 - kind: PodSecurityPolicy
   name: restricted
 {{- end }}
+{{- if eq .Cluster.ConfigItems.audittrail_nakadi_url "" }}
+- name: audittrail-adapter-nakadi
+  kind: PlatformCredentialsSet
+  namespace: kube-system
+{{- end }}


### PR DESCRIPTION
Follow up to https://github.com/zalando-incubator/kubernetes-on-aws/pull/6747.

> This PR updates the Audittrail adapter version. The new version includes functionality which allows the adapter to send events to Nakadi. To enable this, a new config item `audittrail_nakadi_url` has been introduced which will be passed to the adapter to set the target Nakadi URL. 

A new `PlatformCredentialsSet` for the adapter will be deployed when `audittrail_nakadi_url` is set -- utilising `token_version: v2` to allow write permission to Nakadi event streams.