### PR TITLE
Remove focal AMI no longer used

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -693,12 +693,10 @@ tracing_coredns_local_zone_traces_endpoint: ""
 # AMI id given the image name and the Image AWS account owner.
 #
 # [0]: https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/8a9bd1cb2d094038a9e23e646421f8146b48886a/provisioner/template.go#L116
-kuberuntu_image_v1_29_focal_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.29.4-amd64-master-328" "861068367966" }}
-kuberuntu_image_v1_29_focal_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.29.4-arm64-master-328" "861068367966" }}
 kuberuntu_image_v1_29_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.29.4-amd64-master-328" "861068367966" }}
 kuberuntu_image_v1_29_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.29.4-arm64-master-328" "861068367966" }}
 
-# Which distro from the previous config items should be used. Valid options are `focal` and `jammy`. Can be set for each node pool.
+# Which distro from the previous config items should be used. Valid options are only `jammy` for now. Can be set for each node pool.
 kuberuntu_distro_master: "jammy"
 kuberuntu_distro_worker: "jammy"
 


### PR DESCRIPTION
We no longer run `focal` anywhere, remove the AMI.