### PR TITLE
skipper: update image to use amazonlinux base image (step 1/2)

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,5 +1,5 @@
 {{ $internal_version := "v0.21.72-900" }}
-{{ $canary_internal_version := "v0.21.72-900" }}
+{{ $canary_internal_version := "v0.21.76-905" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}
 {{ $canary_args := "" }}


### PR DESCRIPTION
[changes](https://github.com/zalando/skipper/compare/v0.21.72...v0.21.76)

- https://github.com/zalando/skipper/pull/3047
- https://github.com/zalando/skipper/pull/3048
- https://github.com/zalando/skipper/pull/3049
- https://github.com/zalando/skipper/pull/3050
- https://github.com/zalando/skipper/pull/3052