### PR TITLE
Update skipper version, step 2/2

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.19.44-795" }}
+{{ $internal_version := "v0.19.53-804" }}
 {{ $canary_internal_version := "v0.19.53-804" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,5 +1,5 @@
 {{ $internal_version := "v0.19.44-795" }}
-{{ $canary_internal_version := "v0.19.44-795" }}
+{{ $canary_internal_version := "v0.19.53-804" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}
 {{ $canary_args := "" }}


### PR DESCRIPTION
Merge https://github.com/zalando-incubator/kubernetes-on-aws/pull/6945 before this PR

+ update tests to redis 7 (only for CI tests)
+ eskip: separate parsing of predicates and filters 
+ Feature: tlsPassClientCertificates filter
+ routesrv: do not log empty routes as error 
+ feature: comment() filter to comment a given filter chain

FYI https://github.com/zalando/skipper/compare/v0.19.44...v0.19.53