### PR TITLE
Update kube-metrics-adapter to Kubernetes v1.29

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: container-registry.zalando.net/teapot/kube-metrics-adapter:v0.2.2-44-gcafe11a
+        image: container-registry.zalando.net/teapot/kube-metrics-adapter:v0.2.2-46-gf55afc0
         env:
         - name: AWS_REGION
           value: {{ .Cluster.Region }}

--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: container-registry.zalando.net/teapot/kube-metrics-adapter:v0.2.2-35-gdcedc0c
+        image: container-registry.zalando.net/teapot/kube-metrics-adapter:v0.2.2-44-gcafe11a
         env:
         - name: AWS_REGION
           value: {{ .Cluster.Region }}


### PR DESCRIPTION
Updates the kube-metrics-adapter to Kubernetes v1.29

ref: https://github.com/zalando-incubator/kube-metrics-adapter/pull/707