### PR TITLE
Configure dependabot for skipper

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  - package-ecosystem: docker
+    directory: /cluster/manifests/skipper
+    schedule:
+      interval: daily

--- a/cluster/manifests/skipper/hostname-credentials-controller.yaml
+++ b/cluster/manifests/skipper/hostname-credentials-controller.yaml
@@ -1,5 +1,4 @@
 # {{ if eq .Cluster.ConfigItems.skipper_oauth2_ui_login "true" }}
-# {{ $version := "main-11" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -86,7 +85,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: controller
-              image: "container-registry.zalando.net/gwproxy/hostname-credentials-controller:{{ $version }}"
+              image: "container-registry.zalando.net/gwproxy/hostname-credentials-controller:main-11"
               terminationMessagePolicy: FallbackToLogsOnError
               args:
                 - -ingress-selector=application

--- a/cluster/manifests/skipper/secret-combiner.yaml
+++ b/cluster/manifests/skipper/secret-combiner.yaml
@@ -1,5 +1,4 @@
 # {{ if eq .Cluster.ConfigItems.skipper_oauth2_ui_login "true" }}
-# {{ $version := "main-5" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -73,7 +72,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: combiner
-              image: "container-registry.zalando.net/gwproxy/secret-combiner:{{ $version }}"
+              image: "container-registry.zalando.net/gwproxy/secret-combiner:main-5"
               terminationMessagePolicy: FallbackToLogsOnError
               env:
                 - name: NAMESPACE


### PR DESCRIPTION
Dependabot supports Helm charts which use similar template language as CLM. This is an experiment to test whether dependabot can update images in skipper templates.