### PR TITLE
Drop config items for configuration resources (enabled by default)

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -921,10 +921,6 @@ stackset_routegroup_support_enabled: "true"
 # E.g. switching from RouteGroup to Ingress or vice versa.
 stackset_ingress_source_switch_ttl: "5m"
 
-# enable/disable versioned configuration resources support for stackset
-stackset_configmap_support_enabled: "true"
-stackset_secret_support_enabled: "true"
-
 # enable/disable traffic segment support for stackset
 stackset_enable_traffic_segments: "false"
 {{if eq .Cluster.Environment "e2e"}}

--- a/cluster/manifests/stackset-controller/01-stack-crd.yaml
+++ b/cluster/manifests/stackset-controller/01-stack-crd.yaml
@@ -349,7 +349,6 @@ spec:
                 - maxReplicas
                 - metrics
                 type: object
-{{- if or (eq .Cluster.ConfigItems.stackset_configmap_support_enabled "true") (eq .Cluster.ConfigItems.stackset_secret_support_enabled "true") }}
               configurationResources:
                 description: ConfigurationResources describes the ConfigMaps that
                   will be created. Later Secrets and PlatformCredentialSets will also
@@ -358,7 +357,6 @@ spec:
                   description: ConfigurationResourcesSpec makes it possible to defined
                     the config resources to be created
                   properties:
-{{- if eq .Cluster.ConfigItems.stackset_configmap_support_enabled "true" }}
                     configMapRef:
                       description: ConfigMap to be owned by Stack
                       properties:
@@ -367,8 +365,6 @@ spec:
                             TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
                       type: object
-{{ end }}
-{{- if eq .Cluster.ConfigItems.stackset_secret_support_enabled "true" }}
                     secretRef:
                       description: Secret to be owned by Stack
                       properties:
@@ -377,10 +373,8 @@ spec:
                             TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
                       type: object
-{{ end }}
                   type: object
                 type: array
-{{ end }}
               externalIngress:
                 description: Stack specific ExternalIngress, based on the parent StackSet
                   at creation time.

--- a/cluster/manifests/stackset-controller/01-stackset-crd.yaml
+++ b/cluster/manifests/stackset-controller/01-stackset-crd.yaml
@@ -596,7 +596,6 @@ spec:
                         - maxReplicas
                         - metrics
                         type: object
-{{- if or (eq .Cluster.ConfigItems.stackset_configmap_support_enabled "true") (eq .Cluster.ConfigItems.stackset_secret_support_enabled "true") }}
                       configurationResources:
                         description: ConfigurationResources describes the ConfigMaps
                           that will be created. Later Secrets and PlatformCredentialSets
@@ -605,7 +604,6 @@ spec:
                           description: ConfigurationResourcesSpec makes it possible
                             to defined the config resources to be created
                           properties:
-{{- if eq .Cluster.ConfigItems.stackset_configmap_support_enabled "true" }}
                             configMapRef:
                               description: ConfigMap to be owned by Stack
                               properties:
@@ -615,8 +613,6 @@ spec:
                                     uid?'
                                   type: string
                               type: object
-{{ end }}
-{{- if eq .Cluster.ConfigItems.stackset_secret_support_enabled "true" }}
                             secretRef:
                               description: Secret to be owned by Stack
                               properties:
@@ -626,10 +622,8 @@ spec:
                                     uid?'
                                   type: string
                               type: object
-{{ end }}
                           type: object
                         type: array
-{{ end }}
                       minReadySeconds:
                         description: Minimum number of seconds for which a newly created
                           pod should be ready without any of its container crashing,

--- a/cluster/manifests/stackset-controller/deployment.yaml
+++ b/cluster/manifests/stackset-controller/deployment.yaml
@@ -37,12 +37,8 @@ spec:
         - "--enable-routegroup-support"
         - "--ingress-source-switch-ttl={{ .Cluster.ConfigItems.stackset_ingress_source_switch_ttl }}"
 {{- end }}
-{{- if eq .Cluster.ConfigItems.stackset_configmap_support_enabled "true" }}
         - "--enable-configmap-support"
-{{- end }}
-{{- if eq .Cluster.ConfigItems.stackset_secret_support_enabled "true" }}
         - "--enable-secret-support"
-{{- end }}
 {{- if eq .Cluster.ConfigItems.stackset_enable_traffic_segments "true" }}
         - "--enable-traffic-segments"
 {{- end }}

--- a/cluster/manifests/stackset-controller/rbac.yaml
+++ b/cluster/manifests/stackset-controller/rbac.yaml
@@ -99,7 +99,6 @@ rules:
   - create
   - update
   - patch
-{{- if eq .Cluster.ConfigItems.stackset_configmap_support_enabled "true" }}
 - apiGroups:
   - ""
   resources:
@@ -109,8 +108,6 @@ rules:
   - list
   - create
   - update
-{{- end }}
-{{- if eq .Cluster.ConfigItems.stackset_secret_support_enabled "true" }}
 - apiGroups:
   - ""
   resources:
@@ -120,7 +117,6 @@ rules:
   - list
   - create
   - update
-{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
These config items are enabled everywhere by default. Let's drop the config items to clean up.