### PR TITLE
chore(deps): update kubernetes-lifecycle-metrics, kube-node-ready-controller

### DIFF
--- a/cluster/manifests/kube-node-ready-controller/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready-controller/daemonset.yaml
@@ -36,7 +36,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: controller
-        image: container-registry.zalando.net/teapot/kube-node-ready-controller:master-24
+        image: container-registry.zalando.net/teapot/kube-node-ready-controller:master-25
         resources:
           requests:
             cpu: {{.Cluster.ConfigItems.kube_node_ready_controller_cpu}}

--- a/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: kubernetes-lifecycle-metrics
       containers:
         - name: kubernetes-lifecycle-metrics
-          image: "container-registry.zalando.net/teapot/kubernetes-lifecycle-metrics:master-17"
+          image: "container-registry.zalando.net/teapot/kubernetes-lifecycle-metrics:master-18"
           ports:
             - containerPort: 9090
               protocol: TCP


### PR DESCRIPTION
This PR updates  kubernetes-lifecycle-metrics, kube-node-ready-controller to k8s version  v1.29