### PR TITLE
Updates cluster autoscaler to use k8s v1.27.12 client

### DIFF
--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -36,7 +36,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cluster-autoscaler
-        image: container-registry.zalando.net/teapot/kube-cluster-autoscaler:v1.18.2-internal.44
+        image: container-registry.zalando.net/teapot/kube-cluster-autoscaler:v1.18.2-internal.47
         command:
           - ./cluster-autoscaler
           - --v={{.Cluster.ConfigItems.autoscaling_autoscaler_log_level}}


### PR DESCRIPTION
Update the Cluster Autoscaler to use v1.27.12 k8s client. The version is still called v1.18.2 because that is the CA version it's based on.