### PR TITLE
Skip mustache rendering by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -958,7 +958,7 @@ deployment_service_ml_experiments_enabled: "true"
 deployment_service_cf_auto_expand_enabled: "false"
 deployment_service_cf_update_source_branch_changes: "true"
 deployment_service_executor_cdp_permissions: "false"
-deployment_service_skip_mustache_rendering: "false"
+deployment_service_skip_mustache_rendering: "true"
 {{- if eq .Cluster.Environment "test" }}
 # disable CF update of source branch changes in test to avoid updating CF stacks
 # on any PR.


### PR DESCRIPTION
This configuration was rolled out to all channels. Let's switch the default in order to remove the individual configs here: https://github.bus.zalan.do/teapot/cluster-config-manager/blob/main/channels.yaml