### PR TITLE
Update stackset CRDs to Kubernetes v1.30

### DIFF
--- a/cluster/manifests/stackset-controller/01-stack-crd.yaml
+++ b/cluster/manifests/stackset-controller/01-stack-crd.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.4
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: stacks.zalando.org
 spec:
   group: zalando.org
@@ -49,55 +49,60 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: Stack defines one version of an application. It is possible to
+        description: |-
+          Stack defines one version of an application. It is possible to
           switch traffic between multiple versions of an application.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: StackSpecInternal is the spec part of the Stack, including
-              `ingress` and `routegroup` specs inherited from the parent StackSet.
+            description: |-
+              StackSpecInternal is the spec part of the Stack, including `ingress` and
+              `routegroup` specs inherited from the parent StackSet.
             properties:
               autoscaler:
                 description: Autoscaler is the autoscaling definition for a stack
                 properties:
                   behavior:
-                    description: behavior configures the scaling behavior of the target
-                      in both Up and Down directions (scaleUp and scaleDown fields
-                      respectively). If not set, the default HPAScalingRules for scale
-                      up and scale down are used.
+                    description: |-
+                      behavior configures the scaling behavior of the target
+                      in both Up and Down directions (scaleUp and scaleDown fields respectively).
+                      If not set, the default HPAScalingRules for scale up and scale down are used.
                     properties:
                       scaleDown:
-                        description: scaleDown is scaling policy for scaling Down.
-                          If not set, the default value is to allow to scale down
-                          to minReplicas pods, with a 300 second stabilization window
-                          (i.e., the highest recommendation for the last 300sec is
-                          used).
+                        description: |-
+                          scaleDown is scaling policy for scaling Down.
+                          If not set, the default value is to allow to scale down to minReplicas pods, with a
+                          300 second stabilization window (i.e., the highest recommendation for
+                          the last 300sec is used).
                         properties:
                           policies:
-                            description: policies is a list of potential scaling polices
-                              which can be used during scaling. At least one policy
-                              must be specified, otherwise the HPAScalingRules will
-                              be discarded as invalid
+                            description: |-
+                              policies is a list of potential scaling polices which can be used during scaling.
+                              At least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid
                             items:
                               description: HPAScalingPolicy is a single policy which
                                 must hold true for a specified past interval.
                               properties:
                                 periodSeconds:
-                                  description: periodSeconds specifies the window
-                                    of time for which the policy should hold true.
-                                    PeriodSeconds must be greater than zero and less
-                                    than or equal to 1800 (30 min).
+                                  description: |-
+                                    periodSeconds specifies the window of time for which the policy should hold true.
+                                    PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
                                   format: int32
                                   type: integer
                                 type:
@@ -105,9 +110,9 @@ spec:
                                     policy.
                                   type: string
                                 value:
-                                  description: value contains the amount of change
-                                    which is permitted by the policy. It must be greater
-                                    than zero
+                                  description: |-
+                                    value contains the amount of change which is permitted by the policy.
+                                    It must be greater than zero
                                   format: int32
                                   type: integer
                               required:
@@ -118,42 +123,41 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           selectPolicy:
-                            description: selectPolicy is used to specify which policy
-                              should be used. If not set, the default value Max is
-                              used.
+                            description: |-
+                              selectPolicy is used to specify which policy should be used.
+                              If not set, the default value Max is used.
                             type: string
                           stabilizationWindowSeconds:
-                            description: 'stabilizationWindowSeconds is the number
-                              of seconds for which past recommendations should be
-                              considered while scaling up or scaling down. StabilizationWindowSeconds
-                              must be greater than or equal to zero and less than
-                              or equal to 3600 (one hour). If not set, use the default
-                              values: - For scale up: 0 (i.e. no stabilization is
-                              done). - For scale down: 300 (i.e. the stabilization
-                              window is 300 seconds long).'
+                            description: |-
+                              stabilizationWindowSeconds is the number of seconds for which past recommendations should be
+                              considered while scaling up or scaling down.
+                              StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour).
+                              If not set, use the default values:
+                              - For scale up: 0 (i.e. no stabilization is done).
+                              - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
                             format: int32
                             type: integer
                         type: object
                       scaleUp:
-                        description: 'scaleUp is scaling policy for scaling Up. If
-                          not set, the default value is the higher of: * increase
-                          no more than 4 pods per 60 seconds * double the number of
-                          pods per 60 seconds No stabilization is used.'
+                        description: |-
+                          scaleUp is scaling policy for scaling Up.
+                          If not set, the default value is the higher of:
+                            * increase no more than 4 pods per 60 seconds
+                            * double the number of pods per 60 seconds
+                          No stabilization is used.
                         properties:
                           policies:
-                            description: policies is a list of potential scaling polices
-                              which can be used during scaling. At least one policy
-                              must be specified, otherwise the HPAScalingRules will
-                              be discarded as invalid
+                            description: |-
+                              policies is a list of potential scaling polices which can be used during scaling.
+                              At least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid
                             items:
                               description: HPAScalingPolicy is a single policy which
                                 must hold true for a specified past interval.
                               properties:
                                 periodSeconds:
-                                  description: periodSeconds specifies the window
-                                    of time for which the policy should hold true.
-                                    PeriodSeconds must be greater than zero and less
-                                    than or equal to 1800 (30 min).
+                                  description: |-
+                                    periodSeconds specifies the window of time for which the policy should hold true.
+                                    PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
                                   format: int32
                                   type: integer
                                 type:
@@ -161,9 +165,9 @@ spec:
                                     policy.
                                   type: string
                                 value:
-                                  description: value contains the amount of change
-                                    which is permitted by the policy. It must be greater
-                                    than zero
+                                  description: |-
+                                    value contains the amount of change which is permitted by the policy.
+                                    It must be greater than zero
                                   format: int32
                                   type: integer
                               required:
@@ -174,27 +178,26 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           selectPolicy:
-                            description: selectPolicy is used to specify which policy
-                              should be used. If not set, the default value Max is
-                              used.
+                            description: |-
+                              selectPolicy is used to specify which policy should be used.
+                              If not set, the default value Max is used.
                             type: string
                           stabilizationWindowSeconds:
-                            description: 'stabilizationWindowSeconds is the number
-                              of seconds for which past recommendations should be
-                              considered while scaling up or scaling down. StabilizationWindowSeconds
-                              must be greater than or equal to zero and less than
-                              or equal to 3600 (one hour). If not set, use the default
-                              values: - For scale up: 0 (i.e. no stabilization is
-                              done). - For scale down: 300 (i.e. the stabilization
-                              window is 300 seconds long).'
+                            description: |-
+                              stabilizationWindowSeconds is the number of seconds for which past recommendations should be
+                              considered while scaling up or scaling down.
+                              StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour).
+                              If not set, use the default values:
+                              - For scale up: 0 (i.e. no stabilization is done).
+                              - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
                             format: int32
                             type: integer
                         type: object
                     type: object
                   maxReplicas:
-                    description: maxReplicas is the upper limit for the number of
-                      replicas to which the autoscaler can scale up. It cannot be
-                      less that minReplicas.
+                    description: |-
+                      maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up.
+                      It cannot be less that minReplicas.
                     format: int32
                     type: integer
                   metrics:
@@ -212,9 +215,9 @@ spec:
                           format: int32
                           type: integer
                         clusterScalingSchedule:
-                          description: MetricsClusterScalingSchedule specifies the
-                            ClusterScalingSchedule object which should be used for
-                            scaling.
+                          description: |-
+                            MetricsClusterScalingSchedule specifies the ClusterScalingSchedule
+                            object which should be used for scaling.
                           properties:
                             name:
                               description: The name of the referenced ClusterScalingSchedule
@@ -225,13 +228,15 @@ spec:
                           - name
                           type: object
                         container:
-                          description: optional container name that can be used to
-                            scale based on CPU or Memory metrics of a specific container
-                            as opposed to an average of all containers in a pod.
+                          description: |-
+                            optional container name that can be used to scale based on CPU or
+                            Memory metrics of a specific container as opposed to an average of
+                            all containers in a pod.
                           type: string
                         endpoint:
-                          description: MetricsEndpoint specified the endpoint where
-                            the custom endpoint where the metrics can be queried
+                          description: |-
+                            MetricsEndpoint specified the endpoint where the custom endpoint where the metrics
+                            can be queried
                           properties:
                             key:
                               type: string
@@ -249,8 +254,9 @@ spec:
                           - port
                           type: object
                         queue:
-                          description: MetricsQueue specifies the SQS queue whose
-                            length should be used for scaling.
+                          description: |-
+                            MetricsQueue specifies the SQS queue whose length should be used for
+                            scaling.
                           properties:
                             name:
                               type: string
@@ -261,8 +267,9 @@ spec:
                           - region
                           type: object
                         requestsPerSecond:
-                          description: MetricRequestsPerSecond specifies basic information
-                            to scale based on on external RPS metric.
+                          description: |-
+                            MetricRequestsPerSecond specifies basic information to scale based on
+                            on external RPS metric.
                           properties:
                             hostnames:
                               items:
@@ -272,8 +279,9 @@ spec:
                           - hostnames
                           type: object
                         scalingSchedule:
-                          description: MetricsScalingSchedule specifies the ScalingSchedule
-                            object which should be used for scaling.
+                          description: |-
+                            MetricsScalingSchedule specifies the ScalingSchedule object which
+                            should be used for scaling.
                           properties:
                             name:
                               description: The name of the referenced ScalingSchedule
@@ -304,8 +312,9 @@ spec:
                           properties:
                             aggregators:
                               items:
-                                description: ZMONMetricAggregatorType is the type
-                                  of aggregator used in a ZMON based metric.
+                                description: |-
+                                  ZMONMetricAggregatorType is the type of aggregator used in a ZMON based
+                                  metric.
                                 enum:
                                 - avg
                                 - dev
@@ -339,9 +348,9 @@ spec:
                       type: object
                     type: array
                   minReplicas:
-                    description: minReplicas is the lower limit for the number of
-                      replicas to which the autoscaler can scale down. It defaults
-                      to 1 pod.
+                    description: |-
+                      minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down.
+                      It defaults to 1 pod.
                     format: int32
                     type: integer
                 required:
@@ -349,8 +358,9 @@ spec:
                 - metrics
                 type: object
               configurationResources:
-                description: ConfigurationResources describes the ConfigMaps, Secrets,
-                  and/or PlatformCredentialsSet that will be created.
+                description: |-
+                  ConfigurationResources describes the ConfigMaps, Secrets, and/or
+                  PlatformCredentialsSet that will be created.
                 items:
                   description: ConfigurationResourcesSpec makes it possible to defined
                     the config resources to be created
@@ -375,8 +385,15 @@ spec:
                         owned by Stack
                       properties:
                         name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            TODO: Add other useful fields. apiVersion, kind, uid?
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
@@ -405,8 +422,15 @@ spec:
                         by Stack
                       properties:
                         name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            TODO: Add other useful fields. apiVersion, kind, uid?
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
@@ -440,18 +464,19 @@ spec:
                     type: array
                     x-kubernetes-list-type: set
                   metadata:
-                    description: EmbeddedObjectMetaWithAnnotations defines the metadata
-                      which can be attached to a resource. It's a slimmed down version
-                      of metav1.ObjectMeta only containing annotations.
+                    description: |-
+                      EmbeddedObjectMetaWithAnnotations defines the metadata which can be attached
+                      to a resource. It's a slimmed down version of metav1.ObjectMeta only
+                      containing annotations.
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: 'Annotations is an unstructured key value map
-                          stored with a resource that may be set by external tools
-                          to store and retrieve arbitrary metadata. They are not queryable
-                          and should be preserved when modifying objects. More info:
-                          http://kubernetes.io/docs/user-guide/annotations'
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
                         type: object
                     type: object
                   path:
@@ -461,10 +486,10 @@ spec:
                 - hosts
                 type: object
               minReadySeconds:
-                description: Minimum number of seconds for which a newly created pod
-                  should be ready without any of its container crashing, for it to
-                  be considered available. Defaults to 0 (pod will be considered available
-                  as soon as it is ready)
+                description: |-
+                  Minimum number of seconds for which a newly created pod should be ready
+                  without any of its container crashing, for it to be considered available.
+                  Defaults to 0 (pod will be considered available as soon as it is ready)
                 format: int32
                 type: integer
               podTemplate:
@@ -476,29 +501,31 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: 'Annotations is an unstructured key value map
-                          stored with a resource that may be set by external tools
-                          to store and retrieve arbitrary metadata. They are not queryable
-                          and should be preserved when modifying objects. More info:
-                          http://kubernetes.io/docs/user-guide/annotations'
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: 'Map of string keys and values that can be used
-                          to organize and categorize (scope and select) objects. May
-                          match selectors of replication controllers and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
                         type: object
                     type: object
                   spec:
-                    description: 'Specification of the desired behavior of the pod.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    description: |-
+                      Specification of the desired behavior of the pod.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
                     properties:
                       activeDeadlineSeconds:
-                        description: Optional duration in seconds the pod may be active
-                          on the node relative to StartTime before the system will
-                          actively try to mark it failed and kill associated containers.
+                        description: |-
+                          Optional duration in seconds the pod may be active on the node relative to
+                          StartTime before the system will actively try to mark it failed and kill associated containers.
                           Value must be a positive integer.
                         format: int64
                         type: integer
@@ -510,36 +537,27 @@ spec:
                               for the pod.
                             properties:
                               preferredDuringSchedulingIgnoredDuringExecution:
-                                description: The scheduler will prefer to schedule
-                                  pods to nodes that satisfy the affinity expressions
-                                  specified by this field, but it may choose a node
-                                  that violates one or more of the expressions. The
-                                  node that is most preferred is the one with the
-                                  greatest sum of weights, i.e. for each node that
-                                  meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling affinity expressions,
-                                  etc.), compute a sum by iterating through the elements
-                                  of this field and adding "weight" to the sum if
-                                  the node matches the corresponding matchExpressions;
-                                  the node(s) with the highest sum are the most preferred.
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                  node(s) with the highest sum are the most preferred.
                                 items:
-                                  description: An empty preferred scheduling term
-                                    matches all objects with implicit weight 0 (i.e.
-                                    it's a no-op). A null preferred scheduling term
-                                    matches no objects (i.e. is also a no-op).
+                                  description: |-
+                                    An empty preferred scheduling term matches all objects with implicit weight 0
+                                    (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                   properties:
                                     preference:
                                       description: A node selector term, associated
                                         with the corresponding weight.
                                       properties:
                                         matchExpressions:
-                                          description: A list of node selector requirements
-                                            by node's labels.
                                           items:
-                                            description: A node selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
                                             properties:
                                               key:
                                                 type: string
@@ -549,19 +567,15 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             required:
                                             - key
                                             - operator
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         matchFields:
-                                          description: A list of node selector requirements
-                                            by node's fields.
                                           items:
-                                            description: A node selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
                                             properties:
                                               key:
                                                 type: string
@@ -571,11 +585,13 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             required:
                                             - key
                                             - operator
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     weight:
@@ -589,32 +605,26 @@ spec:
                                   - weight
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                               requiredDuringSchedulingIgnoredDuringExecution:
-                                description: If the affinity requirements specified
-                                  by this field are not met at scheduling time, the
-                                  pod will not be scheduled onto the node. If the
-                                  affinity requirements specified by this field cease
-                                  to be met at some point during pod execution (e.g.
-                                  due to an update), the system may or may not try
-                                  to eventually evict the pod from its node.
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to an update), the system
+                                  may or may not try to eventually evict the pod from its node.
                                 properties:
                                   nodeSelectorTerms:
                                     description: Required. A list of node selector
                                       terms. The terms are ORed.
                                     items:
-                                      description: A null or empty node selector term
-                                        matches no objects. The requirements of them
-                                        are ANDed. The TopologySelectorTerm type implements
-                                        a subset of the NodeSelectorTerm.
+                                      description: |-
+                                        A null or empty node selector term matches no objects. The requirements of
+                                        them are ANDed.
+                                        The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                       properties:
                                         matchExpressions:
-                                          description: A list of node selector requirements
-                                            by node's labels.
                                           items:
-                                            description: A node selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
                                             properties:
                                               key:
                                                 type: string
@@ -624,19 +634,15 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             required:
                                             - key
                                             - operator
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         matchFields:
-                                          description: A list of node selector requirements
-                                            by node's fields.
                                           items:
-                                            description: A node selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
                                             properties:
                                               key:
                                                 type: string
@@ -646,14 +652,17 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             required:
                                             - key
                                             - operator
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                 required:
                                 - nodeSelectorTerms
                                 type: object
@@ -665,19 +674,16 @@ spec:
                               other pod(s)).
                             properties:
                               preferredDuringSchedulingIgnoredDuringExecution:
-                                description: The scheduler will prefer to schedule
-                                  pods to nodes that satisfy the affinity expressions
-                                  specified by this field, but it may choose a node
-                                  that violates one or more of the expressions. The
-                                  node that is most preferred is the one with the
-                                  greatest sum of weights, i.e. for each node that
-                                  meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling affinity expressions,
-                                  etc.), compute a sum by iterating through the elements
-                                  of this field and adding "weight" to the sum if
-                                  the node has pods which matches the corresponding
-                                  podAffinityTerm; the node(s) with the highest sum
-                                  are the most preferred.
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
                                 items:
                                   description: The weights of all of the matched WeightedPodAffinityTerm
                                     fields are added per-node to find the most preferred
@@ -688,8 +694,6 @@ spec:
                                         associated with the corresponding weight.
                                       properties:
                                         labelSelector:
-                                          description: A label query over a set of
-                                            resources, in this case pods.
                                           properties:
                                             matchExpressions:
                                               items:
@@ -702,26 +706,30 @@ spec:
                                                     items:
                                                       type: string
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                 required:
                                                 - key
                                                 - operator
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
                                         namespaceSelector:
-                                          description: A label query over the set
-                                            of namespaces that the term applies to.
-                                            The term is applied to the union of the
-                                            namespaces selected by this field and
-                                            the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces
-                                            list means "this pod's namespace". An
-                                            empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               items:
@@ -734,11 +742,13 @@ spec:
                                                     items:
                                                       type: string
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                 required:
                                                 - key
                                                 - operator
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
@@ -746,34 +756,19 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
-                                          description: namespaces specifies a static
-                                            list of namespace names that the term
-                                            applies to. The term is applied to the
-                                            union of the namespaces listed in this
-                                            field and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null
-                                            namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         topologyKey:
-                                          description: This pod should be co-located
-                                            (affinity) or not co-located (anti-affinity)
-                                            with the pods matching the labelSelector
-                                            in the specified namespaces, where co-located
-                                            is defined as running on a node whose
-                                            value of the label with key topologyKey
-                                            matches that of any node on which any
-                                            of the selected pods is running. Empty
-                                            topologyKey is not allowed.
                                           type: string
                                       required:
                                       - topologyKey
                                       type: object
                                     weight:
-                                      description: weight associated with matching
-                                        the corresponding podAffinityTerm, in the
-                                        range 1-100.
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
                                       format: int32
                                       type: integer
                                   required:
@@ -781,40 +776,32 @@ spec:
                                   - weight
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                               requiredDuringSchedulingIgnoredDuringExecution:
-                                description: If the affinity requirements specified
-                                  by this field are not met at scheduling time, the
-                                  pod will not be scheduled onto the node. If the
-                                  affinity requirements specified by this field cease
-                                  to be met at some point during pod execution (e.g.
-                                  due to a pod label update), the system may or may
-                                  not try to eventually evict the pod from its node.
-                                  When there are multiple elements, the lists of nodes
-                                  corresponding to each podAffinityTerm are intersected,
-                                  i.e. all terms must be satisfied.
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                 items:
-                                  description: Defines a set of pods (namely those
-                                    matching the labelSelector relative to the given
-                                    namespace(s)) that this pod should be co-located
-                                    (affinity) or not co-located (anti-affinity) with,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key <topologyKey>
-                                    matches that of any node on which a pod of the
-                                    set of pods is running
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
                                   properties:
                                     labelSelector:
-                                      description: A label query over a set of resources,
-                                        in this case pods.
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
                                             properties:
                                               key:
                                                 type: string
@@ -824,41 +811,59 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             required:
                                             - key
                                             - operator
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces
-                                        that the term applies to. The term is applied
-                                        to the union of the namespaces selected by
-                                        this field and the ones listed in the namespaces
-                                        field. null selector and null or empty namespaces
-                                        list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces.
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
                                             properties:
                                               key:
                                                 type: string
@@ -868,48 +873,42 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             required:
                                             - key
                                             - operator
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaces:
-                                      description: namespaces specifies a static list
-                                        of namespace names that the term applies to.
-                                        The term is applied to the union of the namespaces
-                                        listed in this field and the ones selected
-                                        by namespaceSelector. null or empty namespaces
-                                        list and null namespaceSelector means "this
-                                        pod's namespace".
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     topologyKey:
-                                      description: This pod should be co-located (affinity)
-                                        or not co-located (anti-affinity) with the
-                                        pods matching the labelSelector in the specified
-                                        namespaces, where co-located is defined as
-                                        running on a node whose value of the label
-                                        with key topologyKey matches that of any node
-                                        on which any of the selected pods is running.
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
                                         Empty topologyKey is not allowed.
                                       type: string
                                   required:
                                   - topologyKey
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                             type: object
                           podAntiAffinity:
                             description: Describes pod anti-affinity scheduling rules
@@ -917,19 +916,16 @@ spec:
                               etc. as some other pod(s)).
                             properties:
                               preferredDuringSchedulingIgnoredDuringExecution:
-                                description: The scheduler will prefer to schedule
-                                  pods to nodes that satisfy the anti-affinity expressions
-                                  specified by this field, but it may choose a node
-                                  that violates one or more of the expressions. The
-                                  node that is most preferred is the one with the
-                                  greatest sum of weights, i.e. for each node that
-                                  meets all of the scheduling requirements (resource
-                                  request, requiredDuringScheduling anti-affinity
-                                  expressions, etc.), compute a sum by iterating through
-                                  the elements of this field and adding "weight" to
-                                  the sum if the node has pods which matches the corresponding
-                                  podAffinityTerm; the node(s) with the highest sum
-                                  are the most preferred.
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the anti-affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
                                 items:
                                   description: The weights of all of the matched WeightedPodAffinityTerm
                                     fields are added per-node to find the most preferred
@@ -940,8 +936,6 @@ spec:
                                         associated with the corresponding weight.
                                       properties:
                                         labelSelector:
-                                          description: A label query over a set of
-                                            resources, in this case pods.
                                           properties:
                                             matchExpressions:
                                               items:
@@ -954,31 +948,32 @@ spec:
                                                     items:
                                                       type: string
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                 required:
                                                 - key
                                                 - operator
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
                                         namespaceSelector:
-                                          description: A label query over the set
-                                            of namespaces that the term applies to.
-                                            The term is applied to the union of the
-                                            namespaces selected by this field and
-                                            the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces
-                                            list means "this pod's namespace". An
-                                            empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list
-                                                of label selector requirements. The
-                                                requirements are ANDed.
                                               items:
                                                 properties:
                                                   key:
@@ -989,11 +984,13 @@ spec:
                                                     items:
                                                       type: string
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                 required:
                                                 - key
                                                 - operator
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
@@ -1001,34 +998,19 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
-                                          description: namespaces specifies a static
-                                            list of namespace names that the term
-                                            applies to. The term is applied to the
-                                            union of the namespaces listed in this
-                                            field and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null
-                                            namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         topologyKey:
-                                          description: This pod should be co-located
-                                            (affinity) or not co-located (anti-affinity)
-                                            with the pods matching the labelSelector
-                                            in the specified namespaces, where co-located
-                                            is defined as running on a node whose
-                                            value of the label with key topologyKey
-                                            matches that of any node on which any
-                                            of the selected pods is running. Empty
-                                            topologyKey is not allowed.
                                           type: string
                                       required:
                                       - topologyKey
                                       type: object
                                     weight:
-                                      description: weight associated with matching
-                                        the corresponding podAffinityTerm, in the
-                                        range 1-100.
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
                                       format: int32
                                       type: integer
                                   required:
@@ -1036,40 +1018,32 @@ spec:
                                   - weight
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                               requiredDuringSchedulingIgnoredDuringExecution:
-                                description: If the anti-affinity requirements specified
-                                  by this field are not met at scheduling time, the
-                                  pod will not be scheduled onto the node. If the
-                                  anti-affinity requirements specified by this field
-                                  cease to be met at some point during pod execution
-                                  (e.g. due to a pod label update), the system may
-                                  or may not try to eventually evict the pod from
-                                  its node. When there are multiple elements, the
-                                  lists of nodes corresponding to each podAffinityTerm
-                                  are intersected, i.e. all terms must be satisfied.
+                                description: |-
+                                  If the anti-affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the anti-affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                 items:
-                                  description: Defines a set of pods (namely those
-                                    matching the labelSelector relative to the given
-                                    namespace(s)) that this pod should be co-located
-                                    (affinity) or not co-located (anti-affinity) with,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key <topologyKey>
-                                    matches that of any node on which a pod of the
-                                    set of pods is running
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
                                   properties:
                                     labelSelector:
-                                      description: A label query over a set of resources,
-                                        in this case pods.
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
                                             properties:
                                               key:
                                                 type: string
@@ -1079,41 +1053,59 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             required:
                                             - key
                                             - operator
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces
-                                        that the term applies to. The term is applied
-                                        to the union of the namespaces selected by
-                                        this field and the ones listed in the namespaces
-                                        field. null selector and null or empty namespaces
-                                        list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces.
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
                                             properties:
                                               key:
                                                 type: string
@@ -1123,48 +1115,42 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             required:
                                             - key
                                             - operator
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaces:
-                                      description: namespaces specifies a static list
-                                        of namespace names that the term applies to.
-                                        The term is applied to the union of the namespaces
-                                        listed in this field and the ones selected
-                                        by namespaceSelector. null or empty namespaces
-                                        list and null namespaceSelector means "this
-                                        pod's namespace".
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     topologyKey:
-                                      description: This pod should be co-located (affinity)
-                                        or not co-located (anti-affinity) with the
-                                        pods matching the labelSelector in the specified
-                                        namespaces, where co-located is defined as
-                                        running on a node whose value of the label
-                                        with key topologyKey matches that of any node
-                                        on which any of the selected pods is running.
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
                                         Empty topologyKey is not allowed.
                                       type: string
                                   required:
                                   - topologyKey
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                             type: object
                         type: object
                       automountServiceAccountToken:
@@ -1172,46 +1158,47 @@ spec:
                           a service account token should be automatically mounted.
                         type: boolean
                       containers:
-                        description: List of containers belonging to the pod. Containers
-                          cannot currently be added or removed. There must be at least
-                          one container in a Pod. Cannot be updated.
+                        description: |-
+                          List of containers belonging to the pod.
+                          Containers cannot currently be added or removed.
+                          There must be at least one container in a Pod.
+                          Cannot be updated.
                         items:
                           description: A single application container that you want
                             to run within a pod.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The container
-                                image''s CMD is used if this is not provided. Variable
-                                references $(VAR_NAME) are expanded using the container''s
-                                environment. If a variable cannot be resolved, the
-                                reference in the input string will be unchanged. Double
-                                $$ are reduced to a single $, which allows for escaping
-                                the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
-                                the string literal "$(VAR_NAME)". Escaped references
-                                will never be expanded, regardless of whether the
-                                variable exists or not. Cannot be updated. More info:
-                                https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: |-
+                                Arguments to the entrypoint.
+                                The container image's CMD is used if this is not provided.
+                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             command:
-                              description: 'Entrypoint array. Not executed within
-                                a shell. The container image''s ENTRYPOINT is used
-                                if this is not provided. Variable references $(VAR_NAME)
-                                are expanded using the container''s environment. If
-                                a variable cannot be resolved, the reference in the
-                                input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME)
-                                syntax: i.e. "$$(VAR_NAME)" will produce the string
-                                literal "$(VAR_NAME)". Escaped references will never
-                                be expanded, regardless of whether the variable exists
-                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: |-
+                                Entrypoint array. Not executed within a shell.
+                                The container image's ENTRYPOINT is used if this is not provided.
+                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             env:
-                              description: List of environment variables to set in
-                                the container. Cannot be updated.
+                              description: |-
+                                List of environment variables to set in the container.
+                                Cannot be updated.
                               items:
                                 description: EnvVar represents an environment variable
                                   present in a Container.
@@ -1221,17 +1208,16 @@ spec:
                                       Must be a C_IDENTIFIER.
                                     type: string
                                   value:
-                                    description: 'Variable references $(VAR_NAME)
-                                      are expanded using the previously defined environment
-                                      variables in the container and any service environment
-                                      variables. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged.
-                                      Double $$ are reduced to a single $, which allows
-                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Defaults
-                                      to "".'
+                                    description: |-
+                                      Variable references $(VAR_NAME) are expanded
+                                      using the previously defined environment variables in the container and
+                                      any service environment variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                      "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless of whether the variable
+                                      exists or not.
+                                      Defaults to "".
                                     type: string
                                   valueFrom:
                                     description: Source for the environment variable's
@@ -1241,64 +1227,40 @@ spec:
                                         description: Selects a key of a ConfigMap.
                                         properties:
                                           key:
-                                            description: The key to select.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            default: ""
                                             type: string
                                           optional:
-                                            description: Specify whether the ConfigMap
-                                              or its key must be defined
                                             type: boolean
                                         required:
                                         - key
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       fieldRef:
-                                        description: 'Selects a field of the pod:
-                                          supports metadata.name, metadata.namespace,
-                                          `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                          spec.nodeName, spec.serviceAccountName,
-                                          status.hostIP, status.podIP, status.podIPs.'
                                         properties:
                                           apiVersion:
-                                            description: Version of the schema the
-                                              FieldPath is written in terms of, defaults
-                                              to "v1".
                                             type: string
                                           fieldPath:
-                                            description: Path of the field to select
-                                              in the specified API version.
                                             type: string
                                         required:
                                         - fieldPath
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       resourceFieldRef:
-                                        description: 'Selects a resource of the container:
-                                          only resources limits and requests (limits.cpu,
-                                          limits.memory, limits.ephemeral-storage,
-                                          requests.cpu, requests.memory and requests.ephemeral-storage)
-                                          are currently supported.'
+                                        description: |-
+                                          Selects a resource of the container: only resources limits and requests
+                                          (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                         properties:
                                           containerName:
-                                            description: 'Container name: required
-                                              for volumes, optional for env vars'
                                             type: string
                                           divisor:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Specifies the output format
-                                              of the exposed resources, defaults to
-                                              "1"
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           resource:
-                                            description: 'Required: resource to select'
                                             type: string
                                         required:
                                         - resource
@@ -1309,19 +1271,11 @@ spec:
                                           the pod's namespace
                                         properties:
                                           key:
-                                            description: The key of the secret to
-                                              select from.  Must be a valid secret
-                                              key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            default: ""
                                             type: string
                                           optional:
-                                            description: Specify whether the Secret
-                                              or its key must be defined
                                             type: boolean
                                         required:
                                         - key
@@ -1332,15 +1286,17 @@ spec:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             envFrom:
-                              description: List of sources to populate environment
-                                variables in the container. The keys defined within
-                                a source must be a C_IDENTIFIER. All invalid keys
-                                will be reported as an event when the container is
-                                starting. When a key exists in multiple sources, the
-                                value associated with the last source will take precedence.
-                                Values defined by an Env with a duplicate key will
-                                take precedence. Cannot be updated.
+                              description: |-
+                                List of sources to populate environment variables in the container.
+                                The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is starting. When a key exists in multiple
+                                sources, the value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will take precedence.
+                                Cannot be updated.
                               items:
                                 description: EnvFromSource represents the source of
                                   a set of ConfigMaps
@@ -1349,10 +1305,7 @@ spec:
                                     description: The ConfigMap to select from
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        default: ""
                                         type: string
                                       optional:
                                         description: Specify whether the ConfigMap
@@ -1368,10 +1321,7 @@ spec:
                                     description: The Secret to select from
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        default: ""
                                         type: string
                                       optional:
                                         description: Specify whether the Secret must
@@ -1381,64 +1331,51 @@ spec:
                                     x-kubernetes-map-type: atomic
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             image:
-                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                                This field is optional to allow higher level config
-                                management to default or override container images
-                                in workload controllers like Deployments and StatefulSets.'
+                              description: |-
+                                Container image name.
+                                More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config management to default or override
+                                container images in workload controllers like Deployments and StatefulSets.
                               type: string
                             imagePullPolicy:
-                              description: 'Image pull policy. One of Always, Never,
-                                IfNotPresent. Defaults to Always if :latest tag is
-                                specified, or IfNotPresent otherwise. Cannot be updated.
-                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                              description: |-
+                                Image pull policy.
+                                One of Always, Never, IfNotPresent.
+                                Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                               type: string
                             lifecycle:
-                              description: Actions that the management system should
-                                take in response to container lifecycle events. Cannot
-                                be updated.
+                              description: |-
+                                Actions that the management system should take in response to container lifecycle events.
+                                Cannot be updated.
                               properties:
                                 postStart:
-                                  description: 'PostStart is called immediately after
-                                    a container is created. If the handler fails,
-                                    the container is terminated and restarted according
-                                    to its restart policy. Other management of the
-                                    container blocks until the hook completes. More
-                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  description: |-
+                                    PostStart is called immediately after a container is created. If the handler fails,
+                                    the container is terminated and restarted according to its restart policy.
+                                    Other management of the container blocks until the hook completes.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                   properties:
                                     exec:
                                       description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
-                                            to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                     httpGet:
                                       description: HTTPGet specifies the http request
                                         to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the
-                                            request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom
-                                              header to be used in HTTP probes
                                             properties:
                                               name:
                                                 type: string
@@ -1449,98 +1386,75 @@ spec:
                                             - value
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         path:
-                                          description: Path to access on the HTTP
-                                            server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting
-                                            to the host. Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
+                                    sleep:
+                                      description: Sleep represents the duration that
+                                        the container should sleep before being terminated.
+                                      properties:
+                                        seconds:
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
+                                      type: object
                                     tcpSocket:
-                                      description: Deprecated. TCPSocket is NOT supported
-                                        as a LifecycleHandler and kept for the backward
-                                        compatibility. There are no validation of
-                                        this field and lifecycle hooks will fail in
-                                        runtime when tcp handler is specified.
+                                      description: |-
+                                        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                        for the backward compatibility. There are no validation of this field and
+                                        lifecycle hooks will fail in runtime when tcp handler is specified.
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect
-                                            to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                   type: object
                                 preStop:
-                                  description: 'PreStop is called immediately before
-                                    a container is terminated due to an API request
-                                    or management event such as liveness/startup probe
-                                    failure, preemption, resource contention, etc.
-                                    The handler is not called if the container crashes
-                                    or exits. The Pod''s termination grace period
-                                    countdown begins before the PreStop hook is executed.
-                                    Regardless of the outcome of the handler, the
-                                    container will eventually terminate within the
-                                    Pod''s termination grace period (unless delayed
-                                    by finalizers). Other management of the container
-                                    blocks until the hook completes or until the termination
-                                    grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  description: |-
+                                    PreStop is called immediately before a container is terminated due to an
+                                    API request or management event such as liveness/startup probe failure,
+                                    preemption, resource contention, etc. The handler is not called if the
+                                    container crashes or exits. The Pod's termination grace period countdown begins before the
+                                    PreStop hook is executed. Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the Pod's termination grace
+                                    period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                   properties:
                                     exec:
                                       description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
-                                            to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                     httpGet:
                                       description: HTTPGet specifies the http request
                                         to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the
-                                            request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom
-                                              header to be used in HTTP probes
                                             properties:
                                               name:
                                                 type: string
@@ -1551,45 +1465,41 @@ spec:
                                             - value
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         path:
-                                          description: Path to access on the HTTP
-                                            server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting
-                                            to the host. Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
+                                    sleep:
+                                      description: Sleep represents the duration that
+                                        the container should sleep before being terminated.
+                                      properties:
+                                        seconds:
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
+                                      type: object
                                     tcpSocket:
-                                      description: Deprecated. TCPSocket is NOT supported
-                                        as a LifecycleHandler and kept for the backward
-                                        compatibility. There are no validation of
-                                        this field and lifecycle hooks will fail in
-                                        runtime when tcp handler is specified.
+                                      description: |-
+                                        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                        for the backward compatibility. There are no validation of this field and
+                                        lifecycle hooks will fail in runtime when tcp handler is specified.
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect
-                                            to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
@@ -1597,30 +1507,30 @@ spec:
                                   type: object
                               type: object
                             livenessProbe:
-                              description: 'Periodic probe of container liveness.
-                                Container will be restarted if the probe fails. Cannot
-                                be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: |-
+                                Periodic probe of container liveness.
+                                Container will be restarted if the probe fails.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                               properties:
                                 exec:
                                   description: Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the
-                                    probe to be considered failed after having succeeded.
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                     Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
@@ -1634,11 +1544,12 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service
-                                        to place in the gRPC HealthCheckRequest (see
-                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                        \n If this is not specified, the default behavior
-                                        is defined by gRPC."
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
@@ -1648,9 +1559,9 @@ spec:
                                     to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
                                       description: Custom headers to set in the request.
@@ -1660,19 +1571,15 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name. This
-                                              will be canonicalized upon output, so
-                                              case-variant names will be understood
-                                              as the same header.
                                             type: string
                                           value:
-                                            description: The header field value
                                             type: string
                                         required:
                                         - name
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       description: Path to access on the HTTP server.
                                       type: string
@@ -1680,34 +1587,35 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container
-                                    has started before liveness probes are initiated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the
-                                    probe. Default to 10 seconds. Minimum value is
-                                    1.
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the
-                                    probe to be considered successful after having
-                                    failed. Defaults to 1. Must be 1 for liveness
-                                    and startup. Minimum value is 1.
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
@@ -1722,61 +1630,59 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
-                                  description: Optional duration in seconds the pod
-                                    needs to terminate gracefully upon probe failure.
-                                    The grace period is the duration in seconds after
-                                    the processes running in the pod are sent a termination
-                                    signal and the time when the processes are forcibly
-                                    halted with a kill signal. Set this value longer
-                                    than the expected cleanup time for your process.
-                                    If this value is nil, the pod's terminationGracePeriodSeconds
-                                    will be used. Otherwise, this value overrides
-                                    the value provided by the pod spec. Value must
-                                    be non-negative integer. The value zero indicates
-                                    stop immediately via the kill signal (no opportunity
-                                    to shut down). This is a beta field and requires
-                                    enabling ProbeTerminationGracePeriod feature gate.
-                                    Minimum value is 1. spec.terminationGracePeriodSeconds
-                                    is used if unset.
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the
-                                    probe times out. Defaults to 1 second. Minimum
-                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                               type: object
                             name:
-                              description: Name of the container specified as a DNS_LABEL.
+                              description: |-
+                                Name of the container specified as a DNS_LABEL.
                                 Each container in a pod must have a unique name (DNS_LABEL).
                                 Cannot be updated.
                               type: string
                             ports:
-                              description: List of ports to expose from the container.
-                                Not specifying a port here DOES NOT prevent that port
-                                from being exposed. Any port which is listening on
-                                the default "0.0.0.0" address inside a container will
-                                be accessible from the network. Modifying this array
-                                with strategic merge patch may corrupt the data. For
-                                more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                              description: |-
+                                List of ports to expose from the container. Not specifying a port here
+                                DOES NOT prevent that port from being exposed. Any port which is
+                                listening on the default "0.0.0.0" address inside a container will be
+                                accessible from the network.
+                                Modifying this array with strategic merge patch may corrupt the data.
+                                For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                 Cannot be updated.
                               items:
                                 description: ContainerPort represents a network port
                                   in a single container.
                                 properties:
                                   containerPort:
-                                    description: Number of port to expose on the pod's
-                                      IP address. This must be a valid port number,
-                                      0 < x < 65536.
+                                    description: |-
+                                      Number of port to expose on the pod's IP address.
+                                      This must be a valid port number, 0 < x < 65536.
                                     format: int32
                                     type: integer
                                   hostIP:
@@ -1784,23 +1690,24 @@ spec:
                                       port to.
                                     type: string
                                   hostPort:
-                                    description: Number of port to expose on the host.
-                                      If specified, this must be a valid port number,
-                                      0 < x < 65536. If HostNetwork is specified,
-                                      this must match ContainerPort. Most containers
-                                      do not need this.
+                                    description: |-
+                                      Number of port to expose on the host.
+                                      If specified, this must be a valid port number, 0 < x < 65536.
+                                      If HostNetwork is specified, this must match ContainerPort.
+                                      Most containers do not need this.
                                     format: int32
                                     type: integer
                                   name:
-                                    description: If specified, this must be an IANA_SVC_NAME
-                                      and unique within the pod. Each named port in
-                                      a pod must have a unique name. Name for the
-                                      port that can be referred to by services.
+                                    description: |-
+                                      If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                      named port in a pod must have a unique name. Name for the port that can be
+                                      referred to by services.
                                     type: string
                                   protocol:
                                     default: TCP
-                                    description: Protocol for port. Must be UDP, TCP,
-                                      or SCTP. Defaults to "TCP".
+                                    description: |-
+                                      Protocol for port. Must be UDP, TCP, or SCTP.
+                                      Defaults to "TCP".
                                     type: string
                                 required:
                                 - containerPort
@@ -1811,30 +1718,30 @@ spec:
                               - protocol
                               x-kubernetes-list-type: map
                             readinessProbe:
-                              description: 'Periodic probe of container service readiness.
-                                Container will be removed from service endpoints if
-                                the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: |-
+                                Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if the probe fails.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                               properties:
                                 exec:
                                   description: Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the
-                                    probe to be considered failed after having succeeded.
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                     Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
@@ -1848,11 +1755,12 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service
-                                        to place in the gRPC HealthCheckRequest (see
-                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                        \n If this is not specified, the default behavior
-                                        is defined by gRPC."
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
@@ -1862,9 +1770,9 @@ spec:
                                     to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
                                       description: Custom headers to set in the request.
@@ -1874,19 +1782,15 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name. This
-                                              will be canonicalized upon output, so
-                                              case-variant names will be understood
-                                              as the same header.
                                             type: string
                                           value:
-                                            description: The header field value
                                             type: string
                                         required:
                                         - name
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       description: Path to access on the HTTP server.
                                       type: string
@@ -1894,34 +1798,35 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container
-                                    has started before liveness probes are initiated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the
-                                    probe. Default to 10 seconds. Minimum value is
-                                    1.
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the
-                                    probe to be considered successful after having
-                                    failed. Defaults to 1. Must be 1 for liveness
-                                    and startup. Minimum value is 1.
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
@@ -1936,36 +1841,33 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
-                                  description: Optional duration in seconds the pod
-                                    needs to terminate gracefully upon probe failure.
-                                    The grace period is the duration in seconds after
-                                    the processes running in the pod are sent a termination
-                                    signal and the time when the processes are forcibly
-                                    halted with a kill signal. Set this value longer
-                                    than the expected cleanup time for your process.
-                                    If this value is nil, the pod's terminationGracePeriodSeconds
-                                    will be used. Otherwise, this value overrides
-                                    the value provided by the pod spec. Value must
-                                    be non-negative integer. The value zero indicates
-                                    stop immediately via the kill signal (no opportunity
-                                    to shut down). This is a beta field and requires
-                                    enabling ProbeTerminationGracePeriod feature gate.
-                                    Minimum value is 1. spec.terminationGracePeriodSeconds
-                                    is used if unset.
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the
-                                    probe times out. Defaults to 1 second. Minimum
-                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                               type: object
@@ -1976,14 +1878,14 @@ spec:
                                   resize policy for the container.
                                 properties:
                                   resourceName:
-                                    description: 'Name of the resource to which this
-                                      resource resize policy applies. Supported values:
-                                      cpu, memory.'
+                                    description: |-
+                                      Name of the resource to which this resource resize policy applies.
+                                      Supported values: cpu, memory.
                                     type: string
                                   restartPolicy:
-                                    description: Restart policy to apply when specified
-                                      resource is resized. If not specified, it defaults
-                                      to NotRequired.
+                                    description: |-
+                                      Restart policy to apply when specified resource is resized.
+                                      If not specified, it defaults to NotRequired.
                                     type: string
                                 required:
                                 - resourceName
@@ -1992,25 +1894,31 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             resources:
-                              description: 'Compute Resources required by this container.
-                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              description: |-
+                                Compute Resources required by this container.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                               properties:
                                 claims:
-                                  description: "Claims lists the names of resources,
-                                    defined in spec.resourceClaims, that are used
-                                    by this container. \n This is an alpha field and
-                                    requires enabling the DynamicResourceAllocation
-                                    feature gate. \n This field is immutable. It can
-                                    only be set for containers."
+                                  description: |-
+                                    Claims lists the names of resources, defined in spec.resourceClaims,
+                                    that are used by this container.
+
+
+                                    This is an alpha field and requires enabling the
+                                    DynamicResourceAllocation feature gate.
+
+
+                                    This field is immutable. It can only be set for containers.
                                   items:
                                     description: ResourceClaim references one entry
                                       in PodSpec.ResourceClaims.
                                     properties:
                                       name:
-                                        description: Name must match the name of one
-                                          entry in pod.spec.resourceClaims of the
-                                          Pod where this field is used. It makes that
-                                          resource available inside a container.
+                                        description: |-
+                                          Name must match the name of one entry in pod.spec.resourceClaims of
+                                          the Pod where this field is used. It makes that resource available
+                                          inside a container.
                                         type: string
                                     required:
                                     - name
@@ -2026,8 +1934,9 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Limits describes the maximum amount
-                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                   type: object
                                 requests:
                                   additionalProperties:
@@ -2036,57 +1945,76 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Requests describes the minimum amount
-                                    of compute resources required. If Requests is
-                                    omitted for a container, it defaults to Limits
-                                    if that is explicitly specified, otherwise to
-                                    an implementation-defined value. Requests cannot
-                                    exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                   type: object
                               type: object
                             restartPolicy:
-                              description: 'RestartPolicy defines the restart behavior
-                                of individual containers in a pod. This field may
-                                only be set for init containers, and the only allowed
-                                value is "Always". For non-init containers or when
-                                this field is not specified, the restart behavior
-                                is defined by the Pod''s restart policy and the container
-                                type. Setting the RestartPolicy as "Always" for the
-                                init container will have the following effect: this
-                                init container will be continually restarted on exit
-                                until all regular containers have terminated. Once
-                                all regular containers have completed, all init containers
-                                with restartPolicy "Always" will be shut down. This
-                                lifecycle differs from normal init containers and
-                                is often referred to as a "sidecar" container. Although
-                                this init container still starts in the init container
-                                sequence, it does not wait for the container to complete
-                                before proceeding to the next init container. Instead,
-                                the next init container starts immediately after this
-                                init container is started, or after any startupProbe
-                                has successfully completed.'
+                              description: |-
+                                RestartPolicy defines the restart behavior of individual containers in a pod.
+                                This field may only be set for init containers, and the only allowed value is "Always".
+                                For non-init containers or when this field is not specified,
+                                the restart behavior is defined by the Pod's restart policy and the container type.
+                                Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                                this init container will be continually restarted on
+                                exit until all regular containers have terminated. Once all regular
+                                containers have completed, all init containers with restartPolicy "Always"
+                                will be shut down. This lifecycle differs from normal init containers and
+                                is often referred to as a "sidecar" container. Although this init
+                                container still starts in the init container sequence, it does not wait
+                                for the container to complete before proceeding to the next init
+                                container. Instead, the next init container starts immediately after this
+                                init container is started, or after any startupProbe has successfully
+                                completed.
                               type: string
                             securityContext:
-                              description: 'SecurityContext defines the security options
-                                the container should be run with. If set, the fields
-                                of SecurityContext override the equivalent fields
-                                of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              description: |-
+                                SecurityContext defines the security options the container should be run with.
+                                If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                               properties:
                                 allowPrivilegeEscalation:
-                                  description: 'AllowPrivilegeEscalation controls
-                                    whether a process can gain more privileges than
-                                    its parent process. This bool directly controls
-                                    if the no_new_privs flag will be set on the container
-                                    process. AllowPrivilegeEscalation is true always
-                                    when the container is: 1) run as Privileged 2)
-                                    has CAP_SYS_ADMIN Note that this field cannot
-                                    be set when spec.os.name is windows.'
+                                  description: |-
+                                    AllowPrivilegeEscalation controls whether a process can gain more
+                                    privileges than its parent process. This bool directly controls if
+                                    the no_new_privs flag will be set on the container process.
+                                    AllowPrivilegeEscalation is true always when the container is:
+                                    1) run as Privileged
+                                    2) has CAP_SYS_ADMIN
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
+                                appArmorProfile:
+                                  description: |-
+                                    appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                    overrides the pod's appArmorProfile.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: |-
+                                        localhostProfile indicates a profile loaded on the node that should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must match the loaded name of the profile.
+                                        Must be set if and only if type is "Localhost".
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of AppArmor profile will be applied.
+                                        Valid options are:
+                                          Localhost - a profile pre-loaded on the node.
+                                          RuntimeDefault - the container runtime's default profile.
+                                          Unconfined - no AppArmor enforcement.
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
                                 capabilities:
-                                  description: The capabilities to add/drop when running
-                                    containers. Defaults to the default set of capabilities
-                                    granted by the container runtime. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    The capabilities to add/drop when running containers.
+                                    Defaults to the default set of capabilities granted by the container runtime.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     add:
                                       description: Added capabilities
@@ -2095,6 +2023,7 @@ spec:
                                           type
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     drop:
                                       description: Removed capabilities
                                       items:
@@ -2102,68 +2031,63 @@ spec:
                                           type
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 privileged:
-                                  description: Run container in privileged mode. Processes
-                                    in privileged containers are essentially equivalent
-                                    to root on the host. Defaults to false. Note that
-                                    this field cannot be set when spec.os.name is
-                                    windows.
+                                  description: |-
+                                    Run container in privileged mode.
+                                    Processes in privileged containers are essentially equivalent to root on the host.
+                                    Defaults to false.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
                                 procMount:
-                                  description: procMount denotes the type of proc
-                                    mount to use for the containers. The default is
-                                    DefaultProcMount which uses the container runtime
-                                    defaults for readonly paths and masked paths.
-                                    This requires the ProcMountType feature flag to
-                                    be enabled. Note that this field cannot be set
-                                    when spec.os.name is windows.
+                                  description: |-
+                                    procMount denotes the type of proc mount to use for the containers.
+                                    The default is DefaultProcMount which uses the container runtime defaults for
+                                    readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to be enabled.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: string
                                 readOnlyRootFilesystem:
-                                  description: Whether this container has a read-only
-                                    root filesystem. Default is false. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    Whether this container has a read-only root filesystem.
+                                    Default is false.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
                                 runAsGroup:
-                                  description: The GID to run the entrypoint of the
-                                    container process. Uses runtime default if unset.
-                                    May also be set in PodSecurityContext.  If set
-                                    in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    The GID to run the entrypoint of the container process.
+                                    Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
-                                  description: Indicates that the container must run
-                                    as a non-root user. If true, the Kubelet will
-                                    validate the image at runtime to ensure that it
-                                    does not run as UID 0 (root) and fail to start
-                                    the container if it does. If unset or false, no
-                                    such validation will be performed. May also be
-                                    set in PodSecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence.
+                                  description: |-
+                                    Indicates that the container must run as a non-root user.
+                                    If true, the Kubelet will validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start the container if it does.
+                                    If unset or false, no such validation will be performed.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   type: boolean
                                 runAsUser:
-                                  description: The UID to run the entrypoint of the
-                                    container process. Defaults to user specified
-                                    in image metadata if unspecified. May also be
-                                    set in PodSecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    The UID to run the entrypoint of the container process.
+                                    Defaults to user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
-                                  description: The SELinux context to be applied to
-                                    the container. If unspecified, the container runtime
-                                    will allocate a random SELinux context for each
-                                    container.  May also be set in PodSecurityContext.  If
-                                    set in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    The SELinux context to be applied to the container.
+                                    If unspecified, the container runtime will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -2183,104 +2107,93 @@ spec:
                                       type: string
                                   type: object
                                 seccompProfile:
-                                  description: The seccomp options to use by this
-                                    container. If seccomp options are provided at
-                                    both the pod & container level, the container
-                                    options override the pod options. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    The seccomp options to use by this container. If seccomp options are
+                                    provided at both the pod & container level, the container options
+                                    override the pod options.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     localhostProfile:
-                                      description: localhostProfile indicates a profile
-                                        defined in a file on the node should be used.
-                                        The profile must be preconfigured on the node
-                                        to work. Must be a descending path, relative
-                                        to the kubelet's configured seccomp profile
-                                        location. Must be set if type is "Localhost".
-                                        Must NOT be set for any other type.
+                                      description: |-
+                                        localhostProfile indicates a profile defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                        Must be set if type is "Localhost". Must NOT be set for any other type.
                                       type: string
                                     type:
-                                      description: "type indicates which kind of seccomp
-                                        profile will be applied. Valid options are:
-                                        \n Localhost - a profile defined in a file
-                                        on the node should be used. RuntimeDefault
-                                        - the container runtime default profile should
-                                        be used. Unconfined - no profile should be
-                                        applied."
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied.
+                                        Valid options are:
+
+
+                                        Localhost - a profile defined in a file on the node should be used.
+                                        RuntimeDefault - the container runtime default profile should be used.
+                                        Unconfined - no profile should be applied.
                                       type: string
                                   required:
                                   - type
                                   type: object
                                 windowsOptions:
-                                  description: The Windows specific settings applied
-                                    to all containers. If unspecified, the options
-                                    from the PodSecurityContext will be used. If set
-                                    in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is linux.
+                                  description: |-
+                                    The Windows specific settings applied to all containers.
+                                    If unspecified, the options from the PodSecurityContext will be used.
+                                    If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is linux.
                                   properties:
                                     gmsaCredentialSpec:
-                                      description: GMSACredentialSpec is where the
-                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                        inlines the contents of the GMSA credential
-                                        spec named by the GMSACredentialSpecName field.
+                                      description: |-
+                                        GMSACredentialSpec is where the GMSA admission webhook
+                                        (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                        GMSA credential spec named by the GMSACredentialSpecName field.
                                       type: string
                                     gmsaCredentialSpecName:
                                       description: GMSACredentialSpecName is the name
                                         of the GMSA credential spec to use.
                                       type: string
                                     hostProcess:
-                                      description: HostProcess determines if a container
-                                        should be run as a 'Host Process' container.
-                                        All of a Pod's containers must have the same
-                                        effective HostProcess value (it is not allowed
-                                        to have a mix of HostProcess containers and
-                                        non-HostProcess containers). In addition,
-                                        if HostProcess is true then HostNetwork must
-                                        also be set to true.
+                                      description: |-
+                                        HostProcess determines if a container should be run as a 'Host Process' container.
+                                        All of a Pod's containers must have the same effective HostProcess value
+                                        (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                        In addition, if HostProcess is true then HostNetwork must also be set to true.
                                       type: boolean
                                     runAsUserName:
-                                      description: The UserName in Windows to run
-                                        the entrypoint of the container process. Defaults
-                                        to the user specified in image metadata if
-                                        unspecified. May also be set in PodSecurityContext.
-                                        If set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
+                                      description: |-
+                                        The UserName in Windows to run the entrypoint of the container process.
+                                        Defaults to the user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext. If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: string
                                   type: object
                               type: object
                             startupProbe:
-                              description: 'StartupProbe indicates that the Pod has
-                                successfully initialized. If specified, no other probes
-                                are executed until this completes successfully. If
-                                this probe fails, the Pod will be restarted, just
-                                as if the livenessProbe failed. This can be used to
-                                provide different probe parameters at the beginning
-                                of a Pod''s lifecycle, when it might take a long time
-                                to load data or warm a cache, than during steady-state
-                                operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: |-
+                                StartupProbe indicates that the Pod has successfully initialized.
+                                If specified, no other probes are executed until this completes successfully.
+                                If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                This cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                               properties:
                                 exec:
                                   description: Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the
-                                    probe to be considered failed after having succeeded.
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                     Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
@@ -2294,11 +2207,12 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service
-                                        to place in the gRPC HealthCheckRequest (see
-                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                        \n If this is not specified, the default behavior
-                                        is defined by gRPC."
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
@@ -2308,9 +2222,9 @@ spec:
                                     to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
                                       description: Custom headers to set in the request.
@@ -2320,19 +2234,15 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name. This
-                                              will be canonicalized upon output, so
-                                              case-variant names will be understood
-                                              as the same header.
                                             type: string
                                           value:
-                                            description: The header field value
                                             type: string
                                         required:
                                         - name
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       description: Path to access on the HTTP server.
                                       type: string
@@ -2340,34 +2250,35 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container
-                                    has started before liveness probes are initiated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the
-                                    probe. Default to 10 seconds. Minimum value is
-                                    1.
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the
-                                    probe to be considered successful after having
-                                    failed. Defaults to 1. Must be 1 for liveness
-                                    and startup. Minimum value is 1.
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
@@ -2382,83 +2293,75 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
-                                  description: Optional duration in seconds the pod
-                                    needs to terminate gracefully upon probe failure.
-                                    The grace period is the duration in seconds after
-                                    the processes running in the pod are sent a termination
-                                    signal and the time when the processes are forcibly
-                                    halted with a kill signal. Set this value longer
-                                    than the expected cleanup time for your process.
-                                    If this value is nil, the pod's terminationGracePeriodSeconds
-                                    will be used. Otherwise, this value overrides
-                                    the value provided by the pod spec. Value must
-                                    be non-negative integer. The value zero indicates
-                                    stop immediately via the kill signal (no opportunity
-                                    to shut down). This is a beta field and requires
-                                    enabling ProbeTerminationGracePeriod feature gate.
-                                    Minimum value is 1. spec.terminationGracePeriodSeconds
-                                    is used if unset.
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the
-                                    probe times out. Defaults to 1 second. Minimum
-                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                               type: object
                             stdin:
-                              description: Whether this container should allocate
-                                a buffer for stdin in the container runtime. If this
-                                is not set, reads from stdin in the container will
-                                always result in EOF. Default is false.
+                              description: |-
+                                Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will always result in EOF.
+                                Default is false.
                               type: boolean
                             stdinOnce:
-                              description: Whether the container runtime should close
-                                the stdin channel after it has been opened by a single
-                                attach. When stdin is true the stdin stream will remain
-                                open across multiple attach sessions. If stdinOnce
-                                is set to true, stdin is opened on container start,
-                                is empty until the first client attaches to stdin,
-                                and then remains open and accepts data until the client
-                                disconnects, at which time stdin is closed and remains
-                                closed until the container is restarted. If this flag
-                                is false, a container processes that reads from stdin
-                                will never receive an EOF. Default is false
+                              description: |-
+                                Whether the container runtime should close the stdin channel after it has been opened by
+                                a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                at which time stdin is closed and remains closed until the container is restarted. If this
+                                flag is false, a container processes that reads from stdin will never receive an EOF.
+                                Default is false
                               type: boolean
                             terminationMessagePath:
-                              description: 'Optional: Path at which the file to which
-                                the container''s termination message will be written
-                                is mounted into the container''s filesystem. Message
-                                written is intended to be brief final status, such
-                                as an assertion failure message. Will be truncated
-                                by the node if greater than 4096 bytes. The total
-                                message length across all containers will be limited
-                                to 12kb. Defaults to /dev/termination-log. Cannot
-                                be updated.'
+                              description: |-
+                                Optional: Path at which the file to which the container's termination message
+                                will be written is mounted into the container's filesystem.
+                                Message written is intended to be brief final status, such as an assertion failure message.
+                                Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                all containers will be limited to 12kb.
+                                Defaults to /dev/termination-log.
+                                Cannot be updated.
                               type: string
                             terminationMessagePolicy:
-                              description: Indicate how the termination message should
-                                be populated. File will use the contents of terminationMessagePath
-                                to populate the container status message on both success
-                                and failure. FallbackToLogsOnError will use the last
-                                chunk of container log output if the termination message
-                                file is empty and the container exited with an error.
-                                The log output is limited to 2048 bytes or 80 lines,
-                                whichever is smaller. Defaults to File. Cannot be
-                                updated.
+                              description: |-
+                                Indicate how the termination message should be populated. File will use the contents of
+                                terminationMessagePath to populate the container status message on both success and failure.
+                                FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                message file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                Defaults to File.
+                                Cannot be updated.
                               type: string
                             tty:
-                              description: Whether this container should allocate
-                                a TTY for itself, also requires 'stdin' to be true.
+                              description: |-
+                                Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
                                 Default is false.
                               type: boolean
                             volumeDevices:
@@ -2482,79 +2385,117 @@ spec:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - devicePath
+                              x-kubernetes-list-type: map
                             volumeMounts:
-                              description: Pod volumes to mount into the container's
-                                filesystem. Cannot be updated.
+                              description: |-
+                                Pod volumes to mount into the container's filesystem.
+                                Cannot be updated.
                               items:
                                 description: VolumeMount describes a mounting of a
                                   Volume within a container.
                                 properties:
                                   mountPath:
-                                    description: Path within the container at which
-                                      the volume should be mounted.  Must not contain
-                                      ':'.
+                                    description: |-
+                                      Path within the container at which the volume should be mounted.  Must
+                                      not contain ':'.
                                     type: string
                                   mountPropagation:
-                                    description: mountPropagation determines how mounts
-                                      are propagated from the host to container and
-                                      the other way around. When not set, MountPropagationNone
-                                      is used. This field is beta in 1.10.
+                                    description: |-
+                                      mountPropagation determines how mounts are propagated from the host
+                                      to container and the other way around.
+                                      When not set, MountPropagationNone is used.
+                                      This field is beta in 1.10.
+                                      When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                      (which defaults to None).
                                     type: string
                                   name:
                                     description: This must match the Name of a Volume.
                                     type: string
                                   readOnly:
-                                    description: Mounted read-only if true, read-write
-                                      otherwise (false or unspecified). Defaults to
-                                      false.
+                                    description: |-
+                                      Mounted read-only if true, read-write otherwise (false or unspecified).
+                                      Defaults to false.
                                     type: boolean
+                                  recursiveReadOnly:
+                                    description: |-
+                                      RecursiveReadOnly specifies whether read-only mounts should be handled
+                                      recursively.
+
+
+                                      If ReadOnly is false, this field has no meaning and must be unspecified.
+
+
+                                      If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                      recursively read-only.  If this field is set to IfPossible, the mount is made
+                                      recursively read-only, if it is supported by the container runtime.  If this
+                                      field is set to Enabled, the mount is made recursively read-only if it is
+                                      supported by the container runtime, otherwise the pod will not be started and
+                                      an error will be generated to indicate the reason.
+
+
+                                      If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                      None (or be unspecified, which defaults to None).
+
+
+                                      If this field is not specified, it is treated as an equivalent of Disabled.
+                                    type: string
                                   subPath:
-                                    description: Path within the volume from which
-                                      the container's volume should be mounted. Defaults
-                                      to "" (volume's root).
+                                    description: |-
+                                      Path within the volume from which the container's volume should be mounted.
+                                      Defaults to "" (volume's root).
                                     type: string
                                   subPathExpr:
-                                    description: Expanded path within the volume from
-                                      which the container's volume should be mounted.
-                                      Behaves similarly to SubPath but environment
-                                      variable references $(VAR_NAME) are expanded
-                                      using the container's environment. Defaults
-                                      to "" (volume's root). SubPathExpr and SubPath
-                                      are mutually exclusive.
+                                    description: |-
+                                      Expanded path within the volume from which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                      Defaults to "" (volume's root).
+                                      SubPathExpr and SubPath are mutually exclusive.
                                     type: string
                                 required:
                                 - mountPath
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - mountPath
+                              x-kubernetes-list-type: map
                             workingDir:
-                              description: Container's working directory. If not specified,
-                                the container runtime's default will be used, which
-                                might be configured in the container image. Cannot
-                                be updated.
+                              description: |-
+                                Container's working directory.
+                                If not specified, the container runtime's default will be used, which
+                                might be configured in the container image.
+                                Cannot be updated.
                               type: string
                           required:
                           - name
                           type: object
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       dnsConfig:
-                        description: Specifies the DNS parameters of a pod. Parameters
-                          specified here will be merged to the generated DNS configuration
-                          based on DNSPolicy.
+                        description: |-
+                          Specifies the DNS parameters of a pod.
+                          Parameters specified here will be merged to the generated DNS
+                          configuration based on DNSPolicy.
                         properties:
                           nameservers:
-                            description: A list of DNS name server IP addresses. This
-                              will be appended to the base nameservers generated from
-                              DNSPolicy. Duplicated nameservers will be removed.
+                            description: |-
+                              A list of DNS name server IP addresses.
+                              This will be appended to the base nameservers generated from DNSPolicy.
+                              Duplicated nameservers will be removed.
                             items:
                               type: string
                             type: array
+                            x-kubernetes-list-type: atomic
                           options:
-                            description: A list of DNS resolver options. This will
-                              be merged with the base options generated from DNSPolicy.
-                              Duplicated entries will be removed. Resolution options
-                              given in Options will override those that appear in
-                              the base DNSPolicy.
+                            description: |-
+                              A list of DNS resolver options.
+                              This will be merged with the base options generated from DNSPolicy.
+                              Duplicated entries will be removed. Resolution options given in Options
+                              will override those that appear in the base DNSPolicy.
                             items:
                               description: PodDNSConfigOption defines DNS resolver
                                 options of a pod.
@@ -2566,81 +2507,82 @@ spec:
                                   type: string
                               type: object
                             type: array
+                            x-kubernetes-list-type: atomic
                           searches:
-                            description: A list of DNS search domains for host-name
-                              lookup. This will be appended to the base search paths
-                              generated from DNSPolicy. Duplicated search paths will
-                              be removed.
+                            description: |-
+                              A list of DNS search domains for host-name lookup.
+                              This will be appended to the base search paths generated from DNSPolicy.
+                              Duplicated search paths will be removed.
                             items:
                               type: string
                             type: array
+                            x-kubernetes-list-type: atomic
                         type: object
                       dnsPolicy:
-                        description: Set DNS policy for the pod. Defaults to "ClusterFirst".
-                          Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst',
-                          'Default' or 'None'. DNS parameters given in DNSConfig will
-                          be merged with the policy selected with DNSPolicy. To have
-                          DNS options set along with hostNetwork, you have to specify
-                          DNS policy explicitly to 'ClusterFirstWithHostNet'.
+                        description: |-
+                          Set DNS policy for the pod.
+                          Defaults to "ClusterFirst".
+                          Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
+                          DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy.
+                          To have DNS options set along with hostNetwork, you have to specify DNS policy
+                          explicitly to 'ClusterFirstWithHostNet'.
                         type: string
                       enableServiceLinks:
-                        description: 'EnableServiceLinks indicates whether information
-                          about services should be injected into pod''s environment
-                          variables, matching the syntax of Docker links. Optional:
-                          Defaults to true.'
+                        description: |-
+                          EnableServiceLinks indicates whether information about services should be injected into pod's
+                          environment variables, matching the syntax of Docker links.
+                          Optional: Defaults to true.
                         type: boolean
                       ephemeralContainers:
-                        description: List of ephemeral containers run in this pod.
-                          Ephemeral containers may be run in an existing pod to perform
-                          user-initiated actions such as debugging. This list cannot
-                          be specified when creating a pod, and it cannot be modified
-                          by updating the pod spec. In order to add an ephemeral container
-                          to an existing pod, use the pod's ephemeralcontainers subresource.
+                        description: |-
+                          List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing
+                          pod to perform user-initiated actions such as debugging. This list cannot be specified when
+                          creating a pod, and it cannot be modified by updating the pod spec. In order to add an
+                          ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.
                         items:
-                          description: "An EphemeralContainer is a temporary container
-                            that you may add to an existing Pod for user-initiated
-                            activities such as debugging. Ephemeral containers have
-                            no resource or scheduling guarantees, and they will not
-                            be restarted when they exit or when a Pod is removed or
-                            restarted. The kubelet may evict a Pod if an ephemeral
-                            container causes the Pod to exceed its resource allocation.
-                            \n To add an ephemeral container, use the ephemeralcontainers
-                            subresource of an existing Pod. Ephemeral containers may
-                            not be removed or restarted."
+                          description: |-
+                            An EphemeralContainer is a temporary container that you may add to an existing Pod for
+                            user-initiated activities such as debugging. Ephemeral containers have no resource or
+                            scheduling guarantees, and they will not be restarted when they exit or when a Pod is
+                            removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the
+                            Pod to exceed its resource allocation.
+
+
+                            To add an ephemeral container, use the ephemeralcontainers subresource of an existing
+                            Pod. Ephemeral containers may not be removed or restarted.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The image''s
-                                CMD is used if this is not provided. Variable references
-                                $(VAR_NAME) are expanded using the container''s environment.
-                                If a variable cannot be resolved, the reference in
-                                the input string will be unchanged. Double $$ are
-                                reduced to a single $, which allows for escaping the
-                                $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
-                                the string literal "$(VAR_NAME)". Escaped references
-                                will never be expanded, regardless of whether the
-                                variable exists or not. Cannot be updated. More info:
-                                https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: |-
+                                Arguments to the entrypoint.
+                                The image's CMD is used if this is not provided.
+                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             command:
-                              description: 'Entrypoint array. Not executed within
-                                a shell. The image''s ENTRYPOINT is used if this is
-                                not provided. Variable references $(VAR_NAME) are
-                                expanded using the container''s environment. If a
-                                variable cannot be resolved, the reference in the
-                                input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME)
-                                syntax: i.e. "$$(VAR_NAME)" will produce the string
-                                literal "$(VAR_NAME)". Escaped references will never
-                                be expanded, regardless of whether the variable exists
-                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: |-
+                                Entrypoint array. Not executed within a shell.
+                                The image's ENTRYPOINT is used if this is not provided.
+                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             env:
-                              description: List of environment variables to set in
-                                the container. Cannot be updated.
+                              description: |-
+                                List of environment variables to set in the container.
+                                Cannot be updated.
                               items:
                                 description: EnvVar represents an environment variable
                                   present in a Container.
@@ -2650,17 +2592,16 @@ spec:
                                       Must be a C_IDENTIFIER.
                                     type: string
                                   value:
-                                    description: 'Variable references $(VAR_NAME)
-                                      are expanded using the previously defined environment
-                                      variables in the container and any service environment
-                                      variables. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged.
-                                      Double $$ are reduced to a single $, which allows
-                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Defaults
-                                      to "".'
+                                    description: |-
+                                      Variable references $(VAR_NAME) are expanded
+                                      using the previously defined environment variables in the container and
+                                      any service environment variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                      "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless of whether the variable
+                                      exists or not.
+                                      Defaults to "".
                                     type: string
                                   valueFrom:
                                     description: Source for the environment variable's
@@ -2670,64 +2611,40 @@ spec:
                                         description: Selects a key of a ConfigMap.
                                         properties:
                                           key:
-                                            description: The key to select.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            default: ""
                                             type: string
                                           optional:
-                                            description: Specify whether the ConfigMap
-                                              or its key must be defined
                                             type: boolean
                                         required:
                                         - key
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       fieldRef:
-                                        description: 'Selects a field of the pod:
-                                          supports metadata.name, metadata.namespace,
-                                          `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                          spec.nodeName, spec.serviceAccountName,
-                                          status.hostIP, status.podIP, status.podIPs.'
                                         properties:
                                           apiVersion:
-                                            description: Version of the schema the
-                                              FieldPath is written in terms of, defaults
-                                              to "v1".
                                             type: string
                                           fieldPath:
-                                            description: Path of the field to select
-                                              in the specified API version.
                                             type: string
                                         required:
                                         - fieldPath
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       resourceFieldRef:
-                                        description: 'Selects a resource of the container:
-                                          only resources limits and requests (limits.cpu,
-                                          limits.memory, limits.ephemeral-storage,
-                                          requests.cpu, requests.memory and requests.ephemeral-storage)
-                                          are currently supported.'
+                                        description: |-
+                                          Selects a resource of the container: only resources limits and requests
+                                          (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                         properties:
                                           containerName:
-                                            description: 'Container name: required
-                                              for volumes, optional for env vars'
                                             type: string
                                           divisor:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Specifies the output format
-                                              of the exposed resources, defaults to
-                                              "1"
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           resource:
-                                            description: 'Required: resource to select'
                                             type: string
                                         required:
                                         - resource
@@ -2738,19 +2655,11 @@ spec:
                                           the pod's namespace
                                         properties:
                                           key:
-                                            description: The key of the secret to
-                                              select from.  Must be a valid secret
-                                              key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            default: ""
                                             type: string
                                           optional:
-                                            description: Specify whether the Secret
-                                              or its key must be defined
                                             type: boolean
                                         required:
                                         - key
@@ -2761,15 +2670,17 @@ spec:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             envFrom:
-                              description: List of sources to populate environment
-                                variables in the container. The keys defined within
-                                a source must be a C_IDENTIFIER. All invalid keys
-                                will be reported as an event when the container is
-                                starting. When a key exists in multiple sources, the
-                                value associated with the last source will take precedence.
-                                Values defined by an Env with a duplicate key will
-                                take precedence. Cannot be updated.
+                              description: |-
+                                List of sources to populate environment variables in the container.
+                                The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is starting. When a key exists in multiple
+                                sources, the value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will take precedence.
+                                Cannot be updated.
                               items:
                                 description: EnvFromSource represents the source of
                                   a set of ConfigMaps
@@ -2778,10 +2689,7 @@ spec:
                                     description: The ConfigMap to select from
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        default: ""
                                         type: string
                                       optional:
                                         description: Specify whether the ConfigMap
@@ -2797,10 +2705,7 @@ spec:
                                     description: The Secret to select from
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        default: ""
                                         type: string
                                       optional:
                                         description: Specify whether the Secret must
@@ -2810,60 +2715,48 @@ spec:
                                     x-kubernetes-map-type: atomic
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             image:
-                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                              description: |-
+                                Container image name.
+                                More info: https://kubernetes.io/docs/concepts/containers/images
                               type: string
                             imagePullPolicy:
-                              description: 'Image pull policy. One of Always, Never,
-                                IfNotPresent. Defaults to Always if :latest tag is
-                                specified, or IfNotPresent otherwise. Cannot be updated.
-                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                              description: |-
+                                Image pull policy.
+                                One of Always, Never, IfNotPresent.
+                                Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                               type: string
                             lifecycle:
                               description: Lifecycle is not allowed for ephemeral
                                 containers.
                               properties:
                                 postStart:
-                                  description: 'PostStart is called immediately after
-                                    a container is created. If the handler fails,
-                                    the container is terminated and restarted according
-                                    to its restart policy. Other management of the
-                                    container blocks until the hook completes. More
-                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  description: |-
+                                    PostStart is called immediately after a container is created. If the handler fails,
+                                    the container is terminated and restarted according to its restart policy.
+                                    Other management of the container blocks until the hook completes.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                   properties:
                                     exec:
                                       description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
-                                            to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                     httpGet:
                                       description: HTTPGet specifies the http request
                                         to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the
-                                            request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom
-                                              header to be used in HTTP probes
                                             properties:
                                               name:
                                                 type: string
@@ -2874,98 +2767,75 @@ spec:
                                             - value
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         path:
-                                          description: Path to access on the HTTP
-                                            server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting
-                                            to the host. Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
+                                    sleep:
+                                      description: Sleep represents the duration that
+                                        the container should sleep before being terminated.
+                                      properties:
+                                        seconds:
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
+                                      type: object
                                     tcpSocket:
-                                      description: Deprecated. TCPSocket is NOT supported
-                                        as a LifecycleHandler and kept for the backward
-                                        compatibility. There are no validation of
-                                        this field and lifecycle hooks will fail in
-                                        runtime when tcp handler is specified.
+                                      description: |-
+                                        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                        for the backward compatibility. There are no validation of this field and
+                                        lifecycle hooks will fail in runtime when tcp handler is specified.
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect
-                                            to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                   type: object
                                 preStop:
-                                  description: 'PreStop is called immediately before
-                                    a container is terminated due to an API request
-                                    or management event such as liveness/startup probe
-                                    failure, preemption, resource contention, etc.
-                                    The handler is not called if the container crashes
-                                    or exits. The Pod''s termination grace period
-                                    countdown begins before the PreStop hook is executed.
-                                    Regardless of the outcome of the handler, the
-                                    container will eventually terminate within the
-                                    Pod''s termination grace period (unless delayed
-                                    by finalizers). Other management of the container
-                                    blocks until the hook completes or until the termination
-                                    grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  description: |-
+                                    PreStop is called immediately before a container is terminated due to an
+                                    API request or management event such as liveness/startup probe failure,
+                                    preemption, resource contention, etc. The handler is not called if the
+                                    container crashes or exits. The Pod's termination grace period countdown begins before the
+                                    PreStop hook is executed. Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the Pod's termination grace
+                                    period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                   properties:
                                     exec:
                                       description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
-                                            to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                     httpGet:
                                       description: HTTPGet specifies the http request
                                         to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the
-                                            request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom
-                                              header to be used in HTTP probes
                                             properties:
                                               name:
                                                 type: string
@@ -2976,45 +2846,41 @@ spec:
                                             - value
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         path:
-                                          description: Path to access on the HTTP
-                                            server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting
-                                            to the host. Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
+                                    sleep:
+                                      description: Sleep represents the duration that
+                                        the container should sleep before being terminated.
+                                      properties:
+                                        seconds:
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
+                                      type: object
                                     tcpSocket:
-                                      description: Deprecated. TCPSocket is NOT supported
-                                        as a LifecycleHandler and kept for the backward
-                                        compatibility. There are no validation of
-                                        this field and lifecycle hooks will fail in
-                                        runtime when tcp handler is specified.
+                                      description: |-
+                                        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                        for the backward compatibility. There are no validation of this field and
+                                        lifecycle hooks will fail in runtime when tcp handler is specified.
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect
-                                            to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
@@ -3028,22 +2894,20 @@ spec:
                                   description: Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the
-                                    probe to be considered failed after having succeeded.
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                     Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
@@ -3057,11 +2921,12 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service
-                                        to place in the gRPC HealthCheckRequest (see
-                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                        \n If this is not specified, the default behavior
-                                        is defined by gRPC."
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
@@ -3071,9 +2936,9 @@ spec:
                                     to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
                                       description: Custom headers to set in the request.
@@ -3083,19 +2948,15 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name. This
-                                              will be canonicalized upon output, so
-                                              case-variant names will be understood
-                                              as the same header.
                                             type: string
                                           value:
-                                            description: The header field value
                                             type: string
                                         required:
                                         - name
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       description: Path to access on the HTTP server.
                                       type: string
@@ -3103,34 +2964,35 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container
-                                    has started before liveness probes are initiated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the
-                                    probe. Default to 10 seconds. Minimum value is
-                                    1.
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the
-                                    probe to be considered successful after having
-                                    failed. Defaults to 1. Must be 1 for liveness
-                                    and startup. Minimum value is 1.
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
@@ -3145,43 +3007,40 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
-                                  description: Optional duration in seconds the pod
-                                    needs to terminate gracefully upon probe failure.
-                                    The grace period is the duration in seconds after
-                                    the processes running in the pod are sent a termination
-                                    signal and the time when the processes are forcibly
-                                    halted with a kill signal. Set this value longer
-                                    than the expected cleanup time for your process.
-                                    If this value is nil, the pod's terminationGracePeriodSeconds
-                                    will be used. Otherwise, this value overrides
-                                    the value provided by the pod spec. Value must
-                                    be non-negative integer. The value zero indicates
-                                    stop immediately via the kill signal (no opportunity
-                                    to shut down). This is a beta field and requires
-                                    enabling ProbeTerminationGracePeriod feature gate.
-                                    Minimum value is 1. spec.terminationGracePeriodSeconds
-                                    is used if unset.
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the
-                                    probe times out. Defaults to 1 second. Minimum
-                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                               type: object
                             name:
-                              description: Name of the ephemeral container specified
-                                as a DNS_LABEL. This name must be unique among all
-                                containers, init containers and ephemeral containers.
+                              description: |-
+                                Name of the ephemeral container specified as a DNS_LABEL.
+                                This name must be unique among all containers, init containers and ephemeral containers.
                               type: string
                             ports:
                               description: Ports are not allowed for ephemeral containers.
@@ -3190,9 +3049,9 @@ spec:
                                   in a single container.
                                 properties:
                                   containerPort:
-                                    description: Number of port to expose on the pod's
-                                      IP address. This must be a valid port number,
-                                      0 < x < 65536.
+                                    description: |-
+                                      Number of port to expose on the pod's IP address.
+                                      This must be a valid port number, 0 < x < 65536.
                                     format: int32
                                     type: integer
                                   hostIP:
@@ -3200,23 +3059,24 @@ spec:
                                       port to.
                                     type: string
                                   hostPort:
-                                    description: Number of port to expose on the host.
-                                      If specified, this must be a valid port number,
-                                      0 < x < 65536. If HostNetwork is specified,
-                                      this must match ContainerPort. Most containers
-                                      do not need this.
+                                    description: |-
+                                      Number of port to expose on the host.
+                                      If specified, this must be a valid port number, 0 < x < 65536.
+                                      If HostNetwork is specified, this must match ContainerPort.
+                                      Most containers do not need this.
                                     format: int32
                                     type: integer
                                   name:
-                                    description: If specified, this must be an IANA_SVC_NAME
-                                      and unique within the pod. Each named port in
-                                      a pod must have a unique name. Name for the
-                                      port that can be referred to by services.
+                                    description: |-
+                                      If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                      named port in a pod must have a unique name. Name for the port that can be
+                                      referred to by services.
                                     type: string
                                   protocol:
                                     default: TCP
-                                    description: Protocol for port. Must be UDP, TCP,
-                                      or SCTP. Defaults to "TCP".
+                                    description: |-
+                                      Protocol for port. Must be UDP, TCP, or SCTP.
+                                      Defaults to "TCP".
                                     type: string
                                 required:
                                 - containerPort
@@ -3233,22 +3093,20 @@ spec:
                                   description: Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the
-                                    probe to be considered failed after having succeeded.
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                     Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
@@ -3262,11 +3120,12 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service
-                                        to place in the gRPC HealthCheckRequest (see
-                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                        \n If this is not specified, the default behavior
-                                        is defined by gRPC."
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
@@ -3276,9 +3135,9 @@ spec:
                                     to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
                                       description: Custom headers to set in the request.
@@ -3288,19 +3147,15 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name. This
-                                              will be canonicalized upon output, so
-                                              case-variant names will be understood
-                                              as the same header.
                                             type: string
                                           value:
-                                            description: The header field value
                                             type: string
                                         required:
                                         - name
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       description: Path to access on the HTTP server.
                                       type: string
@@ -3308,34 +3163,35 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container
-                                    has started before liveness probes are initiated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the
-                                    probe. Default to 10 seconds. Minimum value is
-                                    1.
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the
-                                    probe to be considered successful after having
-                                    failed. Defaults to 1. Must be 1 for liveness
-                                    and startup. Minimum value is 1.
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
@@ -3350,36 +3206,33 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
-                                  description: Optional duration in seconds the pod
-                                    needs to terminate gracefully upon probe failure.
-                                    The grace period is the duration in seconds after
-                                    the processes running in the pod are sent a termination
-                                    signal and the time when the processes are forcibly
-                                    halted with a kill signal. Set this value longer
-                                    than the expected cleanup time for your process.
-                                    If this value is nil, the pod's terminationGracePeriodSeconds
-                                    will be used. Otherwise, this value overrides
-                                    the value provided by the pod spec. Value must
-                                    be non-negative integer. The value zero indicates
-                                    stop immediately via the kill signal (no opportunity
-                                    to shut down). This is a beta field and requires
-                                    enabling ProbeTerminationGracePeriod feature gate.
-                                    Minimum value is 1. spec.terminationGracePeriodSeconds
-                                    is used if unset.
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the
-                                    probe times out. Defaults to 1 second. Minimum
-                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                               type: object
@@ -3390,14 +3243,14 @@ spec:
                                   resize policy for the container.
                                 properties:
                                   resourceName:
-                                    description: 'Name of the resource to which this
-                                      resource resize policy applies. Supported values:
-                                      cpu, memory.'
+                                    description: |-
+                                      Name of the resource to which this resource resize policy applies.
+                                      Supported values: cpu, memory.
                                     type: string
                                   restartPolicy:
-                                    description: Restart policy to apply when specified
-                                      resource is resized. If not specified, it defaults
-                                      to NotRequired.
+                                    description: |-
+                                      Restart policy to apply when specified resource is resized.
+                                      If not specified, it defaults to NotRequired.
                                     type: string
                                 required:
                                 - resourceName
@@ -3406,26 +3259,30 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             resources:
-                              description: Resources are not allowed for ephemeral
-                                containers. Ephemeral containers use spare resources
+                              description: |-
+                                Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
                                 already allocated to the pod.
                               properties:
                                 claims:
-                                  description: "Claims lists the names of resources,
-                                    defined in spec.resourceClaims, that are used
-                                    by this container. \n This is an alpha field and
-                                    requires enabling the DynamicResourceAllocation
-                                    feature gate. \n This field is immutable. It can
-                                    only be set for containers."
+                                  description: |-
+                                    Claims lists the names of resources, defined in spec.resourceClaims,
+                                    that are used by this container.
+
+
+                                    This is an alpha field and requires enabling the
+                                    DynamicResourceAllocation feature gate.
+
+
+                                    This field is immutable. It can only be set for containers.
                                   items:
                                     description: ResourceClaim references one entry
                                       in PodSpec.ResourceClaims.
                                     properties:
                                       name:
-                                        description: Name must match the name of one
-                                          entry in pod.spec.resourceClaims of the
-                                          Pod where this field is used. It makes that
-                                          resource available inside a container.
+                                        description: |-
+                                          Name must match the name of one entry in pod.spec.resourceClaims of
+                                          the Pod where this field is used. It makes that resource available
+                                          inside a container.
                                         type: string
                                     required:
                                     - name
@@ -3441,8 +3298,9 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Limits describes the maximum amount
-                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                   type: object
                                 requests:
                                   additionalProperties:
@@ -3451,41 +3309,64 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Requests describes the minimum amount
-                                    of compute resources required. If Requests is
-                                    omitted for a container, it defaults to Limits
-                                    if that is explicitly specified, otherwise to
-                                    an implementation-defined value. Requests cannot
-                                    exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                   type: object
                               type: object
                             restartPolicy:
-                              description: Restart policy for the container to manage
-                                the restart behavior of each container within a pod.
-                                This may only be set for init containers. You cannot
-                                set this field on ephemeral containers.
+                              description: |-
+                                Restart policy for the container to manage the restart behavior of each
+                                container within a pod.
+                                This may only be set for init containers. You cannot set this field on
+                                ephemeral containers.
                               type: string
                             securityContext:
-                              description: 'Optional: SecurityContext defines the
-                                security options the ephemeral container should be
-                                run with. If set, the fields of SecurityContext override
-                                the equivalent fields of PodSecurityContext.'
+                              description: |-
+                                Optional: SecurityContext defines the security options the ephemeral container should be run with.
+                                If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
                               properties:
                                 allowPrivilegeEscalation:
-                                  description: 'AllowPrivilegeEscalation controls
-                                    whether a process can gain more privileges than
-                                    its parent process. This bool directly controls
-                                    if the no_new_privs flag will be set on the container
-                                    process. AllowPrivilegeEscalation is true always
-                                    when the container is: 1) run as Privileged 2)
-                                    has CAP_SYS_ADMIN Note that this field cannot
-                                    be set when spec.os.name is windows.'
+                                  description: |-
+                                    AllowPrivilegeEscalation controls whether a process can gain more
+                                    privileges than its parent process. This bool directly controls if
+                                    the no_new_privs flag will be set on the container process.
+                                    AllowPrivilegeEscalation is true always when the container is:
+                                    1) run as Privileged
+                                    2) has CAP_SYS_ADMIN
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
+                                appArmorProfile:
+                                  description: |-
+                                    appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                    overrides the pod's appArmorProfile.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: |-
+                                        localhostProfile indicates a profile loaded on the node that should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must match the loaded name of the profile.
+                                        Must be set if and only if type is "Localhost".
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of AppArmor profile will be applied.
+                                        Valid options are:
+                                          Localhost - a profile pre-loaded on the node.
+                                          RuntimeDefault - the container runtime's default profile.
+                                          Unconfined - no AppArmor enforcement.
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
                                 capabilities:
-                                  description: The capabilities to add/drop when running
-                                    containers. Defaults to the default set of capabilities
-                                    granted by the container runtime. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    The capabilities to add/drop when running containers.
+                                    Defaults to the default set of capabilities granted by the container runtime.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     add:
                                       description: Added capabilities
@@ -3494,6 +3375,7 @@ spec:
                                           type
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     drop:
                                       description: Removed capabilities
                                       items:
@@ -3501,68 +3383,63 @@ spec:
                                           type
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 privileged:
-                                  description: Run container in privileged mode. Processes
-                                    in privileged containers are essentially equivalent
-                                    to root on the host. Defaults to false. Note that
-                                    this field cannot be set when spec.os.name is
-                                    windows.
+                                  description: |-
+                                    Run container in privileged mode.
+                                    Processes in privileged containers are essentially equivalent to root on the host.
+                                    Defaults to false.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
                                 procMount:
-                                  description: procMount denotes the type of proc
-                                    mount to use for the containers. The default is
-                                    DefaultProcMount which uses the container runtime
-                                    defaults for readonly paths and masked paths.
-                                    This requires the ProcMountType feature flag to
-                                    be enabled. Note that this field cannot be set
-                                    when spec.os.name is windows.
+                                  description: |-
+                                    procMount denotes the type of proc mount to use for the containers.
+                                    The default is DefaultProcMount which uses the container runtime defaults for
+                                    readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to be enabled.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: string
                                 readOnlyRootFilesystem:
-                                  description: Whether this container has a read-only
-                                    root filesystem. Default is false. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    Whether this container has a read-only root filesystem.
+                                    Default is false.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
                                 runAsGroup:
-                                  description: The GID to run the entrypoint of the
-                                    container process. Uses runtime default if unset.
-                                    May also be set in PodSecurityContext.  If set
-                                    in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    The GID to run the entrypoint of the container process.
+                                    Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
-                                  description: Indicates that the container must run
-                                    as a non-root user. If true, the Kubelet will
-                                    validate the image at runtime to ensure that it
-                                    does not run as UID 0 (root) and fail to start
-                                    the container if it does. If unset or false, no
-                                    such validation will be performed. May also be
-                                    set in PodSecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence.
+                                  description: |-
+                                    Indicates that the container must run as a non-root user.
+                                    If true, the Kubelet will validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start the container if it does.
+                                    If unset or false, no such validation will be performed.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   type: boolean
                                 runAsUser:
-                                  description: The UID to run the entrypoint of the
-                                    container process. Defaults to user specified
-                                    in image metadata if unspecified. May also be
-                                    set in PodSecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    The UID to run the entrypoint of the container process.
+                                    Defaults to user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
-                                  description: The SELinux context to be applied to
-                                    the container. If unspecified, the container runtime
-                                    will allocate a random SELinux context for each
-                                    container.  May also be set in PodSecurityContext.  If
-                                    set in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    The SELinux context to be applied to the container.
+                                    If unspecified, the container runtime will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -3582,70 +3459,62 @@ spec:
                                       type: string
                                   type: object
                                 seccompProfile:
-                                  description: The seccomp options to use by this
-                                    container. If seccomp options are provided at
-                                    both the pod & container level, the container
-                                    options override the pod options. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    The seccomp options to use by this container. If seccomp options are
+                                    provided at both the pod & container level, the container options
+                                    override the pod options.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     localhostProfile:
-                                      description: localhostProfile indicates a profile
-                                        defined in a file on the node should be used.
-                                        The profile must be preconfigured on the node
-                                        to work. Must be a descending path, relative
-                                        to the kubelet's configured seccomp profile
-                                        location. Must be set if type is "Localhost".
-                                        Must NOT be set for any other type.
+                                      description: |-
+                                        localhostProfile indicates a profile defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                        Must be set if type is "Localhost". Must NOT be set for any other type.
                                       type: string
                                     type:
-                                      description: "type indicates which kind of seccomp
-                                        profile will be applied. Valid options are:
-                                        \n Localhost - a profile defined in a file
-                                        on the node should be used. RuntimeDefault
-                                        - the container runtime default profile should
-                                        be used. Unconfined - no profile should be
-                                        applied."
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied.
+                                        Valid options are:
+
+
+                                        Localhost - a profile defined in a file on the node should be used.
+                                        RuntimeDefault - the container runtime default profile should be used.
+                                        Unconfined - no profile should be applied.
                                       type: string
                                   required:
                                   - type
                                   type: object
                                 windowsOptions:
-                                  description: The Windows specific settings applied
-                                    to all containers. If unspecified, the options
-                                    from the PodSecurityContext will be used. If set
-                                    in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is linux.
+                                  description: |-
+                                    The Windows specific settings applied to all containers.
+                                    If unspecified, the options from the PodSecurityContext will be used.
+                                    If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is linux.
                                   properties:
                                     gmsaCredentialSpec:
-                                      description: GMSACredentialSpec is where the
-                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                        inlines the contents of the GMSA credential
-                                        spec named by the GMSACredentialSpecName field.
+                                      description: |-
+                                        GMSACredentialSpec is where the GMSA admission webhook
+                                        (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                        GMSA credential spec named by the GMSACredentialSpecName field.
                                       type: string
                                     gmsaCredentialSpecName:
                                       description: GMSACredentialSpecName is the name
                                         of the GMSA credential spec to use.
                                       type: string
                                     hostProcess:
-                                      description: HostProcess determines if a container
-                                        should be run as a 'Host Process' container.
-                                        All of a Pod's containers must have the same
-                                        effective HostProcess value (it is not allowed
-                                        to have a mix of HostProcess containers and
-                                        non-HostProcess containers). In addition,
-                                        if HostProcess is true then HostNetwork must
-                                        also be set to true.
+                                      description: |-
+                                        HostProcess determines if a container should be run as a 'Host Process' container.
+                                        All of a Pod's containers must have the same effective HostProcess value
+                                        (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                        In addition, if HostProcess is true then HostNetwork must also be set to true.
                                       type: boolean
                                     runAsUserName:
-                                      description: The UserName in Windows to run
-                                        the entrypoint of the container process. Defaults
-                                        to the user specified in image metadata if
-                                        unspecified. May also be set in PodSecurityContext.
-                                        If set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
+                                      description: |-
+                                        The UserName in Windows to run the entrypoint of the container process.
+                                        Defaults to the user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext. If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: string
                                   type: object
                               type: object
@@ -3656,22 +3525,20 @@ spec:
                                   description: Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the
-                                    probe to be considered failed after having succeeded.
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                     Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
@@ -3685,11 +3552,12 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service
-                                        to place in the gRPC HealthCheckRequest (see
-                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                        \n If this is not specified, the default behavior
-                                        is defined by gRPC."
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
@@ -3699,9 +3567,9 @@ spec:
                                     to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
                                       description: Custom headers to set in the request.
@@ -3711,19 +3579,15 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name. This
-                                              will be canonicalized upon output, so
-                                              case-variant names will be understood
-                                              as the same header.
                                             type: string
                                           value:
-                                            description: The header field value
                                             type: string
                                         required:
                                         - name
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       description: Path to access on the HTTP server.
                                       type: string
@@ -3731,34 +3595,35 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container
-                                    has started before liveness probes are initiated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the
-                                    probe. Default to 10 seconds. Minimum value is
-                                    1.
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the
-                                    probe to be considered successful after having
-                                    failed. Defaults to 1. Must be 1 for liveness
-                                    and startup. Minimum value is 1.
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
@@ -3773,94 +3638,85 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
-                                  description: Optional duration in seconds the pod
-                                    needs to terminate gracefully upon probe failure.
-                                    The grace period is the duration in seconds after
-                                    the processes running in the pod are sent a termination
-                                    signal and the time when the processes are forcibly
-                                    halted with a kill signal. Set this value longer
-                                    than the expected cleanup time for your process.
-                                    If this value is nil, the pod's terminationGracePeriodSeconds
-                                    will be used. Otherwise, this value overrides
-                                    the value provided by the pod spec. Value must
-                                    be non-negative integer. The value zero indicates
-                                    stop immediately via the kill signal (no opportunity
-                                    to shut down). This is a beta field and requires
-                                    enabling ProbeTerminationGracePeriod feature gate.
-                                    Minimum value is 1. spec.terminationGracePeriodSeconds
-                                    is used if unset.
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the
-                                    probe times out. Defaults to 1 second. Minimum
-                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                               type: object
                             stdin:
-                              description: Whether this container should allocate
-                                a buffer for stdin in the container runtime. If this
-                                is not set, reads from stdin in the container will
-                                always result in EOF. Default is false.
+                              description: |-
+                                Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will always result in EOF.
+                                Default is false.
                               type: boolean
                             stdinOnce:
-                              description: Whether the container runtime should close
-                                the stdin channel after it has been opened by a single
-                                attach. When stdin is true the stdin stream will remain
-                                open across multiple attach sessions. If stdinOnce
-                                is set to true, stdin is opened on container start,
-                                is empty until the first client attaches to stdin,
-                                and then remains open and accepts data until the client
-                                disconnects, at which time stdin is closed and remains
-                                closed until the container is restarted. If this flag
-                                is false, a container processes that reads from stdin
-                                will never receive an EOF. Default is false
+                              description: |-
+                                Whether the container runtime should close the stdin channel after it has been opened by
+                                a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                at which time stdin is closed and remains closed until the container is restarted. If this
+                                flag is false, a container processes that reads from stdin will never receive an EOF.
+                                Default is false
                               type: boolean
                             targetContainerName:
-                              description: "If set, the name of the container from
-                                PodSpec that this ephemeral container targets. The
-                                ephemeral container will be run in the namespaces
-                                (IPC, PID, etc) of this container. If not set then
-                                the ephemeral container uses the namespaces configured
-                                in the Pod spec. \n The container runtime must implement
-                                support for this feature. If the runtime does not
-                                support namespace targeting then the result of setting
-                                this field is undefined."
+                              description: |-
+                                If set, the name of the container from PodSpec that this ephemeral container targets.
+                                The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.
+                                If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+
+                                The container runtime must implement support for this feature. If the runtime does not
+                                support namespace targeting then the result of setting this field is undefined.
                               type: string
                             terminationMessagePath:
-                              description: 'Optional: Path at which the file to which
-                                the container''s termination message will be written
-                                is mounted into the container''s filesystem. Message
-                                written is intended to be brief final status, such
-                                as an assertion failure message. Will be truncated
-                                by the node if greater than 4096 bytes. The total
-                                message length across all containers will be limited
-                                to 12kb. Defaults to /dev/termination-log. Cannot
-                                be updated.'
+                              description: |-
+                                Optional: Path at which the file to which the container's termination message
+                                will be written is mounted into the container's filesystem.
+                                Message written is intended to be brief final status, such as an assertion failure message.
+                                Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                all containers will be limited to 12kb.
+                                Defaults to /dev/termination-log.
+                                Cannot be updated.
                               type: string
                             terminationMessagePolicy:
-                              description: Indicate how the termination message should
-                                be populated. File will use the contents of terminationMessagePath
-                                to populate the container status message on both success
-                                and failure. FallbackToLogsOnError will use the last
-                                chunk of container log output if the termination message
-                                file is empty and the container exited with an error.
-                                The log output is limited to 2048 bytes or 80 lines,
-                                whichever is smaller. Defaults to File. Cannot be
-                                updated.
+                              description: |-
+                                Indicate how the termination message should be populated. File will use the contents of
+                                terminationMessagePath to populate the container status message on both success and failure.
+                                FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                message file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                Defaults to File.
+                                Cannot be updated.
                               type: string
                             tty:
-                              description: Whether this container should allocate
-                                a TTY for itself, also requires 'stdin' to be true.
+                              description: |-
+                                Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
                                 Default is false.
                               type: boolean
                             volumeDevices:
@@ -3884,181 +3740,232 @@ spec:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - devicePath
+                              x-kubernetes-list-type: map
                             volumeMounts:
-                              description: Pod volumes to mount into the container's
-                                filesystem. Subpath mounts are not allowed for ephemeral
-                                containers. Cannot be updated.
+                              description: |-
+                                Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers.
+                                Cannot be updated.
                               items:
                                 description: VolumeMount describes a mounting of a
                                   Volume within a container.
                                 properties:
                                   mountPath:
-                                    description: Path within the container at which
-                                      the volume should be mounted.  Must not contain
-                                      ':'.
+                                    description: |-
+                                      Path within the container at which the volume should be mounted.  Must
+                                      not contain ':'.
                                     type: string
                                   mountPropagation:
-                                    description: mountPropagation determines how mounts
-                                      are propagated from the host to container and
-                                      the other way around. When not set, MountPropagationNone
-                                      is used. This field is beta in 1.10.
+                                    description: |-
+                                      mountPropagation determines how mounts are propagated from the host
+                                      to container and the other way around.
+                                      When not set, MountPropagationNone is used.
+                                      This field is beta in 1.10.
+                                      When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                      (which defaults to None).
                                     type: string
                                   name:
                                     description: This must match the Name of a Volume.
                                     type: string
                                   readOnly:
-                                    description: Mounted read-only if true, read-write
-                                      otherwise (false or unspecified). Defaults to
-                                      false.
+                                    description: |-
+                                      Mounted read-only if true, read-write otherwise (false or unspecified).
+                                      Defaults to false.
                                     type: boolean
+                                  recursiveReadOnly:
+                                    description: |-
+                                      RecursiveReadOnly specifies whether read-only mounts should be handled
+                                      recursively.
+
+
+                                      If ReadOnly is false, this field has no meaning and must be unspecified.
+
+
+                                      If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                      recursively read-only.  If this field is set to IfPossible, the mount is made
+                                      recursively read-only, if it is supported by the container runtime.  If this
+                                      field is set to Enabled, the mount is made recursively read-only if it is
+                                      supported by the container runtime, otherwise the pod will not be started and
+                                      an error will be generated to indicate the reason.
+
+
+                                      If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                      None (or be unspecified, which defaults to None).
+
+
+                                      If this field is not specified, it is treated as an equivalent of Disabled.
+                                    type: string
                                   subPath:
-                                    description: Path within the volume from which
-                                      the container's volume should be mounted. Defaults
-                                      to "" (volume's root).
+                                    description: |-
+                                      Path within the volume from which the container's volume should be mounted.
+                                      Defaults to "" (volume's root).
                                     type: string
                                   subPathExpr:
-                                    description: Expanded path within the volume from
-                                      which the container's volume should be mounted.
-                                      Behaves similarly to SubPath but environment
-                                      variable references $(VAR_NAME) are expanded
-                                      using the container's environment. Defaults
-                                      to "" (volume's root). SubPathExpr and SubPath
-                                      are mutually exclusive.
+                                    description: |-
+                                      Expanded path within the volume from which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                      Defaults to "" (volume's root).
+                                      SubPathExpr and SubPath are mutually exclusive.
                                     type: string
                                 required:
                                 - mountPath
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - mountPath
+                              x-kubernetes-list-type: map
                             workingDir:
-                              description: Container's working directory. If not specified,
-                                the container runtime's default will be used, which
-                                might be configured in the container image. Cannot
-                                be updated.
+                              description: |-
+                                Container's working directory.
+                                If not specified, the container runtime's default will be used, which
+                                might be configured in the container image.
+                                Cannot be updated.
                               type: string
                           required:
                           - name
                           type: object
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       hostAliases:
-                        description: HostAliases is an optional list of hosts and
-                          IPs that will be injected into the pod's hosts file if specified.
-                          This is only valid for non-hostNetwork pods.
+                        description: |-
+                          HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts
+                          file if specified.
                         items:
-                          description: HostAlias holds the mapping between IP and
-                            hostnames that will be injected as an entry in the pod's
-                            hosts file.
+                          description: |-
+                            HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+                            pod's hosts file.
                           properties:
                             hostnames:
                               description: Hostnames for the above IP address.
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             ip:
                               description: IP address of the host file entry.
                               type: string
+                          required:
+                          - ip
                           type: object
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - ip
+                        x-kubernetes-list-type: map
                       hostIPC:
-                        description: 'Use the host''s ipc namespace. Optional: Default
-                          to false.'
+                        description: |-
+                          Use the host's ipc namespace.
+                          Optional: Default to false.
                         type: boolean
                       hostNetwork:
-                        description: Host networking requested for this pod. Use the
-                          host's network namespace. If this option is set, the ports
-                          that will be used must be specified. Default to false.
+                        description: |-
+                          Host networking requested for this pod. Use the host's network namespace.
+                          If this option is set, the ports that will be used must be specified.
+                          Default to false.
                         type: boolean
                       hostPID:
-                        description: 'Use the host''s pid namespace. Optional: Default
-                          to false.'
+                        description: |-
+                          Use the host's pid namespace.
+                          Optional: Default to false.
                         type: boolean
                       hostUsers:
-                        description: 'Use the host''s user namespace. Optional: Default
-                          to true. If set to true or not present, the pod will be
-                          run in the host user namespace, useful for when the pod
-                          needs a feature only available to the host user namespace,
-                          such as loading a kernel module with CAP_SYS_MODULE. When
-                          set to false, a new userns is created for the pod. Setting
-                          false is useful for mitigating container breakout vulnerabilities
-                          even allowing users to run their containers as root without
-                          actually having root privileges on the host. This field
-                          is alpha-level and is only honored by servers that enable
-                          the UserNamespacesSupport feature.'
+                        description: |-
+                          Use the host's user namespace.
+                          Optional: Default to true.
+                          If set to true or not present, the pod will be run in the host user namespace, useful
+                          for when the pod needs a feature only available to the host user namespace, such as
+                          loading a kernel module with CAP_SYS_MODULE.
+                          When set to false, a new userns is created for the pod. Setting false is useful for
+                          mitigating container breakout vulnerabilities even allowing users to run their
+                          containers as root without actually having root privileges on the host.
+                          This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.
                         type: boolean
                       hostname:
-                        description: Specifies the hostname of the Pod If not specified,
-                          the pod's hostname will be set to a system-defined value.
+                        description: |-
+                          Specifies the hostname of the Pod
+                          If not specified, the pod's hostname will be set to a system-defined value.
                         type: string
                       imagePullSecrets:
-                        description: 'ImagePullSecrets is an optional list of references
-                          to secrets in the same namespace to use for pulling any
-                          of the images used by this PodSpec. If specified, these
-                          secrets will be passed to individual puller implementations
-                          for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                        description: |-
+                          ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+                          If specified, these secrets will be passed to individual puller implementations for them to use.
+                          More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
                         items:
-                          description: LocalObjectReference contains enough information
-                            to let you locate the referenced object inside the same
-                            namespace.
+                          description: |-
+                            LocalObjectReference contains enough information to let you locate the
+                            referenced object inside the same namespace.
                           properties:
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       initContainers:
-                        description: 'List of initialization containers belonging
-                          to the pod. Init containers are executed in order prior
-                          to containers being started. If any init container fails,
-                          the pod is considered to have failed and is handled according
-                          to its restartPolicy. The name for an init container or
-                          normal container must be unique among all containers. Init
-                          containers may not have Lifecycle actions, Readiness probes,
-                          Liveness probes, or Startup probes. The resourceRequirements
-                          of an init container are taken into account during scheduling
-                          by finding the highest request/limit for each resource type,
-                          and then using the max of of that value or the sum of the
-                          normal containers. Limits are applied to init containers
-                          in a similar fashion. Init containers cannot currently be
-                          added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                        description: |-
+                          List of initialization containers belonging to the pod.
+                          Init containers are executed in order prior to containers being started. If any
+                          init container fails, the pod is considered to have failed and is handled according
+                          to its restartPolicy. The name for an init container or normal container must be
+                          unique among all containers.
+                          Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+                          The resourceRequirements of an init container are taken into account during scheduling
+                          by finding the highest request/limit for each resource type, and then using the max of
+                          of that value or the sum of the normal containers. Limits are applied to init containers
+                          in a similar fashion.
+                          Init containers cannot currently be added or removed.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
                         items:
                           description: A single application container that you want
                             to run within a pod.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The container
-                                image''s CMD is used if this is not provided. Variable
-                                references $(VAR_NAME) are expanded using the container''s
-                                environment. If a variable cannot be resolved, the
-                                reference in the input string will be unchanged. Double
-                                $$ are reduced to a single $, which allows for escaping
-                                the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
-                                the string literal "$(VAR_NAME)". Escaped references
-                                will never be expanded, regardless of whether the
-                                variable exists or not. Cannot be updated. More info:
-                                https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: |-
+                                Arguments to the entrypoint.
+                                The container image's CMD is used if this is not provided.
+                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             command:
-                              description: 'Entrypoint array. Not executed within
-                                a shell. The container image''s ENTRYPOINT is used
-                                if this is not provided. Variable references $(VAR_NAME)
-                                are expanded using the container''s environment. If
-                                a variable cannot be resolved, the reference in the
-                                input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME)
-                                syntax: i.e. "$$(VAR_NAME)" will produce the string
-                                literal "$(VAR_NAME)". Escaped references will never
-                                be expanded, regardless of whether the variable exists
-                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: |-
+                                Entrypoint array. Not executed within a shell.
+                                The container image's ENTRYPOINT is used if this is not provided.
+                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             env:
-                              description: List of environment variables to set in
-                                the container. Cannot be updated.
+                              description: |-
+                                List of environment variables to set in the container.
+                                Cannot be updated.
                               items:
                                 description: EnvVar represents an environment variable
                                   present in a Container.
@@ -4068,17 +3975,16 @@ spec:
                                       Must be a C_IDENTIFIER.
                                     type: string
                                   value:
-                                    description: 'Variable references $(VAR_NAME)
-                                      are expanded using the previously defined environment
-                                      variables in the container and any service environment
-                                      variables. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged.
-                                      Double $$ are reduced to a single $, which allows
-                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Defaults
-                                      to "".'
+                                    description: |-
+                                      Variable references $(VAR_NAME) are expanded
+                                      using the previously defined environment variables in the container and
+                                      any service environment variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                      "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless of whether the variable
+                                      exists or not.
+                                      Defaults to "".
                                     type: string
                                   valueFrom:
                                     description: Source for the environment variable's
@@ -4088,64 +3994,37 @@ spec:
                                         description: Selects a key of a ConfigMap.
                                         properties:
                                           key:
-                                            description: The key to select.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            default: ""
                                             type: string
                                           optional:
-                                            description: Specify whether the ConfigMap
-                                              or its key must be defined
                                             type: boolean
                                         required:
                                         - key
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       fieldRef:
-                                        description: 'Selects a field of the pod:
-                                          supports metadata.name, metadata.namespace,
-                                          `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                          spec.nodeName, spec.serviceAccountName,
-                                          status.hostIP, status.podIP, status.podIPs.'
                                         properties:
                                           apiVersion:
-                                            description: Version of the schema the
-                                              FieldPath is written in terms of, defaults
-                                              to "v1".
                                             type: string
                                           fieldPath:
-                                            description: Path of the field to select
-                                              in the specified API version.
                                             type: string
                                         required:
                                         - fieldPath
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       resourceFieldRef:
-                                        description: 'Selects a resource of the container:
-                                          only resources limits and requests (limits.cpu,
-                                          limits.memory, limits.ephemeral-storage,
-                                          requests.cpu, requests.memory and requests.ephemeral-storage)
-                                          are currently supported.'
                                         properties:
                                           containerName:
-                                            description: 'Container name: required
-                                              for volumes, optional for env vars'
                                             type: string
                                           divisor:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Specifies the output format
-                                              of the exposed resources, defaults to
-                                              "1"
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           resource:
-                                            description: 'Required: resource to select'
                                             type: string
                                         required:
                                         - resource
@@ -4156,19 +4035,11 @@ spec:
                                           the pod's namespace
                                         properties:
                                           key:
-                                            description: The key of the secret to
-                                              select from.  Must be a valid secret
-                                              key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            default: ""
                                             type: string
                                           optional:
-                                            description: Specify whether the Secret
-                                              or its key must be defined
                                             type: boolean
                                         required:
                                         - key
@@ -4179,15 +4050,17 @@ spec:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             envFrom:
-                              description: List of sources to populate environment
-                                variables in the container. The keys defined within
-                                a source must be a C_IDENTIFIER. All invalid keys
-                                will be reported as an event when the container is
-                                starting. When a key exists in multiple sources, the
-                                value associated with the last source will take precedence.
-                                Values defined by an Env with a duplicate key will
-                                take precedence. Cannot be updated.
+                              description: |-
+                                List of sources to populate environment variables in the container.
+                                The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is starting. When a key exists in multiple
+                                sources, the value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will take precedence.
+                                Cannot be updated.
                               items:
                                 description: EnvFromSource represents the source of
                                   a set of ConfigMaps
@@ -4196,10 +4069,7 @@ spec:
                                     description: The ConfigMap to select from
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        default: ""
                                         type: string
                                       optional:
                                         description: Specify whether the ConfigMap
@@ -4215,10 +4085,7 @@ spec:
                                     description: The Secret to select from
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        default: ""
                                         type: string
                                       optional:
                                         description: Specify whether the Secret must
@@ -4228,64 +4095,51 @@ spec:
                                     x-kubernetes-map-type: atomic
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             image:
-                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                                This field is optional to allow higher level config
-                                management to default or override container images
-                                in workload controllers like Deployments and StatefulSets.'
+                              description: |-
+                                Container image name.
+                                More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config management to default or override
+                                container images in workload controllers like Deployments and StatefulSets.
                               type: string
                             imagePullPolicy:
-                              description: 'Image pull policy. One of Always, Never,
-                                IfNotPresent. Defaults to Always if :latest tag is
-                                specified, or IfNotPresent otherwise. Cannot be updated.
-                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                              description: |-
+                                Image pull policy.
+                                One of Always, Never, IfNotPresent.
+                                Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                               type: string
                             lifecycle:
-                              description: Actions that the management system should
-                                take in response to container lifecycle events. Cannot
-                                be updated.
+                              description: |-
+                                Actions that the management system should take in response to container lifecycle events.
+                                Cannot be updated.
                               properties:
                                 postStart:
-                                  description: 'PostStart is called immediately after
-                                    a container is created. If the handler fails,
-                                    the container is terminated and restarted according
-                                    to its restart policy. Other management of the
-                                    container blocks until the hook completes. More
-                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  description: |-
+                                    PostStart is called immediately after a container is created. If the handler fails,
+                                    the container is terminated and restarted according to its restart policy.
+                                    Other management of the container blocks until the hook completes.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                   properties:
                                     exec:
                                       description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
-                                            to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                     httpGet:
                                       description: HTTPGet specifies the http request
                                         to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the
-                                            request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom
-                                              header to be used in HTTP probes
                                             properties:
                                               name:
                                                 type: string
@@ -4296,98 +4150,75 @@ spec:
                                             - value
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         path:
-                                          description: Path to access on the HTTP
-                                            server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting
-                                            to the host. Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
+                                    sleep:
+                                      description: Sleep represents the duration that
+                                        the container should sleep before being terminated.
+                                      properties:
+                                        seconds:
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
+                                      type: object
                                     tcpSocket:
-                                      description: Deprecated. TCPSocket is NOT supported
-                                        as a LifecycleHandler and kept for the backward
-                                        compatibility. There are no validation of
-                                        this field and lifecycle hooks will fail in
-                                        runtime when tcp handler is specified.
+                                      description: |-
+                                        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                        for the backward compatibility. There are no validation of this field and
+                                        lifecycle hooks will fail in runtime when tcp handler is specified.
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect
-                                            to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                   type: object
                                 preStop:
-                                  description: 'PreStop is called immediately before
-                                    a container is terminated due to an API request
-                                    or management event such as liveness/startup probe
-                                    failure, preemption, resource contention, etc.
-                                    The handler is not called if the container crashes
-                                    or exits. The Pod''s termination grace period
-                                    countdown begins before the PreStop hook is executed.
-                                    Regardless of the outcome of the handler, the
-                                    container will eventually terminate within the
-                                    Pod''s termination grace period (unless delayed
-                                    by finalizers). Other management of the container
-                                    blocks until the hook completes or until the termination
-                                    grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  description: |-
+                                    PreStop is called immediately before a container is terminated due to an
+                                    API request or management event such as liveness/startup probe failure,
+                                    preemption, resource contention, etc. The handler is not called if the
+                                    container crashes or exits. The Pod's termination grace period countdown begins before the
+                                    PreStop hook is executed. Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the Pod's termination grace
+                                    period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                   properties:
                                     exec:
                                       description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
-                                            to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                     httpGet:
                                       description: HTTPGet specifies the http request
                                         to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the
-                                            request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom
-                                              header to be used in HTTP probes
                                             properties:
                                               name:
                                                 type: string
@@ -4398,45 +4229,41 @@ spec:
                                             - value
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         path:
-                                          description: Path to access on the HTTP
-                                            server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting
-                                            to the host. Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
+                                    sleep:
+                                      description: Sleep represents the duration that
+                                        the container should sleep before being terminated.
+                                      properties:
+                                        seconds:
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
+                                      type: object
                                     tcpSocket:
-                                      description: Deprecated. TCPSocket is NOT supported
-                                        as a LifecycleHandler and kept for the backward
-                                        compatibility. There are no validation of
-                                        this field and lifecycle hooks will fail in
-                                        runtime when tcp handler is specified.
+                                      description: |-
+                                        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                        for the backward compatibility. There are no validation of this field and
+                                        lifecycle hooks will fail in runtime when tcp handler is specified.
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect
-                                            to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
@@ -4444,30 +4271,30 @@ spec:
                                   type: object
                               type: object
                             livenessProbe:
-                              description: 'Periodic probe of container liveness.
-                                Container will be restarted if the probe fails. Cannot
-                                be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: |-
+                                Periodic probe of container liveness.
+                                Container will be restarted if the probe fails.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                               properties:
                                 exec:
                                   description: Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the
-                                    probe to be considered failed after having succeeded.
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                     Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
@@ -4481,11 +4308,12 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service
-                                        to place in the gRPC HealthCheckRequest (see
-                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                        \n If this is not specified, the default behavior
-                                        is defined by gRPC."
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
@@ -4495,9 +4323,9 @@ spec:
                                     to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
                                       description: Custom headers to set in the request.
@@ -4507,19 +4335,15 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name. This
-                                              will be canonicalized upon output, so
-                                              case-variant names will be understood
-                                              as the same header.
                                             type: string
                                           value:
-                                            description: The header field value
                                             type: string
                                         required:
                                         - name
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       description: Path to access on the HTTP server.
                                       type: string
@@ -4527,34 +4351,35 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container
-                                    has started before liveness probes are initiated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the
-                                    probe. Default to 10 seconds. Minimum value is
-                                    1.
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the
-                                    probe to be considered successful after having
-                                    failed. Defaults to 1. Must be 1 for liveness
-                                    and startup. Minimum value is 1.
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
@@ -4569,61 +4394,59 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
-                                  description: Optional duration in seconds the pod
-                                    needs to terminate gracefully upon probe failure.
-                                    The grace period is the duration in seconds after
-                                    the processes running in the pod are sent a termination
-                                    signal and the time when the processes are forcibly
-                                    halted with a kill signal. Set this value longer
-                                    than the expected cleanup time for your process.
-                                    If this value is nil, the pod's terminationGracePeriodSeconds
-                                    will be used. Otherwise, this value overrides
-                                    the value provided by the pod spec. Value must
-                                    be non-negative integer. The value zero indicates
-                                    stop immediately via the kill signal (no opportunity
-                                    to shut down). This is a beta field and requires
-                                    enabling ProbeTerminationGracePeriod feature gate.
-                                    Minimum value is 1. spec.terminationGracePeriodSeconds
-                                    is used if unset.
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the
-                                    probe times out. Defaults to 1 second. Minimum
-                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                               type: object
                             name:
-                              description: Name of the container specified as a DNS_LABEL.
+                              description: |-
+                                Name of the container specified as a DNS_LABEL.
                                 Each container in a pod must have a unique name (DNS_LABEL).
                                 Cannot be updated.
                               type: string
                             ports:
-                              description: List of ports to expose from the container.
-                                Not specifying a port here DOES NOT prevent that port
-                                from being exposed. Any port which is listening on
-                                the default "0.0.0.0" address inside a container will
-                                be accessible from the network. Modifying this array
-                                with strategic merge patch may corrupt the data. For
-                                more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                              description: |-
+                                List of ports to expose from the container. Not specifying a port here
+                                DOES NOT prevent that port from being exposed. Any port which is
+                                listening on the default "0.0.0.0" address inside a container will be
+                                accessible from the network.
+                                Modifying this array with strategic merge patch may corrupt the data.
+                                For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                 Cannot be updated.
                               items:
                                 description: ContainerPort represents a network port
                                   in a single container.
                                 properties:
                                   containerPort:
-                                    description: Number of port to expose on the pod's
-                                      IP address. This must be a valid port number,
-                                      0 < x < 65536.
+                                    description: |-
+                                      Number of port to expose on the pod's IP address.
+                                      This must be a valid port number, 0 < x < 65536.
                                     format: int32
                                     type: integer
                                   hostIP:
@@ -4631,23 +4454,24 @@ spec:
                                       port to.
                                     type: string
                                   hostPort:
-                                    description: Number of port to expose on the host.
-                                      If specified, this must be a valid port number,
-                                      0 < x < 65536. If HostNetwork is specified,
-                                      this must match ContainerPort. Most containers
-                                      do not need this.
+                                    description: |-
+                                      Number of port to expose on the host.
+                                      If specified, this must be a valid port number, 0 < x < 65536.
+                                      If HostNetwork is specified, this must match ContainerPort.
+                                      Most containers do not need this.
                                     format: int32
                                     type: integer
                                   name:
-                                    description: If specified, this must be an IANA_SVC_NAME
-                                      and unique within the pod. Each named port in
-                                      a pod must have a unique name. Name for the
-                                      port that can be referred to by services.
+                                    description: |-
+                                      If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                      named port in a pod must have a unique name. Name for the port that can be
+                                      referred to by services.
                                     type: string
                                   protocol:
                                     default: TCP
-                                    description: Protocol for port. Must be UDP, TCP,
-                                      or SCTP. Defaults to "TCP".
+                                    description: |-
+                                      Protocol for port. Must be UDP, TCP, or SCTP.
+                                      Defaults to "TCP".
                                     type: string
                                 required:
                                 - containerPort
@@ -4658,30 +4482,30 @@ spec:
                               - protocol
                               x-kubernetes-list-type: map
                             readinessProbe:
-                              description: 'Periodic probe of container service readiness.
-                                Container will be removed from service endpoints if
-                                the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: |-
+                                Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if the probe fails.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                               properties:
                                 exec:
                                   description: Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the
-                                    probe to be considered failed after having succeeded.
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                     Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
@@ -4695,11 +4519,12 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service
-                                        to place in the gRPC HealthCheckRequest (see
-                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                        \n If this is not specified, the default behavior
-                                        is defined by gRPC."
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
@@ -4709,9 +4534,9 @@ spec:
                                     to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
                                       description: Custom headers to set in the request.
@@ -4721,19 +4546,15 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name. This
-                                              will be canonicalized upon output, so
-                                              case-variant names will be understood
-                                              as the same header.
                                             type: string
                                           value:
-                                            description: The header field value
                                             type: string
                                         required:
                                         - name
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       description: Path to access on the HTTP server.
                                       type: string
@@ -4741,34 +4562,35 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container
-                                    has started before liveness probes are initiated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the
-                                    probe. Default to 10 seconds. Minimum value is
-                                    1.
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the
-                                    probe to be considered successful after having
-                                    failed. Defaults to 1. Must be 1 for liveness
-                                    and startup. Minimum value is 1.
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
@@ -4783,36 +4605,33 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
-                                  description: Optional duration in seconds the pod
-                                    needs to terminate gracefully upon probe failure.
-                                    The grace period is the duration in seconds after
-                                    the processes running in the pod are sent a termination
-                                    signal and the time when the processes are forcibly
-                                    halted with a kill signal. Set this value longer
-                                    than the expected cleanup time for your process.
-                                    If this value is nil, the pod's terminationGracePeriodSeconds
-                                    will be used. Otherwise, this value overrides
-                                    the value provided by the pod spec. Value must
-                                    be non-negative integer. The value zero indicates
-                                    stop immediately via the kill signal (no opportunity
-                                    to shut down). This is a beta field and requires
-                                    enabling ProbeTerminationGracePeriod feature gate.
-                                    Minimum value is 1. spec.terminationGracePeriodSeconds
-                                    is used if unset.
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the
-                                    probe times out. Defaults to 1 second. Minimum
-                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                               type: object
@@ -4823,14 +4642,14 @@ spec:
                                   resize policy for the container.
                                 properties:
                                   resourceName:
-                                    description: 'Name of the resource to which this
-                                      resource resize policy applies. Supported values:
-                                      cpu, memory.'
+                                    description: |-
+                                      Name of the resource to which this resource resize policy applies.
+                                      Supported values: cpu, memory.
                                     type: string
                                   restartPolicy:
-                                    description: Restart policy to apply when specified
-                                      resource is resized. If not specified, it defaults
-                                      to NotRequired.
+                                    description: |-
+                                      Restart policy to apply when specified resource is resized.
+                                      If not specified, it defaults to NotRequired.
                                     type: string
                                 required:
                                 - resourceName
@@ -4839,25 +4658,31 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             resources:
-                              description: 'Compute Resources required by this container.
-                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              description: |-
+                                Compute Resources required by this container.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                               properties:
                                 claims:
-                                  description: "Claims lists the names of resources,
-                                    defined in spec.resourceClaims, that are used
-                                    by this container. \n This is an alpha field and
-                                    requires enabling the DynamicResourceAllocation
-                                    feature gate. \n This field is immutable. It can
-                                    only be set for containers."
+                                  description: |-
+                                    Claims lists the names of resources, defined in spec.resourceClaims,
+                                    that are used by this container.
+
+
+                                    This is an alpha field and requires enabling the
+                                    DynamicResourceAllocation feature gate.
+
+
+                                    This field is immutable. It can only be set for containers.
                                   items:
                                     description: ResourceClaim references one entry
                                       in PodSpec.ResourceClaims.
                                     properties:
                                       name:
-                                        description: Name must match the name of one
-                                          entry in pod.spec.resourceClaims of the
-                                          Pod where this field is used. It makes that
-                                          resource available inside a container.
+                                        description: |-
+                                          Name must match the name of one entry in pod.spec.resourceClaims of
+                                          the Pod where this field is used. It makes that resource available
+                                          inside a container.
                                         type: string
                                     required:
                                     - name
@@ -4873,8 +4698,9 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Limits describes the maximum amount
-                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                   type: object
                                 requests:
                                   additionalProperties:
@@ -4883,57 +4709,76 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Requests describes the minimum amount
-                                    of compute resources required. If Requests is
-                                    omitted for a container, it defaults to Limits
-                                    if that is explicitly specified, otherwise to
-                                    an implementation-defined value. Requests cannot
-                                    exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                   type: object
                               type: object
                             restartPolicy:
-                              description: 'RestartPolicy defines the restart behavior
-                                of individual containers in a pod. This field may
-                                only be set for init containers, and the only allowed
-                                value is "Always". For non-init containers or when
-                                this field is not specified, the restart behavior
-                                is defined by the Pod''s restart policy and the container
-                                type. Setting the RestartPolicy as "Always" for the
-                                init container will have the following effect: this
-                                init container will be continually restarted on exit
-                                until all regular containers have terminated. Once
-                                all regular containers have completed, all init containers
-                                with restartPolicy "Always" will be shut down. This
-                                lifecycle differs from normal init containers and
-                                is often referred to as a "sidecar" container. Although
-                                this init container still starts in the init container
-                                sequence, it does not wait for the container to complete
-                                before proceeding to the next init container. Instead,
-                                the next init container starts immediately after this
-                                init container is started, or after any startupProbe
-                                has successfully completed.'
+                              description: |-
+                                RestartPolicy defines the restart behavior of individual containers in a pod.
+                                This field may only be set for init containers, and the only allowed value is "Always".
+                                For non-init containers or when this field is not specified,
+                                the restart behavior is defined by the Pod's restart policy and the container type.
+                                Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                                this init container will be continually restarted on
+                                exit until all regular containers have terminated. Once all regular
+                                containers have completed, all init containers with restartPolicy "Always"
+                                will be shut down. This lifecycle differs from normal init containers and
+                                is often referred to as a "sidecar" container. Although this init
+                                container still starts in the init container sequence, it does not wait
+                                for the container to complete before proceeding to the next init
+                                container. Instead, the next init container starts immediately after this
+                                init container is started, or after any startupProbe has successfully
+                                completed.
                               type: string
                             securityContext:
-                              description: 'SecurityContext defines the security options
-                                the container should be run with. If set, the fields
-                                of SecurityContext override the equivalent fields
-                                of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              description: |-
+                                SecurityContext defines the security options the container should be run with.
+                                If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                               properties:
                                 allowPrivilegeEscalation:
-                                  description: 'AllowPrivilegeEscalation controls
-                                    whether a process can gain more privileges than
-                                    its parent process. This bool directly controls
-                                    if the no_new_privs flag will be set on the container
-                                    process. AllowPrivilegeEscalation is true always
-                                    when the container is: 1) run as Privileged 2)
-                                    has CAP_SYS_ADMIN Note that this field cannot
-                                    be set when spec.os.name is windows.'
+                                  description: |-
+                                    AllowPrivilegeEscalation controls whether a process can gain more
+                                    privileges than its parent process. This bool directly controls if
+                                    the no_new_privs flag will be set on the container process.
+                                    AllowPrivilegeEscalation is true always when the container is:
+                                    1) run as Privileged
+                                    2) has CAP_SYS_ADMIN
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
+                                appArmorProfile:
+                                  description: |-
+                                    appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                    overrides the pod's appArmorProfile.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: |-
+                                        localhostProfile indicates a profile loaded on the node that should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must match the loaded name of the profile.
+                                        Must be set if and only if type is "Localhost".
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of AppArmor profile will be applied.
+                                        Valid options are:
+                                          Localhost - a profile pre-loaded on the node.
+                                          RuntimeDefault - the container runtime's default profile.
+                                          Unconfined - no AppArmor enforcement.
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
                                 capabilities:
-                                  description: The capabilities to add/drop when running
-                                    containers. Defaults to the default set of capabilities
-                                    granted by the container runtime. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    The capabilities to add/drop when running containers.
+                                    Defaults to the default set of capabilities granted by the container runtime.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     add:
                                       description: Added capabilities
@@ -4942,6 +4787,7 @@ spec:
                                           type
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     drop:
                                       description: Removed capabilities
                                       items:
@@ -4949,68 +4795,63 @@ spec:
                                           type
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 privileged:
-                                  description: Run container in privileged mode. Processes
-                                    in privileged containers are essentially equivalent
-                                    to root on the host. Defaults to false. Note that
-                                    this field cannot be set when spec.os.name is
-                                    windows.
+                                  description: |-
+                                    Run container in privileged mode.
+                                    Processes in privileged containers are essentially equivalent to root on the host.
+                                    Defaults to false.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
                                 procMount:
-                                  description: procMount denotes the type of proc
-                                    mount to use for the containers. The default is
-                                    DefaultProcMount which uses the container runtime
-                                    defaults for readonly paths and masked paths.
-                                    This requires the ProcMountType feature flag to
-                                    be enabled. Note that this field cannot be set
-                                    when spec.os.name is windows.
+                                  description: |-
+                                    procMount denotes the type of proc mount to use for the containers.
+                                    The default is DefaultProcMount which uses the container runtime defaults for
+                                    readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to be enabled.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: string
                                 readOnlyRootFilesystem:
-                                  description: Whether this container has a read-only
-                                    root filesystem. Default is false. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    Whether this container has a read-only root filesystem.
+                                    Default is false.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
                                 runAsGroup:
-                                  description: The GID to run the entrypoint of the
-                                    container process. Uses runtime default if unset.
-                                    May also be set in PodSecurityContext.  If set
-                                    in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    The GID to run the entrypoint of the container process.
+                                    Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
-                                  description: Indicates that the container must run
-                                    as a non-root user. If true, the Kubelet will
-                                    validate the image at runtime to ensure that it
-                                    does not run as UID 0 (root) and fail to start
-                                    the container if it does. If unset or false, no
-                                    such validation will be performed. May also be
-                                    set in PodSecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence.
+                                  description: |-
+                                    Indicates that the container must run as a non-root user.
+                                    If true, the Kubelet will validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start the container if it does.
+                                    If unset or false, no such validation will be performed.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   type: boolean
                                 runAsUser:
-                                  description: The UID to run the entrypoint of the
-                                    container process. Defaults to user specified
-                                    in image metadata if unspecified. May also be
-                                    set in PodSecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    The UID to run the entrypoint of the container process.
+                                    Defaults to user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
-                                  description: The SELinux context to be applied to
-                                    the container. If unspecified, the container runtime
-                                    will allocate a random SELinux context for each
-                                    container.  May also be set in PodSecurityContext.  If
-                                    set in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    The SELinux context to be applied to the container.
+                                    If unspecified, the container runtime will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -5030,104 +4871,93 @@ spec:
                                       type: string
                                   type: object
                                 seccompProfile:
-                                  description: The seccomp options to use by this
-                                    container. If seccomp options are provided at
-                                    both the pod & container level, the container
-                                    options override the pod options. Note that this
-                                    field cannot be set when spec.os.name is windows.
+                                  description: |-
+                                    The seccomp options to use by this container. If seccomp options are
+                                    provided at both the pod & container level, the container options
+                                    override the pod options.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     localhostProfile:
-                                      description: localhostProfile indicates a profile
-                                        defined in a file on the node should be used.
-                                        The profile must be preconfigured on the node
-                                        to work. Must be a descending path, relative
-                                        to the kubelet's configured seccomp profile
-                                        location. Must be set if type is "Localhost".
-                                        Must NOT be set for any other type.
+                                      description: |-
+                                        localhostProfile indicates a profile defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                        Must be set if type is "Localhost". Must NOT be set for any other type.
                                       type: string
                                     type:
-                                      description: "type indicates which kind of seccomp
-                                        profile will be applied. Valid options are:
-                                        \n Localhost - a profile defined in a file
-                                        on the node should be used. RuntimeDefault
-                                        - the container runtime default profile should
-                                        be used. Unconfined - no profile should be
-                                        applied."
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied.
+                                        Valid options are:
+
+
+                                        Localhost - a profile defined in a file on the node should be used.
+                                        RuntimeDefault - the container runtime default profile should be used.
+                                        Unconfined - no profile should be applied.
                                       type: string
                                   required:
                                   - type
                                   type: object
                                 windowsOptions:
-                                  description: The Windows specific settings applied
-                                    to all containers. If unspecified, the options
-                                    from the PodSecurityContext will be used. If set
-                                    in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is linux.
+                                  description: |-
+                                    The Windows specific settings applied to all containers.
+                                    If unspecified, the options from the PodSecurityContext will be used.
+                                    If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is linux.
                                   properties:
                                     gmsaCredentialSpec:
-                                      description: GMSACredentialSpec is where the
-                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                        inlines the contents of the GMSA credential
-                                        spec named by the GMSACredentialSpecName field.
+                                      description: |-
+                                        GMSACredentialSpec is where the GMSA admission webhook
+                                        (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                        GMSA credential spec named by the GMSACredentialSpecName field.
                                       type: string
                                     gmsaCredentialSpecName:
                                       description: GMSACredentialSpecName is the name
                                         of the GMSA credential spec to use.
                                       type: string
                                     hostProcess:
-                                      description: HostProcess determines if a container
-                                        should be run as a 'Host Process' container.
-                                        All of a Pod's containers must have the same
-                                        effective HostProcess value (it is not allowed
-                                        to have a mix of HostProcess containers and
-                                        non-HostProcess containers). In addition,
-                                        if HostProcess is true then HostNetwork must
-                                        also be set to true.
+                                      description: |-
+                                        HostProcess determines if a container should be run as a 'Host Process' container.
+                                        All of a Pod's containers must have the same effective HostProcess value
+                                        (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                        In addition, if HostProcess is true then HostNetwork must also be set to true.
                                       type: boolean
                                     runAsUserName:
-                                      description: The UserName in Windows to run
-                                        the entrypoint of the container process. Defaults
-                                        to the user specified in image metadata if
-                                        unspecified. May also be set in PodSecurityContext.
-                                        If set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
+                                      description: |-
+                                        The UserName in Windows to run the entrypoint of the container process.
+                                        Defaults to the user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext. If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: string
                                   type: object
                               type: object
                             startupProbe:
-                              description: 'StartupProbe indicates that the Pod has
-                                successfully initialized. If specified, no other probes
-                                are executed until this completes successfully. If
-                                this probe fails, the Pod will be restarted, just
-                                as if the livenessProbe failed. This can be used to
-                                provide different probe parameters at the beginning
-                                of a Pod''s lifecycle, when it might take a long time
-                                to load data or warm a cache, than during steady-state
-                                operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              description: |-
+                                StartupProbe indicates that the Pod has successfully initialized.
+                                If specified, no other probes are executed until this completes successfully.
+                                If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                This cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                               properties:
                                 exec:
                                   description: Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the
-                                    probe to be considered failed after having succeeded.
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                     Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
@@ -5141,11 +4971,12 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      description: "Service is the name of the service
-                                        to place in the gRPC HealthCheckRequest (see
-                                        https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                        \n If this is not specified, the default behavior
-                                        is defined by gRPC."
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
@@ -5155,9 +4986,9 @@ spec:
                                     to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
                                       description: Custom headers to set in the request.
@@ -5167,19 +4998,15 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name. This
-                                              will be canonicalized upon output, so
-                                              case-variant names will be understood
-                                              as the same header.
                                             type: string
                                           value:
-                                            description: The header field value
                                             type: string
                                         required:
                                         - name
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       description: Path to access on the HTTP server.
                                       type: string
@@ -5187,34 +5014,35 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container
-                                    has started before liveness probes are initiated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the
-                                    probe. Default to 10 seconds. Minimum value is
-                                    1.
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the
-                                    probe to be considered successful after having
-                                    failed. Defaults to 1. Must be 1 for liveness
-                                    and startup. Minimum value is 1.
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
@@ -5229,83 +5057,75 @@ spec:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
-                                  description: Optional duration in seconds the pod
-                                    needs to terminate gracefully upon probe failure.
-                                    The grace period is the duration in seconds after
-                                    the processes running in the pod are sent a termination
-                                    signal and the time when the processes are forcibly
-                                    halted with a kill signal. Set this value longer
-                                    than the expected cleanup time for your process.
-                                    If this value is nil, the pod's terminationGracePeriodSeconds
-                                    will be used. Otherwise, this value overrides
-                                    the value provided by the pod spec. Value must
-                                    be non-negative integer. The value zero indicates
-                                    stop immediately via the kill signal (no opportunity
-                                    to shut down). This is a beta field and requires
-                                    enabling ProbeTerminationGracePeriod feature gate.
-                                    Minimum value is 1. spec.terminationGracePeriodSeconds
-                                    is used if unset.
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the
-                                    probe times out. Defaults to 1 second. Minimum
-                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                               type: object
                             stdin:
-                              description: Whether this container should allocate
-                                a buffer for stdin in the container runtime. If this
-                                is not set, reads from stdin in the container will
-                                always result in EOF. Default is false.
+                              description: |-
+                                Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will always result in EOF.
+                                Default is false.
                               type: boolean
                             stdinOnce:
-                              description: Whether the container runtime should close
-                                the stdin channel after it has been opened by a single
-                                attach. When stdin is true the stdin stream will remain
-                                open across multiple attach sessions. If stdinOnce
-                                is set to true, stdin is opened on container start,
-                                is empty until the first client attaches to stdin,
-                                and then remains open and accepts data until the client
-                                disconnects, at which time stdin is closed and remains
-                                closed until the container is restarted. If this flag
-                                is false, a container processes that reads from stdin
-                                will never receive an EOF. Default is false
+                              description: |-
+                                Whether the container runtime should close the stdin channel after it has been opened by
+                                a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                at which time stdin is closed and remains closed until the container is restarted. If this
+                                flag is false, a container processes that reads from stdin will never receive an EOF.
+                                Default is false
                               type: boolean
                             terminationMessagePath:
-                              description: 'Optional: Path at which the file to which
-                                the container''s termination message will be written
-                                is mounted into the container''s filesystem. Message
-                                written is intended to be brief final status, such
-                                as an assertion failure message. Will be truncated
-                                by the node if greater than 4096 bytes. The total
-                                message length across all containers will be limited
-                                to 12kb. Defaults to /dev/termination-log. Cannot
-                                be updated.'
+                              description: |-
+                                Optional: Path at which the file to which the container's termination message
+                                will be written is mounted into the container's filesystem.
+                                Message written is intended to be brief final status, such as an assertion failure message.
+                                Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                all containers will be limited to 12kb.
+                                Defaults to /dev/termination-log.
+                                Cannot be updated.
                               type: string
                             terminationMessagePolicy:
-                              description: Indicate how the termination message should
-                                be populated. File will use the contents of terminationMessagePath
-                                to populate the container status message on both success
-                                and failure. FallbackToLogsOnError will use the last
-                                chunk of container log output if the termination message
-                                file is empty and the container exited with an error.
-                                The log output is limited to 2048 bytes or 80 lines,
-                                whichever is smaller. Defaults to File. Cannot be
-                                updated.
+                              description: |-
+                                Indicate how the termination message should be populated. File will use the contents of
+                                terminationMessagePath to populate the container status message on both success and failure.
+                                FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                message file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                Defaults to File.
+                                Cannot be updated.
                               type: string
                             tty:
-                              description: Whether this container should allocate
-                                a TTY for itself, also requires 'stdin' to be true.
+                              description: |-
+                                Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
                                 Default is false.
                               type: boolean
                             volumeDevices:
@@ -5329,100 +5149,152 @@ spec:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - devicePath
+                              x-kubernetes-list-type: map
                             volumeMounts:
-                              description: Pod volumes to mount into the container's
-                                filesystem. Cannot be updated.
+                              description: |-
+                                Pod volumes to mount into the container's filesystem.
+                                Cannot be updated.
                               items:
                                 description: VolumeMount describes a mounting of a
                                   Volume within a container.
                                 properties:
                                   mountPath:
-                                    description: Path within the container at which
-                                      the volume should be mounted.  Must not contain
-                                      ':'.
+                                    description: |-
+                                      Path within the container at which the volume should be mounted.  Must
+                                      not contain ':'.
                                     type: string
                                   mountPropagation:
-                                    description: mountPropagation determines how mounts
-                                      are propagated from the host to container and
-                                      the other way around. When not set, MountPropagationNone
-                                      is used. This field is beta in 1.10.
+                                    description: |-
+                                      mountPropagation determines how mounts are propagated from the host
+                                      to container and the other way around.
+                                      When not set, MountPropagationNone is used.
+                                      This field is beta in 1.10.
+                                      When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                      (which defaults to None).
                                     type: string
                                   name:
                                     description: This must match the Name of a Volume.
                                     type: string
                                   readOnly:
-                                    description: Mounted read-only if true, read-write
-                                      otherwise (false or unspecified). Defaults to
-                                      false.
+                                    description: |-
+                                      Mounted read-only if true, read-write otherwise (false or unspecified).
+                                      Defaults to false.
                                     type: boolean
+                                  recursiveReadOnly:
+                                    description: |-
+                                      RecursiveReadOnly specifies whether read-only mounts should be handled
+                                      recursively.
+
+
+                                      If ReadOnly is false, this field has no meaning and must be unspecified.
+
+
+                                      If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                      recursively read-only.  If this field is set to IfPossible, the mount is made
+                                      recursively read-only, if it is supported by the container runtime.  If this
+                                      field is set to Enabled, the mount is made recursively read-only if it is
+                                      supported by the container runtime, otherwise the pod will not be started and
+                                      an error will be generated to indicate the reason.
+
+
+                                      If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                      None (or be unspecified, which defaults to None).
+
+
+                                      If this field is not specified, it is treated as an equivalent of Disabled.
+                                    type: string
                                   subPath:
-                                    description: Path within the volume from which
-                                      the container's volume should be mounted. Defaults
-                                      to "" (volume's root).
+                                    description: |-
+                                      Path within the volume from which the container's volume should be mounted.
+                                      Defaults to "" (volume's root).
                                     type: string
                                   subPathExpr:
-                                    description: Expanded path within the volume from
-                                      which the container's volume should be mounted.
-                                      Behaves similarly to SubPath but environment
-                                      variable references $(VAR_NAME) are expanded
-                                      using the container's environment. Defaults
-                                      to "" (volume's root). SubPathExpr and SubPath
-                                      are mutually exclusive.
+                                    description: |-
+                                      Expanded path within the volume from which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                      Defaults to "" (volume's root).
+                                      SubPathExpr and SubPath are mutually exclusive.
                                     type: string
                                 required:
                                 - mountPath
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - mountPath
+                              x-kubernetes-list-type: map
                             workingDir:
-                              description: Container's working directory. If not specified,
-                                the container runtime's default will be used, which
-                                might be configured in the container image. Cannot
-                                be updated.
+                              description: |-
+                                Container's working directory.
+                                If not specified, the container runtime's default will be used, which
+                                might be configured in the container image.
+                                Cannot be updated.
                               type: string
                           required:
                           - name
                           type: object
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       nodeName:
-                        description: NodeName is a request to schedule this pod onto
-                          a specific node. If it is non-empty, the scheduler simply
-                          schedules this pod onto that node, assuming that it fits
-                          resource requirements.
+                        description: |-
+                          NodeName is a request to schedule this pod onto a specific node. If it is non-empty,
+                          the scheduler simply schedules this pod onto that node, assuming that it fits resource
+                          requirements.
                         type: string
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: 'NodeSelector is a selector which must be true
-                          for the pod to fit on a node. Selector which must match
-                          a node''s labels for the pod to be scheduled on that node.
-                          More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                        description: |-
+                          NodeSelector is a selector which must be true for the pod to fit on a node.
+                          Selector which must match a node's labels for the pod to be scheduled on that node.
+                          More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
                         type: object
                         x-kubernetes-map-type: atomic
                       os:
-                        description: "Specifies the OS of the containers in the pod.
-                          Some pod and container fields are restricted if this is
-                          set. \n If the OS field is set to linux, the following fields
-                          must be unset: -securityContext.windowsOptions \n If the
-                          OS field is set to windows, following fields must be unset:
-                          - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions
-                          - spec.securityContext.seccompProfile - spec.securityContext.fsGroup
-                          - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls
-                          - spec.shareProcessNamespace - spec.securityContext.runAsUser
-                          - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups
-                          - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile
-                          - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem
-                          - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation
-                          - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser
-                          - spec.containers[*].securityContext.runAsGroup"
+                        description: |-
+                          Specifies the OS of the containers in the pod.
+                          Some pod and container fields are restricted if this is set.
+
+
+                          If the OS field is set to linux, the following fields must be unset:
+                          -securityContext.windowsOptions
+
+
+                          If the OS field is set to windows, following fields must be unset:
+                          - spec.hostPID
+                          - spec.hostIPC
+                          - spec.hostUsers
+                          - spec.securityContext.appArmorProfile
+                          - spec.securityContext.seLinuxOptions
+                          - spec.securityContext.seccompProfile
+                          - spec.securityContext.fsGroup
+                          - spec.securityContext.fsGroupChangePolicy
+                          - spec.securityContext.sysctls
+                          - spec.shareProcessNamespace
+                          - spec.securityContext.runAsUser
+                          - spec.securityContext.runAsGroup
+                          - spec.securityContext.supplementalGroups
+                          - spec.containers[*].securityContext.appArmorProfile
+                          - spec.containers[*].securityContext.seLinuxOptions
+                          - spec.containers[*].securityContext.seccompProfile
+                          - spec.containers[*].securityContext.capabilities
+                          - spec.containers[*].securityContext.readOnlyRootFilesystem
+                          - spec.containers[*].securityContext.privileged
+                          - spec.containers[*].securityContext.allowPrivilegeEscalation
+                          - spec.containers[*].securityContext.procMount
+                          - spec.containers[*].securityContext.runAsUser
+                          - spec.containers[*].securityContext.runAsGroup
                         properties:
                           name:
-                            description: 'Name is the name of the operating system.
-                              The currently supported values are linux and windows.
-                              Additional value may be defined in future and can be
-                              one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
-                              Clients should expect to handle additional values and
-                              treat unrecognized values in this field as os: null'
+                            description: |-
+                              Name is the name of the operating system. The currently supported values are linux and windows.
+                              Additional value may be defined in future and can be one of:
+                              https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                              Clients should expect to handle additional values and treat unrecognized values in this field as os: null
                             type: string
                         required:
                         - name
@@ -5434,46 +5306,45 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Overhead represents the resource overhead associated
-                          with running a pod for a given RuntimeClass. This field
-                          will be autopopulated at admission time by the RuntimeClass
-                          admission controller. If the RuntimeClass admission controller
-                          is enabled, overhead must not be set in Pod create requests.
-                          The RuntimeClass admission controller will reject Pod create
-                          requests which have the overhead already set. If RuntimeClass
-                          is configured and selected in the PodSpec, Overhead will
-                          be set to the value defined in the corresponding RuntimeClass,
-                          otherwise it will remain unset and treated as zero. More
-                          info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
+                        description: |-
+                          Overhead represents the resource overhead associated with running a pod for a given RuntimeClass.
+                          This field will be autopopulated at admission time by the RuntimeClass admission controller. If
+                          the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests.
+                          The RuntimeClass admission controller will reject Pod create requests which have the overhead already
+                          set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value
+                          defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero.
+                          More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md
                         type: object
                       preemptionPolicy:
-                        description: PreemptionPolicy is the Policy for preempting
-                          pods with lower priority. One of Never, PreemptLowerPriority.
+                        description: |-
+                          PreemptionPolicy is the Policy for preempting pods with lower priority.
+                          One of Never, PreemptLowerPriority.
                           Defaults to PreemptLowerPriority if unset.
                         type: string
                       priority:
-                        description: The priority value. Various system components
-                          use this field to find the priority of the pod. When Priority
-                          Admission Controller is enabled, it prevents users from
-                          setting this field. The admission controller populates this
-                          field from PriorityClassName. The higher the value, the
-                          higher the priority.
+                        description: |-
+                          The priority value. Various system components use this field to find the
+                          priority of the pod. When Priority Admission Controller is enabled, it
+                          prevents users from setting this field. The admission controller populates
+                          this field from PriorityClassName.
+                          The higher the value, the higher the priority.
                         format: int32
                         type: integer
                       priorityClassName:
-                        description: If specified, indicates the pod's priority. "system-node-critical"
-                          and "system-cluster-critical" are two special keywords which
-                          indicate the highest priorities with the former being the
-                          highest priority. Any other name must be defined by creating
-                          a PriorityClass object with that name. If not specified,
-                          the pod priority will be default or zero if there is no
+                        description: |-
+                          If specified, indicates the pod's priority. "system-node-critical" and
+                          "system-cluster-critical" are two special keywords which indicate the
+                          highest priorities with the former being the highest priority. Any other
+                          name must be defined by creating a PriorityClass object with that name.
+                          If not specified, the pod priority will be default or zero if there is no
                           default.
                         type: string
                       readinessGates:
-                        description: 'If specified, all readiness gates will be evaluated
-                          for pod readiness. A pod is ready when all its containers
-                          are ready AND all conditions specified in the readiness
-                          gates have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
+                        description: |-
+                          If specified, all readiness gates will be evaluated for pod readiness.
+                          A pod is ready when all its containers are ready AND
+                          all conditions specified in the readiness gates have status equal to "True"
+                          More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates
                         items:
                           description: PodReadinessGate contains the reference to
                             a pod condition
@@ -5486,46 +5357,55 @@ spec:
                           - conditionType
                           type: object
                         type: array
+                        x-kubernetes-list-type: atomic
                       resourceClaims:
-                        description: "ResourceClaims defines which ResourceClaims
-                          must be allocated and reserved before the Pod is allowed
-                          to start. The resources will be made available to those
-                          containers which consume them by name. \n This is an alpha
-                          field and requires enabling the DynamicResourceAllocation
-                          feature gate. \n This field is immutable."
+                        description: |-
+                          ResourceClaims defines which ResourceClaims must be allocated
+                          and reserved before the Pod is allowed to start. The resources
+                          will be made available to those containers which consume them
+                          by name.
+
+
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+
+
+                          This field is immutable.
                         items:
-                          description: PodResourceClaim references exactly one ResourceClaim
-                            through a ClaimSource. It adds a name to it that uniquely
-                            identifies the ResourceClaim inside the Pod. Containers
-                            that need access to the ResourceClaim reference it with
-                            this name.
+                          description: |-
+                            PodResourceClaim references exactly one ResourceClaim through a ClaimSource.
+                            It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
+                            Containers that need access to the ResourceClaim reference it with this name.
                           properties:
                             name:
-                              description: Name uniquely identifies this resource
-                                claim inside the pod. This must be a DNS_LABEL.
+                              description: |-
+                                Name uniquely identifies this resource claim inside the pod.
+                                This must be a DNS_LABEL.
                               type: string
                             source:
                               description: Source describes where to find the ResourceClaim.
                               properties:
                                 resourceClaimName:
-                                  description: ResourceClaimName is the name of a
-                                    ResourceClaim object in the same namespace as
-                                    this pod.
+                                  description: |-
+                                    ResourceClaimName is the name of a ResourceClaim object in the same
+                                    namespace as this pod.
                                   type: string
                                 resourceClaimTemplateName:
-                                  description: "ResourceClaimTemplateName is the name
-                                    of a ResourceClaimTemplate object in the same
-                                    namespace as this pod. \n The template will be
-                                    used to create a new ResourceClaim, which will
-                                    be bound to this pod. When this pod is deleted,
-                                    the ResourceClaim will also be deleted. The pod
-                                    name and resource name, along with a generated
-                                    component, will be used to form a unique name
-                                    for the ResourceClaim, which will be recorded
-                                    in pod.status.resourceClaimStatuses. \n This field
-                                    is immutable and no changes will be made to the
-                                    corresponding ResourceClaim by the control plane
-                                    after creating the ResourceClaim."
+                                  description: |-
+                                    ResourceClaimTemplateName is the name of a ResourceClaimTemplate
+                                    object in the same namespace as this pod.
+
+
+                                    The template will be used to create a new ResourceClaim, which will
+                                    be bound to this pod. When this pod is deleted, the ResourceClaim
+                                    will also be deleted. The pod name and resource name, along with a
+                                    generated component, will be used to form a unique name for the
+                                    ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+
+                                    This field is immutable and no changes will be made to the
+                                    corresponding ResourceClaim by the control plane after creating the
+                                    ResourceClaim.
                                   type: string
                               type: object
                           required:
@@ -5536,40 +5416,41 @@ spec:
                         - name
                         x-kubernetes-list-type: map
                       restartPolicy:
-                        description: 'Restart policy for all containers within the
-                          pod. One of Always, OnFailure, Never. In some contexts,
-                          only a subset of those values may be permitted. Default
-                          to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
+                        description: |-
+                          Restart policy for all containers within the pod.
+                          One of Always, OnFailure, Never. In some contexts, only a subset of those values may be permitted.
+                          Default to Always.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
                         type: string
                       runtimeClassName:
-                        description: 'RuntimeClassName refers to a RuntimeClass object
-                          in the node.k8s.io group, which should be used to run this
-                          pod.  If no RuntimeClass resource matches the named class,
-                          the pod will not be run. If unset or empty, the "legacy"
-                          RuntimeClass will be used, which is an implicit class with
-                          an empty definition that uses the default runtime handler.
-                          More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
+                        description: |-
+                          RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used
+                          to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run.
+                          If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an
+                          empty definition that uses the default runtime handler.
+                          More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class
                         type: string
                       schedulerName:
-                        description: If specified, the pod will be dispatched by specified
-                          scheduler. If not specified, the pod will be dispatched
-                          by default scheduler.
+                        description: |-
+                          If specified, the pod will be dispatched by specified scheduler.
+                          If not specified, the pod will be dispatched by default scheduler.
                         type: string
                       schedulingGates:
-                        description: "SchedulingGates is an opaque list of values
-                          that if specified will block scheduling the pod. If schedulingGates
-                          is not empty, the pod will stay in the SchedulingGated state
-                          and the scheduler will not attempt to schedule the pod.
-                          \n SchedulingGates can only be set at pod creation time,
-                          and be removed only afterwards. \n This is a beta feature
-                          enabled by the PodSchedulingReadiness feature gate."
+                        description: |-
+                          SchedulingGates is an opaque list of values that if specified will block scheduling the pod.
+                          If schedulingGates is not empty, the pod will stay in the SchedulingGated state and the
+                          scheduler will not attempt to schedule the pod.
+
+
+                          SchedulingGates can only be set at pod creation time, and be removed only afterwards.
                         items:
                           description: PodSchedulingGate is associated to a Pod to
                             guard its scheduling.
                           properties:
                             name:
-                              description: Name of the scheduling gate. Each scheduling
-                                gate must have a unique name field.
+                              description: |-
+                                Name of the scheduling gate.
+                                Each scheduling gate must have a unique name field.
                               type: string
                           required:
                           - name
@@ -5579,71 +5460,96 @@ spec:
                         - name
                         x-kubernetes-list-type: map
                       securityContext:
-                        description: 'SecurityContext holds pod-level security attributes
-                          and common container settings. Optional: Defaults to empty.  See
-                          type description for default values of each field.'
+                        description: |-
+                          SecurityContext holds pod-level security attributes and common container settings.
+                          Optional: Defaults to empty.  See type description for default values of each field.
                         properties:
+                          appArmorProfile:
+                            description: |-
+                              appArmorProfile is the AppArmor options to use by the containers in this pod.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            properties:
+                              localhostProfile:
+                                description: |-
+                                  localhostProfile indicates a profile loaded on the node that should be used.
+                                  The profile must be preconfigured on the node to work.
+                                  Must match the loaded name of the profile.
+                                  Must be set if and only if type is "Localhost".
+                                type: string
+                              type:
+                                description: |-
+                                  type indicates which kind of AppArmor profile will be applied.
+                                  Valid options are:
+                                    Localhost - a profile pre-loaded on the node.
+                                    RuntimeDefault - the container runtime's default profile.
+                                    Unconfined - no AppArmor enforcement.
+                                type: string
+                            required:
+                            - type
+                            type: object
                           fsGroup:
-                            description: "A special supplemental group that applies
-                              to all containers in a pod. Some volume types allow
-                              the Kubelet to change the ownership of that volume to
-                              be owned by the pod: \n 1. The owning GID will be the
-                              FSGroup 2. The setgid bit is set (new files created
-                              in the volume will be owned by FSGroup) 3. The permission
-                              bits are OR'd with rw-rw---- \n If unset, the Kubelet
-                              will not modify the ownership and permissions of any
-                              volume. Note that this field cannot be set when spec.os.name
-                              is windows."
+                            description: |-
+                              A special supplemental group that applies to all containers in a pod.
+                              Some volume types allow the Kubelet to change the ownership of that volume
+                              to be owned by the pod:
+
+
+                              1. The owning GID will be the FSGroup
+                              2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                              3. The permission bits are OR'd with rw-rw----
+
+
+                              If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                              Note that this field cannot be set when spec.os.name is windows.
                             format: int64
                             type: integer
                           fsGroupChangePolicy:
-                            description: 'fsGroupChangePolicy defines behavior of
-                              changing ownership and permission of the volume before
-                              being exposed inside Pod. This field will only apply
-                              to volume types which support fsGroup based ownership(and
-                              permissions). It will have no effect on ephemeral volume
-                              types such as: secret, configmaps and emptydir. Valid
-                              values are "OnRootMismatch" and "Always". If not specified,
-                              "Always" is used. Note that this field cannot be set
-                              when spec.os.name is windows.'
+                            description: |-
+                              fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                              before being exposed inside Pod. This field will only apply to
+                              volume types which support fsGroup based ownership(and permissions).
+                              It will have no effect on ephemeral volume types such as: secret, configmaps
+                              and emptydir.
+                              Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           runAsGroup:
-                            description: The GID to run the entrypoint of the container
-                              process. Uses runtime default if unset. May also be
-                              set in SecurityContext.  If set in both SecurityContext
-                              and PodSecurityContext, the value specified in SecurityContext
-                              takes precedence for that container. Note that this
-                              field cannot be set when spec.os.name is windows.
+                            description: |-
+                              The GID to run the entrypoint of the container process.
+                              Uses runtime default if unset.
+                              May also be set in SecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence
+                              for that container.
+                              Note that this field cannot be set when spec.os.name is windows.
                             format: int64
                             type: integer
                           runAsNonRoot:
-                            description: Indicates that the container must run as
-                              a non-root user. If true, the Kubelet will validate
-                              the image at runtime to ensure that it does not run
-                              as UID 0 (root) and fail to start the container if it
-                              does. If unset or false, no such validation will be
-                              performed. May also be set in SecurityContext.  If set
-                              in both SecurityContext and PodSecurityContext, the
-                              value specified in SecurityContext takes precedence.
+                            description: |-
+                              Indicates that the container must run as a non-root user.
+                              If true, the Kubelet will validate the image at runtime to ensure that it
+                              does not run as UID 0 (root) and fail to start the container if it does.
+                              If unset or false, no such validation will be performed.
+                              May also be set in SecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
                             type: boolean
                           runAsUser:
-                            description: The UID to run the entrypoint of the container
-                              process. Defaults to user specified in image metadata
-                              if unspecified. May also be set in SecurityContext.  If
-                              set in both SecurityContext and PodSecurityContext,
-                              the value specified in SecurityContext takes precedence
-                              for that container. Note that this field cannot be set
-                              when spec.os.name is windows.
+                            description: |-
+                              The UID to run the entrypoint of the container process.
+                              Defaults to user specified in image metadata if unspecified.
+                              May also be set in SecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence
+                              for that container.
+                              Note that this field cannot be set when spec.os.name is windows.
                             format: int64
                             type: integer
                           seLinuxOptions:
-                            description: The SELinux context to be applied to all
-                              containers. If unspecified, the container runtime will
-                              allocate a random SELinux context for each container.  May
-                              also be set in SecurityContext.  If set in both SecurityContext
-                              and PodSecurityContext, the value specified in SecurityContext
-                              takes precedence for that container. Note that this
-                              field cannot be set when spec.os.name is windows.
+                            description: |-
+                              The SELinux context to be applied to all containers.
+                              If unspecified, the container runtime will allocate a random SELinux context for each
+                              container.  May also be set in SecurityContext.  If set in
+                              both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence for that container.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               level:
                                 description: Level is SELinux level label that applies
@@ -5663,50 +5569,49 @@ spec:
                                 type: string
                             type: object
                           seccompProfile:
-                            description: The seccomp options to use by the containers
-                              in this pod. Note that this field cannot be set when
-                              spec.os.name is windows.
+                            description: |-
+                              The seccomp options to use by the containers in this pod.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               localhostProfile:
-                                description: localhostProfile indicates a profile
-                                  defined in a file on the node should be used. The
-                                  profile must be preconfigured on the node to work.
-                                  Must be a descending path, relative to the kubelet's
-                                  configured seccomp profile location. Must be set
-                                  if type is "Localhost". Must NOT be set for any
-                                  other type.
+                                description: |-
+                                  localhostProfile indicates a profile defined in a file on the node should be used.
+                                  The profile must be preconfigured on the node to work.
+                                  Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                  Must be set if type is "Localhost". Must NOT be set for any other type.
                                 type: string
                               type:
-                                description: "type indicates which kind of seccomp
-                                  profile will be applied. Valid options are: \n Localhost
-                                  - a profile defined in a file on the node should
-                                  be used. RuntimeDefault - the container runtime
-                                  default profile should be used. Unconfined - no
-                                  profile should be applied."
+                                description: |-
+                                  type indicates which kind of seccomp profile will be applied.
+                                  Valid options are:
+
+
+                                  Localhost - a profile defined in a file on the node should be used.
+                                  RuntimeDefault - the container runtime default profile should be used.
+                                  Unconfined - no profile should be applied.
                                 type: string
                             required:
                             - type
                             type: object
                           supplementalGroups:
-                            description: A list of groups applied to the first process
-                              run in each container, in addition to the container's
-                              primary GID, the fsGroup (if specified), and group memberships
-                              defined in the container image for the uid of the container
-                              process. If unspecified, no additional groups are added
-                              to any container. Note that group memberships defined
-                              in the container image for the uid of the container
-                              process are still effective, even if they are not included
-                              in this list. Note that this field cannot be set when
-                              spec.os.name is windows.
+                            description: |-
+                              A list of groups applied to the first process run in each container, in addition
+                              to the container's primary GID, the fsGroup (if specified), and group memberships
+                              defined in the container image for the uid of the container process. If unspecified,
+                              no additional groups are added to any container. Note that group memberships
+                              defined in the container image for the uid of the container process are still effective,
+                              even if they are not included in this list.
+                              Note that this field cannot be set when spec.os.name is windows.
                             items:
                               format: int64
                               type: integer
                             type: array
+                            x-kubernetes-list-type: atomic
                           sysctls:
-                            description: Sysctls hold a list of namespaced sysctls
-                              used for the pod. Pods with unsupported sysctls (by
-                              the container runtime) might fail to launch. Note that
-                              this field cannot be set when spec.os.name is windows.
+                            description: |-
+                              Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                              sysctls (by the container runtime) might fail to launch.
+                              Note that this field cannot be set when spec.os.name is windows.
                             items:
                               description: Sysctl defines a kernel parameter to be
                                 set
@@ -5722,315 +5627,294 @@ spec:
                               - value
                               type: object
                             type: array
+                            x-kubernetes-list-type: atomic
                           windowsOptions:
-                            description: The Windows specific settings applied to
-                              all containers. If unspecified, the options within a
-                              container's SecurityContext will be used. If set in
-                              both SecurityContext and PodSecurityContext, the value
-                              specified in SecurityContext takes precedence. Note
-                              that this field cannot be set when spec.os.name is linux.
+                            description: |-
+                              The Windows specific settings applied to all containers.
+                              If unspecified, the options within a container's SecurityContext will be used.
+                              If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is linux.
                             properties:
                               gmsaCredentialSpec:
-                                description: GMSACredentialSpec is where the GMSA
-                                  admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                  inlines the contents of the GMSA credential spec
-                                  named by the GMSACredentialSpecName field.
+                                description: |-
+                                  GMSACredentialSpec is where the GMSA admission webhook
+                                  (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                  GMSA credential spec named by the GMSACredentialSpecName field.
                                 type: string
                               gmsaCredentialSpecName:
                                 description: GMSACredentialSpecName is the name of
                                   the GMSA credential spec to use.
                                 type: string
                               hostProcess:
-                                description: HostProcess determines if a container
-                                  should be run as a 'Host Process' container. All
-                                  of a Pod's containers must have the same effective
-                                  HostProcess value (it is not allowed to have a mix
-                                  of HostProcess containers and non-HostProcess containers).
-                                  In addition, if HostProcess is true then HostNetwork
-                                  must also be set to true.
+                                description: |-
+                                  HostProcess determines if a container should be run as a 'Host Process' container.
+                                  All of a Pod's containers must have the same effective HostProcess value
+                                  (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                  In addition, if HostProcess is true then HostNetwork must also be set to true.
                                 type: boolean
                               runAsUserName:
-                                description: The UserName in Windows to run the entrypoint
-                                  of the container process. Defaults to the user specified
-                                  in image metadata if unspecified. May also be set
-                                  in PodSecurityContext. If set in both SecurityContext
-                                  and PodSecurityContext, the value specified in SecurityContext
-                                  takes precedence.
+                                description: |-
+                                  The UserName in Windows to run the entrypoint of the container process.
+                                  Defaults to the user specified in image metadata if unspecified.
+                                  May also be set in PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
                                 type: string
                             type: object
                         type: object
                       serviceAccount:
-                        description: 'DeprecatedServiceAccount is a depreciated alias
-                          for ServiceAccountName. Deprecated: Use serviceAccountName
-                          instead.'
+                        description: |-
+                          DeprecatedServiceAccount is a deprecated alias for ServiceAccountName.
+                          Deprecated: Use serviceAccountName instead.
                         type: string
                       serviceAccountName:
-                        description: 'ServiceAccountName is the name of the ServiceAccount
-                          to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                        description: |-
+                          ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                          More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
                         type: string
                       setHostnameAsFQDN:
-                        description: If true the pod's hostname will be configured
-                          as the pod's FQDN, rather than the leaf name (the default).
-                          In Linux containers, this means setting the FQDN in the
-                          hostname field of the kernel (the nodename field of struct
-                          utsname). In Windows containers, this means setting the
-                          registry value of hostname for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters
-                          to FQDN. If a pod does not have FQDN, this has no effect.
+                        description: |-
+                          If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default).
+                          In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname).
+                          In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters to FQDN.
+                          If a pod does not have FQDN, this has no effect.
                           Default to false.
                         type: boolean
                       shareProcessNamespace:
-                        description: 'Share a single process namespace between all
-                          of the containers in a pod. When this is set containers
-                          will be able to view and signal processes from other containers
-                          in the same pod, and the first process in each container
-                          will not be assigned PID 1. HostPID and ShareProcessNamespace
-                          cannot both be set. Optional: Default to false.'
+                        description: |-
+                          Share a single process namespace between all of the containers in a pod.
+                          When this is set containers will be able to view and signal processes from other containers
+                          in the same pod, and the first process in each container will not be assigned PID 1.
+                          HostPID and ShareProcessNamespace cannot both be set.
+                          Optional: Default to false.
                         type: boolean
                       subdomain:
-                        description: If specified, the fully qualified Pod hostname
-                          will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
-                          domain>". If not specified, the pod will not have a domainname
-                          at all.
+                        description: |-
+                          If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+                          If not specified, the pod will not have a domainname at all.
                         type: string
                       terminationGracePeriodSeconds:
-                        description: Optional duration in seconds the pod needs to
-                          terminate gracefully. May be decreased in delete request.
-                          Value must be non-negative integer. The value zero indicates
-                          stop immediately via the kill signal (no opportunity to
-                          shut down). If this value is nil, the default grace period
-                          will be used instead. The grace period is the duration in
-                          seconds after the processes running in the pod are sent
-                          a termination signal and the time when the processes are
-                          forcibly halted with a kill signal. Set this value longer
-                          than the expected cleanup time for your process. Defaults
-                          to 30 seconds.
+                        description: |-
+                          Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request.
+                          Value must be non-negative integer. The value zero indicates stop immediately via
+                          the kill signal (no opportunity to shut down).
+                          If this value is nil, the default grace period will be used instead.
+                          The grace period is the duration in seconds after the processes running in the pod are sent
+                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                          Set this value longer than the expected cleanup time for your process.
+                          Defaults to 30 seconds.
                         format: int64
                         type: integer
                       tolerations:
                         description: If specified, the pod's tolerations.
                         items:
-                          description: The pod this Toleration is attached to tolerates
-                            any taint that matches the triple <key,value,effect> using
-                            the matching operator <operator>.
+                          description: |-
+                            The pod this Toleration is attached to tolerates any taint that matches
+                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: Effect indicates the taint effect to match.
-                                Empty means match all taint effects. When specified,
-                                allowed values are NoSchedule, PreferNoSchedule and
-                                NoExecute.
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects.
+                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: Key is the taint key that the toleration
-                                applies to. Empty means match all taint keys. If the
-                                key is empty, operator must be Exists; this combination
-                                means to match all values and all keys.
+                              description: |-
+                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: Operator represents a key's relationship
-                                to the value. Valid operators are Exists and Equal.
-                                Defaults to Equal. Exists is equivalent to wildcard
-                                for value, so that a pod can tolerate all taints of
-                                a particular category.
+                              description: |-
+                                Operator represents a key's relationship to the value.
+                                Valid operators are Exists and Equal. Defaults to Equal.
+                                Exists is equivalent to wildcard for value, so that a pod can
+                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: TolerationSeconds represents the period
-                                of time the toleration (which must be of effect NoExecute,
-                                otherwise this field is ignored) tolerates the taint.
-                                By default, it is not set, which means tolerate the
-                                taint forever (do not evict). Zero and negative values
-                                will be treated as 0 (evict immediately) by the system.
+                              description: |-
+                                TolerationSeconds represents the period of time the toleration (which must be
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: Value is the taint value the toleration
-                                matches to. If the operator is Exists, the value should
-                                be empty, otherwise just a regular string.
+                              description: |-
+                                Value is the taint value the toleration matches to.
+                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
+                        x-kubernetes-list-type: atomic
                       topologySpreadConstraints:
-                        description: TopologySpreadConstraints describes how a group
-                          of pods ought to spread across topology domains. Scheduler
-                          will schedule pods in a way which abides by the constraints.
+                        description: |-
+                          TopologySpreadConstraints describes how a group of pods ought to spread across topology
+                          domains. Scheduler will schedule pods in a way which abides by the constraints.
                           All topologySpreadConstraints are ANDed.
                         items:
                           description: TopologySpreadConstraint specifies how to spread
                             matching pods among the given topology.
                           properties:
                             labelSelector:
-                              description: LabelSelector is used to find matching
-                                pods. Pods that match this label selector are counted
-                                to determine the number of pods in their corresponding
-                                topology domain.
+                              description: |-
+                                LabelSelector is used to find matching pods.
+                                Pods that match this label selector are counted to determine the number of pods
+                                in their corresponding topology domain.
                               properties:
                                 matchExpressions:
                                   description: matchExpressions is a list of label
                                     selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
                                     properties:
                                       key:
                                         description: key is the label key that the
                                           selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                     required:
                                     - key
                                     - operator
                                     type: object
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             matchLabelKeys:
-                              description: "MatchLabelKeys is a set of pod label keys
-                                to select the pods over which spreading will be calculated.
-                                The keys are used to lookup values from the incoming
-                                pod labels, those key-value labels are ANDed with
-                                labelSelector to select the group of existing pods
-                                over which spreading will be calculated for the incoming
-                                pod. The same key is forbidden to exist in both MatchLabelKeys
-                                and LabelSelector. MatchLabelKeys cannot be set when
-                                LabelSelector isn't set. Keys that don't exist in
-                                the incoming pod labels will be ignored. A null or
-                                empty list means only match against labelSelector.
-                                \n This is a beta field and requires the MatchLabelKeysInPodTopologySpread
-                                feature gate to be enabled (enabled by default)."
+                              description: |-
+                                MatchLabelKeys is a set of pod label keys to select the pods over which
+                                spreading will be calculated. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are ANDed with labelSelector
+                                to select the group of existing pods over which spreading will be calculated
+                                for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                Keys that don't exist in the incoming pod labels will
+                                be ignored. A null or empty list means only match against labelSelector.
+
+
+                                This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             maxSkew:
-                              description: 'MaxSkew describes the degree to which
-                                pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
-                                it is the maximum permitted difference between the
-                                number of matching pods in the target topology and
-                                the global minimum. The global minimum is the minimum
-                                number of matching pods in an eligible domain or zero
-                                if the number of eligible domains is less than MinDomains.
-                                For example, in a 3-zone cluster, MaxSkew is set to
-                                1, and pods with the same labelSelector spread as
-                                2/2/1: In this case, the global minimum is 1. | zone1
-                                | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
-                                is 1, incoming pod can only be scheduled to zone3
-                                to become 2/2/2; scheduling it onto zone1(zone2) would
-                                make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1).
-                                - if MaxSkew is 2, incoming pod can be scheduled onto
-                                any zone. When `whenUnsatisfiable=ScheduleAnyway`,
-                                it is used to give higher precedence to topologies
-                                that satisfy it. It''s a required field. Default value
-                                is 1 and 0 is not allowed.'
+                              description: |-
+                                MaxSkew describes the degree to which pods may be unevenly distributed.
+                                When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                                between the number of matching pods in the target topology and the global minimum.
+                                The global minimum is the minimum number of matching pods in an eligible domain
+                                or zero if the number of eligible domains is less than MinDomains.
+                                For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                labelSelector spread as 2/2/1:
+                                In this case, the global minimum is 1.
+                                | zone1 | zone2 | zone3 |
+                                |  P P  |  P P  |   P   |
+                                - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                                scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                                violate MaxSkew(1).
+                                - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                                When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                                to topologies that satisfy it.
+                                It's a required field. Default value is 1 and 0 is not allowed.
                               format: int32
                               type: integer
                             minDomains:
-                              description: "MinDomains indicates a minimum number
-                                of eligible domains. When the number of eligible domains
-                                with matching topology keys is less than minDomains,
-                                Pod Topology Spread treats \"global minimum\" as 0,
-                                and then the calculation of Skew is performed. And
-                                when the number of eligible domains with matching
-                                topology keys equals or greater than minDomains, this
-                                value has no effect on scheduling. As a result, when
-                                the number of eligible domains is less than minDomains,
-                                scheduler won't schedule more than maxSkew Pods to
-                                those domains. If value is nil, the constraint behaves
-                                as if MinDomains is equal to 1. Valid values are integers
-                                greater than 0. When value is not nil, WhenUnsatisfiable
-                                must be DoNotSchedule. \n For example, in a 3-zone
-                                cluster, MaxSkew is set to 2, MinDomains is set to
-                                5 and pods with the same labelSelector spread as 2/2/2:
-                                | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  |
-                                The number of domains is less than 5(MinDomains),
-                                so \"global minimum\" is treated as 0. In this situation,
-                                new pod with the same labelSelector cannot be scheduled,
-                                because computed skew will be 3(3 - 0) if new Pod
-                                is scheduled to any of the three zones, it will violate
-                                MaxSkew. \n This is a beta field and requires the
-                                MinDomainsInPodTopologySpread feature gate to be enabled
-                                (enabled by default)."
+                              description: |-
+                                MinDomains indicates a minimum number of eligible domains.
+                                When the number of eligible domains with matching topology keys is less than minDomains,
+                                Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                                And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                                this value has no effect on scheduling.
+                                As a result, when the number of eligible domains is less than minDomains,
+                                scheduler won't schedule more than maxSkew Pods to those domains.
+                                If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                                Valid values are integers greater than 0.
+                                When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+
+                                For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                                labelSelector spread as 2/2/2:
+                                | zone1 | zone2 | zone3 |
+                                |  P P  |  P P  |  P P  |
+                                The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                                In this situation, new pod with the same labelSelector cannot be scheduled,
+                                because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                                it will violate MaxSkew.
                               format: int32
                               type: integer
                             nodeAffinityPolicy:
-                              description: "NodeAffinityPolicy indicates how we will
-                                treat Pod's nodeAffinity/nodeSelector when calculating
-                                pod topology spread skew. Options are: - Honor: only
-                                nodes matching nodeAffinity/nodeSelector are included
-                                in the calculations. - Ignore: nodeAffinity/nodeSelector
-                                are ignored. All nodes are included in the calculations.
-                                \n If this value is nil, the behavior is equivalent
-                                to the Honor policy. This is a beta-level feature
-                                default enabled by the NodeInclusionPolicyInPodTopologySpread
-                                feature flag."
+                              description: |-
+                                NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                                when calculating pod topology spread skew. Options are:
+                                - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                                - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+
+                                If this value is nil, the behavior is equivalent to the Honor policy.
+                                This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                               type: string
                             nodeTaintsPolicy:
-                              description: "NodeTaintsPolicy indicates how we will
-                                treat node taints when calculating pod topology spread
-                                skew. Options are: - Honor: nodes without taints,
-                                along with tainted nodes for which the incoming pod
-                                has a toleration, are included. - Ignore: node taints
-                                are ignored. All nodes are included. \n If this value
-                                is nil, the behavior is equivalent to the Ignore policy.
-                                This is a beta-level feature default enabled by the
-                                NodeInclusionPolicyInPodTopologySpread feature flag."
+                              description: |-
+                                NodeTaintsPolicy indicates how we will treat node taints when calculating
+                                pod topology spread skew. Options are:
+                                - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                                has a toleration, are included.
+                                - Ignore: node taints are ignored. All nodes are included.
+
+
+                                If this value is nil, the behavior is equivalent to the Ignore policy.
+                                This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                               type: string
                             topologyKey:
-                              description: TopologyKey is the key of node labels.
-                                Nodes that have a label with this key and identical
-                                values are considered to be in the same topology.
-                                We consider each <key, value> as a "bucket", and try
-                                to put balanced number of pods into each bucket. We
-                                define a domain as a particular instance of a topology.
-                                Also, we define an eligible domain as a domain whose
-                                nodes meet the requirements of nodeAffinityPolicy
-                                and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
-                                each Node is a domain of that topology. And, if TopologyKey
-                                is "topology.kubernetes.io/zone", each zone is a domain
-                                of that topology. It's a required field.
+                              description: |-
+                                TopologyKey is the key of node labels. Nodes that have a label with this key
+                                and identical values are considered to be in the same topology.
+                                We consider each <key, value> as a "bucket", and try to put balanced number
+                                of pods into each bucket.
+                                We define a domain as a particular instance of a topology.
+                                Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                                nodeAffinityPolicy and nodeTaintsPolicy.
+                                e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                                And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                                It's a required field.
                               type: string
                             whenUnsatisfiable:
-                              description: 'WhenUnsatisfiable indicates how to deal
-                                with a pod if it doesn''t satisfy the spread constraint.
-                                - DoNotSchedule (default) tells the scheduler not
-                                to schedule it. - ScheduleAnyway tells the scheduler
-                                to schedule the pod in any location, but giving higher
-                                precedence to topologies that would help reduce the
-                                skew. A constraint is considered "Unsatisfiable" for
-                                an incoming pod if and only if every possible node
-                                assignment for that pod would violate "MaxSkew" on
-                                some topology. For example, in a 3-zone cluster, MaxSkew
-                                is set to 1, and pods with the same labelSelector
-                                spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P
-                                |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule,
-                                incoming pod can only be scheduled to zone2(zone3)
-                                to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3)
-                                satisfies MaxSkew(1). In other words, the cluster
-                                can still be imbalanced, but scheduler won''t make
-                                it *more* imbalanced. It''s a required field.'
+                              description: |-
+                                WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                                the spread constraint.
+                                - DoNotSchedule (default) tells the scheduler not to schedule it.
+                                - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                  but giving higher precedence to topologies that would help reduce the
+                                  skew.
+                                A constraint is considered "Unsatisfiable" for an incoming pod
+                                if and only if every possible node assignment for that pod would violate
+                                "MaxSkew" on some topology.
+                                For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                labelSelector spread as 3/1/1:
+                                | zone1 | zone2 | zone3 |
+                                | P P P |   P   |   P   |
+                                If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                                to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                                MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                                won't make it *more* imbalanced.
+                                It's a required field.
                               type: string
                           required:
                           - maxSkew
@@ -6043,44 +5927,44 @@ spec:
                         - whenUnsatisfiable
                         x-kubernetes-list-type: map
                       volumes:
-                        description: 'List of volumes that can be mounted by containers
-                          belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                        description: |-
+                          List of volumes that can be mounted by containers belonging to the pod.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes
                         items:
                           description: Volume represents a named volume in a pod that
                             may be accessed by any container in the pod.
                           properties:
                             awsElasticBlockStore:
-                              description: 'awsElasticBlockStore represents an AWS
-                                Disk resource that is attached to a kubelet''s host
-                                machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              description: |-
+                                awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                                kubelet's host machine and then exposed to the pod.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                               properties:
                                 fsType:
-                                  description: 'fsType is the filesystem type of the
-                                    volume that you want to mount. Tip: Ensure that
-                                    the filesystem type is supported by the host operating
-                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified. More info:
-                                    https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                    TODO: how do we prevent errors in the filesystem
-                                    from compromising the machine'
+                                  description: |-
+                                    fsType is the filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: 'partition is the partition in the
-                                    volume that you want to mount. If omitted, the
-                                    default is to mount by volume name. Examples:
-                                    For volume /dev/sda1, you specify the partition
-                                    as "1". Similarly, the volume partition for /dev/sda
-                                    is "0" (or you can leave the property empty).'
+                                  description: |-
+                                    partition is the partition in the volume that you want to mount.
+                                    If omitted, the default is to mount by volume name.
+                                    Examples: For volume /dev/sda1, you specify the partition as "1".
+                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'readOnly value true will force the
-                                    readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: |-
+                                    readOnly value true will force the readOnly setting in VolumeMounts.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: boolean
                                 volumeID:
-                                  description: 'volumeID is unique ID of the persistent
-                                    disk resource in AWS (Amazon EBS volume). More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: |-
+                                    volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: string
                               required:
                               - volumeID
@@ -6102,10 +5986,10 @@ spec:
                                     the blob storage
                                   type: string
                                 fsType:
-                                  description: fsType is Filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified.
+                                  description: |-
+                                    fsType is Filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
                                   description: 'kind expected values are Shared: multiple
@@ -6115,9 +5999,9 @@ spec:
                                     set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: readOnly Defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.
+                                  description: |-
+                                    readOnly Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
@@ -6128,9 +6012,9 @@ spec:
                                 mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: readOnly defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
                                   description: secretName is the  name of secret that
@@ -6148,78 +6032,95 @@ spec:
                                 host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: 'monitors is Required: Monitors is
-                                    a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: |-
+                                    monitors is Required: Monitors is a collection of Ceph monitors
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 path:
                                   description: 'path is Optional: Used as the mounted
                                     root, rather than the full Ceph tree, default
                                     is /'
                                   type: string
                                 readOnly:
-                                  description: 'readOnly is Optional: Defaults to
-                                    false (read/write). ReadOnly here will force the
-                                    ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: |-
+                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: boolean
                                 secretFile:
-                                  description: 'secretFile is Optional: SecretFile
-                                    is the path to key ring for User, default is /etc/ceph/user.secret
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: |-
+                                    secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                                 secretRef:
-                                  description: 'secretRef is Optional: SecretRef is
-                                    reference to the authentication secret for User,
-                                    default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: |-
+                                    secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: 'user is optional: User is the rados
-                                    user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: |-
+                                    user is optional: User is the rados user name, default is admin
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: 'cinder represents a cinder volume attached
-                                and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              description: |-
+                                cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                               properties:
                                 fsType:
-                                  description: 'fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Examples: "ext4", "xfs", "ntfs".
-                                    Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                                 readOnly:
-                                  description: 'readOnly defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: boolean
                                 secretRef:
-                                  description: 'secretRef is optional: points to a
-                                    secret object containing parameters used to connect
-                                    to OpenStack.'
+                                  description: |-
+                                    secretRef is optional: points to a secret object containing parameters used to connect
+                                    to OpenStack.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeID:
-                                  description: 'volumeID used to identify the volume
-                                    in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: |-
+                                    volumeID used to identify the volume in cinder.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                               required:
                               - volumeID
@@ -6229,30 +6130,25 @@ spec:
                                 populate this volume
                               properties:
                                 defaultMode:
-                                  description: 'defaultMode is optional: mode bits
-                                    used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or
-                                    a decimal value between 0 and 511. YAML accepts
-                                    both octal and decimal values, JSON requires decimal
-                                    values for mode bits. Defaults to 0644. Directories
-                                    within the path are not affected by this setting.
-                                    This might be in conflict with other options that
-                                    affect the file mode, like fsGroup, and the result
-                                    can be other mode bits set.'
+                                  description: |-
+                                    defaultMode is optional: mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    Defaults to 0644.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: items if unspecified, each key-value
-                                    pair in the Data field of the referenced ConfigMap
-                                    will be projected into the volume as a file whose
-                                    name is the key and content is the value. If specified,
-                                    the listed keys will be projected into the specified
-                                    paths, and unlisted keys will not be present.
-                                    If a key is specified which is not present in
-                                    the ConfigMap, the volume setup will error unless
-                                    it is marked optional. Paths must be relative
-                                    and may not contain the '..' path or start with
-                                    '..'.
+                                  description: |-
+                                    items if unspecified, each key-value pair in the Data field of the referenced
+                                    ConfigMap will be projected into the volume as a file whose name is the
+                                    key and content is the value. If specified, the listed keys will be
+                                    projected into the specified paths, and unlisted keys will not be
+                                    present. If a key is specified which is not present in the ConfigMap,
+                                    the volume setup will error unless it is marked optional. Paths must be
+                                    relative and may not contain the '..' path or start with '..'.
                                   items:
                                     description: Maps a string key to a path within
                                       a volume.
@@ -6261,35 +6157,31 @@ spec:
                                         description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'mode is Optional: mode bits
-                                          used to set permissions on this file. Must
-                                          be an octal value between 0000 and 0777
-                                          or a decimal value between 0 and 511. YAML
-                                          accepts both octal and decimal values, JSON
-                                          requires decimal values for mode bits. If
-                                          not specified, the volume defaultMode will
-                                          be used. This might be in conflict with
-                                          other options that affect the file mode,
-                                          like fsGroup, and the result can be other
-                                          mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: path is the relative path of
-                                          the file to map the key to. May not be an
-                                          absolute path. May not contain the path
-                                          element '..'. May not start with the string
-                                          '..'.
+                                        description: |-
+                                          path is the relative path of the file to map the key to.
+                                          May not be an absolute path.
+                                          May not contain the path element '..'.
+                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
                                     - path
                                     type: object
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                   type: string
                                 optional:
                                   description: optional specify whether the ConfigMap
@@ -6303,45 +6195,48 @@ spec:
                                 CSI drivers (Beta feature).
                               properties:
                                 driver:
-                                  description: driver is the name of the CSI driver
-                                    that handles this volume. Consult with your admin
-                                    for the correct name as registered in the cluster.
+                                  description: |-
+                                    driver is the name of the CSI driver that handles this volume.
+                                    Consult with your admin for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: fsType to mount. Ex. "ext4", "xfs",
-                                    "ntfs". If not provided, the empty value is passed
-                                    to the associated CSI driver which will determine
-                                    the default filesystem to apply.
+                                  description: |-
+                                    fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                    If not provided, the empty value is passed to the associated CSI driver
+                                    which will determine the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: nodePublishSecretRef is a reference
-                                    to the secret object containing sensitive information
-                                    to pass to the CSI driver to complete the CSI
+                                  description: |-
+                                    nodePublishSecretRef is a reference to the secret object containing
+                                    sensitive information to pass to the CSI driver to complete the CSI
                                     NodePublishVolume and NodeUnpublishVolume calls.
-                                    This field is optional, and  may be empty if no
-                                    secret is required. If the secret object contains
-                                    more than one secret, all secret references are
-                                    passed.
+                                    This field is optional, and  may be empty if no secret is required. If the
+                                    secret object contains more than one secret, all secret references are passed.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 readOnly:
-                                  description: readOnly specifies a read-only configuration
-                                    for the volume. Defaults to false (read/write).
+                                  description: |-
+                                    readOnly specifies a read-only configuration for the volume.
+                                    Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: volumeAttributes stores driver-specific
-                                    properties that are passed to the CSI driver.
-                                    Consult your driver's documentation for supported
-                                    values.
+                                  description: |-
+                                    volumeAttributes stores driver-specific properties that are passed to the CSI
+                                    driver. Consult your driver's documentation for supported values.
                                   type: object
                               required:
                               - driver
@@ -6351,17 +6246,15 @@ spec:
                                 the pod that should populate this volume
                               properties:
                                 defaultMode:
-                                  description: 'Optional: mode bits to use on created
-                                    files by default. Must be a Optional: mode bits
-                                    used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or
-                                    a decimal value between 0 and 511. YAML accepts
-                                    both octal and decimal values, JSON requires decimal
-                                    values for mode bits. Defaults to 0644. Directories
-                                    within the path are not affected by this setting.
-                                    This might be in conflict with other options that
-                                    affect the file mode, like fsGroup, and the result
-                                    can be other mode bits set.'
+                                  description: |-
+                                    Optional: mode bits to use on created files by default. Must be a
+                                    Optional: mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    Defaults to 0644.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
@@ -6374,33 +6267,18 @@ spec:
                                     properties:
                                       fieldRef:
                                         description: 'Required: Selects a field of
-                                          the pod: only annotations, labels, name
-                                          and namespace are supported.'
+                                          the pod: only annotations, labels, name,
+                                          namespace and uid are supported.'
                                         properties:
                                           apiVersion:
-                                            description: Version of the schema the
-                                              FieldPath is written in terms of, defaults
-                                              to "v1".
                                             type: string
                                           fieldPath:
-                                            description: Path of the field to select
-                                              in the specified API version.
                                             type: string
                                         required:
                                         - fieldPath
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       mode:
-                                        description: 'Optional: mode bits used to
-                                          set permissions on this file, must be an
-                                          octal value between 0000 and 0777 or a decimal
-                                          value between 0 and 511. YAML accepts both
-                                          octal and decimal values, JSON requires
-                                          decimal values for mode bits. If not specified,
-                                          the volume defaultMode will be used. This
-                                          might be in conflict with other options
-                                          that affect the file mode, like fsGroup,
-                                          and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
@@ -6411,26 +6289,19 @@ spec:
                                           the relative path must not start with ''..'''
                                         type: string
                                       resourceFieldRef:
-                                        description: 'Selects a resource of the container:
-                                          only resources limits and requests (limits.cpu,
-                                          limits.memory, requests.cpu and requests.memory)
-                                          are currently supported.'
+                                        description: |-
+                                          Selects a resource of the container: only resources limits and requests
+                                          (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                         properties:
                                           containerName:
-                                            description: 'Container name: required
-                                              for volumes, optional for env vars'
                                             type: string
                                           divisor:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Specifies the output format
-                                              of the exposed resources, defaults to
-                                              "1"
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           resource:
-                                            description: 'Required: resource to select'
                                             type: string
                                         required:
                                         - resource
@@ -6440,125 +6311,117 @@ spec:
                                     - path
                                     type: object
                                   type: array
+                                  x-kubernetes-list-type: atomic
                               type: object
                             emptyDir:
-                              description: 'emptyDir represents a temporary directory
-                                that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              description: |-
+                                emptyDir represents a temporary directory that shares a pod's lifetime.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                               properties:
                                 medium:
-                                  description: 'medium represents what type of storage
-                                    medium should back this directory. The default
-                                    is "" which means to use the node''s default medium.
-                                    Must be an empty string (default) or Memory. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  description: |-
+                                    medium represents what type of storage medium should back this directory.
+                                    The default is "" which means to use the node's default medium.
+                                    Must be an empty string (default) or Memory.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: 'sizeLimit is the total amount of local
-                                    storage required for this EmptyDir volume. The
-                                    size limit is also applicable for memory medium.
-                                    The maximum usage on memory medium EmptyDir would
-                                    be the minimum value between the SizeLimit specified
-                                    here and the sum of memory limits of all containers
-                                    in a pod. The default is nil which means that
-                                    the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  description: |-
+                                    sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                    The size limit is also applicable for memory medium.
+                                    The maximum usage on memory medium EmptyDir would be the minimum value between
+                                    the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                    The default is nil which means that the limit is undefined.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: "ephemeral represents a volume that is
-                                handled by a cluster storage driver. The volume's
-                                lifecycle is tied to the pod that defines it - it
-                                will be created before the pod starts, and deleted
-                                when the pod is removed. \n Use this if: a) the volume
-                                is only needed while the pod runs, b) features of
-                                normal volumes like restoring from snapshot or capacity
-                                tracking are needed, c) the storage driver is specified
-                                through a storage class, and d) the storage driver
-                                supports dynamic volume provisioning through a PersistentVolumeClaim
-                                (see EphemeralVolumeSource for more information on
-                                the connection between this volume type and PersistentVolumeClaim).
-                                \n Use PersistentVolumeClaim or one of the vendor-specific
-                                APIs for volumes that persist for longer than the
-                                lifecycle of an individual pod. \n Use CSI for light-weight
-                                local ephemeral volumes if the CSI driver is meant
-                                to be used that way - see the documentation of the
-                                driver for more information. \n A pod can use both
-                                types of ephemeral volumes and persistent volumes
-                                at the same time."
+                              description: |-
+                                ephemeral represents a volume that is handled by a cluster storage driver.
+                                The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                                and deleted when the pod is removed.
+
+
+                                Use this if:
+                                a) the volume is only needed while the pod runs,
+                                b) features of normal volumes like restoring from snapshot or capacity
+                                   tracking are needed,
+                                c) the storage driver is specified through a storage class, and
+                                d) the storage driver supports dynamic volume provisioning through
+                                   a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                   information on the connection between this volume type
+                                   and PersistentVolumeClaim).
+
+
+                                Use PersistentVolumeClaim or one of the vendor-specific
+                                APIs for volumes that persist for longer than the lifecycle
+                                of an individual pod.
+
+
+                                Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                                be used that way - see the documentation of the driver for
+                                more information.
+
+
+                                A pod can use both types of ephemeral volumes and
+                                persistent volumes at the same time.
                               properties:
                                 volumeClaimTemplate:
-                                  description: "Will be used to create a stand-alone
-                                    PVC to provision the volume. The pod in which
-                                    this EphemeralVolumeSource is embedded will be
-                                    the owner of the PVC, i.e. the PVC will be deleted
-                                    together with the pod.  The name of the PVC will
-                                    be `<pod name>-<volume name>` where `<volume name>`
-                                    is the name from the `PodSpec.Volumes` array entry.
-                                    Pod validation will reject the pod if the concatenated
-                                    name is not valid for a PVC (for example, too
-                                    long). \n An existing PVC with that name that
-                                    is not owned by the pod will *not* be used for
-                                    the pod to avoid using an unrelated volume by
-                                    mistake. Starting the pod is then blocked until
-                                    the unrelated PVC is removed. If such a pre-created
-                                    PVC is meant to be used by the pod, the PVC has
-                                    to updated with an owner reference to the pod
-                                    once the pod exists. Normally this should not
-                                    be necessary, but it may be useful when manually
-                                    reconstructing a broken cluster. \n This field
-                                    is read-only and no changes will be made by Kubernetes
-                                    to the PVC after it has been created. \n Required,
-                                    must not be nil."
+                                  description: |-
+                                    Will be used to create a stand-alone PVC to provision the volume.
+                                    The pod in which this EphemeralVolumeSource is embedded will be the
+                                    owner of the PVC, i.e. the PVC will be deleted together with the
+                                    pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                    `<volume name>` is the name from the `PodSpec.Volumes` array
+                                    entry. Pod validation will reject the pod if the concatenated name
+                                    is not valid for a PVC (for example, too long).
+
+
+                                    An existing PVC with that name that is not owned by the pod
+                                    will *not* be used for the pod to avoid using an unrelated
+                                    volume by mistake. Starting the pod is then blocked until
+                                    the unrelated PVC is removed. If such a pre-created PVC is
+                                    meant to be used by the pod, the PVC has to updated with an
+                                    owner reference to the pod once the pod exists. Normally
+                                    this should not be necessary, but it may be useful when
+                                    manually reconstructing a broken cluster.
+
+
+                                    This field is read-only and no changes will be made by Kubernetes
+                                    to the PVC after it has been created.
+
+
+                                    Required, must not be nil.
                                   properties:
                                     metadata:
-                                      description: May contain labels and annotations
-                                        that will be copied into the PVC when creating
-                                        it. No other fields are allowed and will be
-                                        rejected during validation.
+                                      description: |-
+                                        May contain labels and annotations that will be copied into the PVC
+                                        when creating it. No other fields are allowed and will be rejected during
+                                        validation.
                                       type: object
                                     spec:
-                                      description: The specification for the PersistentVolumeClaim.
-                                        The entire content is copied unchanged into
-                                        the PVC that gets created from this template.
-                                        The same fields as in a PersistentVolumeClaim
+                                      description: |-
+                                        The specification for the PersistentVolumeClaim. The entire content is
+                                        copied unchanged into the PVC that gets created from this
+                                        template. The same fields as in a PersistentVolumeClaim
                                         are also valid here.
                                       properties:
                                         accessModes:
-                                          description: 'accessModes contains the desired
-                                            access modes the volume should have. More
-                                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         dataSource:
-                                          description: 'dataSource field can be used
-                                            to specify either: * An existing VolumeSnapshot
-                                            object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                            * An existing PVC (PersistentVolumeClaim)
-                                            If the provisioner or an external controller
-                                            can support the specified data source,
-                                            it will create a new volume based on the
-                                            contents of the specified data source.
-                                            When the AnyVolumeDataSource feature gate
-                                            is enabled, dataSource contents will be
-                                            copied to dataSourceRef, and dataSourceRef
-                                            contents will be copied to dataSource
-                                            when dataSourceRef.namespace is not specified.
-                                            If the namespace is specified, then dataSourceRef
-                                            will not be copied to dataSource.'
                                           properties:
                                             apiGroup:
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                           required:
                                           - kind
@@ -6566,52 +6429,12 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         dataSourceRef:
-                                          description: 'dataSourceRef specifies the
-                                            object from which to populate the volume
-                                            with data, if a non-empty volume is desired.
-                                            This may be any object from a non-empty
-                                            API group (non core object) or a PersistentVolumeClaim
-                                            object. When this field is specified,
-                                            volume binding will only succeed if the
-                                            type of the specified object matches some
-                                            installed volume populator or dynamic
-                                            provisioner. This field will replace the
-                                            functionality of the dataSource field
-                                            and as such if both fields are non-empty,
-                                            they must have the same value. For backwards
-                                            compatibility, when namespace isn''t specified
-                                            in dataSourceRef, both fields (dataSource
-                                            and dataSourceRef) will be set to the
-                                            same value automatically if one of them
-                                            is empty and the other is non-empty. When
-                                            namespace is specified in dataSourceRef,
-                                            dataSource isn''t set to the same value
-                                            and must be empty. There are three important
-                                            differences between dataSource and dataSourceRef:
-                                            * While dataSource only allows two specific
-                                            types of objects, dataSourceRef allows
-                                            any non-core object, as well as PersistentVolumeClaim
-                                            objects. * While dataSource ignores disallowed
-                                            values (dropping them), dataSourceRef
-                                            preserves all values, and generates an
-                                            error if a disallowed value is specified.
-                                            * While dataSource only allows local objects,
-                                            dataSourceRef allows objects in any namespaces.
-                                            (Beta) Using this field requires the AnyVolumeDataSource
-                                            feature gate to be enabled. (Alpha) Using
-                                            the namespace field of dataSourceRef requires
-                                            the CrossNamespaceVolumeDataSource feature
-                                            gate to be enabled.'
                                           properties:
                                             apiGroup:
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                             namespace:
                                               type: string
@@ -6620,27 +6443,7 @@ spec:
                                           - name
                                           type: object
                                         resources:
-                                          description: 'resources represents the minimum
-                                            resources the volume should have. If RecoverVolumeExpansionFailure
-                                            feature is enabled users are allowed to
-                                            specify resource requirements that are
-                                            lower than previous value but must still
-                                            be higher than capacity recorded in the
-                                            status field of the claim. More info:
-                                            https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                           properties:
-                                            claims:
-                                              items:
-                                                properties:
-                                                  name:
-                                                    type: string
-                                                required:
-                                                - name
-                                                type: object
-                                              type: array
-                                              x-kubernetes-list-map-keys:
-                                              - name
-                                              x-kubernetes-list-type: map
                                             limits:
                                               additionalProperties:
                                                 anyOf:
@@ -6659,8 +6462,6 @@ spec:
                                               type: object
                                           type: object
                                         selector:
-                                          description: selector is a label query over
-                                            volumes to consider for binding.
                                           properties:
                                             matchExpressions:
                                               items:
@@ -6673,11 +6474,13 @@ spec:
                                                     items:
                                                       type: string
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                 required:
                                                 - key
                                                 - operator
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
@@ -6685,19 +6488,12 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         storageClassName:
-                                          description: 'storageClassName is the name
-                                            of the StorageClass required by the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                          type: string
+                                        volumeAttributesClassName:
                                           type: string
                                         volumeMode:
-                                          description: volumeMode defines what type
-                                            of volume is required by the claim. Value
-                                            of Filesystem is implied when not included
-                                            in claim spec.
                                           type: string
                                         volumeName:
-                                          description: volumeName is the binding reference
-                                            to the PersistentVolume backing this claim.
                                           type: string
                                       type: object
                                   required:
@@ -6710,21 +6506,20 @@ spec:
                                 exposed to the pod.
                               properties:
                                 fsType:
-                                  description: 'fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified. TODO: how
-                                    do we prevent errors in the filesystem from compromising
-                                    the machine'
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 lun:
                                   description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'readOnly is Optional: Defaults to
-                                    false (read/write). ReadOnly here will force the
-                                    ReadOnly setting in VolumeMounts.'
+                                  description: |-
+                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 targetWWNs:
                                   description: 'targetWWNs is Optional: FC target
@@ -6732,29 +6527,30 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 wwids:
-                                  description: 'wwids Optional: FC volume world wide
-                                    identifiers (wwids) Either wwids or combination
-                                    of targetWWNs and lun must be set, but not both
-                                    simultaneously.'
+                                  description: |-
+                                    wwids Optional: FC volume world wide identifiers (wwids)
+                                    Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                   items:
                                     type: string
                                   type: array
+                                  x-kubernetes-list-type: atomic
                               type: object
                             flexVolume:
-                              description: flexVolume represents a generic volume
-                                resource that is provisioned/attached using an exec
-                                based plugin.
+                              description: |-
+                                flexVolume represents a generic volume resource that is
+                                provisioned/attached using an exec based plugin.
                               properties:
                                 driver:
                                   description: driver is the name of the driver to
                                     use for this volume.
                                   type: string
                                 fsType:
-                                  description: fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". The
-                                    default filesystem depends on FlexVolume script.
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
@@ -6763,23 +6559,28 @@ spec:
                                     extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: 'readOnly is Optional: defaults to
-                                    false (read/write). ReadOnly here will force the
-                                    ReadOnly setting in VolumeMounts.'
+                                  description: |-
+                                    readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: 'secretRef is Optional: secretRef is
-                                    reference to the secret object containing sensitive
-                                    information to pass to the plugin scripts. This
-                                    may be empty if no secret object is specified.
-                                    If the secret object contains more than one secret,
-                                    all secrets are passed to the plugin scripts.'
+                                  description: |-
+                                    secretRef is Optional: secretRef is reference to the secret object containing
+                                    sensitive information to pass to the plugin scripts. This may be
+                                    empty if no secret object is specified. If the secret object
+                                    contains more than one secret, all secrets are passed to the plugin
+                                    scripts.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -6792,9 +6593,9 @@ spec:
                                 control service being running
                               properties:
                                 datasetName:
-                                  description: datasetName is Name of the dataset
-                                    stored as metadata -> name on the dataset for
-                                    Flocker should be considered as deprecated
+                                  description: |-
+                                    datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                    should be considered as deprecated
                                   type: string
                                 datasetUUID:
                                   description: datasetUUID is the UUID of the dataset.
@@ -6802,57 +6603,55 @@ spec:
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: 'gcePersistentDisk represents a GCE Disk
-                                resource that is attached to a kubelet''s host machine
-                                and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              description: |-
+                                gcePersistentDisk represents a GCE Disk resource that is attached to a
+                                kubelet's host machine and then exposed to the pod.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                               properties:
                                 fsType:
-                                  description: 'fsType is filesystem type of the volume
-                                    that you want to mount. Tip: Ensure that the filesystem
-                                    type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred
-                                    to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                    TODO: how do we prevent errors in the filesystem
-                                    from compromising the machine'
+                                  description: |-
+                                    fsType is filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: 'partition is the partition in the
-                                    volume that you want to mount. If omitted, the
-                                    default is to mount by volume name. Examples:
-                                    For volume /dev/sda1, you specify the partition
-                                    as "1". Similarly, the volume partition for /dev/sda
-                                    is "0" (or you can leave the property empty).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: |-
+                                    partition is the partition in the volume that you want to mount.
+                                    If omitted, the default is to mount by volume name.
+                                    Examples: For volume /dev/sda1, you specify the partition as "1".
+                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: 'pdName is unique name of the PD resource
-                                    in GCE. Used to identify the disk in GCE. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: |-
+                                    pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: string
                                 readOnly:
-                                  description: 'readOnly here will force the ReadOnly
-                                    setting in VolumeMounts. Defaults to false. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: |-
+                                    readOnly here will force the ReadOnly setting in VolumeMounts.
+                                    Defaults to false.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: boolean
                               required:
                               - pdName
                               type: object
                             gitRepo:
-                              description: 'gitRepo represents a git repository at
-                                a particular revision. DEPRECATED: GitRepo is deprecated.
-                                To provision a container with a git repo, mount an
-                                EmptyDir into an InitContainer that clones the repo
-                                using git, then mount the EmptyDir into the Pod''s
-                                container.'
+                              description: |-
+                                gitRepo represents a git repository at a particular revision.
+                                DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                                into the Pod's container.
                               properties:
                                 directory:
-                                  description: directory is the target directory name.
-                                    Must not contain or start with '..'.  If '.' is
-                                    supplied, the volume directory will be the git
-                                    repository.  Otherwise, if specified, the volume
-                                    will contain the git repository in the subdirectory
-                                    with the given name.
+                                  description: |-
+                                    directory is the target directory name.
+                                    Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                    git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                    the subdirectory with the given name.
                                   type: string
                                 repository:
                                   description: repository is the URL
@@ -6865,54 +6664,61 @@ spec:
                               - repository
                               type: object
                             glusterfs:
-                              description: 'glusterfs represents a Glusterfs mount
-                                on the host that shares a pod''s lifetime. More info:
-                                https://examples.k8s.io/volumes/glusterfs/README.md'
+                              description: |-
+                                glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                More info: https://examples.k8s.io/volumes/glusterfs/README.md
                               properties:
                                 endpoints:
-                                  description: 'endpoints is the endpoint name that
-                                    details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: |-
+                                    endpoints is the endpoint name that details Glusterfs topology.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 path:
-                                  description: 'path is the Glusterfs volume path.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: |-
+                                    path is the Glusterfs volume path.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 readOnly:
-                                  description: 'readOnly here will force the Glusterfs
-                                    volume to be mounted with read-only permissions.
-                                    Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: |-
+                                    readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                    Defaults to false.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: boolean
                               required:
                               - endpoints
                               - path
                               type: object
                             hostPath:
-                              description: 'hostPath represents a pre-existing file
-                                or directory on the host machine that is directly
-                                exposed to the container. This is generally used for
-                                system agents or other privileged things that are
-                                allowed to see the host machine. Most containers will
-                                NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                --- TODO(jonesdl) We need to restrict who can use
-                                host directory mounts and who can/can not mount host
-                                directories as read/write.'
+                              description: |-
+                                hostPath represents a pre-existing file or directory on the host
+                                machine that is directly exposed to the container. This is generally
+                                used for system agents or other privileged things that are allowed
+                                to see the host machine. Most containers will NOT need this.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                ---
+                                TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
+                                mount host directories as read/write.
                               properties:
                                 path:
-                                  description: 'path of the directory on the host.
-                                    If the path is a symlink, it will follow the link
-                                    to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  description: |-
+                                    path of the directory on the host.
+                                    If the path is a symlink, it will follow the link to the real path.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                                 type:
-                                  description: 'type for HostPath Volume Defaults
-                                    to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  description: |-
+                                    type for HostPath Volume
+                                    Defaults to ""
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: 'iscsi represents an ISCSI Disk resource
-                                that is attached to a kubelet''s host machine and
-                                then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                              description: |-
+                                iscsi represents an ISCSI Disk resource that is attached to a
+                                kubelet's host machine and then exposed to the pod.
+                                More info: https://examples.k8s.io/volumes/iscsi/README.md
                               properties:
                                 chapAuthDiscovery:
                                   description: chapAuthDiscovery defines whether support
@@ -6923,62 +6729,65 @@ spec:
                                     iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: 'fsType is the filesystem type of the
-                                    volume that you want to mount. Tip: Ensure that
-                                    the filesystem type is supported by the host operating
-                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified. More info:
-                                    https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                    TODO: how do we prevent errors in the filesystem
-                                    from compromising the machine'
+                                  description: |-
+                                    fsType is the filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 initiatorName:
-                                  description: initiatorName is the custom iSCSI Initiator
-                                    Name. If initiatorName is specified with iscsiInterface
-                                    simultaneously, new iSCSI interface <target portal>:<volume
-                                    name> will be created for the connection.
+                                  description: |-
+                                    initiatorName is the custom iSCSI Initiator Name.
+                                    If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                    <target portal>:<volume name> will be created for the connection.
                                   type: string
                                 iqn:
                                   description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: iscsiInterface is the interface Name
-                                    that uses an iSCSI transport. Defaults to 'default'
-                                    (tcp).
+                                  description: |-
+                                    iscsiInterface is the interface Name that uses an iSCSI transport.
+                                    Defaults to 'default' (tcp).
                                   type: string
                                 lun:
                                   description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: portals is the iSCSI Target Portal
-                                    List. The portal is either an IP or ip_addr:port
-                                    if the port is other than default (typically TCP
-                                    ports 860 and 3260).
+                                  description: |-
+                                    portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                    is other than default (typically TCP ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 readOnly:
-                                  description: readOnly here will force the ReadOnly
-                                    setting in VolumeMounts. Defaults to false.
+                                  description: |-
+                                    readOnly here will force the ReadOnly setting in VolumeMounts.
+                                    Defaults to false.
                                   type: boolean
                                 secretRef:
                                   description: secretRef is the CHAP Secret for iSCSI
                                     target and initiator authentication
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 targetPortal:
-                                  description: targetPortal is iSCSI Target Portal.
-                                    The Portal is either an IP or ip_addr:port if
-                                    the port is other than default (typically TCP
-                                    ports 860 and 3260).
+                                  description: |-
+                                    targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                    is other than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -6986,43 +6795,51 @@ spec:
                               - targetPortal
                               type: object
                             name:
-                              description: 'name of the volume. Must be a DNS_LABEL
-                                and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              description: |-
+                                name of the volume.
+                                Must be a DNS_LABEL and unique within the pod.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                             nfs:
-                              description: 'nfs represents an NFS mount on the host
-                                that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              description: |-
+                                nfs represents an NFS mount on the host that shares a pod's lifetime
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                               properties:
                                 path:
-                                  description: 'path that is exported by the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: |-
+                                    path that is exported by the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                                 readOnly:
-                                  description: 'readOnly here will force the NFS export
-                                    to be mounted with read-only permissions. Defaults
-                                    to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: |-
+                                    readOnly here will force the NFS export to be mounted with read-only permissions.
+                                    Defaults to false.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: boolean
                                 server:
-                                  description: 'server is the hostname or IP address
-                                    of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: |-
+                                    server is the hostname or IP address of the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                               required:
                               - path
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: 'persistentVolumeClaimVolumeSource represents
-                                a reference to a PersistentVolumeClaim in the same
-                                namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              description: |-
+                                persistentVolumeClaimVolumeSource represents a reference to a
+                                PersistentVolumeClaim in the same namespace.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                               properties:
                                 claimName:
-                                  description: 'claimName is the name of a PersistentVolumeClaim
-                                    in the same namespace as the pod using this volume.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  description: |-
+                                    claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                   type: string
                                 readOnly:
-                                  description: readOnly Will force the ReadOnly setting
-                                    in VolumeMounts. Default false.
+                                  description: |-
+                                    readOnly Will force the ReadOnly setting in VolumeMounts.
+                                    Default false.
                                   type: boolean
                               required:
                               - claimName
@@ -7033,10 +6850,10 @@ spec:
                                 machine
                               properties:
                                 fsType:
-                                  description: fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified.
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
                                   description: pdID is the ID that identifies Photon
@@ -7050,15 +6867,15 @@ spec:
                                 attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: fSType represents the filesystem type
-                                    to mount Must be a filesystem type supported by
-                                    the host operating system. Ex. "ext4", "xfs".
-                                    Implicitly inferred to be "ext4" if unspecified.
+                                  description: |-
+                                    fSType represents the filesystem type to mount
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: readOnly defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
                                   description: volumeID uniquely identifies a Portworx
@@ -7072,16 +6889,13 @@ spec:
                                 secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: defaultMode are the mode bits used
-                                    to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or
-                                    a decimal value between 0 and 511. YAML accepts
-                                    both octal and decimal values, JSON requires decimal
-                                    values for mode bits. Directories within the path
-                                    are not affected by this setting. This might be
-                                    in conflict with other options that affect the
-                                    file mode, like fsGroup, and the result can be
-                                    other mode bits set.
+                                  description: |-
+                                    defaultMode are the mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
@@ -7090,27 +6904,51 @@ spec:
                                     description: Projection that may be projected
                                       along with other supported volume types
                                     properties:
+                                      clusterTrustBundle:
+                                        properties:
+                                          labelSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          signerName:
+                                            type: string
+                                        required:
+                                        - path
+                                        type: object
                                       configMap:
                                         description: configMap information about the
                                           configMap data to project
                                         properties:
                                           items:
-                                            description: items if unspecified, each
-                                              key-value pair in the Data field of
-                                              the referenced ConfigMap will be projected
-                                              into the volume as a file whose name
-                                              is the key and content is the value.
-                                              If specified, the listed keys will be
-                                              projected into the specified paths,
-                                              and unlisted keys will not be present.
-                                              If a key is specified which is not present
-                                              in the ConfigMap, the volume setup will
-                                              error unless it is marked optional.
-                                              Paths must be relative and may not contain
-                                              the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
                                                   type: string
@@ -7124,15 +6962,11 @@ spec:
                                               - path
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            default: ""
                                             type: string
                                           optional:
-                                            description: optional specify whether
-                                              the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -7141,8 +6975,6 @@ spec:
                                           the downwardAPI data to project
                                         properties:
                                           items:
-                                            description: Items is a list of DownwardAPIVolume
-                                              file
                                             items:
                                               properties:
                                                 fieldRef:
@@ -7180,28 +7012,14 @@ spec:
                                               - path
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       secret:
                                         description: secret information about the
                                           secret data to project
                                         properties:
                                           items:
-                                            description: items if unspecified, each
-                                              key-value pair in the Data field of
-                                              the referenced Secret will be projected
-                                              into the volume as a file whose name
-                                              is the key and content is the value.
-                                              If specified, the listed keys will be
-                                              projected into the specified paths,
-                                              and unlisted keys will not be present.
-                                              If a key is specified which is not present
-                                              in the Secret, the volume setup will
-                                              error unless it is marked optional.
-                                              Paths must be relative and may not contain
-                                              the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
                                                   type: string
@@ -7215,15 +7033,11 @@ spec:
                                               - path
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            default: ""
                                             type: string
                                           optional:
-                                            description: optional field specify whether
-                                              the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -7232,67 +7046,48 @@ spec:
                                           about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: audience is the intended
-                                              audience of the token. A recipient of
-                                              a token must identify itself with an
-                                              identifier specified in the audience
-                                              of the token, and otherwise should reject
-                                              the token. The audience defaults to
-                                              the identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: expirationSeconds is the
-                                              requested duration of validity of the
-                                              service account token. As the token
-                                              approaches expiration, the kubelet volume
-                                              plugin will proactively rotate the service
-                                              account token. The kubelet will start
-                                              trying to rotate the token if the token
-                                              is older than 80 percent of its time
-                                              to live or if the token is older than
-                                              24 hours.Defaults to 1 hour and must
-                                              be at least 10 minutes.
                                             format: int64
                                             type: integer
                                           path:
-                                            description: path is the path relative
-                                              to the mount point of the file to project
-                                              the token into.
                                             type: string
                                         required:
                                         - path
                                         type: object
                                     type: object
                                   type: array
+                                  x-kubernetes-list-type: atomic
                               type: object
                             quobyte:
                               description: quobyte represents a Quobyte mount on the
                                 host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: group to map volume access to Default
-                                    is no group
+                                  description: |-
+                                    group to map volume access to
+                                    Default is no group
                                   type: string
                                 readOnly:
-                                  description: readOnly here will force the Quobyte
-                                    volume to be mounted with read-only permissions.
+                                  description: |-
+                                    readOnly here will force the Quobyte volume to be mounted with read-only permissions.
                                     Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: registry represents a single or multiple
-                                    Quobyte Registry services specified as a string
-                                    as host:port pair (multiple entries are separated
-                                    with commas) which acts as the central registry
-                                    for volumes
+                                  description: |-
+                                    registry represents a single or multiple Quobyte Registry services
+                                    specified as a string as host:port pair (multiple entries are separated with commas)
+                                    which acts as the central registry for volumes
                                   type: string
                                 tenant:
-                                  description: tenant owning the given Quobyte volume
-                                    in the Backend Used with dynamically provisioned
-                                    Quobyte volumes, value is set by the plugin
+                                  description: |-
+                                    tenant owning the given Quobyte volume in the Backend
+                                    Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: user to map volume access to Defaults
-                                    to serivceaccount user
+                                  description: |-
+                                    user to map volume access to
+                                    Defaults to serivceaccount user
                                   type: string
                                 volume:
                                   description: volume is a string that references
@@ -7303,60 +7098,74 @@ spec:
                               - volume
                               type: object
                             rbd:
-                              description: 'rbd represents a Rados Block Device mount
-                                on the host that shares a pod''s lifetime. More info:
-                                https://examples.k8s.io/volumes/rbd/README.md'
+                              description: |-
+                                rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md
                               properties:
                                 fsType:
-                                  description: 'fsType is the filesystem type of the
-                                    volume that you want to mount. Tip: Ensure that
-                                    the filesystem type is supported by the host operating
-                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified. More info:
-                                    https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                    TODO: how do we prevent errors in the filesystem
-                                    from compromising the machine'
+                                  description: |-
+                                    fsType is the filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 image:
-                                  description: 'image is the rados image name. More
-                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    image is the rados image name.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 keyring:
-                                  description: 'keyring is the path to key ring for
-                                    RBDUser. Default is /etc/ceph/keyring. More info:
-                                    https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    keyring is the path to key ring for RBDUser.
+                                    Default is /etc/ceph/keyring.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 monitors:
-                                  description: 'monitors is a collection of Ceph monitors.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    monitors is a collection of Ceph monitors.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 pool:
-                                  description: 'pool is the rados pool name. Default
-                                    is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    pool is the rados pool name.
+                                    Default is rbd.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 readOnly:
-                                  description: 'readOnly here will force the ReadOnly
-                                    setting in VolumeMounts. Defaults to false. More
-                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    readOnly here will force the ReadOnly setting in VolumeMounts.
+                                    Defaults to false.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: boolean
                                 secretRef:
-                                  description: 'secretRef is name of the authentication
-                                    secret for RBDUser. If provided overrides keyring.
-                                    Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    secretRef is name of the authentication secret for RBDUser. If provided
+                                    overrides keyring.
+                                    Default is nil.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: 'user is the rados user name. Default
-                                    is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: |-
+                                    user is the rados user name.
+                                    Default is admin.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                               required:
                               - image
@@ -7367,10 +7176,11 @@ spec:
                                 volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Default
-                                    is "xfs".
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs".
+                                    Default is "xfs".
                                   type: string
                                 gateway:
                                   description: gateway is the host address of the
@@ -7381,21 +7191,25 @@ spec:
                                     ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: readOnly Defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.
+                                  description: |-
+                                    readOnly Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: secretRef references to the secret
-                                    for ScaleIO user and other sensitive information.
-                                    If this is not provided, Login operation will
-                                    fail.
+                                  description: |-
+                                    secretRef references to the secret for ScaleIO user and other
+                                    sensitive information. If this is not provided, Login operation will fail.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -7404,8 +7218,8 @@ spec:
                                     communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: storageMode indicates whether the storage
-                                    for a volume should be ThickProvisioned or ThinProvisioned.
+                                  description: |-
+                                    storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
                                     Default is ThinProvisioned.
                                   type: string
                                 storagePool:
@@ -7417,9 +7231,9 @@ spec:
                                     as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: volumeName is the name of a volume
-                                    already created in the ScaleIO system that is
-                                    associated with this volume source.
+                                  description: |-
+                                    volumeName is the name of a volume already created in the ScaleIO system
+                                    that is associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -7427,34 +7241,30 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: 'secret represents a secret that should
-                                populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              description: |-
+                                secret represents a secret that should populate this volume.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                               properties:
                                 defaultMode:
-                                  description: 'defaultMode is Optional: mode bits
-                                    used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or
-                                    a decimal value between 0 and 511. YAML accepts
-                                    both octal and decimal values, JSON requires decimal
-                                    values for mode bits. Defaults to 0644. Directories
-                                    within the path are not affected by this setting.
-                                    This might be in conflict with other options that
-                                    affect the file mode, like fsGroup, and the result
-                                    can be other mode bits set.'
+                                  description: |-
+                                    defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values
+                                    for mode bits. Defaults to 0644.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: items If unspecified, each key-value
-                                    pair in the Data field of the referenced Secret
-                                    will be projected into the volume as a file whose
-                                    name is the key and content is the value. If specified,
-                                    the listed keys will be projected into the specified
-                                    paths, and unlisted keys will not be present.
-                                    If a key is specified which is not present in
-                                    the Secret, the volume setup will error unless
-                                    it is marked optional. Paths must be relative
-                                    and may not contain the '..' path or start with
-                                    '..'.
+                                  description: |-
+                                    items If unspecified, each key-value pair in the Data field of the referenced
+                                    Secret will be projected into the volume as a file whose name is the
+                                    key and content is the value. If specified, the listed keys will be
+                                    projected into the specified paths, and unlisted keys will not be
+                                    present. If a key is specified which is not present in the Secret,
+                                    the volume setup will error unless it is marked optional. Paths must be
+                                    relative and may not contain the '..' path or start with '..'.
                                   items:
                                     description: Maps a string key to a path within
                                       a volume.
@@ -7463,38 +7273,29 @@ spec:
                                         description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'mode is Optional: mode bits
-                                          used to set permissions on this file. Must
-                                          be an octal value between 0000 and 0777
-                                          or a decimal value between 0 and 511. YAML
-                                          accepts both octal and decimal values, JSON
-                                          requires decimal values for mode bits. If
-                                          not specified, the volume defaultMode will
-                                          be used. This might be in conflict with
-                                          other options that affect the file mode,
-                                          like fsGroup, and the result can be other
-                                          mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: path is the relative path of
-                                          the file to map the key to. May not be an
-                                          absolute path. May not contain the path
-                                          element '..'. May not start with the string
-                                          '..'.
+                                        description: |-
+                                          path is the relative path of the file to map the key to.
+                                          May not be an absolute path.
+                                          May not contain the path element '..'.
+                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
                                     - path
                                     type: object
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 optional:
                                   description: optional field specify whether the
                                     Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: 'secretName is the name of the secret
-                                    in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  description: |-
+                                    secretName is the name of the secret in the pod's namespace to use.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                   type: string
                               type: object
                             storageos:
@@ -7502,44 +7303,47 @@ spec:
                                 attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified.
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: readOnly defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: secretRef specifies the secret to use
-                                    for obtaining the StorageOS API credentials.  If
-                                    not specified, default values will be attempted.
+                                  description: |-
+                                    secretRef specifies the secret to use for obtaining the StorageOS API
+                                    credentials.  If not specified, default values will be attempted.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeName:
-                                  description: volumeName is the human-readable name
-                                    of the StorageOS volume.  Volume names are only
-                                    unique within a namespace.
+                                  description: |-
+                                    volumeName is the human-readable name of the StorageOS volume.  Volume
+                                    names are only unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: volumeNamespace specifies the scope
-                                    of the volume within StorageOS.  If no namespace
-                                    is specified then the Pod's namespace will be
-                                    used.  This allows the Kubernetes name scoping
-                                    to be mirrored within StorageOS for tighter integration.
-                                    Set VolumeName to any name to override the default
-                                    behaviour. Set to "default" if you are not using
-                                    namespaces within StorageOS. Namespaces that do
-                                    not pre-exist within StorageOS will be created.
+                                  description: |-
+                                    volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                    namespace is specified then the Pod's namespace will be used.  This allows the
+                                    Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                    Set VolumeName to any name to override the default behaviour.
+                                    Set to "default" if you are not using namespaces within StorageOS.
+                                    Namespaces that do not pre-exist within StorageOS will be created.
                                   type: string
                               type: object
                             vsphereVolume:
@@ -7547,10 +7351,10 @@ spec:
                                 attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: fsType is filesystem type to mount.
-                                    Must be a filesystem type supported by the host
-                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified.
+                                  description: |-
+                                    fsType is filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
                                   description: storagePolicyID is the storage Policy
@@ -7572,13 +7376,17 @@ spec:
                           - name
                           type: object
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                     required:
                     - containers
                     type: object
                 type: object
               replicas:
-                description: Number of desired pods. This is a pointer to distinguish
-                  between explicit zero and not specified. Defaults to 1.
+                description: |-
+                  Number of desired pods. This is a pointer to distinguish between explicit
+                  zero and not specified. Defaults to 1.
                 format: int32
                 type: integer
               routegroup:
@@ -7586,27 +7394,21 @@ spec:
                   at creation time.
                 properties:
                   additionalBackends:
-                    description: AdditionalBackends is the list of additional backends
-                      to use for routing.
+                    description: |-
+                      AdditionalBackends is the list of additional backends to use for
+                      routing.
                     items:
                       properties:
                         address:
                           description: Address is required for type `network`
                           type: string
                         algorithm:
-                          description: Algorithm is required for type `lb`. `roundRobin`
-                            - backend is chosen by the round robin algorithm, starting
-                            with a random selected backend to spread across all backends
-                            from the beginning. `random` - backend is chosen at random.
-                            `consistentHash` - backend is chosen by [consistent hashing](https://en.wikipedia.org/wiki/Consistent_hashing)
-                            algorithm based on the request key. The request key is
-                            derived from `X-Forwarded-For` header or request remote
-                            IP address as the fallback. Use [`consistentHashKey`](filters.md#consistenthashkey)
-                            filter to set the request key. Use [`consistentHashBalanceFactor`](filters.md#consistenthashbalancefactor)
-                            to prevent popular keys from overloading a single backend
-                            endpoint. `powerOfRandomNChoices` - backend is chosen
-                            by selecting N random endpoints and picking the one with
-                            least outstanding requests from them (see http://www.eecs.harvard.edu/~michaelm/postscripts/handbook2001.pdf).
+                          description: |-
+                            Algorithm is required for type `lb`.
+                            `roundRobin` - backend is chosen by the round robin algorithm, starting with a random selected backend to spread across all backends from the beginning.
+                            `random` - backend is chosen at random.
+                            `consistentHash` - backend is chosen by [consistent hashing](https://en.wikipedia.org/wiki/Consistent_hashing) algorithm based on the request key. The request key is derived from `X-Forwarded-For` header or request remote IP address as the fallback. Use [`consistentHashKey`](filters.md#consistenthashkey) filter to set the request key. Use [`consistentHashBalanceFactor`](filters.md#consistenthashbalancefactor) to prevent popular keys from overloading a single backend endpoint.
+                            `powerOfRandomNChoices` - backend is chosen by selecting N random endpoints and picking the one with least outstanding requests from them (see http://www.eecs.harvard.edu/~michaelm/postscripts/handbook2001.pdf).
                           enum:
                           - roundRobin
                           - random
@@ -7630,24 +7432,14 @@ spec:
                           description: ServicePort is required for type `service`
                           type: integer
                         type:
-                          description: Type of the backend. `service`- resolve Kubernetes
-                            service to the available Endpoints belonging to the Service,
-                            and generate load balanced routes using them. `shunt`
-                            - reply directly from the proxy itself. This can be used
-                            to shortcut, for example have a default that replies with
-                            404 or use skipper as a backend serving static content
-                            in demos. `loopback` - lookup again the routing table
-                            to a better matching route after processing the current
-                            route. Like this you can add some headers or change the
-                            request path for some specific matching requests. `dynamic`
-                            - use the backend provided by filters. This allows skipper
-                            as library users to do proxy calls to a certain target
-                            from their own implementation dynamically looked up by
-                            their filters. `lb` - balance the load across multiple
-                            network endpoints using specified algorithm. If algorithm
-                            is not specified it will use the default algorithm set
-                            by Skipper at start. `network` - use arbitrary HTTP or
-                            HTTPS URL.
+                          description: |-
+                            Type of the backend.
+                            `service`- resolve Kubernetes service to the available Endpoints belonging to the Service, and generate load balanced routes using them.
+                            `shunt` - reply directly from the proxy itself. This can be used to shortcut, for example have a default that replies with 404 or use skipper as a backend serving static content in demos.
+                            `loopback` - lookup again the routing table to a better matching route after processing the current route. Like this you can add some headers or change the request path for some specific matching requests.
+                            `dynamic` - use the backend provided by filters. This allows skipper as library users to do proxy calls to a certain target from their own implementation dynamically looked up by their filters.
+                            `lb` - balance the load across multiple network endpoints using specified algorithm. If algorithm is not specified it will use the default algorithm set by Skipper at start.
+                            `network` - use arbitrary HTTP or HTTPS URL.
                           enum:
                           - service
                           - shunt
@@ -7675,18 +7467,19 @@ spec:
                       per stack backends.
                     type: string
                   metadata:
-                    description: EmbeddedObjectMetaWithAnnotations defines the metadata
-                      which can be attached to a resource. It's a slimmed down version
-                      of metav1.ObjectMeta only containing annotations.
+                    description: |-
+                      EmbeddedObjectMetaWithAnnotations defines the metadata which can be attached
+                      to a resource. It's a slimmed down version of metav1.ObjectMeta only
+                      containing annotations.
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: 'Annotations is an unstructured key value map
-                          stored with a resource that may be set by external tools
-                          to store and retrieve arbitrary metadata. They are not queryable
-                          and should be preserved when modifying objects. More info:
-                          http://kubernetes.io/docs/user-guide/annotations'
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
                         type: object
                     type: object
                   routes:
@@ -7695,20 +7488,19 @@ spec:
                     items:
                       properties:
                         backends:
-                          description: RouteGroupBackendReference specifies the list
-                            of backendReference that should be applied to override
-                            the defaultBackends
+                          description: |-
+                            RouteGroupBackendReference specifies the list of backendReference that should
+                            be applied to override the defaultBackends
                           items:
                             properties:
                               backendName:
                                 description: BackendName references backend by name
                                 type: string
                               weight:
-                                description: Weight defines a portion of traffic for
-                                  the referenced backend. It equals to weight divided
-                                  by the sum of all backend weights. When all references
-                                  have zero (or unspecified) weight then traffic is
-                                  split equally between them.
+                                description: |-
+                                  Weight defines a portion of traffic for the referenced backend.
+                                  It equals to weight divided by the sum of all backend weights.
+                                  When all references have zero (or unspecified) weight then traffic is split equally between them.
                                 minimum: 0
                                 type: integer
                             required:
@@ -7764,64 +7556,74 @@ spec:
                 - routes
                 type: object
               service:
-                description: Service can be used to configure a custom service, if
-                  not set stackset-controller will generate a service based on container
-                  port and ingress backendport.
+                description: |-
+                  Service can be used to configure a custom service, if not
+                  set stackset-controller will generate a service based on
+                  container port and ingress backendport.
                 properties:
                   metadata:
-                    description: EmbeddedObjectMetaWithAnnotations defines the metadata
-                      which can be attached to a resource. It's a slimmed down version
-                      of metav1.ObjectMeta only containing annotations.
+                    description: |-
+                      EmbeddedObjectMetaWithAnnotations defines the metadata which can be attached
+                      to a resource. It's a slimmed down version of metav1.ObjectMeta only
+                      containing annotations.
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: 'Annotations is an unstructured key value map
-                          stored with a resource that may be set by external tools
-                          to store and retrieve arbitrary metadata. They are not queryable
-                          and should be preserved when modifying objects. More info:
-                          http://kubernetes.io/docs/user-guide/annotations'
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
                         type: object
                     type: object
                   ports:
-                    description: 'The list of ports that are exposed by this service.
-                      More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                    description: |-
+                      The list of ports that are exposed by this service.
+                      More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                     items:
                       description: ServicePort contains information on service's port.
                       properties:
                         appProtocol:
-                          description: "The application protocol for this port. This
-                            is used as a hint for implementations to offer richer
-                            behavior for protocols that they understand. This field
-                            follows standard Kubernetes label syntax. Valid values
-                            are either: \n * Un-prefixed protocol names - reserved
-                            for IANA standard service names (as per RFC-6335 and https://www.iana.org/assignments/service-names).
-                            \n * Kubernetes-defined prefixed names: * 'kubernetes.io/h2c'
-                            - HTTP/2 over cleartext as described in https://www.rfc-editor.org/rfc/rfc7540
-                            * 'kubernetes.io/ws'  - WebSocket over cleartext as described
-                            in https://www.rfc-editor.org/rfc/rfc6455 * 'kubernetes.io/wss'
-                            - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
-                            \n * Other protocols should use implementation-defined
-                            prefixed names such as mycompany.com/my-custom-protocol."
+                          description: |-
+                            The application protocol for this port.
+                            This is used as a hint for implementations to offer richer behavior for protocols that they understand.
+                            This field follows standard Kubernetes label syntax.
+                            Valid values are either:
+
+
+                            * Un-prefixed protocol names - reserved for IANA standard service names (as per
+                            RFC-6335 and https://www.iana.org/assignments/service-names).
+
+
+                            * Kubernetes-defined prefixed names:
+                              * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+                              * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+                              * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+
+
+                            * Other protocols should use implementation-defined prefixed names such as
+                            mycompany.com/my-custom-protocol.
                           type: string
                         name:
-                          description: The name of this port within the service. This
-                            must be a DNS_LABEL. All ports within a ServiceSpec must
-                            have unique names. When considering the endpoints for
-                            a Service, this must match the 'name' field in the EndpointPort.
+                          description: |-
+                            The name of this port within the service. This must be a DNS_LABEL.
+                            All ports within a ServiceSpec must have unique names. When considering
+                            the endpoints for a Service, this must match the 'name' field in the
+                            EndpointPort.
                             Optional if only one ServicePort is defined on this service.
                           type: string
                         nodePort:
-                          description: 'The port on each node on which this service
-                            is exposed when type is NodePort or LoadBalancer.  Usually
-                            assigned by the system. If a value is specified, in-range,
-                            and not in use it will be used, otherwise the operation
-                            will fail.  If not specified, a port will be allocated
-                            if this Service requires one.  If this field is specified
-                            when creating a Service which does not need it, creation
-                            will fail. This field will be wiped when updating a Service
-                            to no longer need it (e.g. changing type from NodePort
-                            to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                          description: |-
+                            The port on each node on which this service is exposed when type is
+                            NodePort or LoadBalancer.  Usually assigned by the system. If a value is
+                            specified, in-range, and not in use it will be used, otherwise the
+                            operation will fail.  If not specified, a port will be allocated if this
+                            Service requires one.  If this field is specified when creating a
+                            Service which does not need it, creation will fail. This field will be
+                            wiped when updating a Service to no longer need it (e.g. changing type
+                            from NodePort to ClusterIP).
+                            More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
                           format: int32
                           type: integer
                         port:
@@ -7830,22 +7632,23 @@ spec:
                           type: integer
                         protocol:
                           default: TCP
-                          description: The IP protocol for this port. Supports "TCP",
-                            "UDP", and "SCTP". Default is TCP.
+                          description: |-
+                            The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+                            Default is TCP.
                           type: string
                         targetPort:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: 'Number or name of the port to access on the
-                            pods targeted by the service. Number must be in the range
-                            1 to 65535. Name must be an IANA_SVC_NAME. If this is
-                            a string, it will be looked up as a named port in the
-                            target Pod''s container ports. If this is not specified,
-                            the value of the ''port'' field is used (an identity map).
-                            This field is ignored for services with clusterIP=None,
-                            and should be omitted or set equal to the ''port'' field.
-                            More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                          description: |-
+                            Number or name of the port to access on the pods targeted by the service.
+                            Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                            If this is a string, it will be looked up as a named port in the
+                            target Pod's container ports. If this is not specified, the value
+                            of the 'port' field is used (an identity map).
+                            This field is ignored for services with clusterIP=None, and should be
+                            omitted or set equal to the 'port' field.
+                            More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
                           x-kubernetes-int-or-string: true
                       required:
                       - port
@@ -7857,42 +7660,45 @@ spec:
                   deployment
                 properties:
                   rollingUpdate:
-                    description: 'Rolling update config params. Present only if DeploymentStrategyType
-                      = RollingUpdate. --- TODO: Update this to follow our convention
-                      for oneOf, whatever we decide it to be.'
+                    description: |-
+                      Rolling update config params. Present only if DeploymentStrategyType =
+                      RollingUpdate.
+                      ---
+                      TODO: Update this to follow our convention for oneOf, whatever we decide it
+                      to be.
                     properties:
                       maxSurge:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'The maximum number of pods that can be scheduled
-                          above the desired number of pods. Value can be an absolute
-                          number (ex: 5) or a percentage of desired pods (ex: 10%).
-                          This can not be 0 if MaxUnavailable is 0. Absolute number
-                          is calculated from percentage by rounding up. Defaults to
-                          25%. Example: when this is set to 30%, the new ReplicaSet
-                          can be scaled up immediately when the rolling update starts,
-                          such that the total number of old and new pods do not exceed
-                          130% of desired pods. Once old pods have been killed, new
-                          ReplicaSet can be scaled up further, ensuring that total
-                          number of pods running at any time during the update is
-                          at most 130% of desired pods.'
+                        description: |-
+                          The maximum number of pods that can be scheduled above the desired number of
+                          pods.
+                          Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                          This can not be 0 if MaxUnavailable is 0.
+                          Absolute number is calculated from percentage by rounding up.
+                          Defaults to 25%.
+                          Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when
+                          the rolling update starts, such that the total number of old and new pods do not exceed
+                          130% of desired pods. Once old pods have been killed,
+                          new ReplicaSet can be scaled up further, ensuring that total number of pods running
+                          at any time during the update is at most 130% of desired pods.
                         x-kubernetes-int-or-string: true
                       maxUnavailable:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'The maximum number of pods that can be unavailable
-                          during the update. Value can be an absolute number (ex:
-                          5) or a percentage of desired pods (ex: 10%). Absolute number
-                          is calculated from percentage by rounding down. This can
-                          not be 0 if MaxSurge is 0. Defaults to 25%. Example: when
-                          this is set to 30%, the old ReplicaSet can be scaled down
-                          to 70% of desired pods immediately when the rolling update
-                          starts. Once new pods are ready, old ReplicaSet can be scaled
-                          down further, followed by scaling up the new ReplicaSet,
-                          ensuring that the total number of pods available at all
-                          times during the update is at least 70% of desired pods.'
+                        description: |-
+                          The maximum number of pods that can be unavailable during the update.
+                          Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                          Absolute number is calculated from percentage by rounding down.
+                          This can not be 0 if MaxSurge is 0.
+                          Defaults to 25%.
+                          Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods
+                          immediately when the rolling update starts. Once new pods are ready, old ReplicaSet
+                          can be scaled down further, followed by scaling up the new ReplicaSet, ensuring
+                          that the total number of pods available at all times during the update is at
+                          least 70% of desired pods.
                         x-kubernetes-int-or-string: true
                     type: object
                   type:
@@ -7907,9 +7713,10 @@ spec:
             description: StackStatus is the status part of the Stack.
             properties:
               actualTrafficWeight:
-                description: 'ActualTrafficWeight is the actual amount of traffic
-                  currently routed to the stack. TODO: should we be using floats in
-                  the API?'
+                description: |-
+                  ActualTrafficWeight is the actual amount of traffic currently
+                  routed to the stack.
+                  TODO: should we be using floats in the API?
                 format: float
                 type: number
               desiredReplicas:
@@ -7918,17 +7725,20 @@ spec:
                 format: int32
                 type: integer
               desiredTrafficWeight:
-                description: DesiredTrafficWeight is desired amount of traffic to
-                  be routed to the stack.
+                description: |-
+                  DesiredTrafficWeight is desired amount of traffic to be routed to
+                  the stack.
                 format: float
                 type: number
               labelSelector:
-                description: LabelSelector is the label selector used to find all
-                  pods managed by a stack.
+                description: |-
+                  LabelSelector is the label selector used to find all pods managed by
+                  a stack.
                 type: string
               noTrafficSince:
-                description: NoTrafficSince is the timestamp defining the last time
-                  the stack was observed getting traffic.
+                description: |-
+                  NoTrafficSince is the timestamp defining the last time the stack was
+                  observed getting traffic.
                 format: date-time
                 type: string
               prescalingStatus:
@@ -7953,18 +7763,21 @@ spec:
                     type: integer
                 type: object
               readyReplicas:
-                description: ReadyReplicas is the number of ready replicas in the
-                  Deployment managed by the stack.
-                format: int32
-                type: integer
-              replicas:
-                description: Replicas is the number of replicas in the Deployment
+                description: |-
+                  ReadyReplicas is the number of ready replicas in the Deployment
                   managed by the stack.
                 format: int32
                 type: integer
+              replicas:
+                description: |-
+                  Replicas is the number of replicas in the Deployment managed by the
+                  stack.
+                format: int32
+                type: integer
               updatedReplicas:
-                description: UpdatedReplicas is the number of updated replicas in
-                  the Deployment managed by the stack.
+                description: |-
+                  UpdatedReplicas is the number of updated replicas in the Deployment
+                  managed by the stack.
                 format: int32
                 type: integer
             type: object

--- a/cluster/manifests/stackset-controller/01-stackset-crd.yaml
+++ b/cluster/manifests/stackset-controller/01-stackset-crd.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.4
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: stacksets.zalando.org
 spec:
   group: zalando.org
@@ -40,14 +40,19 @@ spec:
         description: StackSet describes an application resource.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -55,7 +60,8 @@ spec:
             description: StackSetSpec is the spec part of the StackSet.
             properties:
               externalIngress:
-                description: ExternalIngress is used to specify the backend port to
+                description: |-
+                  ExternalIngress is used to specify the backend port to
                   generate the services for the stacks.
                 properties:
                   backendPort:
@@ -67,10 +73,12 @@ spec:
                 - backendPort
                 type: object
               ingress:
-                description: Ingress is the information we need to create ingress
-                  and service. Ingress is optional, because other controller might
-                  create ingress objects, but stackset owns the traffic switch. In
-                  this case we would only have a Traffic, but no ingress.
+                description: |-
+                  Ingress is the information we need to create ingress and
+                  service. Ingress is optional, because other controller
+                  might create ingress objects, but stackset owns the traffic
+                  switch. In this case we would only have a Traffic, but no
+                  ingress.
                 properties:
                   backendPort:
                     anyOf:
@@ -84,18 +92,19 @@ spec:
                     type: array
                     x-kubernetes-list-type: set
                   metadata:
-                    description: EmbeddedObjectMetaWithAnnotations defines the metadata
-                      which can be attached to a resource. It's a slimmed down version
-                      of metav1.ObjectMeta only containing annotations.
+                    description: |-
+                      EmbeddedObjectMetaWithAnnotations defines the metadata which can be attached
+                      to a resource. It's a slimmed down version of metav1.ObjectMeta only
+                      containing annotations.
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: 'Annotations is an unstructured key value map
-                          stored with a resource that may be set by external tools
-                          to store and retrieve arbitrary metadata. They are not queryable
-                          and should be preserved when modifying objects. More info:
-                          http://kubernetes.io/docs/user-guide/annotations'
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
                         type: object
                     type: object
                   path:
@@ -105,37 +114,33 @@ spec:
                 - hosts
                 type: object
               minReadyPercent:
-                description: minReadyPercent sets the minimum percentage of Pods expected
+                description: |-
+                  minReadyPercent sets the minimum percentage of Pods expected
                   to be Ready to consider a Stack for traffic switch
                 type: integer
               routegroup:
-                description: RouteGroup is an alternative to ingress allowing more
-                  advanced routing configuration while still maintaining the ability
-                  to switch traffic to stacks. Use this if you need skipper filters
-                  or predicates.
+                description: |-
+                  RouteGroup is an alternative to ingress allowing more advanced
+                  routing configuration while still maintaining the ability to switch
+                  traffic to stacks. Use this if you need skipper filters or
+                  predicates.
                 properties:
                   additionalBackends:
-                    description: AdditionalBackends is the list of additional backends
-                      to use for routing.
+                    description: |-
+                      AdditionalBackends is the list of additional backends to use for
+                      routing.
                     items:
                       properties:
                         address:
                           description: Address is required for type `network`
                           type: string
                         algorithm:
-                          description: Algorithm is required for type `lb`. `roundRobin`
-                            - backend is chosen by the round robin algorithm, starting
-                            with a random selected backend to spread across all backends
-                            from the beginning. `random` - backend is chosen at random.
-                            `consistentHash` - backend is chosen by [consistent hashing](https://en.wikipedia.org/wiki/Consistent_hashing)
-                            algorithm based on the request key. The request key is
-                            derived from `X-Forwarded-For` header or request remote
-                            IP address as the fallback. Use [`consistentHashKey`](filters.md#consistenthashkey)
-                            filter to set the request key. Use [`consistentHashBalanceFactor`](filters.md#consistenthashbalancefactor)
-                            to prevent popular keys from overloading a single backend
-                            endpoint. `powerOfRandomNChoices` - backend is chosen
-                            by selecting N random endpoints and picking the one with
-                            least outstanding requests from them (see http://www.eecs.harvard.edu/~michaelm/postscripts/handbook2001.pdf).
+                          description: |-
+                            Algorithm is required for type `lb`.
+                            `roundRobin` - backend is chosen by the round robin algorithm, starting with a random selected backend to spread across all backends from the beginning.
+                            `random` - backend is chosen at random.
+                            `consistentHash` - backend is chosen by [consistent hashing](https://en.wikipedia.org/wiki/Consistent_hashing) algorithm based on the request key. The request key is derived from `X-Forwarded-For` header or request remote IP address as the fallback. Use [`consistentHashKey`](filters.md#consistenthashkey) filter to set the request key. Use [`consistentHashBalanceFactor`](filters.md#consistenthashbalancefactor) to prevent popular keys from overloading a single backend endpoint.
+                            `powerOfRandomNChoices` - backend is chosen by selecting N random endpoints and picking the one with least outstanding requests from them (see http://www.eecs.harvard.edu/~michaelm/postscripts/handbook2001.pdf).
                           enum:
                           - roundRobin
                           - random
@@ -159,24 +164,14 @@ spec:
                           description: ServicePort is required for type `service`
                           type: integer
                         type:
-                          description: Type of the backend. `service`- resolve Kubernetes
-                            service to the available Endpoints belonging to the Service,
-                            and generate load balanced routes using them. `shunt`
-                            - reply directly from the proxy itself. This can be used
-                            to shortcut, for example have a default that replies with
-                            404 or use skipper as a backend serving static content
-                            in demos. `loopback` - lookup again the routing table
-                            to a better matching route after processing the current
-                            route. Like this you can add some headers or change the
-                            request path for some specific matching requests. `dynamic`
-                            - use the backend provided by filters. This allows skipper
-                            as library users to do proxy calls to a certain target
-                            from their own implementation dynamically looked up by
-                            their filters. `lb` - balance the load across multiple
-                            network endpoints using specified algorithm. If algorithm
-                            is not specified it will use the default algorithm set
-                            by Skipper at start. `network` - use arbitrary HTTP or
-                            HTTPS URL.
+                          description: |-
+                            Type of the backend.
+                            `service`- resolve Kubernetes service to the available Endpoints belonging to the Service, and generate load balanced routes using them.
+                            `shunt` - reply directly from the proxy itself. This can be used to shortcut, for example have a default that replies with 404 or use skipper as a backend serving static content in demos.
+                            `loopback` - lookup again the routing table to a better matching route after processing the current route. Like this you can add some headers or change the request path for some specific matching requests.
+                            `dynamic` - use the backend provided by filters. This allows skipper as library users to do proxy calls to a certain target from their own implementation dynamically looked up by their filters.
+                            `lb` - balance the load across multiple network endpoints using specified algorithm. If algorithm is not specified it will use the default algorithm set by Skipper at start.
+                            `network` - use arbitrary HTTP or HTTPS URL.
                           enum:
                           - service
                           - shunt
@@ -204,18 +199,19 @@ spec:
                       per stack backends.
                     type: string
                   metadata:
-                    description: EmbeddedObjectMetaWithAnnotations defines the metadata
-                      which can be attached to a resource. It's a slimmed down version
-                      of metav1.ObjectMeta only containing annotations.
+                    description: |-
+                      EmbeddedObjectMetaWithAnnotations defines the metadata which can be attached
+                      to a resource. It's a slimmed down version of metav1.ObjectMeta only
+                      containing annotations.
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: 'Annotations is an unstructured key value map
-                          stored with a resource that may be set by external tools
-                          to store and retrieve arbitrary metadata. They are not queryable
-                          and should be preserved when modifying objects. More info:
-                          http://kubernetes.io/docs/user-guide/annotations'
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
                         type: object
                     type: object
                   routes:
@@ -224,20 +220,19 @@ spec:
                     items:
                       properties:
                         backends:
-                          description: RouteGroupBackendReference specifies the list
-                            of backendReference that should be applied to override
-                            the defaultBackends
+                          description: |-
+                            RouteGroupBackendReference specifies the list of backendReference that should
+                            be applied to override the defaultBackends
                           items:
                             properties:
                               backendName:
                                 description: BackendName references backend by name
                                 type: string
                               weight:
-                                description: Weight defines a portion of traffic for
-                                  the referenced backend. It equals to weight divided
-                                  by the sum of all backend weights. When all references
-                                  have zero (or unspecified) weight then traffic is
-                                  split equally between them.
+                                description: |-
+                                  Weight defines a portion of traffic for the referenced backend.
+                                  It equals to weight divided by the sum of all backend weights.
+                                  When all references have zero (or unspecified) weight then traffic is split equally between them.
                                 minimum: 0
                                 type: integer
                             required:
@@ -296,36 +291,41 @@ spec:
                 description: StackLifecycle defines the cleanup rules for old stacks.
                 properties:
                   limit:
-                    description: Limit defines the maximum number of Stacks to keep
-                      around. If the number of Stacks exceeds the limit then the oldest
-                      stacks which are not getting traffic are deleted.
+                    description: |-
+                      Limit defines the maximum number of Stacks to keep around. If the
+                      number of Stacks exceeds the limit then the oldest stacks which are
+                      not getting traffic are deleted.
                     format: int32
                     minimum: 1
                     type: integer
                   scaledownTTLSeconds:
-                    description: ScaledownTTLSeconds is the ttl in seconds for when
-                      Stacks of a StackSet should be scaled down to 0 replicas in
-                      case they are not getting traffic. Defaults to 300 seconds.
+                    description: |-
+                      ScaledownTTLSeconds is the ttl in seconds for when Stacks of a
+                      StackSet should be scaled down to 0 replicas in case they are not
+                      getting traffic.
+                      Defaults to 300 seconds.
                     format: int64
                     type: integer
                 type: object
               stackTemplate:
-                description: StackTemplate container for resources to be created that
+                description: |-
+                  StackTemplate container for resources to be created that
                   belong to one stack.
                 properties:
                   metadata:
-                    description: EmbeddedObjectMetaWithAnnotations defines the metadata
-                      which can be attached to a resource. It's a slimmed down version
-                      of metav1.ObjectMeta only containing annotations.
+                    description: |-
+                      EmbeddedObjectMetaWithAnnotations defines the metadata which can be attached
+                      to a resource. It's a slimmed down version of metav1.ObjectMeta only
+                      containing annotations.
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: 'Annotations is an unstructured key value map
-                          stored with a resource that may be set by external tools
-                          to store and retrieve arbitrary metadata. They are not queryable
-                          and should be preserved when modifying objects. More info:
-                          http://kubernetes.io/docs/user-guide/annotations'
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
                         type: object
                     type: object
                   spec:
@@ -336,35 +336,31 @@ spec:
                           a stack
                         properties:
                           behavior:
-                            description: behavior configures the scaling behavior
-                              of the target in both Up and Down directions (scaleUp
-                              and scaleDown fields respectively). If not set, the
-                              default HPAScalingRules for scale up and scale down
-                              are used.
+                            description: |-
+                              behavior configures the scaling behavior of the target
+                              in both Up and Down directions (scaleUp and scaleDown fields respectively).
+                              If not set, the default HPAScalingRules for scale up and scale down are used.
                             properties:
                               scaleDown:
-                                description: scaleDown is scaling policy for scaling
-                                  Down. If not set, the default value is to allow
-                                  to scale down to minReplicas pods, with a 300 second
-                                  stabilization window (i.e., the highest recommendation
-                                  for the last 300sec is used).
+                                description: |-
+                                  scaleDown is scaling policy for scaling Down.
+                                  If not set, the default value is to allow to scale down to minReplicas pods, with a
+                                  300 second stabilization window (i.e., the highest recommendation for
+                                  the last 300sec is used).
                                 properties:
                                   policies:
-                                    description: policies is a list of potential scaling
-                                      polices which can be used during scaling. At
-                                      least one policy must be specified, otherwise
-                                      the HPAScalingRules will be discarded as invalid
+                                    description: |-
+                                      policies is a list of potential scaling polices which can be used during scaling.
+                                      At least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid
                                     items:
                                       description: HPAScalingPolicy is a single policy
                                         which must hold true for a specified past
                                         interval.
                                       properties:
                                         periodSeconds:
-                                          description: periodSeconds specifies the
-                                            window of time for which the policy should
-                                            hold true. PeriodSeconds must be greater
-                                            than zero and less than or equal to 1800
-                                            (30 min).
+                                          description: |-
+                                            periodSeconds specifies the window of time for which the policy should hold true.
+                                            PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
                                           format: int32
                                           type: integer
                                         type:
@@ -372,8 +368,8 @@ spec:
                                             scaling policy.
                                           type: string
                                         value:
-                                          description: value contains the amount of
-                                            change which is permitted by the policy.
+                                          description: |-
+                                            value contains the amount of change which is permitted by the policy.
                                             It must be greater than zero
                                           format: int32
                                           type: integer
@@ -385,46 +381,42 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   selectPolicy:
-                                    description: selectPolicy is used to specify which
-                                      policy should be used. If not set, the default
-                                      value Max is used.
+                                    description: |-
+                                      selectPolicy is used to specify which policy should be used.
+                                      If not set, the default value Max is used.
                                     type: string
                                   stabilizationWindowSeconds:
-                                    description: 'stabilizationWindowSeconds is the
-                                      number of seconds for which past recommendations
-                                      should be considered while scaling up or scaling
-                                      down. StabilizationWindowSeconds must be greater
-                                      than or equal to zero and less than or equal
-                                      to 3600 (one hour). If not set, use the default
-                                      values: - For scale up: 0 (i.e. no stabilization
-                                      is done). - For scale down: 300 (i.e. the stabilization
-                                      window is 300 seconds long).'
+                                    description: |-
+                                      stabilizationWindowSeconds is the number of seconds for which past recommendations should be
+                                      considered while scaling up or scaling down.
+                                      StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour).
+                                      If not set, use the default values:
+                                      - For scale up: 0 (i.e. no stabilization is done).
+                                      - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
                                     format: int32
                                     type: integer
                                 type: object
                               scaleUp:
-                                description: 'scaleUp is scaling policy for scaling
-                                  Up. If not set, the default value is the higher
-                                  of: * increase no more than 4 pods per 60 seconds
-                                  * double the number of pods per 60 seconds No stabilization
-                                  is used.'
+                                description: |-
+                                  scaleUp is scaling policy for scaling Up.
+                                  If not set, the default value is the higher of:
+                                    * increase no more than 4 pods per 60 seconds
+                                    * double the number of pods per 60 seconds
+                                  No stabilization is used.
                                 properties:
                                   policies:
-                                    description: policies is a list of potential scaling
-                                      polices which can be used during scaling. At
-                                      least one policy must be specified, otherwise
-                                      the HPAScalingRules will be discarded as invalid
+                                    description: |-
+                                      policies is a list of potential scaling polices which can be used during scaling.
+                                      At least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid
                                     items:
                                       description: HPAScalingPolicy is a single policy
                                         which must hold true for a specified past
                                         interval.
                                       properties:
                                         periodSeconds:
-                                          description: periodSeconds specifies the
-                                            window of time for which the policy should
-                                            hold true. PeriodSeconds must be greater
-                                            than zero and less than or equal to 1800
-                                            (30 min).
+                                          description: |-
+                                            periodSeconds specifies the window of time for which the policy should hold true.
+                                            PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
                                           format: int32
                                           type: integer
                                         type:
@@ -432,8 +424,8 @@ spec:
                                             scaling policy.
                                           type: string
                                         value:
-                                          description: value contains the amount of
-                                            change which is permitted by the policy.
+                                          description: |-
+                                            value contains the amount of change which is permitted by the policy.
                                             It must be greater than zero
                                           format: int32
                                           type: integer
@@ -445,28 +437,26 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   selectPolicy:
-                                    description: selectPolicy is used to specify which
-                                      policy should be used. If not set, the default
-                                      value Max is used.
+                                    description: |-
+                                      selectPolicy is used to specify which policy should be used.
+                                      If not set, the default value Max is used.
                                     type: string
                                   stabilizationWindowSeconds:
-                                    description: 'stabilizationWindowSeconds is the
-                                      number of seconds for which past recommendations
-                                      should be considered while scaling up or scaling
-                                      down. StabilizationWindowSeconds must be greater
-                                      than or equal to zero and less than or equal
-                                      to 3600 (one hour). If not set, use the default
-                                      values: - For scale up: 0 (i.e. no stabilization
-                                      is done). - For scale down: 300 (i.e. the stabilization
-                                      window is 300 seconds long).'
+                                    description: |-
+                                      stabilizationWindowSeconds is the number of seconds for which past recommendations should be
+                                      considered while scaling up or scaling down.
+                                      StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour).
+                                      If not set, use the default values:
+                                      - For scale up: 0 (i.e. no stabilization is done).
+                                      - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
                                     format: int32
                                     type: integer
                                 type: object
                             type: object
                           maxReplicas:
-                            description: maxReplicas is the upper limit for the number
-                              of replicas to which the autoscaler can scale up. It
-                              cannot be less that minReplicas.
+                            description: |-
+                              maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up.
+                              It cannot be less that minReplicas.
                             format: int32
                             type: integer
                           metrics:
@@ -484,9 +474,9 @@ spec:
                                   format: int32
                                   type: integer
                                 clusterScalingSchedule:
-                                  description: MetricsClusterScalingSchedule specifies
-                                    the ClusterScalingSchedule object which should
-                                    be used for scaling.
+                                  description: |-
+                                    MetricsClusterScalingSchedule specifies the ClusterScalingSchedule
+                                    object which should be used for scaling.
                                   properties:
                                     name:
                                       description: The name of the referenced ClusterScalingSchedule
@@ -497,15 +487,15 @@ spec:
                                   - name
                                   type: object
                                 container:
-                                  description: optional container name that can be
-                                    used to scale based on CPU or Memory metrics of
-                                    a specific container as opposed to an average
-                                    of all containers in a pod.
+                                  description: |-
+                                    optional container name that can be used to scale based on CPU or
+                                    Memory metrics of a specific container as opposed to an average of
+                                    all containers in a pod.
                                   type: string
                                 endpoint:
-                                  description: MetricsEndpoint specified the endpoint
-                                    where the custom endpoint where the metrics can
-                                    be queried
+                                  description: |-
+                                    MetricsEndpoint specified the endpoint where the custom endpoint where the metrics
+                                    can be queried
                                   properties:
                                     key:
                                       type: string
@@ -523,8 +513,9 @@ spec:
                                   - port
                                   type: object
                                 queue:
-                                  description: MetricsQueue specifies the SQS queue
-                                    whose length should be used for scaling.
+                                  description: |-
+                                    MetricsQueue specifies the SQS queue whose length should be used for
+                                    scaling.
                                   properties:
                                     name:
                                       type: string
@@ -535,9 +526,9 @@ spec:
                                   - region
                                   type: object
                                 requestsPerSecond:
-                                  description: MetricRequestsPerSecond specifies basic
-                                    information to scale based on on external RPS
-                                    metric.
+                                  description: |-
+                                    MetricRequestsPerSecond specifies basic information to scale based on
+                                    on external RPS metric.
                                   properties:
                                     hostnames:
                                       items:
@@ -547,9 +538,9 @@ spec:
                                   - hostnames
                                   type: object
                                 scalingSchedule:
-                                  description: MetricsScalingSchedule specifies the
-                                    ScalingSchedule object which should be used for
-                                    scaling.
+                                  description: |-
+                                    MetricsScalingSchedule specifies the ScalingSchedule object which
+                                    should be used for scaling.
                                   properties:
                                     name:
                                       description: The name of the referenced ScalingSchedule
@@ -580,8 +571,8 @@ spec:
                                   properties:
                                     aggregators:
                                       items:
-                                        description: ZMONMetricAggregatorType is the
-                                          type of aggregator used in a ZMON based
+                                        description: |-
+                                          ZMONMetricAggregatorType is the type of aggregator used in a ZMON based
                                           metric.
                                         enum:
                                         - avg
@@ -616,8 +607,8 @@ spec:
                               type: object
                             type: array
                           minReplicas:
-                            description: minReplicas is the lower limit for the number
-                              of replicas to which the autoscaler can scale down.
+                            description: |-
+                              minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down.
                               It defaults to 1 pod.
                             format: int32
                             type: integer
@@ -626,8 +617,9 @@ spec:
                         - metrics
                         type: object
                       configurationResources:
-                        description: ConfigurationResources describes the ConfigMaps,
-                          Secrets, and/or PlatformCredentialsSet that will be created.
+                        description: |-
+                          ConfigurationResources describes the ConfigMaps, Secrets, and/or
+                          PlatformCredentialsSet that will be created.
                         items:
                           description: ConfigurationResourcesSpec makes it possible
                             to defined the config resources to be created
@@ -652,9 +644,15 @@ spec:
                                 to be owned by Stack
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                   type: string
                               type: object
                               x-kubernetes-map-type: atomic
@@ -683,19 +681,25 @@ spec:
                                 be owned by Stack
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                   type: string
                               type: object
                               x-kubernetes-map-type: atomic
                           type: object
                         type: array
                       minReadySeconds:
-                        description: Minimum number of seconds for which a newly created
-                          pod should be ready without any of its container crashing,
-                          for it to be considered available. Defaults to 0 (pod will
-                          be considered available as soon as it is ready)
+                        description: |-
+                          Minimum number of seconds for which a newly created pod should be ready
+                          without any of its container crashing, for it to be considered available.
+                          Defaults to 0 (pod will be considered available as soon as it is ready)
                         format: int32
                         type: integer
                       podTemplate:
@@ -707,31 +711,32 @@ spec:
                               annotations:
                                 additionalProperties:
                                   type: string
-                                description: 'Annotations is an unstructured key value
-                                  map stored with a resource that may be set by external
-                                  tools to store and retrieve arbitrary metadata.
-                                  They are not queryable and should be preserved when
-                                  modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                                description: |-
+                                  Annotations is an unstructured key value map stored with a resource that may be
+                                  set by external tools to store and retrieve arbitrary metadata. They are not
+                                  queryable and should be preserved when modifying objects.
+                                  More info: http://kubernetes.io/docs/user-guide/annotations
                                 type: object
                               labels:
                                 additionalProperties:
                                   type: string
-                                description: 'Map of string keys and values that can
-                                  be used to organize and categorize (scope and select)
-                                  objects. May match selectors of replication controllers
-                                  and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                                description: |-
+                                  Map of string keys and values that can be used to organize and categorize
+                                  (scope and select) objects. May match selectors of replication controllers
+                                  and services.
+                                  More info: http://kubernetes.io/docs/user-guide/labels
                                 type: object
                             type: object
                           spec:
-                            description: 'Specification of the desired behavior of
-                              the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                            description: |-
+                              Specification of the desired behavior of the pod.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
                             properties:
                               activeDeadlineSeconds:
-                                description: Optional duration in seconds the pod
-                                  may be active on the node relative to StartTime
-                                  before the system will actively try to mark it failed
-                                  and kill associated containers. Value must be a
-                                  positive integer.
+                                description: |-
+                                  Optional duration in seconds the pod may be active on the node relative to
+                                  StartTime before the system will actively try to mark it failed and kill associated containers.
+                                  Value must be a positive integer.
                                 format: int64
                                 type: integer
                               affinity:
@@ -742,40 +747,27 @@ spec:
                                       rules for the pod.
                                     properties:
                                       preferredDuringSchedulingIgnoredDuringExecution:
-                                        description: The scheduler will prefer to
-                                          schedule pods to nodes that satisfy the
-                                          affinity expressions specified by this field,
-                                          but it may choose a node that violates one
-                                          or more of the expressions. The node that
-                                          is most preferred is the one with the greatest
-                                          sum of weights, i.e. for each node that
-                                          meets all of the scheduling requirements
-                                          (resource request, requiredDuringScheduling
-                                          affinity expressions, etc.), compute a sum
-                                          by iterating through the elements of this
-                                          field and adding "weight" to the sum if
-                                          the node matches the corresponding matchExpressions;
-                                          the node(s) with the highest sum are the
-                                          most preferred.
+                                        description: |-
+                                          The scheduler will prefer to schedule pods to nodes that satisfy
+                                          the affinity expressions specified by this field, but it may choose
+                                          a node that violates one or more of the expressions. The node that is
+                                          most preferred is the one with the greatest sum of weights, i.e.
+                                          for each node that meets all of the scheduling requirements (resource
+                                          request, requiredDuringScheduling affinity expressions, etc.),
+                                          compute a sum by iterating through the elements of this field and adding
+                                          "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                          node(s) with the highest sum are the most preferred.
                                         items:
-                                          description: An empty preferred scheduling
-                                            term matches all objects with implicit
-                                            weight 0 (i.e. it's a no-op). A null preferred
-                                            scheduling term matches no objects (i.e.
-                                            is also a no-op).
+                                          description: |-
+                                            An empty preferred scheduling term matches all objects with implicit weight 0
+                                            (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                           properties:
                                             preference:
                                               description: A node selector term, associated
                                                 with the corresponding weight.
                                               properties:
                                                 matchExpressions:
-                                                  description: A list of node selector
-                                                    requirements by node's labels.
                                                   items:
-                                                    description: A node selector requirement
-                                                      is a selector that contains
-                                                      values, a key, and an operator
-                                                      that relates the key and values.
                                                     properties:
                                                       key:
                                                         type: string
@@ -785,19 +777,15 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     required:
                                                     - key
                                                     - operator
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 matchFields:
-                                                  description: A list of node selector
-                                                    requirements by node's fields.
                                                   items:
-                                                    description: A node selector requirement
-                                                      is a selector that contains
-                                                      values, a key, and an operator
-                                                      that relates the key and values.
                                                     properties:
                                                       key:
                                                         type: string
@@ -807,11 +795,13 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     required:
                                                     - key
                                                     - operator
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             weight:
@@ -825,33 +815,26 @@ spec:
                                           - weight
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       requiredDuringSchedulingIgnoredDuringExecution:
-                                        description: If the affinity requirements
-                                          specified by this field are not met at scheduling
-                                          time, the pod will not be scheduled onto
-                                          the node. If the affinity requirements specified
-                                          by this field cease to be met at some point
-                                          during pod execution (e.g. due to an update),
-                                          the system may or may not try to eventually
-                                          evict the pod from its node.
+                                        description: |-
+                                          If the affinity requirements specified by this field are not met at
+                                          scheduling time, the pod will not be scheduled onto the node.
+                                          If the affinity requirements specified by this field cease to be met
+                                          at some point during pod execution (e.g. due to an update), the system
+                                          may or may not try to eventually evict the pod from its node.
                                         properties:
                                           nodeSelectorTerms:
                                             description: Required. A list of node
                                               selector terms. The terms are ORed.
                                             items:
-                                              description: A null or empty node selector
-                                                term matches no objects. The requirements
-                                                of them are ANDed. The TopologySelectorTerm
-                                                type implements a subset of the NodeSelectorTerm.
+                                              description: |-
+                                                A null or empty node selector term matches no objects. The requirements of
+                                                them are ANDed.
+                                                The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                               properties:
                                                 matchExpressions:
-                                                  description: A list of node selector
-                                                    requirements by node's labels.
                                                   items:
-                                                    description: A node selector requirement
-                                                      is a selector that contains
-                                                      values, a key, and an operator
-                                                      that relates the key and values.
                                                     properties:
                                                       key:
                                                         type: string
@@ -861,19 +844,15 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     required:
                                                     - key
                                                     - operator
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 matchFields:
-                                                  description: A list of node selector
-                                                    requirements by node's fields.
                                                   items:
-                                                    description: A node selector requirement
-                                                      is a selector that contains
-                                                      values, a key, and an operator
-                                                      that relates the key and values.
                                                     properties:
                                                       key:
                                                         type: string
@@ -883,14 +862,17 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     required:
                                                     - key
                                                     - operator
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         required:
                                         - nodeSelectorTerms
                                         type: object
@@ -902,21 +884,16 @@ spec:
                                       zone, etc. as some other pod(s)).
                                     properties:
                                       preferredDuringSchedulingIgnoredDuringExecution:
-                                        description: The scheduler will prefer to
-                                          schedule pods to nodes that satisfy the
-                                          affinity expressions specified by this field,
-                                          but it may choose a node that violates one
-                                          or more of the expressions. The node that
-                                          is most preferred is the one with the greatest
-                                          sum of weights, i.e. for each node that
-                                          meets all of the scheduling requirements
-                                          (resource request, requiredDuringScheduling
-                                          affinity expressions, etc.), compute a sum
-                                          by iterating through the elements of this
-                                          field and adding "weight" to the sum if
-                                          the node has pods which matches the corresponding
-                                          podAffinityTerm; the node(s) with the highest
-                                          sum are the most preferred.
+                                        description: |-
+                                          The scheduler will prefer to schedule pods to nodes that satisfy
+                                          the affinity expressions specified by this field, but it may choose
+                                          a node that violates one or more of the expressions. The node that is
+                                          most preferred is the one with the greatest sum of weights, i.e.
+                                          for each node that meets all of the scheduling requirements (resource
+                                          request, requiredDuringScheduling affinity expressions, etc.),
+                                          compute a sum by iterating through the elements of this field and adding
+                                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                          node(s) with the highest sum are the most preferred.
                                         items:
                                           description: The weights of all of the matched
                                             WeightedPodAffinityTerm fields are added
@@ -928,9 +905,6 @@ spec:
                                                 weight.
                                               properties:
                                                 labelSelector:
-                                                  description: A label query over
-                                                    a set of resources, in this case
-                                                    pods.
                                                   properties:
                                                     matchExpressions:
                                                       items:
@@ -943,28 +917,30 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         required:
                                                         - key
                                                         - operator
                                                         type: object
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                     matchLabels:
                                                       additionalProperties:
                                                         type: string
                                                       type: object
                                                   type: object
                                                   x-kubernetes-map-type: atomic
+                                                matchLabelKeys:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                mismatchLabelKeys:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
                                                 namespaceSelector:
-                                                  description: A label query over
-                                                    the set of namespaces that the
-                                                    term applies to. The term is applied
-                                                    to the union of the namespaces
-                                                    selected by this field and the
-                                                    ones listed in the namespaces
-                                                    field. null selector and null
-                                                    or empty namespaces list means
-                                                    "this pod's namespace". An empty
-                                                    selector ({}) matches all namespaces.
                                                   properties:
                                                     matchExpressions:
                                                       items:
@@ -977,11 +953,13 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         required:
                                                         - key
                                                         - operator
                                                         type: object
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                     matchLabels:
                                                       additionalProperties:
                                                         type: string
@@ -989,37 +967,18 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 namespaces:
-                                                  description: namespaces specifies
-                                                    a static list of namespace names
-                                                    that the term applies to. The
-                                                    term is applied to the union of
-                                                    the namespaces listed in this
-                                                    field and the ones selected by
-                                                    namespaceSelector. null or empty
-                                                    namespaces list and null namespaceSelector
-                                                    means "this pod's namespace".
                                                   items:
                                                     type: string
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 topologyKey:
-                                                  description: This pod should be
-                                                    co-located (affinity) or not co-located
-                                                    (anti-affinity) with the pods
-                                                    matching the labelSelector in
-                                                    the specified namespaces, where
-                                                    co-located is defined as running
-                                                    on a node whose value of the label
-                                                    with key topologyKey matches that
-                                                    of any node on which any of the
-                                                    selected pods is running. Empty
-                                                    topologyKey is not allowed.
                                                   type: string
                                               required:
                                               - topologyKey
                                               type: object
                                             weight:
-                                              description: weight associated with
-                                                matching the corresponding podAffinityTerm,
+                                              description: |-
+                                                weight associated with matching the corresponding podAffinityTerm,
                                                 in the range 1-100.
                                               format: int32
                                               type: integer
@@ -1028,44 +987,32 @@ spec:
                                           - weight
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       requiredDuringSchedulingIgnoredDuringExecution:
-                                        description: If the affinity requirements
-                                          specified by this field are not met at scheduling
-                                          time, the pod will not be scheduled onto
-                                          the node. If the affinity requirements specified
-                                          by this field cease to be met at some point
-                                          during pod execution (e.g. due to a pod
-                                          label update), the system may or may not
-                                          try to eventually evict the pod from its
-                                          node. When there are multiple elements,
-                                          the lists of nodes corresponding to each
-                                          podAffinityTerm are intersected, i.e. all
-                                          terms must be satisfied.
+                                        description: |-
+                                          If the affinity requirements specified by this field are not met at
+                                          scheduling time, the pod will not be scheduled onto the node.
+                                          If the affinity requirements specified by this field cease to be met
+                                          at some point during pod execution (e.g. due to a pod label update), the
+                                          system may or may not try to eventually evict the pod from its node.
+                                          When there are multiple elements, the lists of nodes corresponding to each
+                                          podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                         items:
-                                          description: Defines a set of pods (namely
-                                            those matching the labelSelector relative
-                                            to the given namespace(s)) that this pod
-                                            should be co-located (affinity) or not
-                                            co-located (anti-affinity) with, where
-                                            co-located is defined as running on a
-                                            node whose value of the label with key
-                                            <topologyKey> matches that of any node
-                                            on which a pod of the set of pods is running
+                                          description: |-
+                                            Defines a set of pods (namely those matching the labelSelector
+                                            relative to the given namespace(s)) that this pod should be
+                                            co-located (affinity) or not co-located (anti-affinity) with,
+                                            where co-located is defined as running on a node whose value of
+                                            the label with key <topologyKey> matches that of any node on which
+                                            a pod of the set of pods is running
                                           properties:
                                             labelSelector:
-                                              description: A label query over a set
-                                                of resources, in this case pods.
+                                              description: |-
+                                                A label query over a set of resources, in this case pods.
+                                                If it's null, this PodAffinityTerm matches with no Pods.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is
-                                                    a list of label selector requirements.
-                                                    The requirements are ANDed.
                                                   items:
-                                                    description: A label selector
-                                                      requirement is a selector that
-                                                      contains values, a key, and
-                                                      an operator that relates the
-                                                      key and values.
                                                     properties:
                                                       key:
                                                         type: string
@@ -1075,47 +1022,59 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     required:
                                                     - key
                                                     - operator
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map
-                                                    of {key,value} pairs. A single
-                                                    {key,value} in the matchLabels
-                                                    map is equivalent to an element
-                                                    of matchExpressions, whose key
-                                                    field is "key", the operator is
-                                                    "In", and the values array contains
-                                                    only "value". The requirements
-                                                    are ANDed.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
+                                            matchLabelKeys:
+                                              description: |-
+                                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                                be taken into consideration. The keys are used to lookup values from the
+                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                to select the group of existing pods which pods will be taken into consideration
+                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                pod labels will be ignored. The default value is empty.
+                                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            mismatchLabelKeys:
+                                              description: |-
+                                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                be taken into consideration. The keys are used to lookup values from the
+                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                to select the group of existing pods which pods will be taken into consideration
+                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                pod labels will be ignored. The default value is empty.
+                                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
                                             namespaceSelector:
-                                              description: A label query over the
-                                                set of namespaces that the term applies
-                                                to. The term is applied to the union
-                                                of the namespaces selected by this
-                                                field and the ones listed in the namespaces
-                                                field. null selector and null or empty
-                                                namespaces list means "this pod's
-                                                namespace". An empty selector ({})
-                                                matches all namespaces.
+                                              description: |-
+                                                A label query over the set of namespaces that the term applies to.
+                                                The term is applied to the union of the namespaces selected by this field
+                                                and the ones listed in the namespaces field.
+                                                null selector and null or empty namespaces list means "this pod's namespace".
+                                                An empty selector ({}) matches all namespaces.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is
-                                                    a list of label selector requirements.
-                                                    The requirements are ANDed.
                                                   items:
-                                                    description: A label selector
-                                                      requirement is a selector that
-                                                      contains values, a key, and
-                                                      an operator that relates the
-                                                      key and values.
                                                     properties:
                                                       key:
                                                         type: string
@@ -1125,54 +1084,42 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     required:
                                                     - key
                                                     - operator
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map
-                                                    of {key,value} pairs. A single
-                                                    {key,value} in the matchLabels
-                                                    map is equivalent to an element
-                                                    of matchExpressions, whose key
-                                                    field is "key", the operator is
-                                                    "In", and the values array contains
-                                                    only "value". The requirements
-                                                    are ANDed.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaces:
-                                              description: namespaces specifies a
-                                                static list of namespace names that
-                                                the term applies to. The term is applied
-                                                to the union of the namespaces listed
-                                                in this field and the ones selected
-                                                by namespaceSelector. null or empty
-                                                namespaces list and null namespaceSelector
-                                                means "this pod's namespace".
+                                              description: |-
+                                                namespaces specifies a static list of namespace names that the term applies to.
+                                                The term is applied to the union of the namespaces listed in this field
+                                                and the ones selected by namespaceSelector.
+                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             topologyKey:
-                                              description: This pod should be co-located
-                                                (affinity) or not co-located (anti-affinity)
-                                                with the pods matching the labelSelector
-                                                in the specified namespaces, where
-                                                co-located is defined as running on
-                                                a node whose value of the label with
-                                                key topologyKey matches that of any
-                                                node on which any of the selected
-                                                pods is running. Empty topologyKey
-                                                is not allowed.
+                                              description: |-
+                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                selected pods is running.
+                                                Empty topologyKey is not allowed.
                                               type: string
                                           required:
                                           - topologyKey
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                     type: object
                                   podAntiAffinity:
                                     description: Describes pod anti-affinity scheduling
@@ -1180,21 +1127,16 @@ spec:
                                       node, zone, etc. as some other pod(s)).
                                     properties:
                                       preferredDuringSchedulingIgnoredDuringExecution:
-                                        description: The scheduler will prefer to
-                                          schedule pods to nodes that satisfy the
-                                          anti-affinity expressions specified by this
-                                          field, but it may choose a node that violates
-                                          one or more of the expressions. The node
-                                          that is most preferred is the one with the
-                                          greatest sum of weights, i.e. for each node
-                                          that meets all of the scheduling requirements
-                                          (resource request, requiredDuringScheduling
-                                          anti-affinity expressions, etc.), compute
-                                          a sum by iterating through the elements
-                                          of this field and adding "weight" to the
-                                          sum if the node has pods which matches the
-                                          corresponding podAffinityTerm; the node(s)
-                                          with the highest sum are the most preferred.
+                                        description: |-
+                                          The scheduler will prefer to schedule pods to nodes that satisfy
+                                          the anti-affinity expressions specified by this field, but it may choose
+                                          a node that violates one or more of the expressions. The node that is
+                                          most preferred is the one with the greatest sum of weights, i.e.
+                                          for each node that meets all of the scheduling requirements (resource
+                                          request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                          compute a sum by iterating through the elements of this field and adding
+                                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                          node(s) with the highest sum are the most preferred.
                                         items:
                                           description: The weights of all of the matched
                                             WeightedPodAffinityTerm fields are added
@@ -1206,9 +1148,6 @@ spec:
                                                 weight.
                                               properties:
                                                 labelSelector:
-                                                  description: A label query over
-                                                    a set of resources, in this case
-                                                    pods.
                                                   properties:
                                                     matchExpressions:
                                                       items:
@@ -1221,28 +1160,30 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         required:
                                                         - key
                                                         - operator
                                                         type: object
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                     matchLabels:
                                                       additionalProperties:
                                                         type: string
                                                       type: object
                                                   type: object
                                                   x-kubernetes-map-type: atomic
+                                                matchLabelKeys:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                mismatchLabelKeys:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
                                                 namespaceSelector:
-                                                  description: A label query over
-                                                    the set of namespaces that the
-                                                    term applies to. The term is applied
-                                                    to the union of the namespaces
-                                                    selected by this field and the
-                                                    ones listed in the namespaces
-                                                    field. null selector and null
-                                                    or empty namespaces list means
-                                                    "this pod's namespace". An empty
-                                                    selector ({}) matches all namespaces.
                                                   properties:
                                                     matchExpressions:
                                                       items:
@@ -1255,11 +1196,13 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         required:
                                                         - key
                                                         - operator
                                                         type: object
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                     matchLabels:
                                                       additionalProperties:
                                                         type: string
@@ -1267,37 +1210,18 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 namespaces:
-                                                  description: namespaces specifies
-                                                    a static list of namespace names
-                                                    that the term applies to. The
-                                                    term is applied to the union of
-                                                    the namespaces listed in this
-                                                    field and the ones selected by
-                                                    namespaceSelector. null or empty
-                                                    namespaces list and null namespaceSelector
-                                                    means "this pod's namespace".
                                                   items:
                                                     type: string
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 topologyKey:
-                                                  description: This pod should be
-                                                    co-located (affinity) or not co-located
-                                                    (anti-affinity) with the pods
-                                                    matching the labelSelector in
-                                                    the specified namespaces, where
-                                                    co-located is defined as running
-                                                    on a node whose value of the label
-                                                    with key topologyKey matches that
-                                                    of any node on which any of the
-                                                    selected pods is running. Empty
-                                                    topologyKey is not allowed.
                                                   type: string
                                               required:
                                               - topologyKey
                                               type: object
                                             weight:
-                                              description: weight associated with
-                                                matching the corresponding podAffinityTerm,
+                                              description: |-
+                                                weight associated with matching the corresponding podAffinityTerm,
                                                 in the range 1-100.
                                               format: int32
                                               type: integer
@@ -1306,44 +1230,32 @@ spec:
                                           - weight
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       requiredDuringSchedulingIgnoredDuringExecution:
-                                        description: If the anti-affinity requirements
-                                          specified by this field are not met at scheduling
-                                          time, the pod will not be scheduled onto
-                                          the node. If the anti-affinity requirements
-                                          specified by this field cease to be met
-                                          at some point during pod execution (e.g.
-                                          due to a pod label update), the system may
-                                          or may not try to eventually evict the pod
-                                          from its node. When there are multiple elements,
-                                          the lists of nodes corresponding to each
-                                          podAffinityTerm are intersected, i.e. all
-                                          terms must be satisfied.
+                                        description: |-
+                                          If the anti-affinity requirements specified by this field are not met at
+                                          scheduling time, the pod will not be scheduled onto the node.
+                                          If the anti-affinity requirements specified by this field cease to be met
+                                          at some point during pod execution (e.g. due to a pod label update), the
+                                          system may or may not try to eventually evict the pod from its node.
+                                          When there are multiple elements, the lists of nodes corresponding to each
+                                          podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                         items:
-                                          description: Defines a set of pods (namely
-                                            those matching the labelSelector relative
-                                            to the given namespace(s)) that this pod
-                                            should be co-located (affinity) or not
-                                            co-located (anti-affinity) with, where
-                                            co-located is defined as running on a
-                                            node whose value of the label with key
-                                            <topologyKey> matches that of any node
-                                            on which a pod of the set of pods is running
+                                          description: |-
+                                            Defines a set of pods (namely those matching the labelSelector
+                                            relative to the given namespace(s)) that this pod should be
+                                            co-located (affinity) or not co-located (anti-affinity) with,
+                                            where co-located is defined as running on a node whose value of
+                                            the label with key <topologyKey> matches that of any node on which
+                                            a pod of the set of pods is running
                                           properties:
                                             labelSelector:
-                                              description: A label query over a set
-                                                of resources, in this case pods.
+                                              description: |-
+                                                A label query over a set of resources, in this case pods.
+                                                If it's null, this PodAffinityTerm matches with no Pods.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is
-                                                    a list of label selector requirements.
-                                                    The requirements are ANDed.
                                                   items:
-                                                    description: A label selector
-                                                      requirement is a selector that
-                                                      contains values, a key, and
-                                                      an operator that relates the
-                                                      key and values.
                                                     properties:
                                                       key:
                                                         type: string
@@ -1353,47 +1265,59 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     required:
                                                     - key
                                                     - operator
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map
-                                                    of {key,value} pairs. A single
-                                                    {key,value} in the matchLabels
-                                                    map is equivalent to an element
-                                                    of matchExpressions, whose key
-                                                    field is "key", the operator is
-                                                    "In", and the values array contains
-                                                    only "value". The requirements
-                                                    are ANDed.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
+                                            matchLabelKeys:
+                                              description: |-
+                                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                                be taken into consideration. The keys are used to lookup values from the
+                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                to select the group of existing pods which pods will be taken into consideration
+                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                pod labels will be ignored. The default value is empty.
+                                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            mismatchLabelKeys:
+                                              description: |-
+                                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                be taken into consideration. The keys are used to lookup values from the
+                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                to select the group of existing pods which pods will be taken into consideration
+                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                pod labels will be ignored. The default value is empty.
+                                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
                                             namespaceSelector:
-                                              description: A label query over the
-                                                set of namespaces that the term applies
-                                                to. The term is applied to the union
-                                                of the namespaces selected by this
-                                                field and the ones listed in the namespaces
-                                                field. null selector and null or empty
-                                                namespaces list means "this pod's
-                                                namespace". An empty selector ({})
-                                                matches all namespaces.
+                                              description: |-
+                                                A label query over the set of namespaces that the term applies to.
+                                                The term is applied to the union of the namespaces selected by this field
+                                                and the ones listed in the namespaces field.
+                                                null selector and null or empty namespaces list means "this pod's namespace".
+                                                An empty selector ({}) matches all namespaces.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is
-                                                    a list of label selector requirements.
-                                                    The requirements are ANDed.
                                                   items:
-                                                    description: A label selector
-                                                      requirement is a selector that
-                                                      contains values, a key, and
-                                                      an operator that relates the
-                                                      key and values.
                                                     properties:
                                                       key:
                                                         type: string
@@ -1403,54 +1327,42 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     required:
                                                     - key
                                                     - operator
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map
-                                                    of {key,value} pairs. A single
-                                                    {key,value} in the matchLabels
-                                                    map is equivalent to an element
-                                                    of matchExpressions, whose key
-                                                    field is "key", the operator is
-                                                    "In", and the values array contains
-                                                    only "value". The requirements
-                                                    are ANDed.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaces:
-                                              description: namespaces specifies a
-                                                static list of namespace names that
-                                                the term applies to. The term is applied
-                                                to the union of the namespaces listed
-                                                in this field and the ones selected
-                                                by namespaceSelector. null or empty
-                                                namespaces list and null namespaceSelector
-                                                means "this pod's namespace".
+                                              description: |-
+                                                namespaces specifies a static list of namespace names that the term applies to.
+                                                The term is applied to the union of the namespaces listed in this field
+                                                and the ones selected by namespaceSelector.
+                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             topologyKey:
-                                              description: This pod should be co-located
-                                                (affinity) or not co-located (anti-affinity)
-                                                with the pods matching the labelSelector
-                                                in the specified namespaces, where
-                                                co-located is defined as running on
-                                                a node whose value of the label with
-                                                key topologyKey matches that of any
-                                                node on which any of the selected
-                                                pods is running. Empty topologyKey
-                                                is not allowed.
+                                              description: |-
+                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                selected pods is running.
+                                                Empty topologyKey is not allowed.
                                               type: string
                                           required:
                                           - topologyKey
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                     type: object
                                 type: object
                               automountServiceAccountToken:
@@ -1459,51 +1371,47 @@ spec:
                                   mounted.
                                 type: boolean
                               containers:
-                                description: List of containers belonging to the pod.
+                                description: |-
+                                  List of containers belonging to the pod.
                                   Containers cannot currently be added or removed.
-                                  There must be at least one container in a Pod. Cannot
-                                  be updated.
+                                  There must be at least one container in a Pod.
+                                  Cannot be updated.
                                 items:
                                   description: A single application container that
                                     you want to run within a pod.
                                   properties:
                                     args:
-                                      description: 'Arguments to the entrypoint. The
-                                        container image''s CMD is used if this is
-                                        not provided. Variable references $(VAR_NAME)
-                                        are expanded using the container''s environment.
-                                        If a variable cannot be resolved, the reference
-                                        in the input string will be unchanged. Double
-                                        $$ are reduced to a single $, which allows
-                                        for escaping the $(VAR_NAME) syntax: i.e.
-                                        "$$(VAR_NAME)" will produce the string literal
-                                        "$(VAR_NAME)". Escaped references will never
-                                        be expanded, regardless of whether the variable
-                                        exists or not. Cannot be updated. More info:
-                                        https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      description: |-
+                                        Arguments to the entrypoint.
+                                        The container image's CMD is used if this is not provided.
+                                        Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                        cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                        produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                        of whether the variable exists or not. Cannot be updated.
+                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     command:
-                                      description: 'Entrypoint array. Not executed
-                                        within a shell. The container image''s ENTRYPOINT
-                                        is used if this is not provided. Variable
-                                        references $(VAR_NAME) are expanded using
-                                        the container''s environment. If a variable
-                                        cannot be resolved, the reference in the input
-                                        string will be unchanged. Double $$ are reduced
-                                        to a single $, which allows for escaping the
-                                        $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                        produce the string literal "$(VAR_NAME)".
-                                        Escaped references will never be expanded,
-                                        regardless of whether the variable exists
-                                        or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      description: |-
+                                        Entrypoint array. Not executed within a shell.
+                                        The container image's ENTRYPOINT is used if this is not provided.
+                                        Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                        cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                        produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                        of whether the variable exists or not. Cannot be updated.
+                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     env:
-                                      description: List of environment variables to
-                                        set in the container. Cannot be updated.
+                                      description: |-
+                                        List of environment variables to set in the container.
+                                        Cannot be updated.
                                       items:
                                         description: EnvVar represents an environment
                                           variable present in a Container.
@@ -1513,19 +1421,16 @@ spec:
                                               Must be a C_IDENTIFIER.
                                             type: string
                                           value:
-                                            description: 'Variable references $(VAR_NAME)
-                                              are expanded using the previously defined
-                                              environment variables in the container
-                                              and any service environment variables.
-                                              If a variable cannot be resolved, the
-                                              reference in the input string will be
-                                              unchanged. Double $$ are reduced to
-                                              a single $, which allows for escaping
-                                              the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                              will produce the string literal "$(VAR_NAME)".
-                                              Escaped references will never be expanded,
-                                              regardless of whether the variable exists
-                                              or not. Defaults to "".'
+                                            description: |-
+                                              Variable references $(VAR_NAME) are expanded
+                                              using the previously defined environment variables in the container and
+                                              any service environment variables. If a variable cannot be resolved,
+                                              the reference in the input string will be unchanged. Double $$ are reduced
+                                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                              "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                              Escaped references will never be expanded, regardless of whether the variable
+                                              exists or not.
+                                              Defaults to "".
                                             type: string
                                           valueFrom:
                                             description: Source for the environment
@@ -1536,69 +1441,37 @@ spec:
                                                 description: Selects a key of a ConfigMap.
                                                 properties:
                                                   key:
-                                                    description: The key to select.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                    default: ""
                                                     type: string
                                                   optional:
-                                                    description: Specify whether the
-                                                      ConfigMap or its key must be
-                                                      defined
                                                     type: boolean
                                                 required:
                                                 - key
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               fieldRef:
-                                                description: 'Selects a field of the
-                                                  pod: supports metadata.name, metadata.namespace,
-                                                  `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                                  spec.nodeName, spec.serviceAccountName,
-                                                  status.hostIP, status.podIP, status.podIPs.'
                                                 properties:
                                                   apiVersion:
-                                                    description: Version of the schema
-                                                      the FieldPath is written in
-                                                      terms of, defaults to "v1".
                                                     type: string
                                                   fieldPath:
-                                                    description: Path of the field
-                                                      to select in the specified API
-                                                      version.
                                                     type: string
                                                 required:
                                                 - fieldPath
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               resourceFieldRef:
-                                                description: 'Selects a resource of
-                                                  the container: only resources limits
-                                                  and requests (limits.cpu, limits.memory,
-                                                  limits.ephemeral-storage, requests.cpu,
-                                                  requests.memory and requests.ephemeral-storage)
-                                                  are currently supported.'
                                                 properties:
                                                   containerName:
-                                                    description: 'Container name:
-                                                      required for volumes, optional
-                                                      for env vars'
                                                     type: string
                                                   divisor:
                                                     anyOf:
                                                     - type: integer
                                                     - type: string
-                                                    description: Specifies the output
-                                                      format of the exposed resources,
-                                                      defaults to "1"
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
                                                   resource:
-                                                    description: 'Required: resource
-                                                      to select'
                                                     type: string
                                                 required:
                                                 - resource
@@ -1609,19 +1482,11 @@ spec:
                                                   in the pod's namespace
                                                 properties:
                                                   key:
-                                                    description: The key of the secret
-                                                      to select from.  Must be a valid
-                                                      secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                    default: ""
                                                     type: string
                                                   optional:
-                                                    description: Specify whether the
-                                                      Secret or its key must be defined
                                                     type: boolean
                                                 required:
                                                 - key
@@ -1632,16 +1497,17 @@ spec:
                                         - name
                                         type: object
                                       type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
                                     envFrom:
-                                      description: List of sources to populate environment
-                                        variables in the container. The keys defined
-                                        within a source must be a C_IDENTIFIER. All
-                                        invalid keys will be reported as an event
-                                        when the container is starting. When a key
-                                        exists in multiple sources, the value associated
-                                        with the last source will take precedence.
-                                        Values defined by an Env with a duplicate
-                                        key will take precedence. Cannot be updated.
+                                      description: |-
+                                        List of sources to populate environment variables in the container.
+                                        The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                        will be reported as an event when the container is starting. When a key exists in multiple
+                                        sources, the value associated with the last source will take precedence.
+                                        Values defined by an Env with a duplicate key will take precedence.
+                                        Cannot be updated.
                                       items:
                                         description: EnvFromSource represents the
                                           source of a set of ConfigMaps
@@ -1650,10 +1516,7 @@ spec:
                                             description: The ConfigMap to select from
                                             properties:
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                default: ""
                                                 type: string
                                               optional:
                                                 description: Specify whether the ConfigMap
@@ -1670,10 +1533,7 @@ spec:
                                             description: The Secret to select from
                                             properties:
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                default: ""
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -1683,73 +1543,52 @@ spec:
                                             x-kubernetes-map-type: atomic
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     image:
-                                      description: 'Container image name. More info:
-                                        https://kubernetes.io/docs/concepts/containers/images
-                                        This field is optional to allow higher level
-                                        config management to default or override container
-                                        images in workload controllers like Deployments
-                                        and StatefulSets.'
+                                      description: |-
+                                        Container image name.
+                                        More info: https://kubernetes.io/docs/concepts/containers/images
+                                        This field is optional to allow higher level config management to default or override
+                                        container images in workload controllers like Deployments and StatefulSets.
                                       type: string
                                     imagePullPolicy:
-                                      description: 'Image pull policy. One of Always,
-                                        Never, IfNotPresent. Defaults to Always if
-                                        :latest tag is specified, or IfNotPresent
-                                        otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                      description: |-
+                                        Image pull policy.
+                                        One of Always, Never, IfNotPresent.
+                                        Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                       type: string
                                     lifecycle:
-                                      description: Actions that the management system
-                                        should take in response to container lifecycle
-                                        events. Cannot be updated.
+                                      description: |-
+                                        Actions that the management system should take in response to container lifecycle events.
+                                        Cannot be updated.
                                       properties:
                                         postStart:
-                                          description: 'PostStart is called immediately
-                                            after a container is created. If the handler
-                                            fails, the container is terminated and
-                                            restarted according to its restart policy.
-                                            Other management of the container blocks
-                                            until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          description: |-
+                                            PostStart is called immediately after a container is created. If the handler fails,
+                                            the container is terminated and restarted according to its restart policy.
+                                            Other management of the container blocks until the hook completes.
+                                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                           properties:
                                             exec:
                                               description: Exec specifies the action
                                                 to take.
                                               properties:
                                                 command:
-                                                  description: Command is the command
-                                                    line to execute inside the container,
-                                                    the working directory for the
-                                                    command  is root ('/') in the
-                                                    container's filesystem. The command
-                                                    is simply exec'd, it is not run
-                                                    inside a shell, so traditional
-                                                    shell instructions ('|', etc)
-                                                    won't work. To use a shell, you
-                                                    need to explicitly call out to
-                                                    that shell. Exit status of 0 is
-                                                    treated as live/healthy and non-zero
-                                                    is unhealthy.
                                                   items:
                                                     type: string
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               type: object
                                             httpGet:
                                               description: HTTPGet specifies the http
                                                 request to perform.
                                               properties:
                                                 host:
-                                                  description: Host name to connect
-                                                    to, defaults to the pod IP. You
-                                                    probably want to set "Host" in
-                                                    httpHeaders instead.
                                                   type: string
                                                 httpHeaders:
-                                                  description: Custom headers to set
-                                                    in the request. HTTP allows repeated
-                                                    headers.
                                                   items:
-                                                    description: HTTPHeader describes
-                                                      a custom header to be used in
-                                                      HTTP probes
                                                     properties:
                                                       name:
                                                         type: string
@@ -1760,110 +1599,77 @@ spec:
                                                     - value
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 path:
-                                                  description: Path to access on the
-                                                    HTTP server.
                                                   type: string
                                                 port:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Name or number of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                                 scheme:
-                                                  description: Scheme to use for connecting
-                                                    to the host. Defaults to HTTP.
                                                   type: string
                                               required:
                                               - port
                                               type: object
+                                            sleep:
+                                              description: Sleep represents the duration
+                                                that the container should sleep before
+                                                being terminated.
+                                              properties:
+                                                seconds:
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
                                             tcpSocket:
-                                              description: Deprecated. TCPSocket is
-                                                NOT supported as a LifecycleHandler
-                                                and kept for the backward compatibility.
-                                                There are no validation of this field
-                                                and lifecycle hooks will fail in runtime
-                                                when tcp handler is specified.
+                                              description: |-
+                                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                                for the backward compatibility. There are no validation of this field and
+                                                lifecycle hooks will fail in runtime when tcp handler is specified.
                                               properties:
                                                 host:
-                                                  description: 'Optional: Host name
-                                                    to connect to, defaults to the
-                                                    pod IP.'
                                                   type: string
                                                 port:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Number or name of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                               required:
                                               - port
                                               type: object
                                           type: object
                                         preStop:
-                                          description: 'PreStop is called immediately
-                                            before a container is terminated due to
-                                            an API request or management event such
-                                            as liveness/startup probe failure, preemption,
-                                            resource contention, etc. The handler
-                                            is not called if the container crashes
-                                            or exits. The Pod''s termination grace
-                                            period countdown begins before the PreStop
-                                            hook is executed. Regardless of the outcome
-                                            of the handler, the container will eventually
-                                            terminate within the Pod''s termination
-                                            grace period (unless delayed by finalizers).
-                                            Other management of the container blocks
-                                            until the hook completes or until the
-                                            termination grace period is reached. More
-                                            info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          description: |-
+                                            PreStop is called immediately before a container is terminated due to an
+                                            API request or management event such as liveness/startup probe failure,
+                                            preemption, resource contention, etc. The handler is not called if the
+                                            container crashes or exits. The Pod's termination grace period countdown begins before the
+                                            PreStop hook is executed. Regardless of the outcome of the handler, the
+                                            container will eventually terminate within the Pod's termination grace
+                                            period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                            or until the termination grace period is reached.
+                                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                           properties:
                                             exec:
                                               description: Exec specifies the action
                                                 to take.
                                               properties:
                                                 command:
-                                                  description: Command is the command
-                                                    line to execute inside the container,
-                                                    the working directory for the
-                                                    command  is root ('/') in the
-                                                    container's filesystem. The command
-                                                    is simply exec'd, it is not run
-                                                    inside a shell, so traditional
-                                                    shell instructions ('|', etc)
-                                                    won't work. To use a shell, you
-                                                    need to explicitly call out to
-                                                    that shell. Exit status of 0 is
-                                                    treated as live/healthy and non-zero
-                                                    is unhealthy.
                                                   items:
                                                     type: string
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               type: object
                                             httpGet:
                                               description: HTTPGet specifies the http
                                                 request to perform.
                                               properties:
                                                 host:
-                                                  description: Host name to connect
-                                                    to, defaults to the pod IP. You
-                                                    probably want to set "Host" in
-                                                    httpHeaders instead.
                                                   type: string
                                                 httpHeaders:
-                                                  description: Custom headers to set
-                                                    in the request. HTTP allows repeated
-                                                    headers.
                                                   items:
-                                                    description: HTTPHeader describes
-                                                      a custom header to be used in
-                                                      HTTP probes
                                                     properties:
                                                       name:
                                                         type: string
@@ -1874,47 +1680,42 @@ spec:
                                                     - value
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 path:
-                                                  description: Path to access on the
-                                                    HTTP server.
                                                   type: string
                                                 port:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Name or number of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                                 scheme:
-                                                  description: Scheme to use for connecting
-                                                    to the host. Defaults to HTTP.
                                                   type: string
                                               required:
                                               - port
                                               type: object
+                                            sleep:
+                                              description: Sleep represents the duration
+                                                that the container should sleep before
+                                                being terminated.
+                                              properties:
+                                                seconds:
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
                                             tcpSocket:
-                                              description: Deprecated. TCPSocket is
-                                                NOT supported as a LifecycleHandler
-                                                and kept for the backward compatibility.
-                                                There are no validation of this field
-                                                and lifecycle hooks will fail in runtime
-                                                when tcp handler is specified.
+                                              description: |-
+                                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                                for the backward compatibility. There are no validation of this field and
+                                                lifecycle hooks will fail in runtime when tcp handler is specified.
                                               properties:
                                                 host:
-                                                  description: 'Optional: Host name
-                                                    to connect to, defaults to the
-                                                    pod IP.'
                                                   type: string
                                                 port:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Number or name of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                               required:
                                               - port
@@ -1922,35 +1723,32 @@ spec:
                                           type: object
                                       type: object
                                     livenessProbe:
-                                      description: 'Periodic probe of container liveness.
+                                      description: |-
+                                        Periodic probe of container liveness.
                                         Container will be restarted if the probe fails.
-                                        Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       properties:
                                         exec:
                                           description: Exec specifies the action to
                                             take.
                                           properties:
                                             command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                           type: object
                                         failureThreshold:
-                                          description: Minimum consecutive failures
-                                            for the probe to be considered failed
-                                            after having succeeded. Defaults to 3.
-                                            Minimum value is 1.
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         grpc:
@@ -1964,11 +1762,12 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
-                                              description: "Service is the name of
-                                                the service to place in the gRPC HealthCheckRequest
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
                                                 (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                                \n If this is not specified, the default
-                                                behavior is defined by gRPC."
+
+
+                                                If this is not specified, the default behavior is defined by gRPC.
                                               type: string
                                           required:
                                           - port
@@ -1978,10 +1777,9 @@ spec:
                                             request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -1993,21 +1791,15 @@ spec:
                                                   probes
                                                 properties:
                                                   name:
-                                                    description: The header field
-                                                      name. This will be canonicalized
-                                                      upon output, so case-variant
-                                                      names will be understood as
-                                                      the same header.
                                                     type: string
                                                   value:
-                                                    description: The header field
-                                                      value
                                                     type: string
                                                 required:
                                                 - name
                                                 - value
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             path:
                                               description: Path to access on the HTTP
                                                 server.
@@ -2016,36 +1808,35 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         initialDelaySeconds:
-                                          description: 'Number of seconds after the
-                                            container has started before liveness
-                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                         periodSeconds:
-                                          description: How often (in seconds) to perform
-                                            the probe. Default to 10 seconds. Minimum
-                                            value is 1.
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         successThreshold:
-                                          description: Minimum consecutive successes
-                                            for the probe to be considered successful
-                                            after having failed. Defaults to 1. Must
-                                            be 1 for liveness and startup. Minimum
-                                            value is 1.
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         tcpSocket:
@@ -2060,68 +1851,59 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                         terminationGracePeriodSeconds:
-                                          description: Optional duration in seconds
-                                            the pod needs to terminate gracefully
-                                            upon probe failure. The grace period is
-                                            the duration in seconds after the processes
-                                            running in the pod are sent a termination
-                                            signal and the time when the processes
-                                            are forcibly halted with a kill signal.
-                                            Set this value longer than the expected
-                                            cleanup time for your process. If this
-                                            value is nil, the pod's terminationGracePeriodSeconds
-                                            will be used. Otherwise, this value overrides
-                                            the value provided by the pod spec. Value
-                                            must be non-negative integer. The value
-                                            zero indicates stop immediately via the
-                                            kill signal (no opportunity to shut down).
-                                            This is a beta field and requires enabling
-                                            ProbeTerminationGracePeriod feature gate.
-                                            Minimum value is 1. spec.terminationGracePeriodSeconds
-                                            is used if unset.
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                           format: int64
                                           type: integer
                                         timeoutSeconds:
-                                          description: 'Number of seconds after which
-                                            the probe times out. Defaults to 1 second.
-                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                       type: object
                                     name:
-                                      description: Name of the container specified
-                                        as a DNS_LABEL. Each container in a pod must
-                                        have a unique name (DNS_LABEL). Cannot be
-                                        updated.
+                                      description: |-
+                                        Name of the container specified as a DNS_LABEL.
+                                        Each container in a pod must have a unique name (DNS_LABEL).
+                                        Cannot be updated.
                                       type: string
                                     ports:
-                                      description: List of ports to expose from the
-                                        container. Not specifying a port here DOES
-                                        NOT prevent that port from being exposed.
-                                        Any port which is listening on the default
-                                        "0.0.0.0" address inside a container will
-                                        be accessible from the network. Modifying
-                                        this array with strategic merge patch may
-                                        corrupt the data. For more information See
-                                        https://github.com/kubernetes/kubernetes/issues/108255.
+                                      description: |-
+                                        List of ports to expose from the container. Not specifying a port here
+                                        DOES NOT prevent that port from being exposed. Any port which is
+                                        listening on the default "0.0.0.0" address inside a container will be
+                                        accessible from the network.
+                                        Modifying this array with strategic merge patch may corrupt the data.
+                                        For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                         Cannot be updated.
                                       items:
                                         description: ContainerPort represents a network
                                           port in a single container.
                                         properties:
                                           containerPort:
-                                            description: Number of port to expose
-                                              on the pod's IP address. This must be
-                                              a valid port number, 0 < x < 65536.
+                                            description: |-
+                                              Number of port to expose on the pod's IP address.
+                                              This must be a valid port number, 0 < x < 65536.
                                             format: int32
                                             type: integer
                                           hostIP:
@@ -2129,25 +1911,24 @@ spec:
                                               external port to.
                                             type: string
                                           hostPort:
-                                            description: Number of port to expose
-                                              on the host. If specified, this must
-                                              be a valid port number, 0 < x < 65536.
-                                              If HostNetwork is specified, this must
-                                              match ContainerPort. Most containers
-                                              do not need this.
+                                            description: |-
+                                              Number of port to expose on the host.
+                                              If specified, this must be a valid port number, 0 < x < 65536.
+                                              If HostNetwork is specified, this must match ContainerPort.
+                                              Most containers do not need this.
                                             format: int32
                                             type: integer
                                           name:
-                                            description: If specified, this must be
-                                              an IANA_SVC_NAME and unique within the
-                                              pod. Each named port in a pod must have
-                                              a unique name. Name for the port that
-                                              can be referred to by services.
+                                            description: |-
+                                              If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                              named port in a pod must have a unique name. Name for the port that can be
+                                              referred to by services.
                                             type: string
                                           protocol:
                                             default: TCP
-                                            description: Protocol for port. Must be
-                                              UDP, TCP, or SCTP. Defaults to "TCP".
+                                            description: |-
+                                              Protocol for port. Must be UDP, TCP, or SCTP.
+                                              Defaults to "TCP".
                                             type: string
                                         required:
                                         - containerPort
@@ -2158,36 +1939,32 @@ spec:
                                       - protocol
                                       x-kubernetes-list-type: map
                                     readinessProbe:
-                                      description: 'Periodic probe of container service
-                                        readiness. Container will be removed from
-                                        service endpoints if the probe fails. Cannot
-                                        be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: |-
+                                        Periodic probe of container service readiness.
+                                        Container will be removed from service endpoints if the probe fails.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       properties:
                                         exec:
                                           description: Exec specifies the action to
                                             take.
                                           properties:
                                             command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                           type: object
                                         failureThreshold:
-                                          description: Minimum consecutive failures
-                                            for the probe to be considered failed
-                                            after having succeeded. Defaults to 3.
-                                            Minimum value is 1.
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         grpc:
@@ -2201,11 +1978,12 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
-                                              description: "Service is the name of
-                                                the service to place in the gRPC HealthCheckRequest
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
                                                 (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                                \n If this is not specified, the default
-                                                behavior is defined by gRPC."
+
+
+                                                If this is not specified, the default behavior is defined by gRPC.
                                               type: string
                                           required:
                                           - port
@@ -2215,10 +1993,9 @@ spec:
                                             request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -2230,21 +2007,15 @@ spec:
                                                   probes
                                                 properties:
                                                   name:
-                                                    description: The header field
-                                                      name. This will be canonicalized
-                                                      upon output, so case-variant
-                                                      names will be understood as
-                                                      the same header.
                                                     type: string
                                                   value:
-                                                    description: The header field
-                                                      value
                                                     type: string
                                                 required:
                                                 - name
                                                 - value
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             path:
                                               description: Path to access on the HTTP
                                                 server.
@@ -2253,36 +2024,35 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         initialDelaySeconds:
-                                          description: 'Number of seconds after the
-                                            container has started before liveness
-                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                         periodSeconds:
-                                          description: How often (in seconds) to perform
-                                            the probe. Default to 10 seconds. Minimum
-                                            value is 1.
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         successThreshold:
-                                          description: Minimum consecutive successes
-                                            for the probe to be considered successful
-                                            after having failed. Defaults to 1. Must
-                                            be 1 for liveness and startup. Minimum
-                                            value is 1.
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         tcpSocket:
@@ -2297,40 +2067,33 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                         terminationGracePeriodSeconds:
-                                          description: Optional duration in seconds
-                                            the pod needs to terminate gracefully
-                                            upon probe failure. The grace period is
-                                            the duration in seconds after the processes
-                                            running in the pod are sent a termination
-                                            signal and the time when the processes
-                                            are forcibly halted with a kill signal.
-                                            Set this value longer than the expected
-                                            cleanup time for your process. If this
-                                            value is nil, the pod's terminationGracePeriodSeconds
-                                            will be used. Otherwise, this value overrides
-                                            the value provided by the pod spec. Value
-                                            must be non-negative integer. The value
-                                            zero indicates stop immediately via the
-                                            kill signal (no opportunity to shut down).
-                                            This is a beta field and requires enabling
-                                            ProbeTerminationGracePeriod feature gate.
-                                            Minimum value is 1. spec.terminationGracePeriodSeconds
-                                            is used if unset.
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                           format: int64
                                           type: integer
                                         timeoutSeconds:
-                                          description: 'Number of seconds after which
-                                            the probe times out. Defaults to 1 second.
-                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                       type: object
@@ -2342,14 +2105,14 @@ spec:
                                           resource resize policy for the container.
                                         properties:
                                           resourceName:
-                                            description: 'Name of the resource to
-                                              which this resource resize policy applies.
-                                              Supported values: cpu, memory.'
+                                            description: |-
+                                              Name of the resource to which this resource resize policy applies.
+                                              Supported values: cpu, memory.
                                             type: string
                                           restartPolicy:
-                                            description: Restart policy to apply when
-                                              specified resource is resized. If not
-                                              specified, it defaults to NotRequired.
+                                            description: |-
+                                              Restart policy to apply when specified resource is resized.
+                                              If not specified, it defaults to NotRequired.
                                             type: string
                                         required:
                                         - resourceName
@@ -2358,28 +2121,27 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     resources:
-                                      description: 'Compute Resources required by
-                                        this container. Cannot be updated. More info:
-                                        https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                      description: |-
+                                        Compute Resources required by this container.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       properties:
                                         claims:
-                                          description: "Claims lists the names of
-                                            resources, defined in spec.resourceClaims,
-                                            that are used by this container. \n This
-                                            is an alpha field and requires enabling
-                                            the DynamicResourceAllocation feature
-                                            gate. \n This field is immutable. It can
-                                            only be set for containers."
+                                          description: |-
+                                            Claims lists the names of resources, defined in spec.resourceClaims,
+                                            that are used by this container.
+
+
+                                            This is an alpha field and requires enabling the
+                                            DynamicResourceAllocation feature gate.
+
+
+                                            This field is immutable. It can only be set for containers.
                                           items:
                                             description: ResourceClaim references
                                               one entry in PodSpec.ResourceClaims.
                                             properties:
                                               name:
-                                                description: Name must match the name
-                                                  of one entry in pod.spec.resourceClaims
-                                                  of the Pod where this field is used.
-                                                  It makes that resource available
-                                                  inside a container.
                                                 type: string
                                             required:
                                             - name
@@ -2395,9 +2157,9 @@ spec:
                                             - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Limits describes the maximum
-                                            amount of compute resources allowed. More
-                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          description: |-
+                                            Limits describes the maximum amount of compute resources allowed.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                           type: object
                                         requests:
                                           additionalProperties:
@@ -2406,65 +2168,76 @@ spec:
                                             - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Requests describes the minimum
-                                            amount of compute resources required.
-                                            If Requests is omitted for a container,
-                                            it defaults to Limits if that is explicitly
-                                            specified, otherwise to an implementation-defined
-                                            value. Requests cannot exceed Limits.
-                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          description: |-
+                                            Requests describes the minimum amount of compute resources required.
+                                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                           type: object
                                       type: object
                                     restartPolicy:
-                                      description: 'RestartPolicy defines the restart
-                                        behavior of individual containers in a pod.
-                                        This field may only be set for init containers,
-                                        and the only allowed value is "Always". For
-                                        non-init containers or when this field is
-                                        not specified, the restart behavior is defined
-                                        by the Pod''s restart policy and the container
-                                        type. Setting the RestartPolicy as "Always"
-                                        for the init container will have the following
-                                        effect: this init container will be continually
-                                        restarted on exit until all regular containers
-                                        have terminated. Once all regular containers
-                                        have completed, all init containers with restartPolicy
-                                        "Always" will be shut down. This lifecycle
-                                        differs from normal init containers and is
-                                        often referred to as a "sidecar" container.
-                                        Although this init container still starts
-                                        in the init container sequence, it does not
-                                        wait for the container to complete before
-                                        proceeding to the next init container. Instead,
-                                        the next init container starts immediately
-                                        after this init container is started, or after
-                                        any startupProbe has successfully completed.'
+                                      description: |-
+                                        RestartPolicy defines the restart behavior of individual containers in a pod.
+                                        This field may only be set for init containers, and the only allowed value is "Always".
+                                        For non-init containers or when this field is not specified,
+                                        the restart behavior is defined by the Pod's restart policy and the container type.
+                                        Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                                        this init container will be continually restarted on
+                                        exit until all regular containers have terminated. Once all regular
+                                        containers have completed, all init containers with restartPolicy "Always"
+                                        will be shut down. This lifecycle differs from normal init containers and
+                                        is often referred to as a "sidecar" container. Although this init
+                                        container still starts in the init container sequence, it does not wait
+                                        for the container to complete before proceeding to the next init
+                                        container. Instead, the next init container starts immediately after this
+                                        init container is started, or after any startupProbe has successfully
+                                        completed.
                                       type: string
                                     securityContext:
-                                      description: 'SecurityContext defines the security
-                                        options the container should be run with.
-                                        If set, the fields of SecurityContext override
-                                        the equivalent fields of PodSecurityContext.
-                                        More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                      description: |-
+                                        SecurityContext defines the security options the container should be run with.
+                                        If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                        More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                                       properties:
                                         allowPrivilegeEscalation:
-                                          description: 'AllowPrivilegeEscalation controls
-                                            whether a process can gain more privileges
-                                            than its parent process. This bool directly
-                                            controls if the no_new_privs flag will
-                                            be set on the container process. AllowPrivilegeEscalation
-                                            is true always when the container is:
-                                            1) run as Privileged 2) has CAP_SYS_ADMIN
-                                            Note that this field cannot be set when
-                                            spec.os.name is windows.'
+                                          description: |-
+                                            AllowPrivilegeEscalation controls whether a process can gain more
+                                            privileges than its parent process. This bool directly controls if
+                                            the no_new_privs flag will be set on the container process.
+                                            AllowPrivilegeEscalation is true always when the container is:
+                                            1) run as Privileged
+                                            2) has CAP_SYS_ADMIN
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           type: boolean
+                                        appArmorProfile:
+                                          description: |-
+                                            appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                            overrides the pod's appArmorProfile.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            localhostProfile:
+                                              description: |-
+                                                localhostProfile indicates a profile loaded on the node that should be used.
+                                                The profile must be preconfigured on the node to work.
+                                                Must match the loaded name of the profile.
+                                                Must be set if and only if type is "Localhost".
+                                              type: string
+                                            type:
+                                              description: |-
+                                                type indicates which kind of AppArmor profile will be applied.
+                                                Valid options are:
+                                                  Localhost - a profile pre-loaded on the node.
+                                                  RuntimeDefault - the container runtime's default profile.
+                                                  Unconfined - no AppArmor enforcement.
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
                                         capabilities:
-                                          description: The capabilities to add/drop
-                                            when running containers. Defaults to the
-                                            default set of capabilities granted by
-                                            the container runtime. Note that this
-                                            field cannot be set when spec.os.name
-                                            is windows.
+                                          description: |-
+                                            The capabilities to add/drop when running containers.
+                                            Defaults to the default set of capabilities granted by the container runtime.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           properties:
                                             add:
                                               description: Added capabilities
@@ -2473,6 +2246,7 @@ spec:
                                                   POSIX capabilities type
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             drop:
                                               description: Removed capabilities
                                               items:
@@ -2480,75 +2254,63 @@ spec:
                                                   POSIX capabilities type
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                           type: object
                                         privileged:
-                                          description: Run container in privileged
-                                            mode. Processes in privileged containers
-                                            are essentially equivalent to root on
-                                            the host. Defaults to false. Note that
-                                            this field cannot be set when spec.os.name
-                                            is windows.
+                                          description: |-
+                                            Run container in privileged mode.
+                                            Processes in privileged containers are essentially equivalent to root on the host.
+                                            Defaults to false.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           type: boolean
                                         procMount:
-                                          description: procMount denotes the type
-                                            of proc mount to use for the containers.
-                                            The default is DefaultProcMount which
-                                            uses the container runtime defaults for
-                                            readonly paths and masked paths. This
-                                            requires the ProcMountType feature flag
-                                            to be enabled. Note that this field cannot
-                                            be set when spec.os.name is windows.
+                                          description: |-
+                                            procMount denotes the type of proc mount to use for the containers.
+                                            The default is DefaultProcMount which uses the container runtime defaults for
+                                            readonly paths and masked paths.
+                                            This requires the ProcMountType feature flag to be enabled.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           type: string
                                         readOnlyRootFilesystem:
-                                          description: Whether this container has
-                                            a read-only root filesystem. Default is
-                                            false. Note that this field cannot be
-                                            set when spec.os.name is windows.
+                                          description: |-
+                                            Whether this container has a read-only root filesystem.
+                                            Default is false.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           type: boolean
                                         runAsGroup:
-                                          description: The GID to run the entrypoint
-                                            of the container process. Uses runtime
-                                            default if unset. May also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence. Note that this field
-                                            cannot be set when spec.os.name is windows.
+                                          description: |-
+                                            The GID to run the entrypoint of the container process.
+                                            Uses runtime default if unset.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           format: int64
                                           type: integer
                                         runAsNonRoot:
-                                          description: Indicates that the container
-                                            must run as a non-root user. If true,
-                                            the Kubelet will validate the image at
-                                            runtime to ensure that it does not run
-                                            as UID 0 (root) and fail to start the
-                                            container if it does. If unset or false,
-                                            no such validation will be performed.
-                                            May also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence.
+                                          description: |-
+                                            Indicates that the container must run as a non-root user.
+                                            If true, the Kubelet will validate the image at runtime to ensure that it
+                                            does not run as UID 0 (root) and fail to start the container if it does.
+                                            If unset or false, no such validation will be performed.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
                                           type: boolean
                                         runAsUser:
-                                          description: The UID to run the entrypoint
-                                            of the container process. Defaults to
-                                            user specified in image metadata if unspecified.
-                                            May also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence. Note that this field
-                                            cannot be set when spec.os.name is windows.
+                                          description: |-
+                                            The UID to run the entrypoint of the container process.
+                                            Defaults to user specified in image metadata if unspecified.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           format: int64
                                           type: integer
                                         seLinuxOptions:
-                                          description: The SELinux context to be applied
-                                            to the container. If unspecified, the
-                                            container runtime will allocate a random
-                                            SELinux context for each container.  May
-                                            also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence. Note that this field
-                                            cannot be set when spec.os.name is windows.
+                                          description: |-
+                                            The SELinux context to be applied to the container.
+                                            If unspecified, the container runtime will allocate a random SELinux context for each
+                                            container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           properties:
                                             level:
                                               description: Level is SELinux level
@@ -2568,53 +2330,44 @@ spec:
                                               type: string
                                           type: object
                                         seccompProfile:
-                                          description: The seccomp options to use
-                                            by this container. If seccomp options
-                                            are provided at both the pod & container
-                                            level, the container options override
-                                            the pod options. Note that this field
-                                            cannot be set when spec.os.name is windows.
+                                          description: |-
+                                            The seccomp options to use by this container. If seccomp options are
+                                            provided at both the pod & container level, the container options
+                                            override the pod options.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           properties:
                                             localhostProfile:
-                                              description: localhostProfile indicates
-                                                a profile defined in a file on the
-                                                node should be used. The profile must
-                                                be preconfigured on the node to work.
-                                                Must be a descending path, relative
-                                                to the kubelet's configured seccomp
-                                                profile location. Must be set if type
-                                                is "Localhost". Must NOT be set for
-                                                any other type.
+                                              description: |-
+                                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                                The profile must be preconfigured on the node to work.
+                                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                Must be set if type is "Localhost". Must NOT be set for any other type.
                                               type: string
                                             type:
-                                              description: "type indicates which kind
-                                                of seccomp profile will be applied.
-                                                Valid options are: \n Localhost -
-                                                a profile defined in a file on the
-                                                node should be used. RuntimeDefault
-                                                - the container runtime default profile
-                                                should be used. Unconfined - no profile
-                                                should be applied."
+                                              description: |-
+                                                type indicates which kind of seccomp profile will be applied.
+                                                Valid options are:
+
+
+                                                Localhost - a profile defined in a file on the node should be used.
+                                                RuntimeDefault - the container runtime default profile should be used.
+                                                Unconfined - no profile should be applied.
                                               type: string
                                           required:
                                           - type
                                           type: object
                                         windowsOptions:
-                                          description: The Windows specific settings
-                                            applied to all containers. If unspecified,
-                                            the options from the PodSecurityContext
-                                            will be used. If set in both SecurityContext
-                                            and PodSecurityContext, the value specified
-                                            in SecurityContext takes precedence. Note
-                                            that this field cannot be set when spec.os.name
-                                            is linux.
+                                          description: |-
+                                            The Windows specific settings applied to all containers.
+                                            If unspecified, the options from the PodSecurityContext will be used.
+                                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is linux.
                                           properties:
                                             gmsaCredentialSpec:
-                                              description: GMSACredentialSpec is where
-                                                the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                                inlines the contents of the GMSA credential
-                                                spec named by the GMSACredentialSpecName
-                                                field.
+                                              description: |-
+                                                GMSACredentialSpec is where the GMSA admission webhook
+                                                (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                                GMSA credential spec named by the GMSACredentialSpecName field.
                                               type: string
                                             gmsaCredentialSpecName:
                                               description: GMSACredentialSpecName
@@ -2622,67 +2375,51 @@ spec:
                                                 spec to use.
                                               type: string
                                             hostProcess:
-                                              description: HostProcess determines
-                                                if a container should be run as a
-                                                'Host Process' container. All of a
-                                                Pod's containers must have the same
-                                                effective HostProcess value (it is
-                                                not allowed to have a mix of HostProcess
-                                                containers and non-HostProcess containers).
-                                                In addition, if HostProcess is true
-                                                then HostNetwork must also be set
-                                                to true.
+                                              description: |-
+                                                HostProcess determines if a container should be run as a 'Host Process' container.
+                                                All of a Pod's containers must have the same effective HostProcess value
+                                                (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                                In addition, if HostProcess is true then HostNetwork must also be set to true.
                                               type: boolean
                                             runAsUserName:
-                                              description: The UserName in Windows
-                                                to run the entrypoint of the container
-                                                process. Defaults to the user specified
-                                                in image metadata if unspecified.
-                                                May also be set in PodSecurityContext.
-                                                If set in both SecurityContext and
-                                                PodSecurityContext, the value specified
-                                                in SecurityContext takes precedence.
+                                              description: |-
+                                                The UserName in Windows to run the entrypoint of the container process.
+                                                Defaults to the user specified in image metadata if unspecified.
+                                                May also be set in PodSecurityContext. If set in both SecurityContext and
+                                                PodSecurityContext, the value specified in SecurityContext takes precedence.
                                               type: string
                                           type: object
                                       type: object
                                     startupProbe:
-                                      description: 'StartupProbe indicates that the
-                                        Pod has successfully initialized. If specified,
-                                        no other probes are executed until this completes
-                                        successfully. If this probe fails, the Pod
-                                        will be restarted, just as if the livenessProbe
-                                        failed. This can be used to provide different
-                                        probe parameters at the beginning of a Pod''s
-                                        lifecycle, when it might take a long time
-                                        to load data or warm a cache, than during
-                                        steady-state operation. This cannot be updated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: |-
+                                        StartupProbe indicates that the Pod has successfully initialized.
+                                        If specified, no other probes are executed until this completes successfully.
+                                        If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                        This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                        when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                        This cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       properties:
                                         exec:
                                           description: Exec specifies the action to
                                             take.
                                           properties:
                                             command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                           type: object
                                         failureThreshold:
-                                          description: Minimum consecutive failures
-                                            for the probe to be considered failed
-                                            after having succeeded. Defaults to 3.
-                                            Minimum value is 1.
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         grpc:
@@ -2696,11 +2433,12 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
-                                              description: "Service is the name of
-                                                the service to place in the gRPC HealthCheckRequest
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
                                                 (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                                \n If this is not specified, the default
-                                                behavior is defined by gRPC."
+
+
+                                                If this is not specified, the default behavior is defined by gRPC.
                                               type: string
                                           required:
                                           - port
@@ -2710,10 +2448,9 @@ spec:
                                             request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -2725,21 +2462,15 @@ spec:
                                                   probes
                                                 properties:
                                                   name:
-                                                    description: The header field
-                                                      name. This will be canonicalized
-                                                      upon output, so case-variant
-                                                      names will be understood as
-                                                      the same header.
                                                     type: string
                                                   value:
-                                                    description: The header field
-                                                      value
                                                     type: string
                                                 required:
                                                 - name
                                                 - value
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             path:
                                               description: Path to access on the HTTP
                                                 server.
@@ -2748,36 +2479,35 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         initialDelaySeconds:
-                                          description: 'Number of seconds after the
-                                            container has started before liveness
-                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                         periodSeconds:
-                                          description: How often (in seconds) to perform
-                                            the probe. Default to 10 seconds. Minimum
-                                            value is 1.
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         successThreshold:
-                                          description: Minimum consecutive successes
-                                            for the probe to be considered successful
-                                            after having failed. Defaults to 1. Must
-                                            be 1 for liveness and startup. Minimum
-                                            value is 1.
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         tcpSocket:
@@ -2792,93 +2522,76 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                         terminationGracePeriodSeconds:
-                                          description: Optional duration in seconds
-                                            the pod needs to terminate gracefully
-                                            upon probe failure. The grace period is
-                                            the duration in seconds after the processes
-                                            running in the pod are sent a termination
-                                            signal and the time when the processes
-                                            are forcibly halted with a kill signal.
-                                            Set this value longer than the expected
-                                            cleanup time for your process. If this
-                                            value is nil, the pod's terminationGracePeriodSeconds
-                                            will be used. Otherwise, this value overrides
-                                            the value provided by the pod spec. Value
-                                            must be non-negative integer. The value
-                                            zero indicates stop immediately via the
-                                            kill signal (no opportunity to shut down).
-                                            This is a beta field and requires enabling
-                                            ProbeTerminationGracePeriod feature gate.
-                                            Minimum value is 1. spec.terminationGracePeriodSeconds
-                                            is used if unset.
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                           format: int64
                                           type: integer
                                         timeoutSeconds:
-                                          description: 'Number of seconds after which
-                                            the probe times out. Defaults to 1 second.
-                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                       type: object
                                     stdin:
-                                      description: Whether this container should allocate
-                                        a buffer for stdin in the container runtime.
-                                        If this is not set, reads from stdin in the
-                                        container will always result in EOF. Default
-                                        is false.
+                                      description: |-
+                                        Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                        is not set, reads from stdin in the container will always result in EOF.
+                                        Default is false.
                                       type: boolean
                                     stdinOnce:
-                                      description: Whether the container runtime should
-                                        close the stdin channel after it has been
-                                        opened by a single attach. When stdin is true
-                                        the stdin stream will remain open across multiple
-                                        attach sessions. If stdinOnce is set to true,
-                                        stdin is opened on container start, is empty
-                                        until the first client attaches to stdin,
-                                        and then remains open and accepts data until
-                                        the client disconnects, at which time stdin
-                                        is closed and remains closed until the container
-                                        is restarted. If this flag is false, a container
-                                        processes that reads from stdin will never
-                                        receive an EOF. Default is false
+                                      description: |-
+                                        Whether the container runtime should close the stdin channel after it has been opened by
+                                        a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                        sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                        first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                        at which time stdin is closed and remains closed until the container is restarted. If this
+                                        flag is false, a container processes that reads from stdin will never receive an EOF.
+                                        Default is false
                                       type: boolean
                                     terminationMessagePath:
-                                      description: 'Optional: Path at which the file
-                                        to which the container''s termination message
-                                        will be written is mounted into the container''s
-                                        filesystem. Message written is intended to
-                                        be brief final status, such as an assertion
-                                        failure message. Will be truncated by the
-                                        node if greater than 4096 bytes. The total
-                                        message length across all containers will
-                                        be limited to 12kb. Defaults to /dev/termination-log.
-                                        Cannot be updated.'
+                                      description: |-
+                                        Optional: Path at which the file to which the container's termination message
+                                        will be written is mounted into the container's filesystem.
+                                        Message written is intended to be brief final status, such as an assertion failure message.
+                                        Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                        all containers will be limited to 12kb.
+                                        Defaults to /dev/termination-log.
+                                        Cannot be updated.
                                       type: string
                                     terminationMessagePolicy:
-                                      description: Indicate how the termination message
-                                        should be populated. File will use the contents
-                                        of terminationMessagePath to populate the
-                                        container status message on both success and
-                                        failure. FallbackToLogsOnError will use the
-                                        last chunk of container log output if the
-                                        termination message file is empty and the
-                                        container exited with an error. The log output
-                                        is limited to 2048 bytes or 80 lines, whichever
-                                        is smaller. Defaults to File. Cannot be updated.
+                                      description: |-
+                                        Indicate how the termination message should be populated. File will use the contents of
+                                        terminationMessagePath to populate the container status message on both success and failure.
+                                        FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                        message file is empty and the container exited with an error.
+                                        The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                        Defaults to File.
+                                        Cannot be updated.
                                       type: string
                                     tty:
-                                      description: Whether this container should allocate
-                                        a TTY for itself, also requires 'stdin' to
-                                        be true. Default is false.
+                                      description: |-
+                                        Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                        Default is false.
                                       type: boolean
                                     volumeDevices:
                                       description: volumeDevices is the list of block
@@ -2901,84 +2614,118 @@ spec:
                                         - name
                                         type: object
                                       type: array
+                                      x-kubernetes-list-map-keys:
+                                      - devicePath
+                                      x-kubernetes-list-type: map
                                     volumeMounts:
-                                      description: Pod volumes to mount into the container's
-                                        filesystem. Cannot be updated.
+                                      description: |-
+                                        Pod volumes to mount into the container's filesystem.
+                                        Cannot be updated.
                                       items:
                                         description: VolumeMount describes a mounting
                                           of a Volume within a container.
                                         properties:
                                           mountPath:
-                                            description: Path within the container
-                                              at which the volume should be mounted.  Must
+                                            description: |-
+                                              Path within the container at which the volume should be mounted.  Must
                                               not contain ':'.
                                             type: string
                                           mountPropagation:
-                                            description: mountPropagation determines
-                                              how mounts are propagated from the host
+                                            description: |-
+                                              mountPropagation determines how mounts are propagated from the host
                                               to container and the other way around.
-                                              When not set, MountPropagationNone is
-                                              used. This field is beta in 1.10.
+                                              When not set, MountPropagationNone is used.
+                                              This field is beta in 1.10.
+                                              When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                              (which defaults to None).
                                             type: string
                                           name:
                                             description: This must match the Name
                                               of a Volume.
                                             type: string
                                           readOnly:
-                                            description: Mounted read-only if true,
-                                              read-write otherwise (false or unspecified).
+                                            description: |-
+                                              Mounted read-only if true, read-write otherwise (false or unspecified).
                                               Defaults to false.
                                             type: boolean
+                                          recursiveReadOnly:
+                                            description: |-
+                                              RecursiveReadOnly specifies whether read-only mounts should be handled
+                                              recursively.
+
+
+                                              If ReadOnly is false, this field has no meaning and must be unspecified.
+
+
+                                              If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                              recursively read-only.  If this field is set to IfPossible, the mount is made
+                                              recursively read-only, if it is supported by the container runtime.  If this
+                                              field is set to Enabled, the mount is made recursively read-only if it is
+                                              supported by the container runtime, otherwise the pod will not be started and
+                                              an error will be generated to indicate the reason.
+
+
+                                              If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                              None (or be unspecified, which defaults to None).
+
+
+                                              If this field is not specified, it is treated as an equivalent of Disabled.
+                                            type: string
                                           subPath:
-                                            description: Path within the volume from
-                                              which the container's volume should
-                                              be mounted. Defaults to "" (volume's
-                                              root).
+                                            description: |-
+                                              Path within the volume from which the container's volume should be mounted.
+                                              Defaults to "" (volume's root).
                                             type: string
                                           subPathExpr:
-                                            description: Expanded path within the
-                                              volume from which the container's volume
-                                              should be mounted. Behaves similarly
-                                              to SubPath but environment variable
-                                              references $(VAR_NAME) are expanded
-                                              using the container's environment. Defaults
-                                              to "" (volume's root). SubPathExpr and
-                                              SubPath are mutually exclusive.
+                                            description: |-
+                                              Expanded path within the volume from which the container's volume should be mounted.
+                                              Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                              Defaults to "" (volume's root).
+                                              SubPathExpr and SubPath are mutually exclusive.
                                             type: string
                                         required:
                                         - mountPath
                                         - name
                                         type: object
                                       type: array
+                                      x-kubernetes-list-map-keys:
+                                      - mountPath
+                                      x-kubernetes-list-type: map
                                     workingDir:
-                                      description: Container's working directory.
-                                        If not specified, the container runtime's
-                                        default will be used, which might be configured
-                                        in the container image. Cannot be updated.
+                                      description: |-
+                                        Container's working directory.
+                                        If not specified, the container runtime's default will be used, which
+                                        might be configured in the container image.
+                                        Cannot be updated.
                                       type: string
                                   required:
                                   - name
                                   type: object
                                 type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
                               dnsConfig:
-                                description: Specifies the DNS parameters of a pod.
-                                  Parameters specified here will be merged to the
-                                  generated DNS configuration based on DNSPolicy.
+                                description: |-
+                                  Specifies the DNS parameters of a pod.
+                                  Parameters specified here will be merged to the generated DNS
+                                  configuration based on DNSPolicy.
                                 properties:
                                   nameservers:
-                                    description: A list of DNS name server IP addresses.
-                                      This will be appended to the base nameservers
-                                      generated from DNSPolicy. Duplicated nameservers
-                                      will be removed.
+                                    description: |-
+                                      A list of DNS name server IP addresses.
+                                      This will be appended to the base nameservers generated from DNSPolicy.
+                                      Duplicated nameservers will be removed.
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   options:
-                                    description: A list of DNS resolver options. This
-                                      will be merged with the base options generated
-                                      from DNSPolicy. Duplicated entries will be removed.
-                                      Resolution options given in Options will override
-                                      those that appear in the base DNSPolicy.
+                                    description: |-
+                                      A list of DNS resolver options.
+                                      This will be merged with the base options generated from DNSPolicy.
+                                      Duplicated entries will be removed. Resolution options given in Options
+                                      will override those that appear in the base DNSPolicy.
                                     items:
                                       description: PodDNSConfigOption defines DNS
                                         resolver options of a pod.
@@ -2990,87 +2737,82 @@ spec:
                                           type: string
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   searches:
-                                    description: A list of DNS search domains for
-                                      host-name lookup. This will be appended to the
-                                      base search paths generated from DNSPolicy.
+                                    description: |-
+                                      A list of DNS search domains for host-name lookup.
+                                      This will be appended to the base search paths generated from DNSPolicy.
                                       Duplicated search paths will be removed.
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                 type: object
                               dnsPolicy:
-                                description: Set DNS policy for the pod. Defaults
-                                  to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet',
-                                  'ClusterFirst', 'Default' or 'None'. DNS parameters
-                                  given in DNSConfig will be merged with the policy
-                                  selected with DNSPolicy. To have DNS options set
-                                  along with hostNetwork, you have to specify DNS
-                                  policy explicitly to 'ClusterFirstWithHostNet'.
+                                description: |-
+                                  Set DNS policy for the pod.
+                                  Defaults to "ClusterFirst".
+                                  Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
+                                  DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy.
+                                  To have DNS options set along with hostNetwork, you have to specify DNS policy
+                                  explicitly to 'ClusterFirstWithHostNet'.
                                 type: string
                               enableServiceLinks:
-                                description: 'EnableServiceLinks indicates whether
-                                  information about services should be injected into
-                                  pod''s environment variables, matching the syntax
-                                  of Docker links. Optional: Defaults to true.'
+                                description: |-
+                                  EnableServiceLinks indicates whether information about services should be injected into pod's
+                                  environment variables, matching the syntax of Docker links.
+                                  Optional: Defaults to true.
                                 type: boolean
                               ephemeralContainers:
-                                description: List of ephemeral containers run in this
-                                  pod. Ephemeral containers may be run in an existing
-                                  pod to perform user-initiated actions such as debugging.
-                                  This list cannot be specified when creating a pod,
-                                  and it cannot be modified by updating the pod spec.
-                                  In order to add an ephemeral container to an existing
-                                  pod, use the pod's ephemeralcontainers subresource.
+                                description: |-
+                                  List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing
+                                  pod to perform user-initiated actions such as debugging. This list cannot be specified when
+                                  creating a pod, and it cannot be modified by updating the pod spec. In order to add an
+                                  ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.
                                 items:
-                                  description: "An EphemeralContainer is a temporary
-                                    container that you may add to an existing Pod
-                                    for user-initiated activities such as debugging.
-                                    Ephemeral containers have no resource or scheduling
-                                    guarantees, and they will not be restarted when
-                                    they exit or when a Pod is removed or restarted.
-                                    The kubelet may evict a Pod if an ephemeral container
-                                    causes the Pod to exceed its resource allocation.
-                                    \n To add an ephemeral container, use the ephemeralcontainers
-                                    subresource of an existing Pod. Ephemeral containers
-                                    may not be removed or restarted."
+                                  description: |-
+                                    An EphemeralContainer is a temporary container that you may add to an existing Pod for
+                                    user-initiated activities such as debugging. Ephemeral containers have no resource or
+                                    scheduling guarantees, and they will not be restarted when they exit or when a Pod is
+                                    removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the
+                                    Pod to exceed its resource allocation.
+
+
+                                    To add an ephemeral container, use the ephemeralcontainers subresource of an existing
+                                    Pod. Ephemeral containers may not be removed or restarted.
                                   properties:
                                     args:
-                                      description: 'Arguments to the entrypoint. The
-                                        image''s CMD is used if this is not provided.
-                                        Variable references $(VAR_NAME) are expanded
-                                        using the container''s environment. If a variable
-                                        cannot be resolved, the reference in the input
-                                        string will be unchanged. Double $$ are reduced
-                                        to a single $, which allows for escaping the
-                                        $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                        produce the string literal "$(VAR_NAME)".
-                                        Escaped references will never be expanded,
-                                        regardless of whether the variable exists
-                                        or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      description: |-
+                                        Arguments to the entrypoint.
+                                        The image's CMD is used if this is not provided.
+                                        Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                        cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                        produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                        of whether the variable exists or not. Cannot be updated.
+                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     command:
-                                      description: 'Entrypoint array. Not executed
-                                        within a shell. The image''s ENTRYPOINT is
-                                        used if this is not provided. Variable references
-                                        $(VAR_NAME) are expanded using the container''s
-                                        environment. If a variable cannot be resolved,
-                                        the reference in the input string will be
-                                        unchanged. Double $$ are reduced to a single
-                                        $, which allows for escaping the $(VAR_NAME)
-                                        syntax: i.e. "$$(VAR_NAME)" will produce the
-                                        string literal "$(VAR_NAME)". Escaped references
-                                        will never be expanded, regardless of whether
-                                        the variable exists or not. Cannot be updated.
-                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      description: |-
+                                        Entrypoint array. Not executed within a shell.
+                                        The image's ENTRYPOINT is used if this is not provided.
+                                        Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                        cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                        produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                        of whether the variable exists or not. Cannot be updated.
+                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     env:
-                                      description: List of environment variables to
-                                        set in the container. Cannot be updated.
+                                      description: |-
+                                        List of environment variables to set in the container.
+                                        Cannot be updated.
                                       items:
                                         description: EnvVar represents an environment
                                           variable present in a Container.
@@ -3080,19 +2822,16 @@ spec:
                                               Must be a C_IDENTIFIER.
                                             type: string
                                           value:
-                                            description: 'Variable references $(VAR_NAME)
-                                              are expanded using the previously defined
-                                              environment variables in the container
-                                              and any service environment variables.
-                                              If a variable cannot be resolved, the
-                                              reference in the input string will be
-                                              unchanged. Double $$ are reduced to
-                                              a single $, which allows for escaping
-                                              the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                              will produce the string literal "$(VAR_NAME)".
-                                              Escaped references will never be expanded,
-                                              regardless of whether the variable exists
-                                              or not. Defaults to "".'
+                                            description: |-
+                                              Variable references $(VAR_NAME) are expanded
+                                              using the previously defined environment variables in the container and
+                                              any service environment variables. If a variable cannot be resolved,
+                                              the reference in the input string will be unchanged. Double $$ are reduced
+                                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                              "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                              Escaped references will never be expanded, regardless of whether the variable
+                                              exists or not.
+                                              Defaults to "".
                                             type: string
                                           valueFrom:
                                             description: Source for the environment
@@ -3103,69 +2842,37 @@ spec:
                                                 description: Selects a key of a ConfigMap.
                                                 properties:
                                                   key:
-                                                    description: The key to select.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                    default: ""
                                                     type: string
                                                   optional:
-                                                    description: Specify whether the
-                                                      ConfigMap or its key must be
-                                                      defined
                                                     type: boolean
                                                 required:
                                                 - key
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               fieldRef:
-                                                description: 'Selects a field of the
-                                                  pod: supports metadata.name, metadata.namespace,
-                                                  `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                                  spec.nodeName, spec.serviceAccountName,
-                                                  status.hostIP, status.podIP, status.podIPs.'
                                                 properties:
                                                   apiVersion:
-                                                    description: Version of the schema
-                                                      the FieldPath is written in
-                                                      terms of, defaults to "v1".
                                                     type: string
                                                   fieldPath:
-                                                    description: Path of the field
-                                                      to select in the specified API
-                                                      version.
                                                     type: string
                                                 required:
                                                 - fieldPath
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               resourceFieldRef:
-                                                description: 'Selects a resource of
-                                                  the container: only resources limits
-                                                  and requests (limits.cpu, limits.memory,
-                                                  limits.ephemeral-storage, requests.cpu,
-                                                  requests.memory and requests.ephemeral-storage)
-                                                  are currently supported.'
                                                 properties:
                                                   containerName:
-                                                    description: 'Container name:
-                                                      required for volumes, optional
-                                                      for env vars'
                                                     type: string
                                                   divisor:
                                                     anyOf:
                                                     - type: integer
                                                     - type: string
-                                                    description: Specifies the output
-                                                      format of the exposed resources,
-                                                      defaults to "1"
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
                                                   resource:
-                                                    description: 'Required: resource
-                                                      to select'
                                                     type: string
                                                 required:
                                                 - resource
@@ -3176,19 +2883,11 @@ spec:
                                                   in the pod's namespace
                                                 properties:
                                                   key:
-                                                    description: The key of the secret
-                                                      to select from.  Must be a valid
-                                                      secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                    default: ""
                                                     type: string
                                                   optional:
-                                                    description: Specify whether the
-                                                      Secret or its key must be defined
                                                     type: boolean
                                                 required:
                                                 - key
@@ -3199,16 +2898,17 @@ spec:
                                         - name
                                         type: object
                                       type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
                                     envFrom:
-                                      description: List of sources to populate environment
-                                        variables in the container. The keys defined
-                                        within a source must be a C_IDENTIFIER. All
-                                        invalid keys will be reported as an event
-                                        when the container is starting. When a key
-                                        exists in multiple sources, the value associated
-                                        with the last source will take precedence.
-                                        Values defined by an Env with a duplicate
-                                        key will take precedence. Cannot be updated.
+                                      description: |-
+                                        List of sources to populate environment variables in the container.
+                                        The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                        will be reported as an event when the container is starting. When a key exists in multiple
+                                        sources, the value associated with the last source will take precedence.
+                                        Values defined by an Env with a duplicate key will take precedence.
+                                        Cannot be updated.
                                       items:
                                         description: EnvFromSource represents the
                                           source of a set of ConfigMaps
@@ -3217,10 +2917,7 @@ spec:
                                             description: The ConfigMap to select from
                                             properties:
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                default: ""
                                                 type: string
                                               optional:
                                                 description: Specify whether the ConfigMap
@@ -3237,10 +2934,7 @@ spec:
                                             description: The Secret to select from
                                             properties:
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                default: ""
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -3250,68 +2944,49 @@ spec:
                                             x-kubernetes-map-type: atomic
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     image:
-                                      description: 'Container image name. More info:
-                                        https://kubernetes.io/docs/concepts/containers/images'
+                                      description: |-
+                                        Container image name.
+                                        More info: https://kubernetes.io/docs/concepts/containers/images
                                       type: string
                                     imagePullPolicy:
-                                      description: 'Image pull policy. One of Always,
-                                        Never, IfNotPresent. Defaults to Always if
-                                        :latest tag is specified, or IfNotPresent
-                                        otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                      description: |-
+                                        Image pull policy.
+                                        One of Always, Never, IfNotPresent.
+                                        Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                       type: string
                                     lifecycle:
                                       description: Lifecycle is not allowed for ephemeral
                                         containers.
                                       properties:
                                         postStart:
-                                          description: 'PostStart is called immediately
-                                            after a container is created. If the handler
-                                            fails, the container is terminated and
-                                            restarted according to its restart policy.
-                                            Other management of the container blocks
-                                            until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          description: |-
+                                            PostStart is called immediately after a container is created. If the handler fails,
+                                            the container is terminated and restarted according to its restart policy.
+                                            Other management of the container blocks until the hook completes.
+                                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                           properties:
                                             exec:
                                               description: Exec specifies the action
                                                 to take.
                                               properties:
                                                 command:
-                                                  description: Command is the command
-                                                    line to execute inside the container,
-                                                    the working directory for the
-                                                    command  is root ('/') in the
-                                                    container's filesystem. The command
-                                                    is simply exec'd, it is not run
-                                                    inside a shell, so traditional
-                                                    shell instructions ('|', etc)
-                                                    won't work. To use a shell, you
-                                                    need to explicitly call out to
-                                                    that shell. Exit status of 0 is
-                                                    treated as live/healthy and non-zero
-                                                    is unhealthy.
                                                   items:
                                                     type: string
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               type: object
                                             httpGet:
                                               description: HTTPGet specifies the http
                                                 request to perform.
                                               properties:
                                                 host:
-                                                  description: Host name to connect
-                                                    to, defaults to the pod IP. You
-                                                    probably want to set "Host" in
-                                                    httpHeaders instead.
                                                   type: string
                                                 httpHeaders:
-                                                  description: Custom headers to set
-                                                    in the request. HTTP allows repeated
-                                                    headers.
                                                   items:
-                                                    description: HTTPHeader describes
-                                                      a custom header to be used in
-                                                      HTTP probes
                                                     properties:
                                                       name:
                                                         type: string
@@ -3322,110 +2997,77 @@ spec:
                                                     - value
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 path:
-                                                  description: Path to access on the
-                                                    HTTP server.
                                                   type: string
                                                 port:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Name or number of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                                 scheme:
-                                                  description: Scheme to use for connecting
-                                                    to the host. Defaults to HTTP.
                                                   type: string
                                               required:
                                               - port
                                               type: object
+                                            sleep:
+                                              description: Sleep represents the duration
+                                                that the container should sleep before
+                                                being terminated.
+                                              properties:
+                                                seconds:
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
                                             tcpSocket:
-                                              description: Deprecated. TCPSocket is
-                                                NOT supported as a LifecycleHandler
-                                                and kept for the backward compatibility.
-                                                There are no validation of this field
-                                                and lifecycle hooks will fail in runtime
-                                                when tcp handler is specified.
+                                              description: |-
+                                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                                for the backward compatibility. There are no validation of this field and
+                                                lifecycle hooks will fail in runtime when tcp handler is specified.
                                               properties:
                                                 host:
-                                                  description: 'Optional: Host name
-                                                    to connect to, defaults to the
-                                                    pod IP.'
                                                   type: string
                                                 port:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Number or name of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                               required:
                                               - port
                                               type: object
                                           type: object
                                         preStop:
-                                          description: 'PreStop is called immediately
-                                            before a container is terminated due to
-                                            an API request or management event such
-                                            as liveness/startup probe failure, preemption,
-                                            resource contention, etc. The handler
-                                            is not called if the container crashes
-                                            or exits. The Pod''s termination grace
-                                            period countdown begins before the PreStop
-                                            hook is executed. Regardless of the outcome
-                                            of the handler, the container will eventually
-                                            terminate within the Pod''s termination
-                                            grace period (unless delayed by finalizers).
-                                            Other management of the container blocks
-                                            until the hook completes or until the
-                                            termination grace period is reached. More
-                                            info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          description: |-
+                                            PreStop is called immediately before a container is terminated due to an
+                                            API request or management event such as liveness/startup probe failure,
+                                            preemption, resource contention, etc. The handler is not called if the
+                                            container crashes or exits. The Pod's termination grace period countdown begins before the
+                                            PreStop hook is executed. Regardless of the outcome of the handler, the
+                                            container will eventually terminate within the Pod's termination grace
+                                            period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                            or until the termination grace period is reached.
+                                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                           properties:
                                             exec:
                                               description: Exec specifies the action
                                                 to take.
                                               properties:
                                                 command:
-                                                  description: Command is the command
-                                                    line to execute inside the container,
-                                                    the working directory for the
-                                                    command  is root ('/') in the
-                                                    container's filesystem. The command
-                                                    is simply exec'd, it is not run
-                                                    inside a shell, so traditional
-                                                    shell instructions ('|', etc)
-                                                    won't work. To use a shell, you
-                                                    need to explicitly call out to
-                                                    that shell. Exit status of 0 is
-                                                    treated as live/healthy and non-zero
-                                                    is unhealthy.
                                                   items:
                                                     type: string
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               type: object
                                             httpGet:
                                               description: HTTPGet specifies the http
                                                 request to perform.
                                               properties:
                                                 host:
-                                                  description: Host name to connect
-                                                    to, defaults to the pod IP. You
-                                                    probably want to set "Host" in
-                                                    httpHeaders instead.
                                                   type: string
                                                 httpHeaders:
-                                                  description: Custom headers to set
-                                                    in the request. HTTP allows repeated
-                                                    headers.
                                                   items:
-                                                    description: HTTPHeader describes
-                                                      a custom header to be used in
-                                                      HTTP probes
                                                     properties:
                                                       name:
                                                         type: string
@@ -3436,47 +3078,42 @@ spec:
                                                     - value
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 path:
-                                                  description: Path to access on the
-                                                    HTTP server.
                                                   type: string
                                                 port:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Name or number of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                                 scheme:
-                                                  description: Scheme to use for connecting
-                                                    to the host. Defaults to HTTP.
                                                   type: string
                                               required:
                                               - port
                                               type: object
+                                            sleep:
+                                              description: Sleep represents the duration
+                                                that the container should sleep before
+                                                being terminated.
+                                              properties:
+                                                seconds:
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
                                             tcpSocket:
-                                              description: Deprecated. TCPSocket is
-                                                NOT supported as a LifecycleHandler
-                                                and kept for the backward compatibility.
-                                                There are no validation of this field
-                                                and lifecycle hooks will fail in runtime
-                                                when tcp handler is specified.
+                                              description: |-
+                                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                                for the backward compatibility. There are no validation of this field and
+                                                lifecycle hooks will fail in runtime when tcp handler is specified.
                                               properties:
                                                 host:
-                                                  description: 'Optional: Host name
-                                                    to connect to, defaults to the
-                                                    pod IP.'
                                                   type: string
                                                 port:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Number or name of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                               required:
                                               - port
@@ -3492,26 +3129,21 @@ spec:
                                             take.
                                           properties:
                                             command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                           type: object
                                         failureThreshold:
-                                          description: Minimum consecutive failures
-                                            for the probe to be considered failed
-                                            after having succeeded. Defaults to 3.
-                                            Minimum value is 1.
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         grpc:
@@ -3525,11 +3157,12 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
-                                              description: "Service is the name of
-                                                the service to place in the gRPC HealthCheckRequest
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
                                                 (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                                \n If this is not specified, the default
-                                                behavior is defined by gRPC."
+
+
+                                                If this is not specified, the default behavior is defined by gRPC.
                                               type: string
                                           required:
                                           - port
@@ -3539,10 +3172,9 @@ spec:
                                             request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -3554,21 +3186,15 @@ spec:
                                                   probes
                                                 properties:
                                                   name:
-                                                    description: The header field
-                                                      name. This will be canonicalized
-                                                      upon output, so case-variant
-                                                      names will be understood as
-                                                      the same header.
                                                     type: string
                                                   value:
-                                                    description: The header field
-                                                      value
                                                     type: string
                                                 required:
                                                 - name
                                                 - value
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             path:
                                               description: Path to access on the HTTP
                                                 server.
@@ -3577,36 +3203,35 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         initialDelaySeconds:
-                                          description: 'Number of seconds after the
-                                            container has started before liveness
-                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                         periodSeconds:
-                                          description: How often (in seconds) to perform
-                                            the probe. Default to 10 seconds. Minimum
-                                            value is 1.
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         successThreshold:
-                                          description: Minimum consecutive successes
-                                            for the probe to be considered successful
-                                            after having failed. Defaults to 1. Must
-                                            be 1 for liveness and startup. Minimum
-                                            value is 1.
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         tcpSocket:
@@ -3621,48 +3246,40 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                         terminationGracePeriodSeconds:
-                                          description: Optional duration in seconds
-                                            the pod needs to terminate gracefully
-                                            upon probe failure. The grace period is
-                                            the duration in seconds after the processes
-                                            running in the pod are sent a termination
-                                            signal and the time when the processes
-                                            are forcibly halted with a kill signal.
-                                            Set this value longer than the expected
-                                            cleanup time for your process. If this
-                                            value is nil, the pod's terminationGracePeriodSeconds
-                                            will be used. Otherwise, this value overrides
-                                            the value provided by the pod spec. Value
-                                            must be non-negative integer. The value
-                                            zero indicates stop immediately via the
-                                            kill signal (no opportunity to shut down).
-                                            This is a beta field and requires enabling
-                                            ProbeTerminationGracePeriod feature gate.
-                                            Minimum value is 1. spec.terminationGracePeriodSeconds
-                                            is used if unset.
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                           format: int64
                                           type: integer
                                         timeoutSeconds:
-                                          description: 'Number of seconds after which
-                                            the probe times out. Defaults to 1 second.
-                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                       type: object
                                     name:
-                                      description: Name of the ephemeral container
-                                        specified as a DNS_LABEL. This name must be
-                                        unique among all containers, init containers
-                                        and ephemeral containers.
+                                      description: |-
+                                        Name of the ephemeral container specified as a DNS_LABEL.
+                                        This name must be unique among all containers, init containers and ephemeral containers.
                                       type: string
                                     ports:
                                       description: Ports are not allowed for ephemeral
@@ -3672,9 +3289,9 @@ spec:
                                           port in a single container.
                                         properties:
                                           containerPort:
-                                            description: Number of port to expose
-                                              on the pod's IP address. This must be
-                                              a valid port number, 0 < x < 65536.
+                                            description: |-
+                                              Number of port to expose on the pod's IP address.
+                                              This must be a valid port number, 0 < x < 65536.
                                             format: int32
                                             type: integer
                                           hostIP:
@@ -3682,25 +3299,24 @@ spec:
                                               external port to.
                                             type: string
                                           hostPort:
-                                            description: Number of port to expose
-                                              on the host. If specified, this must
-                                              be a valid port number, 0 < x < 65536.
-                                              If HostNetwork is specified, this must
-                                              match ContainerPort. Most containers
-                                              do not need this.
+                                            description: |-
+                                              Number of port to expose on the host.
+                                              If specified, this must be a valid port number, 0 < x < 65536.
+                                              If HostNetwork is specified, this must match ContainerPort.
+                                              Most containers do not need this.
                                             format: int32
                                             type: integer
                                           name:
-                                            description: If specified, this must be
-                                              an IANA_SVC_NAME and unique within the
-                                              pod. Each named port in a pod must have
-                                              a unique name. Name for the port that
-                                              can be referred to by services.
+                                            description: |-
+                                              If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                              named port in a pod must have a unique name. Name for the port that can be
+                                              referred to by services.
                                             type: string
                                           protocol:
                                             default: TCP
-                                            description: Protocol for port. Must be
-                                              UDP, TCP, or SCTP. Defaults to "TCP".
+                                            description: |-
+                                              Protocol for port. Must be UDP, TCP, or SCTP.
+                                              Defaults to "TCP".
                                             type: string
                                         required:
                                         - containerPort
@@ -3719,26 +3335,21 @@ spec:
                                             take.
                                           properties:
                                             command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                           type: object
                                         failureThreshold:
-                                          description: Minimum consecutive failures
-                                            for the probe to be considered failed
-                                            after having succeeded. Defaults to 3.
-                                            Minimum value is 1.
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         grpc:
@@ -3752,11 +3363,12 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
-                                              description: "Service is the name of
-                                                the service to place in the gRPC HealthCheckRequest
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
                                                 (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                                \n If this is not specified, the default
-                                                behavior is defined by gRPC."
+
+
+                                                If this is not specified, the default behavior is defined by gRPC.
                                               type: string
                                           required:
                                           - port
@@ -3766,10 +3378,9 @@ spec:
                                             request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -3781,21 +3392,15 @@ spec:
                                                   probes
                                                 properties:
                                                   name:
-                                                    description: The header field
-                                                      name. This will be canonicalized
-                                                      upon output, so case-variant
-                                                      names will be understood as
-                                                      the same header.
                                                     type: string
                                                   value:
-                                                    description: The header field
-                                                      value
                                                     type: string
                                                 required:
                                                 - name
                                                 - value
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             path:
                                               description: Path to access on the HTTP
                                                 server.
@@ -3804,36 +3409,35 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         initialDelaySeconds:
-                                          description: 'Number of seconds after the
-                                            container has started before liveness
-                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                         periodSeconds:
-                                          description: How often (in seconds) to perform
-                                            the probe. Default to 10 seconds. Minimum
-                                            value is 1.
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         successThreshold:
-                                          description: Minimum consecutive successes
-                                            for the probe to be considered successful
-                                            after having failed. Defaults to 1. Must
-                                            be 1 for liveness and startup. Minimum
-                                            value is 1.
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         tcpSocket:
@@ -3848,40 +3452,33 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                         terminationGracePeriodSeconds:
-                                          description: Optional duration in seconds
-                                            the pod needs to terminate gracefully
-                                            upon probe failure. The grace period is
-                                            the duration in seconds after the processes
-                                            running in the pod are sent a termination
-                                            signal and the time when the processes
-                                            are forcibly halted with a kill signal.
-                                            Set this value longer than the expected
-                                            cleanup time for your process. If this
-                                            value is nil, the pod's terminationGracePeriodSeconds
-                                            will be used. Otherwise, this value overrides
-                                            the value provided by the pod spec. Value
-                                            must be non-negative integer. The value
-                                            zero indicates stop immediately via the
-                                            kill signal (no opportunity to shut down).
-                                            This is a beta field and requires enabling
-                                            ProbeTerminationGracePeriod feature gate.
-                                            Minimum value is 1. spec.terminationGracePeriodSeconds
-                                            is used if unset.
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                           format: int64
                                           type: integer
                                         timeoutSeconds:
-                                          description: 'Number of seconds after which
-                                            the probe times out. Defaults to 1 second.
-                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                       type: object
@@ -3893,14 +3490,14 @@ spec:
                                           resource resize policy for the container.
                                         properties:
                                           resourceName:
-                                            description: 'Name of the resource to
-                                              which this resource resize policy applies.
-                                              Supported values: cpu, memory.'
+                                            description: |-
+                                              Name of the resource to which this resource resize policy applies.
+                                              Supported values: cpu, memory.
                                             type: string
                                           restartPolicy:
-                                            description: Restart policy to apply when
-                                              specified resource is resized. If not
-                                              specified, it defaults to NotRequired.
+                                            description: |-
+                                              Restart policy to apply when specified resource is resized.
+                                              If not specified, it defaults to NotRequired.
                                             type: string
                                         required:
                                         - resourceName
@@ -3909,27 +3506,29 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     resources:
-                                      description: Resources are not allowed for ephemeral
-                                        containers. Ephemeral containers use spare
-                                        resources already allocated to the pod.
+                                      description: |-
+                                        Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
+                                        already allocated to the pod.
                                       properties:
                                         claims:
-                                          description: "Claims lists the names of
-                                            resources, defined in spec.resourceClaims,
-                                            that are used by this container. \n This
-                                            is an alpha field and requires enabling
-                                            the DynamicResourceAllocation feature
-                                            gate. \n This field is immutable. It can
-                                            only be set for containers."
+                                          description: |-
+                                            Claims lists the names of resources, defined in spec.resourceClaims,
+                                            that are used by this container.
+
+
+                                            This is an alpha field and requires enabling the
+                                            DynamicResourceAllocation feature gate.
+
+
+                                            This field is immutable. It can only be set for containers.
                                           items:
                                             description: ResourceClaim references
                                               one entry in PodSpec.ResourceClaims.
                                             properties:
                                               name:
-                                                description: Name must match the name
-                                                  of one entry in pod.spec.resourceClaims
-                                                  of the Pod where this field is used.
-                                                  It makes that resource available
+                                                description: |-
+                                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                                  the Pod where this field is used. It makes that resource available
                                                   inside a container.
                                                 type: string
                                             required:
@@ -3946,9 +3545,9 @@ spec:
                                             - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Limits describes the maximum
-                                            amount of compute resources allowed. More
-                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          description: |-
+                                            Limits describes the maximum amount of compute resources allowed.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                           type: object
                                         requests:
                                           additionalProperties:
@@ -3957,47 +3556,64 @@ spec:
                                             - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Requests describes the minimum
-                                            amount of compute resources required.
-                                            If Requests is omitted for a container,
-                                            it defaults to Limits if that is explicitly
-                                            specified, otherwise to an implementation-defined
-                                            value. Requests cannot exceed Limits.
-                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          description: |-
+                                            Requests describes the minimum amount of compute resources required.
+                                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                           type: object
                                       type: object
                                     restartPolicy:
-                                      description: Restart policy for the container
-                                        to manage the restart behavior of each container
-                                        within a pod. This may only be set for init
-                                        containers. You cannot set this field on ephemeral
-                                        containers.
+                                      description: |-
+                                        Restart policy for the container to manage the restart behavior of each
+                                        container within a pod.
+                                        This may only be set for init containers. You cannot set this field on
+                                        ephemeral containers.
                                       type: string
                                     securityContext:
-                                      description: 'Optional: SecurityContext defines
-                                        the security options the ephemeral container
-                                        should be run with. If set, the fields of
-                                        SecurityContext override the equivalent fields
-                                        of PodSecurityContext.'
+                                      description: |-
+                                        Optional: SecurityContext defines the security options the ephemeral container should be run with.
+                                        If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
                                       properties:
                                         allowPrivilegeEscalation:
-                                          description: 'AllowPrivilegeEscalation controls
-                                            whether a process can gain more privileges
-                                            than its parent process. This bool directly
-                                            controls if the no_new_privs flag will
-                                            be set on the container process. AllowPrivilegeEscalation
-                                            is true always when the container is:
-                                            1) run as Privileged 2) has CAP_SYS_ADMIN
-                                            Note that this field cannot be set when
-                                            spec.os.name is windows.'
+                                          description: |-
+                                            AllowPrivilegeEscalation controls whether a process can gain more
+                                            privileges than its parent process. This bool directly controls if
+                                            the no_new_privs flag will be set on the container process.
+                                            AllowPrivilegeEscalation is true always when the container is:
+                                            1) run as Privileged
+                                            2) has CAP_SYS_ADMIN
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           type: boolean
+                                        appArmorProfile:
+                                          description: |-
+                                            appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                            overrides the pod's appArmorProfile.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            localhostProfile:
+                                              description: |-
+                                                localhostProfile indicates a profile loaded on the node that should be used.
+                                                The profile must be preconfigured on the node to work.
+                                                Must match the loaded name of the profile.
+                                                Must be set if and only if type is "Localhost".
+                                              type: string
+                                            type:
+                                              description: |-
+                                                type indicates which kind of AppArmor profile will be applied.
+                                                Valid options are:
+                                                  Localhost - a profile pre-loaded on the node.
+                                                  RuntimeDefault - the container runtime's default profile.
+                                                  Unconfined - no AppArmor enforcement.
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
                                         capabilities:
-                                          description: The capabilities to add/drop
-                                            when running containers. Defaults to the
-                                            default set of capabilities granted by
-                                            the container runtime. Note that this
-                                            field cannot be set when spec.os.name
-                                            is windows.
+                                          description: |-
+                                            The capabilities to add/drop when running containers.
+                                            Defaults to the default set of capabilities granted by the container runtime.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           properties:
                                             add:
                                               description: Added capabilities
@@ -4006,6 +3622,7 @@ spec:
                                                   POSIX capabilities type
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             drop:
                                               description: Removed capabilities
                                               items:
@@ -4013,75 +3630,63 @@ spec:
                                                   POSIX capabilities type
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                           type: object
                                         privileged:
-                                          description: Run container in privileged
-                                            mode. Processes in privileged containers
-                                            are essentially equivalent to root on
-                                            the host. Defaults to false. Note that
-                                            this field cannot be set when spec.os.name
-                                            is windows.
+                                          description: |-
+                                            Run container in privileged mode.
+                                            Processes in privileged containers are essentially equivalent to root on the host.
+                                            Defaults to false.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           type: boolean
                                         procMount:
-                                          description: procMount denotes the type
-                                            of proc mount to use for the containers.
-                                            The default is DefaultProcMount which
-                                            uses the container runtime defaults for
-                                            readonly paths and masked paths. This
-                                            requires the ProcMountType feature flag
-                                            to be enabled. Note that this field cannot
-                                            be set when spec.os.name is windows.
+                                          description: |-
+                                            procMount denotes the type of proc mount to use for the containers.
+                                            The default is DefaultProcMount which uses the container runtime defaults for
+                                            readonly paths and masked paths.
+                                            This requires the ProcMountType feature flag to be enabled.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           type: string
                                         readOnlyRootFilesystem:
-                                          description: Whether this container has
-                                            a read-only root filesystem. Default is
-                                            false. Note that this field cannot be
-                                            set when spec.os.name is windows.
+                                          description: |-
+                                            Whether this container has a read-only root filesystem.
+                                            Default is false.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           type: boolean
                                         runAsGroup:
-                                          description: The GID to run the entrypoint
-                                            of the container process. Uses runtime
-                                            default if unset. May also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence. Note that this field
-                                            cannot be set when spec.os.name is windows.
+                                          description: |-
+                                            The GID to run the entrypoint of the container process.
+                                            Uses runtime default if unset.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           format: int64
                                           type: integer
                                         runAsNonRoot:
-                                          description: Indicates that the container
-                                            must run as a non-root user. If true,
-                                            the Kubelet will validate the image at
-                                            runtime to ensure that it does not run
-                                            as UID 0 (root) and fail to start the
-                                            container if it does. If unset or false,
-                                            no such validation will be performed.
-                                            May also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence.
+                                          description: |-
+                                            Indicates that the container must run as a non-root user.
+                                            If true, the Kubelet will validate the image at runtime to ensure that it
+                                            does not run as UID 0 (root) and fail to start the container if it does.
+                                            If unset or false, no such validation will be performed.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
                                           type: boolean
                                         runAsUser:
-                                          description: The UID to run the entrypoint
-                                            of the container process. Defaults to
-                                            user specified in image metadata if unspecified.
-                                            May also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence. Note that this field
-                                            cannot be set when spec.os.name is windows.
+                                          description: |-
+                                            The UID to run the entrypoint of the container process.
+                                            Defaults to user specified in image metadata if unspecified.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           format: int64
                                           type: integer
                                         seLinuxOptions:
-                                          description: The SELinux context to be applied
-                                            to the container. If unspecified, the
-                                            container runtime will allocate a random
-                                            SELinux context for each container.  May
-                                            also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence. Note that this field
-                                            cannot be set when spec.os.name is windows.
+                                          description: |-
+                                            The SELinux context to be applied to the container.
+                                            If unspecified, the container runtime will allocate a random SELinux context for each
+                                            container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           properties:
                                             level:
                                               description: Level is SELinux level
@@ -4101,53 +3706,44 @@ spec:
                                               type: string
                                           type: object
                                         seccompProfile:
-                                          description: The seccomp options to use
-                                            by this container. If seccomp options
-                                            are provided at both the pod & container
-                                            level, the container options override
-                                            the pod options. Note that this field
-                                            cannot be set when spec.os.name is windows.
+                                          description: |-
+                                            The seccomp options to use by this container. If seccomp options are
+                                            provided at both the pod & container level, the container options
+                                            override the pod options.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           properties:
                                             localhostProfile:
-                                              description: localhostProfile indicates
-                                                a profile defined in a file on the
-                                                node should be used. The profile must
-                                                be preconfigured on the node to work.
-                                                Must be a descending path, relative
-                                                to the kubelet's configured seccomp
-                                                profile location. Must be set if type
-                                                is "Localhost". Must NOT be set for
-                                                any other type.
+                                              description: |-
+                                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                                The profile must be preconfigured on the node to work.
+                                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                Must be set if type is "Localhost". Must NOT be set for any other type.
                                               type: string
                                             type:
-                                              description: "type indicates which kind
-                                                of seccomp profile will be applied.
-                                                Valid options are: \n Localhost -
-                                                a profile defined in a file on the
-                                                node should be used. RuntimeDefault
-                                                - the container runtime default profile
-                                                should be used. Unconfined - no profile
-                                                should be applied."
+                                              description: |-
+                                                type indicates which kind of seccomp profile will be applied.
+                                                Valid options are:
+
+
+                                                Localhost - a profile defined in a file on the node should be used.
+                                                RuntimeDefault - the container runtime default profile should be used.
+                                                Unconfined - no profile should be applied.
                                               type: string
                                           required:
                                           - type
                                           type: object
                                         windowsOptions:
-                                          description: The Windows specific settings
-                                            applied to all containers. If unspecified,
-                                            the options from the PodSecurityContext
-                                            will be used. If set in both SecurityContext
-                                            and PodSecurityContext, the value specified
-                                            in SecurityContext takes precedence. Note
-                                            that this field cannot be set when spec.os.name
-                                            is linux.
+                                          description: |-
+                                            The Windows specific settings applied to all containers.
+                                            If unspecified, the options from the PodSecurityContext will be used.
+                                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is linux.
                                           properties:
                                             gmsaCredentialSpec:
-                                              description: GMSACredentialSpec is where
-                                                the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                                inlines the contents of the GMSA credential
-                                                spec named by the GMSACredentialSpecName
-                                                field.
+                                              description: |-
+                                                GMSACredentialSpec is where the GMSA admission webhook
+                                                (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                                GMSA credential spec named by the GMSACredentialSpecName field.
                                               type: string
                                             gmsaCredentialSpecName:
                                               description: GMSACredentialSpecName
@@ -4155,26 +3751,18 @@ spec:
                                                 spec to use.
                                               type: string
                                             hostProcess:
-                                              description: HostProcess determines
-                                                if a container should be run as a
-                                                'Host Process' container. All of a
-                                                Pod's containers must have the same
-                                                effective HostProcess value (it is
-                                                not allowed to have a mix of HostProcess
-                                                containers and non-HostProcess containers).
-                                                In addition, if HostProcess is true
-                                                then HostNetwork must also be set
-                                                to true.
+                                              description: |-
+                                                HostProcess determines if a container should be run as a 'Host Process' container.
+                                                All of a Pod's containers must have the same effective HostProcess value
+                                                (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                                In addition, if HostProcess is true then HostNetwork must also be set to true.
                                               type: boolean
                                             runAsUserName:
-                                              description: The UserName in Windows
-                                                to run the entrypoint of the container
-                                                process. Defaults to the user specified
-                                                in image metadata if unspecified.
-                                                May also be set in PodSecurityContext.
-                                                If set in both SecurityContext and
-                                                PodSecurityContext, the value specified
-                                                in SecurityContext takes precedence.
+                                              description: |-
+                                                The UserName in Windows to run the entrypoint of the container process.
+                                                Defaults to the user specified in image metadata if unspecified.
+                                                May also be set in PodSecurityContext. If set in both SecurityContext and
+                                                PodSecurityContext, the value specified in SecurityContext takes precedence.
                                               type: string
                                           type: object
                                       type: object
@@ -4187,26 +3775,21 @@ spec:
                                             take.
                                           properties:
                                             command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                           type: object
                                         failureThreshold:
-                                          description: Minimum consecutive failures
-                                            for the probe to be considered failed
-                                            after having succeeded. Defaults to 3.
-                                            Minimum value is 1.
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         grpc:
@@ -4220,11 +3803,12 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
-                                              description: "Service is the name of
-                                                the service to place in the gRPC HealthCheckRequest
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
                                                 (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                                \n If this is not specified, the default
-                                                behavior is defined by gRPC."
+
+
+                                                If this is not specified, the default behavior is defined by gRPC.
                                               type: string
                                           required:
                                           - port
@@ -4234,10 +3818,9 @@ spec:
                                             request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -4249,21 +3832,15 @@ spec:
                                                   probes
                                                 properties:
                                                   name:
-                                                    description: The header field
-                                                      name. This will be canonicalized
-                                                      upon output, so case-variant
-                                                      names will be understood as
-                                                      the same header.
                                                     type: string
                                                   value:
-                                                    description: The header field
-                                                      value
                                                     type: string
                                                 required:
                                                 - name
                                                 - value
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             path:
                                               description: Path to access on the HTTP
                                                 server.
@@ -4272,36 +3849,35 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         initialDelaySeconds:
-                                          description: 'Number of seconds after the
-                                            container has started before liveness
-                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                         periodSeconds:
-                                          description: How often (in seconds) to perform
-                                            the probe. Default to 10 seconds. Minimum
-                                            value is 1.
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         successThreshold:
-                                          description: Minimum consecutive successes
-                                            for the probe to be considered successful
-                                            after having failed. Defaults to 1. Must
-                                            be 1 for liveness and startup. Minimum
-                                            value is 1.
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         tcpSocket:
@@ -4316,105 +3892,86 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                         terminationGracePeriodSeconds:
-                                          description: Optional duration in seconds
-                                            the pod needs to terminate gracefully
-                                            upon probe failure. The grace period is
-                                            the duration in seconds after the processes
-                                            running in the pod are sent a termination
-                                            signal and the time when the processes
-                                            are forcibly halted with a kill signal.
-                                            Set this value longer than the expected
-                                            cleanup time for your process. If this
-                                            value is nil, the pod's terminationGracePeriodSeconds
-                                            will be used. Otherwise, this value overrides
-                                            the value provided by the pod spec. Value
-                                            must be non-negative integer. The value
-                                            zero indicates stop immediately via the
-                                            kill signal (no opportunity to shut down).
-                                            This is a beta field and requires enabling
-                                            ProbeTerminationGracePeriod feature gate.
-                                            Minimum value is 1. spec.terminationGracePeriodSeconds
-                                            is used if unset.
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                           format: int64
                                           type: integer
                                         timeoutSeconds:
-                                          description: 'Number of seconds after which
-                                            the probe times out. Defaults to 1 second.
-                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                       type: object
                                     stdin:
-                                      description: Whether this container should allocate
-                                        a buffer for stdin in the container runtime.
-                                        If this is not set, reads from stdin in the
-                                        container will always result in EOF. Default
-                                        is false.
+                                      description: |-
+                                        Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                        is not set, reads from stdin in the container will always result in EOF.
+                                        Default is false.
                                       type: boolean
                                     stdinOnce:
-                                      description: Whether the container runtime should
-                                        close the stdin channel after it has been
-                                        opened by a single attach. When stdin is true
-                                        the stdin stream will remain open across multiple
-                                        attach sessions. If stdinOnce is set to true,
-                                        stdin is opened on container start, is empty
-                                        until the first client attaches to stdin,
-                                        and then remains open and accepts data until
-                                        the client disconnects, at which time stdin
-                                        is closed and remains closed until the container
-                                        is restarted. If this flag is false, a container
-                                        processes that reads from stdin will never
-                                        receive an EOF. Default is false
+                                      description: |-
+                                        Whether the container runtime should close the stdin channel after it has been opened by
+                                        a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                        sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                        first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                        at which time stdin is closed and remains closed until the container is restarted. If this
+                                        flag is false, a container processes that reads from stdin will never receive an EOF.
+                                        Default is false
                                       type: boolean
                                     targetContainerName:
-                                      description: "If set, the name of the container
-                                        from PodSpec that this ephemeral container
-                                        targets. The ephemeral container will be run
-                                        in the namespaces (IPC, PID, etc) of this
-                                        container. If not set then the ephemeral container
-                                        uses the namespaces configured in the Pod
-                                        spec. \n The container runtime must implement
-                                        support for this feature. If the runtime does
-                                        not support namespace targeting then the result
-                                        of setting this field is undefined."
+                                      description: |-
+                                        If set, the name of the container from PodSpec that this ephemeral container targets.
+                                        The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.
+                                        If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+
+                                        The container runtime must implement support for this feature. If the runtime does not
+                                        support namespace targeting then the result of setting this field is undefined.
                                       type: string
                                     terminationMessagePath:
-                                      description: 'Optional: Path at which the file
-                                        to which the container''s termination message
-                                        will be written is mounted into the container''s
-                                        filesystem. Message written is intended to
-                                        be brief final status, such as an assertion
-                                        failure message. Will be truncated by the
-                                        node if greater than 4096 bytes. The total
-                                        message length across all containers will
-                                        be limited to 12kb. Defaults to /dev/termination-log.
-                                        Cannot be updated.'
+                                      description: |-
+                                        Optional: Path at which the file to which the container's termination message
+                                        will be written is mounted into the container's filesystem.
+                                        Message written is intended to be brief final status, such as an assertion failure message.
+                                        Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                        all containers will be limited to 12kb.
+                                        Defaults to /dev/termination-log.
+                                        Cannot be updated.
                                       type: string
                                     terminationMessagePolicy:
-                                      description: Indicate how the termination message
-                                        should be populated. File will use the contents
-                                        of terminationMessagePath to populate the
-                                        container status message on both success and
-                                        failure. FallbackToLogsOnError will use the
-                                        last chunk of container log output if the
-                                        termination message file is empty and the
-                                        container exited with an error. The log output
-                                        is limited to 2048 bytes or 80 lines, whichever
-                                        is smaller. Defaults to File. Cannot be updated.
+                                      description: |-
+                                        Indicate how the termination message should be populated. File will use the contents of
+                                        terminationMessagePath to populate the container status message on both success and failure.
+                                        FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                        message file is empty and the container exited with an error.
+                                        The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                        Defaults to File.
+                                        Cannot be updated.
                                       type: string
                                     tty:
-                                      description: Whether this container should allocate
-                                        a TTY for itself, also requires 'stdin' to
-                                        be true. Default is false.
+                                      description: |-
+                                        Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                        Default is false.
                                       type: boolean
                                     volumeDevices:
                                       description: volumeDevices is the list of block
@@ -4437,198 +3994,233 @@ spec:
                                         - name
                                         type: object
                                       type: array
+                                      x-kubernetes-list-map-keys:
+                                      - devicePath
+                                      x-kubernetes-list-type: map
                                     volumeMounts:
-                                      description: Pod volumes to mount into the container's
-                                        filesystem. Subpath mounts are not allowed
-                                        for ephemeral containers. Cannot be updated.
+                                      description: |-
+                                        Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers.
+                                        Cannot be updated.
                                       items:
                                         description: VolumeMount describes a mounting
                                           of a Volume within a container.
                                         properties:
                                           mountPath:
-                                            description: Path within the container
-                                              at which the volume should be mounted.  Must
+                                            description: |-
+                                              Path within the container at which the volume should be mounted.  Must
                                               not contain ':'.
                                             type: string
                                           mountPropagation:
-                                            description: mountPropagation determines
-                                              how mounts are propagated from the host
+                                            description: |-
+                                              mountPropagation determines how mounts are propagated from the host
                                               to container and the other way around.
-                                              When not set, MountPropagationNone is
-                                              used. This field is beta in 1.10.
+                                              When not set, MountPropagationNone is used.
+                                              This field is beta in 1.10.
+                                              When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                              (which defaults to None).
                                             type: string
                                           name:
                                             description: This must match the Name
                                               of a Volume.
                                             type: string
                                           readOnly:
-                                            description: Mounted read-only if true,
-                                              read-write otherwise (false or unspecified).
+                                            description: |-
+                                              Mounted read-only if true, read-write otherwise (false or unspecified).
                                               Defaults to false.
                                             type: boolean
+                                          recursiveReadOnly:
+                                            description: |-
+                                              RecursiveReadOnly specifies whether read-only mounts should be handled
+                                              recursively.
+
+
+                                              If ReadOnly is false, this field has no meaning and must be unspecified.
+
+
+                                              If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                              recursively read-only.  If this field is set to IfPossible, the mount is made
+                                              recursively read-only, if it is supported by the container runtime.  If this
+                                              field is set to Enabled, the mount is made recursively read-only if it is
+                                              supported by the container runtime, otherwise the pod will not be started and
+                                              an error will be generated to indicate the reason.
+
+
+                                              If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                              None (or be unspecified, which defaults to None).
+
+
+                                              If this field is not specified, it is treated as an equivalent of Disabled.
+                                            type: string
                                           subPath:
-                                            description: Path within the volume from
-                                              which the container's volume should
-                                              be mounted. Defaults to "" (volume's
-                                              root).
+                                            description: |-
+                                              Path within the volume from which the container's volume should be mounted.
+                                              Defaults to "" (volume's root).
                                             type: string
                                           subPathExpr:
-                                            description: Expanded path within the
-                                              volume from which the container's volume
-                                              should be mounted. Behaves similarly
-                                              to SubPath but environment variable
-                                              references $(VAR_NAME) are expanded
-                                              using the container's environment. Defaults
-                                              to "" (volume's root). SubPathExpr and
-                                              SubPath are mutually exclusive.
+                                            description: |-
+                                              Expanded path within the volume from which the container's volume should be mounted.
+                                              Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                              Defaults to "" (volume's root).
+                                              SubPathExpr and SubPath are mutually exclusive.
                                             type: string
                                         required:
                                         - mountPath
                                         - name
                                         type: object
                                       type: array
+                                      x-kubernetes-list-map-keys:
+                                      - mountPath
+                                      x-kubernetes-list-type: map
                                     workingDir:
-                                      description: Container's working directory.
-                                        If not specified, the container runtime's
-                                        default will be used, which might be configured
-                                        in the container image. Cannot be updated.
+                                      description: |-
+                                        Container's working directory.
+                                        If not specified, the container runtime's default will be used, which
+                                        might be configured in the container image.
+                                        Cannot be updated.
                                       type: string
                                   required:
                                   - name
                                   type: object
                                 type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
                               hostAliases:
-                                description: HostAliases is an optional list of hosts
-                                  and IPs that will be injected into the pod's hosts
-                                  file if specified. This is only valid for non-hostNetwork
-                                  pods.
+                                description: |-
+                                  HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts
+                                  file if specified.
                                 items:
-                                  description: HostAlias holds the mapping between
-                                    IP and hostnames that will be injected as an entry
-                                    in the pod's hosts file.
+                                  description: |-
+                                    HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+                                    pod's hosts file.
                                   properties:
                                     hostnames:
                                       description: Hostnames for the above IP address.
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     ip:
                                       description: IP address of the host file entry.
                                       type: string
+                                  required:
+                                  - ip
                                   type: object
                                 type: array
+                                x-kubernetes-list-map-keys:
+                                - ip
+                                x-kubernetes-list-type: map
                               hostIPC:
-                                description: 'Use the host''s ipc namespace. Optional:
-                                  Default to false.'
+                                description: |-
+                                  Use the host's ipc namespace.
+                                  Optional: Default to false.
                                 type: boolean
                               hostNetwork:
-                                description: Host networking requested for this pod.
-                                  Use the host's network namespace. If this option
-                                  is set, the ports that will be used must be specified.
+                                description: |-
+                                  Host networking requested for this pod. Use the host's network namespace.
+                                  If this option is set, the ports that will be used must be specified.
                                   Default to false.
                                 type: boolean
                               hostPID:
-                                description: 'Use the host''s pid namespace. Optional:
-                                  Default to false.'
+                                description: |-
+                                  Use the host's pid namespace.
+                                  Optional: Default to false.
                                 type: boolean
                               hostUsers:
-                                description: 'Use the host''s user namespace. Optional:
-                                  Default to true. If set to true or not present,
-                                  the pod will be run in the host user namespace,
-                                  useful for when the pod needs a feature only available
-                                  to the host user namespace, such as loading a kernel
-                                  module with CAP_SYS_MODULE. When set to false, a
-                                  new userns is created for the pod. Setting false
-                                  is useful for mitigating container breakout vulnerabilities
-                                  even allowing users to run their containers as root
-                                  without actually having root privileges on the host.
-                                  This field is alpha-level and is only honored by
-                                  servers that enable the UserNamespacesSupport feature.'
+                                description: |-
+                                  Use the host's user namespace.
+                                  Optional: Default to true.
+                                  If set to true or not present, the pod will be run in the host user namespace, useful
+                                  for when the pod needs a feature only available to the host user namespace, such as
+                                  loading a kernel module with CAP_SYS_MODULE.
+                                  When set to false, a new userns is created for the pod. Setting false is useful for
+                                  mitigating container breakout vulnerabilities even allowing users to run their
+                                  containers as root without actually having root privileges on the host.
+                                  This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.
                                 type: boolean
                               hostname:
-                                description: Specifies the hostname of the Pod If
-                                  not specified, the pod's hostname will be set to
-                                  a system-defined value.
+                                description: |-
+                                  Specifies the hostname of the Pod
+                                  If not specified, the pod's hostname will be set to a system-defined value.
                                 type: string
                               imagePullSecrets:
-                                description: 'ImagePullSecrets is an optional list
-                                  of references to secrets in the same namespace to
-                                  use for pulling any of the images used by this PodSpec.
-                                  If specified, these secrets will be passed to individual
-                                  puller implementations for them to use. More info:
-                                  https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                                description: |-
+                                  ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+                                  If specified, these secrets will be passed to individual puller implementations for them to use.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
                                 items:
-                                  description: LocalObjectReference contains enough
-                                    information to let you locate the referenced object
-                                    inside the same namespace.
+                                  description: |-
+                                    LocalObjectReference contains enough information to let you locate the
+                                    referenced object inside the same namespace.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
                               initContainers:
-                                description: 'List of initialization containers belonging
-                                  to the pod. Init containers are executed in order
-                                  prior to containers being started. If any init container
-                                  fails, the pod is considered to have failed and
-                                  is handled according to its restartPolicy. The name
-                                  for an init container or normal container must be
-                                  unique among all containers. Init containers may
-                                  not have Lifecycle actions, Readiness probes, Liveness
-                                  probes, or Startup probes. The resourceRequirements
-                                  of an init container are taken into account during
-                                  scheduling by finding the highest request/limit
-                                  for each resource type, and then using the max of
-                                  of that value or the sum of the normal containers.
-                                  Limits are applied to init containers in a similar
-                                  fashion. Init containers cannot currently be added
-                                  or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                                description: |-
+                                  List of initialization containers belonging to the pod.
+                                  Init containers are executed in order prior to containers being started. If any
+                                  init container fails, the pod is considered to have failed and is handled according
+                                  to its restartPolicy. The name for an init container or normal container must be
+                                  unique among all containers.
+                                  Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+                                  The resourceRequirements of an init container are taken into account during scheduling
+                                  by finding the highest request/limit for each resource type, and then using the max of
+                                  of that value or the sum of the normal containers. Limits are applied to init containers
+                                  in a similar fashion.
+                                  Init containers cannot currently be added or removed.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
                                 items:
                                   description: A single application container that
                                     you want to run within a pod.
                                   properties:
                                     args:
-                                      description: 'Arguments to the entrypoint. The
-                                        container image''s CMD is used if this is
-                                        not provided. Variable references $(VAR_NAME)
-                                        are expanded using the container''s environment.
-                                        If a variable cannot be resolved, the reference
-                                        in the input string will be unchanged. Double
-                                        $$ are reduced to a single $, which allows
-                                        for escaping the $(VAR_NAME) syntax: i.e.
-                                        "$$(VAR_NAME)" will produce the string literal
-                                        "$(VAR_NAME)". Escaped references will never
-                                        be expanded, regardless of whether the variable
-                                        exists or not. Cannot be updated. More info:
-                                        https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      description: |-
+                                        Arguments to the entrypoint.
+                                        The container image's CMD is used if this is not provided.
+                                        Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                        cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                        produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                        of whether the variable exists or not. Cannot be updated.
+                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     command:
-                                      description: 'Entrypoint array. Not executed
-                                        within a shell. The container image''s ENTRYPOINT
-                                        is used if this is not provided. Variable
-                                        references $(VAR_NAME) are expanded using
-                                        the container''s environment. If a variable
-                                        cannot be resolved, the reference in the input
-                                        string will be unchanged. Double $$ are reduced
-                                        to a single $, which allows for escaping the
-                                        $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                        produce the string literal "$(VAR_NAME)".
-                                        Escaped references will never be expanded,
-                                        regardless of whether the variable exists
-                                        or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      description: |-
+                                        Entrypoint array. Not executed within a shell.
+                                        The container image's ENTRYPOINT is used if this is not provided.
+                                        Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                        cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                        produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                        of whether the variable exists or not. Cannot be updated.
+                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     env:
-                                      description: List of environment variables to
-                                        set in the container. Cannot be updated.
+                                      description: |-
+                                        List of environment variables to set in the container.
+                                        Cannot be updated.
                                       items:
                                         description: EnvVar represents an environment
                                           variable present in a Container.
@@ -4638,19 +4230,16 @@ spec:
                                               Must be a C_IDENTIFIER.
                                             type: string
                                           value:
-                                            description: 'Variable references $(VAR_NAME)
-                                              are expanded using the previously defined
-                                              environment variables in the container
-                                              and any service environment variables.
-                                              If a variable cannot be resolved, the
-                                              reference in the input string will be
-                                              unchanged. Double $$ are reduced to
-                                              a single $, which allows for escaping
-                                              the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                              will produce the string literal "$(VAR_NAME)".
-                                              Escaped references will never be expanded,
-                                              regardless of whether the variable exists
-                                              or not. Defaults to "".'
+                                            description: |-
+                                              Variable references $(VAR_NAME) are expanded
+                                              using the previously defined environment variables in the container and
+                                              any service environment variables. If a variable cannot be resolved,
+                                              the reference in the input string will be unchanged. Double $$ are reduced
+                                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                              "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                              Escaped references will never be expanded, regardless of whether the variable
+                                              exists or not.
+                                              Defaults to "".
                                             type: string
                                           valueFrom:
                                             description: Source for the environment
@@ -4661,69 +4250,37 @@ spec:
                                                 description: Selects a key of a ConfigMap.
                                                 properties:
                                                   key:
-                                                    description: The key to select.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                    default: ""
                                                     type: string
                                                   optional:
-                                                    description: Specify whether the
-                                                      ConfigMap or its key must be
-                                                      defined
                                                     type: boolean
                                                 required:
                                                 - key
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               fieldRef:
-                                                description: 'Selects a field of the
-                                                  pod: supports metadata.name, metadata.namespace,
-                                                  `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                                  spec.nodeName, spec.serviceAccountName,
-                                                  status.hostIP, status.podIP, status.podIPs.'
                                                 properties:
                                                   apiVersion:
-                                                    description: Version of the schema
-                                                      the FieldPath is written in
-                                                      terms of, defaults to "v1".
                                                     type: string
                                                   fieldPath:
-                                                    description: Path of the field
-                                                      to select in the specified API
-                                                      version.
                                                     type: string
                                                 required:
                                                 - fieldPath
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               resourceFieldRef:
-                                                description: 'Selects a resource of
-                                                  the container: only resources limits
-                                                  and requests (limits.cpu, limits.memory,
-                                                  limits.ephemeral-storage, requests.cpu,
-                                                  requests.memory and requests.ephemeral-storage)
-                                                  are currently supported.'
                                                 properties:
                                                   containerName:
-                                                    description: 'Container name:
-                                                      required for volumes, optional
-                                                      for env vars'
                                                     type: string
                                                   divisor:
                                                     anyOf:
                                                     - type: integer
                                                     - type: string
-                                                    description: Specifies the output
-                                                      format of the exposed resources,
-                                                      defaults to "1"
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
                                                   resource:
-                                                    description: 'Required: resource
-                                                      to select'
                                                     type: string
                                                 required:
                                                 - resource
@@ -4734,19 +4291,11 @@ spec:
                                                   in the pod's namespace
                                                 properties:
                                                   key:
-                                                    description: The key of the secret
-                                                      to select from.  Must be a valid
-                                                      secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                    default: ""
                                                     type: string
                                                   optional:
-                                                    description: Specify whether the
-                                                      Secret or its key must be defined
                                                     type: boolean
                                                 required:
                                                 - key
@@ -4757,16 +4306,17 @@ spec:
                                         - name
                                         type: object
                                       type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
                                     envFrom:
-                                      description: List of sources to populate environment
-                                        variables in the container. The keys defined
-                                        within a source must be a C_IDENTIFIER. All
-                                        invalid keys will be reported as an event
-                                        when the container is starting. When a key
-                                        exists in multiple sources, the value associated
-                                        with the last source will take precedence.
-                                        Values defined by an Env with a duplicate
-                                        key will take precedence. Cannot be updated.
+                                      description: |-
+                                        List of sources to populate environment variables in the container.
+                                        The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                        will be reported as an event when the container is starting. When a key exists in multiple
+                                        sources, the value associated with the last source will take precedence.
+                                        Values defined by an Env with a duplicate key will take precedence.
+                                        Cannot be updated.
                                       items:
                                         description: EnvFromSource represents the
                                           source of a set of ConfigMaps
@@ -4775,10 +4325,7 @@ spec:
                                             description: The ConfigMap to select from
                                             properties:
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                default: ""
                                                 type: string
                                               optional:
                                                 description: Specify whether the ConfigMap
@@ -4795,10 +4342,7 @@ spec:
                                             description: The Secret to select from
                                             properties:
                                               name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                default: ""
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -4808,73 +4352,52 @@ spec:
                                             x-kubernetes-map-type: atomic
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     image:
-                                      description: 'Container image name. More info:
-                                        https://kubernetes.io/docs/concepts/containers/images
-                                        This field is optional to allow higher level
-                                        config management to default or override container
-                                        images in workload controllers like Deployments
-                                        and StatefulSets.'
+                                      description: |-
+                                        Container image name.
+                                        More info: https://kubernetes.io/docs/concepts/containers/images
+                                        This field is optional to allow higher level config management to default or override
+                                        container images in workload controllers like Deployments and StatefulSets.
                                       type: string
                                     imagePullPolicy:
-                                      description: 'Image pull policy. One of Always,
-                                        Never, IfNotPresent. Defaults to Always if
-                                        :latest tag is specified, or IfNotPresent
-                                        otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                      description: |-
+                                        Image pull policy.
+                                        One of Always, Never, IfNotPresent.
+                                        Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                       type: string
                                     lifecycle:
-                                      description: Actions that the management system
-                                        should take in response to container lifecycle
-                                        events. Cannot be updated.
+                                      description: |-
+                                        Actions that the management system should take in response to container lifecycle events.
+                                        Cannot be updated.
                                       properties:
                                         postStart:
-                                          description: 'PostStart is called immediately
-                                            after a container is created. If the handler
-                                            fails, the container is terminated and
-                                            restarted according to its restart policy.
-                                            Other management of the container blocks
-                                            until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          description: |-
+                                            PostStart is called immediately after a container is created. If the handler fails,
+                                            the container is terminated and restarted according to its restart policy.
+                                            Other management of the container blocks until the hook completes.
+                                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                           properties:
                                             exec:
                                               description: Exec specifies the action
                                                 to take.
                                               properties:
                                                 command:
-                                                  description: Command is the command
-                                                    line to execute inside the container,
-                                                    the working directory for the
-                                                    command  is root ('/') in the
-                                                    container's filesystem. The command
-                                                    is simply exec'd, it is not run
-                                                    inside a shell, so traditional
-                                                    shell instructions ('|', etc)
-                                                    won't work. To use a shell, you
-                                                    need to explicitly call out to
-                                                    that shell. Exit status of 0 is
-                                                    treated as live/healthy and non-zero
-                                                    is unhealthy.
                                                   items:
                                                     type: string
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               type: object
                                             httpGet:
                                               description: HTTPGet specifies the http
                                                 request to perform.
                                               properties:
                                                 host:
-                                                  description: Host name to connect
-                                                    to, defaults to the pod IP. You
-                                                    probably want to set "Host" in
-                                                    httpHeaders instead.
                                                   type: string
                                                 httpHeaders:
-                                                  description: Custom headers to set
-                                                    in the request. HTTP allows repeated
-                                                    headers.
                                                   items:
-                                                    description: HTTPHeader describes
-                                                      a custom header to be used in
-                                                      HTTP probes
                                                     properties:
                                                       name:
                                                         type: string
@@ -4885,110 +4408,77 @@ spec:
                                                     - value
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 path:
-                                                  description: Path to access on the
-                                                    HTTP server.
                                                   type: string
                                                 port:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Name or number of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                                 scheme:
-                                                  description: Scheme to use for connecting
-                                                    to the host. Defaults to HTTP.
                                                   type: string
                                               required:
                                               - port
                                               type: object
+                                            sleep:
+                                              description: Sleep represents the duration
+                                                that the container should sleep before
+                                                being terminated.
+                                              properties:
+                                                seconds:
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
                                             tcpSocket:
-                                              description: Deprecated. TCPSocket is
-                                                NOT supported as a LifecycleHandler
-                                                and kept for the backward compatibility.
-                                                There are no validation of this field
-                                                and lifecycle hooks will fail in runtime
-                                                when tcp handler is specified.
+                                              description: |-
+                                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                                for the backward compatibility. There are no validation of this field and
+                                                lifecycle hooks will fail in runtime when tcp handler is specified.
                                               properties:
                                                 host:
-                                                  description: 'Optional: Host name
-                                                    to connect to, defaults to the
-                                                    pod IP.'
                                                   type: string
                                                 port:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Number or name of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                               required:
                                               - port
                                               type: object
                                           type: object
                                         preStop:
-                                          description: 'PreStop is called immediately
-                                            before a container is terminated due to
-                                            an API request or management event such
-                                            as liveness/startup probe failure, preemption,
-                                            resource contention, etc. The handler
-                                            is not called if the container crashes
-                                            or exits. The Pod''s termination grace
-                                            period countdown begins before the PreStop
-                                            hook is executed. Regardless of the outcome
-                                            of the handler, the container will eventually
-                                            terminate within the Pod''s termination
-                                            grace period (unless delayed by finalizers).
-                                            Other management of the container blocks
-                                            until the hook completes or until the
-                                            termination grace period is reached. More
-                                            info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          description: |-
+                                            PreStop is called immediately before a container is terminated due to an
+                                            API request or management event such as liveness/startup probe failure,
+                                            preemption, resource contention, etc. The handler is not called if the
+                                            container crashes or exits. The Pod's termination grace period countdown begins before the
+                                            PreStop hook is executed. Regardless of the outcome of the handler, the
+                                            container will eventually terminate within the Pod's termination grace
+                                            period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                            or until the termination grace period is reached.
+                                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                           properties:
                                             exec:
                                               description: Exec specifies the action
                                                 to take.
                                               properties:
                                                 command:
-                                                  description: Command is the command
-                                                    line to execute inside the container,
-                                                    the working directory for the
-                                                    command  is root ('/') in the
-                                                    container's filesystem. The command
-                                                    is simply exec'd, it is not run
-                                                    inside a shell, so traditional
-                                                    shell instructions ('|', etc)
-                                                    won't work. To use a shell, you
-                                                    need to explicitly call out to
-                                                    that shell. Exit status of 0 is
-                                                    treated as live/healthy and non-zero
-                                                    is unhealthy.
                                                   items:
                                                     type: string
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               type: object
                                             httpGet:
                                               description: HTTPGet specifies the http
                                                 request to perform.
                                               properties:
                                                 host:
-                                                  description: Host name to connect
-                                                    to, defaults to the pod IP. You
-                                                    probably want to set "Host" in
-                                                    httpHeaders instead.
                                                   type: string
                                                 httpHeaders:
-                                                  description: Custom headers to set
-                                                    in the request. HTTP allows repeated
-                                                    headers.
                                                   items:
-                                                    description: HTTPHeader describes
-                                                      a custom header to be used in
-                                                      HTTP probes
                                                     properties:
                                                       name:
                                                         type: string
@@ -4999,47 +4489,42 @@ spec:
                                                     - value
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 path:
-                                                  description: Path to access on the
-                                                    HTTP server.
                                                   type: string
                                                 port:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Name or number of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                                 scheme:
-                                                  description: Scheme to use for connecting
-                                                    to the host. Defaults to HTTP.
                                                   type: string
                                               required:
                                               - port
                                               type: object
+                                            sleep:
+                                              description: Sleep represents the duration
+                                                that the container should sleep before
+                                                being terminated.
+                                              properties:
+                                                seconds:
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
                                             tcpSocket:
-                                              description: Deprecated. TCPSocket is
-                                                NOT supported as a LifecycleHandler
-                                                and kept for the backward compatibility.
-                                                There are no validation of this field
-                                                and lifecycle hooks will fail in runtime
-                                                when tcp handler is specified.
+                                              description: |-
+                                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                                for the backward compatibility. There are no validation of this field and
+                                                lifecycle hooks will fail in runtime when tcp handler is specified.
                                               properties:
                                                 host:
-                                                  description: 'Optional: Host name
-                                                    to connect to, defaults to the
-                                                    pod IP.'
                                                   type: string
                                                 port:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Number or name of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                               required:
                                               - port
@@ -5047,35 +4532,32 @@ spec:
                                           type: object
                                       type: object
                                     livenessProbe:
-                                      description: 'Periodic probe of container liveness.
+                                      description: |-
+                                        Periodic probe of container liveness.
                                         Container will be restarted if the probe fails.
-                                        Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       properties:
                                         exec:
                                           description: Exec specifies the action to
                                             take.
                                           properties:
                                             command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                           type: object
                                         failureThreshold:
-                                          description: Minimum consecutive failures
-                                            for the probe to be considered failed
-                                            after having succeeded. Defaults to 3.
-                                            Minimum value is 1.
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         grpc:
@@ -5089,11 +4571,12 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
-                                              description: "Service is the name of
-                                                the service to place in the gRPC HealthCheckRequest
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
                                                 (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                                \n If this is not specified, the default
-                                                behavior is defined by gRPC."
+
+
+                                                If this is not specified, the default behavior is defined by gRPC.
                                               type: string
                                           required:
                                           - port
@@ -5103,10 +4586,9 @@ spec:
                                             request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -5118,21 +4600,15 @@ spec:
                                                   probes
                                                 properties:
                                                   name:
-                                                    description: The header field
-                                                      name. This will be canonicalized
-                                                      upon output, so case-variant
-                                                      names will be understood as
-                                                      the same header.
                                                     type: string
                                                   value:
-                                                    description: The header field
-                                                      value
                                                     type: string
                                                 required:
                                                 - name
                                                 - value
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             path:
                                               description: Path to access on the HTTP
                                                 server.
@@ -5141,36 +4617,35 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         initialDelaySeconds:
-                                          description: 'Number of seconds after the
-                                            container has started before liveness
-                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                         periodSeconds:
-                                          description: How often (in seconds) to perform
-                                            the probe. Default to 10 seconds. Minimum
-                                            value is 1.
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         successThreshold:
-                                          description: Minimum consecutive successes
-                                            for the probe to be considered successful
-                                            after having failed. Defaults to 1. Must
-                                            be 1 for liveness and startup. Minimum
-                                            value is 1.
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         tcpSocket:
@@ -5185,68 +4660,59 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                         terminationGracePeriodSeconds:
-                                          description: Optional duration in seconds
-                                            the pod needs to terminate gracefully
-                                            upon probe failure. The grace period is
-                                            the duration in seconds after the processes
-                                            running in the pod are sent a termination
-                                            signal and the time when the processes
-                                            are forcibly halted with a kill signal.
-                                            Set this value longer than the expected
-                                            cleanup time for your process. If this
-                                            value is nil, the pod's terminationGracePeriodSeconds
-                                            will be used. Otherwise, this value overrides
-                                            the value provided by the pod spec. Value
-                                            must be non-negative integer. The value
-                                            zero indicates stop immediately via the
-                                            kill signal (no opportunity to shut down).
-                                            This is a beta field and requires enabling
-                                            ProbeTerminationGracePeriod feature gate.
-                                            Minimum value is 1. spec.terminationGracePeriodSeconds
-                                            is used if unset.
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                           format: int64
                                           type: integer
                                         timeoutSeconds:
-                                          description: 'Number of seconds after which
-                                            the probe times out. Defaults to 1 second.
-                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                       type: object
                                     name:
-                                      description: Name of the container specified
-                                        as a DNS_LABEL. Each container in a pod must
-                                        have a unique name (DNS_LABEL). Cannot be
-                                        updated.
+                                      description: |-
+                                        Name of the container specified as a DNS_LABEL.
+                                        Each container in a pod must have a unique name (DNS_LABEL).
+                                        Cannot be updated.
                                       type: string
                                     ports:
-                                      description: List of ports to expose from the
-                                        container. Not specifying a port here DOES
-                                        NOT prevent that port from being exposed.
-                                        Any port which is listening on the default
-                                        "0.0.0.0" address inside a container will
-                                        be accessible from the network. Modifying
-                                        this array with strategic merge patch may
-                                        corrupt the data. For more information See
-                                        https://github.com/kubernetes/kubernetes/issues/108255.
+                                      description: |-
+                                        List of ports to expose from the container. Not specifying a port here
+                                        DOES NOT prevent that port from being exposed. Any port which is
+                                        listening on the default "0.0.0.0" address inside a container will be
+                                        accessible from the network.
+                                        Modifying this array with strategic merge patch may corrupt the data.
+                                        For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                         Cannot be updated.
                                       items:
                                         description: ContainerPort represents a network
                                           port in a single container.
                                         properties:
                                           containerPort:
-                                            description: Number of port to expose
-                                              on the pod's IP address. This must be
-                                              a valid port number, 0 < x < 65536.
+                                            description: |-
+                                              Number of port to expose on the pod's IP address.
+                                              This must be a valid port number, 0 < x < 65536.
                                             format: int32
                                             type: integer
                                           hostIP:
@@ -5254,25 +4720,24 @@ spec:
                                               external port to.
                                             type: string
                                           hostPort:
-                                            description: Number of port to expose
-                                              on the host. If specified, this must
-                                              be a valid port number, 0 < x < 65536.
-                                              If HostNetwork is specified, this must
-                                              match ContainerPort. Most containers
-                                              do not need this.
+                                            description: |-
+                                              Number of port to expose on the host.
+                                              If specified, this must be a valid port number, 0 < x < 65536.
+                                              If HostNetwork is specified, this must match ContainerPort.
+                                              Most containers do not need this.
                                             format: int32
                                             type: integer
                                           name:
-                                            description: If specified, this must be
-                                              an IANA_SVC_NAME and unique within the
-                                              pod. Each named port in a pod must have
-                                              a unique name. Name for the port that
-                                              can be referred to by services.
+                                            description: |-
+                                              If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                              named port in a pod must have a unique name. Name for the port that can be
+                                              referred to by services.
                                             type: string
                                           protocol:
                                             default: TCP
-                                            description: Protocol for port. Must be
-                                              UDP, TCP, or SCTP. Defaults to "TCP".
+                                            description: |-
+                                              Protocol for port. Must be UDP, TCP, or SCTP.
+                                              Defaults to "TCP".
                                             type: string
                                         required:
                                         - containerPort
@@ -5283,36 +4748,32 @@ spec:
                                       - protocol
                                       x-kubernetes-list-type: map
                                     readinessProbe:
-                                      description: 'Periodic probe of container service
-                                        readiness. Container will be removed from
-                                        service endpoints if the probe fails. Cannot
-                                        be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: |-
+                                        Periodic probe of container service readiness.
+                                        Container will be removed from service endpoints if the probe fails.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       properties:
                                         exec:
                                           description: Exec specifies the action to
                                             take.
                                           properties:
                                             command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                           type: object
                                         failureThreshold:
-                                          description: Minimum consecutive failures
-                                            for the probe to be considered failed
-                                            after having succeeded. Defaults to 3.
-                                            Minimum value is 1.
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         grpc:
@@ -5326,11 +4787,12 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
-                                              description: "Service is the name of
-                                                the service to place in the gRPC HealthCheckRequest
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
                                                 (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                                \n If this is not specified, the default
-                                                behavior is defined by gRPC."
+
+
+                                                If this is not specified, the default behavior is defined by gRPC.
                                               type: string
                                           required:
                                           - port
@@ -5340,10 +4802,9 @@ spec:
                                             request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -5355,21 +4816,15 @@ spec:
                                                   probes
                                                 properties:
                                                   name:
-                                                    description: The header field
-                                                      name. This will be canonicalized
-                                                      upon output, so case-variant
-                                                      names will be understood as
-                                                      the same header.
                                                     type: string
                                                   value:
-                                                    description: The header field
-                                                      value
                                                     type: string
                                                 required:
                                                 - name
                                                 - value
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             path:
                                               description: Path to access on the HTTP
                                                 server.
@@ -5378,36 +4833,35 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         initialDelaySeconds:
-                                          description: 'Number of seconds after the
-                                            container has started before liveness
-                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                         periodSeconds:
-                                          description: How often (in seconds) to perform
-                                            the probe. Default to 10 seconds. Minimum
-                                            value is 1.
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         successThreshold:
-                                          description: Minimum consecutive successes
-                                            for the probe to be considered successful
-                                            after having failed. Defaults to 1. Must
-                                            be 1 for liveness and startup. Minimum
-                                            value is 1.
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         tcpSocket:
@@ -5422,40 +4876,33 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                         terminationGracePeriodSeconds:
-                                          description: Optional duration in seconds
-                                            the pod needs to terminate gracefully
-                                            upon probe failure. The grace period is
-                                            the duration in seconds after the processes
-                                            running in the pod are sent a termination
-                                            signal and the time when the processes
-                                            are forcibly halted with a kill signal.
-                                            Set this value longer than the expected
-                                            cleanup time for your process. If this
-                                            value is nil, the pod's terminationGracePeriodSeconds
-                                            will be used. Otherwise, this value overrides
-                                            the value provided by the pod spec. Value
-                                            must be non-negative integer. The value
-                                            zero indicates stop immediately via the
-                                            kill signal (no opportunity to shut down).
-                                            This is a beta field and requires enabling
-                                            ProbeTerminationGracePeriod feature gate.
-                                            Minimum value is 1. spec.terminationGracePeriodSeconds
-                                            is used if unset.
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                           format: int64
                                           type: integer
                                         timeoutSeconds:
-                                          description: 'Number of seconds after which
-                                            the probe times out. Defaults to 1 second.
-                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                       type: object
@@ -5467,14 +4914,14 @@ spec:
                                           resource resize policy for the container.
                                         properties:
                                           resourceName:
-                                            description: 'Name of the resource to
-                                              which this resource resize policy applies.
-                                              Supported values: cpu, memory.'
+                                            description: |-
+                                              Name of the resource to which this resource resize policy applies.
+                                              Supported values: cpu, memory.
                                             type: string
                                           restartPolicy:
-                                            description: Restart policy to apply when
-                                              specified resource is resized. If not
-                                              specified, it defaults to NotRequired.
+                                            description: |-
+                                              Restart policy to apply when specified resource is resized.
+                                              If not specified, it defaults to NotRequired.
                                             type: string
                                         required:
                                         - resourceName
@@ -5483,28 +4930,27 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     resources:
-                                      description: 'Compute Resources required by
-                                        this container. Cannot be updated. More info:
-                                        https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                      description: |-
+                                        Compute Resources required by this container.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       properties:
                                         claims:
-                                          description: "Claims lists the names of
-                                            resources, defined in spec.resourceClaims,
-                                            that are used by this container. \n This
-                                            is an alpha field and requires enabling
-                                            the DynamicResourceAllocation feature
-                                            gate. \n This field is immutable. It can
-                                            only be set for containers."
+                                          description: |-
+                                            Claims lists the names of resources, defined in spec.resourceClaims,
+                                            that are used by this container.
+
+
+                                            This is an alpha field and requires enabling the
+                                            DynamicResourceAllocation feature gate.
+
+
+                                            This field is immutable. It can only be set for containers.
                                           items:
                                             description: ResourceClaim references
                                               one entry in PodSpec.ResourceClaims.
                                             properties:
                                               name:
-                                                description: Name must match the name
-                                                  of one entry in pod.spec.resourceClaims
-                                                  of the Pod where this field is used.
-                                                  It makes that resource available
-                                                  inside a container.
                                                 type: string
                                             required:
                                             - name
@@ -5520,9 +4966,9 @@ spec:
                                             - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Limits describes the maximum
-                                            amount of compute resources allowed. More
-                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          description: |-
+                                            Limits describes the maximum amount of compute resources allowed.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                           type: object
                                         requests:
                                           additionalProperties:
@@ -5531,65 +4977,76 @@ spec:
                                             - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Requests describes the minimum
-                                            amount of compute resources required.
-                                            If Requests is omitted for a container,
-                                            it defaults to Limits if that is explicitly
-                                            specified, otherwise to an implementation-defined
-                                            value. Requests cannot exceed Limits.
-                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          description: |-
+                                            Requests describes the minimum amount of compute resources required.
+                                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                           type: object
                                       type: object
                                     restartPolicy:
-                                      description: 'RestartPolicy defines the restart
-                                        behavior of individual containers in a pod.
-                                        This field may only be set for init containers,
-                                        and the only allowed value is "Always". For
-                                        non-init containers or when this field is
-                                        not specified, the restart behavior is defined
-                                        by the Pod''s restart policy and the container
-                                        type. Setting the RestartPolicy as "Always"
-                                        for the init container will have the following
-                                        effect: this init container will be continually
-                                        restarted on exit until all regular containers
-                                        have terminated. Once all regular containers
-                                        have completed, all init containers with restartPolicy
-                                        "Always" will be shut down. This lifecycle
-                                        differs from normal init containers and is
-                                        often referred to as a "sidecar" container.
-                                        Although this init container still starts
-                                        in the init container sequence, it does not
-                                        wait for the container to complete before
-                                        proceeding to the next init container. Instead,
-                                        the next init container starts immediately
-                                        after this init container is started, or after
-                                        any startupProbe has successfully completed.'
+                                      description: |-
+                                        RestartPolicy defines the restart behavior of individual containers in a pod.
+                                        This field may only be set for init containers, and the only allowed value is "Always".
+                                        For non-init containers or when this field is not specified,
+                                        the restart behavior is defined by the Pod's restart policy and the container type.
+                                        Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                                        this init container will be continually restarted on
+                                        exit until all regular containers have terminated. Once all regular
+                                        containers have completed, all init containers with restartPolicy "Always"
+                                        will be shut down. This lifecycle differs from normal init containers and
+                                        is often referred to as a "sidecar" container. Although this init
+                                        container still starts in the init container sequence, it does not wait
+                                        for the container to complete before proceeding to the next init
+                                        container. Instead, the next init container starts immediately after this
+                                        init container is started, or after any startupProbe has successfully
+                                        completed.
                                       type: string
                                     securityContext:
-                                      description: 'SecurityContext defines the security
-                                        options the container should be run with.
-                                        If set, the fields of SecurityContext override
-                                        the equivalent fields of PodSecurityContext.
-                                        More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                      description: |-
+                                        SecurityContext defines the security options the container should be run with.
+                                        If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                        More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                                       properties:
                                         allowPrivilegeEscalation:
-                                          description: 'AllowPrivilegeEscalation controls
-                                            whether a process can gain more privileges
-                                            than its parent process. This bool directly
-                                            controls if the no_new_privs flag will
-                                            be set on the container process. AllowPrivilegeEscalation
-                                            is true always when the container is:
-                                            1) run as Privileged 2) has CAP_SYS_ADMIN
-                                            Note that this field cannot be set when
-                                            spec.os.name is windows.'
+                                          description: |-
+                                            AllowPrivilegeEscalation controls whether a process can gain more
+                                            privileges than its parent process. This bool directly controls if
+                                            the no_new_privs flag will be set on the container process.
+                                            AllowPrivilegeEscalation is true always when the container is:
+                                            1) run as Privileged
+                                            2) has CAP_SYS_ADMIN
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           type: boolean
+                                        appArmorProfile:
+                                          description: |-
+                                            appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                            overrides the pod's appArmorProfile.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            localhostProfile:
+                                              description: |-
+                                                localhostProfile indicates a profile loaded on the node that should be used.
+                                                The profile must be preconfigured on the node to work.
+                                                Must match the loaded name of the profile.
+                                                Must be set if and only if type is "Localhost".
+                                              type: string
+                                            type:
+                                              description: |-
+                                                type indicates which kind of AppArmor profile will be applied.
+                                                Valid options are:
+                                                  Localhost - a profile pre-loaded on the node.
+                                                  RuntimeDefault - the container runtime's default profile.
+                                                  Unconfined - no AppArmor enforcement.
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
                                         capabilities:
-                                          description: The capabilities to add/drop
-                                            when running containers. Defaults to the
-                                            default set of capabilities granted by
-                                            the container runtime. Note that this
-                                            field cannot be set when spec.os.name
-                                            is windows.
+                                          description: |-
+                                            The capabilities to add/drop when running containers.
+                                            Defaults to the default set of capabilities granted by the container runtime.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           properties:
                                             add:
                                               description: Added capabilities
@@ -5598,6 +5055,7 @@ spec:
                                                   POSIX capabilities type
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             drop:
                                               description: Removed capabilities
                                               items:
@@ -5605,75 +5063,63 @@ spec:
                                                   POSIX capabilities type
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                           type: object
                                         privileged:
-                                          description: Run container in privileged
-                                            mode. Processes in privileged containers
-                                            are essentially equivalent to root on
-                                            the host. Defaults to false. Note that
-                                            this field cannot be set when spec.os.name
-                                            is windows.
+                                          description: |-
+                                            Run container in privileged mode.
+                                            Processes in privileged containers are essentially equivalent to root on the host.
+                                            Defaults to false.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           type: boolean
                                         procMount:
-                                          description: procMount denotes the type
-                                            of proc mount to use for the containers.
-                                            The default is DefaultProcMount which
-                                            uses the container runtime defaults for
-                                            readonly paths and masked paths. This
-                                            requires the ProcMountType feature flag
-                                            to be enabled. Note that this field cannot
-                                            be set when spec.os.name is windows.
+                                          description: |-
+                                            procMount denotes the type of proc mount to use for the containers.
+                                            The default is DefaultProcMount which uses the container runtime defaults for
+                                            readonly paths and masked paths.
+                                            This requires the ProcMountType feature flag to be enabled.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           type: string
                                         readOnlyRootFilesystem:
-                                          description: Whether this container has
-                                            a read-only root filesystem. Default is
-                                            false. Note that this field cannot be
-                                            set when spec.os.name is windows.
+                                          description: |-
+                                            Whether this container has a read-only root filesystem.
+                                            Default is false.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           type: boolean
                                         runAsGroup:
-                                          description: The GID to run the entrypoint
-                                            of the container process. Uses runtime
-                                            default if unset. May also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence. Note that this field
-                                            cannot be set when spec.os.name is windows.
+                                          description: |-
+                                            The GID to run the entrypoint of the container process.
+                                            Uses runtime default if unset.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           format: int64
                                           type: integer
                                         runAsNonRoot:
-                                          description: Indicates that the container
-                                            must run as a non-root user. If true,
-                                            the Kubelet will validate the image at
-                                            runtime to ensure that it does not run
-                                            as UID 0 (root) and fail to start the
-                                            container if it does. If unset or false,
-                                            no such validation will be performed.
-                                            May also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence.
+                                          description: |-
+                                            Indicates that the container must run as a non-root user.
+                                            If true, the Kubelet will validate the image at runtime to ensure that it
+                                            does not run as UID 0 (root) and fail to start the container if it does.
+                                            If unset or false, no such validation will be performed.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
                                           type: boolean
                                         runAsUser:
-                                          description: The UID to run the entrypoint
-                                            of the container process. Defaults to
-                                            user specified in image metadata if unspecified.
-                                            May also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence. Note that this field
-                                            cannot be set when spec.os.name is windows.
+                                          description: |-
+                                            The UID to run the entrypoint of the container process.
+                                            Defaults to user specified in image metadata if unspecified.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           format: int64
                                           type: integer
                                         seLinuxOptions:
-                                          description: The SELinux context to be applied
-                                            to the container. If unspecified, the
-                                            container runtime will allocate a random
-                                            SELinux context for each container.  May
-                                            also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence. Note that this field
-                                            cannot be set when spec.os.name is windows.
+                                          description: |-
+                                            The SELinux context to be applied to the container.
+                                            If unspecified, the container runtime will allocate a random SELinux context for each
+                                            container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           properties:
                                             level:
                                               description: Level is SELinux level
@@ -5693,53 +5139,44 @@ spec:
                                               type: string
                                           type: object
                                         seccompProfile:
-                                          description: The seccomp options to use
-                                            by this container. If seccomp options
-                                            are provided at both the pod & container
-                                            level, the container options override
-                                            the pod options. Note that this field
-                                            cannot be set when spec.os.name is windows.
+                                          description: |-
+                                            The seccomp options to use by this container. If seccomp options are
+                                            provided at both the pod & container level, the container options
+                                            override the pod options.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           properties:
                                             localhostProfile:
-                                              description: localhostProfile indicates
-                                                a profile defined in a file on the
-                                                node should be used. The profile must
-                                                be preconfigured on the node to work.
-                                                Must be a descending path, relative
-                                                to the kubelet's configured seccomp
-                                                profile location. Must be set if type
-                                                is "Localhost". Must NOT be set for
-                                                any other type.
+                                              description: |-
+                                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                                The profile must be preconfigured on the node to work.
+                                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                Must be set if type is "Localhost". Must NOT be set for any other type.
                                               type: string
                                             type:
-                                              description: "type indicates which kind
-                                                of seccomp profile will be applied.
-                                                Valid options are: \n Localhost -
-                                                a profile defined in a file on the
-                                                node should be used. RuntimeDefault
-                                                - the container runtime default profile
-                                                should be used. Unconfined - no profile
-                                                should be applied."
+                                              description: |-
+                                                type indicates which kind of seccomp profile will be applied.
+                                                Valid options are:
+
+
+                                                Localhost - a profile defined in a file on the node should be used.
+                                                RuntimeDefault - the container runtime default profile should be used.
+                                                Unconfined - no profile should be applied.
                                               type: string
                                           required:
                                           - type
                                           type: object
                                         windowsOptions:
-                                          description: The Windows specific settings
-                                            applied to all containers. If unspecified,
-                                            the options from the PodSecurityContext
-                                            will be used. If set in both SecurityContext
-                                            and PodSecurityContext, the value specified
-                                            in SecurityContext takes precedence. Note
-                                            that this field cannot be set when spec.os.name
-                                            is linux.
+                                          description: |-
+                                            The Windows specific settings applied to all containers.
+                                            If unspecified, the options from the PodSecurityContext will be used.
+                                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is linux.
                                           properties:
                                             gmsaCredentialSpec:
-                                              description: GMSACredentialSpec is where
-                                                the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                                inlines the contents of the GMSA credential
-                                                spec named by the GMSACredentialSpecName
-                                                field.
+                                              description: |-
+                                                GMSACredentialSpec is where the GMSA admission webhook
+                                                (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                                GMSA credential spec named by the GMSACredentialSpecName field.
                                               type: string
                                             gmsaCredentialSpecName:
                                               description: GMSACredentialSpecName
@@ -5747,67 +5184,51 @@ spec:
                                                 spec to use.
                                               type: string
                                             hostProcess:
-                                              description: HostProcess determines
-                                                if a container should be run as a
-                                                'Host Process' container. All of a
-                                                Pod's containers must have the same
-                                                effective HostProcess value (it is
-                                                not allowed to have a mix of HostProcess
-                                                containers and non-HostProcess containers).
-                                                In addition, if HostProcess is true
-                                                then HostNetwork must also be set
-                                                to true.
+                                              description: |-
+                                                HostProcess determines if a container should be run as a 'Host Process' container.
+                                                All of a Pod's containers must have the same effective HostProcess value
+                                                (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                                In addition, if HostProcess is true then HostNetwork must also be set to true.
                                               type: boolean
                                             runAsUserName:
-                                              description: The UserName in Windows
-                                                to run the entrypoint of the container
-                                                process. Defaults to the user specified
-                                                in image metadata if unspecified.
-                                                May also be set in PodSecurityContext.
-                                                If set in both SecurityContext and
-                                                PodSecurityContext, the value specified
-                                                in SecurityContext takes precedence.
+                                              description: |-
+                                                The UserName in Windows to run the entrypoint of the container process.
+                                                Defaults to the user specified in image metadata if unspecified.
+                                                May also be set in PodSecurityContext. If set in both SecurityContext and
+                                                PodSecurityContext, the value specified in SecurityContext takes precedence.
                                               type: string
                                           type: object
                                       type: object
                                     startupProbe:
-                                      description: 'StartupProbe indicates that the
-                                        Pod has successfully initialized. If specified,
-                                        no other probes are executed until this completes
-                                        successfully. If this probe fails, the Pod
-                                        will be restarted, just as if the livenessProbe
-                                        failed. This can be used to provide different
-                                        probe parameters at the beginning of a Pod''s
-                                        lifecycle, when it might take a long time
-                                        to load data or warm a cache, than during
-                                        steady-state operation. This cannot be updated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: |-
+                                        StartupProbe indicates that the Pod has successfully initialized.
+                                        If specified, no other probes are executed until this completes successfully.
+                                        If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                        This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                        when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                        This cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       properties:
                                         exec:
                                           description: Exec specifies the action to
                                             take.
                                           properties:
                                             command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                           type: object
                                         failureThreshold:
-                                          description: Minimum consecutive failures
-                                            for the probe to be considered failed
-                                            after having succeeded. Defaults to 3.
-                                            Minimum value is 1.
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         grpc:
@@ -5821,11 +5242,12 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
-                                              description: "Service is the name of
-                                                the service to place in the gRPC HealthCheckRequest
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
                                                 (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                                \n If this is not specified, the default
-                                                behavior is defined by gRPC."
+
+
+                                                If this is not specified, the default behavior is defined by gRPC.
                                               type: string
                                           required:
                                           - port
@@ -5835,10 +5257,9 @@ spec:
                                             request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -5850,21 +5271,15 @@ spec:
                                                   probes
                                                 properties:
                                                   name:
-                                                    description: The header field
-                                                      name. This will be canonicalized
-                                                      upon output, so case-variant
-                                                      names will be understood as
-                                                      the same header.
                                                     type: string
                                                   value:
-                                                    description: The header field
-                                                      value
                                                     type: string
                                                 required:
                                                 - name
                                                 - value
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             path:
                                               description: Path to access on the HTTP
                                                 server.
@@ -5873,36 +5288,35 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         initialDelaySeconds:
-                                          description: 'Number of seconds after the
-                                            container has started before liveness
-                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                         periodSeconds:
-                                          description: How often (in seconds) to perform
-                                            the probe. Default to 10 seconds. Minimum
-                                            value is 1.
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         successThreshold:
-                                          description: Minimum consecutive successes
-                                            for the probe to be considered successful
-                                            after having failed. Defaults to 1. Must
-                                            be 1 for liveness and startup. Minimum
-                                            value is 1.
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         tcpSocket:
@@ -5917,93 +5331,76 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                         terminationGracePeriodSeconds:
-                                          description: Optional duration in seconds
-                                            the pod needs to terminate gracefully
-                                            upon probe failure. The grace period is
-                                            the duration in seconds after the processes
-                                            running in the pod are sent a termination
-                                            signal and the time when the processes
-                                            are forcibly halted with a kill signal.
-                                            Set this value longer than the expected
-                                            cleanup time for your process. If this
-                                            value is nil, the pod's terminationGracePeriodSeconds
-                                            will be used. Otherwise, this value overrides
-                                            the value provided by the pod spec. Value
-                                            must be non-negative integer. The value
-                                            zero indicates stop immediately via the
-                                            kill signal (no opportunity to shut down).
-                                            This is a beta field and requires enabling
-                                            ProbeTerminationGracePeriod feature gate.
-                                            Minimum value is 1. spec.terminationGracePeriodSeconds
-                                            is used if unset.
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                           format: int64
                                           type: integer
                                         timeoutSeconds:
-                                          description: 'Number of seconds after which
-                                            the probe times out. Defaults to 1 second.
-                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                       type: object
                                     stdin:
-                                      description: Whether this container should allocate
-                                        a buffer for stdin in the container runtime.
-                                        If this is not set, reads from stdin in the
-                                        container will always result in EOF. Default
-                                        is false.
+                                      description: |-
+                                        Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                        is not set, reads from stdin in the container will always result in EOF.
+                                        Default is false.
                                       type: boolean
                                     stdinOnce:
-                                      description: Whether the container runtime should
-                                        close the stdin channel after it has been
-                                        opened by a single attach. When stdin is true
-                                        the stdin stream will remain open across multiple
-                                        attach sessions. If stdinOnce is set to true,
-                                        stdin is opened on container start, is empty
-                                        until the first client attaches to stdin,
-                                        and then remains open and accepts data until
-                                        the client disconnects, at which time stdin
-                                        is closed and remains closed until the container
-                                        is restarted. If this flag is false, a container
-                                        processes that reads from stdin will never
-                                        receive an EOF. Default is false
+                                      description: |-
+                                        Whether the container runtime should close the stdin channel after it has been opened by
+                                        a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                        sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                        first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                        at which time stdin is closed and remains closed until the container is restarted. If this
+                                        flag is false, a container processes that reads from stdin will never receive an EOF.
+                                        Default is false
                                       type: boolean
                                     terminationMessagePath:
-                                      description: 'Optional: Path at which the file
-                                        to which the container''s termination message
-                                        will be written is mounted into the container''s
-                                        filesystem. Message written is intended to
-                                        be brief final status, such as an assertion
-                                        failure message. Will be truncated by the
-                                        node if greater than 4096 bytes. The total
-                                        message length across all containers will
-                                        be limited to 12kb. Defaults to /dev/termination-log.
-                                        Cannot be updated.'
+                                      description: |-
+                                        Optional: Path at which the file to which the container's termination message
+                                        will be written is mounted into the container's filesystem.
+                                        Message written is intended to be brief final status, such as an assertion failure message.
+                                        Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                        all containers will be limited to 12kb.
+                                        Defaults to /dev/termination-log.
+                                        Cannot be updated.
                                       type: string
                                     terminationMessagePolicy:
-                                      description: Indicate how the termination message
-                                        should be populated. File will use the contents
-                                        of terminationMessagePath to populate the
-                                        container status message on both success and
-                                        failure. FallbackToLogsOnError will use the
-                                        last chunk of container log output if the
-                                        termination message file is empty and the
-                                        container exited with an error. The log output
-                                        is limited to 2048 bytes or 80 lines, whichever
-                                        is smaller. Defaults to File. Cannot be updated.
+                                      description: |-
+                                        Indicate how the termination message should be populated. File will use the contents of
+                                        terminationMessagePath to populate the container status message on both success and failure.
+                                        FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                        message file is empty and the container exited with an error.
+                                        The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                        Defaults to File.
+                                        Cannot be updated.
                                       type: string
                                     tty:
-                                      description: Whether this container should allocate
-                                        a TTY for itself, also requires 'stdin' to
-                                        be true. Default is false.
+                                      description: |-
+                                        Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                        Default is false.
                                       type: boolean
                                     volumeDevices:
                                       description: volumeDevices is the list of block
@@ -6026,109 +5423,153 @@ spec:
                                         - name
                                         type: object
                                       type: array
+                                      x-kubernetes-list-map-keys:
+                                      - devicePath
+                                      x-kubernetes-list-type: map
                                     volumeMounts:
-                                      description: Pod volumes to mount into the container's
-                                        filesystem. Cannot be updated.
+                                      description: |-
+                                        Pod volumes to mount into the container's filesystem.
+                                        Cannot be updated.
                                       items:
                                         description: VolumeMount describes a mounting
                                           of a Volume within a container.
                                         properties:
                                           mountPath:
-                                            description: Path within the container
-                                              at which the volume should be mounted.  Must
+                                            description: |-
+                                              Path within the container at which the volume should be mounted.  Must
                                               not contain ':'.
                                             type: string
                                           mountPropagation:
-                                            description: mountPropagation determines
-                                              how mounts are propagated from the host
+                                            description: |-
+                                              mountPropagation determines how mounts are propagated from the host
                                               to container and the other way around.
-                                              When not set, MountPropagationNone is
-                                              used. This field is beta in 1.10.
+                                              When not set, MountPropagationNone is used.
+                                              This field is beta in 1.10.
+                                              When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                              (which defaults to None).
                                             type: string
                                           name:
                                             description: This must match the Name
                                               of a Volume.
                                             type: string
                                           readOnly:
-                                            description: Mounted read-only if true,
-                                              read-write otherwise (false or unspecified).
+                                            description: |-
+                                              Mounted read-only if true, read-write otherwise (false or unspecified).
                                               Defaults to false.
                                             type: boolean
+                                          recursiveReadOnly:
+                                            description: |-
+                                              RecursiveReadOnly specifies whether read-only mounts should be handled
+                                              recursively.
+
+
+                                              If ReadOnly is false, this field has no meaning and must be unspecified.
+
+
+                                              If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                              recursively read-only.  If this field is set to IfPossible, the mount is made
+                                              recursively read-only, if it is supported by the container runtime.  If this
+                                              field is set to Enabled, the mount is made recursively read-only if it is
+                                              supported by the container runtime, otherwise the pod will not be started and
+                                              an error will be generated to indicate the reason.
+
+
+                                              If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                              None (or be unspecified, which defaults to None).
+
+
+                                              If this field is not specified, it is treated as an equivalent of Disabled.
+                                            type: string
                                           subPath:
-                                            description: Path within the volume from
-                                              which the container's volume should
-                                              be mounted. Defaults to "" (volume's
-                                              root).
+                                            description: |-
+                                              Path within the volume from which the container's volume should be mounted.
+                                              Defaults to "" (volume's root).
                                             type: string
                                           subPathExpr:
-                                            description: Expanded path within the
-                                              volume from which the container's volume
-                                              should be mounted. Behaves similarly
-                                              to SubPath but environment variable
-                                              references $(VAR_NAME) are expanded
-                                              using the container's environment. Defaults
-                                              to "" (volume's root). SubPathExpr and
-                                              SubPath are mutually exclusive.
+                                            description: |-
+                                              Expanded path within the volume from which the container's volume should be mounted.
+                                              Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                              Defaults to "" (volume's root).
+                                              SubPathExpr and SubPath are mutually exclusive.
                                             type: string
                                         required:
                                         - mountPath
                                         - name
                                         type: object
                                       type: array
+                                      x-kubernetes-list-map-keys:
+                                      - mountPath
+                                      x-kubernetes-list-type: map
                                     workingDir:
-                                      description: Container's working directory.
-                                        If not specified, the container runtime's
-                                        default will be used, which might be configured
-                                        in the container image. Cannot be updated.
+                                      description: |-
+                                        Container's working directory.
+                                        If not specified, the container runtime's default will be used, which
+                                        might be configured in the container image.
+                                        Cannot be updated.
                                       type: string
                                   required:
                                   - name
                                   type: object
                                 type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
                               nodeName:
-                                description: NodeName is a request to schedule this
-                                  pod onto a specific node. If it is non-empty, the
-                                  scheduler simply schedules this pod onto that node,
-                                  assuming that it fits resource requirements.
+                                description: |-
+                                  NodeName is a request to schedule this pod onto a specific node. If it is non-empty,
+                                  the scheduler simply schedules this pod onto that node, assuming that it fits resource
+                                  requirements.
                                 type: string
                               nodeSelector:
                                 additionalProperties:
                                   type: string
-                                description: 'NodeSelector is a selector which must
-                                  be true for the pod to fit on a node. Selector which
-                                  must match a node''s labels for the pod to be scheduled
-                                  on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                description: |-
+                                  NodeSelector is a selector which must be true for the pod to fit on a node.
+                                  Selector which must match a node's labels for the pod to be scheduled on that node.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
                                 type: object
                                 x-kubernetes-map-type: atomic
                               os:
-                                description: "Specifies the OS of the containers in
-                                  the pod. Some pod and container fields are restricted
-                                  if this is set. \n If the OS field is set to linux,
-                                  the following fields must be unset: -securityContext.windowsOptions
-                                  \n If the OS field is set to windows, following
-                                  fields must be unset: - spec.hostPID - spec.hostIPC
-                                  - spec.hostUsers - spec.securityContext.seLinuxOptions
-                                  - spec.securityContext.seccompProfile - spec.securityContext.fsGroup
-                                  - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls
-                                  - spec.shareProcessNamespace - spec.securityContext.runAsUser
-                                  - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups
+                                description: |-
+                                  Specifies the OS of the containers in the pod.
+                                  Some pod and container fields are restricted if this is set.
+
+
+                                  If the OS field is set to linux, the following fields must be unset:
+                                  -securityContext.windowsOptions
+
+
+                                  If the OS field is set to windows, following fields must be unset:
+                                  - spec.hostPID
+                                  - spec.hostIPC
+                                  - spec.hostUsers
+                                  - spec.securityContext.appArmorProfile
+                                  - spec.securityContext.seLinuxOptions
+                                  - spec.securityContext.seccompProfile
+                                  - spec.securityContext.fsGroup
+                                  - spec.securityContext.fsGroupChangePolicy
+                                  - spec.securityContext.sysctls
+                                  - spec.shareProcessNamespace
+                                  - spec.securityContext.runAsUser
+                                  - spec.securityContext.runAsGroup
+                                  - spec.securityContext.supplementalGroups
+                                  - spec.containers[*].securityContext.appArmorProfile
                                   - spec.containers[*].securityContext.seLinuxOptions
                                   - spec.containers[*].securityContext.seccompProfile
                                   - spec.containers[*].securityContext.capabilities
                                   - spec.containers[*].securityContext.readOnlyRootFilesystem
                                   - spec.containers[*].securityContext.privileged
                                   - spec.containers[*].securityContext.allowPrivilegeEscalation
-                                  - spec.containers[*].securityContext.procMount -
-                                  spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup"
+                                  - spec.containers[*].securityContext.procMount
+                                  - spec.containers[*].securityContext.runAsUser
+                                  - spec.containers[*].securityContext.runAsGroup
                                 properties:
                                   name:
-                                    description: 'Name is the name of the operating
-                                      system. The currently supported values are linux
-                                      and windows. Additional value may be defined
-                                      in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
-                                      Clients should expect to handle additional values
-                                      and treat unrecognized values in this field
-                                      as os: null'
+                                    description: |-
+                                      Name is the name of the operating system. The currently supported values are linux and windows.
+                                      Additional value may be defined in future and can be one of:
+                                      https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                                      Clients should expect to handle additional values and treat unrecognized values in this field as os: null
                                     type: string
                                 required:
                                 - name
@@ -6140,49 +5581,45 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Overhead represents the resource overhead
-                                  associated with running a pod for a given RuntimeClass.
-                                  This field will be autopopulated at admission time
-                                  by the RuntimeClass admission controller. If the
-                                  RuntimeClass admission controller is enabled, overhead
-                                  must not be set in Pod create requests. The RuntimeClass
-                                  admission controller will reject Pod create requests
-                                  which have the overhead already set. If RuntimeClass
-                                  is configured and selected in the PodSpec, Overhead
-                                  will be set to the value defined in the corresponding
-                                  RuntimeClass, otherwise it will remain unset and
-                                  treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
+                                description: |-
+                                  Overhead represents the resource overhead associated with running a pod for a given RuntimeClass.
+                                  This field will be autopopulated at admission time by the RuntimeClass admission controller. If
+                                  the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests.
+                                  The RuntimeClass admission controller will reject Pod create requests which have the overhead already
+                                  set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value
+                                  defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero.
+                                  More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md
                                 type: object
                               preemptionPolicy:
-                                description: PreemptionPolicy is the Policy for preempting
-                                  pods with lower priority. One of Never, PreemptLowerPriority.
+                                description: |-
+                                  PreemptionPolicy is the Policy for preempting pods with lower priority.
+                                  One of Never, PreemptLowerPriority.
                                   Defaults to PreemptLowerPriority if unset.
                                 type: string
                               priority:
-                                description: The priority value. Various system components
-                                  use this field to find the priority of the pod.
-                                  When Priority Admission Controller is enabled, it
-                                  prevents users from setting this field. The admission
-                                  controller populates this field from PriorityClassName.
+                                description: |-
+                                  The priority value. Various system components use this field to find the
+                                  priority of the pod. When Priority Admission Controller is enabled, it
+                                  prevents users from setting this field. The admission controller populates
+                                  this field from PriorityClassName.
                                   The higher the value, the higher the priority.
                                 format: int32
                                 type: integer
                               priorityClassName:
-                                description: If specified, indicates the pod's priority.
-                                  "system-node-critical" and "system-cluster-critical"
-                                  are two special keywords which indicate the highest
-                                  priorities with the former being the highest priority.
-                                  Any other name must be defined by creating a PriorityClass
-                                  object with that name. If not specified, the pod
-                                  priority will be default or zero if there is no
+                                description: |-
+                                  If specified, indicates the pod's priority. "system-node-critical" and
+                                  "system-cluster-critical" are two special keywords which indicate the
+                                  highest priorities with the former being the highest priority. Any other
+                                  name must be defined by creating a PriorityClass object with that name.
+                                  If not specified, the pod priority will be default or zero if there is no
                                   default.
                                 type: string
                               readinessGates:
-                                description: 'If specified, all readiness gates will
-                                  be evaluated for pod readiness. A pod is ready when
-                                  all its containers are ready AND all conditions
-                                  specified in the readiness gates have status equal
-                                  to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
+                                description: |-
+                                  If specified, all readiness gates will be evaluated for pod readiness.
+                                  A pod is ready when all its containers are ready AND
+                                  all conditions specified in the readiness gates have status equal to "True"
+                                  More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates
                                 items:
                                   description: PodReadinessGate contains the reference
                                     to a pod condition
@@ -6196,50 +5633,56 @@ spec:
                                   - conditionType
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                               resourceClaims:
-                                description: "ResourceClaims defines which ResourceClaims
-                                  must be allocated and reserved before the Pod is
-                                  allowed to start. The resources will be made available
-                                  to those containers which consume them by name.
-                                  \n This is an alpha field and requires enabling
-                                  the DynamicResourceAllocation feature gate. \n This
-                                  field is immutable."
+                                description: |-
+                                  ResourceClaims defines which ResourceClaims must be allocated
+                                  and reserved before the Pod is allowed to start. The resources
+                                  will be made available to those containers which consume them
+                                  by name.
+
+
+                                  This is an alpha field and requires enabling the
+                                  DynamicResourceAllocation feature gate.
+
+
+                                  This field is immutable.
                                 items:
-                                  description: PodResourceClaim references exactly
-                                    one ResourceClaim through a ClaimSource. It adds
-                                    a name to it that uniquely identifies the ResourceClaim
-                                    inside the Pod. Containers that need access to
-                                    the ResourceClaim reference it with this name.
+                                  description: |-
+                                    PodResourceClaim references exactly one ResourceClaim through a ClaimSource.
+                                    It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
+                                    Containers that need access to the ResourceClaim reference it with this name.
                                   properties:
                                     name:
-                                      description: Name uniquely identifies this resource
-                                        claim inside the pod. This must be a DNS_LABEL.
+                                      description: |-
+                                        Name uniquely identifies this resource claim inside the pod.
+                                        This must be a DNS_LABEL.
                                       type: string
                                     source:
                                       description: Source describes where to find
                                         the ResourceClaim.
                                       properties:
                                         resourceClaimName:
-                                          description: ResourceClaimName is the name
-                                            of a ResourceClaim object in the same
+                                          description: |-
+                                            ResourceClaimName is the name of a ResourceClaim object in the same
                                             namespace as this pod.
                                           type: string
                                         resourceClaimTemplateName:
-                                          description: "ResourceClaimTemplateName
-                                            is the name of a ResourceClaimTemplate
+                                          description: |-
+                                            ResourceClaimTemplateName is the name of a ResourceClaimTemplate
                                             object in the same namespace as this pod.
-                                            \n The template will be used to create
-                                            a new ResourceClaim, which will be bound
-                                            to this pod. When this pod is deleted,
-                                            the ResourceClaim will also be deleted.
-                                            The pod name and resource name, along
-                                            with a generated component, will be used
-                                            to form a unique name for the ResourceClaim,
-                                            which will be recorded in pod.status.resourceClaimStatuses.
-                                            \n This field is immutable and no changes
-                                            will be made to the corresponding ResourceClaim
-                                            by the control plane after creating the
-                                            ResourceClaim."
+
+
+                                            The template will be used to create a new ResourceClaim, which will
+                                            be bound to this pod. When this pod is deleted, the ResourceClaim
+                                            will also be deleted. The pod name and resource name, along with a
+                                            generated component, will be used to form a unique name for the
+                                            ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+
+                                            This field is immutable and no changes will be made to the
+                                            corresponding ResourceClaim by the control plane after creating the
+                                            ResourceClaim.
                                           type: string
                                       type: object
                                   required:
@@ -6250,42 +5693,41 @@ spec:
                                 - name
                                 x-kubernetes-list-type: map
                               restartPolicy:
-                                description: 'Restart policy for all containers within
-                                  the pod. One of Always, OnFailure, Never. In some
-                                  contexts, only a subset of those values may be permitted.
-                                  Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
+                                description: |-
+                                  Restart policy for all containers within the pod.
+                                  One of Always, OnFailure, Never. In some contexts, only a subset of those values may be permitted.
+                                  Default to Always.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
                                 type: string
                               runtimeClassName:
-                                description: 'RuntimeClassName refers to a RuntimeClass
-                                  object in the node.k8s.io group, which should be
-                                  used to run this pod.  If no RuntimeClass resource
-                                  matches the named class, the pod will not be run.
-                                  If unset or empty, the "legacy" RuntimeClass will
-                                  be used, which is an implicit class with an empty
-                                  definition that uses the default runtime handler.
-                                  More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
+                                description: |-
+                                  RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used
+                                  to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run.
+                                  If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an
+                                  empty definition that uses the default runtime handler.
+                                  More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class
                                 type: string
                               schedulerName:
-                                description: If specified, the pod will be dispatched
-                                  by specified scheduler. If not specified, the pod
-                                  will be dispatched by default scheduler.
+                                description: |-
+                                  If specified, the pod will be dispatched by specified scheduler.
+                                  If not specified, the pod will be dispatched by default scheduler.
                                 type: string
                               schedulingGates:
-                                description: "SchedulingGates is an opaque list of
-                                  values that if specified will block scheduling the
-                                  pod. If schedulingGates is not empty, the pod will
-                                  stay in the SchedulingGated state and the scheduler
-                                  will not attempt to schedule the pod. \n SchedulingGates
-                                  can only be set at pod creation time, and be removed
-                                  only afterwards. \n This is a beta feature enabled
-                                  by the PodSchedulingReadiness feature gate."
+                                description: |-
+                                  SchedulingGates is an opaque list of values that if specified will block scheduling the pod.
+                                  If schedulingGates is not empty, the pod will stay in the SchedulingGated state and the
+                                  scheduler will not attempt to schedule the pod.
+
+
+                                  SchedulingGates can only be set at pod creation time, and be removed only afterwards.
                                 items:
                                   description: PodSchedulingGate is associated to
                                     a Pod to guard its scheduling.
                                   properties:
                                     name:
-                                      description: Name of the scheduling gate. Each
-                                        scheduling gate must have a unique name field.
+                                      description: |-
+                                        Name of the scheduling gate.
+                                        Each scheduling gate must have a unique name field.
                                       type: string
                                   required:
                                   - name
@@ -6295,79 +5737,96 @@ spec:
                                 - name
                                 x-kubernetes-list-type: map
                               securityContext:
-                                description: 'SecurityContext holds pod-level security
-                                  attributes and common container settings. Optional:
-                                  Defaults to empty.  See type description for default
-                                  values of each field.'
+                                description: |-
+                                  SecurityContext holds pod-level security attributes and common container settings.
+                                  Optional: Defaults to empty.  See type description for default values of each field.
                                 properties:
+                                  appArmorProfile:
+                                    description: |-
+                                      appArmorProfile is the AppArmor options to use by the containers in this pod.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      localhostProfile:
+                                        description: |-
+                                          localhostProfile indicates a profile loaded on the node that should be used.
+                                          The profile must be preconfigured on the node to work.
+                                          Must match the loaded name of the profile.
+                                          Must be set if and only if type is "Localhost".
+                                        type: string
+                                      type:
+                                        description: |-
+                                          type indicates which kind of AppArmor profile will be applied.
+                                          Valid options are:
+                                            Localhost - a profile pre-loaded on the node.
+                                            RuntimeDefault - the container runtime's default profile.
+                                            Unconfined - no AppArmor enforcement.
+                                        type: string
+                                    required:
+                                    - type
+                                    type: object
                                   fsGroup:
-                                    description: "A special supplemental group that
-                                      applies to all containers in a pod. Some volume
-                                      types allow the Kubelet to change the ownership
-                                      of that volume to be owned by the pod: \n 1.
-                                      The owning GID will be the FSGroup 2. The setgid
-                                      bit is set (new files created in the volume
-                                      will be owned by FSGroup) 3. The permission
-                                      bits are OR'd with rw-rw---- \n If unset, the
-                                      Kubelet will not modify the ownership and permissions
-                                      of any volume. Note that this field cannot be
-                                      set when spec.os.name is windows."
+                                    description: |-
+                                      A special supplemental group that applies to all containers in a pod.
+                                      Some volume types allow the Kubelet to change the ownership of that volume
+                                      to be owned by the pod:
+
+
+                                      1. The owning GID will be the FSGroup
+                                      2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                                      3. The permission bits are OR'd with rw-rw----
+
+
+                                      If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     format: int64
                                     type: integer
                                   fsGroupChangePolicy:
-                                    description: 'fsGroupChangePolicy defines behavior
-                                      of changing ownership and permission of the
-                                      volume before being exposed inside Pod. This
-                                      field will only apply to volume types which
-                                      support fsGroup based ownership(and permissions).
-                                      It will have no effect on ephemeral volume types
-                                      such as: secret, configmaps and emptydir. Valid
-                                      values are "OnRootMismatch" and "Always". If
-                                      not specified, "Always" is used. Note that this
-                                      field cannot be set when spec.os.name is windows.'
+                                    description: |-
+                                      fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                                      before being exposed inside Pod. This field will only apply to
+                                      volume types which support fsGroup based ownership(and permissions).
+                                      It will have no effect on ephemeral volume types such as: secret, configmaps
+                                      and emptydir.
+                                      Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     type: string
                                   runAsGroup:
-                                    description: The GID to run the entrypoint of
-                                      the container process. Uses runtime default
-                                      if unset. May also be set in SecurityContext.  If
-                                      set in both SecurityContext and PodSecurityContext,
-                                      the value specified in SecurityContext takes
-                                      precedence for that container. Note that this
-                                      field cannot be set when spec.os.name is windows.
+                                    description: |-
+                                      The GID to run the entrypoint of the container process.
+                                      Uses runtime default if unset.
+                                      May also be set in SecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence
+                                      for that container.
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     format: int64
                                     type: integer
                                   runAsNonRoot:
-                                    description: Indicates that the container must
-                                      run as a non-root user. If true, the Kubelet
-                                      will validate the image at runtime to ensure
-                                      that it does not run as UID 0 (root) and fail
-                                      to start the container if it does. If unset
-                                      or false, no such validation will be performed.
-                                      May also be set in SecurityContext.  If set
-                                      in both SecurityContext and PodSecurityContext,
-                                      the value specified in SecurityContext takes
-                                      precedence.
+                                    description: |-
+                                      Indicates that the container must run as a non-root user.
+                                      If true, the Kubelet will validate the image at runtime to ensure that it
+                                      does not run as UID 0 (root) and fail to start the container if it does.
+                                      If unset or false, no such validation will be performed.
+                                      May also be set in SecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
                                     type: boolean
                                   runAsUser:
-                                    description: The UID to run the entrypoint of
-                                      the container process. Defaults to user specified
-                                      in image metadata if unspecified. May also be
-                                      set in SecurityContext.  If set in both SecurityContext
-                                      and PodSecurityContext, the value specified
-                                      in SecurityContext takes precedence for that
-                                      container. Note that this field cannot be set
-                                      when spec.os.name is windows.
+                                    description: |-
+                                      The UID to run the entrypoint of the container process.
+                                      Defaults to user specified in image metadata if unspecified.
+                                      May also be set in SecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence
+                                      for that container.
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     format: int64
                                     type: integer
                                   seLinuxOptions:
-                                    description: The SELinux context to be applied
-                                      to all containers. If unspecified, the container
-                                      runtime will allocate a random SELinux context
-                                      for each container.  May also be set in SecurityContext.  If
-                                      set in both SecurityContext and PodSecurityContext,
-                                      the value specified in SecurityContext takes
-                                      precedence for that container. Note that this
-                                      field cannot be set when spec.os.name is windows.
+                                    description: |-
+                                      The SELinux context to be applied to all containers.
+                                      If unspecified, the container runtime will allocate a random SELinux context for each
+                                      container.  May also be set in SecurityContext.  If set in
+                                      both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                                      takes precedence for that container.
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     properties:
                                       level:
                                         description: Level is SELinux level label
@@ -6387,55 +5846,49 @@ spec:
                                         type: string
                                     type: object
                                   seccompProfile:
-                                    description: The seccomp options to use by the
-                                      containers in this pod. Note that this field
-                                      cannot be set when spec.os.name is windows.
+                                    description: |-
+                                      The seccomp options to use by the containers in this pod.
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     properties:
                                       localhostProfile:
-                                        description: localhostProfile indicates a
-                                          profile defined in a file on the node should
-                                          be used. The profile must be preconfigured
-                                          on the node to work. Must be a descending
-                                          path, relative to the kubelet's configured
-                                          seccomp profile location. Must be set if
-                                          type is "Localhost". Must NOT be set for
-                                          any other type.
+                                        description: |-
+                                          localhostProfile indicates a profile defined in a file on the node should be used.
+                                          The profile must be preconfigured on the node to work.
+                                          Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                          Must be set if type is "Localhost". Must NOT be set for any other type.
                                         type: string
                                       type:
-                                        description: "type indicates which kind of
-                                          seccomp profile will be applied. Valid options
-                                          are: \n Localhost - a profile defined in
-                                          a file on the node should be used. RuntimeDefault
-                                          - the container runtime default profile
-                                          should be used. Unconfined - no profile
-                                          should be applied."
+                                        description: |-
+                                          type indicates which kind of seccomp profile will be applied.
+                                          Valid options are:
+
+
+                                          Localhost - a profile defined in a file on the node should be used.
+                                          RuntimeDefault - the container runtime default profile should be used.
+                                          Unconfined - no profile should be applied.
                                         type: string
                                     required:
                                     - type
                                     type: object
                                   supplementalGroups:
-                                    description: A list of groups applied to the first
-                                      process run in each container, in addition to
-                                      the container's primary GID, the fsGroup (if
-                                      specified), and group memberships defined in
-                                      the container image for the uid of the container
-                                      process. If unspecified, no additional groups
-                                      are added to any container. Note that group
-                                      memberships defined in the container image for
-                                      the uid of the container process are still effective,
+                                    description: |-
+                                      A list of groups applied to the first process run in each container, in addition
+                                      to the container's primary GID, the fsGroup (if specified), and group memberships
+                                      defined in the container image for the uid of the container process. If unspecified,
+                                      no additional groups are added to any container. Note that group memberships
+                                      defined in the container image for the uid of the container process are still effective,
                                       even if they are not included in this list.
-                                      Note that this field cannot be set when spec.os.name
-                                      is windows.
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     items:
                                       format: int64
                                       type: integer
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   sysctls:
-                                    description: Sysctls hold a list of namespaced
-                                      sysctls used for the pod. Pods with unsupported
-                                      sysctls (by the container runtime) might fail
-                                      to launch. Note that this field cannot be set
-                                      when spec.os.name is windows.
+                                    description: |-
+                                      Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                                      sysctls (by the container runtime) might fail to launch.
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     items:
                                       description: Sysctl defines a kernel parameter
                                         to be set
@@ -6451,159 +5904,136 @@ spec:
                                       - value
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   windowsOptions:
-                                    description: The Windows specific settings applied
-                                      to all containers. If unspecified, the options
-                                      within a container's SecurityContext will be
-                                      used. If set in both SecurityContext and PodSecurityContext,
-                                      the value specified in SecurityContext takes
-                                      precedence. Note that this field cannot be set
-                                      when spec.os.name is linux.
+                                    description: |-
+                                      The Windows specific settings applied to all containers.
+                                      If unspecified, the options within a container's SecurityContext will be used.
+                                      If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is linux.
                                     properties:
                                       gmsaCredentialSpec:
-                                        description: GMSACredentialSpec is where the
-                                          GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                          inlines the contents of the GMSA credential
-                                          spec named by the GMSACredentialSpecName
-                                          field.
+                                        description: |-
+                                          GMSACredentialSpec is where the GMSA admission webhook
+                                          (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                          GMSA credential spec named by the GMSACredentialSpecName field.
                                         type: string
                                       gmsaCredentialSpecName:
                                         description: GMSACredentialSpecName is the
                                           name of the GMSA credential spec to use.
                                         type: string
                                       hostProcess:
-                                        description: HostProcess determines if a container
-                                          should be run as a 'Host Process' container.
-                                          All of a Pod's containers must have the
-                                          same effective HostProcess value (it is
-                                          not allowed to have a mix of HostProcess
-                                          containers and non-HostProcess containers).
-                                          In addition, if HostProcess is true then
-                                          HostNetwork must also be set to true.
+                                        description: |-
+                                          HostProcess determines if a container should be run as a 'Host Process' container.
+                                          All of a Pod's containers must have the same effective HostProcess value
+                                          (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                          In addition, if HostProcess is true then HostNetwork must also be set to true.
                                         type: boolean
                                       runAsUserName:
-                                        description: The UserName in Windows to run
-                                          the entrypoint of the container process.
-                                          Defaults to the user specified in image
-                                          metadata if unspecified. May also be set
-                                          in PodSecurityContext. If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                        description: |-
+                                          The UserName in Windows to run the entrypoint of the container process.
+                                          Defaults to the user specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext. If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         type: string
                                     type: object
                                 type: object
                               serviceAccount:
-                                description: 'DeprecatedServiceAccount is a depreciated
-                                  alias for ServiceAccountName. Deprecated: Use serviceAccountName
-                                  instead.'
+                                description: |-
+                                  DeprecatedServiceAccount is a deprecated alias for ServiceAccountName.
+                                  Deprecated: Use serviceAccountName instead.
                                 type: string
                               serviceAccountName:
-                                description: 'ServiceAccountName is the name of the
-                                  ServiceAccount to use to run this pod. More info:
-                                  https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                                description: |-
+                                  ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                                  More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
                                 type: string
                               setHostnameAsFQDN:
-                                description: If true the pod's hostname will be configured
-                                  as the pod's FQDN, rather than the leaf name (the
-                                  default). In Linux containers, this means setting
-                                  the FQDN in the hostname field of the kernel (the
-                                  nodename field of struct utsname). In Windows containers,
-                                  this means setting the registry value of hostname
-                                  for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters
-                                  to FQDN. If a pod does not have FQDN, this has no
-                                  effect. Default to false.
+                                description: |-
+                                  If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default).
+                                  In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname).
+                                  In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters to FQDN.
+                                  If a pod does not have FQDN, this has no effect.
+                                  Default to false.
                                 type: boolean
                               shareProcessNamespace:
-                                description: 'Share a single process namespace between
-                                  all of the containers in a pod. When this is set
-                                  containers will be able to view and signal processes
-                                  from other containers in the same pod, and the first
-                                  process in each container will not be assigned PID
-                                  1. HostPID and ShareProcessNamespace cannot both
-                                  be set. Optional: Default to false.'
+                                description: |-
+                                  Share a single process namespace between all of the containers in a pod.
+                                  When this is set containers will be able to view and signal processes from other containers
+                                  in the same pod, and the first process in each container will not be assigned PID 1.
+                                  HostPID and ShareProcessNamespace cannot both be set.
+                                  Optional: Default to false.
                                 type: boolean
                               subdomain:
-                                description: If specified, the fully qualified Pod
-                                  hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
-                                  domain>". If not specified, the pod will not have
-                                  a domainname at all.
+                                description: |-
+                                  If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+                                  If not specified, the pod will not have a domainname at all.
                                 type: string
                               terminationGracePeriodSeconds:
-                                description: Optional duration in seconds the pod
-                                  needs to terminate gracefully. May be decreased
-                                  in delete request. Value must be non-negative integer.
-                                  The value zero indicates stop immediately via the
-                                  kill signal (no opportunity to shut down). If this
-                                  value is nil, the default grace period will be used
-                                  instead. The grace period is the duration in seconds
-                                  after the processes running in the pod are sent
-                                  a termination signal and the time when the processes
-                                  are forcibly halted with a kill signal. Set this
-                                  value longer than the expected cleanup time for
-                                  your process. Defaults to 30 seconds.
+                                description: |-
+                                  Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request.
+                                  Value must be non-negative integer. The value zero indicates stop immediately via
+                                  the kill signal (no opportunity to shut down).
+                                  If this value is nil, the default grace period will be used instead.
+                                  The grace period is the duration in seconds after the processes running in the pod are sent
+                                  a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                  Set this value longer than the expected cleanup time for your process.
+                                  Defaults to 30 seconds.
                                 format: int64
                                 type: integer
                               tolerations:
                                 description: If specified, the pod's tolerations.
                                 items:
-                                  description: The pod this Toleration is attached
-                                    to tolerates any taint that matches the triple
-                                    <key,value,effect> using the matching operator
-                                    <operator>.
+                                  description: |-
+                                    The pod this Toleration is attached to tolerates any taint that matches
+                                    the triple <key,value,effect> using the matching operator <operator>.
                                   properties:
                                     effect:
-                                      description: Effect indicates the taint effect
-                                        to match. Empty means match all taint effects.
-                                        When specified, allowed values are NoSchedule,
-                                        PreferNoSchedule and NoExecute.
+                                      description: |-
+                                        Effect indicates the taint effect to match. Empty means match all taint effects.
+                                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                                       type: string
                                     key:
-                                      description: Key is the taint key that the toleration
-                                        applies to. Empty means match all taint keys.
-                                        If the key is empty, operator must be Exists;
-                                        this combination means to match all values
-                                        and all keys.
+                                      description: |-
+                                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                                       type: string
                                     operator:
-                                      description: Operator represents a key's relationship
-                                        to the value. Valid operators are Exists and
-                                        Equal. Defaults to Equal. Exists is equivalent
-                                        to wildcard for value, so that a pod can tolerate
-                                        all taints of a particular category.
+                                      description: |-
+                                        Operator represents a key's relationship to the value.
+                                        Valid operators are Exists and Equal. Defaults to Equal.
+                                        Exists is equivalent to wildcard for value, so that a pod can
+                                        tolerate all taints of a particular category.
                                       type: string
                                     tolerationSeconds:
-                                      description: TolerationSeconds represents the
-                                        period of time the toleration (which must
-                                        be of effect NoExecute, otherwise this field
-                                        is ignored) tolerates the taint. By default,
-                                        it is not set, which means tolerate the taint
-                                        forever (do not evict). Zero and negative
-                                        values will be treated as 0 (evict immediately)
-                                        by the system.
+                                      description: |-
+                                        TolerationSeconds represents the period of time the toleration (which must be
+                                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                        it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                        negative values will be treated as 0 (evict immediately) by the system.
                                       format: int64
                                       type: integer
                                     value:
-                                      description: Value is the taint value the toleration
-                                        matches to. If the operator is Exists, the
-                                        value should be empty, otherwise just a regular
-                                        string.
+                                      description: |-
+                                        Value is the taint value the toleration matches to.
+                                        If the operator is Exists, the value should be empty, otherwise just a regular string.
                                       type: string
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                               topologySpreadConstraints:
-                                description: TopologySpreadConstraints describes how
-                                  a group of pods ought to spread across topology
-                                  domains. Scheduler will schedule pods in a way which
-                                  abides by the constraints. All topologySpreadConstraints
-                                  are ANDed.
+                                description: |-
+                                  TopologySpreadConstraints describes how a group of pods ought to spread across topology
+                                  domains. Scheduler will schedule pods in a way which abides by the constraints.
+                                  All topologySpreadConstraints are ANDed.
                                 items:
                                   description: TopologySpreadConstraint specifies
                                     how to spread matching pods among the given topology.
                                   properties:
                                     labelSelector:
-                                      description: LabelSelector is used to find matching
-                                        pods. Pods that match this label selector
-                                        are counted to determine the number of pods
+                                      description: |-
+                                        LabelSelector is used to find matching pods.
+                                        Pods that match this label selector are counted to determine the number of pods
                                         in their corresponding topology domain.
                                       properties:
                                         matchExpressions:
@@ -6611,193 +6041,158 @@ spec:
                                             of label selector requirements. The requirements
                                             are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
                                                 description: key is the label key
                                                   that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             required:
                                             - key
                                             - operator
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
-                                      description: "MatchLabelKeys is a set of pod
-                                        label keys to select the pods over which spreading
-                                        will be calculated. The keys are used to lookup
-                                        values from the incoming pod labels, those
-                                        key-value labels are ANDed with labelSelector
-                                        to select the group of existing pods over
-                                        which spreading will be calculated for the
-                                        incoming pod. The same key is forbidden to
-                                        exist in both MatchLabelKeys and LabelSelector.
-                                        MatchLabelKeys cannot be set when LabelSelector
-                                        isn't set. Keys that don't exist in the incoming
-                                        pod labels will be ignored. A null or empty
-                                        list means only match against labelSelector.
-                                        \n This is a beta field and requires the MatchLabelKeysInPodTopologySpread
-                                        feature gate to be enabled (enabled by default)."
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select the pods over which
+                                        spreading will be calculated. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are ANDed with labelSelector
+                                        to select the group of existing pods over which spreading will be calculated
+                                        for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                        MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                        Keys that don't exist in the incoming pod labels will
+                                        be ignored. A null or empty list means only match against labelSelector.
+
+
+                                        This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     maxSkew:
-                                      description: 'MaxSkew describes the degree to
-                                        which pods may be unevenly distributed. When
-                                        `whenUnsatisfiable=DoNotSchedule`, it is the
-                                        maximum permitted difference between the number
-                                        of matching pods in the target topology and
-                                        the global minimum. The global minimum is
-                                        the minimum number of matching pods in an
-                                        eligible domain or zero if the number of eligible
-                                        domains is less than MinDomains. For example,
-                                        in a 3-zone cluster, MaxSkew is set to 1,
-                                        and pods with the same labelSelector spread
-                                        as 2/2/1: In this case, the global minimum
-                                        is 1. | zone1 | zone2 | zone3 | |  P P  |  P
-                                        P  |   P   | - if MaxSkew is 1, incoming pod
-                                        can only be scheduled to zone3 to become 2/2/2;
-                                        scheduling it onto zone1(zone2) would make
-                                        the ActualSkew(3-1) on zone1(zone2) violate
-                                        MaxSkew(1). - if MaxSkew is 2, incoming pod
-                                        can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
-                                        it is used to give higher precedence to topologies
-                                        that satisfy it. It''s a required field. Default
-                                        value is 1 and 0 is not allowed.'
+                                      description: |-
+                                        MaxSkew describes the degree to which pods may be unevenly distributed.
+                                        When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                                        between the number of matching pods in the target topology and the global minimum.
+                                        The global minimum is the minimum number of matching pods in an eligible domain
+                                        or zero if the number of eligible domains is less than MinDomains.
+                                        For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                        labelSelector spread as 2/2/1:
+                                        In this case, the global minimum is 1.
+                                        | zone1 | zone2 | zone3 |
+                                        |  P P  |  P P  |   P   |
+                                        - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                                        scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                                        violate MaxSkew(1).
+                                        - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                                        When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                                        to topologies that satisfy it.
+                                        It's a required field. Default value is 1 and 0 is not allowed.
                                       format: int32
                                       type: integer
                                     minDomains:
-                                      description: "MinDomains indicates a minimum
-                                        number of eligible domains. When the number
-                                        of eligible domains with matching topology
-                                        keys is less than minDomains, Pod Topology
-                                        Spread treats \"global minimum\" as 0, and
-                                        then the calculation of Skew is performed.
-                                        And when the number of eligible domains with
-                                        matching topology keys equals or greater than
-                                        minDomains, this value has no effect on scheduling.
-                                        As a result, when the number of eligible domains
-                                        is less than minDomains, scheduler won't schedule
-                                        more than maxSkew Pods to those domains. If
-                                        value is nil, the constraint behaves as if
-                                        MinDomains is equal to 1. Valid values are
-                                        integers greater than 0. When value is not
-                                        nil, WhenUnsatisfiable must be DoNotSchedule.
-                                        \n For example, in a 3-zone cluster, MaxSkew
-                                        is set to 2, MinDomains is set to 5 and pods
-                                        with the same labelSelector spread as 2/2/2:
-                                        | zone1 | zone2 | zone3 | |  P P  |  P P  |
-                                        \ P P  | The number of domains is less than
-                                        5(MinDomains), so \"global minimum\" is treated
-                                        as 0. In this situation, new pod with the
-                                        same labelSelector cannot be scheduled, because
-                                        computed skew will be 3(3 - 0) if new Pod
-                                        is scheduled to any of the three zones, it
-                                        will violate MaxSkew. \n This is a beta field
-                                        and requires the MinDomainsInPodTopologySpread
-                                        feature gate to be enabled (enabled by default)."
+                                      description: |-
+                                        MinDomains indicates a minimum number of eligible domains.
+                                        When the number of eligible domains with matching topology keys is less than minDomains,
+                                        Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                                        And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                                        this value has no effect on scheduling.
+                                        As a result, when the number of eligible domains is less than minDomains,
+                                        scheduler won't schedule more than maxSkew Pods to those domains.
+                                        If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                                        Valid values are integers greater than 0.
+                                        When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+
+                                        For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                                        labelSelector spread as 2/2/2:
+                                        | zone1 | zone2 | zone3 |
+                                        |  P P  |  P P  |  P P  |
+                                        The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                                        In this situation, new pod with the same labelSelector cannot be scheduled,
+                                        because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                                        it will violate MaxSkew.
                                       format: int32
                                       type: integer
                                     nodeAffinityPolicy:
-                                      description: "NodeAffinityPolicy indicates how
-                                        we will treat Pod's nodeAffinity/nodeSelector
-                                        when calculating pod topology spread skew.
-                                        Options are: - Honor: only nodes matching
-                                        nodeAffinity/nodeSelector are included in
-                                        the calculations. - Ignore: nodeAffinity/nodeSelector
-                                        are ignored. All nodes are included in the
-                                        calculations. \n If this value is nil, the
-                                        behavior is equivalent to the Honor policy.
-                                        This is a beta-level feature default enabled
-                                        by the NodeInclusionPolicyInPodTopologySpread
-                                        feature flag."
+                                      description: |-
+                                        NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                                        when calculating pod topology spread skew. Options are:
+                                        - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                                        - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+
+                                        If this value is nil, the behavior is equivalent to the Honor policy.
+                                        This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                                       type: string
                                     nodeTaintsPolicy:
-                                      description: "NodeTaintsPolicy indicates how
-                                        we will treat node taints when calculating
-                                        pod topology spread skew. Options are: - Honor:
-                                        nodes without taints, along with tainted nodes
-                                        for which the incoming pod has a toleration,
-                                        are included. - Ignore: node taints are ignored.
-                                        All nodes are included. \n If this value is
-                                        nil, the behavior is equivalent to the Ignore
-                                        policy. This is a beta-level feature default
-                                        enabled by the NodeInclusionPolicyInPodTopologySpread
-                                        feature flag."
+                                      description: |-
+                                        NodeTaintsPolicy indicates how we will treat node taints when calculating
+                                        pod topology spread skew. Options are:
+                                        - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                                        has a toleration, are included.
+                                        - Ignore: node taints are ignored. All nodes are included.
+
+
+                                        If this value is nil, the behavior is equivalent to the Ignore policy.
+                                        This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                                       type: string
                                     topologyKey:
-                                      description: TopologyKey is the key of node
-                                        labels. Nodes that have a label with this
-                                        key and identical values are considered to
-                                        be in the same topology. We consider each
-                                        <key, value> as a "bucket", and try to put
-                                        balanced number of pods into each bucket.
-                                        We define a domain as a particular instance
-                                        of a topology. Also, we define an eligible
-                                        domain as a domain whose nodes meet the requirements
-                                        of nodeAffinityPolicy and nodeTaintsPolicy.
-                                        e.g. If TopologyKey is "kubernetes.io/hostname",
-                                        each Node is a domain of that topology. And,
-                                        if TopologyKey is "topology.kubernetes.io/zone",
-                                        each zone is a domain of that topology. It's
-                                        a required field.
+                                      description: |-
+                                        TopologyKey is the key of node labels. Nodes that have a label with this key
+                                        and identical values are considered to be in the same topology.
+                                        We consider each <key, value> as a "bucket", and try to put balanced number
+                                        of pods into each bucket.
+                                        We define a domain as a particular instance of a topology.
+                                        Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                                        nodeAffinityPolicy and nodeTaintsPolicy.
+                                        e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                                        And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                                        It's a required field.
                                       type: string
                                     whenUnsatisfiable:
-                                      description: 'WhenUnsatisfiable indicates how
-                                        to deal with a pod if it doesn''t satisfy
-                                        the spread constraint. - DoNotSchedule (default)
-                                        tells the scheduler not to schedule it. -
-                                        ScheduleAnyway tells the scheduler to schedule
-                                        the pod in any location, but giving higher
-                                        precedence to topologies that would help reduce
-                                        the skew. A constraint is considered "Unsatisfiable"
-                                        for an incoming pod if and only if every possible
-                                        node assignment for that pod would violate
-                                        "MaxSkew" on some topology. For example, in
-                                        a 3-zone cluster, MaxSkew is set to 1, and
-                                        pods with the same labelSelector spread as
-                                        3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   |
-                                        If WhenUnsatisfiable is set to DoNotSchedule,
-                                        incoming pod can only be scheduled to zone2(zone3)
-                                        to become 3/2/1(3/1/2) as ActualSkew(2-1)
-                                        on zone2(zone3) satisfies MaxSkew(1). In other
-                                        words, the cluster can still be imbalanced,
-                                        but scheduler won''t make it *more* imbalanced.
-                                        It''s a required field.'
+                                      description: |-
+                                        WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                                        the spread constraint.
+                                        - DoNotSchedule (default) tells the scheduler not to schedule it.
+                                        - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                          but giving higher precedence to topologies that would help reduce the
+                                          skew.
+                                        A constraint is considered "Unsatisfiable" for an incoming pod
+                                        if and only if every possible node assignment for that pod would violate
+                                        "MaxSkew" on some topology.
+                                        For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                        labelSelector spread as 3/1/1:
+                                        | zone1 | zone2 | zone3 |
+                                        | P P P |   P   |   P   |
+                                        If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                                        to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                                        MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                                        won't make it *more* imbalanced.
+                                        It's a required field.
                                       type: string
                                   required:
                                   - maxSkew
@@ -6810,49 +6205,45 @@ spec:
                                 - whenUnsatisfiable
                                 x-kubernetes-list-type: map
                               volumes:
-                                description: 'List of volumes that can be mounted
-                                  by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                                description: |-
+                                  List of volumes that can be mounted by containers belonging to the pod.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes
                                 items:
                                   description: Volume represents a named volume in
                                     a pod that may be accessed by any container in
                                     the pod.
                                   properties:
                                     awsElasticBlockStore:
-                                      description: 'awsElasticBlockStore represents
-                                        an AWS Disk resource that is attached to a
-                                        kubelet''s host machine and then exposed to
-                                        the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                      description: |-
+                                        awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                                        kubelet's host machine and then exposed to the pod.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                       properties:
                                         fsType:
-                                          description: 'fsType is the filesystem type
-                                            of the volume that you want to mount.
-                                            Tip: Ensure that the filesystem type is
-                                            supported by the host operating system.
-                                            Examples: "ext4", "xfs", "ntfs". Implicitly
-                                            inferred to be "ext4" if unspecified.
+                                          description: |-
+                                            fsType is the filesystem type of the volume that you want to mount.
+                                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                             More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                            TODO: how do we prevent errors in the
-                                            filesystem from compromising the machine'
+                                            TODO: how do we prevent errors in the filesystem from compromising the machine
                                           type: string
                                         partition:
-                                          description: 'partition is the partition
-                                            in the volume that you want to mount.
-                                            If omitted, the default is to mount by
-                                            volume name. Examples: For volume /dev/sda1,
-                                            you specify the partition as "1". Similarly,
-                                            the volume partition for /dev/sda is "0"
-                                            (or you can leave the property empty).'
+                                          description: |-
+                                            partition is the partition in the volume that you want to mount.
+                                            If omitted, the default is to mount by volume name.
+                                            Examples: For volume /dev/sda1, you specify the partition as "1".
+                                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                           format: int32
                                           type: integer
                                         readOnly:
-                                          description: 'readOnly value true will force
-                                            the readOnly setting in VolumeMounts.
-                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                          description: |-
+                                            readOnly value true will force the readOnly setting in VolumeMounts.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                           type: boolean
                                         volumeID:
-                                          description: 'volumeID is unique ID of the
-                                            persistent disk resource in AWS (Amazon
-                                            EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                          description: |-
+                                            volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                           type: string
                                       required:
                                       - volumeID
@@ -6875,11 +6266,10 @@ spec:
                                             disk in the blob storage
                                           type: string
                                         fsType:
-                                          description: fsType is Filesystem type to
-                                            mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified.
+                                          description: |-
+                                            fsType is Filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                           type: string
                                         kind:
                                           description: 'kind expected values are Shared:
@@ -6889,8 +6279,8 @@ spec:
                                             availability set). defaults to shared'
                                           type: string
                                         readOnly:
-                                          description: readOnly Defaults to false
-                                            (read/write). ReadOnly here will force
+                                          description: |-
+                                            readOnly Defaults to false (read/write). ReadOnly here will force
                                             the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                       required:
@@ -6903,8 +6293,8 @@ spec:
                                         the pod.
                                       properties:
                                         readOnly:
-                                          description: readOnly defaults to false
-                                            (read/write). ReadOnly here will force
+                                          description: |-
+                                            readOnly defaults to false (read/write). ReadOnly here will force
                                             the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                         secretName:
@@ -6925,85 +6315,95 @@ spec:
                                         on the host that shares a pod's lifetime
                                       properties:
                                         monitors:
-                                          description: 'monitors is Required: Monitors
-                                            is a collection of Ceph monitors More
-                                            info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          description: |-
+                                            monitors is Required: Monitors is a collection of Ceph monitors
+                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         path:
                                           description: 'path is Optional: Used as
                                             the mounted root, rather than the full
                                             Ceph tree, default is /'
                                           type: string
                                         readOnly:
-                                          description: 'readOnly is Optional: Defaults
-                                            to false (read/write). ReadOnly here will
-                                            force the ReadOnly setting in VolumeMounts.
-                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          description: |-
+                                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                           type: boolean
                                         secretFile:
-                                          description: 'secretFile is Optional: SecretFile
-                                            is the path to key ring for User, default
-                                            is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          description: |-
+                                            secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                           type: string
                                         secretRef:
-                                          description: 'secretRef is Optional: SecretRef
-                                            is reference to the authentication secret
-                                            for User, default is empty. More info:
-                                            https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          description: |-
+                                            secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         user:
-                                          description: 'user is optional: User is
-                                            the rados user name, default is admin
-                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          description: |-
+                                            user is optional: User is the rados user name, default is admin
+                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                           type: string
                                       required:
                                       - monitors
                                       type: object
                                     cinder:
-                                      description: 'cinder represents a cinder volume
-                                        attached and mounted on kubelets host machine.
-                                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                      description: |-
+                                        cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                       properties:
                                         fsType:
-                                          description: 'fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Examples:
-                                            "ext4", "xfs", "ntfs". Implicitly inferred
-                                            to be "ext4" if unspecified. More info:
-                                            https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                          description: |-
+                                            fsType is the filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                           type: string
                                         readOnly:
-                                          description: 'readOnly defaults to false
-                                            (read/write). ReadOnly here will force
+                                          description: |-
+                                            readOnly defaults to false (read/write). ReadOnly here will force
                                             the ReadOnly setting in VolumeMounts.
-                                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                           type: boolean
                                         secretRef:
-                                          description: 'secretRef is optional: points
-                                            to a secret object containing parameters
-                                            used to connect to OpenStack.'
+                                          description: |-
+                                            secretRef is optional: points to a secret object containing parameters used to connect
+                                            to OpenStack.
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         volumeID:
-                                          description: 'volumeID used to identify
-                                            the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                          description: |-
+                                            volumeID used to identify the volume in cinder.
+                                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                           type: string
                                       required:
                                       - volumeID
@@ -7013,34 +6413,25 @@ spec:
                                         that should populate this volume
                                       properties:
                                         defaultMode:
-                                          description: 'defaultMode is optional: mode
-                                            bits used to set permissions on created
-                                            files by default. Must be an octal value
-                                            between 0000 and 0777 or a decimal value
-                                            between 0 and 511. YAML accepts both octal
-                                            and decimal values, JSON requires decimal
-                                            values for mode bits. Defaults to 0644.
-                                            Directories within the path are not affected
-                                            by this setting. This might be in conflict
-                                            with other options that affect the file
-                                            mode, like fsGroup, and the result can
-                                            be other mode bits set.'
+                                          description: |-
+                                            defaultMode is optional: mode bits used to set permissions on created files by default.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            Defaults to 0644.
+                                            Directories within the path are not affected by this setting.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         items:
-                                          description: items if unspecified, each
-                                            key-value pair in the Data field of the
-                                            referenced ConfigMap will be projected
-                                            into the volume as a file whose name is
-                                            the key and content is the value. If specified,
-                                            the listed keys will be projected into
-                                            the specified paths, and unlisted keys
-                                            will not be present. If a key is specified
-                                            which is not present in the ConfigMap,
-                                            the volume setup will error unless it
-                                            is marked optional. Paths must be relative
-                                            and may not contain the '..' path or start
-                                            with '..'.
+                                          description: |-
+                                            items if unspecified, each key-value pair in the Data field of the referenced
+                                            ConfigMap will be projected into the volume as a file whose name is the
+                                            key and content is the value. If specified, the listed keys will be
+                                            projected into the specified paths, and unlisted keys will not be
+                                            present. If a key is specified which is not present in the ConfigMap,
+                                            the volume setup will error unless it is marked optional. Paths must be
+                                            relative and may not contain the '..' path or start with '..'.
                                           items:
                                             description: Maps a string key to a path
                                               within a volume.
@@ -7049,39 +6440,26 @@ spec:
                                                 description: key is the key to project.
                                                 type: string
                                               mode:
-                                                description: 'mode is Optional: mode
-                                                  bits used to set permissions on
-                                                  this file. Must be an octal value
-                                                  between 0000 and 0777 or a decimal
-                                                  value between 0 and 511. YAML accepts
-                                                  both octal and decimal values, JSON
-                                                  requires decimal values for mode
-                                                  bits. If not specified, the volume
-                                                  defaultMode will be used. This might
-                                                  be in conflict with other options
-                                                  that affect the file mode, like
-                                                  fsGroup, and the result can be other
-                                                  mode bits set.'
                                                 format: int32
                                                 type: integer
                                               path:
-                                                description: path is the relative
-                                                  path of the file to map the key
-                                                  to. May not be an absolute path.
-                                                  May not contain the path element
-                                                  '..'. May not start with the string
-                                                  '..'.
                                                 type: string
                                             required:
                                             - key
                                             - path
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            TODO: Add other useful fields. apiVersion, kind, uid?
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                           type: string
                                         optional:
                                           description: optional specify whether the
@@ -7095,49 +6473,48 @@ spec:
                                         by certain external CSI drivers (Beta feature).
                                       properties:
                                         driver:
-                                          description: driver is the name of the CSI
-                                            driver that handles this volume. Consult
-                                            with your admin for the correct name as
-                                            registered in the cluster.
+                                          description: |-
+                                            driver is the name of the CSI driver that handles this volume.
+                                            Consult with your admin for the correct name as registered in the cluster.
                                           type: string
                                         fsType:
-                                          description: fsType to mount. Ex. "ext4",
-                                            "xfs", "ntfs". If not provided, the empty
-                                            value is passed to the associated CSI
-                                            driver which will determine the default
-                                            filesystem to apply.
+                                          description: |-
+                                            fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                            If not provided, the empty value is passed to the associated CSI driver
+                                            which will determine the default filesystem to apply.
                                           type: string
                                         nodePublishSecretRef:
-                                          description: nodePublishSecretRef is a reference
-                                            to the secret object containing sensitive
-                                            information to pass to the CSI driver
-                                            to complete the CSI NodePublishVolume
-                                            and NodeUnpublishVolume calls. This field
-                                            is optional, and  may be empty if no secret
-                                            is required. If the secret object contains
-                                            more than one secret, all secret references
-                                            are passed.
+                                          description: |-
+                                            nodePublishSecretRef is a reference to the secret object containing
+                                            sensitive information to pass to the CSI driver to complete the CSI
+                                            NodePublishVolume and NodeUnpublishVolume calls.
+                                            This field is optional, and  may be empty if no secret is required. If the
+                                            secret object contains more than one secret, all secret references are passed.
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         readOnly:
-                                          description: readOnly specifies a read-only
-                                            configuration for the volume. Defaults
-                                            to false (read/write).
+                                          description: |-
+                                            readOnly specifies a read-only configuration for the volume.
+                                            Defaults to false (read/write).
                                           type: boolean
                                         volumeAttributes:
                                           additionalProperties:
                                             type: string
-                                          description: volumeAttributes stores driver-specific
-                                            properties that are passed to the CSI
-                                            driver. Consult your driver's documentation
-                                            for supported values.
+                                          description: |-
+                                            volumeAttributes stores driver-specific properties that are passed to the CSI
+                                            driver. Consult your driver's documentation for supported values.
                                           type: object
                                       required:
                                       - driver
@@ -7148,20 +6525,15 @@ spec:
                                         volume
                                       properties:
                                         defaultMode:
-                                          description: 'Optional: mode bits to use
-                                            on created files by default. Must be a
-                                            Optional: mode bits used to set permissions
-                                            on created files by default. Must be an
-                                            octal value between 0000 and 0777 or a
-                                            decimal value between 0 and 511. YAML
-                                            accepts both octal and decimal values,
-                                            JSON requires decimal values for mode
-                                            bits. Defaults to 0644. Directories within
-                                            the path are not affected by this setting.
-                                            This might be in conflict with other options
-                                            that affect the file mode, like fsGroup,
-                                            and the result can be other mode bits
-                                            set.'
+                                          description: |-
+                                            Optional: mode bits to use on created files by default. Must be a
+                                            Optional: mode bits used to set permissions on created files by default.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            Defaults to 0644.
+                                            Directories within the path are not affected by this setting.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         items:
@@ -7175,71 +6547,33 @@ spec:
                                               fieldRef:
                                                 description: 'Required: Selects a
                                                   field of the pod: only annotations,
-                                                  labels, name and namespace are supported.'
+                                                  labels, name, namespace and uid
+                                                  are supported.'
                                                 properties:
                                                   apiVersion:
-                                                    description: Version of the schema
-                                                      the FieldPath is written in
-                                                      terms of, defaults to "v1".
                                                     type: string
                                                   fieldPath:
-                                                    description: Path of the field
-                                                      to select in the specified API
-                                                      version.
                                                     type: string
                                                 required:
                                                 - fieldPath
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               mode:
-                                                description: 'Optional: mode bits
-                                                  used to set permissions on this
-                                                  file, must be an octal value between
-                                                  0000 and 0777 or a decimal value
-                                                  between 0 and 511. YAML accepts
-                                                  both octal and decimal values, JSON
-                                                  requires decimal values for mode
-                                                  bits. If not specified, the volume
-                                                  defaultMode will be used. This might
-                                                  be in conflict with other options
-                                                  that affect the file mode, like
-                                                  fsGroup, and the result can be other
-                                                  mode bits set.'
                                                 format: int32
                                                 type: integer
                                               path:
-                                                description: 'Required: Path is  the
-                                                  relative path name of the file to
-                                                  be created. Must not be absolute
-                                                  or contain the ''..'' path. Must
-                                                  be utf-8 encoded. The first item
-                                                  of the relative path must not start
-                                                  with ''..'''
                                                 type: string
                                               resourceFieldRef:
-                                                description: 'Selects a resource of
-                                                  the container: only resources limits
-                                                  and requests (limits.cpu, limits.memory,
-                                                  requests.cpu and requests.memory)
-                                                  are currently supported.'
                                                 properties:
                                                   containerName:
-                                                    description: 'Container name:
-                                                      required for volumes, optional
-                                                      for env vars'
                                                     type: string
                                                   divisor:
                                                     anyOf:
                                                     - type: integer
                                                     - type: string
-                                                    description: Specifies the output
-                                                      format of the exposed resources,
-                                                      defaults to "1"
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
                                                   resource:
-                                                    description: 'Required: resource
-                                                      to select'
                                                     type: string
                                                 required:
                                                 - resource
@@ -7249,131 +6583,111 @@ spec:
                                             - path
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                     emptyDir:
-                                      description: 'emptyDir represents a temporary
-                                        directory that shares a pod''s lifetime. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                      description: |-
+                                        emptyDir represents a temporary directory that shares a pod's lifetime.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                       properties:
                                         medium:
-                                          description: 'medium represents what type
-                                            of storage medium should back this directory.
-                                            The default is "" which means to use the
-                                            node''s default medium. Must be an empty
-                                            string (default) or Memory. More info:
-                                            https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                          description: |-
+                                            medium represents what type of storage medium should back this directory.
+                                            The default is "" which means to use the node's default medium.
+                                            Must be an empty string (default) or Memory.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                           type: string
                                         sizeLimit:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: 'sizeLimit is the total amount
-                                            of local storage required for this EmptyDir
-                                            volume. The size limit is also applicable
-                                            for memory medium. The maximum usage on
-                                            memory medium EmptyDir would be the minimum
-                                            value between the SizeLimit specified
-                                            here and the sum of memory limits of all
-                                            containers in a pod. The default is nil
-                                            which means that the limit is undefined.
-                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                          description: |-
+                                            sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                            The size limit is also applicable for memory medium.
+                                            The maximum usage on memory medium EmptyDir would be the minimum value between
+                                            the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                            The default is nil which means that the limit is undefined.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     ephemeral:
-                                      description: "ephemeral represents a volume
-                                        that is handled by a cluster storage driver.
-                                        The volume's lifecycle is tied to the pod
-                                        that defines it - it will be created before
-                                        the pod starts, and deleted when the pod is
-                                        removed. \n Use this if: a) the volume is
-                                        only needed while the pod runs, b) features
-                                        of normal volumes like restoring from snapshot
-                                        or capacity tracking are needed, c) the storage
-                                        driver is specified through a storage class,
-                                        and d) the storage driver supports dynamic
-                                        volume provisioning through a PersistentVolumeClaim
-                                        (see EphemeralVolumeSource for more information
-                                        on the connection between this volume type
-                                        and PersistentVolumeClaim). \n Use PersistentVolumeClaim
-                                        or one of the vendor-specific APIs for volumes
-                                        that persist for longer than the lifecycle
-                                        of an individual pod. \n Use CSI for light-weight
-                                        local ephemeral volumes if the CSI driver
-                                        is meant to be used that way - see the documentation
-                                        of the driver for more information. \n A pod
-                                        can use both types of ephemeral volumes and
-                                        persistent volumes at the same time."
+                                      description: |-
+                                        ephemeral represents a volume that is handled by a cluster storage driver.
+                                        The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                                        and deleted when the pod is removed.
+
+
+                                        Use this if:
+                                        a) the volume is only needed while the pod runs,
+                                        b) features of normal volumes like restoring from snapshot or capacity
+                                           tracking are needed,
+                                        c) the storage driver is specified through a storage class, and
+                                        d) the storage driver supports dynamic volume provisioning through
+                                           a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                           information on the connection between this volume type
+                                           and PersistentVolumeClaim).
+
+
+                                        Use PersistentVolumeClaim or one of the vendor-specific
+                                        APIs for volumes that persist for longer than the lifecycle
+                                        of an individual pod.
+
+
+                                        Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                                        be used that way - see the documentation of the driver for
+                                        more information.
+
+
+                                        A pod can use both types of ephemeral volumes and
+                                        persistent volumes at the same time.
                                       properties:
                                         volumeClaimTemplate:
-                                          description: "Will be used to create a stand-alone
-                                            PVC to provision the volume. The pod in
-                                            which this EphemeralVolumeSource is embedded
-                                            will be the owner of the PVC, i.e. the
-                                            PVC will be deleted together with the
-                                            pod.  The name of the PVC will be `<pod
-                                            name>-<volume name>` where `<volume name>`
-                                            is the name from the `PodSpec.Volumes`
-                                            array entry. Pod validation will reject
-                                            the pod if the concatenated name is not
-                                            valid for a PVC (for example, too long).
-                                            \n An existing PVC with that name that
-                                            is not owned by the pod will *not* be
-                                            used for the pod to avoid using an unrelated
-                                            volume by mistake. Starting the pod is
-                                            then blocked until the unrelated PVC is
-                                            removed. If such a pre-created PVC is
-                                            meant to be used by the pod, the PVC has
-                                            to updated with an owner reference to
-                                            the pod once the pod exists. Normally
-                                            this should not be necessary, but it may
-                                            be useful when manually reconstructing
-                                            a broken cluster. \n This field is read-only
-                                            and no changes will be made by Kubernetes
+                                          description: |-
+                                            Will be used to create a stand-alone PVC to provision the volume.
+                                            The pod in which this EphemeralVolumeSource is embedded will be the
+                                            owner of the PVC, i.e. the PVC will be deleted together with the
+                                            pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                            `<volume name>` is the name from the `PodSpec.Volumes` array
+                                            entry. Pod validation will reject the pod if the concatenated name
+                                            is not valid for a PVC (for example, too long).
+
+
+                                            An existing PVC with that name that is not owned by the pod
+                                            will *not* be used for the pod to avoid using an unrelated
+                                            volume by mistake. Starting the pod is then blocked until
+                                            the unrelated PVC is removed. If such a pre-created PVC is
+                                            meant to be used by the pod, the PVC has to updated with an
+                                            owner reference to the pod once the pod exists. Normally
+                                            this should not be necessary, but it may be useful when
+                                            manually reconstructing a broken cluster.
+
+
+                                            This field is read-only and no changes will be made by Kubernetes
                                             to the PVC after it has been created.
-                                            \n Required, must not be nil."
+
+
+                                            Required, must not be nil.
                                           properties:
                                             metadata:
-                                              description: May contain labels and
-                                                annotations that will be copied into
-                                                the PVC when creating it. No other
-                                                fields are allowed and will be rejected
-                                                during validation.
+                                              description: |-
+                                                May contain labels and annotations that will be copied into the PVC
+                                                when creating it. No other fields are allowed and will be rejected during
+                                                validation.
                                               type: object
                                             spec:
-                                              description: The specification for the
-                                                PersistentVolumeClaim. The entire
-                                                content is copied unchanged into the
-                                                PVC that gets created from this template.
-                                                The same fields as in a PersistentVolumeClaim
+                                              description: |-
+                                                The specification for the PersistentVolumeClaim. The entire content is
+                                                copied unchanged into the PVC that gets created from this
+                                                template. The same fields as in a PersistentVolumeClaim
                                                 are also valid here.
                                               properties:
                                                 accessModes:
-                                                  description: 'accessModes contains
-                                                    the desired access modes the volume
-                                                    should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                                   items:
                                                     type: string
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 dataSource:
-                                                  description: 'dataSource field can
-                                                    be used to specify either: * An
-                                                    existing VolumeSnapshot object
-                                                    (snapshot.storage.k8s.io/VolumeSnapshot)
-                                                    * An existing PVC (PersistentVolumeClaim)
-                                                    If the provisioner or an external
-                                                    controller can support the specified
-                                                    data source, it will create a
-                                                    new volume based on the contents
-                                                    of the specified data source.
-                                                    When the AnyVolumeDataSource feature
-                                                    gate is enabled, dataSource contents
-                                                    will be copied to dataSourceRef,
-                                                    and dataSourceRef contents will
-                                                    be copied to dataSource when dataSourceRef.namespace
-                                                    is not specified. If the namespace
-                                                    is specified, then dataSourceRef
-                                                    will not be copied to dataSource.'
                                                   properties:
                                                     apiGroup:
                                                       type: string
@@ -7387,50 +6701,6 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 dataSourceRef:
-                                                  description: 'dataSourceRef specifies
-                                                    the object from which to populate
-                                                    the volume with data, if a non-empty
-                                                    volume is desired. This may be
-                                                    any object from a non-empty API
-                                                    group (non core object) or a PersistentVolumeClaim
-                                                    object. When this field is specified,
-                                                    volume binding will only succeed
-                                                    if the type of the specified object
-                                                    matches some installed volume
-                                                    populator or dynamic provisioner.
-                                                    This field will replace the functionality
-                                                    of the dataSource field and as
-                                                    such if both fields are non-empty,
-                                                    they must have the same value.
-                                                    For backwards compatibility, when
-                                                    namespace isn''t specified in
-                                                    dataSourceRef, both fields (dataSource
-                                                    and dataSourceRef) will be set
-                                                    to the same value automatically
-                                                    if one of them is empty and the
-                                                    other is non-empty. When namespace
-                                                    is specified in dataSourceRef,
-                                                    dataSource isn''t set to the same
-                                                    value and must be empty. There
-                                                    are three important differences
-                                                    between dataSource and dataSourceRef:
-                                                    * While dataSource only allows
-                                                    two specific types of objects,
-                                                    dataSourceRef allows any non-core
-                                                    object, as well as PersistentVolumeClaim
-                                                    objects. * While dataSource ignores
-                                                    disallowed values (dropping them),
-                                                    dataSourceRef preserves all values,
-                                                    and generates an error if a disallowed
-                                                    value is specified. * While dataSource
-                                                    only allows local objects, dataSourceRef
-                                                    allows objects in any namespaces.
-                                                    (Beta) Using this field requires
-                                                    the AnyVolumeDataSource feature
-                                                    gate to be enabled. (Alpha) Using
-                                                    the namespace field of dataSourceRef
-                                                    requires the CrossNamespaceVolumeDataSource
-                                                    feature gate to be enabled.'
                                                   properties:
                                                     apiGroup:
                                                       type: string
@@ -7445,29 +6715,7 @@ spec:
                                                   - name
                                                   type: object
                                                 resources:
-                                                  description: 'resources represents
-                                                    the minimum resources the volume
-                                                    should have. If RecoverVolumeExpansionFailure
-                                                    feature is enabled users are allowed
-                                                    to specify resource requirements
-                                                    that are lower than previous value
-                                                    but must still be higher than
-                                                    capacity recorded in the status
-                                                    field of the claim. More info:
-                                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                                   properties:
-                                                    claims:
-                                                      items:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                        required:
-                                                        - name
-                                                        type: object
-                                                      type: array
-                                                      x-kubernetes-list-map-keys:
-                                                      - name
-                                                      x-kubernetes-list-type: map
                                                     limits:
                                                       additionalProperties:
                                                         anyOf:
@@ -7486,9 +6734,6 @@ spec:
                                                       type: object
                                                   type: object
                                                 selector:
-                                                  description: selector is a label
-                                                    query over volumes to consider
-                                                    for binding.
                                                   properties:
                                                     matchExpressions:
                                                       items:
@@ -7501,11 +6746,13 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         required:
                                                         - key
                                                         - operator
                                                         type: object
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                     matchLabels:
                                                       additionalProperties:
                                                         type: string
@@ -7513,21 +6760,12 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 storageClassName:
-                                                  description: 'storageClassName is
-                                                    the name of the StorageClass required
-                                                    by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                  type: string
+                                                volumeAttributesClassName:
                                                   type: string
                                                 volumeMode:
-                                                  description: volumeMode defines
-                                                    what type of volume is required
-                                                    by the claim. Value of Filesystem
-                                                    is implied when not included in
-                                                    claim spec.
                                                   type: string
                                                 volumeName:
-                                                  description: volumeName is the binding
-                                                    reference to the PersistentVolume
-                                                    backing this claim.
                                                   type: string
                                               type: object
                                           required:
@@ -7540,13 +6778,11 @@ spec:
                                         and then exposed to the pod.
                                       properties:
                                         fsType:
-                                          description: 'fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified. TODO: how do
-                                            we prevent errors in the filesystem from
-                                            compromising the machine'
+                                          description: |-
+                                            fsType is the filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                            TODO: how do we prevent errors in the filesystem from compromising the machine
                                           type: string
                                         lun:
                                           description: 'lun is Optional: FC target
@@ -7554,9 +6790,9 @@ spec:
                                           format: int32
                                           type: integer
                                         readOnly:
-                                          description: 'readOnly is Optional: Defaults
-                                            to false (read/write). ReadOnly here will
-                                            force the ReadOnly setting in VolumeMounts.'
+                                          description: |-
+                                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                         targetWWNs:
                                           description: 'targetWWNs is Optional: FC
@@ -7564,30 +6800,30 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         wwids:
-                                          description: 'wwids Optional: FC volume
-                                            world wide identifiers (wwids) Either
-                                            wwids or combination of targetWWNs and
-                                            lun must be set, but not both simultaneously.'
+                                          description: |-
+                                            wwids Optional: FC volume world wide identifiers (wwids)
+                                            Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                     flexVolume:
-                                      description: flexVolume represents a generic
-                                        volume resource that is provisioned/attached
-                                        using an exec based plugin.
+                                      description: |-
+                                        flexVolume represents a generic volume resource that is
+                                        provisioned/attached using an exec based plugin.
                                       properties:
                                         driver:
                                           description: driver is the name of the driver
                                             to use for this volume.
                                           type: string
                                         fsType:
-                                          description: fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". The default filesystem
-                                            depends on FlexVolume script.
+                                          description: |-
+                                            fsType is the filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                           type: string
                                         options:
                                           additionalProperties:
@@ -7596,24 +6832,28 @@ spec:
                                             field holds extra command options if any.'
                                           type: object
                                         readOnly:
-                                          description: 'readOnly is Optional: defaults
-                                            to false (read/write). ReadOnly here will
-                                            force the ReadOnly setting in VolumeMounts.'
+                                          description: |-
+                                            readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                         secretRef:
-                                          description: 'secretRef is Optional: secretRef
-                                            is reference to the secret object containing
-                                            sensitive information to pass to the plugin
-                                            scripts. This may be empty if no secret
-                                            object is specified. If the secret object
-                                            contains more than one secret, all secrets
-                                            are passed to the plugin scripts.'
+                                          description: |-
+                                            secretRef is Optional: secretRef is reference to the secret object containing
+                                            sensitive information to pass to the plugin scripts. This may be
+                                            empty if no secret object is specified. If the secret object
+                                            contains more than one secret, all secrets are passed to the plugin
+                                            scripts.
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -7627,10 +6867,9 @@ spec:
                                         running
                                       properties:
                                         datasetName:
-                                          description: datasetName is Name of the
-                                            dataset stored as metadata -> name on
-                                            the dataset for Flocker should be considered
-                                            as deprecated
+                                          description: |-
+                                            datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                            should be considered as deprecated
                                           type: string
                                         datasetUUID:
                                           description: datasetUUID is the UUID of
@@ -7639,62 +6878,55 @@ spec:
                                           type: string
                                       type: object
                                     gcePersistentDisk:
-                                      description: 'gcePersistentDisk represents a
-                                        GCE Disk resource that is attached to a kubelet''s
-                                        host machine and then exposed to the pod.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                      description: |-
+                                        gcePersistentDisk represents a GCE Disk resource that is attached to a
+                                        kubelet's host machine and then exposed to the pod.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                       properties:
                                         fsType:
-                                          description: 'fsType is filesystem type
-                                            of the volume that you want to mount.
-                                            Tip: Ensure that the filesystem type is
-                                            supported by the host operating system.
-                                            Examples: "ext4", "xfs", "ntfs". Implicitly
-                                            inferred to be "ext4" if unspecified.
+                                          description: |-
+                                            fsType is filesystem type of the volume that you want to mount.
+                                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                             More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                            TODO: how do we prevent errors in the
-                                            filesystem from compromising the machine'
+                                            TODO: how do we prevent errors in the filesystem from compromising the machine
                                           type: string
                                         partition:
-                                          description: 'partition is the partition
-                                            in the volume that you want to mount.
-                                            If omitted, the default is to mount by
-                                            volume name. Examples: For volume /dev/sda1,
-                                            you specify the partition as "1". Similarly,
-                                            the volume partition for /dev/sda is "0"
-                                            (or you can leave the property empty).
-                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                          description: |-
+                                            partition is the partition in the volume that you want to mount.
+                                            If omitted, the default is to mount by volume name.
+                                            Examples: For volume /dev/sda1, you specify the partition as "1".
+                                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                           format: int32
                                           type: integer
                                         pdName:
-                                          description: 'pdName is unique name of the
-                                            PD resource in GCE. Used to identify the
-                                            disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                          description: |-
+                                            pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                           type: string
                                         readOnly:
-                                          description: 'readOnly here will force the
-                                            ReadOnly setting in VolumeMounts. Defaults
-                                            to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                          description: |-
+                                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                                            Defaults to false.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                           type: boolean
                                       required:
                                       - pdName
                                       type: object
                                     gitRepo:
-                                      description: 'gitRepo represents a git repository
-                                        at a particular revision. DEPRECATED: GitRepo
-                                        is deprecated. To provision a container with
-                                        a git repo, mount an EmptyDir into an InitContainer
-                                        that clones the repo using git, then mount
-                                        the EmptyDir into the Pod''s container.'
+                                      description: |-
+                                        gitRepo represents a git repository at a particular revision.
+                                        DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                        EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                                        into the Pod's container.
                                       properties:
                                         directory:
-                                          description: directory is the target directory
-                                            name. Must not contain or start with '..'.  If
-                                            '.' is supplied, the volume directory
-                                            will be the git repository.  Otherwise,
-                                            if specified, the volume will contain
-                                            the git repository in the subdirectory
-                                            with the given name.
+                                          description: |-
+                                            directory is the target directory name.
+                                            Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                            git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                            the subdirectory with the given name.
                                           type: string
                                         repository:
                                           description: repository is the URL
@@ -7707,59 +6939,61 @@ spec:
                                       - repository
                                       type: object
                                     glusterfs:
-                                      description: 'glusterfs represents a Glusterfs
-                                        mount on the host that shares a pod''s lifetime.
-                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                                      description: |-
+                                        glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md
                                       properties:
                                         endpoints:
-                                          description: 'endpoints is the endpoint
-                                            name that details Glusterfs topology.
-                                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                          description: |-
+                                            endpoints is the endpoint name that details Glusterfs topology.
+                                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                           type: string
                                         path:
-                                          description: 'path is the Glusterfs volume
-                                            path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                          description: |-
+                                            path is the Glusterfs volume path.
+                                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                           type: string
                                         readOnly:
-                                          description: 'readOnly here will force the
-                                            Glusterfs volume to be mounted with read-only
-                                            permissions. Defaults to false. More info:
-                                            https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                          description: |-
+                                            readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                            Defaults to false.
+                                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                           type: boolean
                                       required:
                                       - endpoints
                                       - path
                                       type: object
                                     hostPath:
-                                      description: 'hostPath represents a pre-existing
-                                        file or directory on the host machine that
-                                        is directly exposed to the container. This
-                                        is generally used for system agents or other
-                                        privileged things that are allowed to see
-                                        the host machine. Most containers will NOT
-                                        need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                        --- TODO(jonesdl) We need to restrict who
-                                        can use host directory mounts and who can/can
-                                        not mount host directories as read/write.'
+                                      description: |-
+                                        hostPath represents a pre-existing file or directory on the host
+                                        machine that is directly exposed to the container. This is generally
+                                        used for system agents or other privileged things that are allowed
+                                        to see the host machine. Most containers will NOT need this.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                        ---
+                                        TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
+                                        mount host directories as read/write.
                                       properties:
                                         path:
-                                          description: 'path of the directory on the
-                                            host. If the path is a symlink, it will
-                                            follow the link to the real path. More
-                                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                          description: |-
+                                            path of the directory on the host.
+                                            If the path is a symlink, it will follow the link to the real path.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                           type: string
                                         type:
-                                          description: 'type for HostPath Volume Defaults
-                                            to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                          description: |-
+                                            type for HostPath Volume
+                                            Defaults to ""
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                           type: string
                                       required:
                                       - path
                                       type: object
                                     iscsi:
-                                      description: 'iscsi represents an ISCSI Disk
-                                        resource that is attached to a kubelet''s
-                                        host machine and then exposed to the pod.
-                                        More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                                      description: |-
+                                        iscsi represents an ISCSI Disk resource that is attached to a
+                                        kubelet's host machine and then exposed to the pod.
+                                        More info: https://examples.k8s.io/volumes/iscsi/README.md
                                       properties:
                                         chapAuthDiscovery:
                                           description: chapAuthDiscovery defines whether
@@ -7770,31 +7004,27 @@ spec:
                                             support iSCSI Session CHAP authentication
                                           type: boolean
                                         fsType:
-                                          description: 'fsType is the filesystem type
-                                            of the volume that you want to mount.
-                                            Tip: Ensure that the filesystem type is
-                                            supported by the host operating system.
-                                            Examples: "ext4", "xfs", "ntfs". Implicitly
-                                            inferred to be "ext4" if unspecified.
+                                          description: |-
+                                            fsType is the filesystem type of the volume that you want to mount.
+                                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                             More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                            TODO: how do we prevent errors in the
-                                            filesystem from compromising the machine'
+                                            TODO: how do we prevent errors in the filesystem from compromising the machine
                                           type: string
                                         initiatorName:
-                                          description: initiatorName is the custom
-                                            iSCSI Initiator Name. If initiatorName
-                                            is specified with iscsiInterface simultaneously,
-                                            new iSCSI interface <target portal>:<volume
-                                            name> will be created for the connection.
+                                          description: |-
+                                            initiatorName is the custom iSCSI Initiator Name.
+                                            If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                            <target portal>:<volume name> will be created for the connection.
                                           type: string
                                         iqn:
                                           description: iqn is the target iSCSI Qualified
                                             Name.
                                           type: string
                                         iscsiInterface:
-                                          description: iscsiInterface is the interface
-                                            Name that uses an iSCSI transport. Defaults
-                                            to 'default' (tcp).
+                                          description: |-
+                                            iscsiInterface is the interface Name that uses an iSCSI transport.
+                                            Defaults to 'default' (tcp).
                                           type: string
                                         lun:
                                           description: lun represents iSCSI Target
@@ -7802,35 +7032,39 @@ spec:
                                           format: int32
                                           type: integer
                                         portals:
-                                          description: portals is the iSCSI Target
-                                            Portal List. The portal is either an IP
-                                            or ip_addr:port if the port is other than
-                                            default (typically TCP ports 860 and 3260).
+                                          description: |-
+                                            portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                            is other than default (typically TCP ports 860 and 3260).
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         readOnly:
-                                          description: readOnly here will force the
-                                            ReadOnly setting in VolumeMounts. Defaults
-                                            to false.
+                                          description: |-
+                                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                                            Defaults to false.
                                           type: boolean
                                         secretRef:
                                           description: secretRef is the CHAP Secret
                                             for iSCSI target and initiator authentication
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         targetPortal:
-                                          description: targetPortal is iSCSI Target
-                                            Portal. The Portal is either an IP or
-                                            ip_addr:port if the port is other than
-                                            default (typically TCP ports 860 and 3260).
+                                          description: |-
+                                            targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                            is other than default (typically TCP ports 860 and 3260).
                                           type: string
                                       required:
                                       - iqn
@@ -7838,48 +7072,51 @@ spec:
                                       - targetPortal
                                       type: object
                                     name:
-                                      description: 'name of the volume. Must be a
-                                        DNS_LABEL and unique within the pod. More
-                                        info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      description: |-
+                                        name of the volume.
+                                        Must be a DNS_LABEL and unique within the pod.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     nfs:
-                                      description: 'nfs represents an NFS mount on
-                                        the host that shares a pod''s lifetime More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                      description: |-
+                                        nfs represents an NFS mount on the host that shares a pod's lifetime
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                       properties:
                                         path:
-                                          description: 'path that is exported by the
-                                            NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                          description: |-
+                                            path that is exported by the NFS server.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                           type: string
                                         readOnly:
-                                          description: 'readOnly here will force the
-                                            NFS export to be mounted with read-only
-                                            permissions. Defaults to false. More info:
-                                            https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                          description: |-
+                                            readOnly here will force the NFS export to be mounted with read-only permissions.
+                                            Defaults to false.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                           type: boolean
                                         server:
-                                          description: 'server is the hostname or
-                                            IP address of the NFS server. More info:
-                                            https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                          description: |-
+                                            server is the hostname or IP address of the NFS server.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                           type: string
                                       required:
                                       - path
                                       - server
                                       type: object
                                     persistentVolumeClaim:
-                                      description: 'persistentVolumeClaimVolumeSource
-                                        represents a reference to a PersistentVolumeClaim
-                                        in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                      description: |-
+                                        persistentVolumeClaimVolumeSource represents a reference to a
+                                        PersistentVolumeClaim in the same namespace.
+                                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                       properties:
                                         claimName:
-                                          description: 'claimName is the name of a
-                                            PersistentVolumeClaim in the same namespace
-                                            as the pod using this volume. More info:
-                                            https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                          description: |-
+                                            claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                           type: string
                                         readOnly:
-                                          description: readOnly Will force the ReadOnly
-                                            setting in VolumeMounts. Default false.
+                                          description: |-
+                                            readOnly Will force the ReadOnly setting in VolumeMounts.
+                                            Default false.
                                           type: boolean
                                       required:
                                       - claimName
@@ -7890,11 +7127,10 @@ spec:
                                         and mounted on kubelets host machine
                                       properties:
                                         fsType:
-                                          description: fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified.
+                                          description: |-
+                                            fsType is the filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                           type: string
                                         pdID:
                                           description: pdID is the ID that identifies
@@ -7909,15 +7145,14 @@ spec:
                                         machine
                                       properties:
                                         fsType:
-                                          description: fSType represents the filesystem
-                                            type to mount Must be a filesystem type
-                                            supported by the host operating system.
-                                            Ex. "ext4", "xfs". Implicitly inferred
-                                            to be "ext4" if unspecified.
+                                          description: |-
+                                            fSType represents the filesystem type to mount
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                           type: string
                                         readOnly:
-                                          description: readOnly defaults to false
-                                            (read/write). ReadOnly here will force
+                                          description: |-
+                                            readOnly defaults to false (read/write). ReadOnly here will force
                                             the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                         volumeID:
@@ -7933,18 +7168,13 @@ spec:
                                         API
                                       properties:
                                         defaultMode:
-                                          description: defaultMode are the mode bits
-                                            used to set permissions on created files
-                                            by default. Must be an octal value between
-                                            0000 and 0777 or a decimal value between
-                                            0 and 511. YAML accepts both octal and
-                                            decimal values, JSON requires decimal
-                                            values for mode bits. Directories within
-                                            the path are not affected by this setting.
-                                            This might be in conflict with other options
-                                            that affect the file mode, like fsGroup,
-                                            and the result can be other mode bits
-                                            set.
+                                          description: |-
+                                            defaultMode are the mode bits used to set permissions on created files by default.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            Directories within the path are not affected by this setting.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         sources:
@@ -7954,6 +7184,45 @@ spec:
                                             description: Projection that may be projected
                                               along with other supported volume types
                                             properties:
+                                              clusterTrustBundle:
+                                                properties:
+                                                  labelSelector:
+                                                    properties:
+                                                      matchExpressions:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            operator:
+                                                              type: string
+                                                            values:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                          - key
+                                                          - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                  path:
+                                                    type: string
+                                                  signerName:
+                                                    type: string
+                                                required:
+                                                - path
+                                                type: object
                                               configMap:
                                                 description: configMap information
                                                   about the configMap data to project
@@ -7973,16 +7242,11 @@ spec:
                                                       - path
                                                       type: object
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                   name:
-                                                    description: 'Name of the referent.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                    default: ""
                                                     type: string
                                                   optional:
-                                                    description: optional specify
-                                                      whether the ConfigMap or its
-                                                      keys must be defined
                                                     type: boolean
                                                 type: object
                                                 x-kubernetes-map-type: atomic
@@ -7991,8 +7255,6 @@ spec:
                                                   about the downwardAPI data to project
                                                 properties:
                                                   items:
-                                                    description: Items is a list of
-                                                      DownwardAPIVolume file
                                                     items:
                                                       properties:
                                                         fieldRef:
@@ -8030,6 +7292,7 @@ spec:
                                                       - path
                                                       type: object
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                 type: object
                                               secret:
                                                 description: secret information about
@@ -8050,16 +7313,11 @@ spec:
                                                       - path
                                                       type: object
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                   name:
-                                                    description: 'Name of the referent.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                    default: ""
                                                     type: string
                                                   optional:
-                                                    description: optional field specify
-                                                      whether the Secret or its key
-                                                      must be defined
                                                     type: boolean
                                                 type: object
                                                 x-kubernetes-map-type: atomic
@@ -8069,59 +7327,47 @@ spec:
                                                   data to project
                                                 properties:
                                                   audience:
-                                                    description: audience is the intended
-                                                      audience of the token. A recipient
-                                                      of a token must identify itself
-                                                      with an identifier specified
-                                                      in the audience of the token,
-                                                      and otherwise should reject
-                                                      the token. The audience defaults
-                                                      to the identifier of the apiserver.
                                                     type: string
                                                   expirationSeconds:
                                                     format: int64
                                                     type: integer
                                                   path:
-                                                    description: path is the path
-                                                      relative to the mount point
-                                                      of the file to project the token
-                                                      into.
                                                     type: string
                                                 required:
                                                 - path
                                                 type: object
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                     quobyte:
                                       description: quobyte represents a Quobyte mount
                                         on the host that shares a pod's lifetime
                                       properties:
                                         group:
-                                          description: group to map volume access
-                                            to Default is no group
+                                          description: |-
+                                            group to map volume access to
+                                            Default is no group
                                           type: string
                                         readOnly:
-                                          description: readOnly here will force the
-                                            Quobyte volume to be mounted with read-only
-                                            permissions. Defaults to false.
+                                          description: |-
+                                            readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                            Defaults to false.
                                           type: boolean
                                         registry:
-                                          description: registry represents a single
-                                            or multiple Quobyte Registry services
-                                            specified as a string as host:port pair
-                                            (multiple entries are separated with commas)
-                                            which acts as the central registry for
-                                            volumes
+                                          description: |-
+                                            registry represents a single or multiple Quobyte Registry services
+                                            specified as a string as host:port pair (multiple entries are separated with commas)
+                                            which acts as the central registry for volumes
                                           type: string
                                         tenant:
-                                          description: tenant owning the given Quobyte
-                                            volume in the Backend Used with dynamically
-                                            provisioned Quobyte volumes, value is
-                                            set by the plugin
+                                          description: |-
+                                            tenant owning the given Quobyte volume in the Backend
+                                            Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                           type: string
                                         user:
-                                          description: user to map volume access to
+                                          description: |-
+                                            user to map volume access to
                                             Defaults to serivceaccount user
                                           type: string
                                         volume:
@@ -8133,61 +7379,74 @@ spec:
                                       - volume
                                       type: object
                                     rbd:
-                                      description: 'rbd represents a Rados Block Device
-                                        mount on the host that shares a pod''s lifetime.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md'
+                                      description: |-
+                                        rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                        More info: https://examples.k8s.io/volumes/rbd/README.md
                                       properties:
                                         fsType:
-                                          description: 'fsType is the filesystem type
-                                            of the volume that you want to mount.
-                                            Tip: Ensure that the filesystem type is
-                                            supported by the host operating system.
-                                            Examples: "ext4", "xfs", "ntfs". Implicitly
-                                            inferred to be "ext4" if unspecified.
+                                          description: |-
+                                            fsType is the filesystem type of the volume that you want to mount.
+                                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                             More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                            TODO: how do we prevent errors in the
-                                            filesystem from compromising the machine'
+                                            TODO: how do we prevent errors in the filesystem from compromising the machine
                                           type: string
                                         image:
-                                          description: 'image is the rados image name.
-                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          description: |-
+                                            image is the rados image name.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                           type: string
                                         keyring:
-                                          description: 'keyring is the path to key
-                                            ring for RBDUser. Default is /etc/ceph/keyring.
-                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          description: |-
+                                            keyring is the path to key ring for RBDUser.
+                                            Default is /etc/ceph/keyring.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                           type: string
                                         monitors:
-                                          description: 'monitors is a collection of
-                                            Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          description: |-
+                                            monitors is a collection of Ceph monitors.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         pool:
-                                          description: 'pool is the rados pool name.
-                                            Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          description: |-
+                                            pool is the rados pool name.
+                                            Default is rbd.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                           type: string
                                         readOnly:
-                                          description: 'readOnly here will force the
-                                            ReadOnly setting in VolumeMounts. Defaults
-                                            to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          description: |-
+                                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                                            Defaults to false.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                           type: boolean
                                         secretRef:
-                                          description: 'secretRef is name of the authentication
-                                            secret for RBDUser. If provided overrides
-                                            keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          description: |-
+                                            secretRef is name of the authentication secret for RBDUser. If provided
+                                            overrides keyring.
+                                            Default is nil.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         user:
-                                          description: 'user is the rados user name.
-                                            Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          description: |-
+                                            user is the rados user name.
+                                            Default is admin.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                           type: string
                                       required:
                                       - image
@@ -8199,10 +7458,11 @@ spec:
                                         nodes.
                                       properties:
                                         fsType:
-                                          description: fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Default is "xfs".
+                                          description: |-
+                                            fsType is the filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs", "ntfs".
+                                            Default is "xfs".
                                           type: string
                                         gateway:
                                           description: gateway is the host address
@@ -8214,21 +7474,25 @@ spec:
                                             configured storage.
                                           type: string
                                         readOnly:
-                                          description: readOnly Defaults to false
-                                            (read/write). ReadOnly here will force
+                                          description: |-
+                                            readOnly Defaults to false (read/write). ReadOnly here will force
                                             the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                         secretRef:
-                                          description: secretRef references to the
-                                            secret for ScaleIO user and other sensitive
-                                            information. If this is not provided,
-                                            Login operation will fail.
+                                          description: |-
+                                            secretRef references to the secret for ScaleIO user and other
+                                            sensitive information. If this is not provided, Login operation will fail.
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -8238,9 +7502,9 @@ spec:
                                             false
                                           type: boolean
                                         storageMode:
-                                          description: storageMode indicates whether
-                                            the storage for a volume should be ThickProvisioned
-                                            or ThinProvisioned. Default is ThinProvisioned.
+                                          description: |-
+                                            storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                                            Default is ThinProvisioned.
                                           type: string
                                         storagePool:
                                           description: storagePool is the ScaleIO
@@ -8252,10 +7516,9 @@ spec:
                                             system as configured in ScaleIO.
                                           type: string
                                         volumeName:
-                                          description: volumeName is the name of a
-                                            volume already created in the ScaleIO
-                                            system that is associated with this volume
-                                            source.
+                                          description: |-
+                                            volumeName is the name of a volume already created in the ScaleIO system
+                                            that is associated with this volume source.
                                           type: string
                                       required:
                                       - gateway
@@ -8263,38 +7526,30 @@ spec:
                                       - system
                                       type: object
                                     secret:
-                                      description: 'secret represents a secret that
-                                        should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                      description: |-
+                                        secret represents a secret that should populate this volume.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                       properties:
                                         defaultMode:
-                                          description: 'defaultMode is Optional: mode
-                                            bits used to set permissions on created
-                                            files by default. Must be an octal value
-                                            between 0000 and 0777 or a decimal value
-                                            between 0 and 511. YAML accepts both octal
-                                            and decimal values, JSON requires decimal
-                                            values for mode bits. Defaults to 0644.
-                                            Directories within the path are not affected
-                                            by this setting. This might be in conflict
-                                            with other options that affect the file
-                                            mode, like fsGroup, and the result can
-                                            be other mode bits set.'
+                                          description: |-
+                                            defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values
+                                            for mode bits. Defaults to 0644.
+                                            Directories within the path are not affected by this setting.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         items:
-                                          description: items If unspecified, each
-                                            key-value pair in the Data field of the
-                                            referenced Secret will be projected into
-                                            the volume as a file whose name is the
-                                            key and content is the value. If specified,
-                                            the listed keys will be projected into
-                                            the specified paths, and unlisted keys
-                                            will not be present. If a key is specified
-                                            which is not present in the Secret, the
-                                            volume setup will error unless it is marked
-                                            optional. Paths must be relative and may
-                                            not contain the '..' path or start with
-                                            '..'.
+                                          description: |-
+                                            items If unspecified, each key-value pair in the Data field of the referenced
+                                            Secret will be projected into the volume as a file whose name is the
+                                            key and content is the value. If specified, the listed keys will be
+                                            projected into the specified paths, and unlisted keys will not be
+                                            present. If a key is specified which is not present in the Secret,
+                                            the volume setup will error unless it is marked optional. Paths must be
+                                            relative and may not contain the '..' path or start with '..'.
                                           items:
                                             description: Maps a string key to a path
                                               within a volume.
@@ -8303,42 +7558,24 @@ spec:
                                                 description: key is the key to project.
                                                 type: string
                                               mode:
-                                                description: 'mode is Optional: mode
-                                                  bits used to set permissions on
-                                                  this file. Must be an octal value
-                                                  between 0000 and 0777 or a decimal
-                                                  value between 0 and 511. YAML accepts
-                                                  both octal and decimal values, JSON
-                                                  requires decimal values for mode
-                                                  bits. If not specified, the volume
-                                                  defaultMode will be used. This might
-                                                  be in conflict with other options
-                                                  that affect the file mode, like
-                                                  fsGroup, and the result can be other
-                                                  mode bits set.'
                                                 format: int32
                                                 type: integer
                                               path:
-                                                description: path is the relative
-                                                  path of the file to map the key
-                                                  to. May not be an absolute path.
-                                                  May not contain the path element
-                                                  '..'. May not start with the string
-                                                  '..'.
                                                 type: string
                                             required:
                                             - key
                                             - path
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         optional:
                                           description: optional field specify whether
                                             the Secret or its keys must be defined
                                           type: boolean
                                         secretName:
-                                          description: 'secretName is the name of
-                                            the secret in the pod''s namespace to
-                                            use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                          description: |-
+                                            secretName is the name of the secret in the pod's namespace to use.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                           type: string
                                       type: object
                                     storageos:
@@ -8347,48 +7584,47 @@ spec:
                                         nodes.
                                       properties:
                                         fsType:
-                                          description: fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified.
+                                          description: |-
+                                            fsType is the filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                           type: string
                                         readOnly:
-                                          description: readOnly defaults to false
-                                            (read/write). ReadOnly here will force
+                                          description: |-
+                                            readOnly defaults to false (read/write). ReadOnly here will force
                                             the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                         secretRef:
-                                          description: secretRef specifies the secret
-                                            to use for obtaining the StorageOS API
-                                            credentials.  If not specified, default
-                                            values will be attempted.
+                                          description: |-
+                                            secretRef specifies the secret to use for obtaining the StorageOS API
+                                            credentials.  If not specified, default values will be attempted.
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         volumeName:
-                                          description: volumeName is the human-readable
-                                            name of the StorageOS volume.  Volume
+                                          description: |-
+                                            volumeName is the human-readable name of the StorageOS volume.  Volume
                                             names are only unique within a namespace.
                                           type: string
                                         volumeNamespace:
-                                          description: volumeNamespace specifies the
-                                            scope of the volume within StorageOS.  If
-                                            no namespace is specified then the Pod's
-                                            namespace will be used.  This allows the
-                                            Kubernetes name scoping to be mirrored
-                                            within StorageOS for tighter integration.
-                                            Set VolumeName to any name to override
-                                            the default behaviour. Set to "default"
-                                            if you are not using namespaces within
-                                            StorageOS. Namespaces that do not pre-exist
-                                            within StorageOS will be created.
+                                          description: |-
+                                            volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                            namespace is specified then the Pod's namespace will be used.  This allows the
+                                            Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                            Set VolumeName to any name to override the default behaviour.
+                                            Set to "default" if you are not using namespaces within StorageOS.
+                                            Namespaces that do not pre-exist within StorageOS will be created.
                                           type: string
                                       type: object
                                     vsphereVolume:
@@ -8397,11 +7633,10 @@ spec:
                                         machine
                                       properties:
                                         fsType:
-                                          description: fsType is filesystem type to
-                                            mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified.
+                                          description: |-
+                                            fsType is filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                           type: string
                                         storagePolicyID:
                                           description: storagePolicyID is the storage
@@ -8424,81 +7659,89 @@ spec:
                                   - name
                                   type: object
                                 type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
                             required:
                             - containers
                             type: object
                         type: object
                       replicas:
-                        description: Number of desired pods. This is a pointer to
-                          distinguish between explicit zero and not specified. Defaults
-                          to 1.
+                        description: |-
+                          Number of desired pods. This is a pointer to distinguish between explicit
+                          zero and not specified. Defaults to 1.
                         format: int32
                         type: integer
                       service:
-                        description: Service can be used to configure a custom service,
-                          if not set stackset-controller will generate a service based
-                          on container port and ingress backendport.
+                        description: |-
+                          Service can be used to configure a custom service, if not
+                          set stackset-controller will generate a service based on
+                          container port and ingress backendport.
                         properties:
                           metadata:
-                            description: EmbeddedObjectMetaWithAnnotations defines
-                              the metadata which can be attached to a resource. It's
-                              a slimmed down version of metav1.ObjectMeta only containing
-                              annotations.
+                            description: |-
+                              EmbeddedObjectMetaWithAnnotations defines the metadata which can be attached
+                              to a resource. It's a slimmed down version of metav1.ObjectMeta only
+                              containing annotations.
                             properties:
                               annotations:
                                 additionalProperties:
                                   type: string
-                                description: 'Annotations is an unstructured key value
-                                  map stored with a resource that may be set by external
-                                  tools to store and retrieve arbitrary metadata.
-                                  They are not queryable and should be preserved when
-                                  modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                                description: |-
+                                  Annotations is an unstructured key value map stored with a resource that may be
+                                  set by external tools to store and retrieve arbitrary metadata. They are not
+                                  queryable and should be preserved when modifying objects.
+                                  More info: http://kubernetes.io/docs/user-guide/annotations
                                 type: object
                             type: object
                           ports:
-                            description: 'The list of ports that are exposed by this
-                              service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                            description: |-
+                              The list of ports that are exposed by this service.
+                              More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                             items:
                               description: ServicePort contains information on service's
                                 port.
                               properties:
                                 appProtocol:
-                                  description: "The application protocol for this
-                                    port. This is used as a hint for implementations
-                                    to offer richer behavior for protocols that they
-                                    understand. This field follows standard Kubernetes
-                                    label syntax. Valid values are either: \n * Un-prefixed
-                                    protocol names - reserved for IANA standard service
-                                    names (as per RFC-6335 and https://www.iana.org/assignments/service-names).
-                                    \n * Kubernetes-defined prefixed names: * 'kubernetes.io/h2c'
-                                    - HTTP/2 over cleartext as described in https://www.rfc-editor.org/rfc/rfc7540
-                                    * 'kubernetes.io/ws'  - WebSocket over cleartext
-                                    as described in https://www.rfc-editor.org/rfc/rfc6455
-                                    * 'kubernetes.io/wss' - WebSocket over TLS as
-                                    described in https://www.rfc-editor.org/rfc/rfc6455
-                                    \n * Other protocols should use implementation-defined
-                                    prefixed names such as mycompany.com/my-custom-protocol."
+                                  description: |-
+                                    The application protocol for this port.
+                                    This is used as a hint for implementations to offer richer behavior for protocols that they understand.
+                                    This field follows standard Kubernetes label syntax.
+                                    Valid values are either:
+
+
+                                    * Un-prefixed protocol names - reserved for IANA standard service names (as per
+                                    RFC-6335 and https://www.iana.org/assignments/service-names).
+
+
+                                    * Kubernetes-defined prefixed names:
+                                      * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+                                      * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+                                      * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+
+
+                                    * Other protocols should use implementation-defined prefixed names such as
+                                    mycompany.com/my-custom-protocol.
                                   type: string
                                 name:
-                                  description: The name of this port within the service.
-                                    This must be a DNS_LABEL. All ports within a ServiceSpec
-                                    must have unique names. When considering the endpoints
-                                    for a Service, this must match the 'name' field
-                                    in the EndpointPort. Optional if only one ServicePort
-                                    is defined on this service.
+                                  description: |-
+                                    The name of this port within the service. This must be a DNS_LABEL.
+                                    All ports within a ServiceSpec must have unique names. When considering
+                                    the endpoints for a Service, this must match the 'name' field in the
+                                    EndpointPort.
+                                    Optional if only one ServicePort is defined on this service.
                                   type: string
                                 nodePort:
-                                  description: 'The port on each node on which this
-                                    service is exposed when type is NodePort or LoadBalancer.  Usually
-                                    assigned by the system. If a value is specified,
-                                    in-range, and not in use it will be used, otherwise
-                                    the operation will fail.  If not specified, a
-                                    port will be allocated if this Service requires
-                                    one.  If this field is specified when creating
-                                    a Service which does not need it, creation will
-                                    fail. This field will be wiped when updating a
-                                    Service to no longer need it (e.g. changing type
-                                    from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                                  description: |-
+                                    The port on each node on which this service is exposed when type is
+                                    NodePort or LoadBalancer.  Usually assigned by the system. If a value is
+                                    specified, in-range, and not in use it will be used, otherwise the
+                                    operation will fail.  If not specified, a port will be allocated if this
+                                    Service requires one.  If this field is specified when creating a
+                                    Service which does not need it, creation will fail. This field will be
+                                    wiped when updating a Service to no longer need it (e.g. changing type
+                                    from NodePort to ClusterIP).
+                                    More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
                                   format: int32
                                   type: integer
                                 port:
@@ -8508,23 +7751,23 @@ spec:
                                   type: integer
                                 protocol:
                                   default: TCP
-                                  description: The IP protocol for this port. Supports
-                                    "TCP", "UDP", and "SCTP". Default is TCP.
+                                  description: |-
+                                    The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+                                    Default is TCP.
                                   type: string
                                 targetPort:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: 'Number or name of the port to access
-                                    on the pods targeted by the service. Number must
-                                    be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
-                                    If this is a string, it will be looked up as a
-                                    named port in the target Pod''s container ports.
-                                    If this is not specified, the value of the ''port''
-                                    field is used (an identity map). This field is
-                                    ignored for services with clusterIP=None, and
-                                    should be omitted or set equal to the ''port''
-                                    field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                                  description: |-
+                                    Number or name of the port to access on the pods targeted by the service.
+                                    Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                    If this is a string, it will be looked up as a named port in the
+                                    target Pod's container ports. If this is not specified, the value
+                                    of the 'port' field is used (an identity map).
+                                    This field is ignored for services with clusterIP=None, and should be
+                                    omitted or set equal to the 'port' field.
+                                    More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
@@ -8536,47 +7779,45 @@ spec:
                           underlying deployment
                         properties:
                           rollingUpdate:
-                            description: 'Rolling update config params. Present only
-                              if DeploymentStrategyType = RollingUpdate. --- TODO:
-                              Update this to follow our convention for oneOf, whatever
-                              we decide it to be.'
+                            description: |-
+                              Rolling update config params. Present only if DeploymentStrategyType =
+                              RollingUpdate.
+                              ---
+                              TODO: Update this to follow our convention for oneOf, whatever we decide it
+                              to be.
                             properties:
                               maxSurge:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: 'The maximum number of pods that can
-                                  be scheduled above the desired number of pods. Value
-                                  can be an absolute number (ex: 5) or a percentage
-                                  of desired pods (ex: 10%). This can not be 0 if
-                                  MaxUnavailable is 0. Absolute number is calculated
-                                  from percentage by rounding up. Defaults to 25%.
-                                  Example: when this is set to 30%, the new ReplicaSet
-                                  can be scaled up immediately when the rolling update
-                                  starts, such that the total number of old and new
-                                  pods do not exceed 130% of desired pods. Once old
-                                  pods have been killed, new ReplicaSet can be scaled
-                                  up further, ensuring that total number of pods running
-                                  at any time during the update is at most 130% of
-                                  desired pods.'
+                                description: |-
+                                  The maximum number of pods that can be scheduled above the desired number of
+                                  pods.
+                                  Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                  This can not be 0 if MaxUnavailable is 0.
+                                  Absolute number is calculated from percentage by rounding up.
+                                  Defaults to 25%.
+                                  Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when
+                                  the rolling update starts, such that the total number of old and new pods do not exceed
+                                  130% of desired pods. Once old pods have been killed,
+                                  new ReplicaSet can be scaled up further, ensuring that total number of pods running
+                                  at any time during the update is at most 130% of desired pods.
                                 x-kubernetes-int-or-string: true
                               maxUnavailable:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: 'The maximum number of pods that can
-                                  be unavailable during the update. Value can be an
-                                  absolute number (ex: 5) or a percentage of desired
-                                  pods (ex: 10%). Absolute number is calculated from
-                                  percentage by rounding down. This can not be 0 if
-                                  MaxSurge is 0. Defaults to 25%. Example: when this
-                                  is set to 30%, the old ReplicaSet can be scaled
-                                  down to 70% of desired pods immediately when the
-                                  rolling update starts. Once new pods are ready,
-                                  old ReplicaSet can be scaled down further, followed
-                                  by scaling up the new ReplicaSet, ensuring that
-                                  the total number of pods available at all times
-                                  during the update is at least 70% of desired pods.'
+                                description: |-
+                                  The maximum number of pods that can be unavailable during the update.
+                                  Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                  Absolute number is calculated from percentage by rounding down.
+                                  This can not be 0 if MaxSurge is 0.
+                                  Defaults to 25%.
+                                  Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods
+                                  immediately when the rolling update starts. Once new pods are ready, old ReplicaSet
+                                  can be scaled down further, followed by scaling up the new ReplicaSet, ensuring
+                                  that the total number of pods available at all times during the update is at
+                                  least 70% of desired pods.
                                 x-kubernetes-int-or-string: true
                             type: object
                           type:
@@ -8595,13 +7836,15 @@ spec:
                 - spec
                 type: object
               traffic:
-                description: Traffic is the mapping from a stackset to stack with
-                  weights. It defines the desired traffic. Clients that orchestrate
-                  traffic switching should write this part.
+                description: |-
+                  Traffic is the mapping from a stackset to stack with
+                  weights. It defines the desired traffic. Clients that
+                  orchestrate traffic switching should write this part.
                 items:
-                  description: DesiredTraffic is the desired traffic setting to direct
-                    traffic to a stack. This is meant to use by clients to orchestrate
-                    traffic switching.
+                  description: |-
+                    DesiredTraffic is the desired traffic setting to direct traffic to
+                    a stack. This is meant to use by clients to orchestrate traffic
+                    switching.
                   properties:
                     stackName:
                       type: string
@@ -8621,14 +7864,15 @@ spec:
             description: StackSetStatus is the status section of the StackSet resource.
             properties:
               observedStackVersion:
-                description: 'ObservedStackVersion is the version of Stack generated
-                  from the current StackSet definition. TODO: add a more detailed
-                  comment'
+                description: |-
+                  ObservedStackVersion is the version of Stack generated from the current StackSet definition.
+                  TODO: add a more detailed comment
                 type: string
               readyStacks:
-                description: 'ReadyStacks is the number of stacks managed by the StackSet
-                  which are considered ready. a Stack is considered ready if: replicas
-                  == readyReplicas == updatedReplicas.'
+                description: |-
+                  ReadyStacks is the number of stacks managed by the StackSet which
+                  are considered ready. a Stack is considered ready if:
+                  replicas == readyReplicas == updatedReplicas.
                 format: int32
                 type: integer
               stacks:
@@ -8636,17 +7880,19 @@ spec:
                 format: int32
                 type: integer
               stacksWithTraffic:
-                description: StacksWithTraffic is the number of stacks managed by
-                  the StackSet which are getting traffic.
+                description: |-
+                  StacksWithTraffic is the number of stacks managed by the StackSet
+                  which are getting traffic.
                 format: int32
                 type: integer
               traffic:
                 description: Traffic is the actual traffic setting on services for
                   this stackset
                 items:
-                  description: Traffic is the actual traffic setting on services for
-                    this stackset, controllers interested in current traffic decision
-                    should read this.
+                  description: |-
+                    Traffic is the actual traffic setting on services for this
+                    stackset, controllers interested in current traffic decision should
+                    read this.
                   properties:
                     serviceName:
                       type: string


### PR DESCRIPTION
Update the stackset CRDs to a version generated with Kubernetes v1.30, this includes among other things support for defining `lifecycle.preStop.sleep` as introduced in: #7762 