### PR TITLE
admission-controller: Handle config defined capabilities [2/2]

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -203,7 +203,7 @@ write_files:
             limits:
               memory: {{ .Values.InstanceInfo.MemoryFraction (parseInt64 .Cluster.ConfigItems.apiserver_memory_limit_percent)}}
 {{- end }}
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-206
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-208
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
Follow up to #7616 (#7616 must be fully merged before merging this)

Updates the version of admission-controller to one supporting the config defined capabilities for Pod Security policy. 