### PR TITLE
Update stackset-controller version to v1.4.52

### DIFF
--- a/cluster/manifests/stackset-controller/deployment.yaml
+++ b/cluster/manifests/stackset-controller/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $version := "v1.4.49" }}
+{{ $version := "v1.4.52" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/test/e2e/stackset/go.mod
+++ b/test/e2e/stackset/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 toolchain go1.22.0
 
-require github.com/zalando-incubator/stackset-controller v1.4.49
+require github.com/zalando-incubator/stackset-controller v1.4.52
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -31,12 +31,14 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.19.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/testify v1.8.4 // indirect
 	github.com/szuecs/routegroup-client v0.25.0 // indirect
 	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/oauth2 v0.17.0 // indirect

--- a/test/e2e/stackset/go.sum
+++ b/test/e2e/stackset/go.sum
@@ -506,8 +506,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-github.com/zalando-incubator/stackset-controller v1.4.49 h1:nkq9d9QwIPTiZmautcgGnZX5ACgbcM+KgoKMXhSralI=
-github.com/zalando-incubator/stackset-controller v1.4.49/go.mod h1:HJ9bcBTgGl4bUA10mqC5/7TuvXOuC/Qh77WbOxU3LHY=
+github.com/zalando-incubator/stackset-controller v1.4.52 h1:Fvf7YpFswtb4iE6ha+C0z4KO1oZU92Mbt8YPjK/rxGc=
+github.com/zalando-incubator/stackset-controller v1.4.52/go.mod h1:HJ9bcBTgGl4bUA10mqC5/7TuvXOuC/Qh77WbOxU3LHY=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.6/go.mod h1:qXsaaIqmgQH0T+OPdb99Bf+PKfBBQVAdyD6TY9G8XM4=
 go.etcd.io/etcd/api/v3 v3.5.4/go.mod h1:5GB2vv4A4AOn3yk7MftYGHkUfGtDHnEraIjym4dYz5A=


### PR DESCRIPTION
https://github.com/zalando-incubator/stackset-controller/releases/tag/v1.4.52

Main feature:
- Prevent scaling up stacks without traffic (https://github.com/zalando-incubator/stackset-controller/pull/542)
