### PR TITLE
fix: skipper fleet to use Go version 1.22.5

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.21.139-963" }}
+{{ $internal_version := "v0.21.141-965" }}
 {{ $canary_internal_version := "v0.21.141-965" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}


### PR DESCRIPTION
fix: skipper fleet to use Go version 1.22.5