### PR TITLE
Update components to kube 1.28 [1/N]

### DIFF
--- a/cluster/manifests/03-ebs-csi/controller.yaml
+++ b/cluster/manifests/03-ebs-csi/controller.yaml
@@ -35,7 +35,7 @@ spec:
         runAsUser: 1000
       containers:
         - name: ebs-plugin
-          image: container-registry.zalando.net/teapot/aws-ebs-csi-driver:v1.27.0-master-15
+          image: container-registry.zalando.net/teapot/aws-ebs-csi-driver:v1.28.0-master-16
           args:
             - controller
             - --endpoint=$(CSI_ENDPOINT)
@@ -82,7 +82,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: csi-provisioner
-          image: container-registry.zalando.net/teapot/external-provisioner:v4.0.0-eks-1-27-25-master-15
+          image: container-registry.zalando.net/teapot/external-provisioner:v4.0.0-eks-1-28-20-master-16
           args:
             - --csi-address=$(ADDRESS)
             - --v=2
@@ -107,7 +107,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: csi-attacher
-          image: container-registry.zalando.net/teapot/external-attacher:v4.5.0-eks-1-27-25-master-15
+          image: container-registry.zalando.net/teapot/external-attacher:v4.5.0-eks-1-28-20-master-16
           args:
             - --csi-address=$(ADDRESS)
             - --v=2
@@ -129,7 +129,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: csi-resizer
-          image: container-registry.zalando.net/teapot/external-resizer:v1.10.0-eks-1-27-25-master-15
+          image: container-registry.zalando.net/teapot/external-resizer:v1.10.0-eks-1-28-20-master-16
           args:
             - --csi-address=$(ADDRESS)
             - --v=2
@@ -151,7 +151,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: liveness-probe
-          image: container-registry.zalando.net/teapot/livenessprobe:v2.12.0-eks-1-27-25-master-15
+          image: container-registry.zalando.net/teapot/livenessprobe:v2.12.0-eks-1-28-20-master-16
           args:
             - --csi-address=/csi/csi.sock
           resources:

--- a/cluster/manifests/03-ebs-csi/node.yaml
+++ b/cluster/manifests/03-ebs-csi/node.yaml
@@ -34,7 +34,7 @@ spec:
         runAsUser: 0
       containers:
         - name: ebs-plugin
-          image: container-registry.zalando.net/teapot/aws-ebs-csi-driver:v1.27.0-master-15
+          image: container-registry.zalando.net/teapot/aws-ebs-csi-driver:v1.28.0-master-16
           args:
             - node
             - --endpoint=$(CSI_ENDPOINT)
@@ -77,7 +77,7 @@ spec:
             privileged: true
             readOnlyRootFilesystem: true
         - name: node-driver-registrar
-          image: container-registry.zalando.net/teapot/node-driver-registrar:v2.10.0-eks-1-27-25-master-15
+          image: container-registry.zalando.net/teapot/node-driver-registrar:v2.10.0-eks-1-28-20-master-16
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
@@ -114,7 +114,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: liveness-probe
-          image: container-registry.zalando.net/teapot/livenessprobe:v2.12.0-eks-1-27-25-master-15
+          image: container-registry.zalando.net/teapot/livenessprobe:v2.12.0-eks-1-28-20-master-16
           args:
             - --csi-address=/csi/csi.sock
           volumeMounts:

--- a/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         operator: Exists
       containers:
       - name: cluster-lifecycle-controller
-        image: container-registry.zalando.net/teapot/cluster-lifecycle-controller:master-37
+        image: container-registry.zalando.net/teapot/cluster-lifecycle-controller:master-38
         args:
             - --drain-grace-period={{.Cluster.ConfigItems.drain_grace_period}}
             - --drain-min-pod-lifetime={{.Cluster.ConfigItems.drain_min_pod_lifetime}}

--- a/cluster/manifests/event-logger/statefulset.yaml
+++ b/cluster/manifests/event-logger/statefulset.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: kubernetes-event-logger
       containers:
       - name: logger
-        image: container-registry.zalando.net/teapot/event-logger:master-11
+        image: container-registry.zalando.net/teapot/event-logger:master-12
         args:
             - --snapshot-namespace=kube-system
             - --snapshot-name=kubernetes-event-logger

--- a/cluster/manifests/kube-node-ready-controller/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready-controller/daemonset.yaml
@@ -36,7 +36,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: controller
-        image: container-registry.zalando.net/teapot/kube-node-ready-controller:master-23
+        image: container-registry.zalando.net/teapot/kube-node-ready-controller:master-24
         resources:
           requests:
             cpu: {{.Cluster.ConfigItems.kube_node_ready_controller_cpu}}

--- a/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: kubernetes-lifecycle-metrics
       containers:
         - name: kubernetes-lifecycle-metrics
-          image: "container-registry.zalando.net/teapot/kubernetes-lifecycle-metrics:master-16"
+          image: "container-registry.zalando.net/teapot/kubernetes-lifecycle-metrics:master-17"
           ports:
             - containerPort: 9090
               protocol: TCP

--- a/cluster/manifests/pdb-controller/deployment.yaml
+++ b/cluster/manifests/pdb-controller/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: pdb-controller
       containers:
       - name: pdb-controller
-        image: container-registry.zalando.net/teapot/pdb-controller:master-30
+        image: container-registry.zalando.net/teapot/pdb-controller:master-31
         args:
           - --debug
 {{- if .Cluster.ConfigItems.pdb_controller_non_ready_ttl }}

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -271,7 +271,7 @@ write_files:
             - mountPath: /etc/kubernetes/ssl
               name: ssl-certs-kubernetes
               readOnly: true
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/k8s-authnz-webhook:master-128
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/k8s-authnz-webhook:master-130
           name: webhook
           ports:
           - containerPort: 8081

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -203,7 +203,7 @@ write_files:
             limits:
               memory: {{ .Values.InstanceInfo.MemoryFraction (parseInt64 .Cluster.ConfigItems.apiserver_memory_limit_percent)}}
 {{- end }}
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-198
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-200
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
Update the following components to Kubernetes v1.28

* kube-node-ready-controller
* cluster-lifecycle-controller
* pdb-controller
* admission-controller
* k8s-authnz-webhook
* event-logger
* kubernetes-lifecycle-metrics
* csi components