### PR TITLE
feature: ingress enable cert tag filter [2/2]

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -51,11 +51,7 @@ kube_aws_ingress_controller_cert_polling_interval: "2m"
 # sets the default LB type: "network" or "application" are valid choices (overwritten by nlb_switch)
 kube_aws_ingress_default_lb_type: "application"
 # cert filter
-{{if eq .Cluster.Environment "production"}}
-kube_aws_ingress_controller_cert_filter_tag: ""
-{{else}}
 kube_aws_ingress_controller_cert_filter_tag: "kubernetes=enabled"
-{{end}}
 
 # ALB to NLB switch
 # "pre":


### PR DESCRIPTION
production clusters were already changed via cluster-registry. This will now set it as default for all clusters such that new clusters will have this behavior from the beginning.

see also https://github.com/zalando-incubator/kubernetes-on-aws/pull/7114