### PR TITLE
Clean up Skipper Passive Health Check (PHC) configuration

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -72,11 +72,9 @@ skipper_ingress_hpa_scale_up_max_perc: "100"
 {{if eq .Cluster.Environment "production"}}
 skipper_ingress_min_replicas: "3"
 skipper_ingress_max_replicas: "300"
-skipper_ingress_health_check_main_fleet: "false"
 {{else}}
 skipper_ingress_min_replicas: "2"
 skipper_ingress_max_replicas: "50"
-skipper_ingress_health_check_main_fleet: "true"
 {{end}}
 skipper_ingress_cpu: "1000m"
 skipper_ingress_memory: "1500Mi"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -305,7 +305,7 @@ spec:
 {{ if .Cluster.ConfigItems.skipper_ingress_inline_routes }}
           - "-inline-routes={{ .Cluster.ConfigItems.skipper_ingress_inline_routes }}"
 {{ end }}
-{{ if and (.Cluster.ConfigItems.skipper_ingress_health_check_options) (or (eq .name "skipper-ingress-canary") (eq .Cluster.ConfigItems.skipper_ingress_health_check_main_fleet "true")) }}
+{{ if .Cluster.ConfigItems.skipper_ingress_health_check_options }}
           - "-passive-health-check={{ .Cluster.ConfigItems.skipper_ingress_health_check_options }}"
 {{ end }}
 {{ if .Cluster.ConfigItems.skipper_ingress_refuse_payload }}


### PR DESCRIPTION
This configuration is deployed to all clusters and proved to cause no incidents, so all auxiliary config items could be removed.