### PR TITLE
adding permissions to create/update platformcredentialsset by cdp

### DIFF
--- a/cluster/manifests/roles/cdp-controller-rbac.yaml
+++ b/cluster/manifests/roles/cdp-controller-rbac.yaml
@@ -111,6 +111,17 @@ rules:
   - watch
   - update
   - patch
+- apiGroups:
+  - "zalando.org"
+  resources:
+  - platformcredentialssets
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
contributes to https://github.bus.zalan.do/automata/issues/issues/4984

as part of automated traffic switching, giving cdp permission to create platformcredentialsset which will be required to connect to metric provider from user's clusters