### PR TITLE
update AMI with k8s 1.30.3 and ipv6

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -704,8 +704,8 @@ tracing_coredns_local_zone_traces_endpoint: ""
 # AMI id given the image name and the Image AWS account owner.
 #
 # [0]: https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/8a9bd1cb2d094038a9e23e646421f8146b48886a/provisioner/template.go#L116
-kuberuntu_image_v1_30_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.30.2-amd64-master-341" "861068367966" }}
-kuberuntu_image_v1_30_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.30.2-arm64-master-341" "861068367966" }}
+kuberuntu_image_v1_30_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.30.3-amd64-master-343" "861068367966" }}
+kuberuntu_image_v1_30_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.30.3-arm64-master-343" "861068367966" }}
 
 # Which distro from the previous config items should be used. Valid options are only `jammy` for now. Can be set for each node pool.
 kuberuntu_distro_master: "jammy"


### PR DESCRIPTION
Update k8s AMI to include k8s v1.30.3 and optional ipv6 support.

Reference: https://github.bus.zalan.do/teapot/kubernetes-on-ubuntu/pull/365