### PR TITLE
PCS: set preserveUnknownFields=false for all clusters

### DIFF
--- a/cluster/manifests/01-platformcredentialsset/customresourcedefinition.yaml
+++ b/cluster/manifests/01-platformcredentialsset/customresourcedefinition.yaml
@@ -5,9 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   name: platformcredentialssets.zalando.org
 spec:
-  # {{ if eq .Cluster.Environment "test" }}
   preserveUnknownFields: false
-  # {{ end }}
   scope: Namespaced
   group: zalando.org
   names:


### PR DESCRIPTION
Follow up to https://github.com/zalando-incubator/kubernetes-on-aws/pull/7284 (see for context)

Set `preserveUnknownFields=false` also in production clusters to fix validation in _all_ clusters.