### PR TITLE
skipper: update main fleet to version v0.21.124

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.21.108-941" }}
+{{ $internal_version := "v0.21.124-947" }}
 {{ $canary_internal_version := "v0.21.124-947" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}


### PR DESCRIPTION
* docs: cleanup deprecated -lb-healthcheck-interval flag: https://github.com/zalando/skipper/pull/3099
* build(deps): bump amazonlinux from 5478f82 to 0d172f8 in /fuzz: https://github.com/zalando/skipper/pull/3105
* build(deps): bump golang.org/x/net from 0.25.0 to 0.26.0: https://github.com/zalando/skipper/pull/3100
* build(deps): bump github.com/instana/go-sensor from 1.62.1 to 1.63.0: https://github.com/zalando/skipper/pull/3104
* build(deps): bump golang.org/x/oauth2 from 0.20.0 to 0.21.0: https://github.com/zalando/skipper/pull/3102
* build(deps): bump github.com/miekg/dns from 1.1.59 to 1.1.61: https://github.com/zalando/skipper/pull/3109
* build(deps): bump github.com/redis/go-redis/v9 from 9.5.2 to 9.5.3: https://github.com/zalando/skipper/pull/3110
* build(deps): bump google.golang.org/protobuf from 1.34.1 to 1.34.2: https://github.com/zalando/skipper/pull/3108
* routing: log route update id: https://github.com/zalando/skipper/pull/3112
* build(deps): bump actions/checkout from 4.1.6 to 4.1.7: https://github.com/zalando/skipper/pull/3107
* routing: measure route update latency: https://github.com/zalando/skipper/pull/3113
* doc: mention DCO and what to do in your commit: https://github.com/zalando/skipper/pull/3114
* routing: refactor update id logging: https://github.com/zalando/skipper/pull/3116
* OPA: Add response status to control plane traces: https://github.com/zalando/skipper/pull/3118
* routing: measure CreateFilter latency: https://github.com/zalando/skipper/pull/3115

diff https://github.com/zalando/skipper/compare/v0.21.108...v0.21.124

depends on merging https://github.com/zalando-incubator/kubernetes-on-aws/pull/7720 to stable
