### PR TITLE
[CHERRYPICK] Set infrastructure tag to Falso in SSM document.

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -2131,6 +2131,9 @@ Resources:
   SessionManagerPreferencesDocument:
     Type: AWS::SSM::Document
     Properties:
+      Tags:
+        - Key: InfrastructureComponent
+          Value: "false"
       UpdateMethod: NewVersion
       Name: SSM-SessionManagerRunShell
       DocumentFormat: YAML


### PR DESCRIPTION
Remove infrastructure component tag from SSM document, introduced in https://github.com/zalando-incubator/kubernetes-on-aws/pull/7916