### PR TITLE
Disable kube2iam on master nodes in production

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -728,11 +728,7 @@ kube2iam_memory: "100Mi"
 # configure whether kube2iam should only run on worker nodes.
 # This depends on control_plane_asg_lifecycle_hook=false as kube-node-ready
 # doesn't work without kube2iam.
-{{if eq .Cluster.Environment "production"}}
-kube2iam_worker_only: "false"
-{{else}}
 kube2iam_worker_only: "true"
-{{end}}
 
 # CIDR configuration for nodes and pods
 # Changing this will change the number of nodes and pods we can schedule in the


### PR DESCRIPTION
With #7249 we can also exclude kube2iam on master nodes because nothing depend on it running there.

This would further enable running master nodes with IMDSv2 enforced (#6669)

Similar to #7083 but for production clusters.