### PR TITLE
Remove deployment key and config items.

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -819,6 +819,7 @@ Resources:
               - Action:
                   - kms:Decrypt
                 Effect: Allow
+                Resource: "*"
                 Condition:
                   StringLike:
                     "kms:RequestAlias": "alias/deployment-secret"

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -714,63 +714,6 @@ Resources:
         - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-AllowPowerUser"
       RoleName: "{{.Cluster.LocalID}}-deployment"
     Type: 'AWS::IAM::Role'
-{{- if and (eq .Cluster.ConfigItems.deployment_secret_key_managed "true") (ne .Cluster.Environment "e2e") }}
-  DeploymentSecretKey:
-    Properties:
-      Description: Key used by deployment pipeline for secret encryption/decryption
-      EnableKeyRotation: false
-      Enabled: true
-      KeyPolicy:
-        Id: "{{.Cluster.LocalID}}-deployment-key"
-        Statement:
-          - Action:
-              - 'kms:ReEncrypt*'
-              - 'kms:Create*'
-              - 'kms:Describe*'
-              - 'kms:Enable*'
-              - 'kms:Encrypt'
-              - 'kms:Decrypt'
-              - 'kms:List*'
-              - 'kms:Put*'
-              - 'kms:Update*'
-              - 'kms:Revoke*'
-              - 'kms:Disable*'
-              - 'kms:Get*'
-              - 'kms:Delete*'
-              - 'kms:ScheduleKeyDeletion'
-              - 'kms:CancelKeyDeletion'
-              - 'kms:TagResource'
-              - 'kms:UntagResource'
-            Effect: Allow
-            Principal:
-              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
-            Resource: '*'
-            Sid: Allow access for Key Administrators
-          - Action:
-              - 'kms:Decrypt'
-            Effect: Allow
-            # Avoid circular dependencies because CF still can't do this properly
-            Principal: "*"
-            Condition:
-              ArnEquals:
-                aws:PrincipalArn:
-                  - !GetAtt DeploymentIAMRole.Arn
-                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/{{.Cluster.LocalID}}-deployment-service-deployment"
-            Resource: '*'
-            Sid: Allow access for deployment system to decrypt the keys
-        Version: 2012-10-17
-      KeyUsage: ENCRYPT_DECRYPT
-    Type: 'AWS::KMS::Key'
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
-  DeploymentSecretKeyAlias:
-    Properties:
-      AliasName: "alias/{{.Cluster.LocalID}}-deployment-secret"
-      TargetKeyId: !Ref DeploymentSecretKey
-    Type: 'AWS::KMS::Alias'
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
-{{- end }}
   DeploymentServiceBucket:
     Type: AWS::S3::Bucket
     DeletionPolicy: Delete
@@ -876,17 +819,9 @@ Resources:
               - Action:
                   - kms:Decrypt
                 Effect: Allow
-{{- if and (eq .Cluster.ConfigItems.deployment_secret_key_managed "true") (ne .Cluster.Environment "e2e") }}
-                Resource:
-                  - !GetAtt DeploymentSecretKey.Arn
-{{- else }}
-                Resource: "*"
-{{- if and (eq .Cluster.ConfigItems.deployment_secret_decrypt_any "false") (ne .Cluster.Environment "e2e") }}
                 Condition:
                   StringLike:
                     "kms:RequestAlias": "alias/deployment-secret"
-{{- end }}
-{{- end }}
               - Action:
                   - 'sts:AssumeRole'
                 Effect: Allow

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1037,9 +1037,3 @@ min_domains_in_pod_topology_spread_enabled: "true"
 # enable CronJobTimeZone
 # https://v1-24.docs.kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones
 cronjob_time_zone_enabled: "true"
-
-# flag to control if the deployment secret key is managed by the cluster stack
-# or not. When set to a value != "true" the key will be removed from the stack.
-# TODO: remove after migrating out of all cluster stacks.
-deployment_secret_key_managed: "true"
-deployment_secret_decrypt_any: "true"

--- a/cluster/manifests/deployment-service/controller-statefulset.yaml
+++ b/cluster/manifests/deployment-service/controller-statefulset.yaml
@@ -32,9 +32,7 @@ spec:
           image: "container-registry.zalando.net/teapot/deployment-controller:master-165"
           args:
             - "--config-namespace=kube-system"
-{{- if eq .Cluster.ConfigItems.deployment_secret_decrypt_any "false" }}
             - "--decrypt-kms-alias-arn=arn:aws:kms:{{ .Cluster.Region }}:{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:alias/deployment-secret"
-{{- end }}
           env:
             - name: AWS_REGION
               value: "{{.Cluster.Region}}"


### PR DESCRIPTION
Removes deployment key creation from CloudFormation and config keys used to migrate to AILM deployment secret. We finished migrating today for all cluster, so this Pull Request is a no-op.