### PR TITLE
flex karpenter node-pool configurations

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1146,3 +1146,9 @@ control_plane_graceful_shutdown: "true"
 #  fs.aio-max-nr = 8388608
 #  fs.inotify.max_user_watches = 100000
 sysctl_settings: ""
+
+
+
+# scheduling_controls
+teapot_admission_controller_scheduling_controls_enabled: "false"
+teapot_admission_controller_scheduling_controls_default_architecture: "amd64"

--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -52,6 +52,8 @@ data:
 {{- end}}
 
   pod.env-inject.node-options.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_inject_node_options_environment_variable }}"
+  pod.scheduling-controls.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_scheduling_controls_enabled }}"
+  pod.scheduling-controls.default-architecture: "{{ .Cluster.ConfigItems.teapot_admission_controller_scheduling_controls_default_architecture }}"
 
   podfactory.container-resource-check.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_validate_pod_template_resources }}"
   podfactory.application-label-check.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_validate_application_label }}"

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -155,6 +155,18 @@ spec:
             - "c7in"
             - "m7in"
             - "r7in"
+#{{ else if (gt (len .NodePool.InstanceTypes) 0) }}
+        - key: "node.kubernetes.io/instance-type"
+          operator: In
+          values:
+#      {{ range $type := .NodePool.InstanceTypes }}
+          - "{{ $type }}"
+#      {{ end }}
+#{{ end }}
+
+# safety guards to prevent the use of unwanted instance types in case the user has not specified any specific instance types
+#{{ if or (eq .NodePool.KarpenterInstanceTypeStrategy "default-for-karpenter") (eq .NodePool.KarpenterInstanceTypeStrategy "not-specified") }}
+        # exclude unwanted sizes
         - key: "karpenter.k8s.aws/instance-size"
           operator: "NotIn"
           values:
@@ -166,14 +178,19 @@ spec:
             - "c5d.large"
             - "m5d.large"
             - "r5d.large"
-#{{ else }}
-        - key: "node.kubernetes.io/instance-type"
-          operator: In
+#{{end}}
+
+#{{ if (index .NodePool.ConfigItems "requirements") }}
+#    {{ range $requirement := .NodePool.KarpenterRequirements }}
+        - key: "{{ $requirement.Key }}"
+          operator: "{{ $requirement.Operator }}"
           values:
-#      {{ range $type := .NodePool.InstanceTypes }}
-          - "{{ $type }}"
-#      {{ end }}
+#         {{ range $value := $requirement.Values }}
+            - "{{ $value}}"
+#         {{ end }}
+#    {{ end }}
 #{{ end }}
+        # other configuration
         - key: "karpenter.sh/capacity-type"
           operator: In
           values:


### PR DESCRIPTION
- allow not specifying instance-types
- allow custom requirements by users
- configure the admission controller with the flags necessary for the scheduling controls feature

related to https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/775