### PR TITLE
reduce the disruption budget of the karpenter node pools node pools

### DIFF
--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -198,6 +198,10 @@ spec:
   # Configuration in this section constrains how aggressive Karpenter can be with performing operations
   # like rolling Nodes due to them hitting their maximum lifetime (expiry) or scaling down nodes to reduce cluster cost
   disruption:
+    # limit the maximum number of nodes that can be removed from the NodePool at once to 10 nodes for clusters with gte 200 nodes
+    budgets:
+      - nodes: "5%"
+      - nodes: "10"
     # Describes which types of Nodes Karpenter should consider for consolidation
     # If using 'WhenUnderutilized', Karpenter will consider all nodes for consolidation and attempt to remove or replace Nodes when it discovers that the Node is underutilized and could be changed to reduce cost
     # If using `WhenEmpty`, Karpenter will only consider nodes for consolidation that contain no workload pods


### PR DESCRIPTION
many users reported that karpenter is aggressive in disrupting pods. this budget reduces the maximum number of nodes to be disrupted at a time from 10% to the minimum of 5% or 10 nodes