### PR TITLE
Karpenter setup modifications

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -551,14 +551,14 @@ Resources:
           PolicyName: root
       RoleName: "{{.Cluster.LocalID}}-app-autoscaler"
     Type: 'AWS::IAM::Role'
-{{- if eq .Cluster.ConfigItems.karpenter_pools_enabled "true"}}
-  KarpenterNodeInstanceProfile:
+  KarpenterNodeInstanceProfile: # instance profile for worker nodes spawn by karpenter controller
     Type: "AWS::IAM::InstanceProfile"
     Properties:
       InstanceProfileName: "{{ .Cluster.ID | awsValidID }}-WorkerKarpenter-InstanceProfile"
       Path: "/"
       Roles:
         - !Ref WorkerIAMRole
+{{- if eq .Cluster.ConfigItems.karpenter_pools_enabled "true"}}
   KarpenterIAMRole: # role for the karpenter controller
     Properties:
       AssumeRolePolicyDocument:

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -28,6 +28,10 @@ cluster_autoscaler_max_graceful_termination_sec: "1209600" # 2 weeks
 cluster_autoscaler_max_usnchedulable_pods_considered: "1000"
 
 # karpenter settings
+# DO NOT SET TO FALSE IF THE CLUSTER HAS KARPENTER POOLS OR NODES. REFER TO TEAPOT DOCS  FOR HOW TO ROLLBACK KARPENTER
+# https://teapot.docs.zalando.net/howtos/karpenter-operations/
+karpenter_pools_enabled: "false"
+
 karpenter_controller_cpu: "25m"
 karpenter_controller_memory: "256Mi"
 # set log level of karpenter: error|debug
@@ -994,8 +998,6 @@ config_provider_service: "false"
 
 # enable SizeMemoryBackedVolumes feature flag
 enable_size_memory_backed_volumes: "true"
-
-karpenter_pools_enabled: "false"
 
 # enable StatefulSetAutoDeletePVC feature flag
 # https://kubernetes.io/blog/2021/12/16/kubernetes-1-23-statefulset-pvc-auto-deletion/

--- a/cluster/manifests/z-karpenter/deployment.yaml
+++ b/cluster/manifests/z-karpenter/deployment.yaml
@@ -77,7 +77,7 @@ spec:
             - name: KUBERNETES_MIN_VERSION
               value: 1.22.0-0
             - name: LOG_LEVEL
-              value: info
+              value: {{ .Cluster.ConfigItems.karpenter_log_level }}
             - name: MEMORY_LIMIT
               valueFrom:
                 resourceFieldRef:


### PR DESCRIPTION
- the instance profile that karpenter controller uses  for the workers it spawns is not under a feature flag. this guarantees it ALWAYS exists in the cluster even if not used. it has 0 costs and can prevent issues when the feature flag is turned off while there is already nodes running
- fix minor configuration issue