### PR TITLE
Update VPA to v1.0.0

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -475,8 +475,8 @@ horizontal_pod_autoscaler_tolerance: "0.1"
 horizontal_pod_downscale_stabilization: "5m0s"
 
 # Vertical pod autoscaler version for controlling roll-out, can be "current" or "legacy"
-# current => v0.11.0-internal.17
-# legacy => v0.6.1-internal.16
+# current => v1.0.0-internal.20
+# legacy => v0.12.0-internal.19
 vertical_pod_autoscaler_version: "current"
 
 # Cluster update settings

--- a/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
@@ -26,9 +26,9 @@ spec:
       containers:
       - name: admission-controller
         {{if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "current"}}
-        image: container-registry.zalando.net/teapot/vpa-admission-controller:v0.12.0-internal.19
+        image: container-registry.zalando.net/teapot/vpa-admission-controller:v1.0.0-internal.20
         {{else if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "legacy"}}
-        image: container-registry.zalando.net/teapot/vpa-admission-controller:v0.11.0-internal.17
+        image: container-registry.zalando.net/teapot/vpa-admission-controller:v0.12.0-internal.19
         {{end}}
         command:
           - /admission-controller

--- a/cluster/manifests/01-vertical-pod-autoscaler/rbac.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/rbac.yaml
@@ -42,8 +42,6 @@ rules:
       - list
       - watch
       - create
-      - update
-      - patch
   - apiGroups:
       - "poc.autoscaling.k8s.io"
     resources:
@@ -52,7 +50,6 @@ rules:
       - get
       - list
       - watch
-      - patch
   - apiGroups:
       - "autoscaling.k8s.io"
     resources:
@@ -61,6 +58,18 @@ rules:
       - get
       - list
       - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:vpa-status-actor
+rules:
+  - apiGroups:
+      - "autoscaling.k8s.io"
+    resources:
+      - verticalpodautoscalers/status
+    verbs:
+      - get
       - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -110,17 +119,12 @@ metadata:
     component: vpa
 rules:
   - apiGroups:
+      - "apps"
       - "extensions"
     resources:
       - replicasets
     verbs:
       - get
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - delete
   - apiGroups:
       - ""
     resources:
@@ -166,6 +170,19 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  name: system:vpa-status-actor
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:vpa-status-actor
+subjects:
+  - kind: ServiceAccount
+    name: vpa-recommender
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
   name: system:vpa-checkpoint-actor
   labels:
     application: kubernetes
@@ -187,6 +204,13 @@ metadata:
     application: kubernetes
     component: vpa
 rules:
+  - apiGroups:
+    - '*'
+    resources:
+    - '*/scale'
+    verbs:
+    - get
+    - watch
   - apiGroups:
       - ""
     resources:
@@ -241,7 +265,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: system:vpa-evictionter-binding
+  name: system:vpa-evictioner-binding
   labels:
     application: kubernetes
     component: vpa
@@ -253,6 +277,15 @@ subjects:
   - kind: ServiceAccount
     name: vpa-updater
     namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vpa-admission-controller
+  namespace: kube-system
+  labels:
+    application: kubernetes
+    component: vpa-admission-controller
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -271,15 +304,6 @@ metadata:
   labels:
     application: kubernetes
     component: vpa-updater
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: vpa-admission-controller
-  namespace: kube-system
-  labels:
-    application: kubernetes
-    component: vpa-admission-controller
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -375,6 +399,6 @@ roleRef:
   kind: ClusterRole
   name: system:vpa-status-reader
 subjects:
-- kind: ServiceAccount
-  name: vpa-updater
-  namespace: kube-system
+  - kind: ServiceAccount
+    name: vpa-updater
+    namespace: kube-system

--- a/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
@@ -24,9 +24,9 @@ spec:
       containers:
       - name: recommender
         {{if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "current"}}
-        image: container-registry.zalando.net/teapot/vpa-recommender:v0.12.0-internal.19
+        image: container-registry.zalando.net/teapot/vpa-recommender:v1.0.0-internal.20
         {{else if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "legacy"}}
-        image: container-registry.zalando.net/teapot/vpa-recommender:v0.11.0-internal.17
+        image: container-registry.zalando.net/teapot/vpa-recommender:v0.12.0-internal.19
         {{end}}
         args:
         - --logtostderr

--- a/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
@@ -24,9 +24,9 @@ spec:
       containers:
       - name: updater
         {{if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "current"}}
-        image: container-registry.zalando.net/teapot/vpa-updater:v0.12.0-internal.19
+        image: container-registry.zalando.net/teapot/vpa-updater:v1.0.0-internal.20
         {{else if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "legacy"}}
-        image: container-registry.zalando.net/teapot/vpa-updater:v0.11.0-internal.17
+        image: container-registry.zalando.net/teapot/vpa-updater:v0.12.0-internal.19
         {{end}}
         command:
           - ./updater


### PR DESCRIPTION
Update the vertical-pod-autoscaler components to a version based on upstream v1.0.0: https://github.com/zalando-incubator/autoscaler/pull/108

The version is updated via the config-item: `vertical_pod_autoscaler_version=current|legacy` such that we run the new version by default, but can easily switch back by setting `vertical_pod_autoscaler_version=legacy`. This is done as it's hard to validate the VPA without running it for some time.