### PR TITLE
Don't set Cluster.ID on etcd LT tags

### DIFF
--- a/cluster/etcd/stack.yaml
+++ b/cluster/etcd/stack.yaml
@@ -43,7 +43,7 @@ Resources:
           - Key: component
             Value: etcd-cluster
           - Key: Name
-            Value: 'etcd-cluster ({{.Cluster.ID}})'
+            Value: 'etcd-cluster'
         NetworkInterfaces:
           - DeviceIndex: 0
             AssociatePublicIpAddress: true


### PR DESCRIPTION
Don't include `Cluster.ID` in the Name tag of the etcd launch template.

With the tag we create a new launch template on _every_ e2e cluster which is not desirable. Having the cluster.ID is also not meaningful for the etcd launch template.