### PR TITLE
Revert "Patch kube-scheduler to fix crash"

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -664,11 +664,7 @@ write_files:
         hostNetwork: true
         containers:
         - name: kube-scheduler
-{{- if eq .Cluster.ConfigItems.kubernetes_scheduler_image "zalando" }}
-          image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/kube-scheduler-internal:v1.30.1-master-121
-{{- else }}
-          image: nonexistent.zalan.do/teapot/kube-scheduler:fixed
-{{- end }}
+          image: nonexistent.zalan.do/teapot/{{if eq .Cluster.ConfigItems.kubernetes_scheduler_image "zalando" }}kube-scheduler-internal{{else}}kube-scheduler{{end}}:fixed
           args:
           - --config=/etc/kubernetes/config/scheduler-config.yaml
           - --leader-elect=true


### PR DESCRIPTION
This reverts commit 8bf251e0e56ff80a5f80fccefbabf145597e9da9.

Since Kubernetes v1.30.2 a custom kube-scheduler patch is not needed (forgot to revert this change when updating to v1.30.2).