### PR TITLE
[WIP] External cloud provider [2/2]

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -689,10 +689,10 @@ kuberuntu_image_v1_25_focal_amd64: {{ amiID "zalando-ubuntu-focal-20.04-kubernet
 kuberuntu_image_v1_25_focal_arm64: {{ amiID "zalando-ubuntu-focal-20.04-kubernetes-production-v1.25.16-arm64-master-305" "861068367966" }}
 kuberuntu_image_v1_25_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.25.16-amd64-master-305" "861068367966" }}
 kuberuntu_image_v1_25_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.25.16-arm64-master-305" "861068367966" }}
-kuberuntu_image_v1_26_focal_amd64: {{ amiID "zalando-ubuntu-focal-20.04-kubernetes-production-v1.26.14-amd64-master-314" "861068367966" }}
-kuberuntu_image_v1_26_focal_arm64: {{ amiID "zalando-ubuntu-focal-20.04-kubernetes-production-v1.26.14-arm64-master-314" "861068367966" }}
-kuberuntu_image_v1_26_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.26.14-amd64-master-314" "861068367966" }}
-kuberuntu_image_v1_26_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.26.14-arm64-master-314" "861068367966" }}
+kuberuntu_image_v1_26_focal_amd64: {{ amiID "zalando-ubuntu-focal-20.04-kubernetes-production-v1.26.14-amd64-master-317" "861068367966" }}
+kuberuntu_image_v1_26_focal_arm64: {{ amiID "zalando-ubuntu-focal-20.04-kubernetes-production-v1.26.14-arm64-master-317" "861068367966" }}
+kuberuntu_image_v1_26_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.26.14-amd64-master-317" "861068367966" }}
+kuberuntu_image_v1_26_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.26.14-arm64-master-317" "861068367966" }}
 
 # Which distro from the previous config items should be used. Valid options are `focal` and `jammy`. Can be set for each node pool.
 {{if eq .Cluster.Environment "test"}}

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -15,7 +15,7 @@ write_files:
       AWS_DEFAULT_REGION={{ .Cluster.Region }}
 
   - owner: root:root
-    path: /etc/kubernetes/config/kubelet.yaml
+    path: /etc/kubernetes/config/kubelet.yaml.template
     content: |
       # https://github.com/kubernetes/kubernetes/blob/v1.13.6/staging/src/k8s.io/kubelet/config/v1beta1/types.go
       apiVersion: kubelet.config.k8s.io/v1beta1
@@ -71,6 +71,9 @@ write_files:
       shutdownGracePeriod: "120s"
       shutdownGracePeriodCriticalPods: "80s"
 {{- end }}
+      # variables are replaced on instance start-up.
+      providerID: __PROVIDER_ID__
+      clusterDNS: [__CLUSTER_DNS__]
 
   - owner: root:root
     path: /etc/kubernetes/manifests/kube-apiserver.yaml
@@ -127,7 +130,7 @@ write_files:
           - --runtime-config=authorization.k8s.io/v1beta1=true,scheduling.k8s.io/v1alpha1=true,admissionregistration.k8s.io/v1beta1=true
           - --authentication-token-webhook-config-file=/etc/kubernetes/config/authn.yaml
           - --authentication-token-webhook-cache-ttl=10s
-          - --cloud-provider=aws
+          - --cloud-provider=external
           - --authorization-mode=Node,Webhook,RBAC
           - --authorization-webhook-config-file=/etc/kubernetes/config/authz.yaml
           - --authorization-webhook-version=v1
@@ -599,7 +602,7 @@ write_files:
           - --leader-elect=true
           - --service-account-private-key-file=/etc/kubernetes/ssl/service-account-private-key.pem
           - --root-ca-file=/etc/kubernetes/ssl/ca.pem
-          - --cloud-provider=aws
+          - --cloud-provider=external
           - --cloud-config=/etc/kubernetes/cloud-config.ini
           - --feature-gates=StatefulSetAutoDeletePVC={{ .Cluster.ConfigItems.enable_statefulset_autodelete_pvc }},TopologyAwareHints={{ .Cluster.ConfigItems.enable_topology_aware_hints }},CronJobTimeZone={{.Cluster.ConfigItems.cronjob_time_zone_enabled}},MaxUnavailableStatefulSet={{.Cluster.ConfigItems.max_unavailable_statefulset_enabled}}
           - --use-service-account-credentials=true

--- a/cluster/node-pools/worker-splitaz/userdata.yaml
+++ b/cluster/node-pools/worker-splitaz/userdata.yaml
@@ -54,7 +54,7 @@ write_files:
       current-context: kubelet-context
 
   - owner: root:root
-    path: /etc/kubernetes/config/kubelet.yaml
+    path: /etc/kubernetes/config/kubelet.yaml.template
     content: |
       # https://github.com/kubernetes/kubernetes/blob/v1.13.6/staging/src/k8s.io/kubelet/config/v1beta1/types.go
       apiVersion: kubelet.config.k8s.io/v1beta1
@@ -107,6 +107,9 @@ write_files:
           cacheAuthorizedTTL: "5m"
           cacheUnauthorizedTTL: "30s"
       protectKernelDefaults: true
+      # variables are replaced on instance start-up.
+      providerID: __PROVIDER_ID__
+      clusterDNS: [__CLUSTER_DNS__]
 
 {{- if and .Cluster.ConfigItems.vm_dirty_background_bytes .Cluster.ConfigItems.vm_dirty_bytes }}
   - owner: root:root


### PR DESCRIPTION
Run kubelet with external cloud provider (requirement from Kubernetes v1.27)

This changes the kubelet configuration in the following way so it's compatible with Kubernetes v1.27

It basically does the following changes in the AMI:

* Switch kubelet flag `--cloud-provider` from `aws` to `external`
* Add `--hostname-override` to set the EC2 internal DNS name as host. This was previously done by the `aws` cloud-provider logic.
* Set `--image-credential-provider` flags on kubelet
  * Add image credential provider config to tell kubelet how to authorize pulls from ECR
  * Add the `ecr-credential-provider` binary used to get ECR credentials (what was previously done by `--cloud-provider=aws`). We use the binary distributed for EKS which is available in a public S3 bucket managed by AWS.
* Introduces simple templating for the kubelet.yaml config file defined in [kubernetes-on-aws](https://github.com/zalando-incubator/kubernetes-on-aws/pull/6947/files#diff-fb712e77981d2e840a03b53964fd2fb37d9cd137e35b2db4d1dbb36f5170fb44R17-R76). This allows injecting `providerID` on instance startup, which has to be added manually and has to be in the `kubelet.yaml`. Same is done for clusterDNS which also can't be set as a flag from Kubernetes v1.27.

### Reference

https://cloud-provider-aws.sigs.k8s.io/prerequisites/
ECR: https://github.com/awslabs/amazon-eks-ami/commit/42c3f524cd74d82c7ea4aaecbc0d46c1c39d2095

## TODO

* [x] Describe changes
* [ ] Use latest valid image
* [x] Adjust resources