### PR TITLE
Update skipper version, step 2/2

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,4 +1,4 @@
-{{ $internal_version := "v0.21.161-981" }}
+{{ $internal_version := "v0.21.169-989" }}
 {{ $canary_internal_version := "v0.21.169-989" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}


### PR DESCRIPTION
Canary was updated here: https://github.com/zalando-incubator/kubernetes-on-aws/pull/7941

+ https://github.com/zalando/skipper/pull/3175
+ https://github.com/zalando/skipper/pull/3174
+ https://github.com/zalando/skipper/pull/3173
+ https://github.com/zalando/skipper/pull/3172
+ https://github.com/zalando/skipper/pull/3170
+ https://github.com/zalando/skipper/pull/3176
+ https://github.com/zalando/skipper/pull/3160
+ https://github.com/zalando/skipper/pull/3184
+ https://github.com/zalando/skipper/pull/3185
+ https://github.com/zalando/skipper/pull/3186
+ https://github.com/zalando/skipper/pull/3181
+ https://github.com/zalando/skipper/pull/3183
+ https://github.com/zalando/skipper/pull/3187