### PR TITLE
Update deployment service version.

### DIFF
--- a/cluster/manifests/deployment-service/controller-statefulset.yaml
+++ b/cluster/manifests/deployment-service/controller-statefulset.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
         - name: "deployment-service-controller"
-          image: "container-registry.zalando.net/teapot/deployment-controller:master-182"
+          image: "container-registry.zalando.net/teapot/deployment-controller:master-186"
           args:
             - "--config-namespace=kube-system"
             - "--decrypt-kms-alias-arn=arn:aws:kms:{{ .Cluster.Region }}:{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:alias/deployment-secret"

--- a/cluster/manifests/deployment-service/status-service-deployment.yaml
+++ b/cluster/manifests/deployment-service/status-service-deployment.yaml
@@ -1,5 +1,5 @@
 {{ $image   := "container-registry.zalando.net/teapot/deployment-status-service" }}
-{{ $version := "master-182" }}
+{{ $version := "master-186" }}
 
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Updates deployment-controller and deployment-status-service to the latest version. This version removes support for probing central ingress and routegroup resources in StackSets. We don't need this probing, because we migrated all StackSets to use traffic segments.