### PR TITLE
Update RBAC to correspond to fabric-gateway-controller code

### DIFF
--- a/cluster/manifests/fabric-gateway/01-rbac.yaml
+++ b/cluster/manifests/fabric-gateway/01-rbac.yaml
@@ -20,6 +20,7 @@ rules:
     resources:
       - fabricgateways
     verbs:
+      - get
       - list
       - watch
   - apiGroups:


### PR DESCRIPTION
Just a small change for fabric-gateway-controller not to fail because of lack of permissions.