### PR TITLE
Add ConfigMap to hyped-articles-lifecycle-management controller role

### DIFF
--- a/cluster/manifests/roles/hyped-articles-lifecycle-rbac.yaml
+++ b/cluster/manifests/roles/hyped-articles-lifecycle-rbac.yaml
@@ -11,6 +11,7 @@ rules:
   resourceNames:
   - articles-protection-config
   - article-protection-config
+  - article-protection-config-invite-only
   verbs:
   - get
   - create


### PR DESCRIPTION
Update the hyped-articles-lifecycle-management `ClusterRole` with a new ConfigMap required by the controller.