### PR TITLE
lower karpenter resource thresholds

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -28,8 +28,8 @@ cluster_autoscaler_max_graceful_termination_sec: "1209600" # 2 weeks
 cluster_autoscaler_max_usnchedulable_pods_considered: "1000"
 
 # karpenter settings
-karpenter_controller_cpu: "170m"
-karpenter_controller_memory: "250Mi"
+karpenter_controller_cpu: "25m"
+karpenter_controller_memory: "100Mi"
 # set log level of karpenter: error|debug
 karpenter_log_level: "error"
 


### PR DESCRIPTION
There is work underway to dynamically scale VPAs for master node DaemonSets, including karpenter. [See Issue](https://github.bus.zalan.do/teapot/issues/issues/3469).

For this patch to succeed, the current threshold used in `minAllowed` is too high. When the VPA is updated to add a `maxAllowed` value that is lower than this fixed higher threshold, it fails and the patch cannot succeed.

This fix should allow the patch to succeed, and is safe since as of now, karpenter VPA doesn't have any upper limits and can scale up if it needs to.

More details: https://github.com/zalando-incubator/kubernetes-on-aws/pull/6931#issuecomment-1936327793