### PR TITLE
Update StackSet Controller

### DIFF
--- a/cluster/manifests/stackset-controller/deployment.yaml
+++ b/cluster/manifests/stackset-controller/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $version := "v1.4.33" }}
+{{ $version := "v1.4.34" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/test/e2e/stackset/go.mod
+++ b/test/e2e/stackset/go.mod
@@ -2,7 +2,7 @@ module github.com/zalando-incubator/kubernetes-on-aws/test/e2e/stackset
 
 go 1.21
 
-require github.com/zalando-incubator/stackset-controller v1.4.33
+require github.com/zalando-incubator/stackset-controller v1.4.34
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/test/e2e/stackset/go.sum
+++ b/test/e2e/stackset/go.sum
@@ -493,8 +493,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-github.com/zalando-incubator/stackset-controller v1.4.33 h1:DkbUxlROutOnBrBgg5VuPnXoUmABH2iH830WO36Fy5Y=
-github.com/zalando-incubator/stackset-controller v1.4.33/go.mod h1:1BOmpWXc2sG7jQ9pM1orQSR8ngUaRZUguAx0SBTdC2k=
+github.com/zalando-incubator/stackset-controller v1.4.34 h1:TvdTvVGzkOakCI3W9CABbLVFArsNkBZiV40tPQ/f19I=
+github.com/zalando-incubator/stackset-controller v1.4.34/go.mod h1:1BOmpWXc2sG7jQ9pM1orQSR8ngUaRZUguAx0SBTdC2k=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.6/go.mod h1:qXsaaIqmgQH0T+OPdb99Bf+PKfBBQVAdyD6TY9G8XM4=
 go.etcd.io/etcd/api/v3 v3.5.0/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQcPvs=


### PR DESCRIPTION
This [StackSet controller version](https://github.com/zalando-incubator/stackset-controller/releases/tag/v1.4.34) only deletes central Ingress/RouteGroup if all segments exist, when converting a StackSet to Ingress Versioning.