### PR TITLE
Update skipper version, step 2/2

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.21.101-934" }}
+{{ $internal_version := "v0.21.108-941" }}
 {{ $canary_internal_version := "v0.21.108-941" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}


### PR DESCRIPTION
Merge https://github.com/zalando-incubator/kubernetes-on-aws/pull/7648 before this one

+ config: support multiple default filters flag values https://github.com/zalando/skipper/pull/3084
+ build(deps): bump docker/login-action from 3.1.0 to 3.2.0 https://github.com/zalando/skipper/pull/3090
+ build(deps): bump github.com/redis/go-redis/v9 from 9.5.1 to 9.5.2 https://github.com/zalando/skipper/pull/3092
+ build(deps): bump github.com/open-policy-agent/opa-envoy-plugin from 0.64.1-envoy to 0.65.0-envoy https://github.com/zalando/skipper/pull/3093
+ metrics: add start label for prometheus counters https://github.com/zalando/skipper/pull/3089
+ Reduce errors in decision logs that are operational https://github.com/zalando/skipper/pull/3086
+ doc: review and update ingress usage docs https://github.com/zalando/skipper/pull/3094
+ build: trim path https://github.com/zalando/skipper/pull/3095
+ OPA: Add decision outcome to span https://github.com/zalando/skipper/pull/3096
+ Set log level of PHC dropping an endpoint to debug https://github.com/zalando/skipper/pull/3098

FYI https://github.com/zalando/skipper/compare/v0.21.101...v0.21.108