### PR TITLE
Fix runtime policy handling

### DIFF
--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -152,6 +152,7 @@ data:
 {{- range $group, $provider := nodeLifeCycleProviderPerNodePoolGroup .Cluster.NodePools }}
   pod.node-lifecycle.provider.{{ $group }}: "{{ $provider }}"
 {{- end}}
+  pod.node-lifecycle.provider.master: "zalando"
 
   pod.runtime-policy.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_runtime_policy_enabled }}"
   pod.runtime-policy.default: "{{ .Cluster.ConfigItems.teapot_admission_controller_runtime_policy_default }}"

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -202,7 +202,7 @@ write_files:
             limits:
               memory: {{ .Values.InstanceInfo.MemoryFraction (parseInt64 .Cluster.ConfigItems.apiserver_memory_limit_percent)}}
 {{- end }}
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-191
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-194
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
Follow up to #6979 

This fixes the runtime policy injection in the following ways:

* Make sure to fall back to default runtime policy if nothing is set (from #6979).
* Exclude daemonset pods which should not be in scope of runtime policy as they should run on _all_ nodes.
* Don't inject if the default matches what the pod is requesting for the zalando provider (this was an issue introduced in #6979).
* Don't have runtime-policy logic in scope of exclude namespace (this means it will also apply to kube-system pods)
* Treat pods targeting the master nodes (via toleration) as part of the master pool which uses `zalando` lifecycle provider. This avoid injecting a karpenter relevant node selector for pods running on the master nodes, when the default pool is using `karpenter`.