### PR TITLE
[e2e] replace deprecated k8s registry with the new one for e2e images

### DIFF
--- a/test/e2e/admission_controller.go
+++ b/test/e2e/admission_controller.go
@@ -42,7 +42,7 @@ const (
 	application  = "e2e-test-application"
 	component    = "e2e-test-component"
 	environment  = "e2e-test-environment"
-	dockerImage  = "k8s.gcr.io/busybox"
+	dockerImage  = "registry.k8s.io/busybox"
 )
 
 var _ = describe("Admission controller tests", func() {

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -935,7 +935,7 @@ func createVectorPod(nameprefix, namespace string, labels map[string]string) *v1
 			Containers: []v1.Container{
 				{
 					Name:  "cuda-vector-add",
-					Image: "k8s.gcr.io/cuda-vector-add:v0.1",
+					Image: "registry.k8s.io/cuda-vector-add:v0.1",
 					Resources: corev1.ResourceRequirements{
 						Limits: v1.ResourceList{
 							NVIDIAGPUResourceName: *resource.NewQuantity(1, resource.DecimalSI),


### PR DESCRIPTION
`k8s.gcr.io` registry was deprecated more than a year ago and is frozen now, we should move to the new `registry.k8s.io` for the images used in our e2e tests

https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/