### PR TITLE
Revert "skipper: do not use service account with routesrv"

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -81,9 +81,7 @@ spec:
               parent-resource-hash: 71556441059f2d033fb06b1e73df03598c7ecaa6
 {{- end }}
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
-{{ if ne .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
       serviceAccountName: skipper-ingress
-{{ end }}
       terminationGracePeriodSeconds: {{ .Cluster.ConfigItems.skipper_termination_grace_period }}
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true


### PR DESCRIPTION
This reverts commit e0ad690d252402da8dc268d13d94332188f9021e (#6999).

Skipper needs ServiceAccount to fetch OPA policy from S3.