### PR TITLE
skipper: require unique hosts in RouteGroup CRD

### DIFF
--- a/cluster/manifests/01-routegroup/routegroup-crd.yaml
+++ b/cluster/manifests/01-routegroup/routegroup-crd.yaml
@@ -137,6 +137,7 @@ spec:
                   type: string
                 minItems: 1
                 type: array
+                x-kubernetes-list-type: set
               routes:
                 description: Routes describe how a matching HTTP request is handled
                   and where it is forwarded to
@@ -222,6 +223,7 @@ spec:
                         type: string
                       minItems: 1
                       type: array
+                      x-kubernetes-list-type: set
                     secretName:
                       description: |-
                         SecretName is the name of the secret used to terminate TLS traffic.


### PR DESCRIPTION
See changes https://github.com/szuecs/routegroup-client/pull/41

Skipper webhook currently requires unique hosts so this is a safe change.