### PR TITLE
Drop old deploy-service-status [3/3]

### DIFF
--- a/cluster/manifests/deployment-service/status-service-ingress.yaml
+++ b/cluster/manifests/deployment-service/status-service-ingress.yaml
@@ -8,15 +8,6 @@ metadata:
     component: "status-service"
 spec:
   rules:
-    - host: "deployment-status-service.{{.Values.hosted_zone}}"
-      http:
-        paths:
-          - backend:
-              service:
-                name: "deployment-service-status-service"
-                port:
-                  name: http
-            pathType: ImplementationSpecific
     - host: "deployment-status-svc-{{.Cluster.Alias}}.{{.Values.hosted_zone}}"
       http:
         paths:


### PR DESCRIPTION
Follow up to #7511

Drop the legacy status service hostname, no longer needed.