### PR TITLE
update kubernetes-lifecycle-metrics

### DIFF
--- a/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: kubernetes-lifecycle-metrics
       containers:
         - name: kubernetes-lifecycle-metrics
-          image: "container-registry.zalando.net/teapot/kubernetes-lifecycle-metrics:master-20"
+          image: "container-registry.zalando.net/teapot/kubernetes-lifecycle-metrics:master-21"
           ports:
             - containerPort: 9090
               protocol: TCP

--- a/cluster/manifests/kubernetes-lifecycle-metrics/rbac.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/rbac.yaml
@@ -10,7 +10,7 @@ metadata:
   name: kubernetes-lifecycle-metrics
 rules:
 - apiGroups: [""]
-  resources: ["pods", "events"]
+  resources: ["pods", "events", "nodes"]
   verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cluster/node-pools/worker-combined/stack.yaml
+++ b/cluster/node-pools/worker-combined/stack.yaml
@@ -72,6 +72,9 @@ Resources:
       - Key: k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/node-pool
         PropagateAtLaunch: true
         Value: {{ .NodePool.Name }}
+      - Key: k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/profile
+        PropagateAtLaunch: true
+        Value: {{ .NodePool.Profile }}
       - Key: k8s.io/cluster-autoscaler/node-template/label/lifecycle-status
         PropagateAtLaunch: true
         Value: ready

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -78,6 +78,9 @@ Resources:
       - Key: k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/node-pool
         PropagateAtLaunch: true
         Value: {{ $data.NodePool.Name }}
+      - Key: k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/profile
+        PropagateAtLaunch: true
+        Value: {{ $data.NodePool.Profile }}
       - Key: k8s.io/cluster-autoscaler/node-template/label/lifecycle-status
         PropagateAtLaunch: true
         Value: ready


### PR DESCRIPTION
fixed a bug in kubernetes-lifecycle-metrics

- the node watcher was initialized but not run in the previous version