### PR TITLE
[ALPHA] Use hostnetwork for aws-cloud-controller-manager to access ec2 metadata

### DIFF
--- a/cluster/manifests/aws-cloud-controller-manager/daemonset.yaml
+++ b/cluster/manifests/aws-cloud-controller-manager/daemonset.yaml
@@ -20,6 +20,7 @@ spec:
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
+      hostNetwork: true
       containers:
       - args:
         - --v=2


### PR DESCRIPTION
Adding #7095 directly to alpha as e2e is broken without this.