### PR TITLE
Exclude c5d.large from default Karpenter instance-types

### DIFF
--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -49,6 +49,11 @@ spec:
       operator: "NotIn"
       values:
         - "metal"
+    # exclude instance-types with slow SSD
+    - key: "node.kubernetes.io/instance-type"
+      operator: "NotIn"
+      values:
+        - "c5d.large"
 {{- else }}
     - key: "node.kubernetes.io/instance-type"
       operator: In


### PR DESCRIPTION
Small optimization to exclude `c5d.large` from the default instance types for karpenter pools. The motivation is that the SSD on `c5d.large` is very slow, and combined with our AMI logic to move the `podruntime` folder to the SSD, this slows down startup of the instance and gives no disk space or performance improvement compared to the root EBS gp3 volume.