### PR TITLE
[RUN e2e] Update kube-dns images to latest version 1.23.1

### DIFF
--- a/cluster/manifests/coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/coredns-local/daemonset-coredns.yaml
@@ -92,7 +92,7 @@ spec:
 {{ end }}
 {{ if eq .Cluster.ConfigItems.dns_cache "dnsmasq" }}
       - name: dnsmasq
-        image: container-registry.zalando.net/teapot/k8s-dns-dnsmasq-nanny:1.17.4-master-15
+        image: container-registry.zalando.net/teapot/k8s-dns-dnsmasq-nanny:1.23.1-master-17
         securityContext:
           privileged: true
         livenessProbe:
@@ -134,7 +134,7 @@ spec:
             cpu: {{.Cluster.ConfigItems.dns_dnsmasq_cpu}}
             memory: {{.Cluster.ConfigItems.dns_dnsmasq_mem}}
       - name: sidecar
-        image: container-registry.zalando.net/teapot/k8s-dns-sidecar:1.17.4-master-15
+        image: container-registry.zalando.net/teapot/k8s-dns-sidecar:1.23.1-master-17
         securityContext:
           privileged: true
         livenessProbe:


### PR DESCRIPTION
Test that the rotation of daemonset during e2e introduced in #7725  will catch the broken dnsmasq update in this change.