### PR TITLE
Add allowed capabilties via admission-controller config [1/2]

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -655,6 +655,11 @@ teapot_admission_controller_pod_security_policy_privileged_service_accounts: ""
 {{ end }}
 teapot_admission_controller_pod_security_policy_privileged_allow_privilege_escalation: "false"
 
+# comma separated list of restricted or privileged capabilities that are allowed
+# to be used by pods.
+teapot_admission_controller_pod_security_policy_additional_restricted_capabilities: ""
+teapot_admission_controller_pod_security_policy_privileged_capabilities: ""
+
 # Prevent the use of a particular AZ as much as possible
 blocked_availability_zone: ""
 

--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -106,6 +106,30 @@ data:
   pod.pod-security-policy.privileged-service-accounts.{{ $sa }}: ""
 {{- end}}
 
+  pod.pod-security-policy.allowed-restricted-capabilities.AUDIT_WRITE: ""
+  pod.pod-security-policy.allowed-restricted-capabilities.CHOWN: ""
+  pod.pod-security-policy.allowed-restricted-capabilities.DAC_OVERRIDE: ""
+  pod.pod-security-policy.allowed-restricted-capabilities.FOWNER: ""
+  pod.pod-security-policy.allowed-restricted-capabilities.FSETID: ""
+  pod.pod-security-policy.allowed-restricted-capabilities.KILL: ""
+  pod.pod-security-policy.allowed-restricted-capabilities.MKNOD: ""
+  pod.pod-security-policy.allowed-restricted-capabilities.NET_BIND_SERVICE: ""
+  pod.pod-security-policy.allowed-restricted-capabilities.NET_RAW: ""
+  pod.pod-security-policy.allowed-restricted-capabilities.SETFCAP: ""
+  pod.pod-security-policy.allowed-restricted-capabilities.SETGID: ""
+  pod.pod-security-policy.allowed-restricted-capabilities.SETPCAP: ""
+  pod.pod-security-policy.allowed-restricted-capabilities.SETUID: ""
+  pod.pod-security-policy.allowed-restricted-capabilities.SYS_CHROOT: ""
+  pod.pod-security-policy.allowed-restricted-capabilities.SYS_NICE: ""
+{{- range $cap := split .Cluster.ConfigItems.teapot_admission_controller_pod_security_policy_additional_restricted_capabilities "," }}
+  pod.pod-security-policy.allowed-restricted-capabilities.{{ $cap }}: ""
+{{- end}}
+
+{{- range $cap := split .Cluster.ConfigItems.teapot_admission_controller_pod_security_policy_privileged_capabilities "," }}
+  pod.pod-security-policy.allowed-privileged-capabilities.{{ $cap }}: ""
+{{- end}}
+
+
 {{- range $sysctl := split .Cluster.ConfigItems.allowed_unsafe_sysctls "," }}
   pod.pod-security-policy.allowed-unsafe-sysctls.{{ $sysctl }}: ""
 {{- end}}


### PR DESCRIPTION
Configure capabilities via admission-controller config to allow additional capabilities per cluster