### PR TITLE
Update to Prometheus v2.53.0

### DIFF
--- a/cluster/manifests/prometheus/statefulset.yaml
+++ b/cluster/manifests/prometheus/statefulset.yaml
@@ -35,9 +35,9 @@ spec:
           value: "1"
       initContainers:
       - name: generate-config
-        image: container-registry.zalando.net/library/alpine-3:3-20240325
+        image: container-registry.zalando.net/library/amazonlinux-2023-slim:main-810.1131-20240701
         command:
-        - /bin/sh
+        - /bin/bash
         args:
         - -c
         - sed s/'@@POD_NAME@@'/${POD_NAME}/g /etc/prometheus/prometheus.yml > /prometheus/prometheus.yaml ; cp /etc/prometheus/prometheus.rules.yml /prometheus/prometheus.rules.yaml
@@ -57,7 +57,7 @@ spec:
           mountPath: /prometheus
       containers:
       - name: prometheus
-        image: container-registry.zalando.net/teapot/prometheus:v2.51.0-master-54
+        image: container-registry.zalando.net/teapot/prometheus:v2.53.0-master-55
         args:
         - "--config.file=/prometheus/prometheus.yaml"
         - "--storage.tsdb.path=/prometheus/"


### PR DESCRIPTION
* Update to Prometheus v2.53.0 https://github.com/prometheus/prometheus/releases/tag/v2.53.0
* Update init container to use amazonlinux-2023-slim instead of alpine as it has no CVEs.