### PR TITLE
skipper: replace parent-resource-hash selector

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -76,9 +76,7 @@ spec:
           whenUnsatisfiable: DoNotSchedule
           labelSelector:
             matchLabels:
-              # This is kind of stupid, but would work for now. Ideally we should just stop filtering out the pods in
-              # kube-system in our admitters, since we've never really had any issues with them.
-              parent-resource-hash: 71556441059f2d033fb06b1e73df03598c7ecaa6
+              deployment: skipper-ingress
 {{- end }}
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       serviceAccountName: skipper-ingress
@@ -488,9 +486,7 @@ spec:
           whenUnsatisfiable: DoNotSchedule
           labelSelector:
             matchLabels:
-              # This is kind of stupid, but would work for now. Ideally we should just stop filtering out the pods in
-              # kube-system in our admitters, since we've never really had any issues with them.
-              parent-resource-hash: abd943226b6885f66785592be28bdf303863fbac
+              deployment: skipper-ingress-routesrv
 {{- end }}
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       serviceAccountName: skipper-ingress-routesrv

--- a/cluster/manifests/skipper/skipper-redis.yaml
+++ b/cluster/manifests/skipper/skipper-redis.yaml
@@ -34,9 +34,7 @@ spec:
           whenUnsatisfiable: DoNotSchedule
           labelSelector:
             matchLabels:
-              # This is kind of stupid, but would work for now. Ideally we should just stop filtering out the pods in
-              # kube-system in our admitters, since we've never really had any issues with them.
-              parent-resource-hash: 97bcb33ef5bafb09bdbf83fc09c11e5f5fc84dad
+              statefulset: skipper-ingress-redis
 {{- end }}
       affinity:
         podAntiAffinity:


### PR DESCRIPTION
Use `kind: name` labels introduced for skipper-ingress application
consolidation (see https://github.com/zalando-incubator/kubernetes-on-aws/pull/4855 and https://github.com/zalando-incubator/kubernetes-on-aws/pull/4847).

This is a less obscure approach compared to use of `parent-resource-hash`
label (see https://github.com/zalando-incubator/kubernetes-on-aws/pull/4758) added by admission controller which is simply a hash of pod
owner kind and name:
```console
~$ echo -n Deployment-skipper-ingress | sha1sum
71556441059f2d033fb06b1e73df03598c7ecaa6  -
~$ echo -n Deployment-skipper-ingress-routesrv | sha1sum
abd943226b6885f66785592be28bdf303863fbac  -
~$ echo -n StatefulSet-skipper-ingress-redis | sha1sum
97bcb33ef5bafb09bdbf83fc09c11e5f5fc84dad  -
```