### PR TITLE
double the memory of karpenter controller

### DIFF
--- a/cluster/manifests/z-karpenter/vpa.yaml
+++ b/cluster/manifests/z-karpenter/vpa.yaml
@@ -25,8 +25,8 @@ spec:
         {{ range $NodePool := .Cluster.NodePools}}
         {{ if eq $NodePool.Name "default-master" }}
           # Scaling is relative to r6g.large (smallest master node)
-          # 0.064 -> ~1024Mi memory, 0.025 -> ~50m CPU
-          memory: {{ scaleQuantity (instanceTypeMemoryQuantity (index .InstanceTypes 0)) 0.064 }}
+          # 0.134 -> ~2048Mi memory, 0.025 -> ~50m CPU
+          memory: {{ scaleQuantity (instanceTypeMemoryQuantity (index .InstanceTypes 0)) 0.134 }}
           cpu: {{ scaleQuantity (instanceTypeCPUQuantity (index .InstanceTypes 0)) 0.025 }}
         {{ end }}
         {{ end }}


### PR DESCRIPTION
during load test, it turns out that karpenter needs more memory during peak times (spikes). we checked and there is enough capacity 