### PR TITLE
Update kube-static-egress-controller to Kubernetes v1.28

### DIFF
--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: kube-static-egress-controller
       containers:
       - name: controller
-        image: container-registry.zalando.net/teapot/kube-static-egress-controller:v0.2.14-master-45
+        image: container-registry.zalando.net/teapot/kube-static-egress-controller:v0.2.15-master-46
         args:
         - "--provider=aws"
         - "--vpc-id={{.Cluster.ConfigItems.vpc_id}}"


### PR DESCRIPTION
Updates the kube-static-egress-controller to Kubernetes v1.28

ref: https://github.com/szuecs/kube-static-egress-controller/pull/51