### PR TITLE
Use `-enable-versioning=true` instead of `-enable-versioning`

### DIFF
--- a/cluster/manifests/fabric-gateway/deployment.yaml
+++ b/cluster/manifests/fabric-gateway/deployment.yaml
@@ -48,7 +48,7 @@ spec:
             - -allow-all-filters=true
             {{ end }}
             {{ if eq .Cluster.ConfigItems.fabric_gateway_controller_enable_versioning "true" }}
-            - -enable-versioning
+            - -enable-versioning=true
             {{ end }}
           resources:
             requests:


### PR DESCRIPTION
The new cmdline options causes less confusion and has no way it could be misinterpreted.