### PR TITLE
Don't make resource tagging depending on Jammy

### DIFF
--- a/cluster/node-pools/worker-combined/stack.yaml
+++ b/cluster/node-pools/worker-combined/stack.yaml
@@ -124,7 +124,6 @@ Resources:
     Properties:
       LaunchTemplateName: '{{.Cluster.LocalID}}-{{ .NodePool.Name }}'
       LaunchTemplateData:
-{{- if eq .Cluster.ConfigItems.kuberuntu_distro_worker "jammy" }}
         TagSpecifications:
         - ResourceType: "volume"
           Tags:
@@ -140,7 +139,6 @@ Resources:
             Value: "shared-resource"
           - Key: Name
             Value: "{{ .NodePool.Name }} ({{ .Cluster.ID }})"
-{{- end }}
         BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -137,7 +137,6 @@ Resources:
     Properties:
       LaunchTemplateName: '{{ .Cluster.LocalID }}-{{ .NodePool.Name }}'
       LaunchTemplateData:
-{{- if eq .Cluster.ConfigItems.kuberuntu_distro_worker "jammy" }}
         TagSpecifications:
         - ResourceType: "volume"
           Tags:
@@ -153,7 +152,6 @@ Resources:
             Value: "shared-resource"
           - Key: Name
             Value: "{{ $data.NodePool.Name }} ({{ $data.Cluster.ID }})"
-{{- end }}
         BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:


### PR DESCRIPTION
In #6716 we made tagging of worker node volumes a feature enabled together with the update to Ubuntu 22.04 because it requires the rotation of nodes.

Since then we had to roll back Ubuntu 22.04 in several clusters which then removed the volume tagging for new nodes.

Instead of combining it with Ubuntu 22.04, combine this with the roll out of Kubernetes v1.26. This will roll nodes in clusters with focal (Ubuntu 20.04 nodes).