### PR TITLE
skipper: update canary version to v0.21.62

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,5 +1,5 @@
 {{ $internal_version := "v0.21.54-882" }}
-{{ $canary_internal_version := "v0.21.54-882" }}
+{{ $canary_internal_version := "v0.21.62-890" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}
 {{ $canary_args := "" }}


### PR DESCRIPTION
[Changes](https://github.com/zalando/skipper/compare/v0.21.54...v0.21.62)

* https://github.com/zalando/skipper/pull/3025
* https://github.com/zalando/skipper/pull/3031
* https://github.com/zalando/skipper/pull/3033
* https://github.com/zalando/skipper/pull/3032
* https://github.com/zalando/skipper/pull/3030
* https://github.com/zalando/skipper/pull/3027
* https://github.com/zalando/skipper/pull/3028
* https://github.com/zalando/skipper/pull/3023
* https://github.com/zalando/skipper/pull/3020
* https://github.com/zalando/skipper/pull/3022