### PR TITLE
[e2e] add kube-system as soft fail namespace in admission-controller pod admitter

### DIFF
--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -46,6 +46,7 @@ clusters:
     teapot_admission_controller_daemonset_reserved_cpu: "518m"
     karpenter_pools_enabled: "true"
     okta_auth_client_id: "kubernetes.cluster.teapot-e2e"
+    teapot_admission_controller_validate_pod_images_soft_fail_namespaces: "^kube-system$"
   criticality_level: 1
   environment: e2e
   id: ${CLUSTER_ID}


### PR DESCRIPTION
The `Create Cluster` step in the e2e pipeline often fails a lot for all kube-system pods with the following error

```bash
INFO [2024-08-20 22:02:34,670]: Still updating: deployment kube-system/autoscaling-buffer-eu-central-1a, 0/1 updated [Created new replica set "autoscaling-buffer-eu-central-1a-5fc99f47c8" Deployment does not have minimum availability. admission webhook "pod-admitter.teapot.zalan.do" denied the request: image check for 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/pause:3.7-master-21 failed: token not available]
```

As a workaround, adding a config-item to our e2e clusters to allow certain whitelisted namespace images to be allowed in case docker-meta API has issues. This enables `kube-system` as a whitelisted namespace so e2e doesn't fail and create cluster step can succeed.
