### PR TITLE
Enable versioned configuration resources support for all environments

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -894,13 +894,8 @@ stackset_routegroup_support_enabled: "true"
 stackset_ingress_source_switch_ttl: "5m"
 
 # enable/disable versioned configuration resources support for stackset
-{{if eq .Cluster.Environment "production"}}
-stackset_configmap_support_enabled: "false"
-stackset_secret_support_enabled: "false"
-{{else}}
 stackset_configmap_support_enabled: "true"
 stackset_secret_support_enabled: "true"
-{{end}}
 
 # enable/disable traffic segment support for stackset
 stackset_enable_traffic_segments: "false"


### PR DESCRIPTION
Enable versioned configuration resources support for **all** environments.

If have set the config items to `false` in the registry so that we can opt-in clusters gradually by removing the config item.