### PR TITLE
deployment-service: support multiple clusters per account [1/2]

### DIFF
--- a/cluster/manifests/deployment-service/status-service-ingress.yaml
+++ b/cluster/manifests/deployment-service/status-service-ingress.yaml
@@ -17,3 +17,12 @@ spec:
                 port:
                   name: http
             pathType: ImplementationSpecific
+    - host: "deployment-status-service-{{.Cluster.Alias}}.{{.Values.hosted_zone}}"
+      http:
+        paths:
+          - backend:
+              service:
+                name: "deployment-service-status-service"
+                port:
+                  name: http
+            pathType: ImplementationSpecific


### PR DESCRIPTION
The deployment-service currently assumes one cluster per AWS account because it uses the following format for the status-service url:

```
https://deployment-status-service.{{.Values.hosted_zone}}
```

If there are multiple clusters in an account, the name will overlap and the deployment-status-service for the second cluster will not be reachable.

The proposed fix is to suffix the `deployment-status-service` part with the cluster Alias such that it becomes unique for each cluster within a single account and the same hosted zone.

This is the first of two steps where we just add the new name as an additional one on the ingress. After this is rolled out, the second step is to change the value in the [config](https://github.com/zalando-incubator/kubernetes-on-aws/blob/d8026637ffc06e0b2e7fcc6243069e9f3d922741/cluster/manifests/deployment-service/01-config.yaml#L17).