### PR TITLE
Make etcd DNS record configurable

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -650,6 +650,7 @@ blocked_availability_zone: ""
 
 # etcd cluster
 etcd_stack_name: "etcd-cluster-etcd"
+etcd_dns_record_prefixes: "etcd-server.{{.Cluster.Region}}"
 
 {{if eq .Cluster.Environment "production"}}
 etcd_instance_count: "5"
@@ -661,7 +662,7 @@ etcd_instance_type: "t3.medium"
 
 etcd_scalyr_key: ""
 
-etcd_ami: {{ amiID "zalando-ubuntu-etcd-production-v3.5.9-amd64-main-24" "861068367966"}}
+etcd_ami: {{ amiID "zalando-ubuntu-etcd-production-v3.5.9-amd64-main-33" "861068367966"}}
 
 cluster_dns: "coredns"
 coredns_log_svc_names: "true"

--- a/cluster/etcd/stack.yaml
+++ b/cluster/etcd/stack.yaml
@@ -67,6 +67,7 @@ Resources:
                   ETCD_TRUSTED_CA_FILE=/etc/etcd/ssl/ca.cert
                   ETCD_LOG_LEVEL=info
                   HOSTED_ZONE="{{.Values.hosted_zone}}"
+                  ETCD_DNS_RECORD_PREFIXES="{{.Cluster.ConfigItems.etcd_dns_record_prefixes}}"
                   S3_CERTS_BUCKET="{{ .Values.S3GeneratedFilesPath }}"
                   AWS_DEFAULT_REGION="{{ .Cluster.Region }}"
             runcmd:

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -18,6 +18,7 @@ clusters:
     etcd_client_ca_cert: "${ETCD_CLIENT_CA_CERT}"
     etcd_client_ca_key: "${ETCD_CLIENT_CA_KEY}"
     etcd_scalyr_key: "${ETCD_SCALYR_KEY}"
+    etcd_dns_record_prefixes: "etcd-server.etcd"
     docker_meta_url: https://docker-meta.stups-test.zalan.do
     vpa_enabled: "true"
     lightstep_token: "${LIGHTSTEP_TOKEN}"


### PR DESCRIPTION
This makes the etcd DNS record configurable and default to `etcd-server.<region>.<hosted-zone>` instead of `etcd-server.etcd`.

The AMI is updated to accept the `ETCD_DNS_RECORD_PREFIXES` environment variable which enables it to configure the etcd DNS record name based on that instead of relying on the CF stack name as it was before.

## TODO

* [x] Ensure all existing clusters have `etcd_dns_record_prefixes=etcd-server.etcd` set to avoid changes for those.