### PR TITLE
authnz: Add support for okta postgres-admin group

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -271,7 +271,7 @@ write_files:
             - mountPath: /etc/kubernetes/ssl
               name: ssl-certs-kubernetes
               readOnly: true
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/k8s-authnz-webhook:master-130
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/k8s-authnz-webhook:master-132
           name: webhook
           ports:
           - containerPort: 8081


### PR DESCRIPTION
Updates the `k8s-authnz-webhook` to add support for the `okta:common/postgres-admin` group which is the group name when authentication via okta compared to `CollaboratorPostgresAdmin` as it's called in ZACK.