### PR TITLE
Add region condition to SSM session logging

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -2148,6 +2148,7 @@ Resources:
           shellProfile:
             linux: 'bash'
 
+{{- if eq .Cluster.Region "eu-central-1"}}
   SessionManagerSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
     Properties:
@@ -2181,6 +2182,7 @@ Resources:
                 Resource:
                   - !GetAtt SessionManagerLogGroup.Arn
       RoleName: "SessionManagerSubscriptionFilterRole"
+{{- end }}
 
   AWSNodeDecommissionerIAMRole:
     Type: 'AWS::IAM::Role'


### PR DESCRIPTION
Follow up to https://github.com/zalando-incubator/kubernetes-on-aws/pull/7916

Currently we do not have a `destination` configured for regions outside of `eu-central-1`. For now, exclude sending logs to the centralised account in other regions.