### PR TITLE
Add NVIDIA's `dcgm-exporter` to export GPU metrics to Prometheus

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -387,6 +387,10 @@ flannel_memory: "100Mi"
 nvidia_device_plugin_cpu: "10m"
 nvidia_device_plugin_memory: "50Mi"
 
+# nvidia dcgm exporter
+nvidia_dcgm_exporter_cpu: "10m"
+nvidia_dcgm_exporter_memory: "200Mi"
+
 # static egress controller settings
 static_egress_controller_enabled: "true"
 

--- a/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
+++ b/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
@@ -24,6 +24,9 @@ spec:
         component: nvidia-gpu-device-plugin
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9400"
+        prometheus.io/scrape: "true"
     spec:
       serviceAccountName: nvidia
       tolerations:
@@ -48,6 +51,9 @@ spec:
       - name: device-plugin
         hostPath:
           path: /var/lib/kubelet/device-plugins
+      - name: pod-gpu-resources
+        hostPath:
+          path: /opt/podruntime/kubelet/pod-resources
       containers:
       - name: nvidia-gpu-device-plugin
         image: container-registry.zalando.net/teapot/nvidia-gpu-device-plugin:v0.14.5-master-10
@@ -68,3 +74,27 @@ spec:
         volumeMounts:
         - name: device-plugin
           mountPath: /var/lib/kubelet/device-plugins
+      - name: dcgm-exporter
+        image: container-registry.zalando.net/teapot/nvidia-dcgm-exporter:v3.3.6-3.4.2-ubuntu22.04-master-11
+        args:
+        - --kubernetes
+        - --address=:9400
+        resources:
+          requests:
+            cpu: "{{ .Cluster.ConfigItems.nvidia_dcgm_exporter_cpu }}"
+            memory: "{{ .Cluster.ConfigItems.nvidia_dcgm_exporter_memory }}"
+          limits:
+            cpu: "{{ .Cluster.ConfigItems.nvidia_dcgm_exporter_cpu }}"
+            memory: "{{ .Cluster.ConfigItems.nvidia_dcgm_exporter_memory }}"
+        ports:
+        - name: metrics
+          containerPort: 9400
+        securityContext:
+          runAsNonRoot: false
+          runAsUser: 0
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - name: pod-gpu-resources
+          mountPath: /var/lib/kubelet/pod-resources
+          readOnly: true


### PR DESCRIPTION
Adds NVIDIA's Data Center GPU Manager (DCGM) Prometheus Exporter as a sidecar to the already configured NVIDIA device plugin and configures Prometheus to scrape its metrics endpoint.

For https://github.bus.zalan.do/zooport/issues/issues/4628