### PR TITLE
Fix VPA limit for ebs-csi-controller

### DIFF
--- a/cluster/manifests/03-ebs-csi/vpa.yaml
+++ b/cluster/manifests/03-ebs-csi/vpa.yaml
@@ -15,12 +15,16 @@ spec:
     updateMode: Auto
   resourcePolicy:
     containerPolicies:
+    - containerName: ebs-plugin
+      mode: "Off"
+    - containerName: liveness-probe
+      mode: "Off"
     - containerName: csi-provisioner
     {{ range $NodePool := .Cluster.NodePools }}
     {{ if eq $NodePool.Name "default-master" }}
     # Scaling is relative to r6g.large (smallest master node)
-    # 0.006 -> ~90Mi memory, 0.031 -> ~55m CPU
-    {{ $scaledCPU := scaleQuantity ( instanceTypeCPUQuantity ( index .InstanceTypes 0 )) 0.031 }}
+    # 0.006 -> ~90Mi memory, 0.0061 -> ~11m CPU (per container)
+    {{ $scaledCPU := scaleQuantity ( instanceTypeCPUQuantity ( index .InstanceTypes 0 )) 0.0061 }}
     {{ $scaledMemory := scaleQuantity ( instanceTypeMemoryQuantity ( index .InstanceTypes 0 )) 0.006 }}
       maxAllowed:
         cpu: {{ $scaledCPU }}


### PR DESCRIPTION
In https://github.com/zalando-incubator/kubernetes-on-aws/pull/6931 we introduced dynamic scaling for control plane components based on the master node instance type size.

For the ebs-csi-controller we did not consider that it has more than 3 containers and we applied the total limit to each container making the CPU limit go above what is possible on the smallest instance type `r6g.large`. Fix this in the following way:

1. Don't autoscale the containers we never intended to autoscale
2. Divide the limit by 3 such that the total CPU limit on the smallest node becomes: `10 + 10 + (3*11) ~= 53` (target was 55). 