### PR TITLE
Allow users to use coordination.k8s.io api for Leader election

### DIFF
--- a/cluster/manifests/roles/poweruser-role.yaml
+++ b/cluster/manifests/roles/poweruser-role.yaml
@@ -232,4 +232,11 @@ rules:
   - deletecollection
   - patch
   - update
-
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - update
+  - patch

--- a/cluster/manifests/roles/readonly-role.yaml
+++ b/cluster/manifests/roles/readonly-role.yaml
@@ -254,4 +254,3 @@ rules:
   - get
   - list
   - watch
-


### PR DESCRIPTION
This allows the poweruser role access to use the `coordination.k8s.io` API which is used by controllers for leader election. Users wanting to deploy operators that use this API should be allowed to.

Ref: https://kubernetes.io/docs/concepts/architecture/leases/