### PR TITLE
Disable kube2iam on master nodes in test

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -713,6 +713,15 @@ audit_webhook_batch_max_size: "250"
 kube2iam_cpu: "25m"
 kube2iam_memory: "100Mi"
 
+# configure whether kube2iam should only run on worker nodes.
+# This depends on control_plane_asg_lifecycle_hook=false as kube-node-ready
+# doesn't work without kube2iam.
+{{if eq .Cluster.Environment "production"}}
+kube2iam_worker_only: "false"
+{{else}}
+kube2iam_worker_only: "true"
+{{end}}
+
 # CIDR configuration for nodes and pods
 # Changing this will change the number of nodes and pods we can schedule in the
 # cluster: https://cloud.google.com/kubernetes-engine/docs/how-to/flexible-pod-cidr

--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -21,6 +21,10 @@ spec:
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
+{{- if and (eq .Cluster.ConfigItems.kube2iam_worker_only "true") (eq .Cluster.ConfigItems.control_plane_asg_lifecycle_hook "false") }}
+      nodeSelector:
+        node.kubernetes.io/role: worker
+{{- end }}
       dnsConfig:
         options:
           - name: ndots


### PR DESCRIPTION
With #7074 we can also exclude kube2iam on master nodes because nothing depend on it running there.

This would further enable running master nodes with IMDSv2 enforced (#6669)