### PR TITLE
Fix arch on focal 1.26 build

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -660,10 +660,10 @@ kuberuntu_image_v1_25_focal_amd64: {{ amiID "zalando-ubuntu-focal-20.04-kubernet
 kuberuntu_image_v1_25_focal_arm64: {{ amiID "zalando-ubuntu-focal-20.04-kubernetes-production-v1.25.16-arm64-master-305" "861068367966" }}
 kuberuntu_image_v1_25_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.25.16-amd64-master-305" "861068367966" }}
 kuberuntu_image_v1_25_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.25.16-arm64-master-305" "861068367966" }}
-kuberuntu_image_v1_26_focal_amd64: {{ amiID "zalando-ubuntu-focal-20.04-kubernetes-production-v1.26.14-amd64-master-312" "861068367966" }}
-kuberuntu_image_v1_26_focal_arm64: {{ amiID "zalando-ubuntu-focal-20.04-kubernetes-production-v1.26.14-arm64-master-312" "861068367966" }}
-kuberuntu_image_v1_26_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.26.14-amd64-master-312" "861068367966" }}
-kuberuntu_image_v1_26_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.26.14-arm64-master-312" "861068367966" }}
+kuberuntu_image_v1_26_focal_amd64: {{ amiID "zalando-ubuntu-focal-20.04-kubernetes-production-v1.26.14-amd64-master-314" "861068367966" }}
+kuberuntu_image_v1_26_focal_arm64: {{ amiID "zalando-ubuntu-focal-20.04-kubernetes-production-v1.26.14-arm64-master-314" "861068367966" }}
+kuberuntu_image_v1_26_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.26.14-amd64-master-314" "861068367966" }}
+kuberuntu_image_v1_26_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.26.14-arm64-master-314" "861068367966" }}
 
 # Which distro from the previous config items should be used. Valid options are `focal` and `jammy`. Can be set for each node pool.
 {{if eq .Cluster.Environment "test"}}


### PR DESCRIPTION
Follow up to #7005

Also fix the arch in the focal 1.26 amd64 AMI as it was wrongly set to arm64. 