### PR TITLE
Update components to use Kubernetes v1.25 client libraries

### DIFF
--- a/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         operator: Exists
       containers:
       - name: cluster-lifecycle-controller
-        image: container-registry.zalando.net/teapot/cluster-lifecycle-controller:master-34
+        image: container-registry.zalando.net/teapot/cluster-lifecycle-controller:master-35
         args:
             - --drain-grace-period={{.Cluster.ConfigItems.drain_grace_period}}
             - --drain-min-pod-lifetime={{.Cluster.ConfigItems.drain_min_pod_lifetime}}

--- a/cluster/manifests/deployment-service/controller-statefulset.yaml
+++ b/cluster/manifests/deployment-service/controller-statefulset.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
         - name: "deployment-service-controller"
-          image: "container-registry.zalando.net/teapot/deployment-controller:master-168"
+          image: "container-registry.zalando.net/teapot/deployment-controller:master-169"
           args:
             - "--config-namespace=kube-system"
             - "--decrypt-kms-alias-arn=arn:aws:kms:{{ .Cluster.Region }}:{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:alias/deployment-secret"

--- a/cluster/manifests/deployment-service/status-service-deployment.yaml
+++ b/cluster/manifests/deployment-service/status-service-deployment.yaml
@@ -1,5 +1,5 @@
 {{ $image   := "container-registry.zalando.net/teapot/deployment-status-service" }}
-{{ $version := "master-168" }}
+{{ $version := "master-169" }}
 
 apiVersion: apps/v1
 kind: Deployment

--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: container-registry.zalando.net/teapot/kube-metrics-adapter:v0.2.2
+        image: container-registry.zalando.net/teapot/kube-metrics-adapter:v0.2.2-11-g91acacb
         env:
         - name: AWS_REGION
           value: {{ .Cluster.Region }}

--- a/cluster/manifests/kube-node-ready-controller/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready-controller/daemonset.yaml
@@ -36,7 +36,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: controller
-        image: container-registry.zalando.net/teapot/kube-node-ready-controller:master-20
+        image: container-registry.zalando.net/teapot/kube-node-ready-controller:master-21
         resources:
           requests:
             cpu: {{.Cluster.ConfigItems.kube_node_ready_controller_cpu}}

--- a/cluster/manifests/kube-node-ready/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready/daemonset.yaml
@@ -1,4 +1,4 @@
-{{ $version := "master-27" }}
+{{ $version := "master-29" }}
 
 apiVersion: apps/v1
 kind: DaemonSet

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -202,7 +202,7 @@ write_files:
             limits:
               memory: {{ .Values.InstanceInfo.MemoryFraction (parseInt64 .Cluster.ConfigItems.apiserver_memory_limit_percent)}}
 {{- end }}
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-190
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-191
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
Updates following components to use Kubernetes v1.25 client libraries

* cluster-lifecycle-controller
* deployment-service
* admission-controller
* kube-node-ready
* kube-node-ready-controller
* kube-metrics-adapter