### PR TITLE
Make use of kube-scheduler's config file

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -877,6 +877,9 @@ max_unavailable_statefulset_enabled: "false"
 # to ensure all secrets are encrypted/decrypted all secrets need to be rewritten after masters have been rolled
 enable_encryption: "true"
 
+# enable non-default profiles for the default scheduler
+enable_scheduler_profiles: "true"
+
 # default ttl for kube janitor for resources build from PRs
 kube_janitor_default_pr_ttl: "1w"  # 1 week
 # enable cleanup of pr resources other than namespaces

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -867,6 +867,19 @@ write_files:
       kind: KubeSchedulerConfiguration
       clientConnection:
         kubeconfig: /etc/kubernetes/scheduler-kubeconfig
+      profiles:
+        - schedulerName: default-scheduler
+          pluginConfig:
+            - name: PodTopologySpread
+              args:
+                defaultConstraints:
+                  - maxSkew: 1
+                    topologyKey: kubernetes.io/hostname
+                    whenUnsatisfiable: ScheduleAnyway
+                  - maxSkew: 1
+                    topologyKey: topology.kubernetes.io/zone
+                    whenUnsatisfiable: ScheduleAnyway
+                defaultingType: List
 
 {{ if eq .Cluster.ConfigItems.event_rate_limit_enable "true"}}
   # Enabling EventRateLimit admission plugin

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -666,7 +666,7 @@ write_files:
         - name: kube-scheduler
           image: nonexistent.zalan.do/teapot/{{if eq .Cluster.ConfigItems.kubernetes_scheduler_image "zalando" }}kube-scheduler-internal{{else}}kube-scheduler{{end}}:fixed
           args:
-          - --kubeconfig=/etc/kubernetes/scheduler-kubeconfig
+          - --config=/etc/kubernetes/config/scheduler-config.yaml
           - --leader-elect=true
           - --feature-gates=MinDomainsInPodTopologySpread={{ .Cluster.ConfigItems.min_domains_in_pod_topology_spread_enabled }}
           - --profiling={{ .Cluster.ConfigItems.enable_control_plane_profiling }}
@@ -689,6 +689,9 @@ write_files:
           - mountPath: /etc/kubernetes/ssl
             name: ssl-certs-kubernetes
             readOnly: true
+          - mountPath: /etc/kubernetes/config
+            name: kubernetes-configs
+            readOnly: true
         volumes:
         - hostPath:
             path: /etc/kubernetes/ssl
@@ -697,6 +700,9 @@ write_files:
             path: /etc/kubernetes/scheduler-kubeconfig
             type: File
           name: kubeconfig
+        - hostPath:
+            path: /etc/kubernetes/config
+          name: kubernetes-configs
 
   - owner: root:root
     path: /etc/kubernetes/config/tokenfile.csv
@@ -852,6 +858,15 @@ write_files:
       {{- if eq .Cluster.ConfigItems.enable_encryption "true" }}
           - identity: {}
       {{- end }}
+
+  - owner: root:root
+    path: /etc/kubernetes/config/scheduler-config.yaml
+    permissions: '0400'
+    content: |
+      apiVersion: kubescheduler.config.k8s.io/v1
+      kind: KubeSchedulerConfiguration
+      clientConnection:
+        kubeconfig: /etc/kubernetes/scheduler-kubeconfig
 
 {{ if eq .Cluster.ConfigItems.event_rate_limit_enable "true"}}
   # Enabling EventRateLimit admission plugin

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -874,9 +874,6 @@ write_files:
               args:
                 defaultConstraints:
                   - maxSkew: 1
-                    topologyKey: kubernetes.io/hostname
-                    whenUnsatisfiable: ScheduleAnyway
-                  - maxSkew: 1
                     topologyKey: topology.kubernetes.io/zone
                     whenUnsatisfiable: ScheduleAnyway
                 defaultingType: List

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -867,6 +867,7 @@ write_files:
       kind: KubeSchedulerConfiguration
       clientConnection:
         kubeconfig: /etc/kubernetes/scheduler-kubeconfig
+{{- if eq .Cluster.ConfigItems.enable_scheduler_profiles "true" }}
       profiles:
         - schedulerName: default-scheduler
           pluginConfig:
@@ -877,6 +878,7 @@ write_files:
                     topologyKey: topology.kubernetes.io/zone
                     whenUnsatisfiable: ScheduleAnyway
                 defaultingType: List
+{{- end}}
 
 {{ if eq .Cluster.ConfigItems.event_rate_limit_enable "true"}}
   # Enabling EventRateLimit admission plugin


### PR DESCRIPTION
Scheduler can make scheduling decision by taking [podTopologySpreads into account globally](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#cluster-level-default-constraints) (without users or admission-controller injecting anything). This needs to be configured in `kube-scheduler`'s config file. This PR introduces the config file so that it can be used later.

I'm getting a better result on a simple deployment. Although it's hard to test on two different clusters because their available capacity is different.

`teapot` cluster

![Screenshot 2024-06-17 at 16 03 43](https://github.com/zalando-incubator/kubernetes-on-aws/assets/36162/998f50f3-c4c9-4f25-ae21-a9e870089941)

This e2e cluster

![Screenshot 2024-06-17 at 16 04 21](https://github.com/zalando-incubator/kubernetes-on-aws/assets/36162/e437cbde-c7aa-4d70-bffc-0467cdeec7bf)
