### PR TITLE
eks: PoC: Zalando IAM AWS Proxy

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -185,7 +185,7 @@ Resources:
     Type: "AWS::EKS::AccessEntry"
     Properties:
       ClusterName: !Ref EKSCluster
-      PrincipalArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/zalando-iam"
+      PrincipalArn: !GetAtt EKSZalandoIAMIAMRole.Arn
       Username: "zalando-iam:zalando:service:{{`{{SessionName}}`}}"
       Type: "STANDARD"
   # TODO: IAM POLICY
@@ -255,6 +255,71 @@ Resources:
 {{- else }}
       - !Ref EKSCNIIPv6Policy
 {{- end }}
+  EKSZalandoIAMProxyIAMRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: "{{.Cluster.LocalID}}-zalando-iam-aws-proxy"
+      AssumeRolePolicyDocument: !Sub
+        - |
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Principal": {
+                  "Service": [
+                    "ec2.amazonaws.com"
+                  ]
+                },
+                "Action": [
+                  "sts:AssumeRole"
+                ]
+              },
+              {
+                "Effect": "Allow",
+                "Principal": {
+                  "Federated": [
+                    "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
+                  ]
+                },
+                "Action": [
+                  "sts:AssumeRoleWithWebIdentity"
+                ],
+                "Condition": {
+                  "StringEquals": {
+                    "${OIDC}:sub": "system:serviceaccount:kube-system:zalando-iam-aws-proxy"
+                  }
+                }
+              }
+            ]
+          }
+        - OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
+      Path: /
+      Policies:
+      - PolicyDocument:
+          Statement:
+            - Action: "sts:AssumeRole"
+              Effect: Allow
+              Resource: "*"
+            - Action: "sts:SetSourceIdentity"
+              Effect: Allow
+              Resource: "*"
+          Version: 2012-10-17
+        PolicyName: root
+  EKSZalandoIAMIAMRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: "{{.Cluster.LocalID}}-zalando-iam"
+      Path: /
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action:
+              - 'sts:AssumeRole'
+              - 'sts:SetSourceIdentity'
+        Version: '2012-10-17'
   EKSOIDCProvider:
     Type: AWS::IAM::OIDCProvider
     Properties:

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -702,8 +702,8 @@ tracing_coredns_local_zone_traces_endpoint: ""
 # AMI id given the image name and the Image AWS account owner.
 #
 # [0]: https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/8a9bd1cb2d094038a9e23e646421f8146b48886a/provisioner/template.go#L116
-kuberuntu_image_v1_30_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-test-v1.30.2-amd64-pr-314-27" "861068367966" }}
-kuberuntu_image_v1_30_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-test-v1.30.2-arm64-pr-314-27" "861068367966" }}
+kuberuntu_image_v1_30_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-test-v1.30.2-amd64-pr-314-28" "861068367966" }}
+kuberuntu_image_v1_30_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-test-v1.30.2-arm64-pr-314-28" "861068367966" }}
 
 # Which distro from the previous config items should be used. Valid options are only `jammy` for now. Can be set for each node pool.
 kuberuntu_distro_master: "jammy"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1101,3 +1101,8 @@ eks_ip_family: "ipv4"
 # prefix delegation can only be configured for ipv4. For ipv6 it can only be
 # true.
 aws_vpc_cni_prefix_delegation: "true"
+eks_zalando_iam_aws_proxy_cpu: "100m"
+eks_zalando_iam_aws_proxy_memory: "512Mi"
+eks_zalando_iam_aws_proxy_hpa_max_replicas: "10"
+eks_zalando_iam_aws_proxy_hpa_cpu_target: "80"
+eks_zalando_iam_aws_proxy_hpa_memory_target: "80"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -702,8 +702,8 @@ tracing_coredns_local_zone_traces_endpoint: ""
 # AMI id given the image name and the Image AWS account owner.
 #
 # [0]: https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/8a9bd1cb2d094038a9e23e646421f8146b48886a/provisioner/template.go#L116
-kuberuntu_image_v1_30_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.30.2-amd64-master-341" "861068367966" }}
-kuberuntu_image_v1_30_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.30.2-arm64-master-341" "861068367966" }}
+kuberuntu_image_v1_30_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-test-v1.30.2-amd64-pr-314-27" "861068367966" }}
+kuberuntu_image_v1_30_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-test-v1.30.2-arm64-pr-314-27" "861068367966" }}
 
 # Which distro from the previous config items should be used. Valid options are only `jammy` for now. Can be set for each node pool.
 kuberuntu_distro_master: "jammy"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -702,8 +702,8 @@ tracing_coredns_local_zone_traces_endpoint: ""
 # AMI id given the image name and the Image AWS account owner.
 #
 # [0]: https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/8a9bd1cb2d094038a9e23e646421f8146b48886a/provisioner/template.go#L116
-kuberuntu_image_v1_30_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-test-v1.30.2-amd64-pr-314-28" "861068367966" }}
-kuberuntu_image_v1_30_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-test-v1.30.2-arm64-pr-314-28" "861068367966" }}
+kuberuntu_image_v1_30_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.30.3-amd64-master-343" "861068367966" }}
+kuberuntu_image_v1_30_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.30.3-arm64-master-343" "861068367966" }}
 
 # Which distro from the previous config items should be used. Valid options are only `jammy` for now. Can be set for each node pool.
 kuberuntu_distro_master: "jammy"

--- a/cluster/manifests/deployment-service/controller-rbac.yaml
+++ b/cluster/manifests/deployment-service/controller-rbac.yaml
@@ -97,6 +97,11 @@ subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: User
     name: zalando-iam:zalando:service:k8sapi-local_deployment-service-executor
+  # {{ if eq .Cluster.Provider "zalando-eks" }}
+  - kind: ServiceAccount
+    name: "deployment-service-controller"
+    namespace: "kube-system"
+  # {{ end }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -113,6 +118,11 @@ subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: User
     name: zalando-iam:zalando:service:k8sapi-local_deployment-service-executor
+  # {{ if eq .Cluster.Provider "zalando-eks" }}
+  - kind: ServiceAccount
+    name: "deployment-service-controller"
+    namespace: "kube-system"
+  # {{ end }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -129,6 +139,11 @@ subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: User
     name: zalando-iam:zalando:service:k8sapi-local_deployment-service-executor
+  # {{ if eq .Cluster.Provider "zalando-eks" }}
+  - kind: ServiceAccount
+    name: "deployment-service-controller"
+    namespace: "kube-system"
+  # {{ end }}
 ---
 {{- if eq .Cluster.ConfigItems.deployment_service_executor_cdp_permissions "true" }}
 kind: ClusterRole
@@ -172,6 +187,11 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
   name: zalando-iam:zalando:service:k8sapi-local_deployment-service-executor
+  # {{ if eq .Cluster.Provider "zalando-eks" }}
+  - kind: ServiceAccount
+    name: "deployment-service-controller"
+    namespace: "kube-system"
+  # {{ end }}
 ---
 {{- end }}
 kind: Role

--- a/cluster/manifests/deployment-service/controller-statefulset.yaml
+++ b/cluster/manifests/deployment-service/controller-statefulset.yaml
@@ -33,6 +33,9 @@ spec:
           args:
             - "--config-namespace=kube-system"
             - "--decrypt-kms-alias-arn=arn:aws:kms:{{ .Cluster.Region }}:{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:alias/deployment-secret"
+            # {{ if eq .Cluster.Provider "zalando-eks" }}
+            - --use-service-account
+            # {{ end }}
           env:
             - name: AWS_REGION
               value: "{{.Cluster.Region}}"

--- a/cluster/manifests/zalando-iam-aws-proxy/deployment.yaml
+++ b/cluster/manifests/zalando-iam-aws-proxy/deployment.yaml
@@ -1,0 +1,117 @@
+# {{ if eq .Cluster.Provider "zalando-eks" }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zalando-iam-aws-proxy
+  namespace: kube-system
+  labels:
+    application: kubernetes
+    component: zalando-iam-aws-proxy
+spec:
+  selector:
+    matchLabels:
+      deployment: zalando-iam-aws-proxy
+  template:
+    metadata:
+      labels:
+        application: kubernetes
+        component: zalando-iam-aws-proxy
+        deployment: zalando-iam-aws-proxy
+      annotations:
+        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
+    spec:
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+      serviceAccountName: zalando-iam-aws-proxy
+      containers:
+      - name: proxy
+        image: mikkeloscar/zalando-iam-aws-proxy:1
+        args:
+        - "--apiserver-url=https://kubernetes.default.svc.cluster.local"
+        - "--ca-file-path=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+        - "--cluster-id={{.Cluster.ID | eksID}}"
+        - "--role-arn=arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/{{.Cluster.LocalID}}-zalando-iam"
+        - "--tokeninfo-url=https://identity.zalando.com=http://:9021/oauth2/tokeninfo"
+        # {{- if ne .Cluster.Environment "production"}}
+        - "--tokeninfo-url=https://sandbox.identity.zalando.com=http://:9022/oauth2/tokeninfo"
+        # {{- end}}
+        resources:
+          limits:
+            cpu: "{{.Cluster.ConfigItems.eks_zalando_iam_aws_proxy_cpu}}"
+            memory: "{{.Cluster.ConfigItems.eks_zalando_iam_aws_proxy_memory}}"
+          requests:
+            cpu: "{{.Cluster.ConfigItems.eks_zalando_iam_aws_proxy_cpu}}"
+            memory: "{{.Cluster.ConfigItems.eks_zalando_iam_aws_proxy_memory}}"
+        lifecycle:
+          preStop:
+            sleep:
+              seconds: 20
+      - name: tokeninfo
+        image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/foundation/platform-iam-tokeninfo:master-113
+        env:
+        - name: OPENID_PROVIDER_CONFIGURATION_URL
+          value: https://identity.zalando.com/.well-known/openid-configuration
+        - name: BUSINESS_PARTNERS
+          value: {{ .Cluster.ConfigItems.apiserver_business_partner_ids }}
+        ports:
+        - containerPort: 9021
+        lifecycle:
+          preStop:
+            sleep:
+              seconds: 20
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 9021
+          periodSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 9021
+          periodSeconds: 3
+          failureThreshold: 2
+        resources:
+          limits:
+            cpu: 50m
+            memory: 100Mi
+      # {{- if ne .Cluster.Environment "production"}}
+      - name: tokeninfo-sandbox
+        image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/foundation/platform-iam-tokeninfo:master-113
+        env:
+        - name: OPENID_PROVIDER_CONFIGURATION_URL
+          value: https://sandbox.identity.zalando.com/.well-known/openid-configuration
+        - name: ISSUER
+          value: "https://sandbox.identity.zalando.com"
+        - name: LISTEN_ADDRESS
+          value: ":9022"
+        - name: METRICS_LISTEN_ADDRESS
+          value: ":9023"
+        - name: BUSINESS_PARTNERS
+          value: {{ .Cluster.ConfigItems.apiserver_business_partner_ids }}
+        ports:
+        - containerPort: 9022
+        lifecycle:
+          preStop:
+            sleep:
+              seconds: 20
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 9022
+          periodSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 9022
+          periodSeconds: 3
+          failureThreshold: 2
+        resources:
+          limits:
+            cpu: 50m
+            memory: 100Mi
+      # {{- end}}
+# {{ end }}

--- a/cluster/manifests/zalando-iam-aws-proxy/deployment.yaml
+++ b/cluster/manifests/zalando-iam-aws-proxy/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: zalando-iam-aws-proxy
       containers:
       - name: proxy
-        image: mikkeloscar/zalando-iam-aws-proxy:1
+        image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/zalando-iam-aws-proxy:main-1
         args:
         - "--apiserver-url=https://kubernetes.default.svc.cluster.local"
         - "--ca-file-path=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"

--- a/cluster/manifests/zalando-iam-aws-proxy/hpa.yaml
+++ b/cluster/manifests/zalando-iam-aws-proxy/hpa.yaml
@@ -1,0 +1,32 @@
+# {{ if eq .Cluster.Provider "zalando-eks" }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: zalando-iam-aws-proxy
+  namespace: kube-system
+  labels:
+    application: kubernetes
+    component: zalando-iam-aws-proxy
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: zalando-iam-aws-proxy
+  minReplicas: 2
+  maxReplicas: {{.Cluster.ConfigItems.eks_zalando_iam_aws_proxy_hpa_max_replicas}}
+  metrics:
+  - type: ContainerResource
+    containerResource:
+      name: cpu
+      container: proxy
+      target:
+        type: Utilization
+        averageUtilization: {{.Cluster.ConfigItems.eks_zalando_iam_aws_proxy_hpa_cpu_target}}
+  - type: ContainerResource
+    containerResource:
+      name: memory
+      container: proxy
+      target:
+        type: Utilization
+        averageUtilization: {{.Cluster.ConfigItems.eks_zalando_iam_aws_proxy_hpa_memory_target}}
+# {{ end }}

--- a/cluster/manifests/zalando-iam-aws-proxy/rbac.yaml
+++ b/cluster/manifests/zalando-iam-aws-proxy/rbac.yaml
@@ -1,0 +1,12 @@
+# {{ if eq .Cluster.Provider "zalando-eks" }}
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: zalando-iam-aws-proxy
+  namespace: kube-system
+  labels:
+    application: kubernetes
+    component: zalando-iam-aws-proxy
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/{{ .Cluster.LocalID }}-zalando-iam-aws-proxy"
+# {{ end }}

--- a/cluster/manifests/zalando-iam-aws-proxy/routegroup.yaml
+++ b/cluster/manifests/zalando-iam-aws-proxy/routegroup.yaml
@@ -1,0 +1,26 @@
+# {{ if eq .Cluster.Provider "zalando-eks" }}
+apiVersion: zalando.org/v1
+kind: RouteGroup
+metadata:
+  name: zalando-iam-aws-proxy
+  namespace: kube-system
+  labels:
+    application: kubernetes
+    component: zalando-iam-aws-proxy
+spec:
+  hosts:
+    - {{.Cluster.LocalID}}-zalando-iam-aws-proxy.{{ .Values.hosted_zone }}
+  backends:
+    - name: zalando-iam-aws-proxy
+      type: service
+      serviceName: zalando-iam-aws-proxy
+      servicePort: 80
+  defaultBackends:
+    - backendName: zalando-iam-aws-proxy
+  routes:
+    - pathSubtree: /
+      predicates:
+        - HeaderRegexp("Authorization", "^Bearer .+")
+      filters:
+        - oauthTokeninfoAnyKV("realm", "/services")
+# {{ end }}

--- a/cluster/manifests/zalando-iam-aws-proxy/service.yaml
+++ b/cluster/manifests/zalando-iam-aws-proxy/service.yaml
@@ -1,0 +1,18 @@
+# {{ if eq .Cluster.Provider "zalando-eks" }}
+kind: Service
+apiVersion: v1
+metadata:
+  name: zalando-iam-aws-proxy
+  namespace: kube-system
+  labels:
+    application: kubernetes
+    component: zalando-iam-aws-proxy
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    deployment: zalando-iam-aws-proxy
+# {{ end }}

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -190,11 +190,7 @@ spec:
       kubelet:
         clusterDNS: [ "10.0.1.100" ]
         cpuCFSQuota: false
-#{{ if eq .Cluster.Provider "zalando-eks" }}
-        # TODO: Uses lower limit for simplicity need to support dynamic value based
-        # on instance type.
-        maxPods: 10
-#{{ else }}
+#{{ if ne .Cluster.Provider "zalando-eks" }}
 # {{ if ne .Cluster.ConfigItems.karpenter_max_pods_per_node "" }}
         maxPods: {{ .Cluster.ConfigItems.karpenter_max_pods_per_node }}
 # {{ else }}

--- a/cluster/node-pools/worker-splitaz/userdata.yaml
+++ b/cluster/node-pools/worker-splitaz/userdata.yaml
@@ -85,9 +85,9 @@ write_files:
       podPidsLimit: {{ .NodePool.ConfigItems.pod_max_pids }}
       cpuManagerPolicy: {{ .NodePool.ConfigItems.cpu_manager_policy }}
 {{- if eq .Cluster.Provider "zalando-eks" }}
-      # TODO: Uses lower limit for simplicity need to support dynamic value
-      # based on instance type.
-      maxPods: 14
+      # replaced with dynamic value based on instance type during instance
+      # start-up.
+      maxPods: __MAX_PODS__
 {{- else }}
       maxPods: {{ nodeCIDRMaxPods (parseInt64 .Cluster.ConfigItems.node_cidr_mask_size) (parseInt64 .Cluster.ConfigItems.node_max_pods_extra_capacity) }}
 {{- end }}

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -26,7 +26,7 @@ RUN chmod +x /usr/bin/kubectl
 COPY --from=builder /go/bin/ginkgo /usr/local/bin/ginkgo
 
 # copy CLM
-COPY --from=container-registry.zalando.net/teapot/cluster-lifecycle-manager:latest /clm /usr/bin/clm
+COPY --from=container-registry-test.zalando.net/teapot/cluster-lifecycle-manager:pr-777-9 /clm /usr/bin/clm
 COPY --from=container-registry.zalando.net/teapot/aws-account-creator:latest /aws-account-creator /usr/bin/aws-account-creator
 
 ADD . /workdir


### PR DESCRIPTION
This adds a Proof of Concept proxy which can translate from Zalando IAM tokens to AWS IAM credentials which gives access in EKS.

The AWS IAM credentials are mapped to a username in Kubernetes: `zalando-iam:zalando:service:{{SessionName}}` Where `SessionName` will be the `UID` of the Zalando IAM token. Such that a user for a service becomes e.g.: `zalando-iam:zalando:service:stups_<app_id>` which is what we have in place today.

The idea is that the proxy works as a secondary API-endpoint to be called by services with Zalando IAM tokens: `https://<local-id>-zalando-iam-aws-proxy.<account>.zalan.do`

It may even make sense to set this URL as the `api_server_url` in cluster registry for EKS clusters, such that existing clients like CDP will just transparently work.