### PR TITLE
skipper: add hostname-credentials-controller version labels

### DIFF
--- a/cluster/manifests/skipper/hostname-credentials-controller.yaml
+++ b/cluster/manifests/skipper/hostname-credentials-controller.yaml
@@ -100,6 +100,7 @@ metadata:
   labels:
     application: skipper-ingress
     component: hostname-credentials
+    version: "{{ $version }}"
 spec:
   schedule: "* * * * *"
   concurrencyPolicy: Forbid
@@ -113,6 +114,7 @@ spec:
           labels:
             application: skipper-ingress
             component: hostname-credentials
+            version: "{{ $version }}"
           annotations:
             kubernetes-log-watcher/scalyr-parser: |
               [{"container": "controller", "parser": "keyValue"}]


### PR DESCRIPTION
We use verson labels for other componets and its handy to have it for kubectl, e.g.:
```
kubectl -n=kube-system get pods -lapplication=skipper-ingress -Lversion
```