### PR TITLE
Fix condition for maxPods

### DIFF
--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -176,8 +176,9 @@ spec:
         cpuCFSQuota: false
 # {{ if ne .Cluster.ConfigItems.karpenter_max_pods_per_node "" }}
         maxPods: {{ .Cluster.ConfigItems.karpenter_max_pods_per_node }}
-# {{ end }}
+# {{ else }}
         maxPods: {{ nodeCIDRMaxPods (parseInt64 .Cluster.ConfigItems.node_cidr_mask_size) (parseInt64 .Cluster.ConfigItems.node_max_pods_extra_capacity) }}
+# {{ end }}
         systemReserved:
           cpu: "{{ .Cluster.ConfigItems.kubelet_system_reserved_cpu }}"
           memory: "{{ .Cluster.ConfigItems.kubelet_system_reserved_memory }}"


### PR DESCRIPTION
In #7093 the condition was missing the else clause, fix that to either set a fixed `maxPods` value or a automatic one.