### PR TITLE
Revert "Update etcd-proxy to use static base image"

### DIFF
--- a/cluster/manifests/emergency-access-service/deployment.yaml
+++ b/cluster/manifests/emergency-access-service/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: emergency-access-service
       containers:
       - name: apiserver-proxy
-        image: container-registry.zalando.net/teapot/etcd-proxy:master-11
+        image: container-registry.zalando.net/teapot/etcd-proxy:master-10
         command:
         - /bin/sh
         args:


### PR DESCRIPTION
Reverts zalando-incubator/kubernetes-on-aws#7589

Reverting as this container depends on `/bin/sh` which was with the upgrade to static base image.