### PR TITLE
Fix deployment-status-service dns name length issue

### DIFF
--- a/cluster/manifests/deployment-service/status-service-ingress.yaml
+++ b/cluster/manifests/deployment-service/status-service-ingress.yaml
@@ -17,7 +17,7 @@ spec:
                 port:
                   name: http
             pathType: ImplementationSpecific
-    - host: "deployment-status-service-{{.Cluster.Alias}}.{{.Values.hosted_zone}}"
+    - host: "deployment-status-svc-{{.Cluster.Alias}}.{{.Values.hosted_zone}}"
       http:
         paths:
           - backend:


### PR DESCRIPTION
Follow up to #7509

We have one cluster where the alias is too long for the DNS limit of 63. Do this hack to reduce the length of the record :shrug: 