### PR TITLE
More aggresive image gc

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -530,6 +530,9 @@ kubelet_system_reserved_memory: "164Mi"
 kubelet_kube_reserved_cpu: "100m"
 kubelet_kube_reserved_memory: "282Mi"
 
+kubelet_image_gc_high_threshold: 50
+kubelet_image_gc_low_threshold: 40
+
 {{if eq .Cluster.Environment "production"}}
 teapot_admission_controller_validate_application_label: "true"
 teapot_admission_controller_validate_base_images: "true"

--- a/cluster/node-pools/worker-splitaz/userdata.yaml
+++ b/cluster/node-pools/worker-splitaz/userdata.yaml
@@ -62,6 +62,8 @@ write_files:
       cgroupDriver: systemd
       containerLogMaxSize: "50Mi"
       containerLogMaxFiles: 2
+      imageGCHighThresholdPercent: {{.Cluster.ConfigItems.kubelet_image_gc_high_threshold}}
+      imageGCLowThresholdPercent: {{.Cluster.ConfigItems.kubelet_image_gc_low_threshold}}
       clusterDomain: cluster.local
       cpuCFSQuota: false
       featureGates:


### PR DESCRIPTION
This introduces configuring `imageGCHighThresholdPercent` and `imageGCLowThresholdPercent` on the kubelet of worker nodes to do more aggressive image GC than the default settings which only starts garbage collection once reaching 80% disk usage.

This change is motivated by disks getting 80% full because of old images laying around. A good example is a 9 days old node which has many version of the sunrise image running:

```
sunrise-frontend                                                                main-1270                                   cc9c90a83d5a    9 days ago        linux/amd64    329.2 MiB    124.4 MiB
sunrise-frontend                                                                main-1271                                   fe7c18f426e2    8 days ago        linux/amd64    329.3 MiB    124.4 MiB
sunrise-frontend                                                                main-1272                                   3826c9ff901d    7 days ago        linux/amd64    329.3 MiB    124.4 MiB
sunrise-frontend                                                                main-1273                                   184995d31be6    7 days ago        linux/amd64    329.3 MiB    124.4 MiB
sunrise-frontend                                                                main-1275                                   aa1a4703ec83    7 days ago        linux/amd64    329.3 MiB    124.4 MiB
sunrise-frontend                                                                main-1276                                   de50522a66d5    7 days ago        linux/amd64    329.3 MiB    124.4 MiB
sunrise-frontend                                                                main-1277                                   24d83067e881    7 days ago        linux/amd64    329.3 MiB    124.4 MiB
sunrise-frontend                                                                main-1278                                   52e649069f6e    4 days ago        linux/amd64    329.3 MiB    124.4 MiB
sunrise-frontend                                                                main-1280                                   2e8c126546f2    4 days ago        linux/amd64    329.3 MiB    124.4 MiB
sunrise-frontend                                                                main-1281                                   86b1312bde12    3 days ago        linux/amd64    329.3 MiB    124.4 MiB
sunrise-frontend                                                                main-1282                                   c68589f80c9a    2 days ago        linux/amd64    325.2 MiB    123.0 MiB
sunrise-frontend                                                                main-1283                                   6582c40d191e    2 days ago        linux/amd64    325.2 MiB    123.0 MiB
sunrise-frontend                                                                main-1284                                   f4434a5c5345    2 days ago        linux/amd64    325.2 MiB    123.0 MiB
sunrise-frontend                                                                main-1285                                   935c993a96a6    24 hours ago      linux/amd64    325.2 MiB    123.0 MiB
```

Only the last version is running, but the old images are staying around

Change the settings to do GC at 40% instead of at 80%

https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/