### PR TITLE
Update kubenurse to v1.13.1

### DIFF
--- a/cluster/manifests/kubenurse/daemonset.yaml
+++ b/cluster/manifests/kubenurse/daemonset.yaml
@@ -55,7 +55,7 @@ spec:
               value: "{{.Cluster.ConfigItems.network_monitoring_check_neighborhood}}"
             - name: KUBENURSE_HISTOGRAM_BUCKETS
               value: 0.005,0.05,0.5,1,5,10
-          image: "container-registry.zalando.net/teapot/kubenurse:v1.7.0-histogram-main-7"
+          image: "container-registry.zalando.net/teapot/kubenurse:v1.13.1-main-8.custom"
           resources:
             requests:
               cpu: "{{.Cluster.ConfigItems.network_monitoring_daemonset_cpu}}"


### PR DESCRIPTION
* Updates kubenurse to the latest version
* Uses static base image.