### PR TITLE
[e2e] Refactor code

### DIFF
--- a/test/e2e/audit.go
+++ b/test/e2e/audit.go
@@ -121,7 +121,7 @@ func expectEvents(f *framework.Framework, expectedEvents []utils.AuditEvent) {
 	// to find all expected events. However, we're waiting for 5 minutes to avoid flakes.
 	pollingInterval := 30 * time.Second
 	pollingTimeout := 5 * time.Minute
-	err := wait.Poll(pollingInterval, pollingTimeout, func() (bool, error) {
+	err := wait.PollUntilContextTimeout(context.TODO(), pollingInterval, pollingTimeout, false, func(context.Context) (bool, error) {
 		// Fetch the log stream.
 		stream, err := f.ClientSet.CoreV1().RESTClient().Get().AbsPath("/logs/kube-audit.log").Stream(context.TODO())
 		if err != nil {

--- a/test/e2e/authorisation_test.go
+++ b/test/e2e/authorisation_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -941,7 +940,7 @@ var _ = describe("Authorization tests [Authorization] [RBAC] [Zalando]", func() 
 				rsp, err := client.Do(req)
 				Expect(err).NotTo(HaveOccurred())
 
-				body, err := ioutil.ReadAll(rsp.Body)
+				body, err := io.ReadAll(rsp.Body)
 				Expect(err).NotTo(HaveOccurred())
 
 				verifyResponse(rsp.StatusCode, body, subtest)

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -52,11 +52,11 @@ var (
 	pollLongTimeout = 5 * time.Minute
 )
 
-// type ConditionFunc func() (done bool, err error)
-// Poll(interval, timeout time.Duration, condition ConditionFunc)
+// type wait.ConditionWithContextFunc func(context.Context) (done bool, err error)
+// PollUntilContextTimeout(ctx, interval, timeout time.Duration, immediate bool, condition wait.ConditionWithContextFunc)
 func waitForRouteGroup(cs rgclient.ZalandoInterface, name, ns string, d time.Duration) (string, error) {
 	var addr string
-	err := wait.Poll(10*time.Second, d, func() (done bool, err error) {
+	err := wait.PollUntilContextTimeout(context.TODO(), 10*time.Second, d, false, func(context.Context) (done bool, err error) {
 		rg, err := cs.ZalandoV1().RouteGroups(ns).Get(context.TODO(), name, metav1.GetOptions{ResourceVersion: "0"})
 		if err != nil {
 			return true, err
@@ -719,7 +719,7 @@ func waitForResponseReturnResponse(req *http.Request, timeout time.Duration, exp
 
 func waitForReplicas(deploymentName, namespace string, kubeClient clientset.Interface, timeout time.Duration, desiredReplicas int) {
 	interval := 20 * time.Second
-	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
+	err := wait.PollUntilContextTimeout(context.TODO(), interval, timeout, true, func(context.Context) (bool, error) {
 		deployment, err := kubeClient.AppsV1().Deployments(namespace).Get(context.TODO(), deploymentName, metav1.GetOptions{})
 		if err != nil {
 			framework.Failf("Failed to get replication controller %s: %v", deployment, err)

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -52,8 +52,6 @@ var (
 	pollLongTimeout = 5 * time.Minute
 )
 
-// type wait.ConditionWithContextFunc func(context.Context) (done bool, err error)
-// PollUntilContextTimeout(ctx, interval, timeout time.Duration, immediate bool, condition wait.ConditionWithContextFunc)
 func waitForRouteGroup(cs rgclient.ZalandoInterface, name, ns string, d time.Duration) (string, error) {
 	var addr string
 	err := wait.PollUntilContextTimeout(context.TODO(), 10*time.Second, d, false, func(context.Context) (done bool, err error) {


### PR DESCRIPTION
Refactor code to address linter comments

1. Refactor deprecated `wait.Poll*` functions.
2. Refactor deprecated `io/ioutil` package.