### PR TITLE
Update StackSet Controller version.

### DIFF
--- a/cluster/manifests/stackset-controller/deployment.yaml
+++ b/cluster/manifests/stackset-controller/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $version := "v1.4.41" }}
+{{ $version := "v1.4.44" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/cluster/manifests/stackset-controller/deployment.yaml
+++ b/cluster/manifests/stackset-controller/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $version := "v1.4.44" }}
+{{ $version := "v1.4.45" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/test/e2e/stackset/go.mod
+++ b/test/e2e/stackset/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 toolchain go1.22.0
 
-require github.com/zalando-incubator/stackset-controller v1.4.41
+require github.com/zalando-incubator/stackset-controller v1.4.44
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/test/e2e/stackset/go.mod
+++ b/test/e2e/stackset/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 toolchain go1.22.0
 
-require github.com/zalando-incubator/stackset-controller v1.4.44
+require github.com/zalando-incubator/stackset-controller v1.4.45
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/test/e2e/stackset/go.sum
+++ b/test/e2e/stackset/go.sum
@@ -506,8 +506,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-github.com/zalando-incubator/stackset-controller v1.4.41 h1:SqXCehy3gTc0RXvEwWwuufwR1Wh9jKz+lS6IwRxHpyY=
-github.com/zalando-incubator/stackset-controller v1.4.41/go.mod h1:cs6DeHcxl4xAAXl5pK1oAoxjKbmp10PBLKqYqw21VxI=
+github.com/zalando-incubator/stackset-controller v1.4.44 h1:iX+k59V4PmHmssrV73hLbC7rLBy4KmyvKFl6pY+MqdM=
+github.com/zalando-incubator/stackset-controller v1.4.44/go.mod h1:cs6DeHcxl4xAAXl5pK1oAoxjKbmp10PBLKqYqw21VxI=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.6/go.mod h1:qXsaaIqmgQH0T+OPdb99Bf+PKfBBQVAdyD6TY9G8XM4=
 go.etcd.io/etcd/api/v3 v3.5.4/go.mod h1:5GB2vv4A4AOn3yk7MftYGHkUfGtDHnEraIjym4dYz5A=

--- a/test/e2e/stackset/go.sum
+++ b/test/e2e/stackset/go.sum
@@ -506,8 +506,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-github.com/zalando-incubator/stackset-controller v1.4.44 h1:iX+k59V4PmHmssrV73hLbC7rLBy4KmyvKFl6pY+MqdM=
-github.com/zalando-incubator/stackset-controller v1.4.44/go.mod h1:cs6DeHcxl4xAAXl5pK1oAoxjKbmp10PBLKqYqw21VxI=
+github.com/zalando-incubator/stackset-controller v1.4.45 h1:oQvWhC80vyrMLvcZOjVqmdFCou/StLqHS18XxaTSmbc=
+github.com/zalando-incubator/stackset-controller v1.4.45/go.mod h1:cs6DeHcxl4xAAXl5pK1oAoxjKbmp10PBLKqYqw21VxI=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.6/go.mod h1:qXsaaIqmgQH0T+OPdb99Bf+PKfBBQVAdyD6TY9G8XM4=
 go.etcd.io/etcd/api/v3 v3.5.4/go.mod h1:5GB2vv4A4AOn3yk7MftYGHkUfGtDHnEraIjym4dYz5A=


### PR DESCRIPTION
New StackSet Controller version handling conversion of "Shallow" StackSets:
* [1.4.45](https://github.com/zalando-incubator/stackset-controller/releases/tag/v1.4.45).
* [1.4.44](https://github.com/zalando-incubator/stackset-controller/releases/tag/v1.4.44). 