### PR TITLE
skipper: remove deprecated flags

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -190,7 +190,6 @@ spec:
           - "-enable-ratelimits"
           - "-experimental-upgrade"
           - "-metrics-exp-decay-sample"
-          - "-lb-healthcheck-interval=3s"
           - "-metrics-flavour=prometheus"
           - "-enable-connection-metrics"
           - "-enable-route-lifo-metrics"
@@ -198,7 +197,6 @@ spec:
           - "-enable-api-usage-monitoring"
           - "-api-usage-monitoring-realm-keys=https://identity.zalando.com/realm"
           - "-api-usage-monitoring-client-keys=https://identity.zalando.com/managed-id,sub"
-          - "-api-usage-monitoring-default-client-tracking-pattern=services[.].*"
 {{ if ne .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
           - "-default-filters-dir=/etc/config/default-filters"
 {{ end }}


### PR DESCRIPTION
* `-lb-healthcheck-interval` (https://github.com/zalando/skipper/pull/2906)
* `-api-usage-monitoring-default-client-tracking-pattern` (https://github.com/zalando/skipper/pull/950 and https://github.com/zalando/skipper/pull/1029)