### PR TITLE
Fix calculating karpenter vpa max CPU

### DIFF
--- a/cluster/manifests/z-karpenter/vpa.yaml
+++ b/cluster/manifests/z-karpenter/vpa.yaml
@@ -25,9 +25,9 @@ spec:
         {{ range $NodePool := .Cluster.NodePools}}
         {{ if eq $NodePool.Name "default-master" }}
           # Scaling is relative to r6g.large (smallest master node)
-          # 0.064 -> ~1024Mi memory, 0.027 -> ~50m CPU
+          # 0.064 -> ~1024Mi memory, 0.025 -> ~50m CPU
           memory: {{ scaleQuantity (instanceTypeMemoryQuantity (index .InstanceTypes 0)) 0.064 }}
-          cpu: {{ scaleQuantity (instanceTypeCPUQuantity (index .InstanceTypes 0)) 0.027 }}
+          cpu: {{ scaleQuantity (instanceTypeCPUQuantity (index .InstanceTypes 0)) 0.025 }}
         {{ end }}
         {{ end }}
 {{end}}


### PR DESCRIPTION
Follow up to https://github.com/zalando-incubator/kubernetes-on-aws/pull/6931

The scale should be based on the full CPU availble on the instance type and not based on the allocatable CPU. Eg. before we calculated `50m / 1800m ~= 0.027` But the right calculation is `50m / 2000m = 0.025` otherwise the max becomes 54m instead of 50m.

This is to make room for all things as we have packed all master components to fit on 1799 (1803 because of this issue which doesn't fit with 1800m allocatable)

