### PR TITLE
EKS branch cleanup

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1104,7 +1104,6 @@ sysctl_settings: ""
 # enables/disables the minDomains field for pod topology spread.
 min_domains_in_pod_topology_spread_enabled: "true"
 
-eks: "false"
 eks_control_plane_logging: "false"
 eks_ip_family: "ipv4"
 # prefix delegation can only be configured for ipv4. For ipv6 it can only be

--- a/cluster/manifests/01-coredns-local/service-coredns.yaml
+++ b/cluster/manifests/01-coredns-local/service-coredns.yaml
@@ -9,8 +9,8 @@ metadata:
 spec:
   selector:
     component: coredns
-{{- if ne .Cluster.Provider "zalando-eks"}}
-# TODO: what to do with eks service range?
+{{- if or (ne .Cluster.Provider "zalando-eks") (ne .Cluster.ConfigItems.eks_ip_family "ipv6")}}
+  # Only set ip for ipv4 clusters
   clusterIP: 10.5.0.11
 {{- end}}
   ports:

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -37,7 +37,6 @@ spec:
         args:
         - --source=service
         - --source=ingress
-        # TODO: support routegroup with eks ipv6
         - --source=skipper-routegroup
 {{- range split .Cluster.ConfigItems.external_dns_domain_filter "," }}
         - --domain-filter={{ . }}
@@ -53,7 +52,6 @@ spec:
         - --aws-zones-cache-duration={{ .Cluster.ConfigItems.external_dns_zones_cache_duration }}
         - --annotation-filter=external-dns.alpha.kubernetes.io/exclude notin (true)
         - --policy={{ .Cluster.ConfigItems.external_dns_policy }}
-        - --log-level=debug
         resources:
           requests:
             cpu: 50m

--- a/cluster/manifests/skipper/service-internal.yaml
+++ b/cluster/manifests/skipper/service-internal.yaml
@@ -14,10 +14,8 @@ metadata:
     component: ingress
 spec:
   type: ClusterIP
-{{- if ne .Cluster.Provider "zalando-eks"}}
-# TODO: how to do internal-ingress?
-# function to derive IP from range?
-# Can be hardcoded for ipv4, must be dynamic for ipv6
+{{- if or (ne .Cluster.Provider "zalando-eks") (ne .Cluster.ConfigItems.eks_ip_family "ipv6")}}
+  # Only set ip for ipv4 clusters
   clusterIP: 10.5.99.99
 {{- end}}
   ports:


### PR DESCRIPTION
* Drop the `eks` config-item no longer used since we use `Provider` to determine eks or not.
* Use the constant service IPs for coreDNS and skipper-internal service in ipv4 mode, possible since: #7805 
* Cleanup changes to external-dns which is no longer needed