### PR TITLE
add config-item to toggle nvidia-dcgm-exporter sidecar

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -387,6 +387,7 @@ nvidia_device_plugin_cpu: "10m"
 nvidia_device_plugin_memory: "50Mi"
 
 # nvidia dcgm exporter
+nvidia_dcgm_exporter_enabled: "false"
 nvidia_dcgm_exporter_cpu: "10m"
 nvidia_dcgm_exporter_memory: "200Mi"
 

--- a/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
+++ b/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
@@ -74,6 +74,7 @@ spec:
         volumeMounts:
         - name: device-plugin
           mountPath: /var/lib/kubelet/device-plugins
+{{- if eq .Cluster.ConfigItems.nvidia_dcgm_exporter_enabled "true" }}
       - name: dcgm-exporter
         image: container-registry.zalando.net/teapot/nvidia-dcgm-exporter:v3.3.6-3.4.2-ubuntu22.04-master-11
         args:
@@ -94,6 +95,7 @@ spec:
           runAsUser: 0
           capabilities:
             add: ["SYS_ADMIN"]
+{{- end}}
         volumeMounts:
         - name: pod-gpu-resources
           mountPath: /var/lib/kubelet/pod-resources

--- a/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
+++ b/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
@@ -24,9 +24,11 @@ spec:
         component: nvidia-gpu-device-plugin
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
+{{- if eq .Cluster.ConfigItems.nvidia_dcgm_exporter_enabled "true" }}
         prometheus.io/path: /metrics
         prometheus.io/port: "9400"
         prometheus.io/scrape: "true"
+{{- end}}
     spec:
       serviceAccountName: nvidia
       tolerations:
@@ -51,9 +53,11 @@ spec:
       - name: device-plugin
         hostPath:
           path: /var/lib/kubelet/device-plugins
+{{- if eq .Cluster.ConfigItems.nvidia_dcgm_exporter_enabled "true" }}
       - name: pod-gpu-resources
         hostPath:
           path: /opt/podruntime/kubelet/pod-resources
+{{- end}}
       containers:
       - name: nvidia-gpu-device-plugin
         image: container-registry.zalando.net/teapot/nvidia-gpu-device-plugin:v0.14.5-master-10
@@ -95,8 +99,8 @@ spec:
           runAsUser: 0
           capabilities:
             add: ["SYS_ADMIN"]
-{{- end}}
         volumeMounts:
         - name: pod-gpu-resources
           mountPath: /var/lib/kubelet/pod-resources
           readOnly: true
+{{- end}}


### PR DESCRIPTION
It was discovered recently that this sidecar container is quite resource intensive and it's injected by default to all the nvidia-gpu-device-plugin pods that run on any GPU node. This helps us control when we can run this exporter as needed.