### PR TITLE
Add MaxUnavailableStatefulSet feature flag to controller-manager

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -601,7 +601,7 @@ write_files:
           - --root-ca-file=/etc/kubernetes/ssl/ca.pem
           - --cloud-provider=aws
           - --cloud-config=/etc/kubernetes/cloud-config.ini
-          - --feature-gates=StatefulSetAutoDeletePVC={{ .Cluster.ConfigItems.enable_statefulset_autodelete_pvc }},TopologyAwareHints={{ .Cluster.ConfigItems.enable_topology_aware_hints }},CronJobTimeZone={{.Cluster.ConfigItems.cronjob_time_zone_enabled}}
+          - --feature-gates=StatefulSetAutoDeletePVC={{ .Cluster.ConfigItems.enable_statefulset_autodelete_pvc }},TopologyAwareHints={{ .Cluster.ConfigItems.enable_topology_aware_hints }},CronJobTimeZone={{.Cluster.ConfigItems.cronjob_time_zone_enabled}},MaxUnavailableStatefulSet={{.Cluster.ConfigItems.max_unavailable_statefulset_enabled}}
           - --use-service-account-credentials=true
           - --configure-cloud-routes=false
           - --allocate-node-cidrs=true


### PR DESCRIPTION
Follow up to #6898 

Set the `MaxUnavailableStatefulSet` feature flag also on the controller-manager.

Ref: https://github.com/kubernetes/kubernetes/blob/c5f43560a4f98f2af3743a59299fb79f07924373/pkg/controller/statefulset/stateful_set_control.go#L656