### PR TITLE
Don't bind collaborator to PowerUser access

### DIFF
--- a/cluster/manifests/roles/poweruser-binding.yaml
+++ b/cluster/manifests/roles/poweruser-binding.yaml
@@ -24,6 +24,3 @@ subjects:
 - kind: Group
   name: "okta:common/engineer"
   apiGroup: rbac.authorization.k8s.io
-- kind: Group
-  name: "okta:common/collaborator"
-  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
With okta we have accidentially given the `collaborator` poweruser by default. The intention is that they still need to request manual access (engineer role) to be able to do poweruser actions.

Drop binding from `poweruser` to `okta:common/collaborator`