### PR TITLE
Kubernetes v1.30.2 components [3/X]

### DIFF
--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
       hostNetwork: true
       containers:
       - name: audittrail-adapter
-        image: container-registry.zalando.net/teapot/audittrail-adapter:master-64
+        image: container-registry.zalando.net/teapot/audittrail-adapter:master-65
         env:
           - name: AWS_REGION
             value: "{{ .Cluster.Region }}"

--- a/cluster/manifests/cronjob-fixer/deployment.yaml
+++ b/cluster/manifests/cronjob-fixer/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: cronjob-fixer
       containers:
         - name: cronjob-fixer
-          image: "container-registry.zalando.net/teapot/cronjob-fixer:master-15"
+          image: "container-registry.zalando.net/teapot/cronjob-fixer:master-16"
           resources:
             limits:
               cpu: 5m

--- a/cluster/manifests/event-logger/statefulset.yaml
+++ b/cluster/manifests/event-logger/statefulset.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: kubernetes-event-logger
       containers:
       - name: logger
-        image: container-registry.zalando.net/teapot/event-logger:master-14
+        image: container-registry.zalando.net/teapot/event-logger:master-15
         args:
             - --snapshot-namespace=kube-system
             - --snapshot-name=kubernetes-event-logger

--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -37,7 +37,7 @@ spec:
             memory: 50Mi
       containers:
       - name: delayed-install-cni
-        image: container-registry.zalando.net/teapot/flannel-awaiter:master-12
+        image: container-registry.zalando.net/teapot/flannel-awaiter:master-13
         command:
         - /await
         stdin: true

--- a/cluster/manifests/kubelet-summary-metrics/deployment.yaml
+++ b/cluster/manifests/kubelet-summary-metrics/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: kubelet-summary-metrics
       containers:
       - name: proxy
-        image: container-registry.zalando.net/teapot/kubelet-summary-metrics:main-5
+        image: container-registry.zalando.net/teapot/kubelet-summary-metrics:main-6
         resources:
           limits:
             cpu: "{{.Cluster.ConfigItems.kubelet_summary_metrics_cpu}}"

--- a/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: kubernetes-lifecycle-metrics
       containers:
         - name: kubernetes-lifecycle-metrics
-          image: "container-registry.zalando.net/teapot/kubernetes-lifecycle-metrics:master-21"
+          image: "container-registry.zalando.net/teapot/kubernetes-lifecycle-metrics:master-22"
           ports:
             - containerPort: 9090
               protocol: TCP

--- a/cluster/manifests/spot-node-rescheduler/cronjob.yaml
+++ b/cluster/manifests/spot-node-rescheduler/cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: spot-node-rescheduler
-            image: container-registry.zalando.net/teapot/spot-node-rescheduler:main-8
+            image: container-registry.zalando.net/teapot/spot-node-rescheduler:main-9
             resources:
               limits:
                 cpu: "{{ .Cluster.ConfigItems.spot_node_rescheduler_cpu }}"

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -271,7 +271,7 @@ write_files:
             - mountPath: /etc/kubernetes/ssl
               name: ssl-certs-kubernetes
               readOnly: true
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/k8s-authnz-webhook:master-134
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/k8s-authnz-webhook:master-135
           name: webhook
           ports:
           - containerPort: 8081


### PR DESCRIPTION
Updates the following component to Kubernetes v1.30:

- audittrail-adapter
- cronjob-fixer
- event-logger
- flannel-awaiter
- kubelet-summary-metrics
- kubernetes-lifecycle-metrics
- spot-node-rescheduler
- k8s-authnz-webhook