### PR TITLE
[e2e] fix flake tests with image validation API errors

### DIFF
--- a/test/e2e/apiserver.go
+++ b/test/e2e/apiserver.go
@@ -49,17 +49,17 @@ const (
 	compliantImage7 = "container-registry.zalando.net/teapot/skipper:v0.21.6"
 	compliantImage8 = "container-registry.zalando.net/teapot/skipper:v0.21.7"
 
-	// these are non-compliant because of expired base image
-	nonCompliantImage1  = "container-registry.zalando.net/teapot/skipper:v0.16.0"
-	nonCompliantImage2  = "container-registry.zalando.net/teapot/skipper:v0.16.1"
-	nonCompliantImage3  = "container-registry.zalando.net/teapot/skipper:v0.16.2"
-	nonCompliantImage4  = "container-registry.zalando.net/teapot/skipper:v0.16.3"
-	nonCompliantImage5  = "container-registry.zalando.net/teapot/skipper:v0.16.4"
-	nonCompliantImage6  = "container-registry.zalando.net/teapot/skipper:v0.16.5"
-	nonCompliantImage7  = "container-registry.zalando.net/teapot/skipper:v0.16.6"
-	nonCompliantImage8  = "container-registry.zalando.net/teapot/skipper:v0.16.7"
-	nonCompliantImage9  = "container-registry.zalando.net/teapot/skipper:v0.16.8"
-	nonCompliantImage10 = "container-registry.zalando.net/teapot/skipper:v0.16.9"
+	// these are non-compliant because of being test images
+	nonCompliantImage1  = "container-registry-test.zalando.net/teapot/skipper-test:pr-3380-1"
+	nonCompliantImage2  = "container-registry-test.zalando.net/teapot/skipper-test:pr-3379-1"
+	nonCompliantImage3  = "container-registry-test.zalando.net/teapot/skipper-test:pr-3378-1"
+	nonCompliantImage4  = "container-registry-test.zalando.net/teapot/skipper-test:pr-3377-1"
+	nonCompliantImage5  = "container-registry-test.zalando.net/teapot/skipper-test:pr-3376-1"
+	nonCompliantImage6  = "container-registry-test.zalando.net/teapot/skipper-test:pr-3373-1"
+	nonCompliantImage7  = "container-registry-test.zalando.net/teapot/skipper-test:pr-3372-1"
+	nonCompliantImage8  = "container-registry-test.zalando.net/teapot/skipper-test:pr-3371-1"
+	nonCompliantImage9  = "container-registry-test.zalando.net/teapot/skipper-test:pr-3375-9"
+	nonCompliantImage10 = "container-registry-test.zalando.net/teapot/skipper-test:pr-3374-8"
 	waitForPodTimeout   = 5 * time.Minute
 )
 

--- a/test/e2e/apiserver.go
+++ b/test/e2e/apiserver.go
@@ -50,16 +50,16 @@ const (
 	compliantImage8 = "container-registry.zalando.net/teapot/skipper:v0.21.7"
 
 	// these are non-compliant because of expired base image
-	nonCompliantImage1  = "container-registry.zalando.net/teapot/skipper:v0.19.0"
-	nonCompliantImage2  = "container-registry.zalando.net/teapot/skipper:v0.19.1"
-	nonCompliantImage3  = "container-registry.zalando.net/teapot/skipper:v0.19.2"
-	nonCompliantImage4  = "container-registry.zalando.net/teapot/skipper:v0.19.3"
-	nonCompliantImage5  = "container-registry.zalando.net/teapot/skipper:v0.19.4"
-	nonCompliantImage6  = "container-registry.zalando.net/teapot/skipper:v0.19.5"
-	nonCompliantImage7  = "container-registry.zalando.net/teapot/skipper:v0.19.6"
-	nonCompliantImage8  = "container-registry.zalando.net/teapot/skipper:v0.19.7"
-	nonCompliantImage9  = "container-registry.zalando.net/teapot/skipper:v0.19.8"
-	nonCompliantImage10 = "container-registry.zalando.net/teapot/skipper:v0.19.9"
+	nonCompliantImage1  = "container-registry.zalando.net/teapot/skipper:v0.16.0"
+	nonCompliantImage2  = "container-registry.zalando.net/teapot/skipper:v0.16.1"
+	nonCompliantImage3  = "container-registry.zalando.net/teapot/skipper:v0.16.2"
+	nonCompliantImage4  = "container-registry.zalando.net/teapot/skipper:v0.16.3"
+	nonCompliantImage5  = "container-registry.zalando.net/teapot/skipper:v0.16.4"
+	nonCompliantImage6  = "container-registry.zalando.net/teapot/skipper:v0.16.5"
+	nonCompliantImage7  = "container-registry.zalando.net/teapot/skipper:v0.16.6"
+	nonCompliantImage8  = "container-registry.zalando.net/teapot/skipper:v0.16.7"
+	nonCompliantImage9  = "container-registry.zalando.net/teapot/skipper:v0.16.8"
+	nonCompliantImage10 = "container-registry.zalando.net/teapot/skipper:v0.16.9"
 	waitForPodTimeout   = 5 * time.Minute
 )
 

--- a/test/e2e/apiserver.go
+++ b/test/e2e/apiserver.go
@@ -39,7 +39,8 @@ import (
 )
 
 const (
-	compliantImage1 = "container-registry.zalando.net/teapot/skipper:v0.21.0" // these are several compliant images
+	// these are several compliant images
+	compliantImage1 = "container-registry.zalando.net/teapot/skipper:v0.21.0"
 	compliantImage2 = "container-registry.zalando.net/teapot/skipper:v0.21.1"
 	compliantImage3 = "container-registry.zalando.net/teapot/skipper:v0.21.2"
 	compliantImage4 = "container-registry.zalando.net/teapot/skipper:v0.21.3"
@@ -49,16 +50,16 @@ const (
 	compliantImage8 = "container-registry.zalando.net/teapot/skipper:v0.21.7"
 
 	// these are non-compliant because of expired base image
-	nonCompliantImage1  = "registry.opensource.zalan.do/teapot/skipper:v0.14.0"
-	nonCompliantImage2  = "registry.opensource.zalan.do/teapot/skipper:v0.14.1"
-	nonCompliantImage3  = "registry.opensource.zalan.do/teapot/skipper:v0.14.2"
-	nonCompliantImage4  = "registry.opensource.zalan.do/teapot/skipper:v0.14.3"
-	nonCompliantImage5  = "registry.opensource.zalan.do/teapot/skipper:v0.14.4"
-	nonCompliantImage6  = "registry.opensource.zalan.do/teapot/skipper:v0.14.5"
-	nonCompliantImage7  = "registry.opensource.zalan.do/teapot/skipper:v0.14.6"
-	nonCompliantImage8  = "registry.opensource.zalan.do/teapot/skipper:v0.14.7"
-	nonCompliantImage9  = "registry.opensource.zalan.do/teapot/skipper:v0.14.8"
-	nonCompliantImage10 = "registry.opensource.zalan.do/teapot/skipper:v0.14.9"
+	nonCompliantImage1  = "container-registry.zalando.net/teapot/skipper:v0.19.0"
+	nonCompliantImage2  = "container-registry.zalando.net/teapot/skipper:v0.19.1"
+	nonCompliantImage3  = "container-registry.zalando.net/teapot/skipper:v0.19.2"
+	nonCompliantImage4  = "container-registry.zalando.net/teapot/skipper:v0.19.3"
+	nonCompliantImage5  = "container-registry.zalando.net/teapot/skipper:v0.19.4"
+	nonCompliantImage6  = "container-registry.zalando.net/teapot/skipper:v0.19.5"
+	nonCompliantImage7  = "container-registry.zalando.net/teapot/skipper:v0.19.6"
+	nonCompliantImage8  = "container-registry.zalando.net/teapot/skipper:v0.19.7"
+	nonCompliantImage9  = "container-registry.zalando.net/teapot/skipper:v0.19.8"
+	nonCompliantImage10 = "container-registry.zalando.net/teapot/skipper:v0.19.9"
 	waitForPodTimeout   = 5 * time.Minute
 )
 

--- a/test/e2e/apiserver.go
+++ b/test/e2e/apiserver.go
@@ -39,24 +39,26 @@ import (
 )
 
 const (
-	compliantImage1     = "registry.opensource.zalan.do/teapot/skipper:v0.14.0" // these are several compliant images
-	compliantImage2     = "registry.opensource.zalan.do/teapot/skipper:v0.14.1"
-	compliantImage3     = "registry.opensource.zalan.do/teapot/skipper:v0.14.2"
-	compliantImage4     = "registry.opensource.zalan.do/teapot/skipper:v0.14.3"
-	compliantImage5     = "registry.opensource.zalan.do/teapot/skipper:v0.14.4"
-	compliantImage6     = "registry.opensource.zalan.do/teapot/skipper:v0.14.5"
-	compliantImage7     = "registry.opensource.zalan.do/teapot/skipper:v0.14.6"
-	compliantImage8     = "registry.opensource.zalan.do/teapot/skipper:v0.14.7"
-	nonCompliantImage1  = "registry.opensource.zalan.do/teapot/skipper-test:pr-2080-2" // these are several non-compliant images
-	nonCompliantImage2  = "registry.opensource.zalan.do/teapot/skipper-test:pr-2080-3"
-	nonCompliantImage3  = "registry.opensource.zalan.do/teapot/skipper-test:pr-2080-5"
-	nonCompliantImage4  = "registry.opensource.zalan.do/teapot/skipper-test:pr-2080-6"
-	nonCompliantImage5  = "registry.opensource.zalan.do/teapot/skipper-test:pr-2080-7"
-	nonCompliantImage6  = "registry.opensource.zalan.do/teapot/skipper-test:pr-2080-8"
-	nonCompliantImage7  = "registry.opensource.zalan.do/teapot/skipper-test:pr-2080-10"
-	nonCompliantImage8  = "registry.opensource.zalan.do/teapot/skipper-test:pr-2080-11"
-	nonCompliantImage9  = "registry.opensource.zalan.do/teapot/skipper-test:pr-2080-12"
-	nonCompliantImage10 = "registry.opensource.zalan.do/teapot/skipper-test:pr-2080-13"
+	compliantImage1 = "container-registry.zalando.net/teapot/skipper:v0.19.0" // these are several compliant images
+	compliantImage2 = "container-registry.zalando.net/teapot/skipper:v0.19.1"
+	compliantImage3 = "container-registry.zalando.net/teapot/skipper:v0.19.2"
+	compliantImage4 = "container-registry.zalando.net/teapot/skipper:v0.19.3"
+	compliantImage5 = "container-registry.zalando.net/teapot/skipper:v0.19.4"
+	compliantImage6 = "container-registry.zalando.net/teapot/skipper:v0.19.5"
+	compliantImage7 = "container-registry.zalando.net/teapot/skipper:v0.19.6"
+	compliantImage8 = "container-registry.zalando.net/teapot/skipper:v0.19.7"
+
+	// these are non-compliant because of expired base image
+	nonCompliantImage1  = "registry.opensource.zalan.do/teapot/skipper:v0.14.0"
+	nonCompliantImage2  = "registry.opensource.zalan.do/teapot/skipper:v0.14.1"
+	nonCompliantImage3  = "registry.opensource.zalan.do/teapot/skipper:v0.14.2"
+	nonCompliantImage4  = "registry.opensource.zalan.do/teapot/skipper:v0.14.3"
+	nonCompliantImage5  = "registry.opensource.zalan.do/teapot/skipper:v0.14.4"
+	nonCompliantImage6  = "registry.opensource.zalan.do/teapot/skipper:v0.14.5"
+	nonCompliantImage7  = "registry.opensource.zalan.do/teapot/skipper:v0.14.6"
+	nonCompliantImage8  = "registry.opensource.zalan.do/teapot/skipper:v0.14.7"
+	nonCompliantImage9  = "registry.opensource.zalan.do/teapot/skipper:v0.14.8"
+	nonCompliantImage10 = "registry.opensource.zalan.do/teapot/skipper:v0.14.9"
 	waitForPodTimeout   = 5 * time.Minute
 )
 

--- a/test/e2e/apiserver.go
+++ b/test/e2e/apiserver.go
@@ -39,14 +39,14 @@ import (
 )
 
 const (
-	compliantImage1 = "container-registry.zalando.net/teapot/skipper:v0.19.0" // these are several compliant images
-	compliantImage2 = "container-registry.zalando.net/teapot/skipper:v0.19.1"
-	compliantImage3 = "container-registry.zalando.net/teapot/skipper:v0.19.2"
-	compliantImage4 = "container-registry.zalando.net/teapot/skipper:v0.19.3"
-	compliantImage5 = "container-registry.zalando.net/teapot/skipper:v0.19.4"
-	compliantImage6 = "container-registry.zalando.net/teapot/skipper:v0.19.5"
-	compliantImage7 = "container-registry.zalando.net/teapot/skipper:v0.19.6"
-	compliantImage8 = "container-registry.zalando.net/teapot/skipper:v0.19.7"
+	compliantImage1 = "container-registry.zalando.net/teapot/skipper:v0.21.0" // these are several compliant images
+	compliantImage2 = "container-registry.zalando.net/teapot/skipper:v0.21.1"
+	compliantImage3 = "container-registry.zalando.net/teapot/skipper:v0.21.2"
+	compliantImage4 = "container-registry.zalando.net/teapot/skipper:v0.21.3"
+	compliantImage5 = "container-registry.zalando.net/teapot/skipper:v0.21.4"
+	compliantImage6 = "container-registry.zalando.net/teapot/skipper:v0.21.5"
+	compliantImage7 = "container-registry.zalando.net/teapot/skipper:v0.21.6"
+	compliantImage8 = "container-registry.zalando.net/teapot/skipper:v0.21.7"
 
 	// these are non-compliant because of expired base image
 	nonCompliantImage1  = "registry.opensource.zalan.do/teapot/skipper:v0.14.0"

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -46,7 +46,7 @@ clusters:
     teapot_admission_controller_daemonset_reserved_cpu: "518m"
     karpenter_pools_enabled: "true"
     okta_auth_client_id: "kubernetes.cluster.teapot-e2e"
-    teapot_admission_controller_validate_pod_images_soft_fail_namespaces: "^kube-system$"
+    teapot_admission_controller_validate_pod_images_soft_fail_namespaces: "^kube-system$,^image-policy-test"
   criticality_level: 1
   environment: e2e
   id: ${CLUSTER_ID}

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -46,7 +46,7 @@ clusters:
     teapot_admission_controller_daemonset_reserved_cpu: "518m"
     karpenter_pools_enabled: "true"
     okta_auth_client_id: "kubernetes.cluster.teapot-e2e"
-    teapot_admission_controller_validate_pod_images_soft_fail_namespaces: "^kube-system$,^image-policy-test"
+    teapot_admission_controller_validate_pod_images_soft_fail_namespaces: "^kube-system$"
   criticality_level: 1
   environment: e2e
   id: ${CLUSTER_ID}


### PR DESCRIPTION
E2e tests often fail because the image validation API return 502 return status, which causes the image admission to fail and the test fails. 


```
Reason:FailedCreate Message:admission webhook \"pod-admitter.teapot.zalan.do\" denied the request: image check for registry.opensource.zalan.do/teapot/skipper:v0.14.0 failed: unexpected HTTP response status: 502 Bad Gateway
```

Looking at docker-meta logs we see the base image has expired
```
INFO:meta.opa:'registry.opensource.zalan.do/teapot/skipper:v0.17.2' base image is not allowed (['base image registry.opensource.zalan.do/library/alpine-3:3-20230731 is expired.']). OPA Input:
```

This PR updates the compliant images so that the check doesn't fail.