### PR TITLE
`journald-reader`: mount `/usr` to access `libsystemd` and `python`

### DIFF
--- a/cluster/manifests/node-monitor/daemonset.yaml
+++ b/cluster/manifests/node-monitor/daemonset.yaml
@@ -115,7 +115,7 @@ spec:
               mountPath: /host
               readOnly: true
 {{- if eq .Cluster.ConfigItems.journald_reader_enabled "true" }}
-        - image: container-registry.zalando.net/teapot/journald-reader:master-15
+        - image: container-registry.zalando.net/teapot/journald-reader:master-19
           name: journald-reader
           env:
             - name: JOURNALD_READER_CHECKPOINT_FILE
@@ -134,6 +134,9 @@ spec:
               readOnly: true
             - mountPath: /journald-reader-state
               name: journald-reader-state
+            - mountPath: /usr
+              name: usr
+              readOnly: true
 {{- end }}
       automountServiceAccountToken: false
       terminationGracePeriodSeconds: 30
@@ -147,6 +150,9 @@ spec:
         - name: sys
           hostPath:
             path: /sys
+        - name: usr
+          hostPath:
+            path: /usr
         - name: containerd
           hostPath:
             path: /opt/podruntime/containerd


### PR DESCRIPTION
This allows to run `journald-reader` with a minimal/static image.

Requires the latest AMI (>=master-336), so let's merge this after/with the next AMI update.

DO NOT MERGE: AMI update and DaemonSet update have to be executed in two different rollouts.