### PR TITLE
Import Session Manager document

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -2132,7 +2132,7 @@ Resources:
     Type: AWS::SSM::Document
     Properties:
       UpdateMethod: NewVersion
-      Name: SSM-SessionManagerRunShell
+      Name: !ImportValue "SessionManagerDocumentName"
       DocumentFormat: YAML
       DocumentType: Session
       Content:
@@ -2467,3 +2467,7 @@ Outputs:
     Export:
       Name: '{{ .Cluster.ID}}:etcd-encryption-key'
     Value: !Ref EtcdEncryptionKey
+  SessionManagerPreferencesDocument:
+    Export:
+      Name: 'SessionManagerDocumentName'
+    Value: !Ref SessionManagerPreferencesDocument


### PR DESCRIPTION
The `SSM-SessionManagerRunShell` document is used to configure Session Manager preferences and must use this specific name. In order to share the Session Manager preferences document across multiple stacks, the resource must be exported and imported.