### PR TITLE
Update VPA to v1.1.2

### DIFF
--- a/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
@@ -26,9 +26,9 @@ spec:
       containers:
       - name: admission-controller
         {{if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "current"}}
-        image: container-registry.zalando.net/teapot/vpa-admission-controller:v1.1.1-main-1-custom
+        image: container-registry.zalando.net/teapot/vpa-admission-controller:v1.1.2-main-2-custom
         {{else if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "legacy"}}
-        image: container-registry.zalando.net/teapot/vpa-admission-controller:v1.0.0-internal.20
+        image: container-registry.zalando.net/teapot/vpa-admission-controller:v1.1.1-main-1-custom
         {{end}}
         command:
           - /admission-controller

--- a/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
@@ -24,9 +24,9 @@ spec:
       containers:
       - name: recommender
         {{if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "current"}}
-        image: container-registry.zalando.net/teapot/vpa-recommender:v1.1.1-main-1-custom
+        image: container-registry.zalando.net/teapot/vpa-recommender:v1.1.2-main-2-custom
         {{else if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "legacy"}}
-        image: container-registry.zalando.net/teapot/vpa-recommender:v1.0.0-internal.20
+        image: container-registry.zalando.net/teapot/vpa-recommender:v1.1.1-main-1-custom
         {{end}}
         args:
         - --logtostderr

--- a/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
@@ -24,9 +24,9 @@ spec:
       containers:
       - name: updater
         {{if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "current"}}
-        image: container-registry.zalando.net/teapot/vpa-updater:v1.1.1-main-1-custom
+        image: container-registry.zalando.net/teapot/vpa-updater:v1.1.2-main-2-custom
         {{else if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "legacy"}}
-        image: container-registry.zalando.net/teapot/vpa-updater:v1.0.0-internal.20
+        image: container-registry.zalando.net/teapot/vpa-updater:v1.1.1-main-1-custom
         {{end}}
         command:
           - ./updater


### PR DESCRIPTION
https://github.com/kubernetes/autoscaler/releases/tag/vertical-pod-autoscaler-1.1.2

Update VPA to v1.1.2 and makes v1.1.1 the fallback (legacy)