### PR TITLE
Tag Network Interfaces with application/component

### DIFF
--- a/cluster/etcd/stack.yaml
+++ b/cluster/etcd/stack.yaml
@@ -36,6 +36,14 @@ Resources:
             Value: kubernetes
           - Key: component
             Value: etcd-cluster
+        - ResourceType: "network-interface"
+          Tags:
+          - Key: application
+            Value: kubernetes
+          - Key: component
+            Value: etcd-cluster
+          - Key: Name
+            Value: 'etcd-cluster ({{.Cluster.ID}})'
         NetworkInterfaces:
           - DeviceIndex: 0
             AssociatePublicIpAddress: true

--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -56,6 +56,14 @@ Resources:
             Value: kubernetes
           - Key: component
             Value: control-plane
+        - ResourceType: "network-interface"
+          Tags:
+          - Key: application
+            Value: kubernetes
+          - Key: component
+            Value: control-plane
+          - Key: Name
+            Value: "{{ .NodePool.Name }} ({{ .Cluster.ID }})"
 {{ if .Values.supports_t2_unlimited }}
         CreditSpecification:
           CpuCredits: unlimited

--- a/cluster/node-pools/worker-combined/stack.yaml
+++ b/cluster/node-pools/worker-combined/stack.yaml
@@ -132,6 +132,14 @@ Resources:
             Value: kubernetes
           - Key: component
             Value: "shared-resource"
+        - ResourceType: "network-interface"
+          Tags:
+          - Key: application
+            Value: kubernetes
+          - Key: component
+            Value: "shared-resource"
+          - Key: Name
+            Value: "{{ .NodePool.Name }} ({{ .Cluster.ID }})"
 {{- end }}
         BlockDeviceMappings:
         - DeviceName: /dev/sda1

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -145,6 +145,14 @@ Resources:
             Value: kubernetes
           - Key: component
             Value: "shared-resource"
+        - ResourceType: "network-interface"
+          Tags:
+          - Key: application
+            Value: kubernetes
+          - Key: component
+            Value: "shared-resource"
+          - Key: Name
+            Value: "{{ $data.NodePool.Name }} ({{ $data.Cluster.ID }})"
 {{- end }}
         BlockDeviceMappings:
         - DeviceName: /dev/sda1


### PR DESCRIPTION
Since public IPs now have a cost, it makes sense to tag Network interfaces created for instances with the application/component tags such that the cost can be attributed in AWS Cost explorer.

Similar to for volumes #6716 