### PR TITLE
Add admission for ephemeralcontainers

### DIFF
--- a/cluster/manifests/01-admission-control/teapot.yaml
+++ b/cluster/manifests/01-admission-control/teapot.yaml
@@ -18,7 +18,7 @@ webhooks:
       - operations: [ "CREATE", "UPDATE" ]
         apiGroups: [""]
         apiVersions: ["v1"]
-        resources: ["pods"]
+        resources: ["pods", "pods/ephemeralcontainers"]
 {{- if eq .Cluster.ConfigItems.teapot_admission_controller_inject_environment_variables "true" }}
   - name: pod-binding-admitter.teapot.zalan.do
     clientConfig:

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -202,7 +202,7 @@ write_files:
             limits:
               memory: {{ .Values.InstanceInfo.MemoryFraction (parseInt64 .Cluster.ConfigItems.apiserver_memory_limit_percent)}}
 {{- end }}
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-194
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-195
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
This adds admission of ephemeral containers enabled since Kubernetes v1.25.

This admission will replace ZECR vanity image names with the ecr URL, validate production readiness of images and it will inject the standard envar as are injected in normal pod containers.

The MutatingWebhookConfiguration resource is called `pods/ephemeralcontainers` which is triggered via an update to the pods/ephemeralcontainers api of an existing pod. The request that the admission-controller gets is identical to a pods request, e.g. old and new pod where the new includes the ephemeral container being added.

See https://kubernetes.io/docs/concepts/workloads/pods/ephemeral-containers/