### PR TITLE
Add support for additional cluster regions

### DIFF
--- a/cluster/etcd/stack.yaml
+++ b/cluster/etcd/stack.yaml
@@ -211,7 +211,7 @@ Resources:
     Properties:
       # This is a hack to make the name fit the pattern allowed by the kms key
       # currently provisioned outside of CLM.
-      RoleName: "etcd-cluster-etcd-EtcdRole-{{.Cluster.ConfigItems.etcd_stack_name}}"
+      RoleName: "etcd-cluster-etcd-EtcdRole-{{.Cluster.ConfigItems.etcd_stack_name}}-{{.Cluster.Region}}"
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
       AssumeRolePolicyDocument:

--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -40,7 +40,7 @@ spec:
         - --scaling-schedule-default-scaling-window={{.Cluster.ConfigItems.kube_metrics_adapter_default_scaling_window}}
         - --scaling-schedule-ramp-steps={{.Cluster.ConfigItems.kube_metrics_adapter_scaling_schedule_ramp_steps}}
         - --aws-external-metrics
-        - --aws-region=eu-central-1
+        - --aws-region={{.Cluster.Region}}
         - --aws-region=eu-west-1
         - --skipper-backends-annotation=zalando.org/backend-weights
         {{ if eq .Cluster.Environment "production" }}

--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -8,7 +8,7 @@ Metadata:
 
 Mappings:
   Images:
-    eu-central-1:
+    {{.Cluster.Region}}:
       # Use the node pool's architecture to construct the config item name that we're using to get the AMI name.
       MachineImage: '{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_29_" .NodePool.ConfigItems.kuberuntu_distro_master "_" .Values.InstanceInfo.Architecture) }}'
 

--- a/cluster/node-pools/worker-combined/stack.yaml
+++ b/cluster/node-pools/worker-combined/stack.yaml
@@ -8,7 +8,7 @@ Metadata:
 
 Mappings:
   Images:
-    eu-central-1:
+    {{.Cluster.Region}}:
       # Use the node pool's architecture to construct the config item name that we're using to get the AMI name.
       MachineImage: '{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_29_" .NodePool.ConfigItems.kuberuntu_distro_worker "_" .Values.InstanceInfo.Architecture) }}'
 

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -8,7 +8,7 @@ Metadata:
 
 Mappings:
   Images:
-    eu-central-1:
+    {{.Cluster.Region}}:
       # Use the node pool's architecture to construct the config item name that we're using to get the AMI name.
       MachineImage: '{{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_29_" .NodePool.ConfigItems.kuberuntu_distro_worker "_" .Values.InstanceInfo.Architecture) }}'
 


### PR DESCRIPTION
This PR contains additions for enabling the creation of a Kubernetes cluster in additional regions:
- update the node pool mappings to be region specific
- rename the etcd IAM role name to include the region
- update kube-metrics-adapter to use the current region 