### PR TITLE
Update kube-static-egress-controller to v1.27

### DIFF
--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: kube-static-egress-controller
       containers:
       - name: controller
-        image: container-registry.zalando.net/teapot/kube-static-egress-controller:v0.2.13-master-44
+        image: container-registry.zalando.net/teapot/kube-static-egress-controller:v0.2.14-master-45
         args:
         - "--provider=aws"
         - "--vpc-id={{.Cluster.ConfigItems.vpc_id}}"


### PR DESCRIPTION
Updates the `kube-static-egress-controller` to Kubernetes v1.27