### PR TITLE
Update VPA CRD

### DIFF
--- a/cluster/manifests/01-vertical-pod-autoscaler/01-crd.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/01-crd.yaml
@@ -1,715 +1,11 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: verticalpodautoscalers.autoscaling.k8s.io
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes/kubernetes/pull/63797
-spec:
-  group: autoscaling.k8s.io
-  names:
-    kind: VerticalPodAutoscaler
-    listKind: VerticalPodAutoscalerList
-    plural: verticalpodautoscalers
-    shortNames:
-    - vpa
-    singular: verticalpodautoscaler
-  scope: Namespaced
-  versions:
-  - name: v1beta1
-    served: true
-    storage: false
-    schema:
-      openAPIV3Schema:
-        description: VerticalPodAutoscaler is the configuration for a vertical pod
-          autoscaler, which automatically manages pod resources based on historical
-          and real time resource utilization.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: 'Specification of the behavior of the autoscaler. More info:
-              https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status.'
-            properties:
-              resourcePolicy:
-                description: Controls how the autoscaler computes recommended resources.
-                  The resource policy may be used to set constraints on the recommendations
-                  for individual containers. If not specified, the autoscaler computes
-                  recommended resources for all containers in the pod, without additional
-                  constraints.
-                properties:
-                  containerPolicies:
-                    description: Per-container resource policies.
-                    items:
-                      description: ContainerResourcePolicy controls how autoscaler
-                        computes the recommended resources for a specific container.
-                      properties:
-                        containerName:
-                          description: Name of the container or DefaultContainerResourcePolicy,
-                            in which case the policy is used by the containers that
-                            don't have their own policy specified.
-                          type: string
-                        maxAllowed:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: Specifies the maximum amount of resources that
-                            will be recommended for the container. The default is
-                            no maximum.
-                          type: object
-                        minAllowed:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: Specifies the minimal amount of resources that
-                            will be recommended for the container. The default is
-                            no minimum.
-                          type: object
-                        mode:
-                          description: Whether autoscaler is enabled for the container.
-                            The default is "Auto".
-                          type: string
-                      type: object
-                    type: array
-                type: object
-              selector:
-                description: 'A label query that determines the set of pods controlled
-                  by the Autoscaler. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
-                properties:
-                  matchExpressions:
-                    description: matchExpressions is a list of label selector requirements.
-                      The requirements are ANDed.
-                    items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
-                      properties:
-                        key:
-                          description: key is the label key that the selector applies
-                            to.
-                          type: string
-                        operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
-                          type: string
-                        values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
-                            merge patch.
-                          items:
-                            type: string
-                          type: array
-                      required:
-                      - key
-                      - operator
-                      type: object
-                    type: array
-                  matchLabels:
-                    additionalProperties:
-                      type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
-                    type: object
-                type: object
-              updatePolicy:
-                description: Describes the rules on how changes are applied to the
-                  pods. If not specified, all fields in the `PodUpdatePolicy` are
-                  set to their default values.
-                properties:
-                  updateMode:
-                    description: Controls when autoscaler applies changes to the pod
-                      resources. The default is 'Auto'.
-                    type: string
-                type: object
-            required:
-            - selector
-            type: object
-          status:
-            description: Current information about the autoscaler.
-            properties:
-              conditions:
-                description: Conditions is the set of conditions required for this
-                  autoscaler to scale its target, and indicates whether or not those
-                  conditions are met.
-                items:
-                  description: VerticalPodAutoscalerCondition describes the state
-                    of a VerticalPodAutoscaler at a certain point.
-                  properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another
-                      format: date-time
-                      type: string
-                    message:
-                      description: message is a human-readable explanation containing
-                        details about the transition
-                      type: string
-                    reason:
-                      description: reason is the reason for the condition's last transition.
-                      type: string
-                    status:
-                      description: status is the status of the condition (True, False,
-                        Unknown)
-                      type: string
-                    type:
-                      description: type describes the current condition
-                      type: string
-                  required:
-                  - status
-                  - type
-                  type: object
-                type: array
-              recommendation:
-                description: The most recently computed amount of resources recommended
-                  by the autoscaler for the controlled pods.
-                properties:
-                  containerRecommendations:
-                    description: Resources recommended by the autoscaler for each
-                      container.
-                    items:
-                      description: RecommendedContainerResources is the recommendation
-                        of resources computed by autoscaler for a specific container.
-                        Respects the container resource policy if present in the spec.
-                        In particular the recommendation is not produced for containers
-                        with `ContainerScalingMode` set to 'Off'.
-                      properties:
-                        containerName:
-                          description: Name of the container.
-                          type: string
-                        lowerBound:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: Minimum recommended amount of resources. Observes
-                            ContainerResourcePolicy. This amount is not guaranteed
-                            to be sufficient for the application to operate in a stable
-                            way, however running with less resources is likely to
-                            have significant impact on performance/availability.
-                          type: object
-                        target:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: Recommended amount of resources. Observes ContainerResourcePolicy.
-                          type: object
-                        uncappedTarget:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: The most recent recommended resources target
-                            computed by the autoscaler for the controlled pods, based
-                            only on actual resource usage, not taking into account
-                            the ContainerResourcePolicy. May differ from the Recommendation
-                            if the actual resource usage causes the target to violate
-                            the ContainerResourcePolicy (lower than MinAllowed or
-                            higher that MaxAllowed). Used only as status indication,
-                            will not affect actual resource assignment.
-                          type: object
-                        upperBound:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: Maximum recommended amount of resources. Observes
-                            ContainerResourcePolicy. Any resources allocated beyond
-                            this value are likely wasted. This value may be larger
-                            than the maximum amount of application is actually capable
-                            of consuming.
-                          type: object
-                      required:
-                      - target
-                      type: object
-                    type: array
-                type: object
-            type: object
-        required:
-        - spec
-        type: object
-  - name: v1beta2
-    schema:
-      openAPIV3Schema:
-        description: VerticalPodAutoscaler is the configuration for a vertical pod
-          autoscaler, which automatically manages pod resources based on historical
-          and real time resource utilization.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: 'Specification of the behavior of the autoscaler. More info:
-              https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status.'
-            properties:
-              resourcePolicy:
-                description: Controls how the autoscaler computes recommended resources.
-                  The resource policy may be used to set constraints on the recommendations
-                  for individual containers. If not specified, the autoscaler computes
-                  recommended resources for all containers in the pod, without additional
-                  constraints.
-                properties:
-                  containerPolicies:
-                    description: Per-container resource policies.
-                    items:
-                      description: ContainerResourcePolicy controls how autoscaler
-                        computes the recommended resources for a specific container.
-                      properties:
-                        containerName:
-                          description: Name of the container or DefaultContainerResourcePolicy,
-                            in which case the policy is used by the containers that
-                            don't have their own policy specified.
-                          type: string
-                        maxAllowed:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: Specifies the maximum amount of resources that
-                            will be recommended for the container. The default is
-                            no maximum.
-                          type: object
-                        minAllowed:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: Specifies the minimal amount of resources that
-                            will be recommended for the container. The default is
-                            no minimum.
-                          type: object
-                        mode:
-                          description: Whether autoscaler is enabled for the container.
-                            The default is "Auto".
-                          type: string
-                      type: object
-                    type: array
-                type: object
-              targetRef:
-                description: TargetRef points to the controller managing the set of
-                  pods for the autoscaler to control - e.g. Deployment, StatefulSet.
-                  VerticalPodAutoscaler can be targeted at controller implementing
-                  scale subresource (the pod set is retrieved from the controller's
-                  ScaleStatus) or some well known controllers (e.g. for DaemonSet
-                  the pod set is read from the controller's spec). If VerticalPodAutoscaler
-                  cannot use specified target it will report ConfigUnsupported condition.
-                  Note that VerticalPodAutoscaler does not require full implementation
-                  of scale subresource - it will not use it to modify the replica
-                  count. The only thing retrieved is a label selector matching pods
-                  grouped by the target resource.
-                properties:
-                  apiVersion:
-                    description: API version of the referent
-                    type: string
-                  kind:
-                    description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
-                    type: string
-                  name:
-                    description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
-                    type: string
-                required:
-                - kind
-                - name
-                type: object
-              updatePolicy:
-                description: Describes the rules on how changes are applied to the
-                  pods. If not specified, all fields in the `PodUpdatePolicy` are
-                  set to their default values.
-                properties:
-                  updateMode:
-                    description: Controls when autoscaler applies changes to the pod
-                      resources. The default is 'Auto'.
-                    type: string
-                type: object
-            required:
-            - targetRef
-            type: object
-          status:
-            description: Current information about the autoscaler.
-            properties:
-              conditions:
-                description: Conditions is the set of conditions required for this
-                  autoscaler to scale its target, and indicates whether or not those
-                  conditions are met.
-                items:
-                  description: VerticalPodAutoscalerCondition describes the state
-                    of a VerticalPodAutoscaler at a certain point.
-                  properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another
-                      format: date-time
-                      type: string
-                    message:
-                      description: message is a human-readable explanation containing
-                        details about the transition
-                      type: string
-                    reason:
-                      description: reason is the reason for the condition's last transition.
-                      type: string
-                    status:
-                      description: status is the status of the condition (True, False,
-                        Unknown)
-                      type: string
-                    type:
-                      description: type describes the current condition
-                      type: string
-                  required:
-                  - status
-                  - type
-                  type: object
-                type: array
-              recommendation:
-                description: The most recently computed amount of resources recommended
-                  by the autoscaler for the controlled pods.
-                properties:
-                  containerRecommendations:
-                    description: Resources recommended by the autoscaler for each
-                      container.
-                    items:
-                      description: RecommendedContainerResources is the recommendation
-                        of resources computed by autoscaler for a specific container.
-                        Respects the container resource policy if present in the spec.
-                        In particular the recommendation is not produced for containers
-                        with `ContainerScalingMode` set to 'Off'.
-                      properties:
-                        containerName:
-                          description: Name of the container.
-                          type: string
-                        lowerBound:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: Minimum recommended amount of resources. Observes
-                            ContainerResourcePolicy. This amount is not guaranteed
-                            to be sufficient for the application to operate in a stable
-                            way, however running with less resources is likely to
-                            have significant impact on performance/availability.
-                          type: object
-                        target:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: Recommended amount of resources. Observes ContainerResourcePolicy.
-                          type: object
-                        uncappedTarget:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: The most recent recommended resources target
-                            computed by the autoscaler for the controlled pods, based
-                            only on actual resource usage, not taking into account
-                            the ContainerResourcePolicy. May differ from the Recommendation
-                            if the actual resource usage causes the target to violate
-                            the ContainerResourcePolicy (lower than MinAllowed or
-                            higher that MaxAllowed). Used only as status indication,
-                            will not affect actual resource assignment.
-                          type: object
-                        upperBound:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: Maximum recommended amount of resources. Observes
-                            ContainerResourcePolicy. Any resources allocated beyond
-                            this value are likely wasted. This value may be larger
-                            than the maximum amount of application is actually capable
-                            of consuming.
-                          type: object
-                      required:
-                      - target
-                      type: object
-                    type: array
-                type: object
-            type: object
-        required:
-        - spec
-        type: object
-    served: true
-    storage: true
-  - name: v1
-    schema:
-      openAPIV3Schema:
-        description: VerticalPodAutoscaler is the configuration for a vertical pod
-          autoscaler, which automatically manages pod resources based on historical
-          and real time resource utilization.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: 'Specification of the behavior of the autoscaler. More info:
-              https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status.'
-            properties:
-              resourcePolicy:
-                description: Controls how the autoscaler computes recommended resources.
-                  The resource policy may be used to set constraints on the recommendations
-                  for individual containers. If not specified, the autoscaler computes
-                  recommended resources for all containers in the pod, without additional
-                  constraints.
-                properties:
-                  containerPolicies:
-                    description: Per-container resource policies.
-                    items:
-                      description: ContainerResourcePolicy controls how autoscaler
-                        computes the recommended resources for a specific container.
-                      properties:
-                        containerName:
-                          description: Name of the container or DefaultContainerResourcePolicy,
-                            in which case the policy is used by the containers that
-                            don't have their own policy specified.
-                          type: string
-                        maxAllowed:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: Specifies the maximum amount of resources that
-                            will be recommended for the container. The default is
-                            no maximum.
-                          type: object
-                        minAllowed:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: Specifies the minimal amount of resources that
-                            will be recommended for the container. The default is
-                            no minimum.
-                          type: object
-                        mode:
-                          description: Whether autoscaler is enabled for the container.
-                            The default is "Auto".
-                          type: string
-                      type: object
-                    type: array
-                type: object
-              targetRef:
-                description: TargetRef points to the controller managing the set of
-                  pods for the autoscaler to control - e.g. Deployment, StatefulSet.
-                  VerticalPodAutoscaler can be targeted at controller implementing
-                  scale subresource (the pod set is retrieved from the controller's
-                  ScaleStatus) or some well known controllers (e.g. for DaemonSet
-                  the pod set is read from the controller's spec). If VerticalPodAutoscaler
-                  cannot use specified target it will report ConfigUnsupported condition.
-                  Note that VerticalPodAutoscaler does not require full implementation
-                  of scale subresource - it will not use it to modify the replica
-                  count. The only thing retrieved is a label selector matching pods
-                  grouped by the target resource.
-                properties:
-                  apiVersion:
-                    description: API version of the referent
-                    type: string
-                  kind:
-                    description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
-                    type: string
-                  name:
-                    description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
-                    type: string
-                required:
-                - kind
-                - name
-                type: object
-              updatePolicy:
-                description: Describes the rules on how changes are applied to the
-                  pods. If not specified, all fields in the `PodUpdatePolicy` are
-                  set to their default values.
-                properties:
-                  updateMode:
-                    description: Controls when autoscaler applies changes to the pod
-                      resources. The default is 'Auto'.
-                    type: string
-                type: object
-            required:
-            - targetRef
-            type: object
-          status:
-            description: Current information about the autoscaler.
-            properties:
-              conditions:
-                description: Conditions is the set of conditions required for this
-                  autoscaler to scale its target, and indicates whether or not those
-                  conditions are met.
-                items:
-                  description: VerticalPodAutoscalerCondition describes the state
-                    of a VerticalPodAutoscaler at a certain point.
-                  properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another
-                      format: date-time
-                      type: string
-                    message:
-                      description: message is a human-readable explanation containing
-                        details about the transition
-                      type: string
-                    reason:
-                      description: reason is the reason for the condition's last transition.
-                      type: string
-                    status:
-                      description: status is the status of the condition (True, False,
-                        Unknown)
-                      type: string
-                    type:
-                      description: type describes the current condition
-                      type: string
-                  required:
-                  - status
-                  - type
-                  type: object
-                type: array
-              recommendation:
-                description: The most recently computed amount of resources recommended
-                  by the autoscaler for the controlled pods.
-                properties:
-                  containerRecommendations:
-                    description: Resources recommended by the autoscaler for each
-                      container.
-                    items:
-                      description: RecommendedContainerResources is the recommendation
-                        of resources computed by autoscaler for a specific container.
-                        Respects the container resource policy if present in the spec.
-                        In particular the recommendation is not produced for containers
-                        with `ContainerScalingMode` set to 'Off'.
-                      properties:
-                        containerName:
-                          description: Name of the container.
-                          type: string
-                        lowerBound:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: Minimum recommended amount of resources. Observes
-                            ContainerResourcePolicy. This amount is not guaranteed
-                            to be sufficient for the application to operate in a stable
-                            way, however running with less resources is likely to
-                            have significant impact on performance/availability.
-                          type: object
-                        target:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: Recommended amount of resources. Observes ContainerResourcePolicy.
-                          type: object
-                        uncappedTarget:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: The most recent recommended resources target
-                            computed by the autoscaler for the controlled pods, based
-                            only on actual resource usage, not taking into account
-                            the ContainerResourcePolicy. May differ from the Recommendation
-                            if the actual resource usage causes the target to violate
-                            the ContainerResourcePolicy (lower than MinAllowed or
-                            higher that MaxAllowed). Used only as status indication,
-                            will not affect actual resource assignment.
-                          type: object
-                        upperBound:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: Maximum recommended amount of resources. Observes
-                            ContainerResourcePolicy. Any resources allocated beyond
-                            this value are likely wasted. This value may be larger
-                            than the maximum amount of application is actually capable
-                            of consuming.
-                          type: object
-                      required:
-                      - target
-                      type: object
-                    type: array
-                type: object
-            type: object
-        required:
-        - spec
-        type: object
-    served: true
-    storage: false
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
   name: verticalpodautoscalercheckpoints.autoscaling.k8s.io
-  annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes/kubernetes/pull/63797
 spec:
   group: autoscaling.k8s.io
   names:
@@ -721,9 +17,100 @@ spec:
     singular: verticalpodautoscalercheckpoint
   scope: Namespaced
   versions:
-  - name: v1beta2
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: VerticalPodAutoscalerCheckpoint is the checkpoint of the internal
+          state of VPA that is used for recovery after recommender's restart.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: 'Specification of the checkpoint. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status.'
+            properties:
+              containerName:
+                description: Name of the checkpointed container.
+                type: string
+              vpaObjectName:
+                description: Name of the VPA object that stored VerticalPodAutoscalerCheckpoint
+                  object.
+                type: string
+            type: object
+          status:
+            description: Data of the checkpoint.
+            properties:
+              cpuHistogram:
+                description: Checkpoint of histogram for consumption of CPU.
+                properties:
+                  bucketWeights:
+                    description: Map from bucket index to bucket weight.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  referenceTimestamp:
+                    description: Reference timestamp for samples collected within
+                      this histogram.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  totalWeight:
+                    description: Sum of samples to be used as denominator for weights
+                      from BucketWeights.
+                    type: number
+                type: object
+              firstSampleStart:
+                description: Timestamp of the fist sample from the histograms.
+                format: date-time
+                nullable: true
+                type: string
+              lastSampleStart:
+                description: Timestamp of the last sample from the histograms.
+                format: date-time
+                nullable: true
+                type: string
+              lastUpdateTime:
+                description: The time when the status was last refreshed.
+                format: date-time
+                nullable: true
+                type: string
+              memoryHistogram:
+                description: Checkpoint of histogram for consumption of memory.
+                properties:
+                  bucketWeights:
+                    description: Map from bucket index to bucket weight.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  referenceTimestamp:
+                    description: Reference timestamp for samples collected within
+                      this histogram.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  totalWeight:
+                    description: Sum of samples to be used as denominator for weights
+                      from BucketWeights.
+                    type: number
+                type: object
+              totalSamplesCount:
+                description: Total number of samples in the histograms.
+                type: integer
+              version:
+                description: Version of the format of the stored data.
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+  - name: v1beta2
     schema:
       openAPIV3Schema:
         description: VerticalPodAutoscalerCheckpoint is the checkpoint of the internal
@@ -759,15 +146,15 @@ spec:
                 description: Checkpoint of histogram for consumption of CPU.
                 properties:
                   bucketWeights:
-                    type: object
-                    additionalProperties: true
                     description: Map from bucket index to bucket weight.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                   referenceTimestamp:
                     description: Reference timestamp for samples collected within
                       this histogram.
                     format: date-time
-                    type: string
                     nullable: true
+                    type: string
                   totalWeight:
                     description: Sum of samples to be used as denominator for weights
                       from BucketWeights.
@@ -776,31 +163,31 @@ spec:
               firstSampleStart:
                 description: Timestamp of the fist sample from the histograms.
                 format: date-time
-                type: string
                 nullable: true
+                type: string
               lastSampleStart:
                 description: Timestamp of the last sample from the histograms.
                 format: date-time
-                type: string
                 nullable: true
+                type: string
               lastUpdateTime:
                 description: The time when the status was last refreshed.
                 format: date-time
-                type: string
                 nullable: true
+                type: string
               memoryHistogram:
                 description: Checkpoint of histogram for consumption of memory.
                 properties:
                   bucketWeights:
-                    type: object
-                    additionalProperties: true
                     description: Map from bucket index to bucket weight.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                   referenceTimestamp:
                     description: Reference timestamp for samples collected within
                       this histogram.
                     format: date-time
-                    type: string
                     nullable: true
+                    type: string
                   totalWeight:
                     description: Sum of samples to be used as denominator for weights
                       from BucketWeights.
@@ -814,13 +201,56 @@ spec:
                 type: string
             type: object
         type: object
-  - name: v1
     served: true
     storage: false
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes/kubernetes/pull/63797
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: verticalpodautoscalers.autoscaling.k8s.io
+spec:
+  group: autoscaling.k8s.io
+  names:
+    kind: VerticalPodAutoscaler
+    listKind: VerticalPodAutoscalerList
+    plural: verticalpodautoscalers
+    shortNames:
+    - vpa
+    singular: verticalpodautoscaler
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.updatePolicy.updateMode
+      name: Mode
+      type: string
+    - jsonPath: .status.recommendation.containerRecommendations[0].target.cpu
+      name: CPU
+      type: string
+    - jsonPath: .status.recommendation.containerRecommendations[0].target.memory
+      name: Mem
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='RecommendationProvided')].status
+      name: Provided
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
-        description: VerticalPodAutoscalerCheckpoint is the checkpoint of the internal
-          state of VPA that is used for recovery after recommender's restart.
+        description: VerticalPodAutoscaler is the configuration for a vertical pod
+          autoscaler, which automatically manages pod resources based on historical
+          and real time resource utilization.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -835,75 +265,493 @@ spec:
           metadata:
             type: object
           spec:
-            description: 'Specification of the checkpoint. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status.'
+            description: 'Specification of the behavior of the autoscaler. More info:
+              https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status.'
             properties:
-              containerName:
-                description: Name of the checkpointed container.
-                type: string
-              vpaObjectName:
-                description: Name of the VPA object that stored VerticalPodAutoscalerCheckpoint
-                  object.
-                type: string
+              recommenders:
+                description: Recommender responsible for generating recommendation
+                  for this object. List should be empty (then the default recommender
+                  will generate the recommendation) or contain exactly one recommender.
+                items:
+                  description: VerticalPodAutoscalerRecommenderSelector points to
+                    a specific Vertical Pod Autoscaler recommender. In the future
+                    it might pass parameters to the recommender.
+                  properties:
+                    name:
+                      description: Name of the recommender responsible for generating
+                        recommendation for this object.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              resourcePolicy:
+                description: Controls how the autoscaler computes recommended resources.
+                  The resource policy may be used to set constraints on the recommendations
+                  for individual containers. If not specified, the autoscaler computes
+                  recommended resources for all containers in the pod, without additional
+                  constraints.
+                properties:
+                  containerPolicies:
+                    description: Per-container resource policies.
+                    items:
+                      description: ContainerResourcePolicy controls how autoscaler
+                        computes the recommended resources for a specific container.
+                      properties:
+                        containerName:
+                          description: Name of the container or DefaultContainerResourcePolicy,
+                            in which case the policy is used by the containers that
+                            don't have their own policy specified.
+                          type: string
+                        controlledResources:
+                          description: Specifies the type of recommendations that
+                            will be computed (and possibly applied) by VPA. If not
+                            specified, the default of [ResourceCPU, ResourceMemory]
+                            will be used.
+                          items:
+                            description: ResourceName is the name identifying various
+                              resources in a ResourceList.
+                            type: string
+                          type: array
+                        controlledValues:
+                          description: Specifies which resource values should be controlled.
+                            The default is "RequestsAndLimits".
+                          enum:
+                          - RequestsAndLimits
+                          - RequestsOnly
+                          type: string
+                        maxAllowed:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: Specifies the maximum amount of resources that
+                            will be recommended for the container. The default is
+                            no maximum.
+                          type: object
+                        minAllowed:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: Specifies the minimal amount of resources that
+                            will be recommended for the container. The default is
+                            no minimum.
+                          type: object
+                        mode:
+                          description: Whether autoscaler is enabled for the container.
+                            The default is "Auto".
+                          enum:
+                          - Auto
+                          - "Off"
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: TargetRef points to the controller managing the set of
+                  pods for the autoscaler to control - e.g. Deployment, StatefulSet.
+                  VerticalPodAutoscaler can be targeted at controller implementing
+                  scale subresource (the pod set is retrieved from the controller's
+                  ScaleStatus) or some well known controllers (e.g. for DaemonSet
+                  the pod set is read from the controller's spec). If VerticalPodAutoscaler
+                  cannot use specified target it will report ConfigUnsupported condition.
+                  Note that VerticalPodAutoscaler does not require full implementation
+                  of scale subresource - it will not use it to modify the replica
+                  count. The only thing retrieved is a label selector matching pods
+                  grouped by the target resource.
+                properties:
+                  apiVersion:
+                    description: API version of the referent
+                    type: string
+                  kind:
+                    description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                    type: string
+                  name:
+                    description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              updatePolicy:
+                description: Describes the rules on how changes are applied to the
+                  pods. If not specified, all fields in the `PodUpdatePolicy` are
+                  set to their default values.
+                properties:
+                  minReplicas:
+                    description: Minimal number of replicas which need to be alive
+                      for Updater to attempt pod eviction (pending other checks like
+                      PDB). Only positive values are allowed. Overrides global '--min-replicas'
+                      flag.
+                    format: int32
+                    type: integer
+                  updateMode:
+                    description: Controls when autoscaler applies changes to the pod
+                      resources. The default is 'Auto'.
+                    enum:
+                    - "Off"
+                    - Initial
+                    - Recreate
+                    - Auto
+                    type: string
+                type: object
+            required:
+            - targetRef
             type: object
           status:
-            description: Data of the checkpoint.
+            description: Current information about the autoscaler.
             properties:
-              cpuHistogram:
-                description: Checkpoint of histogram for consumption of CPU.
+              conditions:
+                description: Conditions is the set of conditions required for this
+                  autoscaler to scale its target, and indicates whether or not those
+                  conditions are met.
+                items:
+                  description: VerticalPodAutoscalerCondition describes the state
+                    of a VerticalPodAutoscaler at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human-readable explanation containing
+                        details about the transition
+                      type: string
+                    reason:
+                      description: reason is the reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: status is the status of the condition (True, False,
+                        Unknown)
+                      type: string
+                    type:
+                      description: type describes the current condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              recommendation:
+                description: The most recently computed amount of resources recommended
+                  by the autoscaler for the controlled pods.
                 properties:
-                  bucketWeights:
-                    type: object
-                    additionalProperties: true
-                    description: Map from bucket index to bucket weight.
-                  referenceTimestamp:
-                    description: Reference timestamp for samples collected within
-                      this histogram.
-                    format: date-time
-                    type: string
-                    nullable: true
-                  totalWeight:
-                    description: Sum of samples to be used as denominator for weights
-                      from BucketWeights.
-                    type: number
+                  containerRecommendations:
+                    description: Resources recommended by the autoscaler for each
+                      container.
+                    items:
+                      description: RecommendedContainerResources is the recommendation
+                        of resources computed by autoscaler for a specific container.
+                        Respects the container resource policy if present in the spec.
+                        In particular the recommendation is not produced for containers
+                        with `ContainerScalingMode` set to 'Off'.
+                      properties:
+                        containerName:
+                          description: Name of the container.
+                          type: string
+                        lowerBound:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: Minimum recommended amount of resources. Observes
+                            ContainerResourcePolicy. This amount is not guaranteed
+                            to be sufficient for the application to operate in a stable
+                            way, however running with less resources is likely to
+                            have significant impact on performance/availability.
+                          type: object
+                        target:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: Recommended amount of resources. Observes ContainerResourcePolicy.
+                          type: object
+                        uncappedTarget:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: The most recent recommended resources target
+                            computed by the autoscaler for the controlled pods, based
+                            only on actual resource usage, not taking into account
+                            the ContainerResourcePolicy. May differ from the Recommendation
+                            if the actual resource usage causes the target to violate
+                            the ContainerResourcePolicy (lower than MinAllowed or
+                            higher that MaxAllowed). Used only as status indication,
+                            will not affect actual resource assignment.
+                          type: object
+                        upperBound:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: Maximum recommended amount of resources. Observes
+                            ContainerResourcePolicy. Any resources allocated beyond
+                            this value are likely wasted. This value may be larger
+                            than the maximum amount of application is actually capable
+                            of consuming.
+                          type: object
+                      required:
+                      - target
+                      type: object
+                    type: array
                 type: object
-              firstSampleStart:
-                description: Timestamp of the fist sample from the histograms.
-                format: date-time
-                type: string
-                nullable: true
-              lastSampleStart:
-                description: Timestamp of the last sample from the histograms.
-                format: date-time
-                type: string
-                nullable: true
-              lastUpdateTime:
-                description: The time when the status was last refreshed.
-                format: date-time
-                type: string
-                nullable: true
-              memoryHistogram:
-                description: Checkpoint of histogram for consumption of memory.
-                properties:
-                  bucketWeights:
-                    type: object
-                    additionalProperties: true
-                    description: Map from bucket index to bucket weight.
-                  referenceTimestamp:
-                    description: Reference timestamp for samples collected within
-                      this histogram.
-                    format: date-time
-                    type: string
-                    nullable: true
-                  totalWeight:
-                    description: Sum of samples to be used as denominator for weights
-                      from BucketWeights.
-                    type: number
-                type: object
-              totalSamplesCount:
-                description: Total number of samples in the histograms.
-                type: integer
-              version:
-                description: Version of the format of the stored data.
-                type: string
             type: object
+        required:
+        - spec
         type: object
+    served: true
+    storage: true
+    subresources: {}
+  - name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: VerticalPodAutoscaler is the configuration for a vertical pod
+          autoscaler, which automatically manages pod resources based on historical
+          and real time resource utilization.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: 'Specification of the behavior of the autoscaler. More info:
+              https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status.'
+            properties:
+              resourcePolicy:
+                description: Controls how the autoscaler computes recommended resources.
+                  The resource policy may be used to set constraints on the recommendations
+                  for individual containers. If not specified, the autoscaler computes
+                  recommended resources for all containers in the pod, without additional
+                  constraints.
+                properties:
+                  containerPolicies:
+                    description: Per-container resource policies.
+                    items:
+                      description: ContainerResourcePolicy controls how autoscaler
+                        computes the recommended resources for a specific container.
+                      properties:
+                        containerName:
+                          description: Name of the container or DefaultContainerResourcePolicy,
+                            in which case the policy is used by the containers that
+                            don't have their own policy specified.
+                          type: string
+                        maxAllowed:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: Specifies the maximum amount of resources that
+                            will be recommended for the container. The default is
+                            no maximum.
+                          type: object
+                        minAllowed:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: Specifies the minimal amount of resources that
+                            will be recommended for the container. The default is
+                            no minimum.
+                          type: object
+                        mode:
+                          description: Whether autoscaler is enabled for the container.
+                            The default is "Auto".
+                          enum:
+                          - Auto
+                          - "Off"
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: TargetRef points to the controller managing the set of
+                  pods for the autoscaler to control - e.g. Deployment, StatefulSet.
+                  VerticalPodAutoscaler can be targeted at controller implementing
+                  scale subresource (the pod set is retrieved from the controller's
+                  ScaleStatus) or some well known controllers (e.g. for DaemonSet
+                  the pod set is read from the controller's spec). If VerticalPodAutoscaler
+                  cannot use specified target it will report ConfigUnsupported condition.
+                  Note that VerticalPodAutoscaler does not require full implementation
+                  of scale subresource - it will not use it to modify the replica
+                  count. The only thing retrieved is a label selector matching pods
+                  grouped by the target resource.
+                properties:
+                  apiVersion:
+                    description: API version of the referent
+                    type: string
+                  kind:
+                    description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                    type: string
+                  name:
+                    description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              updatePolicy:
+                description: Describes the rules on how changes are applied to the
+                  pods. If not specified, all fields in the `PodUpdatePolicy` are
+                  set to their default values.
+                properties:
+                  updateMode:
+                    description: Controls when autoscaler applies changes to the pod
+                      resources. The default is 'Auto'.
+                    enum:
+                    - "Off"
+                    - Initial
+                    - Recreate
+                    - Auto
+                    type: string
+                type: object
+            required:
+            - targetRef
+            type: object
+          status:
+            description: Current information about the autoscaler.
+            properties:
+              conditions:
+                description: Conditions is the set of conditions required for this
+                  autoscaler to scale its target, and indicates whether or not those
+                  conditions are met.
+                items:
+                  description: VerticalPodAutoscalerCondition describes the state
+                    of a VerticalPodAutoscaler at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human-readable explanation containing
+                        details about the transition
+                      type: string
+                    reason:
+                      description: reason is the reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: status is the status of the condition (True, False,
+                        Unknown)
+                      type: string
+                    type:
+                      description: type describes the current condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              recommendation:
+                description: The most recently computed amount of resources recommended
+                  by the autoscaler for the controlled pods.
+                properties:
+                  containerRecommendations:
+                    description: Resources recommended by the autoscaler for each
+                      container.
+                    items:
+                      description: RecommendedContainerResources is the recommendation
+                        of resources computed by autoscaler for a specific container.
+                        Respects the container resource policy if present in the spec.
+                        In particular the recommendation is not produced for containers
+                        with `ContainerScalingMode` set to 'Off'.
+                      properties:
+                        containerName:
+                          description: Name of the container.
+                          type: string
+                        lowerBound:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: Minimum recommended amount of resources. Observes
+                            ContainerResourcePolicy. This amount is not guaranteed
+                            to be sufficient for the application to operate in a stable
+                            way, however running with less resources is likely to
+                            have significant impact on performance/availability.
+                          type: object
+                        target:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: Recommended amount of resources. Observes ContainerResourcePolicy.
+                          type: object
+                        uncappedTarget:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: The most recent recommended resources target
+                            computed by the autoscaler for the controlled pods, based
+                            only on actual resource usage, not taking into account
+                            the ContainerResourcePolicy. May differ from the Recommendation
+                            if the actual resource usage causes the target to violate
+                            the ContainerResourcePolicy (lower than MinAllowed or
+                            higher that MaxAllowed). Used only as status indication,
+                            will not affect actual resource assignment.
+                          type: object
+                        upperBound:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: Maximum recommended amount of resources. Observes
+                            ContainerResourcePolicy. Any resources allocated beyond
+                            this value are likely wasted. This value may be larger
+                            than the maximum amount of application is actually capable
+                            of consuming.
+                          type: object
+                      required:
+                      - target
+                      type: object
+                    type: array
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/cluster/manifests/02-kube-aws-iam-controller/vpa.yaml
+++ b/cluster/manifests/02-kube-aws-iam-controller/vpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling.k8s.io/v1beta2
+apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: kube-aws-iam-controller

--- a/cluster/manifests/03-ebs-csi/vpa.yaml
+++ b/cluster/manifests/03-ebs-csi/vpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling.k8s.io/v1beta2
+apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: ebs-csi-controller

--- a/cluster/manifests/cronjob-fixer/vpa.yaml
+++ b/cluster/manifests/cronjob-fixer/vpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling.k8s.io/v1beta2
+apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: cronjob-fixer

--- a/cluster/manifests/deployment-service/status-service-vpa.yaml
+++ b/cluster/manifests/deployment-service/status-service-vpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling.k8s.io/v1beta2
+apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: "deployment-service-status-service"

--- a/cluster/manifests/external-dns/vpa.yaml
+++ b/cluster/manifests/external-dns/vpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling.k8s.io/v1beta2
+apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: external-dns

--- a/cluster/manifests/ingress-controller/vpa.yaml
+++ b/cluster/manifests/ingress-controller/vpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling.k8s.io/v1beta2
+apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: kube-ingress-aws-controller

--- a/cluster/manifests/kube-downscaler/vpa.yaml
+++ b/cluster/manifests/kube-downscaler/vpa.yaml
@@ -1,5 +1,5 @@
 {{ if eq .Cluster.ConfigItems.downscaler_enabled "true" }}
-apiVersion: autoscaling.k8s.io/v1beta2
+apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: kube-downscaler

--- a/cluster/manifests/kube-janitor/vpa.yaml
+++ b/cluster/manifests/kube-janitor/vpa.yaml
@@ -1,5 +1,5 @@
 {{ if ne .Cluster.Environment "production" }}
-apiVersion: autoscaling.k8s.io/v1beta2
+apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: kube-janitor

--- a/cluster/manifests/kube-metrics-adapter/vpa.yaml
+++ b/cluster/manifests/kube-metrics-adapter/vpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling.k8s.io/v1beta2
+apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: kube-metrics-adapter

--- a/cluster/manifests/kube-state-metrics/vpa.yaml
+++ b/cluster/manifests/kube-state-metrics/vpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling.k8s.io/v1beta2
+apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: kube-state-metrics

--- a/cluster/manifests/kubenurse/prometheus.yaml
+++ b/cluster/manifests/kubenurse/prometheus.yaml
@@ -76,7 +76,7 @@ spec:
         fsGroup: 65534
       terminationGracePeriodSeconds: 60
 ---
-apiVersion: autoscaling.k8s.io/v1beta2
+apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: kubenurse-prometheus-vpa

--- a/cluster/manifests/kubernetes-lifecycle-metrics/vpa.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/vpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling.k8s.io/v1beta2
+apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: kubernetes-lifecycle-metrics-vpa

--- a/cluster/manifests/metrics-server/metrics-server-vpa.yaml
+++ b/cluster/manifests/metrics-server/metrics-server-vpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling.k8s.io/v1beta2
+apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: metrics-server-vpa

--- a/cluster/manifests/pdb-controller/vpa.yaml
+++ b/cluster/manifests/pdb-controller/vpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling.k8s.io/v1beta2
+apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: pdb-controller

--- a/cluster/manifests/prometheus/prometheus-vpa.yaml
+++ b/cluster/manifests/prometheus/prometheus-vpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling.k8s.io/v1beta2
+apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: prometheus-vpa

--- a/cluster/manifests/stackset-controller/vpa.yaml
+++ b/cluster/manifests/stackset-controller/vpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling.k8s.io/v1beta2
+apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: stackset-controller

--- a/cluster/manifests/z-karpenter/vpa.yaml
+++ b/cluster/manifests/z-karpenter/vpa.yaml
@@ -1,6 +1,6 @@
 {{ if eq .Cluster.ConfigItems.karpenter_pools_enabled "true"}}
 ---
-apiVersion: autoscaling.k8s.io/v1beta2
+apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: karpenter-vpa


### PR DESCRIPTION
This updates the VPA CRD to the version related to the version of the VPA we run.

It still serves `v1beta1`, `v1beta2` and `v1`, but the `v1` spec is updated to include the field `controlledResources` which is used by the vpa-recommender but was not defined in the spec.

Updates all our VPAs to v1.