### PR TITLE
Configure flannel-awaiter requests.

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -381,6 +381,9 @@ kube_proxy_verbose_level: "2"
 flannel_cpu: "25m"
 flannel_memory: "100Mi"
 
+flannel_awaiter_cpu: "25m"
+flannel_awaiter_memory: "50Mi"
+
 # nvidia device plugin
 nvidia_device_plugin_cpu: "10m"
 nvidia_device_plugin_memory: "50Mi"

--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -43,12 +43,12 @@ spec:
         stdin: true
         resources:
           requests:
-            cpu: 25m
-            memory: 50Mi
+            cpu: "{{ .Cluster.ConfigItems.flannel_awaiter_cpu }}"
+            memory: "{{ .Cluster.ConfigItems.flannel_awaiter_memory }}"
             ephemeral-storage: 256Mi
           limits:
-            cpu: 25m
-            memory: 50Mi
+            cpu: "{{ .Cluster.ConfigItems.flannel_awaiter_cpu }}"
+            memory: "{{ .Cluster.ConfigItems.flannel_awaiter_memory }}"
         startupProbe:
           exec:
             command:


### PR DESCRIPTION
Configures flannel-awaiter requests. Flannel awaiter was being OOMKilled in `search` cluster, this Pull Request allows persisting memory and CPU limits/request of flannel-awaiter.