### PR TITLE
Patch kube-scheduler to fix crash

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -664,7 +664,11 @@ write_files:
         hostNetwork: true
         containers:
         - name: kube-scheduler
-          image: nonexistent.zalan.do/teapot/{{if eq .Cluster.ConfigItems.kubernetes_scheduler_image "zalando" }}kube-scheduler-internal{{else}}kube-scheduler{{end}}:fixed
+{{- if eq .Cluster.ConfigItems.kubernetes_scheduler_image "zalando" }}
+          image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/kube-scheduler-internal:v1.30.1-master-121
+{{- else }}
+          image: nonexistent.zalan.do/teapot/kube-scheduler:fixed
+{{- end }}
           args:
           - --kubeconfig=/etc/kubernetes/scheduler-kubeconfig
           - --leader-elect=true


### PR DESCRIPTION
This adds a version of the `kube-scheduler` with this patch applied: https://github.com/kubernetes/kubernetes/pull/124933 to avoid crashes as outlined in: https://github.com/kubernetes/kubernetes/issues/124930

Note: this is simply updating the image which will rotate only master nodes as opposed to update the whole AMI as we usually do since only the kube-scheduler needs an update. We will build a new AMI once the upstream fix is merged and released.