### PR TITLE
Revert "use distroless container build for skipper-ingress"

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,5 +1,5 @@
 {{ $internal_version := "v0.20.5-813" }}
-{{ $canary_internal_version := "v0.20.15-825" }}
+{{ $canary_internal_version := "v0.20.15-824" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}
 {{ $canary_args := "" }}


### PR DESCRIPTION
Reverts zalando-incubator/kubernetes-on-aws#7037