### PR TITLE
Align deployment-service config key with reality

### DIFF
--- a/cluster/manifests/deployment-service/01-config.yaml
+++ b/cluster/manifests/deployment-service/01-config.yaml
@@ -20,4 +20,4 @@ data:
   ml-experiment-deployment-role-arn: "arn:aws:iam::{{accountID .Cluster.InfrastructureAccount}}:role/{{.Cluster.LocalID}}-deployment-service-ml-experiment-deployment"
 {{- end }}
   cloudformation-enable-auto-expand: "{{.Cluster.ConfigItems.deployment_service_cf_auto_expand_enabled}}"
-  cloudformation-allow-update-source-branch-changes: "{{.Cluster.ConfigItems.deployment_service_cf_update_source_branch_changes}}"
+  cloudformation-update-source-branch-changes: "{{.Cluster.ConfigItems.deployment_service_cf_update_source_branch_changes}}"


### PR DESCRIPTION
The key over at `deployment-service` is actually different: https://github.bus.zalan.do/teapot/deployment-service/blob/454182013bae7d1b906cef9241e1a2cd1c3d28fc/pkg/deployment_config/config.go#L29