### PR TITLE
kube-aws-iam-controller: Don't assume worker role on eks

### DIFF
--- a/cluster/manifests/03-kube-aws-iam-controller/deployment.yaml
+++ b/cluster/manifests/03-kube-aws-iam-controller/deployment.yaml
@@ -33,7 +33,9 @@ spec:
           value: "{{.Cluster.Region}}"
         args:
         - --debug
+        # {{if ne .Cluster.Provider "zalando-eks"}}
         - "--assume-role={{.Cluster.LocalID}}-worker"
+        # {{end}}
         resources:
           limits:
             cpu: "{{.Cluster.ConfigItems.kube_aws_iam_controller_cpu}}"


### PR DESCRIPTION
Since kube-aws-iam-controller runs on a worker node on eks based cluster, it doesn't need to assume the worker role.