### PR TITLE
feature: allow to disable cross zone balancing

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -37,7 +37,6 @@ karpenter_log_level: "error"
 kube_aws_ingress_controller_ssl_policy: "ELBSecurityPolicy-TLS-1-2-2017-01"
 kube_aws_ingress_controller_idle_timeout: "1m"
 kube_aws_ingress_controller_deregistration_delay_timeout: "10s"
-kube_aws_ingress_controller_ingress_version: "v1"
 # allow using NLBs for ingress
 # This opens skipper-ingress ports 9998 and 9999 on all worker nodes
 kube_aws_ingress_controller_nlb_enabled: "true"

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -56,7 +56,6 @@ spec:
             - --load-balancer-type={{ .Cluster.ConfigItems.kube_aws_ingress_default_lb_type }}
             # {{ end }}
             - --cert-polling-interval={{ .Cluster.ConfigItems.kube_aws_ingress_controller_cert_polling_interval }}
-            - --ingress-api-version=networking.k8s.io/{{ .Cluster.ConfigItems.kube_aws_ingress_controller_ingress_version }}
           env:
             - name: CUSTOM_FILTERS
               value: "tag:kubernetes.io/cluster/{{ .Cluster.ID }}=owned tag:node.kubernetes.io/role=worker tag:zalando.org/ingress-enabled=true"

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -1,4 +1,4 @@
-# {{ $version := "v0.14.41" }}
+# {{ $version := "v0.15.5" }}
 
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
https://github.com/zalando-incubator/kube-ingress-aws-controller/compare/v0.14.41...v0.15.5

* feature: allow to disable cross zone balancing
* Limit ingress support to only networking.k8s.io/v1
* fix: Set the default ingress API Version
* updates: aws sdk and uuid dependencies