### PR TITLE
[TEST E2E] Validate AMI works with MACAddressPolicy=none

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -685,10 +685,10 @@ kuberuntu_image_v1_26_focal_amd64: {{ amiID "zalando-ubuntu-focal-20.04-kubernet
 kuberuntu_image_v1_26_focal_arm64: {{ amiID "zalando-ubuntu-focal-20.04-kubernetes-production-v1.26.14-arm64-master-317" "861068367966" }}
 kuberuntu_image_v1_26_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.26.14-amd64-master-317" "861068367966" }}
 kuberuntu_image_v1_26_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.26.14-arm64-master-317" "861068367966" }}
-kuberuntu_image_v1_27_focal_amd64: {{ amiID "zalando-ubuntu-focal-20.04-kubernetes-production-v1.27.12-amd64-master-321" "861068367966" }}
-kuberuntu_image_v1_27_focal_arm64: {{ amiID "zalando-ubuntu-focal-20.04-kubernetes-production-v1.27.12-arm64-master-321" "861068367966" }}
-kuberuntu_image_v1_27_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.27.12-amd64-master-321" "861068367966" }}
-kuberuntu_image_v1_27_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.27.12-arm64-master-321" "861068367966" }}
+kuberuntu_image_v1_27_focal_amd64: {{ amiID "zalando-ubuntu-focal-20.04-kubernetes-test-v1.27.12-amd64-pr-347-1" "861068367966" }}
+kuberuntu_image_v1_27_focal_arm64: {{ amiID "zalando-ubuntu-focal-20.04-kubernetes-test-v1.27.12-arm64-pr-347-1" "861068367966" }}
+kuberuntu_image_v1_27_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-test-v1.27.12-amd64-pr-347-1" "861068367966" }}
+kuberuntu_image_v1_27_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-test-v1.27.12-arm64-pr-347-1" "861068367966" }}
 
 # Which distro from the previous config items should be used. Valid options are `focal` and `jammy`. Can be set for each node pool.
 {{if eq .Cluster.Environment "test"}}


### PR DESCRIPTION
This is just to test that an AMI with `MACAddressPolicy=none` works in our setup.

This setting would be needed for AWS VPC CNI and if it works we don't need to run a patched AMI version to test that in connection with EKS.