### PR TITLE
Fix runtime policy injection for prod

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -202,7 +202,7 @@ write_files:
             limits:
               memory: {{ .Values.InstanceInfo.MemoryFraction (parseInt64 .Cluster.ConfigItems.apiserver_memory_limit_percent)}}
 {{- end }}
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-191
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-192
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
Make sure to fall back to default runtime policy if nothing is set.

This fixes the issue that pods on karpenter nodes in production clusters would _not_ get the `karpenter.sh/capacity-type: "on-demand"` injected if they didn't specify a runtime policy explicitly.