### PR TITLE
skipper: update canary version to v0.21.84

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -79,7 +79,7 @@ skipper_ingress_max_replicas: "50"
 {{end}}
 skipper_ingress_cpu: "1000m"
 skipper_ingress_memory: "1500Mi"
-skipper_ingress_health_check_options: "period=10s,min-requests=10,max-drop-probability=0.9"
+skipper_ingress_health_check_options: "period=10s,min-requests=10,min-drop-probability=0.05,max-drop-probability=0.9"
 
 # Enables deployment of canary version
 skipper_ingress_canary_enabled: "true"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,5 +1,5 @@
 {{ $internal_version := "v0.21.76-905" }}
-{{ $canary_internal_version := "v0.21.76-905" }}
+{{ $canary_internal_version := "v0.21.84-913" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}
 {{ $canary_args := "" }}


### PR DESCRIPTION
[Changes](https://github.com/zalando/skipper/compare/v0.21.76...v0.21.84)

* https://github.com/zalando/skipper/pull/3060
* https://github.com/zalando/skipper/pull/3061
* https://github.com/zalando/skipper/pull/3062
* https://github.com/zalando/skipper/pull/3063
* https://github.com/zalando/skipper/pull/3064
* https://github.com/zalando/skipper/pull/3057
* https://github.com/zalando/skipper/pull/3055
* https://github.com/zalando/skipper/pull/3053

Also configures required min-drop-probability for passive health checker.