### PR TITLE
Add option to inject NODE_OPTIONS envvar

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -492,6 +492,11 @@ teapot_admission_controller_max_ephemeral_storage_request: "5Gi"
 teapot_admission_controller_application_min_creation_time: "2019-06-03T12:00:00Z"
 teapot_admission_controller_ndots: "2"
 teapot_admission_controller_inject_environment_variables: "true"
+{{ if eq .Cluster.Environment "test" }}
+teapot_admission_controller_inject_node_options_environment_variable: "true"
+{{ else }}
+teapot_admission_controller_inject_node_options_environment_variable: "false"
+{{ end }}
 teapot_admission_controller_deployment_default_max_surge: "5%"
 teapot_admission_controller_deployment_default_max_unavailable: "1"
 teapot_admission_controller_inject_aws_waiter: "true"

--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -50,6 +50,8 @@ data:
   pod.env-inject.variable.LOG4J_FORMAT_MSG_NO_LOOKUPS: "true"
 {{- end}}
 
+  pod.env-inject.node-options.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_inject_node_options_environment_variable }}"
+
   podfactory.container-resource-check.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_validate_pod_template_resources }}"
   podfactory.application-label-check.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_validate_application_label }}"
   podfactory.application-label-check.minimum-creation-time: "{{ .Cluster.ConfigItems.teapot_admission_controller_application_min_creation_time }}"

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -205,7 +205,7 @@ write_files:
             limits:
               memory: {{ .Values.InstanceInfo.MemoryFraction (parseInt64 .Cluster.ConfigItems.apiserver_memory_limit_percent)}}
 {{- end }}
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-188
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-189
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
tThis optionally adds an option for injecting `NODE_OPTIONS=--max-old-space-size=` into containers to mitigate issues with nodejs 18 running on Ubuntu 22.04 (cgroup v2).

When enabled, this injects the environment variable into all containers if the feature is enabled. The idea is to enable this feature in all test clusters to validate that setting `NODE_OPTIONS=` in non-nodejs apps doesn't have a negative effect, and if that is successful to enable it in all production clusters _with_ nodejs apps.