### PR TITLE
skipper: update main version to v0.19.44

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.19.32-783" }}
+{{ $internal_version := "v0.19.44-795" }}
 {{ $canary_internal_version := "v0.19.44-795" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}


### PR DESCRIPTION
https://github.com/zalando/skipper/compare/v0.19.32...v0.19.44

The change contains https://github.com/zalando/skipper/pull/2903 and https://github.com/zalando/skipper/pull/2904