### PR TITLE
Update RBAC to correspond to fabric-gateway-controller code

### DIFF
--- a/cluster/manifests/fabric-gateway/01-rbac.yaml
+++ b/cluster/manifests/fabric-gateway/01-rbac.yaml
@@ -39,6 +39,7 @@ rules:
       - create
       - update
       - patch
+      - delete
   - apiGroups:
       - zalando.org
     resources:
@@ -64,6 +65,7 @@ rules:
       - get
       - create
       - delete
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Just a small change for fabric-gateway-controller not to fail because of lack of permissions.