### PR TITLE
Update StackSet controller end-2-end flags.

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -904,11 +904,10 @@ stackset_configmap_support_enabled: "false"
 {{end}}
 
 # enable/disable traffic segment support for stackset
+stackset_enable_traffic_segments: "false"
 {{if eq .Cluster.Environment "e2e"}}
-stackset_enable_traffic_segments: "true"
 stackset_annotated_traffic_segments: "true"
 {{else}}
-stackset_enable_traffic_segments: "false"
 stackset_annotated_traffic_segments: "false"
 {{end}}
 

--- a/cluster/manifests/stackset-controller/deployment.yaml
+++ b/cluster/manifests/stackset-controller/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $version := "v1.4.27" }}
+{{ $version := "v1.4.31" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
* Updates StackSet controller to [latest version](https://github.com/zalando-incubator/stackset-controller/releases/tag/v1.4.31).
* Updates flags in end-2-end tests supporting traffic segments in StackSets with annotation, according to [this release](https://github.com/zalando-incubator/stackset-controller/releases/tag/v1.4.29) of StackSet Controller.