### PR TITLE
skipper: add config item for default authentication filters

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -112,6 +112,8 @@ skipper_validate_query: "true"
 skipper_validate_query_log: "false"
 
 skipper_default_filters: 'disableAccessLog(2,3,404,429) -> fifo(2000,20,"1s")'
+# skipper_default_filters_authentication defines filters that implement default request authentication
+skipper_default_filters_authentication: ''
 skipper_default_filters_append: 'stateBagToTag("auth-user", "client.uid")'
 skipper_disabled_filters: "static,bearerinjector"
 skipper_lua_sources: "file"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -256,6 +256,7 @@ spec:
           - "-disabled-filters={{ .Cluster.ConfigItems.skipper_disabled_filters }}"
 {{ if ne .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
           - '-default-filters-prepend={{ .Cluster.ConfigItems.skipper_default_filters }}'
+          - '-default-filters-append={{ .Cluster.ConfigItems.skipper_default_filters_authentication }}'
           - '-default-filters-append={{ .Cluster.ConfigItems.skipper_default_filters_append }}'
   {{ if .Cluster.ConfigItems.skipper_edit_route_placeholders }}
           {{ range $placeholder := split .Cluster.ConfigItems.skipper_edit_route_placeholders "[cf724afc]" }}
@@ -541,6 +542,7 @@ spec:
           - "-reverse-source-predicate"
           - "-default-filters-dir=/etc/config/default-filters"
           - '-default-filters-prepend={{ .Cluster.ConfigItems.skipper_default_filters }}'
+          - '-default-filters-append={{ .Cluster.ConfigItems.skipper_default_filters_authentication }}'
           - '-default-filters-append={{ .Cluster.ConfigItems.skipper_default_filters_append }}'
 {{ if eq .Cluster.ConfigItems.skipper_ingress_redis_swarm_enabled "true" }}
           - "-enable-swarm"


### PR DESCRIPTION
Currently we enable default authentication using existing `skipper_default_filters_append`.

This change adds a dedicated config item to separate default authentication filters from other default filters and make it easier to manage.