### PR TITLE
skipper: update version (step 2/2)

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.21.91-921" }}
+{{ $internal_version := "v0.21.96-927" }}
 {{ $canary_internal_version := "v0.21.96-927" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}


### PR DESCRIPTION
use slimmer version from amazon-linux

changes:

- https://github.com/zalando/skipper/pull/3077
- https://github.com/zalando/skipper/pull/3074
- https://github.com/zalando/skipper/pull/3075
- https://github.com/zalando/skipper/pull/3071
- https://github.com/zalando/skipper/pull/3076


https://github.com/zalando/skipper/compare/v0.21.91...v0.21.96

depends on https://github.com/zalando-incubator/kubernetes-on-aws/pull/7539