### PR TITLE
Give deployment-service permission to handle resource cleanup tasks

### DIFF
--- a/cluster/manifests/deployment-service/controller-rbac.yaml
+++ b/cluster/manifests/deployment-service/controller-rbac.yaml
@@ -22,6 +22,8 @@ rules:
     resources:
       - cdpdeploymenttasks
       - cdpdeploymenttasks/status
+      - cdpresourcecleanuptasks
+      - cdpresourcecleanuptasks/status
     verbs:
       - get
       - list
@@ -138,6 +140,8 @@ rules:
   resources:
   - cdpdeploymenttasks
   - cdpdeploymenttasks/status
+  - cdpresourcecleanuptasks
+  - cdpresourcecleanuptasks/status
   verbs:
   - create
   - get

--- a/cluster/manifests/roles/deployment-service.yaml
+++ b/cluster/manifests/roles/deployment-service.yaml
@@ -11,6 +11,8 @@ rules:
     resources:
       - cdpdeploymenttasks
       - cdpdeploymenttasks/status
+      - cdpresourcecleanuptasks
+      - cdpresourcecleanuptasks/status
     verbs:
       - get
       - list


### PR DESCRIPTION
Both controller and API components need access to the resource cleanup tasks.