### PR TITLE
Update components to Static base image [1/X]

### DIFF
--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
       hostNetwork: true
       containers:
       - name: audittrail-adapter
-        image: container-registry.zalando.net/teapot/audittrail-adapter:master-52
+        image: container-registry.zalando.net/teapot/audittrail-adapter:master-64
         env:
           - name: AWS_REGION
             value: "{{ .Cluster.Region }}"

--- a/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         operator: Exists
       containers:
       - name: cluster-lifecycle-controller
-        image: container-registry.zalando.net/teapot/cluster-lifecycle-controller:master-39
+        image: container-registry.zalando.net/teapot/cluster-lifecycle-controller:master-40
         args:
             - --drain-grace-period={{.Cluster.ConfigItems.drain_grace_period}}
             - --drain-min-pod-lifetime={{.Cluster.ConfigItems.drain_min_pod_lifetime}}

--- a/cluster/manifests/cronjob-fixer/deployment.yaml
+++ b/cluster/manifests/cronjob-fixer/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: cronjob-fixer
       containers:
         - name: cronjob-fixer
-          image: "container-registry.zalando.net/teapot/cronjob-fixer:master-13"
+          image: "container-registry.zalando.net/teapot/cronjob-fixer:master-15"
           resources:
             limits:
               cpu: 5m

--- a/cluster/manifests/event-logger/statefulset.yaml
+++ b/cluster/manifests/event-logger/statefulset.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: kubernetes-event-logger
       containers:
       - name: logger
-        image: container-registry.zalando.net/teapot/event-logger:master-13
+        image: container-registry.zalando.net/teapot/event-logger:master-14
         args:
             - --snapshot-namespace=kube-system
             - --snapshot-name=kubernetes-event-logger

--- a/cluster/manifests/kube-node-ready-controller/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready-controller/daemonset.yaml
@@ -36,7 +36,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: controller
-        image: container-registry.zalando.net/teapot/kube-node-ready-controller:master-25
+        image: container-registry.zalando.net/teapot/kube-node-ready-controller:master-26
         resources:
           requests:
             cpu: {{.Cluster.ConfigItems.kube_node_ready_controller_cpu}}

--- a/cluster/manifests/kube-node-ready/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready/daemonset.yaml
@@ -1,4 +1,4 @@
-{{ $version := "master-30" }}
+{{ $version := "master-33" }}
 
 apiVersion: apps/v1
 kind: DaemonSet

--- a/cluster/manifests/kubelet-summary-metrics/deployment.yaml
+++ b/cluster/manifests/kubelet-summary-metrics/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: kubelet-summary-metrics
       containers:
       - name: proxy
-        image: container-registry.zalando.net/teapot/kubelet-summary-metrics:main-3
+        image: container-registry.zalando.net/teapot/kubelet-summary-metrics:main-5
         resources:
           limits:
             cpu: "{{.Cluster.ConfigItems.kubelet_summary_metrics_cpu}}"

--- a/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: kubernetes-lifecycle-metrics
       containers:
         - name: kubernetes-lifecycle-metrics
-          image: "container-registry.zalando.net/teapot/kubernetes-lifecycle-metrics:master-18"
+          image: "container-registry.zalando.net/teapot/kubernetes-lifecycle-metrics:master-19"
           ports:
             - containerPort: 9090
               protocol: TCP

--- a/cluster/manifests/spot-node-rescheduler/cronjob.yaml
+++ b/cluster/manifests/spot-node-rescheduler/cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: spot-node-rescheduler
-            image: container-registry.zalando.net/teapot/spot-node-rescheduler:main-6
+            image: container-registry.zalando.net/teapot/spot-node-rescheduler:main-8
             resources:
               limits:
                 cpu: "{{ .Cluster.ConfigItems.spot_node_rescheduler_cpu }}"

--- a/cluster/manifests/z-karpenter/deployment.yaml
+++ b/cluster/manifests/z-karpenter/deployment.yaml
@@ -50,7 +50,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
-          image: "container-registry.zalando.net/teapot/karpenter:0.36.1-main-23.patched"
+          image: "container-registry.zalando.net/teapot/karpenter:0.36.1-main-24.patched"
           imagePullPolicy: IfNotPresent
           env:
             - name: KUBERNETES_MIN_VERSION

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -203,7 +203,7 @@ write_files:
             limits:
               memory: {{ .Values.InstanceInfo.MemoryFraction (parseInt64 .Cluster.ConfigItems.apiserver_memory_limit_percent)}}
 {{- end }}
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-204
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-205
           name: admission-controller
           lifecycle:
             preStop:

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -271,7 +271,7 @@ write_files:
             - mountPath: /etc/kubernetes/ssl
               name: ssl-certs-kubernetes
               readOnly: true
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/k8s-authnz-webhook:master-133
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/k8s-authnz-webhook:master-134
           name: webhook
           ports:
           - containerPort: 8081


### PR DESCRIPTION
Updates the following components to use a static base image

* kube-node-ready
* kube-node-ready-controller
* kubernetes-lifecycle-metrics
* event-logger
* karpenter
* cluster-lifecycle-controller
* admission-controller
* k8s-authnz-webhook
* spot-node-rescheduler
* cronjob-fixer
* audittrail-adapter
* kubelet-summary-metrics