### PR TITLE
skipper: go update to go1.22.2 - step 2/2

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.21.36-864" }}
+{{ $internal_version := "v0.21.40-868" }}
 {{ $canary_internal_version := "v0.21.40-868" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}


### PR DESCRIPTION
skipper: go update to go1.22.2 - step 2/2

merge after https://github.com/zalando-incubator/kubernetes-on-aws/pull/7255 is in stable