### PR TITLE
Do not create account level Session Manager preferences document during e2e

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -2132,7 +2132,11 @@ Resources:
     Type: AWS::SSM::Document
     Properties:
       UpdateMethod: NewVersion
-      Name: SSM-SessionManagerRunShell
+{{ if eq .Cluster.Environment "e2e" }} # test for valid cloudformation in e2e tests, but do not set account level preferences
+      Name: "SSM-SessionManagerRunShell-{{.Cluster.LocalID}}"
+{{ else }}
+      Name: "SSM-SessionManagerRunShell"
+{{- end }}
       DocumentFormat: YAML
       DocumentType: Session
       Content:


### PR DESCRIPTION
Due to conflicting ownership of the AWS Account level Session Manager preferences document, only create a session-level `Document` during e2e testing.