### PR TITLE
Remove traffic segment field from deployment-service configuration.

### DIFF
--- a/cluster/manifests/deployment-service/01-config.yaml
+++ b/cluster/manifests/deployment-service/01-config.yaml
@@ -20,5 +20,4 @@ data:
   ml-experiment-deployment-role-arn: "arn:aws:iam::{{accountID .Cluster.InfrastructureAccount}}:role/{{.Cluster.LocalID}}-deployment-service-ml-experiment-deployment"
 {{- end }}
   cloudformation-enable-auto-expand: "{{.Cluster.ConfigItems.deployment_service_cf_auto_expand_enabled}}"
-  probe-for-traffic-segments: "true"
   cloudformation-allow-update-source-branch-changes: "{{.Cluster.ConfigItems.deployment_service_cf_update_source_branch_changes}}"


### PR DESCRIPTION
Now the we merged https://github.com/zalando-incubator/kubernetes-on-aws/pull/7294 and updated CDP Steps accordingly, there is no need for `probe-for-traffic-segments` anymore.