### PR TITLE
Limit number of pods per node for Karpenter nodes

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -32,6 +32,8 @@ karpenter_controller_cpu: "25m"
 karpenter_controller_memory: "256Mi"
 # set log level of karpenter: error|debug
 karpenter_log_level: "error"
+# restrict the maximum number of pods for karpenter nodes
+karpenter_max_pods_per_node: "32"
 
 # ALB config created by kube-aws-ingress-controller
 kube_aws_ingress_controller_ssl_policy: "ELBSecurityPolicy-TLS-1-2-2017-01"

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -174,6 +174,9 @@ spec:
       kubelet:
         clusterDNS: [ "10.0.1.100" ]
         cpuCFSQuota: false
+# {{ if ne .Cluster.ConfigItems.karpenter_max_pods_per_node "" }}
+        maxPods: {{ .Cluster.ConfigItems.karpenter_max_pods_per_node }}
+# {{ end }}
         maxPods: {{ nodeCIDRMaxPods (parseInt64 .Cluster.ConfigItems.node_cidr_mask_size) (parseInt64 .Cluster.ConfigItems.node_max_pods_extra_capacity) }}
         systemReserved:
           cpu: "{{ .Cluster.ConfigItems.kubelet_system_reserved_cpu }}"


### PR DESCRIPTION
This introduces a pod per node limit for Karpenter

The motivation for this is that we see an issue where karpenter, in an effort to optimize bin-packing, creates very big nodes with a lot of pods. However, it does not take into account our relative small disk size on the nodes, meaning all the pod images take up the disk leading to pods getting evicted because of low disk space.

By limiting the number of pods we effectively limit the number of images and reduce the risk of the node being full. In non-karpenter setup this is mitigated by only allowing smaller nodes to be scheduled which which naturally can't have so many pods, but by limiting the number of pods instead of the size of nodes, karpenter can still schedule a big node if needed, but it should optimize the node size based on the pod limit constraint.

The default of 32 pods it based on the production node setup where we have 32 pods per node limited by the network layout. This is maybe extra conservative but we can always adjust it.