### PR TITLE
fabric: update version to master-240

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -317,7 +317,7 @@ skipper_open_policy_agent_styra_token: ""
 #   - production: runs the controller
 #
 fabric_gateway_controller_mode: "disabled"
-fabric_gateway_controller_version: "master-237"
+fabric_gateway_controller_version: "master-240"
 fabric_gateway_controller_cpu: "50m"
 fabric_gateway_controller_memory: "150Mi"
 fabric_gateway_crd_v1_enabled: "false"


### PR DESCRIPTION
* Bump github.com/szuecs/routegroup-client from 0.24.0 to 0.25.0
* controller: ignore failures caused by terminating namespace
* build: support go1.22