### PR TITLE
skipper: enable topology-spread by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -96,15 +96,14 @@ skipper_ingress_binpack: "false"
 {{end}}
 # skipper node-pool
 enable_dedicate_nodepool_skipper: "true"
+skipper_topology_spread_enabled: "true"
 {{if eq .Cluster.Environment "e2e"}}
 skipper_attach_only_to_skipper_node_pool: "false"
-skipper_topology_spread_enabled: "true"
 {{else}}
 skipper_attach_only_to_skipper_node_pool: "true"
-skipper_topology_spread_enabled: "false"
 {{end}}
-skipper_suppress_route_update_logs: "true"
 
+skipper_suppress_route_update_logs: "true"
 skipper_validate_query: "true"
 skipper_validate_query_log: "false"
 


### PR DESCRIPTION
skipper: enable topology-spread by default that we use in production via CR