### PR TITLE
Increase timeout for gpu e2e test

### DIFF
--- a/test/e2e/gpu.go
+++ b/test/e2e/gpu.go
@@ -48,7 +48,7 @@ var _ = describe("GPU job processing", func() {
 		pod := createVectorPod(nameprefix, ns, labels)
 		_, err := cs.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "Could not create POD %s", pod.Name)
-		framework.ExpectNoError(e2epod.WaitForPodSuccessInNamespace(context.TODO(), f.ClientSet, pod.Name, pod.Namespace))
+		framework.ExpectNoError(e2epod.WaitForPodSuccessInNamespaceTimeout(context.TODO(), f.ClientSet, pod.Name, pod.Namespace, 15*time.Minute))
 		for {
 			p, err := cs.CoreV1().Pods(ns).Get(context.TODO(), pod.Name, metav1.GetOptions{})
 			if err != nil {


### PR DESCRIPTION
The GPU e2e test is often flaky because a GPU node is not created in time and therefore the pod doesn't get scheduled.

The default timeout is 5 min. but because GPU nodes have local storage, where we have a special setup, it sometimes take several minutes to get a GPU node ready to run a pod. Increase the timeout to reduce the chance of a node not getting ready in a reasonable time. 