### PR TITLE
Allow vpa-updater to delete pods

### DIFF
--- a/cluster/manifests/01-vertical-pod-autoscaler/rbac.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/rbac.yaml
@@ -128,6 +128,12 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - pods
+    verbs:
+      - delete
+  - apiGroups:
+      - ""
+    resources:
       - pods/eviction
     verbs:
       - create


### PR DESCRIPTION
Another fix for #7211

The vpa-updater component still needs to be able to delete pods or it will not replace pods to be scaled up:

```
failed: failed to delete pod kube-system/kube-state-metrics-684f88c74-xbwpw: pods "kube-state-metrics-684f88c74-xbwpw" is forbidden: User "system:serviceaccount:kube-system:vpa-updater" cannot delete resource "pods" in API group "" in the namespace "kube-system": access undecided system:serviceaccount:kube-system:vpa-updater/[system:serviceaccounts system:serviceaccounts:kube-system system:authenticated]
```

~Not sure why it's not using the eviction API as the upstream RBAC config would indicate, but for now enable deletion to avoid breaking behavior.~

This is because it's part of our patches: https://github.com/zalando-incubator/autoscaler/blame/c8b9704da2cd706e4c2b7e251ad160b0fa0643c8/vertical-pod-autoscaler/pkg/updater/eviction/pods_eviction_restriction.go#L139 we likely could switch this to use eviction API, but let's "stop the bleeding" by allowing deletion of pods.