### PR TITLE
Scale master node Daemonset VPAs dynamically relative to master node size

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -29,7 +29,11 @@ cluster_autoscaler_max_usnchedulable_pods_considered: "1000"
 
 # karpenter settings
 karpenter_controller_cpu: "25m"
+<<<<<<< HEAD
 karpenter_controller_memory: "100Mi"
+=======
+karpenter_controller_memory: "250Mi"
+>>>>>>> 8a39d9dd (set karpenter cpu default to 25m)
 # set log level of karpenter: error|debug
 karpenter_log_level: "error"
 

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -417,7 +417,7 @@ metrics_service_mem_max: "4Gi"
 metrics_server_metric_resolution: "15s"
 
 kube_aws_iam_controller_cpu: "5m"
-kube_aws_iam_controller_mem_max: "1Gi"
+kube_aws_iam_controller_mem: "50Mi"
 
 kube_state_metrics_cpu: "100m"
 kube_state_metrics_mem_max: "4Gi"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -735,6 +735,7 @@ allowed_unsafe_sysctls: "net.ipv4.tcp_keepalive_time,net.ipv4.tcp_keepalive_intv
 
 # the maximum amount of memory for EBS CSI controller's sidecars
 ebs_csi_controller_sidecar_memory: "80Mi"
+ebs_csi_controller_sidecar_cpu: "10m"
 
 # pull images in parallel
 serialize_image_pulls: "false"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -29,11 +29,7 @@ cluster_autoscaler_max_usnchedulable_pods_considered: "1000"
 
 # karpenter settings
 karpenter_controller_cpu: "25m"
-<<<<<<< HEAD
 karpenter_controller_memory: "100Mi"
-=======
-karpenter_controller_memory: "250Mi"
->>>>>>> 8a39d9dd (set karpenter cpu default to 25m)
 # set log level of karpenter: error|debug
 karpenter_log_level: "error"
 

--- a/cluster/manifests/02-kube-aws-iam-controller/deployment.yaml
+++ b/cluster/manifests/02-kube-aws-iam-controller/deployment.yaml
@@ -34,10 +34,10 @@ spec:
         resources:
           limits:
             cpu: "{{.Cluster.ConfigItems.kube_aws_iam_controller_cpu}}"
-            memory: "{{.Cluster.ConfigItems.kube_aws_iam_controller_mem_max}}"
+            memory: "{{.Cluster.ConfigItems.kube_aws_iam_controller_mem}}"
           requests:
             cpu: "{{.Cluster.ConfigItems.kube_aws_iam_controller_cpu}}"
-            memory: "{{.Cluster.ConfigItems.kube_aws_iam_controller_mem_max}}"
+            memory: "{{.Cluster.ConfigItems.kube_aws_iam_controller_mem}}"
       tolerations:
       - key: node.kubernetes.io/role
         value: master

--- a/cluster/manifests/02-kube-aws-iam-controller/vpa.yaml
+++ b/cluster/manifests/02-kube-aws-iam-controller/vpa.yaml
@@ -18,7 +18,7 @@ spec:
     - containerName: kube-aws-iam-controller
       maxAllowed:
         {{ range $NodePool := .Cluster.NodePools }}
-        {{ if eq $NodePool.name "default-master" }}
+        {{ if eq $NodePool.Name "default-master" }}
         # Scaling is relative to r6g.large (smallest master node)
         # 0.014 -> 25m CPU, 0.003 -> 50Mi memory
         cpu: {{ scaleQuantity ( instanceTypeCPU ( index .InstanceTypes 0 )) 0.014 }}

--- a/cluster/manifests/02-kube-aws-iam-controller/vpa.yaml
+++ b/cluster/manifests/02-kube-aws-iam-controller/vpa.yaml
@@ -21,7 +21,7 @@ spec:
         {{ if eq $NodePool.Name "default-master" }}
         # Scaling is relative to r6g.large (smallest master node)
         # 0.014 -> 25m CPU, 0.003 -> 50Mi memory
-        cpu: {{ scaleQuantity ( instanceTypeCPU ( index .InstanceTypes 0 )) 0.014 }}
-        memory: {{ scaleQuantity ( instanceTypeMemory ( index .InstanceTypes 0 )) 0.003 }}
+        cpu: {{ scaleQuantity ( instanceTypeCPUQuantity ( index .InstanceTypes 0 )) 0.014 }}
+        memory: {{ scaleQuantity ( instanceTypeMemoryQuantity ( index .InstanceTypes 0 )) 0.003 }}
         {{ end }}
         {{ end }}

--- a/cluster/manifests/02-kube-aws-iam-controller/vpa.yaml
+++ b/cluster/manifests/02-kube-aws-iam-controller/vpa.yaml
@@ -17,4 +17,11 @@ spec:
     containerPolicies:
     - containerName: kube-aws-iam-controller
       maxAllowed:
-        memory: {{.Cluster.ConfigItems.kube_aws_iam_controller_mem_max}}
+        {{ range $NodePool := .Cluster.NodePools }}
+        {{ if eq $NodePool.name "default-master" }}
+        # Scaling is relative to r6g.large (smallest master node)
+        # 0.014 -> 25m CPU, 0.003 -> 50Mi memory
+        cpu: {{ scaleQuantity ( instanceTypeCPU ( index .InstanceTypes 0 )) 0.014 }}
+        memory: {{ scaleQuantity ( instanceTypeMemory ( index .InstanceTypes 0 )) 0.003 }}
+        {{ end }}
+        {{ end }}

--- a/cluster/manifests/03-ebs-csi/controller.yaml
+++ b/cluster/manifests/03-ebs-csi/controller.yaml
@@ -95,10 +95,10 @@ spec:
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
           resources:
             requests:
-              cpu: 10m
+              cpu: {{ .Cluster.ConfigItems.ebs_csi_controller_sidecar_cpu }}
               memory: {{ .Cluster.ConfigItems.ebs_csi_controller_sidecar_memory }}
             limits:
-              cpu: 10m
+              cpu: {{ .Cluster.ConfigItems.ebs_csi_controller_sidecar_cpu }}
               memory: {{ .Cluster.ConfigItems.ebs_csi_controller_sidecar_memory }}
           volumeMounts:
             - name: socket-dir
@@ -117,10 +117,10 @@ spec:
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
           resources:
             requests:
-              cpu: 10m
+              cpu: {{ .Cluster.ConfigItems.ebs_csi_controller_sidecar_cpu }}
               memory: {{ .Cluster.ConfigItems.ebs_csi_controller_sidecar_memory }}
             limits:
-              cpu: 10m
+              cpu: {{ .Cluster.ConfigItems.ebs_csi_controller_sidecar_cpu }}
               memory: {{ .Cluster.ConfigItems.ebs_csi_controller_sidecar_memory }}
           volumeMounts:
             - name: socket-dir
@@ -139,10 +139,10 @@ spec:
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
           resources:
             requests:
-              cpu: 10m
+              cpu: {{ .Cluster.ConfigItems.ebs_csi_controller_sidecar_cpu }}
               memory: {{ .Cluster.ConfigItems.ebs_csi_controller_sidecar_memory }}
             limits:
-              cpu: 10m
+              cpu: {{ .Cluster.ConfigItems.ebs_csi_controller_sidecar_cpu }}
               memory: {{ .Cluster.ConfigItems.ebs_csi_controller_sidecar_memory }}
           volumeMounts:
             - name: socket-dir

--- a/cluster/manifests/03-ebs-csi/vpa.yaml
+++ b/cluster/manifests/03-ebs-csi/vpa.yaml
@@ -17,7 +17,7 @@ spec:
     containerPolicies:
     - containerName: csi-provisioner
     {{ range $NodePool := .Cluster.NodePools }}
-    {{ if eq $NodePool.name "default-master" }}
+    {{ if eq $NodePool.Name "default-master" }}
     # Scaling is relative to r6g.large (smallest master node)
     # 0.006 -> ~90Mi memory, 0.031 -> ~55m CPU
     {{ $scaledCPU := scaleQuantity ( instanceTypeCPU ( index .InstanceTypes 0 )) 0.031 }}

--- a/cluster/manifests/03-ebs-csi/vpa.yaml
+++ b/cluster/manifests/03-ebs-csi/vpa.yaml
@@ -20,8 +20,8 @@ spec:
     {{ if eq $NodePool.Name "default-master" }}
     # Scaling is relative to r6g.large (smallest master node)
     # 0.006 -> ~90Mi memory, 0.031 -> ~55m CPU
-    {{ $scaledCPU := scaleQuantity ( instanceTypeCPU ( index .InstanceTypes 0 )) 0.031 }}
-    {{ $scaledMemory := scaleQuantity ( instanceTypeMemory ( index .InstanceTypes 0 )) 0.006 }}
+    {{ $scaledCPU := scaleQuantity ( instanceTypeCPUQuantity ( index .InstanceTypes 0 )) 0.031 }}
+    {{ $scaledMemory := scaleQuantity ( instanceTypeMemoryQuantity ( index .InstanceTypes 0 )) 0.006 }}
       maxAllowed:
         cpu: {{ $scaledCPU }}
         memory: {{ $scaledMemory }}

--- a/cluster/manifests/03-ebs-csi/vpa.yaml
+++ b/cluster/manifests/03-ebs-csi/vpa.yaml
@@ -16,11 +16,22 @@ spec:
   resourcePolicy:
     containerPolicies:
     - containerName: csi-provisioner
+    {{ range $NodePool := .Cluster.NodePools }}
+    {{ if eq $NodePool.name "default-master" }}
+    # Scaling is relative to r6g.large (smallest master node)
+    # 0.006 -> ~90Mi memory, 0.031 -> ~55m CPU
+    {{ $scaledCPU := scaleQuantity ( instanceTypeCPU ( index .InstanceTypes 0 )) 0.031 }}
+    {{ $scaledMemory := scaleQuantity ( instanceTypeMemory ( index .InstanceTypes 0 )) 0.006 }}
       maxAllowed:
-        memory: {{ .Cluster.ConfigItems.ebs_csi_controller_sidecar_memory }}
+        cpu: {{ $scaledCPU }}
+        memory: {{ $scaledMemory }}
     - containerName: csi-attacher
       maxAllowed:
-        memory: {{ .Cluster.ConfigItems.ebs_csi_controller_sidecar_memory }}
+        cpu: {{ $scaledCPU }}
+        memory: {{ $scaledMemory }}
     - containerName: csi-resizer
       maxAllowed:
-        memory: {{ .Cluster.ConfigItems.ebs_csi_controller_sidecar_memory }}
+        cpu: {{ $scaledCPU }}
+        memory: {{ $scaledMemory }}
+    {{ end }}
+    {{ end }}

--- a/cluster/manifests/z-karpenter/vpa.yaml
+++ b/cluster/manifests/z-karpenter/vpa.yaml
@@ -24,6 +24,8 @@ spec:
         maxAllowed:
         {{ range $NodePool := .Cluster.NodePools}}
         {{ if eq $NodePool.Name "default-master" }}
+          # Scaling is relative to r6g.large (smallest master node)
+          # 0.016 -> ~250Mi memory, 0.027 -> ~50m CPU
           memory: {{ scaleQuantity (instanceTypeMemory (index .InstanceTypes 0)) 0.016 }}
           cpu: {{ scaleQuantity (instanceTypeCPU (index .InstanceTypes 0)) 0.027 }}
         {{ end }}

--- a/cluster/manifests/z-karpenter/vpa.yaml
+++ b/cluster/manifests/z-karpenter/vpa.yaml
@@ -19,6 +19,13 @@ spec:
     containerPolicies:
       - containerName: controller
         minAllowed:
-          memory: {{.Cluster.ConfigItems.karpenter_controller_memory}}
-          cpu: {{.Cluster.ConfigItems.karpenter_controller_cpu}}
+          memory: .Cluster.ConfigItems.karpenter_controller_memory
+          cpu: .Cluster.ConfigItems.karpenter_controller_cpu
+        maxAllowed:
+        {{ range $NodePool := .Cluster.NodePools}}
+        {{ if eq $NodePool.Name "default-master" }}
+          memory: {{ scaleQuantity (instanceTypeMemory (index .InstanceTypes 0)) 0.016 }}
+          cpu: {{ scaleQuantity (instanceTypeCPU (index .InstanceTypes 0)) 0.027 }}
+        {{ end }}
+        {{ end }}
 {{end}}

--- a/cluster/manifests/z-karpenter/vpa.yaml
+++ b/cluster/manifests/z-karpenter/vpa.yaml
@@ -19,8 +19,8 @@ spec:
     containerPolicies:
       - containerName: controller
         minAllowed:
-          memory: .Cluster.ConfigItems.karpenter_controller_memory
-          cpu: .Cluster.ConfigItems.karpenter_controller_cpu
+          memory: {{ .Cluster.ConfigItems.karpenter_controller_memory }}
+          cpu: {{ .Cluster.ConfigItems.karpenter_controller_cpu }}
         maxAllowed:
         {{ range $NodePool := .Cluster.NodePools}}
         {{ if eq $NodePool.Name "default-master" }}

--- a/cluster/manifests/z-karpenter/vpa.yaml
+++ b/cluster/manifests/z-karpenter/vpa.yaml
@@ -26,8 +26,8 @@ spec:
         {{ if eq $NodePool.Name "default-master" }}
           # Scaling is relative to r6g.large (smallest master node)
           # 0.016 -> ~250Mi memory, 0.027 -> ~50m CPU
-          memory: {{ scaleQuantity (instanceTypeMemory (index .InstanceTypes 0)) 0.016 }}
-          cpu: {{ scaleQuantity (instanceTypeCPU (index .InstanceTypes 0)) 0.027 }}
+          memory: {{ scaleQuantity (instanceTypeMemoryQuantity (index .InstanceTypes 0)) 0.016 }}
+          cpu: {{ scaleQuantity (instanceTypeCPUQuantity (index .InstanceTypes 0)) 0.027 }}
         {{ end }}
         {{ end }}
 {{end}}


### PR DESCRIPTION
Size master node DaemonSet VPAs relative to the size of the master node instance. The following master node Daemonsets use a VerticalPodAutoscaler:

- [x] `karpenter`
- [x] `ebs-csi-controller`
- [x] `kube-aws-iam-controller`

The scaling factors used in templates were computed here: https://github.bus.zalan.do/teapot/issues/issues/3469#issuecomment-5134926

Reference Issue: https://github.bus.zalan.do/teapot/issues/issues/3469
Depends on the patch in `cluster-lifecycle-manager` that implements the used template functions: https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/743 