### PR TITLE
skipper: setup lua environment for operators

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -109,7 +109,8 @@ skipper_validate_query_log: "false"
 
 skipper_default_filters: 'disableAccessLog(2,3,404,429) -> fifo(2000,20,"1s")'
 skipper_default_filters_append: 'stateBagToTag("auth-user", "client.uid")'
-skipper_disabled_filters: "lua,static,bearerinjector"
+skipper_disabled_filters: "static,bearerinjector"
+skipper_lua_sources: "file"
 skipper_edit_route_placeholders: ""
 skipper_ingress_inline_routes: ""
 skipper_ingress_refuse_payload: ""

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -253,6 +253,7 @@ spec:
           - "-idle-timeout-server={{ .Cluster.ConfigItems.skipper_idle_timeout_server }}"
           - "-read-timeout-server={{ .Cluster.ConfigItems.skipper_read_timeout_server }}"
           - "-write-timeout-server={{ .Cluster.ConfigItems.skipper_write_timeout_server }}"
+          - "-lua-sources={{ .Cluster.ConfigItems.skipper_lua_sources }}"
           - "-disabled-filters={{ .Cluster.ConfigItems.skipper_disabled_filters }}"
 {{ if ne .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
           - '-default-filters-prepend={{ .Cluster.ConfigItems.skipper_default_filters }}'


### PR DESCRIPTION
skipper: setup lua environment such that operators can create lua files via configmap to be used in routes