### PR TITLE
ingress-controller: configure keyValue log parser

### DIFF
--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -19,6 +19,8 @@ spec:
         application: kube-ingress-aws-controller
         version: "{{ $version }}"
       annotations:
+        kubernetes-log-watcher/scalyr-parser: |
+          [{"container": "controller", "parser": "keyValue"}]
         logging/destination: "{{ .Cluster.ConfigItems.log_destination_both }}"
         prometheus.io/path: /metrics
         prometheus.io/port: "7979"


### PR DESCRIPTION
Configure built-in keyValue parser for containers using https://github.com/sirupsen/logrus that logs in the format compatible with https://pkg.go.dev/github.com/kr/logfmt

See previous #6535