### PR TITLE
update kubernetes-lifecycle-metrics version

### DIFF
--- a/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: kubernetes-lifecycle-metrics
       containers:
         - name: kubernetes-lifecycle-metrics
-          image: "container-registry.zalando.net/teapot/kubernetes-lifecycle-metrics:master-19"
+          image: "container-registry.zalando.net/teapot/kubernetes-lifecycle-metrics:master-20"
           ports:
             - containerPort: 9090
               protocol: TCP


### PR DESCRIPTION
related:
https://github.bus.zalan.do/teapot/kubernetes-lifecycle-metrics/pull/19

"collecting the node-profile of a node. from which we can know if the node is karpenter node or CA node.
this can help making the SLO (pod startup time) visualize what improvement we have due to karpenter"