### PR TITLE
Create SSM Documents per Cluster

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -2125,7 +2125,7 @@ Resources:
   SessionManagerLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: "SessionManager-{{.Cluster.LocalID}}"
+      LogGroupName: "SessionManager-{{.Cluster.Alias}}"
       RetentionInDays: 30
 
   SessionManagerPreferencesDocument:
@@ -2148,7 +2148,7 @@ Resources:
     Properties:
       LogGroupName: !Ref SessionManagerLogGroup
       RoleArn: !GetAtt SessionManagerSubscriptionFilterRole.Arn
-      FilterName: "SessionManager-{{.Cluster.LocalID}}"
+      FilterName: "SessionManager-{{.Cluster.Alias}}"
       FilterPattern: ""
       DestinationArn: "{{.Cluster.ConfigItems.session_manager_destination_arn}}"
 
@@ -2175,7 +2175,7 @@ Resources:
                   - "logs:PutLogEvents"
                 Resource:
                   - !GetAtt SessionManagerLogGroup.Arn
-      RoleName: "SessionManager-{{.Cluster.LocalID}}"
+      RoleName: "SessionManager-{{.Cluster.Alias}}"
 {{- end }}
 
   AWSNodeDecommissionerIAMRole:

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -2130,8 +2130,6 @@ Resources:
 
   SessionManagerPreferencesDocument:
     Type: AWS::SSM::Document
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
     Properties:
       UpdateMethod: NewVersion
       Name: "SSM-SessionManager-{{.Cluster.Alias}}"
@@ -2141,6 +2139,14 @@ Resources:
         schemaVersion: '1.0'
         description: Document to hold settings for Kubernetes EC2 SSM sessions
         sessionType: Standard_Stream
+        inputs:
+          cloudWatchLogGroupName: !Ref SessionManagerLogGroup
+          cloudWatchEncryptionEnabled: false
+          cloudWatchStreamingEnabled: true
+          runAsEnabled: false
+          idleSessionTimeout: '20'
+          shellProfile:
+            linux: 'bash'
 
 {{- if eq .Cluster.Region "eu-central-1"}}
   SessionManagerSubscriptionFilter:

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -2125,7 +2125,7 @@ Resources:
   SessionManagerLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: "SessionManager-{{accountID .Cluster.InfrastructureAccount}}-{{.Cluster.LocalID}}"
+      LogGroupName: "SessionManager-{{.Cluster.LocalID}}"
       RetentionInDays: 30
 
   SessionManagerPreferencesDocument:
@@ -2133,20 +2133,13 @@ Resources:
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
-      Tags:
-        - Key: InfrastructureComponent
-          Value: "false"
       UpdateMethod: NewVersion
-{{ if eq .Cluster.Environment "e2e" }} # test for valid cloudformation in e2e tests, but do not set account level preferences
-      Name: "SSM-SessionManagerRunShell-{{.Cluster.LocalID}}"
-{{ else }}
-      Name: "SSM-SessionManagerRunShell"
-{{- end }}
+      Name: "SSM-SessionManager-{{.Cluster.Alias}}"
       DocumentFormat: YAML
       DocumentType: Session
       Content:
         schemaVersion: '1.0'
-        description: Document to hold regional settings for Session Manager
+        description: Document to hold settings for Kubernetes EC2 SSM sessions
         sessionType: Standard_Stream
 
 {{- if eq .Cluster.Region "eu-central-1"}}
@@ -2155,7 +2148,7 @@ Resources:
     Properties:
       LogGroupName: !Ref SessionManagerLogGroup
       RoleArn: !GetAtt SessionManagerSubscriptionFilterRole.Arn
-      FilterName: "SessionManager-{{accountID .Cluster.InfrastructureAccount}}-{{.Cluster.LocalID}}"
+      FilterName: "SessionManager-{{.Cluster.LocalID}}"
       FilterPattern: ""
       DestinationArn: "{{.Cluster.ConfigItems.session_manager_destination_arn}}"
 


### PR DESCRIPTION
Create an SSM Document per cluster instead of utilising the account wide `SSM-SessionManagerRunShell` Document to manage SSM system preferences. Due to the retention policies introduced in https://github.com/zalando-incubator/kubernetes-on-aws/pull/8024, the default Document will remain in the accounts while a new `SSM-SessionManager-<cluster-alias>` Document holding session configuration will be created.