### PR TITLE
Update skipper version, step 2/2

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.21.91-921" }}
+{{ $internal_version := "v0.21.99-931" }}
 {{ $canary_internal_version := "v0.21.99-931" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}


### PR DESCRIPTION
Merge https://github.com/zalando-incubator/kubernetes-on-aws/pull/7565 first

+ build(deps): bump github.com/prometheus/client_golang from 1.19.0 to 1.19.1 https://github.com/zalando/skipper/pull/3077
+ build(deps): bump google.golang.org/protobuf from 1.34.0 to 1.34.1 https://github.com/zalando/skipper/pull/3076
+ build(deps): bump golang.org/x/net from 0.24.0 to 0.25.0 https://github.com/zalando/skipper/pull/3074
+ phc: refactor testcases https://github.com/zalando/skipper/pull/3071
+ build(deps): bump github.com/testcontainers/testcontainers-go from 0.30.0 to 0.31.0 https://github.com/zalando/skipper/pull/3075
+ build(deps): bump actions/checkout from 4.1.5 to 4.1.6 https://github.com/zalando/skipper/pull/3082
+ build(deps): bump alpine from c5b1261 to 77726ef in /packaging https://github.com/zalando/skipper/pull/3083
+ Added max-unhealthy-endpoints-ratio cmdline parameter for PHC https://github.com/zalando/skipper/pull/3081

FYI https://github.com/zalando/skipper/compare/v0.21.91...v0.21.99