### PR TITLE
skipper: use amazonlinux slim again but with `curl` (step 2/2)

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.21.99-931" }}
+{{ $internal_version := "v0.21.101-934" }}
 {{ $canary_internal_version := "v0.21.101-934" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}


### PR DESCRIPTION
This change should be backward compatible since old images had both `curl` & `wget` while newer images only have `curl`

while it's backward compatible we still need to be cautious because this change will affect **canary** & **main fleet**

This is another attempt to deploy the slimmer image, it was tested here https://github.com/zalando-incubator/kubernetes-on-aws/pull/7521

The other flow was reverted by https://github.com/zalando-incubator/kubernetes-on-aws/pull/7555

It also include simple skipper changes:

- https://github.com/zalando/skipper/pull/3088
- https://github.com/zalando/skipper/pull/3085

diff https://github.com/zalando/skipper/compare/v0.21.99...v0.21.101

depends on https://github.com/zalando-incubator/kubernetes-on-aws/pull/7607 until it's merged to stable