### PR TITLE
skipper: update canary version to v0.19.40

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,5 +1,5 @@
 {{ $internal_version := "v0.19.32-783" }}
-{{ $canary_internal_version := "v0.19.39-790" }}
+{{ $canary_internal_version := "v0.19.40-791" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}
 {{ $canary_args := "" }}


### PR DESCRIPTION
https://github.com/zalando/skipper/compare/v0.19.39...v0.19.40

The change contains https://github.com/zalando/skipper/pull/2903