### PR TITLE
fix: skipper build go version 1.22.5

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,5 +1,5 @@
 {{ $internal_version := "v0.21.139-963" }}
-{{ $canary_internal_version := "v0.21.139-963" }}
+{{ $canary_internal_version := "v0.21.141-965" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}
 {{ $canary_args := "" }}


### PR DESCRIPTION
fix: skipper build go version 1.22.5