### PR TITLE
fix: skipper-ingress dataplane AWS role for OPA

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -312,3 +312,10 @@ post_apply:
 - name: system:cloud-controller-manager
   kind: ClusterRoleBinding
 {{- end }}
+# TODO(sszuecs) cleanup skipper-ingress roles after successful change
+# - name: skipper-ingress
+#   kind: ClusterRole
+#   namespace: kube-system
+# - name: skipper-ingress
+#   kind: ClusterRoleBinding
+#   namespace: kube-system

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -81,9 +81,7 @@ spec:
               parent-resource-hash: 71556441059f2d033fb06b1e73df03598c7ecaa6
 {{- end }}
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
-{{ if ne .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
       serviceAccountName: skipper-ingress
-{{ end }}
       terminationGracePeriodSeconds: {{ .Cluster.ConfigItems.skipper_termination_grace_period }}
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true

--- a/cluster/manifests/skipper/rbac.yaml
+++ b/cluster/manifests/skipper/rbac.yaml
@@ -5,12 +5,27 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
+    component: ingress
 {{ if eq .Cluster.ConfigItems.skipper_open_policy_agent_enabled "true" }}
   # Note: if the role extends beyond OPA use, this condition can be removed
   annotations:
     iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-app-skipper-ingress"
 {{ end }}
 ---
+apiVersion: v1
+kind: ServiceAccount
+
+metadata:
+  name: skipper-ingress-routesrv
+  namespace: kube-system
+  labels:
+    application: skipper-ingress
+    component: routesrv
+---
+# TODO(sszuecs) after successful rollout we can delete all permissions
+# (not the ClusterRole -> we need PSP for hostnetwork), because
+# component=ingress does not need kubernetes RBAC permissions to
+# apiserver
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -44,6 +59,51 @@ rules:
   - get
   - list
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: skipper-ingress-routesrv
+rules:
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+- apiGroups: [""]
+  resources: ["namespaces", "services", "endpoints", "pods"]
+  verbs: ["get", "list"]
+- apiGroups:
+    - discovery.k8s.io
+  resources:
+    - endpointslices
+  verbs:
+    - get
+    - list
+- apiGroups:
+  - zalando.org
+  resources:
+  - routegroups
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: skipper-ingress-routesrv
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: skipper-ingress-routesrv
+subjects:
+- kind: ServiceAccount
+  name: skipper-ingress-routesrv
+  namespace: kube-system
+---
+# TODO(sszuecs) after successful rollout we can delete this, because
+# ingress does not have access to kube-apiserver
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:


### PR DESCRIPTION
fix: skipper-ingress needs access to its svcaccount because OPA requires AWS role to access S3 (follow up on https://github.com/zalando-incubator/kubernetes-on-aws/pull/6999)
prepare: svcaccount and roles to switch routesrv to its own role set to reduce permissions for ingress and routesrv to least priveleges model