### PR TITLE
Update kube-metrics-adapter to Kubernetes v1.27

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: container-registry.zalando.net/teapot/kube-metrics-adapter:v0.2.2-11-g91acacb
+        image: container-registry.zalando.net/teapot/kube-metrics-adapter:v0.2.2-17-gc973a9e
         env:
         - name: AWS_REGION
           value: {{ .Cluster.Region }}


### PR DESCRIPTION
Updates kube-metrics-adapter to Kubernetes v1.27

ref: https://github.com/zalando-incubator/kube-metrics-adapter/pull/680