### PR TITLE
feature: enable to switch nlb zone affinity

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -47,6 +47,7 @@ kube_aws_ingress_controller_deregistration_delay_timeout: "10s"
 # This opens skipper-ingress ports 9998 and 9999 on all worker nodes
 kube_aws_ingress_controller_nlb_enabled: "true"
 kube_aws_ingress_controller_nlb_cross_zone: "true"
+kube_aws_ingress_controller_nlb_zone_affinity: "any_availability_zone"
 kube_aws_ingress_controller_cert_polling_interval: "2m"
 # sets the default LB type: "network" or "application" are valid choices (overwritten by nlb_switch)
 kube_aws_ingress_default_lb_type: "application"

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -1,4 +1,4 @@
-# {{ $version := "v0.15.13" }}
+# {{ $version := "v0.15.15" }}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -42,6 +42,7 @@ spec:
             # {{ if eq .Cluster.ConfigItems.kube_aws_ingress_controller_nlb_cross_zone "true" }}
             - --nlb-cross-zone
             # {{ end }}
+            - --nlb-zone-affinity={{ .Cluster.ConfigItems.kube_aws_ingress_controller_nlb_zone_affinity }}
             - --cluster-local-domain=cluster.local
             - --deny-internal-domains
             - --additional-stack-tags=InfrastructureComponent=true


### PR DESCRIPTION
feature: enable to switch nlb zone affinity

This will not change the NLB configuration. It only enables us to do so.
see also doc PR https://github.com/zalando-incubator/kube-ingress-aws-controller/pull/695