### PR TITLE
feature: ingress enable cert tag filter [1/2]

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1141,6 +1141,9 @@ Resources:
               - Action: 'acm:DescribeCertificate'
                 Effect: Allow
                 Resource: '*'
+              - Action: 'acm:ListTagsForCertificate'
+                Effect: Allow
+                Resource: '*'
               - Action: 'autoscaling:DescribeAutoScalingGroups'
                 Effect: Allow
                 Resource: '*'
@@ -1224,7 +1227,7 @@ Resources:
       RoleName: "{{.Cluster.LocalID}}-app-ingr-ctrl"
     Type: 'AWS::IAM::Role'
 {{ if eq .Cluster.ConfigItems.skipper_open_policy_agent_enabled "true" }}
-  # Note: this is not strictly specific to Open Policy Agent and can be extend 
+  # Note: this is not strictly specific to Open Policy Agent and can be extend
   # if Skipper Ingress needs to access other AWS resources
   SkipperIngressIAMRole:
     Properties:

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -46,6 +46,12 @@ kube_aws_ingress_controller_nlb_cross_zone: "true"
 kube_aws_ingress_controller_cert_polling_interval: "2m"
 # sets the default LB type: "network" or "application" are valid choices (overwritten by nlb_switch)
 kube_aws_ingress_default_lb_type: "application"
+# cert filter
+{{if eq .Cluster.Environment "production"}}
+kube_aws_ingress_controller_cert_filter_tag: ""
+{{else}}
+kube_aws_ingress_controller_cert_filter_tag: "kubernetes=enabled"
+{{end}}
 
 # ALB to NLB switch
 # "pre":

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -56,6 +56,9 @@ spec:
             - --load-balancer-type={{ .Cluster.ConfigItems.kube_aws_ingress_default_lb_type }}
             # {{ end }}
             - --cert-polling-interval={{ .Cluster.ConfigItems.kube_aws_ingress_controller_cert_polling_interval }}
+            # {{ if .Cluster.ConfigItems.kube_aws_ingress_controller_cert_filter_tag }}
+            - --cert-filter-tag="{{ .Cluster.ConfigItems.kube_aws_ingress_controller_cert_filter_tag }}"
+            # {{ end }}
           env:
             - name: CUSTOM_FILTERS
               value: "tag:kubernetes.io/cluster/{{ .Cluster.ID }}=owned tag:node.kubernetes.io/role=worker tag:zalando.org/ingress-enabled=true"

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -57,7 +57,7 @@ spec:
             # {{ end }}
             - --cert-polling-interval={{ .Cluster.ConfigItems.kube_aws_ingress_controller_cert_polling_interval }}
             # {{ if .Cluster.ConfigItems.kube_aws_ingress_controller_cert_filter_tag }}
-            - --cert-filter-tag="{{ .Cluster.ConfigItems.kube_aws_ingress_controller_cert_filter_tag }}"
+            - --cert-filter-tag={{ .Cluster.ConfigItems.kube_aws_ingress_controller_cert_filter_tag }}
             # {{ end }}
           env:
             - name: CUSTOM_FILTERS


### PR DESCRIPTION
Enabled for test as first step. Test certs are all tagged so nothing should happen. It is also enabled for e2e clusters
All new created certs have to have the ACM tag `kubernetes=enabled` to make sure that our ingress controller will pick them up to use in cloud load balancers. It's a safety feature to make sure manually created certificates are not automatically picked up, but there is an active choice to do so.