### PR TITLE
Cloud controller log annotation

### DIFF
--- a/cluster/manifests/aws-cloud-controller-manager/daemonset.yaml
+++ b/cluster/manifests/aws-cloud-controller-manager/daemonset.yaml
@@ -17,6 +17,8 @@ spec:
         daemonset: aws-cloud-controller-manager
         application: kubernetes
         component: aws-cloud-controller-manager
+      annotations:
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
       containers:
       - args:


### PR DESCRIPTION
Follow up to #6950 

Add logging destination annotation to `aws-cloud-controller-manager`