### PR TITLE
PlatformCredentialsSet: configure spec.preserveUnknownFields=false

### DIFF
--- a/cluster/manifests/01-platformcredentialsset/customresourcedefinition.yaml
+++ b/cluster/manifests/01-platformcredentialsset/customresourcedefinition.yaml
@@ -5,6 +5,9 @@ kind: CustomResourceDefinition
 metadata:
   name: platformcredentialssets.zalando.org
 spec:
+  # {{ if eq .Cluster.Environment "test" }}
+  preserveUnknownFields: false
+  # {{ end }}
   scope: Namespaced
   group: zalando.org
   names:


### PR DESCRIPTION
Explicitly set `preserveUnknownFields: false` to enable strict CRD validation and prohibit unknown fields in test environment first.

Conversion of CRD from v1beta1 to v1 (see #2991) resulted in `preserveUnknownFields: true`:
```
$ kubectl --context=example get crd platformcredentialssets.zalando.org -o yaml | grep preserveUnknownFields
  preserveUnknownFields: true
    message: 'spec.preserveUnknownFields: Invalid value: true: must be false'
```
and requires explicit false value to reset.

See also https://github.com/kubernetes-sigs/controller-tools/issues/476#issuecomment-691519936