### PR TITLE
fix: missing image label that we need for versioned metrics

### DIFF
--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -442,7 +442,7 @@ data:
         replacement: $1:10250
       metric_relabel_configs:
       - action: labeldrop
-        regex: "(name|id|image)"
+        regex: "(name|id)"
       - action: replace
         source_labels: ['container']
         target_label: container_name


### PR DESCRIPTION
fix: missing image label that we need for versioned metrics