### PR TITLE
skipper: update version to v0.20.15

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,5 +1,5 @@
 {{ $internal_version := "v0.20.5-813" }}
-{{ $canary_internal_version := "v0.20.14-823" }}
+{{ $canary_internal_version := "v0.20.15-824" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}
 {{ $canary_args := "" }}


### PR DESCRIPTION
This fixes redis:6 support, see https://github.com/zalando/skipper/pull/2949

https://github.com/zalando/skipper/compare/v0.20.14...v0.20.15