### PR TITLE
egress: Update to Kubernetes v1.30.2 + aws-sdk-go-v2

### DIFF
--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: kube-static-egress-controller
       containers:
       - name: controller
-        image: container-registry.zalando.net/teapot/kube-static-egress-controller:v0.2.16-master-47
+        image: container-registry.zalando.net/teapot/kube-static-egress-controller:v0.3.0-master-48
         args:
         - "--provider=aws"
         - "--vpc-id={{.Cluster.ConfigItems.vpc_id}}"


### PR DESCRIPTION
Updates the kube-static-egress component.

* Updates to Kubernetes v1.30.2: https://github.com/szuecs/kube-static-egress-controller/pull/53
* Updates to aws-sdk-go-v2: https://github.com/szuecs/kube-static-egress-controller/pull/54