### PR TITLE
skipper: use redis 7

### DIFF
--- a/cluster/manifests/skipper/skipper-redis.yaml
+++ b/cluster/manifests/skipper/skipper-redis.yaml
@@ -3,7 +3,7 @@ kind: StatefulSet
 metadata:
   labels:
     application: skipper-ingress-redis
-    version: v6.2.7
+    version: v7.2.4
   annotations:
     zalando.org/update-using-hpa-replicas: skipper-ingress-redis
   name: skipper-ingress-redis
@@ -19,7 +19,7 @@ spec:
       labels:
         statefulset: skipper-ingress-redis
         application: skipper-ingress-redis
-        version: v6.2.7
+        version: v7.2.4
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
@@ -50,7 +50,7 @@ spec:
                 - skipper-ingress-redis
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       containers:
-      - image: container-registry.zalando.net/library/redis-6-alpine:6-alpine-20220622
+      - image: container-registry.zalando.net/library/redis-7-alpine:7-alpine-20240226
         name: skipper-ingress-redis
         args:
         - /usr/local/bin/docker-entrypoint.sh


### PR DESCRIPTION
https://raw.githubusercontent.com/redis/redis/7.2/00-RELEASENOTES

The https://github.com/zalando/skipper/pull/2895 updates skipper tests to use redis-7