### PR TITLE
Use hostNetwork for EC2 metadata access for aws-cloud-controller-manager

### DIFF
--- a/cluster/manifests/aws-cloud-controller-manager/daemonset.yaml
+++ b/cluster/manifests/aws-cloud-controller-manager/daemonset.yaml
@@ -20,6 +20,7 @@ spec:
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
+      hostNetwork: true
       containers:
       - args:
         - --v=2


### PR DESCRIPTION
With #7083 and later #6669 the aws-cloud-controller-manager can't connect to the ec2 metadata to discover some initial information.

Enable hostNetwork such that it has direct access without kube2iam.