### PR TITLE
Update etcd-proxy base image

### DIFF
--- a/cluster/manifests/emergency-access-service/deployment.yaml
+++ b/cluster/manifests/emergency-access-service/deployment.yaml
@@ -28,12 +28,11 @@ spec:
       serviceAccountName: emergency-access-service
       containers:
       - name: apiserver-proxy
-        image: container-registry.zalando.net/teapot/etcd-proxy:master-10
-        command:
-        - /bin/sh
+        image: container-registry.zalando.net/teapot/etcd-proxy:master-11
         args:
-        - -c
-        - "exec /etcd-proxy --listen-address 127.0.0.1:333 $KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT"
+        - "--listen-address"
+        - "127.0.0.1:333"
+        - "$(KUBERNETES_SERVICE_HOST):$(KUBERNETES_SERVICE_PORT)"
         resources:
           requests:
             cpu: 25m


### PR DESCRIPTION
Alternative version of #7589 which doesn't depend on `/bin/sh` which is no longer in the image.