### PR TITLE
Allow readonly and poweruser roles access to configmaps/status

### DIFF
--- a/cluster/manifests/roles/poweruser-role.yaml
+++ b/cluster/manifests/roles/poweruser-role.yaml
@@ -19,6 +19,7 @@ rules:
   - ''
   resources:
   - configmaps
+  - configmaps/status
   - endpoints
   - limitranges
   - namespaces

--- a/cluster/manifests/roles/readonly-role.yaml
+++ b/cluster/manifests/roles/readonly-role.yaml
@@ -23,6 +23,7 @@ rules:
   - bindings
   - componentstatuses
   - configmaps
+  - configmaps/status
   - endpoints
   - limitranges
   - namespaces


### PR DESCRIPTION
Not sure if these sub-resources really exist but `kuberay` defines them [here](https://github.com/ray-project/kuberay/blob/40a946a57f9aae943d7deae13a54bb1ec6288621/helm-chart/kuberay-operator/templates/leader_election_role.yaml#L23-L27). This allows `deployment-service` to deploy RBAC permissions that access `configmaps/status` which should be fairly safe.

For https://github.bus.zalan.do/zooport/issues/issues/4764