### PR TITLE
Revert "use slimmer version from amazon-linux"

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,5 +1,5 @@
 {{ $internal_version := "v0.21.91-921" }}
-{{ $canary_internal_version := "v0.21.96-927" }}
+{{ $canary_internal_version := "v0.21.91-921" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}
 {{ $canary_args := "" }}


### PR DESCRIPTION
This reverts commit 2dcefb9b678dd548c4e75e45cccba44a3eaa7135 due to CrashLoop.

See #7539