### PR TITLE
Zmon role can list tags for IAM certificates

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1664,6 +1664,9 @@ Resources:
               - Action: 'acm:ListCertificates'
                 Effect: Allow
                 Resource: '*'
+              - Action: 'acm:ListTagsForCertificate'
+                Effect: Allow
+                Resource: '*'
               - Action: 'airflow:CreateCliToken'
                 Effect: Allow
                 Resource: '*'


### PR DESCRIPTION
Reopened from https://github.com/zalando-incubator/kubernetes-on-aws/pull/7359, I have write access to the repository now.

As discussed, I need Zmon AWS agent to be able to collect tags for certificates, so that I can be more specific when targeting ACM Certificates with checks