### PR TITLE
Use static base image for more components

### DIFF
--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: kube-static-egress-controller
       containers:
       - name: controller
-        image: container-registry.zalando.net/teapot/kube-static-egress-controller:v0.3.0-master-48
+        image: container-registry.zalando.net/teapot/kube-static-egress-controller:v0.3.0-master-49
         args:
         - "--provider=aws"
         - "--vpc-id={{.Cluster.ConfigItems.vpc_id}}"

--- a/cluster/manifests/pdb-controller/deployment.yaml
+++ b/cluster/manifests/pdb-controller/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: pdb-controller
       containers:
       - name: pdb-controller
-        image: container-registry.zalando.net/teapot/pdb-controller:master-33
+        image: container-registry.zalando.net/teapot/pdb-controller:master-34
         args:
           - --debug
 {{- if .Cluster.ConfigItems.pdb_controller_non_ready_ttl }}


### PR DESCRIPTION
* Use static base image for pdb-controller
* Use static base image for kube-static-egress-controller