### PR TITLE
admission-controller: Native sleep preStop hook

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -203,7 +203,7 @@ write_files:
             limits:
               memory: {{ .Values.InstanceInfo.MemoryFraction (parseInt64 .Cluster.ConfigItems.apiserver_memory_limit_percent)}}
 {{- end }}
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-209
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-211
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
This version of admission-controller injects a preStop hook into pods using the native `preStop.sleep` featue: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-implementations

That is, it's injecting:

```yaml
lifecycle:
  preStop:
    sleep:
      seconds: 20
```

Instead of what it previously did which was:

```yaml
lifecycle:
  preStop:
    exec:
      command: ["sleep", "20"]
``` 

This way a `sleep` binary is no longer a requirement in container images.

This update also updating dependencies to Kubernetes v1.30.2