### PR TITLE
Update Stackset Controller for versioned PlatformCredentialsSet support

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -920,7 +920,7 @@ stackset_routegroup_support_enabled: "true"
 stackset_inline_configmap_support_enabled: "false"
 
 # enable/disable platformCredentialsSet support for stackset
-stackset_pcs_support_enabled: "false"
+stackset_pcs_support_enabled: "true"
 
 # Enable/Disable profiling for Kubernetes components
 enable_control_plane_profiling: "false"

--- a/cluster/manifests/stackset-controller/deployment.yaml
+++ b/cluster/manifests/stackset-controller/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $version := "v1.4.64" }}
+{{ $version := "v1.4.67" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/cluster/manifests/stackset-controller/deployment.yaml
+++ b/cluster/manifests/stackset-controller/deployment.yaml
@@ -38,6 +38,9 @@ spec:
 {{- end }}
         - "--enable-configmap-support"
         - "--enable-secret-support"
+{{- if eq .Cluster.ConfigItems.stackset_pcs_support_enabled "true" }}
+        - "--enable-pcs-support"
+{{- end }}
 {{if eq .Cluster.Environment "e2e"}}
         - "--sync-ingress-annotation=example.org/i-haz-synchronize"
         - "--sync-ingress-annotation=teapot.org/the-best"

--- a/cluster/manifests/stackset-controller/rbac.yaml
+++ b/cluster/manifests/stackset-controller/rbac.yaml
@@ -117,6 +117,19 @@ rules:
   - list
   - create
   - update
+{{- if eq .Cluster.ConfigItems.stackset_pcs_support_enabled "true" }}
+- apiGroups:
+  - "zalando.org"
+  resources:
+  - platformcredentialssets
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - patch
+  - delete
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/test/e2e/stackset/go.mod
+++ b/test/e2e/stackset/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 toolchain go1.22.0
 
-require github.com/zalando-incubator/stackset-controller v1.4.64
+require github.com/zalando-incubator/stackset-controller v1.4.67
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/test/e2e/stackset/go.sum
+++ b/test/e2e/stackset/go.sum
@@ -193,8 +193,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-github.com/zalando-incubator/stackset-controller v1.4.64 h1:6imt+pGk3kShm48GBYrH589phgADdowMvFqgOW4r9F0=
-github.com/zalando-incubator/stackset-controller v1.4.64/go.mod h1:1bKOeeMdnuy3LGp1Jd+yc528hXKy0mEnJtUVrCXFqqM=
+github.com/zalando-incubator/stackset-controller v1.4.67 h1:O1q5C/7PANA0+zkylDpqbuYQpkZ1NESFdhZ2X/++5OI=
+github.com/zalando-incubator/stackset-controller v1.4.67/go.mod h1:1bKOeeMdnuy3LGp1Jd+yc528hXKy0mEnJtUVrCXFqqM=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=


### PR DESCRIPTION
Following ConfigMaps https://github.com/zalando-incubator/kubernetes-on-aws/pull/6576 and Secrets https://github.com/zalando-incubator/kubernetes-on-aws/pull/6893,
PlatformCredentialsSet versioning per Stack is also supported
by the Stackset Controller.

Instead of using referencing of already deployed resource, the
`PlatformCredentialsSet` is defined within the Stackset manifest,
then created and managed by the Stackset Controller.

Ref: https://github.com/zalando-incubator/stackset-controller/commit/1d8c713559e7d40709cd182deb055093f43a2da9, https://github.com/zalando-incubator/kubernetes-on-aws/pull/7304