### PR TITLE
Update to kube2iam 0.11.2 + static base image

### DIFF
--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -38,7 +38,7 @@ spec:
         effect: NoExecute
       hostNetwork: true
       containers:
-      - image: container-registry.zalando.net/teapot/kube2iam:0.11.1-master-13
+      - image: container-registry.zalando.net/teapot/kube2iam:0.11.2-master-17.patched
         name: kube2iam
         args:
         - --auto-discover-base-arn


### PR DESCRIPTION
https://github.com/jtblin/kube2iam/releases/tag/0.11.2

Updates kube2iam to a version that is custom built with patches to go modules to avoid any CVEs. The build is using the static base image.