### PR TITLE
e2e: enable access via Okta

### DIFF
--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -43,6 +43,7 @@ clusters:
     stackset_ingress_source_switch_ttl: "1m"
     teapot_admission_controller_daemonset_reserved_cpu: "518m"
     karpenter_pools_enabled: "true"
+    okta_auth_client_id: "kubernetes.cluster.teapot-e2e"
   criticality_level: 1
   environment: e2e
   id: ${CLUSTER_ID}


### PR DESCRIPTION
Enable access to e2e clusters via Okta by using a static client id: `kubernetes.cluster.teapot-e2e` for all e2e clusters. This will allow people with a role for the `teapot-e2e` account access to all e2e clusters in this account.