### PR TITLE
Update skipper version, step 2/2 

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.21.62-890" }}
+{{ $internal_version := "v0.21.72-900" }}
 {{ $canary_internal_version := "v0.21.72-900" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}


### PR DESCRIPTION
Merge https://github.com/zalando-incubator/kubernetes-on-aws/pull/7388 and https://github.com/zalando-incubator/kubernetes-on-aws/pull/7402 first

+ added PHC-related logs https://github.com/zalando/skipper/pull/3036
+ phc: add a metric counter for endpoints that opted out before load balancing https://github.com/zalando/skipper/pull/3035
+ Change condition of PHC to reduce amount of produced logs https://github.com/zalando/skipper/pull/3046
+ add span logs for redis spans with error https://github.com/zalando/skipper/pull/3045
+ filters: deprecate OpenTracing in FilterContext https://github.com/zalando/skipper/pull/3044
+ proxy: use proxy tracing setTag helper https://github.com/zalando/skipper/pull/3043
+ config: refactor test defaultConfig https://github.com/zalando/skipper/pull/3042
+ Specify tracing span kind on creation https://github.com/zalando/skipper/pull/3039

FYI https://github.com/zalando/skipper/compare/v0.21.62...v0.21.72