### PR TITLE
skipper: fix redis service port

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -209,8 +209,8 @@ spec:
 {{ else }}
           - "-kubernetes-redis-service-namespace=kube-system"
           - "-kubernetes-redis-service-name=skipper-ingress-redis"
-{{ end }}
           - "-kubernetes-redis-service-port=6379"
+{{ end }}
 {{ end }}
           - "-histogram-metric-buckets=.0001,.00025,.0005,.00075,.001,.0025,.005,.0075,.01,.025,.05,.075,.1,.2,.3,.4,.5,.75,1,2,3,4,5,7,10,15,20,30,60,120,300,600"
           - >-
@@ -538,6 +538,7 @@ spec:
           - "-enable-swarm"
           - "-kubernetes-redis-service-namespace=kube-system"
           - "-kubernetes-redis-service-name=skipper-ingress-redis"
+          - "-kubernetes-redis-service-port=6379"
 {{ end }}
 {{ if eq .Cluster.ConfigItems.skipper_oauth2_ui_login "true" }}
           - "-enable-oauth2-grant-flow"


### PR DESCRIPTION
Move `-kubernetes-redis-service-port` to the proper else branch of skipper config and add missing value of routesrv config for consistency.