### PR TITLE
Make Session Manager logging resources unique per cluster

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -2125,7 +2125,7 @@ Resources:
   SessionManagerLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: "SessionManagerLogGroup-{{accountID .Cluster.InfrastructureAccount}}"
+      LogGroupName: "SessionManager-{{accountID .Cluster.InfrastructureAccount}}-{{.Cluster.LocalID}}"
       RetentionInDays: 30
 
   SessionManagerPreferencesDocument:
@@ -2154,7 +2154,7 @@ Resources:
     Properties:
       LogGroupName: !Ref SessionManagerLogGroup
       RoleArn: !GetAtt SessionManagerSubscriptionFilterRole.Arn
-      FilterName: "SessionManagerSubscriptionFilter-{{accountID .Cluster.InfrastructureAccount}}"
+      FilterName: "SessionManager-{{accountID .Cluster.InfrastructureAccount}}-{{.Cluster.LocalID}}"
       FilterPattern: ""
       DestinationArn: "{{.Cluster.ConfigItems.session_manager_destination_arn}}"
 
@@ -2181,7 +2181,7 @@ Resources:
                   - "logs:PutLogEvents"
                 Resource:
                   - !GetAtt SessionManagerLogGroup.Arn
-      RoleName: "SessionManagerSubscriptionFilterRole"
+      RoleName: "SessionManager-{{.Cluster.LocalID}}"
 {{- end }}
 
   AWSNodeDecommissionerIAMRole:


### PR DESCRIPTION
Add a unique Cluster ID to Session Manager resources to avoid resource conflicts in accounts with multiple clusters