### PR TITLE
collect node profile, will be used for enriching metrics on Karpenter

### DIFF
--- a/cluster/manifests/kube-state-metrics/deployment.yaml
+++ b/cluster/manifests/kube-state-metrics/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         image: container-registry.zalando.net/teapot/kube-state-metrics:v2.10.1-master-24
         args:
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
-        - --metric-labels-allowlist=pods=[{{.Cluster.ConfigItems.observability_metrics_pods_labels}}],ingresses=[{{.Cluster.ConfigItems.observability_metrics_ingresses_labels}}],nodes=[topology.kubernetes.io/zone,node.kubernetes.io/instance-type,node.kubernetes.io/node-pool,node.kubernetes.io/role,dedicated]
+        - --metric-labels-allowlist=pods=[{{.Cluster.ConfigItems.observability_metrics_pods_labels}}],ingresses=[{{.Cluster.ConfigItems.observability_metrics_ingresses_labels}}],nodes=[topology.kubernetes.io/zone,node.kubernetes.io/instance-type,node.kubernetes.io/node-pool,node.kubernetes.io/role,node.kubernetes.io/profile,dedicated]
         - --metric-annotations-allowlist=pods=[{{.Cluster.ConfigItems.observability_metrics_pods_annotations}}]
         ports:
         - containerPort: 8080


### PR DESCRIPTION
collecting the node-profile of a node. from which we can know if the node is karpenter node or CA node.
this can help generating meaningful metrics on how karpenter perform VS CA