### PR TITLE
Give karpenter more memory by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -29,7 +29,7 @@ cluster_autoscaler_max_usnchedulable_pods_considered: "1000"
 
 # karpenter settings
 karpenter_controller_cpu: "25m"
-karpenter_controller_memory: "100Mi"
+karpenter_controller_memory: "256Mi"
 # set log level of karpenter: error|debug
 karpenter_log_level: "error"
 

--- a/cluster/manifests/z-karpenter/vpa.yaml
+++ b/cluster/manifests/z-karpenter/vpa.yaml
@@ -25,8 +25,8 @@ spec:
         {{ range $NodePool := .Cluster.NodePools}}
         {{ if eq $NodePool.Name "default-master" }}
           # Scaling is relative to r6g.large (smallest master node)
-          # 0.016 -> ~250Mi memory, 0.027 -> ~50m CPU
-          memory: {{ scaleQuantity (instanceTypeMemoryQuantity (index .InstanceTypes 0)) 0.016 }}
+          # 0.064 -> ~1024Mi memory, 0.027 -> ~50m CPU
+          memory: {{ scaleQuantity (instanceTypeMemoryQuantity (index .InstanceTypes 0)) 0.064 }}
           cpu: {{ scaleQuantity (instanceTypeCPUQuantity (index .InstanceTypes 0)) 0.027 }}
         {{ end }}
         {{ end }}


### PR DESCRIPTION
100Mi is not quite enough for karpenter on a new cluster. This leads to karpenter pods OOMkilled for some time before VPA kicks in and this makes e2e unstable.

Set default to 256Mi and allow up to 1024Mi (6.4%) on `r6g.large` which is plenty of space. On `m6g.large` it would be 512Mi which is also not bad if we ever run smaller nodes and plenty for the other components as well.