### PR TITLE
Update ExternalDNS to v0.14.2

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: container-registry.zalando.net/teapot/external-dns:v0.13.6-master-38
+        image: container-registry.zalando.net/teapot/external-dns:v0.14.2-master-40
         args:
         - --source=service
         - --source=ingress


### PR DESCRIPTION
Update ExternalDNS to v0.14.2

https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.14.2
https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.14.1
https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.14.0