### PR TITLE
Revert "Fix runtime policy injection for prod"

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -202,7 +202,7 @@ write_files:
             limits:
               memory: {{ .Values.InstanceInfo.MemoryFraction (parseInt64 .Cluster.ConfigItems.apiserver_memory_limit_percent)}}
 {{- end }}
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-192
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-191
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
Reverts zalando-incubator/kubernetes-on-aws#6979

Revert because it has a potential negative side effect for non karpenter node pools 