### PR TITLE
update karpenter version

### DIFF
--- a/cluster/manifests/z-karpenter/deployment.yaml
+++ b/cluster/manifests/z-karpenter/deployment.yaml
@@ -50,7 +50,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
-          image: "container-registry.zalando.net/teapot/karpenter:0.36.1-main-22"
+          image: "container-registry.zalando.net/teapot/karpenter:0.36.1-main-23.patched"
           imagePullPolicy: IfNotPresent
           env:
             - name: KUBERNETES_MIN_VERSION
@@ -97,6 +97,9 @@ spec:
               value: "0.075"
             - name: RESERVED_ENIS
               value: "0"
+            {{ $pod_cidr_size := "15" }}
+            - name: MAX_NODE_CLAIMS
+              value: "{{ nodeCIDRMaxNodesPodCIDR (parseInt64 $pod_cidr_size) (parseInt64 .Cluster.ConfigItems.node_cidr_mask_size) (parseInt64 .Cluster.ConfigItems.reserved_nodes) }}"
           ports:
             - name: http-metrics
               containerPort: 8000
@@ -129,7 +132,7 @@ spec:
             - weight: 50
               preference:
                 matchExpressions:
-                - key: karpenter.sh/provisioner-name
+                - key: karpenter.sh/nodepool
                   operator: DoesNotExist
             - weight: 100
               preference:


### PR DESCRIPTION
this update adds a new flag/env variable to karpenter to cap the maximum number of nodes possible in the cluster

it was tested on a pet cluster where I set the max to 5 nodes
at this state, I started to see the controller errors below
<img width="1447" alt="Screenshot 2024-05-08 at 15 39 04" src="https://github.com/zalando-incubator/kubernetes-on-aws/assets/1551247/bcb56f5d-c10c-414f-934f-df34de6a759b">

```
karpenter-786d6d9cc6-r5sv4 controller {"level":"ERROR","time":"2024-05-08T13:38:19.506Z","logger":"controller.disruption","message":"disrupting via \"consolidation\", disrupting candidates, launching replacement nodeclaim (command-id: b3f9a105-c4ef-4946-af76-5d09d8e452b7), creating node claim, number of NodeClaims has reached or exceeded global limit of 5","commit":"fb4d75f-dirty"}
```