### PR TITLE
Allow zmon-worker to access airflow ressources

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1664,6 +1664,12 @@ Resources:
               - Action: 'acm:ListCertificates'
                 Effect: Allow
                 Resource: '*'
+              - Action: 'airflow:CreateCliToken'
+                Effect: Allow
+                Resource: '*'
+              - Action: 'airflow:ListEnvironments'
+                Effect: Allow
+                Resource: '*'
               - Action: 'autoscaling:Describe*'
                 Effect: Allow
                 Resource: '*'


### PR DESCRIPTION
We added a new feature to the zmon-workers to enable Builders to  execute airflow cli commands easily to monitor their environment. This change is already part of the zmon-worker and has been tested in the test environments with manual adjustments to add the missing roles to the cluster. 

This PR should enable stable cluster to use this feature without ressorting to manual Role Modifications.