### PR TITLE
Update skipper version, step 2/2

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.19.53-804" }}
+{{ $internal_version := "v0.20.5-813" }}
 {{ $canary_internal_version := "v0.20.5-813" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}


### PR DESCRIPTION
+ dataclients/kubernetes: change GetEndpointAddresses to return addresses without scheme and port (the reason of major version bump)
+ dataclients/kubernetes: remove endpoint addresses cache
+ dataclients/kubernetes/kubernetestest: support getting resource by name

Merge https://github.com/zalando-incubator/kubernetes-on-aws/pull/6985 first

FYI https://github.com/zalando/skipper/compare/v0.19.53...v0.20.5