### PR TITLE
skipper: update main fleet version to v0.21.139

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.21.124-947" }}
+{{ $internal_version := "v0.21.139-963" }}
 {{ $canary_internal_version := "v0.21.139-963" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}


### PR DESCRIPTION
* build(deps): bump alpine from `77726ef` to `b89d9c9` in /packaging: https://github.com/zalando/skipper/pull/3122
* build(deps): bump docker/build-push-action from 5.4.0 to 6.1.0: https://github.com/zalando/skipper/pull/3124
* build(deps): bump amazonlinux from `0d172f8` to `b0016cb` in /fuzz: https://github.com/zalando/skipper/pull/3125
* Facilitate OPA decision correlation with business flows: https://github.com/zalando/skipper/pull/3041
* config: fix defaultFiltersFlags.String: https://github.com/zalando/skipper/pull/3127
* config: fix defaultFiltersFlags yaml test case: https://github.com/zalando/skipper/pull/3128
* filters/auth: add token validator filter: https://github.com/zalando/skipper/pull/3126
* metrics: register skipper_filter_create_duration_seconds: https://github.com/zalando/skipper/pull/3129
* cmd/skipper: allow exclusion of insecure cipher suites: https://github.com/zalando/skipper/pull/3123
* Revert "Facilitate OPA decision correlation with business flows (#3041)": https://github.com/zalando/skipper/pull/3138
* build(deps): bump docker/build-push-action from 6.1.0 to 6.2.0: https://github.com/zalando/skipper/pull/3134
* dependabot: group GoLang dependencies update: https://github.com/zalando/skipper/pull/3136
* build(deps): bump github.com/open-policy-agent/opa from 0.65.0 to 0.66.0: https://github.com/zalando/skipper/pull/3135
* build(deps): bump amazonlinux from `b0016cb` to `5bf7910` in /fuzz: https://github.com/zalando/skipper/pull/3133
* metrics: refactor prometheus metric registration: https://github.com/zalando/skipper/pull/3132

diff https://github.com/zalando/skipper/compare/v0.21.124...v0.21.139

depends on https://github.com/zalando-incubator/kubernetes-on-aws/pull/7786