### PR TITLE
Add ClusterRole and ClusterRoleBinding for deployment-service-executor User

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -952,6 +952,7 @@ deployment_service_lightstep_token: ""
 deployment_service_ml_experiments_enabled: "true"
 deployment_service_cf_auto_expand_enabled: "false"
 deployment_service_cf_update_source_branch_changes: "true"
+deployment_service_executor_cdp_permissions: "false"
 {{- if eq .Cluster.Environment "test" }}
 # disable CF update of source branch changes in test to avoid updating CF stacks
 # on any PR.

--- a/cluster/manifests/deployment-service/controller-rbac.yaml
+++ b/cluster/manifests/deployment-service/controller-rbac.yaml
@@ -124,6 +124,48 @@ subjects:
     kind: User
     name: zalando-iam:zalando:service:k8sapi-local_deployment-service-executor
 ---
+{{- if eq .Cluster.ConfigItems.deployment_service_executor_cdp_permissions "true" }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "deployment-service-executor-cdpdeploymenttasks"
+  labels:
+    application: "deployment-service"
+    component: "controller"
+rules:
+- apiGroups:
+  - deployment.zalando.org
+  resources:
+  - cdpdeploymenttasks
+  - cdpdeploymenttasks/status
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+  - deletecollection
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+  name: "deployment-service-executor-cdpdeploymenttasks"
+  labels:
+    application: "deployment-service"
+    component: "controller"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: deployment-service-executor-cdpdeploymenttasks
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: zalando-iam:zalando:service:k8sapi-local_deployment-service-executor
+---
+{{- end }}
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:


### PR DESCRIPTION
Update the `zalando-iam:zalando:service:k8sapi-local_deployment-service-executor` User permissions to allow interaction with the `cdpdeploymenttasks` and `cdpdeploymenttasks/status` CRDs.