### PR TITLE
Add support for inline ConfigMaps in StackSet CRD

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -926,6 +926,9 @@ stackset_routegroup_support_enabled: "true"
 # E.g. switching from RouteGroup to Ingress or vice versa.
 stackset_ingress_source_switch_ttl: "5m"
 
+# enable/disable inline configmap support for stackset
+stackset_inline_configmap_support_enabled: "false"
+
 # enable/disable traffic segment support for stackset
 stackset_enable_traffic_segments: "false"
 {{if eq .Cluster.Environment "e2e"}}

--- a/cluster/manifests/stackset-controller/01-stack-crd.yaml
+++ b/cluster/manifests/stackset-controller/01-stack-crd.yaml
@@ -357,6 +357,20 @@ spec:
                   description: ConfigurationResourcesSpec makes it possible to defined
                     the config resources to be created
                   properties:
+{{- if eq .Cluster.ConfigItems.stackset_inline_configmap_support_enabled "true" }}
+                    configMap:
+                      description: ConfigMap to be owned by Stack
+                      properties:
+                        data:
+                          additionalProperties:
+                            type: string
+                          description: Data of the ConfigMap
+                          type: object
+                        name:
+                          description: Name of the ConfigMap
+                          type: string
+                      type: object
+{{ end }}
                     configMapRef:
                       description: ConfigMap to be owned by Stack
                       properties:

--- a/cluster/manifests/stackset-controller/01-stackset-crd.yaml
+++ b/cluster/manifests/stackset-controller/01-stackset-crd.yaml
@@ -604,6 +604,20 @@ spec:
                           description: ConfigurationResourcesSpec makes it possible
                             to defined the config resources to be created
                           properties:
+{{- if eq .Cluster.ConfigItems.stackset_inline_configmap_support_enabled "true" }}
+                            configMap:
+                              description: ConfigMap to be owned by Stack
+                              properties:
+                                data:
+                                  additionalProperties:
+                                    type: string
+                                  description: Data of the ConfigMap
+                                  type: object
+                                name:
+                                  description: Name of the ConfigMap
+                                  type: string
+                              type: object
+{{ end }}
                             configMapRef:
                               description: ConfigMap to be owned by Stack
                               properties:


### PR DESCRIPTION
Update StackSet CRD for inline ConfigMaps. This is just an early version to update CRD in stackset-controller's e2e cluster to be able to run the test cases.