### PR TITLE
Make canary-only configuration for skipper-ingress possible

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -77,6 +77,7 @@ skipper_ingress_memory: "1500Mi"
 
 # Enables deployment of canary version
 skipper_ingress_canary_enabled: "true"
+skipper_ingress_test_single_pod: "false"
 
 # When set to true (and dedicated node pool for skipper is also true) the
 # daemonset overhead will be subtracted from the cpu settings such

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -39,6 +39,8 @@ metadata:
 spec:
 {{ if index . "replicas" }}
   replicas: {{ .replicas }}
+{{ else if eq .Cluster.ConfigItems.skipper_ingress_test_single_pod "true" }}
+  replicas: 0
 {{ end }}
   strategy:
     rollingUpdate:


### PR DESCRIPTION
When "skipper_ingress_canary_enabled" and "skipper_ingress_test_single_pod" are both "true"