### PR TITLE
Update Admission Controller.

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -202,7 +202,7 @@ write_files:
             limits:
               memory: {{ .Values.InstanceInfo.MemoryFraction (parseInt64 .Cluster.ConfigItems.apiserver_memory_limit_percent)}}
 {{- end }}
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-195
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-196
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
Updates the Admission Controller. Main change: deny using the annotation `zalando.org/aws-load-balancer-shared: "false"` in StackSets.