### PR TITLE
skipper: configure terminationMessagePolicy

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -88,6 +88,7 @@ spec:
       containers:
       - name: skipper-ingress
         image: container-registry.zalando.net/teapot/skipper-internal:{{ .internal_version }}
+        terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - name: ingress-port
           containerPort: 9999
@@ -510,6 +511,7 @@ spec:
       containers:
       - name: routesrv
         image: container-registry.zalando.net/teapot/skipper:{{ $version }}
+        terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - name: ingress-port
           containerPort: 9990


### PR DESCRIPTION
configure terminationMessagePolicy for skipper and routesrv containers to have last log messages in the pod status.
See https://kubernetes.io/docs/tasks/debug/debug-application/determine-reason-pod-failure/