### PR TITLE
Revert "Update skipper version, step 1/2"

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,5 +1,5 @@
 {{ $internal_version := "v0.21.101-934" }}
-{{ $canary_internal_version := "v0.21.108-941" }}
+{{ $canary_internal_version := "v0.21.101-934" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}
 {{ $canary_args := "" }}


### PR DESCRIPTION
This reverts commit 7ca2d495f394466dad6322f9ea78603cc7a1eb3a because of skipper pod seems to not work https://github.com/zalando-incubator/kubernetes-on-aws/pull/7655#issuecomment-2157603705 .