### PR TITLE
rename configmap in config-provider-service rbac

### DIFF
--- a/cluster/manifests/roles/config-provider-rbac.yaml
+++ b/cluster/manifests/roles/config-provider-rbac.yaml
@@ -10,7 +10,7 @@ rules:
   - configmaps
   resourceNames:
   - business-partners-config
-  - sales-channels-config
+  - cfas-sales-channels-config
   verbs:
   - get
   - create


### PR DESCRIPTION
It was requested in a support ticket that a renaming is required of a ConfigMap resource in the ClusterRole for the `config-provider-service`. 

Reference: https://github.bus.zalan.do/zooport/issues/issues/4550