### PR TITLE
flip the order of nvidia driver's nodeAffinities to mitigate a karpenter bug

### DIFF
--- a/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
+++ b/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
@@ -41,13 +41,13 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: zalando.org/nvidia-gpu
-                operator: Exists
-            - matchExpressions:
               - key: karpenter.k8s.aws/instance-gpu-manufacturer
                 operator: In
                 values:
                 - nvidia
+            - matchExpressions:
+              - key: zalando.org/nvidia-gpu
+                operator: Exists
       priorityClassName: system-node-critical
       volumes:
       - name: device-plugin


### PR DESCRIPTION
it seems that karpenter has a bug where it only considers the first affinity of a daemonset when calculating daemonset resources of a node pool

[here](https://github.com/kubernetes-sigs/karpenter/blob/main/pkg/scheduling/requirements.go#L104) it is reading only the first of the affinities relying on an outer loop to remove the affinity and continue with the next one

this loop is not happening for daemonset calculation as seen [here](https://github.com/kubernetes-sigs/karpenter/blob/main/pkg/controllers/provisioning/scheduling/scheduler.go#L344)
