### PR TITLE
Disable kube-node-ready on master nodes

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1034,11 +1034,7 @@ apiserver_memory_limit_percent: "80"
 apiserver_max_requests_inflight: "400"
 
 # specify if control plane nodes should rely on ASG Lifecycle Hook or not
-{{- if eq .Cluster.Environment "production" }}
-control_plane_asg_lifecycle_hook: "true"
-{{- else }}
 control_plane_asg_lifecycle_hook: "false"
-{{- end }}
 
 # enable graceful shutdown on the control_plane nodes
 control_plane_graceful_shutdown: "true"


### PR DESCRIPTION
Similar to #7074, but for production

`kube-node-ready` is becoming less and less relevant and has the following issues in the current setup:

* Slows down recovery of master nodes in case of issues with the control plane
* Depends on ec2 instance metadata endpoint which we want to restrict _eventually_
* The ASG lifecycle hook signal is not relevant anymore since we have pod disruption budgets etc.

For this reason, after running with it disabled in test for a month also disable it from production clusters by default. Removing this from masters will also let us get rid of kube2iam on master nodes.