### PR TITLE
deployment-service: restrict access to healthcheck endpoint

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -291,3 +291,7 @@ post_apply:
 - name: prometheus
   kind: Ingress
   namespace: kube-system
+
+- name: deployment-service-status-service
+  kind: Ingress
+  namespace: kube-system

--- a/cluster/manifests/deployment-service/status-service-ingress.yaml
+++ b/cluster/manifests/deployment-service/status-service-ingress.yaml
@@ -1,19 +1,27 @@
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: zalando.org/v1
+kind: RouteGroup
 metadata:
-  name: "deployment-service-status-service"
-  namespace: "kube-system"
+  name: deployment-service-status-service
+  namespace: kube-system
   labels:
-    application: "deployment-service"
-    component: "status-service"
+    application: deployment-service
+    component: status-service
 spec:
-  rules:
-    - host: "deployment-status-svc-{{.Cluster.Alias}}.{{.Values.hosted_zone}}"
-      http:
-        paths:
-          - backend:
-              service:
-                name: "deployment-service-status-service"
-                port:
-                  name: http
-            pathType: ImplementationSpecific
+  hosts:
+    - deployment-status-svc-{{ .Cluster.Alias }}.{{ .Values.hosted_zone }}
+  backends:
+    - name: deployment-service-status-service
+      type: service
+      serviceName: deployment-service-status-service
+      servicePort: 80
+    - name: shunt
+      type: shunt
+  defaultBackends:
+    - backendName: deployment-service-status-service
+  routes:
+    - pathSubtree: /
+    - path: /healthz
+      filters:
+        - status(403)
+      backends:
+        - backendName: shunt


### PR DESCRIPTION
Add a RouteGroup with a route that restricts access to /healthz.