### PR TITLE
Remove legacy Runtime policy toggle

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -609,10 +609,8 @@ teapot_admission_controller_topology_spread_timeout: 7m
 
 # Enable and configure runtime-policy annotation
 {{if eq .Cluster.Environment "production"}}
-teapot_admission_controller_runtime_policy_enabled: "false"
 teapot_admission_controller_runtime_policy_default: "require-on-demand"
 {{else}}
-teapot_admission_controller_runtime_policy_enabled: "true"
 teapot_admission_controller_runtime_policy_default: "allow-spot"
 {{end}}
 # Enforce a certain policy (<empty>|allow-spot|require-on-demand) for a cluster,

--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -179,7 +179,6 @@ data:
 {{- end}}
   pod.node-lifecycle.provider.master: "zalando"
 
-  pod.runtime-policy.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_runtime_policy_enabled }}"
   pod.runtime-policy.default: "{{ .Cluster.ConfigItems.teapot_admission_controller_runtime_policy_default }}"
   pod.runtime-policy.enforced: "{{ .Cluster.ConfigItems.teapot_admission_controller_runtime_policy_enforced }}"
   pod.runtime-policy.spot-hard-assignment: "{{ .Cluster.ConfigItems.teapot_admission_controller_runtime_policy_spot_hard_assignment }}"


### PR DESCRIPTION
This config is not used in the admission-controller, so remove it to avoid confusion about the feature being enable or not. It is enabled by node pool by default.