### PR TITLE
Remove Kubernetes-on-Ubuntu v1.28 images

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -693,10 +693,6 @@ tracing_coredns_local_zone_traces_endpoint: ""
 # AMI id given the image name and the Image AWS account owner.
 #
 # [0]: https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/8a9bd1cb2d094038a9e23e646421f8146b48886a/provisioner/template.go#L116
-kuberuntu_image_v1_28_focal_amd64: {{ amiID "zalando-ubuntu-focal-20.04-kubernetes-production-v1.28.8-amd64-master-321" "861068367966" }}
-kuberuntu_image_v1_28_focal_arm64: {{ amiID "zalando-ubuntu-focal-20.04-kubernetes-production-v1.28.8-arm64-master-321" "861068367966" }}
-kuberuntu_image_v1_28_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.28.8-amd64-master-321" "861068367966" }}
-kuberuntu_image_v1_28_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.28.8-arm64-master-321" "861068367966" }}
 kuberuntu_image_v1_29_focal_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.29.4-amd64-master-328" "861068367966" }}
 kuberuntu_image_v1_29_focal_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.29.4-arm64-master-328" "861068367966" }}
 kuberuntu_image_v1_29_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.29.4-amd64-master-328" "861068367966" }}


### PR DESCRIPTION
This PR removes the default Kubernetes on Ubuntu `v1.28` AMIs which are no longer in use.