### PR TITLE
Disable cadvisor by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -361,7 +361,7 @@ event_rate_limit_config_burst: "1000"
 cadvisor_cpu: "150m"
 cadvisor_memory: "150Mi"
 cadvisor_profiling_enabled: "false"
-cadvisor_enabled: "true"
+cadvisor_enabled: "false"
 
 # settings for enabling the kubelet-summary-metrics proxy and prometheus metric
 # collection.


### PR DESCRIPTION
Disable cadvisor by default.

This is done because the same metrics are provided by the kubelet embedded cadvisor, so there is no need to run/maintain a custom one.

The current clusters have `cadvisor_enabled=true` set via cluster-config-manager so this change is a no-op for existing clusters.