### PR TITLE
skipper: set skipper_prometheus_start_label_enabled by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -122,7 +122,8 @@ skipper_endpointslices_enabled: "true"
 
 skipper_compress_encodings: "gzip,deflate,br"
 
-skipper_prometheus_start_label_enabled: "false"
+# Adds "start" label to each prometheus counter with the value of counter creation timestamp as unix nanoseconds
+skipper_prometheus_start_label_enabled: "true"
 
 # skipper profiling settings, 0 keeps default, <0 disable, >0 enable with value
 # https://pkg.go.dev/runtime@master#SetBlockProfileRate


### PR DESCRIPTION
The config `skipper_prometheus_start_label_enabled` is enabled in all clusters so make it true by default.

See #7676