### PR TITLE
ingress-controller: update to v0.15.19

### DIFF
--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -1,4 +1,4 @@
-# {{ $version := "v0.15.16" }}
+# {{ $version := "v0.15.19" }}
 
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Updates dependencies and used static base image.

[Changes](https://github.com/zalando-incubator/kube-ingress-aws-controller/compare/v0.15.16...v0.15.19)