### PR TITLE
Make nvidia device plugin resources configurable

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -366,6 +366,10 @@ kube_proxy_verbose_level: "2"
 flannel_cpu: "25m"
 flannel_memory: "100Mi"
 
+# nvidia device plugin
+nvidia_device_plugin_cpu: "10m"
+nvidia_device_plugin_memory: "50Mi"
+
 # static egress controller settings
 static_egress_controller_enabled: "true"
 

--- a/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
+++ b/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
@@ -56,11 +56,11 @@ spec:
         - --pass-device-specs
         resources:
           requests:
-            cpu: 50m
-            memory: 25Mi
+            cpu: "{{ .Cluster.ConfigItems.nvidia_device_plugin_cpu }}"
+            memory: "{{ .Cluster.ConfigItems.nvidia_device_plugin_memory }}"
           limits:
-            cpu: 50m
-            memory: 25Mi
+            cpu: "{{ .Cluster.ConfigItems.nvidia_device_plugin_cpu }}"
+            memory: "{{ .Cluster.ConfigItems.nvidia_device_plugin_memory }}"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
The nvidia device plugin was crashing in the data cluster with OOM errors.

* Make the resources configurable via config-item
* Adjust the resources based on usage (more memory, lower cpu requests).

```
kubectl --namespace kube-system top pod | grep nvidia
nvidia-gpu-device-plugin-rg2d9                                         1m           25Mi
```