### PR TITLE
Update deployment-service with support for cleanup seconds

### DIFF
--- a/cluster/manifests/deployment-service/00-crd.yaml
+++ b/cluster/manifests/deployment-service/00-crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: cdpdeploymenttasks.deployment.zalando.org
 spec:
   group: deployment.zalando.org
@@ -20,14 +20,19 @@ spec:
           CloudFormation resources to the cluster.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -35,14 +40,21 @@ spec:
             description: CDPDeploymentTaskSpec is the spec part of the CDPDeploymentTask.
             properties:
               aborted:
-                description: If set to true, the controller should stop processing
-                  the deployment task and change its phase to Aborted.
+                description: |-
+                  If set to true, the controller should stop processing the deployment task and change its
+                  phase to Aborted.
                 type: boolean
               changeCause:
-                description: A human-readable description of the current deployment,
-                  to be used as the change cause in deployments and other resources
-                  that support it.
+                description: |-
+                  A human-readable description of the current deployment, to be used as the change cause in deployments and other
+                  resources that support it.
                 type: string
+              cleanupSeconds:
+                description: |-
+                  The duration for how long to wait for the controller to clean up the resources after the task has finished.
+                  If unspecified, the controller will not clean up the resources.
+                format: int64
+                type: integer
               deploymentID:
                 description: CDP deployment ID
                 type: string
@@ -74,17 +86,17 @@ spec:
                     type: string
                 type: object
               taskKind:
-                description: The kind of this deployment task. Currently only 'Standard'
-                  and 'MLExperiment' tasks are supported. If unset, the task is considered
-                  to use the 'Standard' kind.
+                description: |-
+                  The kind of this deployment task. Currently only 'Standard' and 'MLExperiment' tasks are supported. If unset,
+                  the task is considered to use the 'Standard' kind.
                 enum:
                 - Standard
                 - MLExperiment
                 type: string
               timeoutSeconds:
-                description: The duration for how long to wait for Kubernetes resources
-                  to become ready. If the task is not yet finished, the controller
-                  would stop processing it and moved it to the Expired state.
+                description: |-
+                  The duration for how long to wait for Kubernetes resources to become ready. If the task is not yet finished,
+                  the controller would stop processing it and moved it to the Expired state.
                 format: int64
                 type: integer
             required:
@@ -111,16 +123,19 @@ spec:
                 type: integer
               phase:
                 default: Created
-                description: 'Phase reflects the current lifecycle phase of the deployment
-                  task. The following values are currently available:  Created: deployment
-                  task was submitted to the cluster, the controller will deploy the
-                  resources described in it.  WaitingForResources: resources described
-                  in the task have been deployed to the cluster, the controller is
-                  waiting for the update to be finished.  Aborted: deployment task
-                  has been aborted by setting spec.aborted to true.  Succeeded: deployment
-                  task has finished successfully.  Failed: deployment task has finished
-                  with an error.  Expired: deployment task hasn''t finished before
-                  the timeout.'
+                description: |-
+                  Phase reflects the current lifecycle phase of the deployment task. The following values
+                  are currently available:
+                   Created: deployment task was submitted to the cluster, the controller will deploy the resources described in it.
+                   WaitingForResources: resources described in the task have been deployed to the cluster, the controller is waiting for the update to be finished.
+                   Aborted: deployment task has been aborted by setting spec.aborted to true.
+                   Succeeded: deployment task has finished successfully.
+                   Failed: deployment task has finished with an error.
+                   Expired: deployment task hasn't finished before the timeout.
+                   CleanupScheduled: resource cleanup was requested and the worker is waiting for the cleanup timeout given.
+                   WaitingForCleanup: deployment task has finished, the controller is waiting for the cleanup to be finished.
+                   CleanupSucceeded: deployment task has finished, the cleanup has been successful.
+                   CleanupFailed: deployment task has finished, the cleanup has failed.
                 enum:
                 - Created
                 - Deploying
@@ -129,6 +144,10 @@ spec:
                 - Succeeded
                 - Failed
                 - Expired
+                - CleanupScheduled
+                - WaitingForCleanup
+                - CleanupSucceeded
+                - CleanupFailed
                 type: string
               resources:
                 description: List of resources in this task.
@@ -182,10 +201,9 @@ spec:
                   type: object
                 type: array
               resourcesDeployedAt:
-                description: The timestamp when the resources have been deployed.
-                  For Kubernetes resources this means that they've been applied to
-                  the cluster, for CloudFormation this means that the stack updates
-                  have finished as well.
+                description: |-
+                  The timestamp when the resources have been deployed. For Kubernetes resources this means that they've been applied
+                  to the cluster, for CloudFormation this means that the stack updates have finished as well.
                 format: date-time
                 type: string
               updatedAt:

--- a/cluster/manifests/deployment-service/controller-statefulset.yaml
+++ b/cluster/manifests/deployment-service/controller-statefulset.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
         - name: "deployment-service-controller"
-          image: "container-registry.zalando.net/teapot/deployment-controller:master-190"
+          image: "container-registry.zalando.net/teapot/deployment-controller:master-193"
           args:
             - "--config-namespace=kube-system"
             - "--decrypt-kms-alias-arn=arn:aws:kms:{{ .Cluster.Region }}:{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:alias/deployment-secret"

--- a/cluster/manifests/deployment-service/status-service-deployment.yaml
+++ b/cluster/manifests/deployment-service/status-service-deployment.yaml
@@ -1,5 +1,5 @@
 {{ $image   := "container-registry.zalando.net/teapot/deployment-status-service" }}
-{{ $version := "master-190" }}
+{{ $version := "master-193" }}
 
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
This adds the `cleanup_seconds` field and new task states as well as deploys the latest version of deployment-service.

This version doesn't _do_ anything with the `cleanup_seconds` yet.