### PR TITLE
Improve code quality for e2e tests by fixing linter errors

### DIFF
--- a/test/e2e/admission_controller.go
+++ b/test/e2e/admission_controller.go
@@ -19,7 +19,6 @@ package e2e
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -56,13 +55,12 @@ var _ = describe("Admission controller tests", func() {
 
 	It("Admission controller should inject platform environment variables [Zalando]", func() {
 		nameprefix := "deployment-info-test"
-		podname := fmt.Sprintf("deployment-info-test-pod")
 		var replicas int32 = 1
 		ns := f.Namespace.Name
 
 		By("Creating deployment " + nameprefix + " in namespace " + ns)
 
-		deployment := createDeploymentWithDeploymentInfo(nameprefix+"-", ns, podname, replicas)
+		deployment := createDeploymentWithDeploymentInfo(nameprefix+"-", ns, replicas)
 		_, err := cs.AppsV1().Deployments(ns).Create(context.TODO(), deployment, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		labelSelector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
@@ -175,7 +173,7 @@ func createInvalidOwnerPod(namespace, podname string) *v1.Pod {
 	}
 }
 
-func createDeploymentWithDeploymentInfo(nameprefix, namespace, podname string, replicas int32) *appsv1.Deployment {
+func createDeploymentWithDeploymentInfo(nameprefix, namespace string, replicas int32) *appsv1.Deployment {
 	zero := int64(0)
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/authorisation_test.go
+++ b/test/e2e/authorisation_test.go
@@ -411,9 +411,7 @@ func verifyResponse(status int, body []byte, test testItem) {
 }
 
 var _ = describe("Authorization tests [Authorization] [RBAC] [Zalando]", func() {
-	should := fmt.Sprintf(
-		"should validate permissions for [Authorization] [RBAC] [Zalando]",
-	)
+	should := "should validate permissions for [Authorization] [RBAC] [Zalando]"
 	It(should, func() {
 		conf, err := framework.LoadConfig()
 		Expect(err).NotTo(HaveOccurred()) // BDD = Because :DDD

--- a/test/e2e/gpu.go
+++ b/test/e2e/gpu.go
@@ -61,7 +61,7 @@ var _ = describe("GPU job processing", func() {
 			}
 			n := p.Status.ContainerStatuses[0].State.Terminated.ExitCode
 			if n != 0 {
-				framework.ExpectNoError(fmt.Errorf("Expected POD %s to terminate with exit code 0", pod.Name))
+				framework.ExpectNoError(fmt.Errorf("expected POD %s to terminate with exit code 0", pod.Name))
 				return
 			}
 			logs, err := getPodLogs(cs, ns, pod.Name, "cuda-vector-add", false)

--- a/test/e2e/ingress.go
+++ b/test/e2e/ingress.go
@@ -478,7 +478,7 @@ var ___ = describe("Ingress tests paths", func() {
 
 		By(fmt.Sprintf("Testing for ingress %s/%s we want to get a 200 for path %s without change from the other path", ingressUpdate.Namespace, ingressUpdate.Name, bepath))
 		beurl = "https://" + hostName + bepath
-		bereq, err = http.NewRequest("GET", beurl, nil)
+		bereq, _ = http.NewRequest("GET", beurl, nil)
 		resp, err = getAndWaitResponse(rt, bereq, 10*time.Second, http.StatusOK)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -601,7 +601,7 @@ var ____ = describe("Ingress tests custom routes", func() {
 		reqRedirectURL := resp.Header.Get("Location")
 		By(fmt.Sprintf("Testing for ingress %s/%s rediretc Location we want to get a 200 for URL %s", ingressUpdate.Namespace, ingressUpdate.Name, reqRedirectURL))
 		Expect(redirectDestinationURL).To(Equal(reqRedirectURL))
-		redirectreq, err := http.NewRequest("GET", reqRedirectURL, nil)
+		redirectreq, _ := http.NewRequest("GET", reqRedirectURL, nil)
 		resp, err = getAndWaitResponse(rt, redirectreq, 10*time.Second, http.StatusOK)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -780,7 +780,7 @@ var _____ = describe("Ingress tests paths", func() {
 
 		By(fmt.Sprintf("Testing for ingress %s/%s we want to get a 200 for path %s without change from the other path", ingressUpdate.Namespace, ingressUpdate.Name, bepath))
 		beurl = "https://" + hostName + bepath
-		bereq, err = http.NewRequest("GET", beurl, nil)
+		bereq, _ = http.NewRequest("GET", beurl, nil)
 		resp, err = getAndWaitResponse(rt, bereq, 10*time.Second, http.StatusOK)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -790,7 +790,7 @@ var _____ = describe("Ingress tests paths", func() {
 
 		By(fmt.Sprintf("Testing for ingress %s/%s we want to get a 200 for path %s/path/prefix/match and pathType Prefix", ingressUpdate.Namespace, ingressUpdate.Name, bepath2))
 		beurl = "https://" + hostName + bepath2 + "/path/prefix/match"
-		bereq, err = http.NewRequest("GET", beurl, nil)
+		bereq, _ = http.NewRequest("GET", beurl, nil)
 		resp, err = getAndWaitResponse(rt, bereq, 10*time.Second, http.StatusOK)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -913,7 +913,7 @@ var ______ = describe("Ingress tests custom routes", func() {
 		reqRedirectURL := resp.Header.Get("Location")
 		By(fmt.Sprintf("Testing for ingress %s/%s rediretc Location we want to get a 200 for URL %s", ingressUpdate.Namespace, ingressUpdate.Name, reqRedirectURL))
 		Expect(redirectDestinationURL).To(Equal(reqRedirectURL))
-		redirectreq, err := http.NewRequest("GET", reqRedirectURL, nil)
+		redirectreq, _ := http.NewRequest("GET", reqRedirectURL, nil)
 		resp, err = getAndWaitResponse(rt, redirectreq, 10*time.Second, http.StatusOK)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))

--- a/test/e2e/kube_metrics_adapter_test.go
+++ b/test/e2e/kube_metrics_adapter_test.go
@@ -176,7 +176,6 @@ type CustomMetricTestCase struct {
 	rgClient        rgclient.Interface
 	jig             *ingress.TestJig
 	deployment      *appsv1.Deployment
-	pod             *corev1.Pod
 	initialReplicas int
 	scaledReplicas  int
 	ingress         *netv1.Ingress

--- a/test/e2e/node_test.go
+++ b/test/e2e/node_test.go
@@ -15,7 +15,6 @@ import (
 	admissionapi "k8s.io/pod-security-admission/api"
 
 	. "github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
 )
 
@@ -220,6 +219,6 @@ var _ = describe("Node tests", func() {
 		framework.ExpectNoError(e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, pod.Name, pod.Namespace, framework.PodDeleteTimeout))
 
 		_, err = cs.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-		gomega.Expect(apierrors.IsNotFound(err)).To(gomega.BeTrue(), "node should not be found")
+		Expect(apierrors.IsNotFound(err)).To(BeTrue(), "node should not be found")
 	})
 })

--- a/test/e2e/routegroup.go
+++ b/test/e2e/routegroup.go
@@ -390,7 +390,9 @@ rBackend: Path("/backend") -> inlineContent("%s") -> <shunt>;
 			return code == http.StatusTooManyRequests
 		}, false)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(resp).To(Equal(expectedResponse))
+		s, err = getBody(resp)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(s).To(Equal(expectedResponse))
 	})
 
 	It("Should create blue-green routes [RouteGroup] [Zalando]", func() {

--- a/test/e2e/routegroup.go
+++ b/test/e2e/routegroup.go
@@ -269,14 +269,14 @@ rBackend4: Path("/router-response") -> inlineContent("NOT OK") -> <shunt>;
 
 		// response for / is from our backend
 		By("checking the response code of a request without required request header, we can check if predicate match works correctly")
-		req, err := http.NewRequest("GET", "https://"+hostName+"/backend", nil)
+		req, _ := http.NewRequest("GET", "https://"+hostName+"/backend", nil)
 		resp, err = waitForResponseReturnResponse(req, 10*time.Minute, isNotFound, false)
 		Expect(err).NotTo(HaveOccurred())
 		resp.Body.Close()
 
 		// checking backend route with predicates and filters
 		By("checking the response status code for a request to /backend without correct headers we should get 404")
-		err = waitForResponse("https://"+hostName+"/backend", "https", 10*time.Minute, isNotFound, false)
+		waitForResponse("https://"+hostName+"/backend", "https", 10*time.Minute, isNotFound, false)
 		By("checking the response for a request to /backend with the right header we know if we got the correct route")
 		req, err = http.NewRequest("GET", "https://"+hostName+"/backend", nil)
 		Expect(err).NotTo(HaveOccurred())
@@ -390,7 +390,7 @@ rBackend: Path("/backend") -> inlineContent("%s") -> <shunt>;
 			return code == http.StatusTooManyRequests
 		}, false)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(s).To(Equal(expectedResponse))
+		Expect(resp).To(Equal(expectedResponse))
 	})
 
 	It("Should create blue-green routes [RouteGroup] [Zalando]", func() {
@@ -571,7 +571,7 @@ rBackend: Path("/blue-green") -> status(202) -> inlineContent("%s") -> <shunt>;`
 
 		// RouteGroup
 		By("Creating a routegroup with name " + serviceName + "-" + serviceName2 + " in namespace " + ns + " with hostname " + hostName)
-		rg := createRouteGroupWithBackends(serviceName+"-"+serviceName2, hostName, ns, labels, nil, port,
+		rg := createRouteGroupWithBackends(serviceName+"-"+serviceName2, hostName, ns, labels, nil,
 			[]rgv1.RouteGroupBackend{
 				{
 					Name:        expectedResponse,

--- a/test/e2e/routegroup.go
+++ b/test/e2e/routegroup.go
@@ -391,7 +391,7 @@ rBackend: Path("/backend") -> inlineContent("%s") -> <shunt>;
 		}, false)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp).NotTo(BeNil())
-		Expect(resp.StatusCode).To(Eqal(http.StatusTooManyRequests))
+		Expect(resp.StatusCode).To(Equal(http.StatusTooManyRequests))
 	})
 
 	It("Should create blue-green routes [RouteGroup] [Zalando]", func() {

--- a/test/e2e/routegroup.go
+++ b/test/e2e/routegroup.go
@@ -390,9 +390,8 @@ rBackend: Path("/backend") -> inlineContent("%s") -> <shunt>;
 			return code == http.StatusTooManyRequests
 		}, false)
 		Expect(err).NotTo(HaveOccurred())
-		s, err = getBody(resp)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(s).To(Equal(expectedResponse))
+		Expect(resp).NotTo(BeNil())
+		Expect(resp.StatusCode).To(Eqal(http.StatusTooManyRequests))
 	})
 
 	It("Should create blue-green routes [RouteGroup] [Zalando]", func() {


### PR DESCRIPTION
1. remove unused parameters from functions
2. rename unused variables to _
3. uncapitalise error msg text
4. remove duplicate imports

Also, a routegroup e2e test had a bug where it was using a response value from a previous request, it got caught because of the linter complaining that the new response value was never used. (`routegroup.go` line 393)