### PR TITLE
Rotate nodes with old daemonset pods before e2e

### DIFF
--- a/test/e2e/.gitignore
+++ b/test/e2e/.gitignore
@@ -5,3 +5,4 @@ base_config/
 internal_config.sh
 .kube/
 stackset-e2e
+check-daemonset-updated

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -1,5 +1,5 @@
 # builder image
-FROM golang:1.21 as builder
+FROM golang:1.22 as builder
 
 RUN CGO_ENABLED=0 go install github.com/onsi/ginkgo/v2/ginkgo@v2.13.0
 

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -4,6 +4,7 @@ BINARY       ?= kubernetes-on-aws-e2e
 VERSION      ?= $(shell git describe --tags --always --dirty)
 KUBE_VERSION ?= v1.29.4
 IMAGE        ?= pierone.stups.zalan.do/teapot/$(BINARY)
+SOURCES      = $(shell find . -name '*.go')
 TAG          ?= $(VERSION)
 DOCKERFILE   ?= Dockerfile
 
@@ -12,21 +13,24 @@ default: build
 deps:
 	CGO_ENABLED=0 go install github.com/onsi/ginkgo/v2/ginkgo@v2.13.0
 
-e2e.test: go.mod
+e2e.test: go.mod $(SOURCES)
 	go test -v -c -o e2e.test
 
 stackset-e2e:
 	CGO_ENABLED=0 go test -modfile stackset/go.mod -c -o stackset-e2e github.com/zalando-incubator/stackset-controller/cmd/e2e
 
-build: e2e.test stackset-e2e
+check-daemonset-updated: go.mod daemonset-updated/main.go
+	CGO_ENABLED=0 go build -trimpath -v -o $@ ./daemonset-updated
 
-build/linux/amd64/e2e.test: go.mod
+build: e2e.test stackset-e2e check-daemonset-updated
+
+build/linux/amd64/e2e.test: go.mod $(SOURCES)
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -v -c -o $@
 
 build/linux/amd64/stackset-e2e:
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -modfile stackset/go.mod -c -o $@ github.com/zalando-incubator/stackset-controller/cmd/e2e
 
-build/linux/arm64/e2e.test: go.mod
+build/linux/arm64/e2e.test: go.mod $(SOURCES)
 	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go test -v -c -o $@
 
 build/linux/arm64/stackset-e2e:
@@ -49,4 +53,5 @@ build.push.multiarch: build.linux.amd64 #build.linux.arm64
 clean:
 	rm -rf e2e.test
 	rm -rf stackset-e2e
+	rm -rf check-daemonset-updated
 	rm -rf build

--- a/test/e2e/daemonset-updated/main.go
+++ b/test/e2e/daemonset-updated/main.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log"
+	"os"
+	"strconv"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func main() {
+	kubeClient, err := newClient()
+	if err != nil {
+		log.Fatalf("Failed to setup Kubernetes client: %v", err)
+	}
+
+	for {
+		ctx := context.Background()
+		candidates, err := candidateNodes(ctx, kubeClient)
+		if err != nil {
+			log.Printf("Failed to get candidate nodes: %v", err)
+			continue
+		}
+
+		if len(candidates) == 0 {
+			log.Printf("No nodes with old daemonset pods found, exiting")
+			break
+		}
+
+		decomissioningNodes := 0
+		for _, node := range candidates {
+			if node.Node.Labels["lifecycle-status"] != "ready" {
+				decomissioningNodes++
+				continue
+			}
+
+			if err := decommissionNode(ctx, kubeClient, node); err != nil {
+				log.Printf("Failed to decommission node %s: %v", node.Node.Name, err)
+			}
+			log.Printf("Marked node %s for decommissioning", node.Node.Name)
+			decomissioningNodes++
+		}
+
+		log.Printf("Waiting for %d nodes with old daemonset pods to decommission", decomissioningNodes)
+		time.Sleep(30 * time.Second)
+	}
+
+}
+
+// newClient will try to create an in-cluster client if possible, otherwise create one with configuration from $KUBECONFIG or $HOME/.kube/config
+func newClient() (kubernetes.Interface, error) {
+	// first try to get client from kubeconfig
+	kubeconfig := os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		kubeconfig = os.ExpandEnv("${HOME}/.kube/configs")
+	}
+
+	// if no kubeconfig is found, try in-cluster config
+	_, err := os.Stat(kubeconfig)
+	if err != nil {
+		if e, ok := err.(*os.PathError); ok && errors.Is(e.Err, os.ErrNotExist) {
+			// Try in-cluster config
+			cfg, err := rest.InClusterConfig()
+			if err != nil {
+				return nil, err
+			}
+			return kubernetes.NewForConfig(cfg)
+		}
+		return nil, err
+	}
+
+	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+	return kubernetes.NewForConfig(cfg)
+}
+
+type Node struct {
+	Pods []v1.Pod
+	Node *v1.Node
+}
+
+func candidateNodes(ctx context.Context, client kubernetes.Interface) ([]*Node, error) {
+	nodeMapping, err := nodeMapping(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+
+	daemonsets, err := onDeleteDaemonsets(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+
+	candidates := make([]*Node, 0, len(nodeMapping))
+	for _, node := range nodeMapping {
+		for _, p := range node.Pods {
+			if oldDaemonsetPod(p, daemonsets) {
+				candidates = append(candidates, node)
+			}
+		}
+	}
+
+	return candidates, nil
+}
+
+func oldDaemonsetPod(pod v1.Pod, onDeleteDaemonsets map[dsID]int64) bool {
+	for _, owner := range pod.ObjectMeta.OwnerReferences {
+		if owner.Kind != "DaemonSet" {
+			continue
+		}
+
+		dsID := dsID{
+			Name:      owner.Name,
+			Namespace: pod.Namespace,
+			UID:       owner.UID,
+		}
+
+		podGenStr, ok := pod.Labels["pod-template-generation"]
+		if !ok {
+			continue
+		}
+
+		podGen, err := strconv.ParseInt(podGenStr, 10, 64)
+		if err != nil {
+			continue
+		}
+
+		if gen, ok := onDeleteDaemonsets[dsID]; ok && podGen != gen {
+			return true
+		}
+	}
+
+	return false
+}
+
+func nodeMapping(ctx context.Context, client kubernetes.Interface) (map[string]*Node, error) {
+	nodes, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	nodeMapping := map[string]*Node{}
+	for _, node := range nodes.Items {
+		n := node
+		nodeMapping[node.Name] = &Node{
+			Node: &n,
+		}
+	}
+
+	pods, err := client.CoreV1().Pods(v1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, pod := range pods.Items {
+		if node, ok := nodeMapping[pod.Spec.NodeName]; ok {
+			// filter out failed/completed pods as they don't
+			// consume any capacity on a node.
+			switch pod.Status.Phase {
+			case v1.PodSucceeded, v1.PodFailed:
+				continue
+			}
+			node.Pods = append(node.Pods, pod)
+		}
+	}
+
+	return nodeMapping, nil
+}
+
+type dsID struct {
+	Name      string
+	Namespace string
+	UID       types.UID
+}
+
+func onDeleteDaemonsets(ctx context.Context, client kubernetes.Interface) (map[dsID]int64, error) {
+	onDeleteDaemonsets := make(map[dsID]int64, 0)
+	daemonsets, err := client.AppsV1().DaemonSets(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, ds := range daemonsets.Items {
+		if ds.Spec.UpdateStrategy.Type == appsv1.OnDeleteDaemonSetStrategyType {
+			onDeleteDaemonsets[dsID{
+				Name:      ds.Name,
+				Namespace: ds.Namespace,
+				UID:       ds.UID,
+			}] = ds.Generation
+		}
+	}
+
+	return onDeleteDaemonsets, nil
+}
+
+func decommissionNode(ctx context.Context, client kubernetes.Interface, node *Node) error {
+	taint := v1.Taint{
+		Key:    "decommission-pending",
+		Value:  "spot-replacement",
+		Effect: v1.TaintEffectNoSchedule,
+	}
+
+	node.Node.Labels["lifecycle-status"] = "decommission-pending"
+	node.Node.Spec.Taints = append(node.Node.Spec.Taints, taint)
+
+	_, err := client.CoreV1().Nodes().Update(ctx, node.Node, metav1.UpdateOptions{})
+	return err
+}

--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -141,9 +141,14 @@ if [ "$create_cluster" = true ]; then
         --registry=head_cluster.yaml \
         --manage-etcd-stack
 
+    # rotate nodes with old daemonset pods and update strategy onDelete
+    # This is important to ensure we e2e test against e.g. latest coredns daemonset
+    ./check-daemonset-updated
+
     # Wait for the resources to be ready after the update
     # TODO: make a feature of CLM --wait-for-kube-system
     ./wait-for-update.py --timeout 1200
+
 fi
 
 if [ "$e2e" = true ]; then


### PR DESCRIPTION
The coredns daemonset has update strategy `OnDelete` meaning the pods will only be updated if the node is replaced and a new pod is created for new nodes. This is done to avoid downtime of coredns which would break our DNS availability temporary on a node.

This has the problem that updates to the coredns daemonset is not properly tested during e2e, because most of the nodes will be running the previous version.

This PR adds a small tool `check-daemonset-updated` which is run after CLM during cluster creation for e2e, this ensure that if coredns is updated all the nodes are also rotated until there are no old coredns pods. This increases the time to create an e2e cluster, but only for cases where coredns is updated.