### PR TITLE
explicitly set 1 replica for external-dns

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     application: kubernetes
     component: external-dns
 spec:
+  replicas: 1
   strategy:
     type: Recreate
   selector:


### PR DESCRIPTION
This is a simple way to ensure that external-dns is started after CLM applies in case it was previously scaled to 0.