### PR TITLE
Enable traffic segment probing when cluster supports either annotated segments or segments by default.

### DIFF
--- a/cluster/manifests/deployment-service/01-config.yaml
+++ b/cluster/manifests/deployment-service/01-config.yaml
@@ -20,5 +20,7 @@ data:
   ml-experiment-deployment-role-arn: "arn:aws:iam::{{accountID .Cluster.InfrastructureAccount}}:role/{{.Cluster.LocalID}}-deployment-service-ml-experiment-deployment"
 {{- end }}
   cloudformation-enable-auto-expand: "{{.Cluster.ConfigItems.deployment_service_cf_auto_expand_enabled}}"
-  probe-for-traffic-segments: "{{.Cluster.ConfigItems.stackset_enable_traffic_segments}}"
+{{- if or (eq .Cluster.ConfigItems.stackset_enable_traffic_segments "true") (eq .Cluster.ConfigItems.stackset_annotated_traffic_segments "true") }}
+  probe-for-traffic-segments: "true"
+{{- end }}
   cloudformation-allow-update-source-branch-changes: "{{.Cluster.ConfigItems.deployment_service_cf_update_source_branch_changes}}"


### PR DESCRIPTION
We need to update the templating because of the change I applied in the flags for StackSet controller here https://github.com/zalando-incubator/stackset-controller/pull/575