### PR TITLE
Set default prefix for external-dns

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -809,7 +809,7 @@ custom_dns_zone: "" # zone name e.g. example.org
 custom_dns_zone_nameservers: "" # space separated list of nameserver IP addresses
 
 # prefix prepended to ownership TXT records for external-dns
-external_dns_ownership_prefix: ""
+external_dns_ownership_prefix: "_external-dns."
 # domains that should be included by ExternalDNS ("" includes all hosted zones in the account. Separate multiple domains with a comma)
 external_dns_domain_filter: ""
 # domains that should be ignored by ExternalDNS


### PR DESCRIPTION
All clusters have been migrated to use this prefix for external-dns records. Simply make it the default.