### PR TITLE
Update admission-controller with granular node options fix

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -205,7 +205,7 @@ write_files:
             limits:
               memory: {{ .Values.InstanceInfo.MemoryFraction (parseInt64 .Cluster.ConfigItems.apiserver_memory_limit_percent)}}
 {{- end }}
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-189
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-190
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
admission-controller with support for `admission.zalando.org/nodejs-inject-node-options` annotation.

This re-uses the same config item from https://github.com/zalando-incubator/kubernetes-on-aws/pull/6857, enabled by default in test, disabled in production.