### PR TITLE
skipper: remove deprecated enable_skipper_eastwest config

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -230,15 +230,6 @@ zmon_kairosdb_url: "https://data-service.zmon.zalan.do/kairosdb-proxy"
 ## Nakadi URL (for the stats API)
 nakadi_url: ""
 
-# skipper east-west feature - deprecated configuration
-# enable_skipper_eastwest is the legacy feature gate for the automatic
-# ingress.cluster.local addresses created by skipper.
-# enable_skipper_eastwest_dns only enables DNS and assumes users define the
-# ingress.cluster.local names explicitly on ingress/routegroup/stacksets
-enable_skipper_eastwest_dns: "true"
-enable_skipper_eastwest: "false"
-
-
 # enable temporary logging of ingress.cluster.local names
 # used to find services for which it's being used.
 skipper_eastwest_dns_log_enabled: "false"

--- a/cluster/manifests/coredns-local/configmap-local.yaml
+++ b/cluster/manifests/coredns-local/configmap-local.yaml
@@ -65,7 +65,6 @@ data:
     }
 {{ end }}
 
-{{ if eq .Cluster.ConfigItems.enable_skipper_eastwest_dns "true"}}
     ingress.cluster.local:9254 {
 {{ if eq .Cluster.ConfigItems.skipper_eastwest_dns_log_enabled "true"}}
         log
@@ -81,7 +80,6 @@ data:
         prometheus :9153
         ready :9155
     }
-{{ end }}
 
     # Defines that this server is authority for reverse
     # lookups for these ranges.

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -166,10 +166,6 @@ spec:
           - "-address=:9999"
           - "-wait-first-route-load"
           - "-wait-for-healthcheck-interval={{ .Cluster.ConfigItems.skipper_wait_for_healthcheck_interval }}"
-{{ if and (ne .Cluster.ConfigItems.skipper_routesrv_enabled "exec") (eq .Cluster.ConfigItems.enable_skipper_eastwest "true")}}
-          - "-enable-kubernetes-east-west"
-          - "-kubernetes-east-west-domain=.ingress.cluster.local"
-{{ end }}
 {{ if ne .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
           - "-kubernetes-east-west-range-domains=ingress.cluster.local"
           - "-kubernetes-east-west-range-predicates=ClientIP(\"10.2.0.0/15\", \"{{ .Values.vpc_ipv4_cidr }}\")"
@@ -533,10 +529,6 @@ spec:
           - "-enable-kubernetes-endpointslices={{ .Cluster.ConfigItems.skipper_endpointslices_enabled }}"
           - "-address=:9990"
           - "-wait-for-healthcheck-interval={{ .Cluster.ConfigItems.skipper_wait_for_healthcheck_interval }}"
-{{ if eq .Cluster.ConfigItems.enable_skipper_eastwest "true"}}
-          - "-enable-kubernetes-east-west"
-          - "-kubernetes-east-west-domain=.ingress.cluster.local"
-{{ end }}
           - "-kubernetes-east-west-range-domains=ingress.cluster.local"
           - "-kubernetes-east-west-range-predicates=ClientIP(\"10.2.0.0/15\", \"{{ .Values.vpc_ipv4_cidr }}\")"
           - "-reverse-source-predicate"


### PR DESCRIPTION
The east-west feature is always enabled by `-kubernetes-east-west-range-domains` therefore also enable `ingress.cluster.local` DNS zone unconditionally by removing `enable_skipper_eastwest_dns`.