### PR TITLE
step2: use distroless container build for skipper-ingress

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.20.5-813" }}
+{{ $internal_version := "v0.20.15-825" }}
 {{ $canary_internal_version := "v0.20.15-824" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}


### PR DESCRIPTION
use debug containers to attach to the pod in case you want to debug from inside the container

wait for https://github.com/zalando-incubator/kubernetes-on-aws/pull/7037 to be deployed to stable