### PR TITLE
Make jammy the default for worker nodes

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -693,13 +693,8 @@ kuberuntu_image_v1_28_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernet
 kuberuntu_image_v1_28_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.28.8-arm64-master-321" "861068367966" }}
 
 # Which distro from the previous config items should be used. Valid options are `focal` and `jammy`. Can be set for each node pool.
-{{if eq .Cluster.Environment "test"}}
 kuberuntu_distro_master: "jammy"
 kuberuntu_distro_worker: "jammy"
-{{else}}
-kuberuntu_distro_master: "jammy"
-kuberuntu_distro_worker: "focal"
-{{end}}
 
 # Feature toggle for auditing events
 audit_pod_events: "true"


### PR DESCRIPTION
Make `jammy` (Ubuntu 22.04) the default for worker nodes as we're progressing with the roll out.

All clusters that has to run `focal` already have the config-item set.

This will ensure new clusters start with `jammy` as default.