### PR TITLE
[TESTING ONLY] Custom AMI for p4de.24xlarge testing

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -672,6 +672,12 @@ kuberuntu_image_v1_25_focal_arm64: {{ amiID "zalando-ubuntu-focal-20.04-kubernet
 kuberuntu_image_v1_25_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.25.16-amd64-master-304" "861068367966" }}
 kuberuntu_image_v1_25_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.25.16-arm64-master-304" "861068367966" }}
 
+# FOR TESTING ONLY:
+kuberuntu_image_v1_25_jammy_with_gpu_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-test-v1.25.16-amd64-pr-320-12" "861068367966" }}
+
+# set to false on a node pool to enable ssm access for non Administrator users.
+tag_instance_infrastructure_component: "true"
+
 # Which distro from the previous config items should be used. Valid options are `focal` and `jammy`. Can be set for each node pool.
 {{if eq .Cluster.Environment "test"}}
 kuberuntu_distro_master: "jammy"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -673,7 +673,7 @@ kuberuntu_image_v1_25_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernet
 kuberuntu_image_v1_25_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.25.16-arm64-master-304" "861068367966" }}
 
 # FOR TESTING ONLY:
-kuberuntu_image_v1_25_jammy_with_gpu_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-test-v1.25.16-amd64-pr-320-12" "861068367966" }}
+kuberuntu_image_v1_25_jammy_with_gpu_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-test-v1.25.16-amd64-pr-320-23" "861068367966" }}
 
 # set to false on a node pool to enable ssm access for non Administrator users.
 tag_instance_infrastructure_component: "true"

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -2,7 +2,9 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: Kubernetes default worker node pool
 Metadata:
   Tags:
+{{- if eq .Cluster.ConfigItems.tag_instance_infrastructure_component "true" }}
     InfrastructureComponent: "true"
+{{- end }}
     application: "kubernetes"
     component: "shared-resource"
 


### PR DESCRIPTION
This PR is purely for enabling testing of an in-progress AMI to enable support for `p4de.24xlarge` instances.

The idea is that a cluster switched to this PR branch will be able to run a node-pool like this:

```yaml
- config_items:
    labels: dedicated=gpu-p4de,zalando.org/nvidia-gpu=nvidia-a100
    taints: dedicated=gpu-p4de:NoSchedule
    kuberuntu_distro_worker: "jammy_with_gpu"
    tag_instance_infrastructure_component: "false"
  discount_strategy: none
  instance_types:
  - p4de.24xlarge
  max_size: 30
  min_size: 0
  name: gpu-p4de
  profile: worker-splitaz
```

With will run the special AMI defined as: `kuberuntu_image_v1_24_jammy_with_gpu_amd64`. To change the AMI to test, only that config-item needs to be changed in this PR and the node pool will be updated.