### PR TITLE
Update kube-node-ready-controller dependencies to Kubernetes v1.30

### DIFF
--- a/cluster/manifests/kube-node-ready-controller/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready-controller/daemonset.yaml
@@ -36,7 +36,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: controller
-        image: container-registry.zalando.net/teapot/kube-node-ready-controller:master-26
+        image: container-registry.zalando.net/teapot/kube-node-ready-controller:master-27
         resources:
           requests:
             cpu: {{.Cluster.ConfigItems.kube_node_ready_controller_cpu}}


### PR DESCRIPTION
Updates the `kube-node-ready-controller` dependencies to Kubernetes v1.30