### PR TITLE
skipper: increase redis termination grace period

### DIFF
--- a/cluster/manifests/skipper/skipper-redis.yaml
+++ b/cluster/manifests/skipper/skipper-redis.yaml
@@ -47,6 +47,7 @@ spec:
                 values:
                 - skipper-ingress-redis
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
+      terminationGracePeriodSeconds: 45
       containers:
       - image: container-registry.zalando.net/library/redis-7-alpine:7-alpine-20240226
         name: skipper-ingress-redis
@@ -74,7 +75,7 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["sleep","30"]
+              command: ["sleep", "30"]
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler


### PR DESCRIPTION
Default termination grace period is 30s and matches a delay added by #5817 which sometimes leads to sporadic FailedPreStopHook events.

Follow up on #5817