### PR TITLE
Update CA to support more instance-types

### DIFF
--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -36,7 +36,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cluster-autoscaler
-        image: container-registry.zalando.net/teapot/kube-cluster-autoscaler:v1.18.2-internal.43
+        image: container-registry.zalando.net/teapot/kube-cluster-autoscaler:v1.18.2-internal.44
         command:
           - ./cluster-autoscaler
           - --v={{.Cluster.ConfigItems.autoscaling_autoscaler_log_level}}


### PR DESCRIPTION
Updates the CA to a version supporting the latest available instance types. Most importantly `p4de.*` types.

Ref: https://github.com/zalando-incubator/autoscaler/pull/106