### PR TITLE
deployment-service: Inject source information tags in CF stacks

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -945,6 +945,13 @@ deployment_service_tokeninfo_url: ""
 deployment_service_lightstep_token: ""
 deployment_service_ml_experiments_enabled: "true"
 deployment_service_cf_auto_expand_enabled: "false"
+deployment_service_cf_update_source_branch_changes: "true"
+{{- if eq .Cluster.Environment "test" }}
+# disable CF update of source branch changes in test to avoid updating CF stacks
+# on any PR.
+deployment_service_cf_update_source_branch_changes: "false"
+{{- end }}
+
 
 # Will be dropped after the migration
 deployment_service_enabled: "true"

--- a/cluster/manifests/deployment-service/01-config.yaml
+++ b/cluster/manifests/deployment-service/01-config.yaml
@@ -21,3 +21,4 @@ data:
 {{- end }}
   cloudformation-enable-auto-expand: "{{.Cluster.ConfigItems.deployment_service_cf_auto_expand_enabled}}"
   probe-for-traffic-segments: "{{.Cluster.ConfigItems.stackset_enable_traffic_segments}}"
+  cloudformation-allow-update-source-branch-changes: "{{.Cluster.ConfigItems.deployment_service_cf_update_source_branch_changes}}"

--- a/cluster/manifests/deployment-service/controller-statefulset.yaml
+++ b/cluster/manifests/deployment-service/controller-statefulset.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
         - name: "deployment-service-controller"
-          image: "container-registry.zalando.net/teapot/deployment-controller:master-165"
+          image: "container-registry.zalando.net/teapot/deployment-controller:master-168"
           args:
             - "--config-namespace=kube-system"
             - "--decrypt-kms-alias-arn=arn:aws:kms:{{ .Cluster.Region }}:{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:alias/deployment-secret"

--- a/cluster/manifests/deployment-service/status-service-deployment.yaml
+++ b/cluster/manifests/deployment-service/status-service-deployment.yaml
@@ -1,5 +1,5 @@
 {{ $image   := "container-registry.zalando.net/teapot/deployment-status-service" }}
-{{ $version := "master-165" }}
+{{ $version := "master-168" }}
 
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Updates the deployment service to inject source info tags in CF stacks. This previously only happened if the template of the CF stack changed, but now it also happens if any of the source info tags change.

For test cluster we disable update of changes to the branch tag because this would lead to a change on every PR which is not desired.