### PR TITLE
Include alias in Prometheus endpoint

### DIFF
--- a/cluster/manifests/prometheus/ingress.yaml
+++ b/cluster/manifests/prometheus/ingress.yaml
@@ -9,6 +9,7 @@ metadata:
 spec:
   hosts:
     - system-prometheus.{{ .Values.hosted_zone }}
+    - system-prometheus-{{ .Cluster.Alias }}.{{ .Values.hosted_zone }}
   backends:
     - name: prometheus
       type: service

--- a/cluster/manifests/prometheus/ingress.yaml
+++ b/cluster/manifests/prometheus/ingress.yaml
@@ -23,6 +23,7 @@ spec:
         - HeaderRegexp("Authorization", "^Bearer .+")
       filters:
         - oauthTokeninfoAnyKV("realm", "/employees", "realm", "/services")
+        - enableAccessLog()
 
     # {{ if .Cluster.ConfigItems.prometheus_ui_users }}
     #   {{ $uidKVs := "" }}
@@ -34,4 +35,5 @@ spec:
       filters:
         - oauthGrant()
         - oauthTokeninfoAnyKV({{ $uidKVs }})
+        - enableAccessLog()
     # {{ end }}


### PR DESCRIPTION
When running multiple clusters in a single AWS account, the prometheus endpoint would overlap between the clusters. Add a hostname which includes the alias such that it can be by cluster without overlap.

Similar to #7509