### PR TITLE
Dev to kube 1.29 manual

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -693,13 +693,8 @@ kuberuntu_image_v1_28_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernet
 kuberuntu_image_v1_28_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.28.8-arm64-master-321" "861068367966" }}
 
 # Which distro from the previous config items should be used. Valid options are `focal` and `jammy`. Can be set for each node pool.
-{{if eq .Cluster.Environment "test"}}
 kuberuntu_distro_master: "jammy"
 kuberuntu_distro_worker: "jammy"
-{{else}}
-kuberuntu_distro_master: "jammy"
-kuberuntu_distro_worker: "focal"
-{{end}}
 
 # Feature toggle for auditing events
 audit_pod_events: "true"

--- a/test/e2e/gpu.go
+++ b/test/e2e/gpu.go
@@ -48,7 +48,7 @@ var _ = describe("GPU job processing", func() {
 		pod := createVectorPod(nameprefix, ns, labels)
 		_, err := cs.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "Could not create POD %s", pod.Name)
-		framework.ExpectNoError(e2epod.WaitForPodSuccessInNamespace(context.TODO(), f.ClientSet, pod.Name, pod.Namespace))
+		framework.ExpectNoError(e2epod.WaitForPodSuccessInNamespaceTimeout(context.TODO(), f.ClientSet, pod.Name, pod.Namespace, 15*time.Minute))
 		for {
 			p, err := cs.CoreV1().Pods(ns).Get(context.TODO(), pod.Name, metav1.GetOptions{})
 			if err != nil {


### PR DESCRIPTION
Manual PR from `dev` to `kube-1.29` because of merge conflict.

* https://github.com/zalando-incubator/kubernetes-on-aws/pull/7376
* https://github.com/zalando-incubator/kubernetes-on-aws/pull/7374