### PR TITLE
Add simple DNS e2e test

### DIFF
--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -1,5 +1,5 @@
 # builder image
-FROM golang:1.21 as builder
+FROM golang:1.22 as builder
 
 RUN CGO_ENABLED=0 go install github.com/onsi/ginkgo/v2/ginkgo@v2.13.0
 

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -4,6 +4,7 @@ BINARY       ?= kubernetes-on-aws-e2e
 VERSION      ?= $(shell git describe --tags --always --dirty)
 KUBE_VERSION ?= v1.29.4
 IMAGE        ?= pierone.stups.zalan.do/teapot/$(BINARY)
+SOURCES      = $(shell find . -name '*.go')
 TAG          ?= $(VERSION)
 DOCKERFILE   ?= Dockerfile
 
@@ -12,7 +13,7 @@ default: build
 deps:
 	CGO_ENABLED=0 go install github.com/onsi/ginkgo/v2/ginkgo@v2.13.0
 
-e2e.test: go.mod
+e2e.test: go.mod $(SOURCES)
 	go test -v -c -o e2e.test
 
 stackset-e2e:
@@ -20,13 +21,13 @@ stackset-e2e:
 
 build: e2e.test stackset-e2e
 
-build/linux/amd64/e2e.test: go.mod
+build/linux/amd64/e2e.test: go.mod $(SOURCES)
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -v -c -o $@
 
 build/linux/amd64/stackset-e2e:
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -modfile stackset/go.mod -c -o $@ github.com/zalando-incubator/stackset-controller/cmd/e2e
 
-build/linux/arm64/e2e.test: go.mod
+build/linux/arm64/e2e.test: go.mod $(SOURCES)
 	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go test -v -c -o $@
 
 build/linux/arm64/stackset-e2e:

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -185,6 +185,15 @@ clusters:
       labels: dedicated=worker-karpenter
       taints: dedicated=worker-karpenter:NoSchedule
   - discount_strategy: none
+    instance_types: ["default-for-karpenter"]
+    min_size: 0
+    max_size: 0
+    profile: worker-karpenter
+    name: worker-karpenter-dns-test
+    config_items:
+      labels: dedicated=dns-test
+      taints: dedicated=dns-test:NoSchedule
+  - discount_strategy: none
     instance_types:
     - "m6g.large"
     min_size: 0

--- a/test/e2e/dns.go
+++ b/test/e2e/dns.go
@@ -1,0 +1,61 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	admissionapi "k8s.io/pod-security-admission/api"
+
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var _ = describe("DNS working", func() {
+	f := framework.NewDefaultFramework("dns")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelBaseline
+	var cs kubernetes.Interface
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+	})
+
+	f.It("Should run a pod on a new node to verify DNS daemonset [Zalando] [DNS]", f.WithSlow(), func(ctx context.Context) {
+		ns := f.Namespace.Name
+		nameprefix := "dns-test-"
+		labels := map[string]string{
+			"application": "dns-check",
+		}
+
+		By("Creating a pod which runs dns-checker on a new node")
+		pod := createDNSCheckPod(nameprefix, ns, labels)
+		_, err := cs.CoreV1().Pods(ns).Create(ctx, pod, metav1.CreateOptions{})
+		framework.ExpectNoError(err, "Could not create POD %s", pod.Name)
+		framework.ExpectNoError(waitForPodSuccessInNamespaceTimeout(ctx, f.ClientSet, pod.Name, pod.Namespace, 10*time.Minute))
+	})
+})
+
+// waitForPodSuccessInNamespaceTimeout returns nil if the pod reached state success, or an error if it reached failure or ran too long.
+// This is a copy of the upstream function but using `gomega.StopTrying` to fail early if the pod failed.
+func waitForPodSuccessInNamespaceTimeout(ctx context.Context, c clientset.Interface, podName, namespace string, timeout time.Duration) error {
+	return e2epod.WaitForPodCondition(ctx, c, namespace, podName, fmt.Sprintf("%s or %s", v1.PodSucceeded, v1.PodFailed), timeout, func(pod *v1.Pod) (bool, error) {
+		if pod.DeletionTimestamp == nil && pod.Spec.RestartPolicy == v1.RestartPolicyAlways {
+			return true, fmt.Errorf("pod %q will never terminate with a succeeded state since its restart policy is Always", podName)
+		}
+
+		switch pod.Status.Phase {
+		case v1.PodSucceeded:
+			return true, nil
+		case v1.PodFailed:
+			return true, gomega.StopTrying(fmt.Sprintf("pod %q failed with status: %+v", podName, pod.Status))
+		default:
+			return false, nil
+		}
+	})
+}


### PR DESCRIPTION
This adds a simple DNS e2e test which simply runs a pod on a _new_ node such that we test against an update to CoreDNS daemonset.

The test is very basic and only tries to do `nslookup` to `google.com` with a timeout of 1 second (you can't do lower timeout in `nslookup`).
This should be enough to catch the delay we saw with the roll out of #7647

* [ ] Check updating similar as #7647 will be caught by e2e.