### PR TITLE
Update default PHC configuration items

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -84,7 +84,7 @@ skipper_ingress_max_replicas: "50"
 {{end}}
 skipper_ingress_cpu: "1000m"
 skipper_ingress_memory: "1500Mi"
-skipper_ingress_health_check_options: "period=10s,min-requests=10,max-drop-probability=0.9"
+skipper_ingress_health_check_options: "period=10s,min-requests=10,min-drop-probability=0.05,max-drop-probability=0.9,max-unhealthy-endpoints-ratio=0.9"
 
 # Enables deployment of canary version
 skipper_ingress_canary_enabled: "true"


### PR DESCRIPTION
It is completely safe to do so because the same configuration is already applied to all clusters.