### PR TITLE
Introduce separate config item for pod factory configmap deletion protection

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -632,9 +632,11 @@ teapot_admission_controller_graceful_termination: "true"
 {{if eq .Cluster.Environment "e2e"}}
 # allow deletion of active configmaps in e2e clusters because some tests rely on it
 teapot_admission_controller_configmap_deletion_protection_enabled: "false"
+teapot_admission_controller_configmap_deletion_protection_factories_enabled: "false"
 {{else}}
 # prevent deletion of active configmaps in all test and production clusters
 teapot_admission_controller_configmap_deletion_protection_enabled: "true"
+teapot_admission_controller_configmap_deletion_protection_factories_enabled: "true"
 {{end}}
 
 # Enable and configure Pod Security Policy rules implemented in admission-controller.

--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: kube-system
 data:
   configmap.deletion-protection.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_configmap_deletion_protection_enabled }}"
+  configmap.deletion-protection.enable_factories: "{{ .Cluster.ConfigItems.teapot_admission_controller_configmap_deletion_protection_factories_enabled }}"
 
   daemonset.reserved.cpu: "{{ .Cluster.ConfigItems.teapot_admission_controller_daemonset_reserved_cpu }}"
   daemonset.reserved.memory: "{{ .Cluster.ConfigItems.teapot_admission_controller_daemonset_reserved_memory }}"

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -203,7 +203,7 @@ write_files:
             limits:
               memory: {{ .Values.InstanceInfo.MemoryFraction (parseInt64 .Cluster.ConfigItems.apiserver_memory_limit_percent)}}
 {{- end }}
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-201
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-202
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
This will allow us to toggle configmap deletion protection for `running pods` and `pod factory objects` separately.

The former is widely accepted but the latter doesn't work everywhere. In order to make progress, let's separate them and enable the former everywhere while we think what we do with the latter.