### PR TITLE
skipper: update main fleet to v0.21.161

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.21.150-974" }}
+{{ $internal_version := "v0.21.161-981" }}
 {{ $canary_internal_version := "v0.21.161-981" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}


### PR DESCRIPTION
* https://github.com/zalando/skipper/pull/3167
* https://github.com/zalando/skipper/pull/3166
* https://github.com/zalando/skipper/pull/3165
* https://github.com/zalando/skipper/pull/3164
* https://github.com/zalando/skipper/pull/3162
* https://github.com/zalando/skipper/pull/3161
* https://github.com/zalando/skipper/pull/3159
* https://github.com/zalando/skipper/pull/3158
* https://github.com/zalando/skipper/pull/3070
* https://github.com/zalando/skipper/pull/3140
* https://github.com/zalando/skipper/pull/3155

[Changes](https://github.com/zalando/skipper/compare/v0.21.150...v0.21.161)

Canary update was done there: https://github.com/zalando-incubator/kubernetes-on-aws/pull/7891