### PR TITLE
Enable StackSet's versioned Secret support in e2e tests

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -907,7 +907,11 @@ stackset_configmap_support_enabled: "false"
 {{end}}
 
 # enable/disable secret support for stackset
+{{if eq .Cluster.Environment "e2e"}}
+stackset_secret_support_enabled: "true"
+{{else}}
 stackset_secret_support_enabled: "false"
+{{end}}
 
 # enable/disable traffic segment support for stackset
 stackset_enable_traffic_segments: "false"


### PR DESCRIPTION
This is to make sure that e2e tests pass when this feature is enabled.