### PR TITLE
update deployment-service deps for k8s v1.30

### DIFF
--- a/cluster/manifests/deployment-service/00-crd.yaml
+++ b/cluster/manifests/deployment-service/00-crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: cdpdeploymenttasks.deployment.zalando.org
 spec:
   group: deployment.zalando.org

--- a/cluster/manifests/deployment-service/controller-statefulset.yaml
+++ b/cluster/manifests/deployment-service/controller-statefulset.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
         - name: "deployment-service-controller"
-          image: "container-registry.zalando.net/teapot/deployment-controller:master-203"
+          image: "container-registry.zalando.net/teapot/deployment-controller:master-204"
           args:
             - "--config-namespace=kube-system"
             - "--decrypt-kms-alias-arn=arn:aws:kms:{{ .Cluster.Region }}:{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:alias/deployment-secret"

--- a/cluster/manifests/deployment-service/status-service-deployment.yaml
+++ b/cluster/manifests/deployment-service/status-service-deployment.yaml
@@ -1,5 +1,5 @@
 {{ $image   := "container-registry.zalando.net/teapot/deployment-status-service" }}
-{{ $version := "master-203" }}
+{{ $version := "master-204" }}
 
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
As a follow-up for updating dependencies in the deployment-service to use Kubernetes v1.30 based libraries, this PR is for rolling out the new version.