### PR TITLE
skipper: update canary to v0.20.14

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,5 +1,5 @@
 {{ $internal_version := "v0.20.5-813" }}
-{{ $canary_internal_version := "v0.20.5-813" }}
+{{ $canary_internal_version := "v0.20.14-823" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}
 {{ $canary_args := "" }}


### PR DESCRIPTION
* [net/redisclient: fix nil pointer dereference](https://github.com/zalando/skipper/pull/2939)
* [docs/reference/filters: fix teeLoopback example](https://github.com/zalando/skipper/pull/2948)
* [Initial benchmark for OPA filters](https://github.com/zalando/skipper/pull/2896)
* [Fix Open Policy Agent filter in standalone use](https://github.com/zalando/skipper/pull/2945)
* [build(deps): bump github.com/testcontainers/testcontainers-go](https://github.com/zalando/skipper/pull/2944)
* [build(deps): bump github.com/instana/go-sensor from 1.59.0 to 1.60.0](https://github.com/zalando/skipper/pull/2943)
* [build(deps): bump github.com/tidwall/gjson from 1.17.0 to 1.17.1](https://github.com/zalando/skipper/pull/2942)
* [build(deps): bump github.com/redis/go-redis/v9 from 9.4.0 to 9.5.0](https://github.com/zalando/skipper/pull/2941)
* [skipper: discover redis shards without fetching full cluster state](https://github.com/zalando/skipper/pull/2934)
* [OPA: authorization based on request body](https://github.com/zalando/skipper/pull/2518)
* [Created mock tests for ongoing Passive Health Check feature](https://github.com/zalando/skipper/pull/2938)

https://github.com/zalando/skipper/compare/v0.20.5...v0.20.14