### PR TITLE
Update components to kubernetes 1.29

### DIFF
--- a/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         operator: Exists
       containers:
       - name: cluster-lifecycle-controller
-        image: container-registry.zalando.net/teapot/cluster-lifecycle-controller:master-38
+        image: container-registry.zalando.net/teapot/cluster-lifecycle-controller:master-39
         args:
             - --drain-grace-period={{.Cluster.ConfigItems.drain_grace_period}}
             - --drain-min-pod-lifetime={{.Cluster.ConfigItems.drain_min_pod_lifetime}}

--- a/cluster/manifests/deployment-service/controller-statefulset.yaml
+++ b/cluster/manifests/deployment-service/controller-statefulset.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
         - name: "deployment-service-controller"
-          image: "container-registry.zalando.net/teapot/deployment-controller:master-188"
+          image: "container-registry.zalando.net/teapot/deployment-controller:master-190"
           args:
             - "--config-namespace=kube-system"
             - "--decrypt-kms-alias-arn=arn:aws:kms:{{ .Cluster.Region }}:{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:alias/deployment-secret"

--- a/cluster/manifests/deployment-service/status-service-deployment.yaml
+++ b/cluster/manifests/deployment-service/status-service-deployment.yaml
@@ -1,5 +1,5 @@
 {{ $image   := "container-registry.zalando.net/teapot/deployment-status-service" }}
-{{ $version := "master-188" }}
+{{ $version := "master-190" }}
 
 apiVersion: apps/v1
 kind: Deployment

--- a/cluster/manifests/stackset-controller/deployment.yaml
+++ b/cluster/manifests/stackset-controller/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $version := "v1.4.70" }}
+{{ $version := "v1.4.72" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
Includes

deployment-service:
* Return error messages for production environment, when validating image tags.
* Update libraries for Kubernetes 1.29

stackset-controller:
* Wait for ownerReferences to appear on the resources
* Update libraries for Kubernetes 1.29

cluster-lifecycle-controller:
* Update libraries for Kubernetes 1.29