### PR TITLE
skipper: require hosts in RouteGroup CRD

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -316,6 +316,9 @@ skipper_ingress_default_lb_algorithm: "powerOfRandomNChoices"
 
 skipper_ingress_disable_catchall_routes: "true"
 
+# Original RouteGroup CRD does not require hosts but we explicitly want it specified in our infrastructure
+skipper_ingress_routegroup_crd_require_hosts: "true"
+
 # Set defaults values that would enable Open Policy Agent in a skipper filter
 skipper_open_policy_agent_enabled: "false"
 skipper_open_policy_agent_styra_token: ""

--- a/cluster/manifests/01-routegroup/routegroup-crd.yaml
+++ b/cluster/manifests/01-routegroup/routegroup-crd.yaml
@@ -145,9 +145,9 @@ spec:
                 description: List of hostnames for the RouteGroup
                 items:
                   pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?([.][a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
-                  minItems: 1 # original CRD allows empty hosts but we explicitly want it specified in our infrastructure
                   type: string
                 type: array
+                minItems: 1
               routes:
                 description: Routes describe how a matching HTTP request is handled
                   and where it is forwarded to
@@ -218,6 +218,9 @@ spec:
                 type: array
             required:
             - backends
+            # {{ if eq .Cluster.ConfigItems.skipper_ingress_routegroup_crd_require_hosts "true" }}
+            - hosts
+            # {{ end }}
             type: object
           status:
             properties:


### PR DESCRIPTION
* it was required and was broken by https://github.com/zalando-incubator/kubernetes-on-aws/pull/3912
* make it configurable