### PR TITLE
Increase EBS root volume size.

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -900,7 +900,7 @@ stackset_controller_mem_max: "4Gi"
 
 # EBS settings for the root volume
 ebs_master_root_volume_size: "50"
-ebs_root_volume_size: "50"
+ebs_root_volume_size: "100"
 ebs_root_volume_delete_on_termination: "true"
 
 # Priority class used for critical system pods


### PR DESCRIPTION
Since kubernetes 1.26, many clusters have Pods being Evicted or Erroring because of disk pressure in the root volume. This Pull request mitigates this problem by increaseing the default for EBS root volume size.