### PR TITLE
[e2e] use framework.ExpectNoError for assertions

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -91,7 +91,7 @@ var _ = describe("Thing under test, func() {
 		}()
             // creates the Ingress Object
 		_, err := cs.CoreV1().Foo(ns).Create(foo)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 	})
 })
 ```
@@ -118,7 +118,7 @@ var _ = describe("Thing under test, func() {
   	Expect(err2).NotTo(HaveOccurred())
   }()
   _, err = cs.CoreV1().Pods(ns).Create(pod)
-  Expect(err).NotTo(HaveOccurred())
+  framework.ExpectNoError(err)
   framework.ExpectNoError(f.WaitForPodRunning(pod.Name))
 ```
 
@@ -142,7 +142,7 @@ var _ = describe("Thing under test, func() {
   	Expect(err2).NotTo(HaveOccurred())
   }()
   _, err := cs.CoreV1().Services(ns).Create(service)
-  Expect(err).NotTo(HaveOccurred())
+  framework.ExpectNoError(err)
 ```
 
 ### Create a Ingress and wait for external components to be created
@@ -168,11 +168,11 @@ Create Kubernetes ingress object:
   	Expect(err2).NotTo(HaveOccurred())
   }()
   ingressCreate, err := cs.NetworkingV1beta1().Ingresses(ns).Create(ing)
-  Expect(err).NotTo(HaveOccurred())
+  framework.ExpectNoError(err)
   addr, err := jig.WaitForIngressAddress(cs, ns, ingressCreate.Name, 3*time.Minute)
-  Expect(err).NotTo(HaveOccurred())
+  framework.ExpectNoError(err)
   ingress, err := cs.NetworkingV1beta1().Ingresses(ns).Get(ing.Name, metav1.GetOptions{ResourceVersion: "0"})
-  Expect(err).NotTo(HaveOccurred())
+  framework.ExpectNoError(err)
   By(fmt.Sprintf("ALB endpoint from ingress status: %s", ingress.Status.LoadBalancer.Ingress[0].Hostname))
 ```
 
@@ -182,15 +182,15 @@ Follow up code, that waits for creations to be happen:
   // skipper http -> https redirect
   By("Waiting for skipper route to default redirect from http to https, to see that our ingress-controller and skipper works")
   err = waitForResponse(addr, "http", 2*time.Minute, 301, true)
-  Expect(err).NotTo(HaveOccurred())
+  framework.ExpectNoError(err)
   // ALB ready
   By("Waiting for ALB to create endpoint " + addr + " and skipper route, to see that our ingress-controller and skipper works")
   err = waitForResponse(addr, "https", 2*time.Minute, 200, true) // insecure=true
-  Expect(err).NotTo(HaveOccurred())
+  framework.ExpectNoError(err)
   // DNS ready
   By("Waiting for DNS to see that mate and skipper route to service and pod works")
   err = waitForResponse(hostName, "https", 2*time.Minute, 200, false)
-  Expect(err).NotTo(HaveOccurred())
+  framework.ExpectNoError(err)
 ```
 
 ### FAQ

--- a/test/e2e/admission_controller.go
+++ b/test/e2e/admission_controller.go
@@ -62,18 +62,18 @@ var _ = describe("Admission controller tests", func() {
 
 		deployment := createDeploymentWithDeploymentInfo(nameprefix+"-", ns, replicas)
 		_, err := cs.AppsV1().Deployments(ns).Create(context.TODO(), deployment, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		labelSelector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		err = waitForDeploymentWithCondition(cs, ns, deployment.Name, "MinimumReplicasAvailable", appsv1.DeploymentAvailable)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		//pods are not returned here
 		_, err = e2epod.WaitForPodsWithLabelRunningReady(context.TODO(), cs, ns, labelSelector, int(replicas), 1*time.Minute)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		pods, err := cs.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector.String()})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(len(pods.Items)).To(Equal(1))
 
 		pod := pods.Items[0]
@@ -82,12 +82,12 @@ var _ = describe("Admission controller tests", func() {
 
 		// Check the injected node zone
 		node, err := cs.CoreV1().Nodes().Get(context.TODO(), pod.Spec.NodeName, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		nodeZone := node.Labels["topology.kubernetes.io/zone"]
 		Expect(pod.Annotations).To(HaveKeyWithValue("topology.kubernetes.io/zone", nodeZone))
 
 		envarValues, err := fetchEnvarValues(cs, ns, pod.Name)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// Check the environment variable values
 
@@ -123,10 +123,10 @@ var _ = describe("Admission controller tests", func() {
 		By("Creating pod " + podName + " in namespace " + ns)
 		pod := createInvalidOwnerPod(ns, podName)
 		_, err := cs.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		err = e2epod.WaitForPodSuccessInNamespaceTimeout(context.TODO(), cs, podName, ns, 15*time.Minute)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 	})
 })
 

--- a/test/e2e/apiserver.go
+++ b/test/e2e/apiserver.go
@@ -77,20 +77,20 @@ var _ = describe("Image Policy Tests (Deployment)", func() {
 
 		deployment := createImagePolicyWebhookTestDeployment(namePrefix, namespace, compliantImage1, appLabel, int32(replicas))
 		_, err := cs.AppsV1().Deployments(namespace).Create(context.TODO(), deployment, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		defer func() {
 			By(fmt.Sprintf("Delete a Deployment: %s", deployment.Name))
 			defer GinkgoRecover()
 			err := cs.AppsV1().Deployments(namespace).Delete(context.TODO(), deployment.Name, metav1.DeleteOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 		}()
 
 		err = waitForDeploymentWithCondition(cs, namespace, deployment.Name, "MinimumReplicasAvailable", appsv1.DeploymentAvailable)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		_, err = e2epod.WaitForPodsWithLabelRunningReady(context.TODO(), cs, namespace, appLabelSelector(appLabel), replicas, waitForPodTimeout)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 	})
 
 	It("Should not create Deployment using non-compliant image [Image-Policy] [Non-Compliant] [Zalando]", func() {
@@ -103,17 +103,17 @@ var _ = describe("Image Policy Tests (Deployment)", func() {
 
 		deployment := createImagePolicyWebhookTestDeployment(namePrefix, namespace, nonCompliantImage1, podName, int32(replicas))
 		_, err := cs.AppsV1().Deployments(namespace).Create(context.TODO(), deployment, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		defer func() {
 			By(fmt.Sprintf("Delete a Deployment: %s", deployment.Name))
 			defer GinkgoRecover()
 			err := cs.AppsV1().Deployments(namespace).Delete(context.TODO(), deployment.Name, metav1.DeleteOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 		}()
 
 		err = waitForDeploymentWithCondition(cs, namespace, deployment.Name, "FailedCreate", appsv1.DeploymentReplicaFailure)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 	})
 })
 
@@ -136,20 +136,20 @@ var _ = describe("Image Policy Tests (Deployment) (when disabled)", func() {
 
 		deployment := createImagePolicyWebhookTestDeployment(namePrefix, namespace, nonCompliantImage2, appLabel, int32(replicas))
 		_, err := cs.AppsV1().Deployments(namespace).Create(context.TODO(), deployment, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		defer func() {
 			By(fmt.Sprintf("Delete a Deployment: %s", deployment.Name))
 			defer GinkgoRecover()
 			err := cs.AppsV1().Deployments(namespace).Delete(context.TODO(), deployment.Name, metav1.DeleteOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 		}()
 
 		err = waitForDeploymentWithCondition(cs, namespace, deployment.Name, "MinimumReplicasAvailable", appsv1.DeploymentAvailable)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		_, err = e2epod.WaitForPodsWithLabelRunningReady(context.TODO(), cs, namespace, appLabelSelector(appLabel), replicas, waitForPodTimeout)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 	})
 })
 
@@ -171,17 +171,17 @@ var _ = describe("Image Policy Tests (Pods)", func() {
 
 		pod := createImagePolicyWebhookTestPod(namePrefix, namespace, compliantImage2, appLabel)
 		_, err := cs.CoreV1().Pods(namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		defer func() {
 			By(fmt.Sprintf("Delete a pod: %s", pod.Name))
 			defer GinkgoRecover()
 			err := cs.CoreV1().Pods(namespace).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 		}()
 
 		_, err = e2epod.WaitForPodsWithLabelRunningReady(context.TODO(), cs, namespace, appLabelSelector(appLabel), 1, waitForPodTimeout)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 	})
 
 	It("Should not create pod with non-compliant image [Image-Policy] [Non-Compliant] [Zalando]", func() {
@@ -215,17 +215,17 @@ var _ = describe("Image Policy Tests (Pods) (when disabled)", func() {
 
 		pod := createImagePolicyWebhookTestPod(namePrefix, namespace, nonCompliantImage4, appLabel)
 		_, err := cs.CoreV1().Pods(namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		defer func() {
 			By(fmt.Sprintf("Delete a pod: %s", pod.Name))
 			defer GinkgoRecover()
 			err := cs.CoreV1().Pods(namespace).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 		}()
 
 		_, err = e2epod.WaitForPodsWithLabelRunningReady(context.TODO(), cs, namespace, appLabelSelector(appLabel), 1, waitForPodTimeout)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 	})
 })
 
@@ -247,30 +247,30 @@ var _ = describe("Image Policy Tests (Pods Update Path)", func() {
 
 		pod := createImagePolicyWebhookTestPod(namePrefix, namespace, compliantImage3, appLabel)
 		_, err := cs.CoreV1().Pods(namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		defer func() {
 			By(fmt.Sprintf("Delete a pod: %s", pod.Name))
 			defer GinkgoRecover()
 			err := cs.CoreV1().Pods(namespace).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 		}()
 
 		_, err = e2epod.WaitForPodsWithLabelRunningReady(context.TODO(), cs, namespace, appLabelSelector(appLabel), 1, waitForPodTimeout)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		By("Updating pod " + namePrefix + " in namespace " + namespace)
 
 		pod, err = cs.CoreV1().Pods(namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		pod.Spec.Containers[0].Image = compliantImage4
 
 		_, err = cs.CoreV1().Pods(namespace).Update(context.TODO(), pod, metav1.UpdateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		_, err = e2epod.WaitForPodsWithLabelRunningReady(context.TODO(), cs, namespace, appLabelSelector(appLabel), 1, waitForPodTimeout)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 	})
 
 	It("Should not update pod with non-compliant image [Image-Policy] [Non-Compliant] [Zalando]", func() {
@@ -282,20 +282,20 @@ var _ = describe("Image Policy Tests (Pods Update Path)", func() {
 
 		pod := createImagePolicyWebhookTestPod(namePrefix, namespace, compliantImage5, appLabel)
 		_, err := cs.CoreV1().Pods(namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		defer func() {
 			By(fmt.Sprintf("Delete a pod: %s", pod.Name))
 			defer GinkgoRecover()
 			err := cs.CoreV1().Pods(namespace).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 		}()
 
 		_, err = e2epod.WaitForPodsWithLabelRunningReady(context.TODO(), cs, namespace, appLabelSelector(appLabel), 1, waitForPodTimeout)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		pod, err = cs.CoreV1().Pods(namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		By("Updating pod " + namePrefix + " in namespace " + namespace)
 
@@ -324,30 +324,30 @@ var _ = describe("Image Policy Tests (Pods Update Path) (when disabled)", func()
 
 		pod := createImagePolicyWebhookTestPod(namePrefix, namespace, compliantImage6, appLabel)
 		_, err := cs.CoreV1().Pods(namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		defer func() {
 			By(fmt.Sprintf("Delete a pod: %s", pod.Name))
 			defer GinkgoRecover()
 			err := cs.CoreV1().Pods(namespace).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 		}()
 
 		_, err = e2epod.WaitForPodsWithLabelRunningReady(context.TODO(), cs, namespace, appLabelSelector(appLabel), 1, waitForPodTimeout)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		pod, err = cs.CoreV1().Pods(namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		By("Updating pod " + namePrefix + " in namespace " + namespace)
 
 		pod.Spec.Containers[0].Image = nonCompliantImage6
 
 		_, err = cs.CoreV1().Pods(namespace).Update(context.TODO(), pod, metav1.UpdateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		_, err = e2epod.WaitForPodsWithLabelRunningReady(context.TODO(), cs, namespace, appLabelSelector(appLabel), 1, waitForPodTimeout)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 	})
 })
 
@@ -370,19 +370,19 @@ var _ = describe("Image Policy Tests (StatefulSet)", func() {
 
 		statefulSet := createImagePolicyWebhookTestStatefulSet(namePrefix, namespace, compliantImage7, appLabel, int32(replicas))
 		_, err := cs.AppsV1().StatefulSets(namespace).Create(context.TODO(), statefulSet, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		defer func() {
 			By(fmt.Sprintf("Delete a StatefulSet: %s", statefulSet.Name))
 			defer GinkgoRecover()
 			err := cs.AppsV1().StatefulSets(namespace).Delete(context.TODO(), statefulSet.Name, metav1.DeleteOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 		}()
 
 		statefulset.WaitForRunningAndReady(context.TODO(), cs, int32(replicas), statefulSet)
 
 		_, err = e2epod.WaitForPodsWithLabelRunningReady(context.TODO(), cs, namespace, appLabelSelector(appLabel), replicas, waitForPodTimeout)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 	})
 
 	It("Should not create StatefulSet using non-compliant image [Image-Policy] [Non-Compliant] [Zalando]", func() {
@@ -395,13 +395,13 @@ var _ = describe("Image Policy Tests (StatefulSet)", func() {
 
 		statefulSet := createImagePolicyWebhookTestStatefulSet(namePrefix, namespace, nonCompliantImage7, appLabel, int32(replicas))
 		_, err := cs.AppsV1().StatefulSets(namespace).Create(context.TODO(), statefulSet, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		defer func() {
 			By(fmt.Sprintf("Delete a StatefulSet: %s", statefulSet.Name))
 			defer GinkgoRecover()
 			err := cs.AppsV1().StatefulSets(namespace).Delete(context.TODO(), statefulSet.Name, metav1.DeleteOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 		}()
 
 		_, err = e2epod.WaitForPodsWithLabelRunningReady(context.TODO(), cs, namespace, appLabelSelector(appLabel), 1, 1*time.Minute)
@@ -429,19 +429,19 @@ var _ = describe("Image Policy Tests (StatefulSet) (when disabled)", func() {
 
 		statefulSet := createImagePolicyWebhookTestStatefulSet(namePrefix, namespace, nonCompliantImage8, appLabel, int32(replicas))
 		_, err := cs.AppsV1().StatefulSets(namespace).Create(context.TODO(), statefulSet, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		defer func() {
 			By(fmt.Sprintf("Delete a StatefulSet: %s", statefulSet.Name))
 			defer GinkgoRecover()
 			err := cs.AppsV1().StatefulSets(namespace).Delete(context.TODO(), statefulSet.Name, metav1.DeleteOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 		}()
 
 		statefulset.WaitForRunningAndReady(context.TODO(), cs, int32(replicas), statefulSet)
 
 		_, err = e2epod.WaitForPodsWithLabelRunningReady(context.TODO(), cs, namespace, appLabelSelector(appLabel), replicas, waitForPodTimeout)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 	})
 })
 
@@ -463,13 +463,13 @@ var _ = describe("Image Policy Tests (Job)", func() {
 
 		jobObj := createImagePolicyWebhookTestJob(namePrefix, namespace, compliantImage8, appLabel)
 		_, err := cs.BatchV1().Jobs(namespace).Create(context.TODO(), jobObj, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		defer func() {
 			By(fmt.Sprintf("Delete a Job: %s", jobObj.Name))
 			defer GinkgoRecover()
 			err := cs.BatchV1().Jobs(namespace).Delete(context.TODO(), jobObj.Name, metav1.DeleteOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 		}()
 
 		job.WaitForJobComplete(context.TODO(), cs, namespace, jobObj.Name, 1)
@@ -484,13 +484,13 @@ var _ = describe("Image Policy Tests (Job)", func() {
 
 		jobObj := createImagePolicyWebhookTestJob(namePrefix, namespace, nonCompliantImage9, appLabel)
 		_, err := cs.BatchV1().Jobs(namespace).Create(context.TODO(), jobObj, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		defer func() {
 			By(fmt.Sprintf("Delete a Job: %s", jobObj.Name))
 			defer GinkgoRecover()
 			err := cs.BatchV1().Jobs(namespace).Delete(context.TODO(), jobObj.Name, metav1.DeleteOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 		}()
 
 		job.WaitForJobComplete(context.TODO(), cs, namespace, jobObj.Name, 1)
@@ -515,13 +515,13 @@ var _ = describe("Image Policy Tests (Job) (when disabled)", func() {
 
 		jobObj := createImagePolicyWebhookTestJob(namePrefix, namespace, nonCompliantImage10, appLabel)
 		_, err := cs.BatchV1().Jobs(namespace).Create(context.TODO(), jobObj, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		defer func() {
 			By(fmt.Sprintf("Delete a Job: %s", jobObj.Name))
 			defer GinkgoRecover()
 			err := cs.BatchV1().Jobs(namespace).Delete(context.TODO(), jobObj.Name, metav1.DeleteOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 		}()
 
 		job.WaitForJobComplete(context.TODO(), cs, namespace, jobObj.Name, 1)
@@ -549,13 +549,13 @@ var _ = describe("ECR Registry Pull", func() {
 
 		jobObj := createTestJob(namePrefix, "ecr-image-pull-test", namespace, ecrStagingImage, appLabel, args)
 		_, err := cs.BatchV1().Jobs(namespace).Create(context.TODO(), jobObj, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		defer func() {
 			By(fmt.Sprintf("Delete a Job: %s", jobObj.Name))
 			defer GinkgoRecover()
 			err := cs.BatchV1().Jobs(namespace).Delete(context.TODO(), jobObj.Name, metav1.DeleteOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 		}()
 
 		job.WaitForJobComplete(context.TODO(), cs, namespace, jobObj.Name, 1)
@@ -573,13 +573,13 @@ var _ = describe("ECR Registry Pull", func() {
 
 		jobObj := createTestJob(namePrefix, "ecr-image-pull-test", namespace, vanityStagingImage, appLabel, args)
 		_, err := cs.BatchV1().Jobs(namespace).Create(context.TODO(), jobObj, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		defer func() {
 			By(fmt.Sprintf("Delete a Job: %s", jobObj.Name))
 			defer GinkgoRecover()
 			err := cs.BatchV1().Jobs(namespace).Delete(context.TODO(), jobObj.Name, metav1.DeleteOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 		}()
 
 		job.WaitForJobComplete(context.TODO(), cs, namespace, jobObj.Name, 1)

--- a/test/e2e/authorisation_test.go
+++ b/test/e2e/authorisation_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 
 	"k8s.io/kubernetes/test/e2e/framework"
 )
@@ -413,7 +412,7 @@ var _ = describe("Authorization tests [Authorization] [RBAC] [Zalando]", func() 
 	should := "should validate permissions for [Authorization] [RBAC] [Zalando]"
 	It(should, func() {
 		conf, err := framework.LoadConfig()
-		Expect(err).NotTo(HaveOccurred()) // BDD = Because :DDD
+		framework.ExpectNoError(err) // BDD = Because :DDD
 
 		host := conf.Host
 		client := http.DefaultClient
@@ -936,12 +935,12 @@ var _ = describe("Authorization tests [Authorization] [RBAC] [Zalando]", func() 
 				By(subtest.String())
 
 				req, err := makeReq(subtest.subjectReview())
-				Expect(err).NotTo(HaveOccurred())
+				framework.ExpectNoError(err)
 				rsp, err := client.Do(req)
-				Expect(err).NotTo(HaveOccurred())
+				framework.ExpectNoError(err)
 
 				body, err := io.ReadAll(rsp.Body)
-				Expect(err).NotTo(HaveOccurred())
+				framework.ExpectNoError(err)
 
 				verifyResponse(rsp.StatusCode, body, subtest)
 			}

--- a/test/e2e/aws_iam.go
+++ b/test/e2e/aws_iam.go
@@ -39,14 +39,14 @@ var _ = describe("AWS IAM Integration (kube-aws-iam-controller)", func() {
 
 		By("Creating an awsiamrole client")
 		config, err := framework.LoadConfig()
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		config.QPS = f.Options.ClientQPS
 		config.Burst = f.Options.ClientBurst
 		if f.Options.GroupVersion != nil {
 			config.GroupVersion = f.Options.GroupVersion
 		}
 		zcs, err = awsiamrole.NewForConfig(config)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 	})
 
 	It("Should get AWS IAM credentials [AWS-IAM] [Zalando]", func() {
@@ -56,7 +56,7 @@ var _ = describe("AWS IAM Integration (kube-aws-iam-controller)", func() {
 		By("Creating a awscli POD in namespace " + ns)
 		pod := createAWSIAMPod("aws-iam-", ns, E2ES3AWSIAMBucket())
 		_, err := cs.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// AWSIAMRole
 		By("Creating AWSIAMRole " + awsIAMRoleRS + " in namespace " + ns)
@@ -68,7 +68,7 @@ var _ = describe("AWS IAM Integration (kube-aws-iam-controller)", func() {
 			Expect(err2).NotTo(HaveOccurred())
 		}()
 		_, err = zcs.ZalandoV1().AWSIAMRoles(ns).Create(context.TODO(), rs, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		framework.ExpectNoError(e2epod.WaitForPodSuccessInNamespace(context.TODO(), f.ClientSet, pod.Name, pod.Namespace))
 	})
@@ -79,12 +79,12 @@ var _ = describe("AWS IAM Integration (kube-aws-iam-controller)", func() {
 		By("Creating a awscli POD in namespace " + ns)
 		pod := createAWSCLIPod("aws-iam-", ns, []string{"s3", "ls", fmt.Sprintf("s3://%s", E2ES3AWSIAMBucket())})
 		_, err := cs.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		framework.ExpectNoError(e2epod.WaitForPodTerminatedInNamespace(context.TODO(), f.ClientSet, pod.Name, "", pod.Namespace))
 
 		p, err := cs.CoreV1().Pods(ns).Get(context.TODO(), pod.Name, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(p.Status.ContainerStatuses).NotTo(BeEmpty(), "No container statuses found")
 		Expect(p.Status.ContainerStatuses[0].State.Terminated).NotTo(BeNil(), "Expected to find a terminated container")
 		Expect(p.Status.ContainerStatuses[0].State.Terminated.ExitCode).To(BeEquivalentTo(255), "Expected the container to exit with an error status code")

--- a/test/e2e/external_dns.go
+++ b/test/e2e/external_dns.go
@@ -55,14 +55,14 @@ var _ = describe("External DNS creation", func() {
 		By("Creating service " + serviceName + " in namespace " + ns)
 		defer func() {
 			err := cs.CoreV1().Services(ns).Delete(ctx, serviceName, metav1.DeleteOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 		}()
 
 		hostName := fmt.Sprintf("%s-%d.%s", serviceName, time.Now().UTC().Unix(), E2EHostedZone())
 		service := createServiceTypeLoadbalancer(serviceName, hostName, labels, port)
 
 		_, err := cs.CoreV1().Services(ns).Create(ctx, service, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		By("Submitting the pod to kubernetes")
 		route := fmt.Sprintf(`* -> inlineContent("%s") -> <shunt>`, "OK")
@@ -75,7 +75,7 @@ var _ = describe("External DNS creation", func() {
 		}()
 
 		_, err = cs.CoreV1().Pods(ns).Create(ctx, pod, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, pod.Namespace))
 
@@ -83,6 +83,6 @@ var _ = describe("External DNS creation", func() {
 		// wait for DNS and for pod to be reachable.
 		By("Waiting up to " + timeout.String() + " for " + hostName + " to be reachable")
 		err = waitForSuccessfulResponse(hostName, timeout)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 	})
 })

--- a/test/e2e/infra.go
+++ b/test/e2e/infra.go
@@ -28,7 +28,7 @@ var _ = describe("Infrastructure tests", func() {
 	It("Mirror pods should be created for the main Kubernetes components [Zalando]", func() {
 		for _, application := range []string{"kube-apiserver", "kube-controller-manager", "kube-scheduler"} {
 			pods, err := podsForApplication(cs, application)
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 			Expect(filterMirrorPods(pods)).NotTo(BeEmpty())
 		}
 	})
@@ -37,10 +37,10 @@ var _ = describe("Infrastructure tests", func() {
 		// When modifying this list, don't forget to modify cluster/manifests/e2e-resources/pool-reserve.yaml
 		for _, pool := range []string{"default-worker-splitaz", "worker-combined", "worker-limit-az", "worker-instance-storage"} {
 			deploy, err := cs.AppsV1().Deployments("default").Get(context.Background(), fmt.Sprintf("pool-reserve-%s", pool), metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 
 			err = deployment.WaitForDeploymentComplete(cs, deploy)
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 		}
 	})
 

--- a/test/e2e/ingress.go
+++ b/test/e2e/ingress.go
@@ -64,7 +64,7 @@ var _ = describe("Ingress ALB creation", func() {
 			Expect(err2).NotTo(HaveOccurred())
 		}()
 		_, err := cs.CoreV1().Services(ns).Create(context.TODO(), service, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// POD
 		By("Creating a POD with prefix " + nameprefix + " in namespace " + ns)
@@ -78,7 +78,7 @@ var _ = describe("Ingress ALB creation", func() {
 		}()
 
 		_, err = cs.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(context.TODO(), f.ClientSet, pod.Name, pod.Namespace))
 
 		// Ingress
@@ -92,27 +92,27 @@ var _ = describe("Ingress ALB creation", func() {
 			Expect(err2).NotTo(HaveOccurred())
 		}()
 		ingressCreate, err := cs.NetworkingV1().Ingresses(ns).Create(context.TODO(), ing, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		addr, err := jig.WaitForIngressAddress(context.TODO(), cs, ns, ingressCreate.Name, 10*time.Minute)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		ingress, err := cs.NetworkingV1().Ingresses(ns).Get(context.TODO(), ing.Name, metav1.GetOptions{ResourceVersion: "0"})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		By(fmt.Sprintf("ALB endpoint from ingress status: %s", ingress.Status.LoadBalancer.Ingress[0].Hostname))
 
 		//  skipper http -> https redirect
 		By("Waiting for skipper route to default redirect from http to https, to see that our ingress-controller and skipper works")
 		err = waitForResponse(addr, "http", 10*time.Minute, isRedirect, true)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// ALB ready
 		By("Waiting for ALB to create endpoint " + addr + " and skipper route, to see that our ingress-controller and skipper works")
 		err = waitForResponse(addr, "https", 10*time.Minute, isNotFound, true)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// DNS ready
 		By("Waiting for DNS to see that external-dns and skipper route to service and pod works")
 		err = waitForResponse(hostName, "https", 10*time.Minute, isSuccess, false)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 	})
 })
 
@@ -145,37 +145,37 @@ var __ = describe("Ingress tests simple", func() {
 		By("Creating a deployment with " + serviceName + " in namespace " + ns)
 		depl := createSkipperBackendDeployment(serviceName, ns, route, labels, int32(targetPort), replicas)
 		_, err := cs.AppsV1().Deployments(ns).Create(context.TODO(), depl, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		By("Creating service " + serviceName + " in namespace " + ns)
 		service := createServiceTypeClusterIP(serviceName, labels, port, targetPort)
 		_, err = cs.CoreV1().Services(ns).Create(context.TODO(), service, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		ing := createIngress(serviceName, hostName, ns, "/", netv1.PathTypeImplementationSpecific, labels, nil, port)
 		ingressCreate, err := cs.NetworkingV1().Ingresses(ns).Create(context.TODO(), ing, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		addr, err := jig.WaitForIngressAddress(context.TODO(), cs, ns, ingressCreate.Name, waitTime)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		_, err = cs.NetworkingV1().Ingresses(ns).Get(context.TODO(), ing.Name, metav1.GetOptions{ResourceVersion: "0"})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// skipper http -> https redirect
 		By("Waiting for skipper route to default redirect from http to https, to see that our ingress-controller and skipper works")
 		err = waitForResponse(addr, "http", waitTime, isRedirect, true)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// ALB ready
 		By("Waiting for ALB to create endpoint " + addr + " and skipper route, to see that our ingress-controller and skipper works")
 		err = waitForResponse(addr, "https", waitTime, isNotFound, true)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// DNS ready
 		By("Waiting for DNS to see that external-dns and skipper route to service and pod works")
 		err = waitForResponse(hostName, "https", waitTime, isSuccess, false)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// Test that we get content from the default ingress
 		By("By checking the content of the reply we see that the ingress stack works")
@@ -185,11 +185,11 @@ var __ = describe("Ingress tests simple", func() {
 		}()
 		url := "https://" + hostName + "/"
 		req, err := http.NewRequest("GET", url, nil)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		resp, err := rt.RoundTrip(req)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		s, err := getBody(resp)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(s).To(Equal(backendContent))
 
 		// Start actual ingress tests
@@ -208,13 +208,13 @@ var __ = describe("Ingress tests simple", func() {
 			port,
 		)
 		ingressUpdate, err := cs.NetworkingV1().Ingresses(ingressCreate.ObjectMeta.Namespace).Update(context.TODO(), updatedIng, metav1.UpdateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		By(fmt.Sprintf("Waiting for ingress %s/%s we wait to get a 200 with the right content for the next request", ingressUpdate.Namespace, ingressUpdate.Name))
 		resp, err = getAndWaitResponse(rt, req, 10*time.Second, http.StatusOK)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 		s, err = getBody(resp)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(s).To(Equal(backendContent))
 
 		// Test ingress Predicates with Method("PUT")
@@ -232,10 +232,10 @@ var __ = describe("Ingress tests simple", func() {
 			port,
 		)
 		ingressUpdate, err = cs.NetworkingV1().Ingresses(ingressCreate.ObjectMeta.Namespace).Update(context.TODO(), updatedIng, metav1.UpdateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		By(fmt.Sprintf("Waiting for ingress %s/%s we wait to get a 404 for the next request", ingressUpdate.Namespace, ingressUpdate.Name))
 		resp, err = getAndWaitResponse(rt, req, 10*time.Second, http.StatusNotFound)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
 
 		// Test ingress Filters
@@ -255,62 +255,62 @@ var __ = describe("Ingress tests simple", func() {
 			port,
 		)
 		ingressUpdate, err = cs.NetworkingV1().Ingresses(ingressCreate.ObjectMeta.Namespace).Update(context.TODO(), updatedIng, metav1.UpdateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		By(fmt.Sprintf("Waiting for ingress %s/%s we wait to get a 200 with %s header set to %s for the next request", ingressUpdate.Namespace, ingressUpdate.Name, headerKey, headerVal))
 		time.Sleep(10 * time.Second) // wait for routing change propagation
 		resp, err = getAndWaitResponse(rt, req, 10*time.Second, http.StatusOK)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 		Expect(resp.Header.Get(headerKey)).To(Equal(headerVal))
 		s, err = getBody(resp)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(s).To(Equal(backendContent))
 
 		// Test additional hostname
 		additionalHostname := fmt.Sprintf("foo-%d.%s", time.Now().UTC().Unix(), E2EHostedZone())
 		addHostIng := addHostIngress(updatedIng, additionalHostname)
 		ingressUpdate, err = cs.NetworkingV1().Ingresses(ingressCreate.ObjectMeta.Namespace).Update(context.TODO(), addHostIng, metav1.UpdateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		By("Waiting for new DNS hostname to be resolvable " + additionalHostname)
 		err = waitForResponse(additionalHostname, "https", waitTime, isSuccess, false)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		By(fmt.Sprintf("Testing the old hostname %s for ingress %s/%s we make sure old routes are working", hostName, ingressUpdate.Namespace, ingressUpdate.Name))
 		resp, err = getAndWaitResponse(rt, req, 10*time.Second, http.StatusOK)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 		s, err = getBody(resp)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(s).To(Equal(backendContent))
 		By(fmt.Sprintf("Testing the new hostname %s for ingress %s/%s we make sure old routes are working", additionalHostname, ingressUpdate.Namespace, ingressUpdate.Name))
 		url = "https://" + additionalHostname + "/"
 		req, err = http.NewRequest("GET", url, nil)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		resp, err = getAndWaitResponse(rt, req, 10*time.Second, http.StatusOK)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 		s, err = getBody(resp)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(s).To(Equal(backendContent))
 
 		// Test changed path
 		newPath := "/foo"
 		changePathIng := changePathIngress(updatedIng, newPath)
 		ingressUpdate, err = cs.NetworkingV1().Ingresses(ingressCreate.ObjectMeta.Namespace).Update(context.TODO(), changePathIng, metav1.UpdateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		By(fmt.Sprintf("Waiting for ingress %s/%s we wait to get a 404 for the old request, because of the path route", ingressUpdate.Namespace, ingressUpdate.Name))
 		resp, err = getAndWaitResponse(rt, req, 10*time.Second, http.StatusNotFound)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
 		pathURL := "https://" + hostName + newPath
 		pathReq, err := http.NewRequest("GET", pathURL, nil)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		By(fmt.Sprintf("Waiting for ingress %s/%s we wait to get a 200 for a new request to the path route", ingressUpdate.Namespace, ingressUpdate.Name))
 		resp, err = getAndWaitResponse(rt, pathReq, 10*time.Second, http.StatusOK)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 		s, err = getBody(resp)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(s).To(Equal(backendContent))
 	})
 })
@@ -350,47 +350,47 @@ var ___ = describe("Ingress tests paths", func() {
 		By("Creating a deployment with " + serviceName + " in namespace " + ns)
 		depl := createSkipperBackendDeployment(serviceName, ns, route, labels, int32(targetPort), replicas)
 		_, err := cs.AppsV1().Deployments(ns).Create(context.TODO(), depl, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		By("Creating a 2nd deployment with " + serviceName2 + " in namespace " + ns)
 		depl2 := createSkipperBackendDeployment(serviceName2, ns, route2, labels2, int32(targetPort), replicas)
 		_, err = cs.AppsV1().Deployments(ns).Create(context.TODO(), depl2, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		By("Creating service " + serviceName + " in namespace " + ns)
 		service := createServiceTypeClusterIP(serviceName, labels, port, targetPort)
 		_, err = cs.CoreV1().Services(ns).Create(context.TODO(), service, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		By("Creating service " + serviceName2 + " in namespace " + ns)
 		service2 := createServiceTypeClusterIP(serviceName2, labels2, port, targetPort)
 		_, err = cs.CoreV1().Services(ns).Create(context.TODO(), service2, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		By("Creating ingress " + serviceName + " in namespace " + ns + "with hostname " + hostName)
 		ing := createIngress(serviceName, hostName, ns, "/", netv1.PathTypeImplementationSpecific, labels, nil, port)
 		ingressCreate, err := cs.NetworkingV1().Ingresses(ns).Create(context.TODO(), ing, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		addr, err := jig.WaitForIngressAddress(context.TODO(), cs, ns, ingressCreate.Name, waitTime)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		_, err = cs.NetworkingV1().Ingresses(ns).Get(context.TODO(), ing.Name, metav1.GetOptions{ResourceVersion: "0"})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// skipper http -> https redirect
 		By("Waiting for skipper route to default redirect from http to https, to see that our ingress-controller and skipper works")
 		err = waitForResponse(addr, "http", waitTime, isRedirect, true)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// ALB ready
 		By("Waiting for ALB to create endpoint " + addr + " and skipper route, to see that our ingress-controller and skipper works")
 		err = waitForResponse(addr, "https", waitTime, isNotFound, true)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// DNS ready
 		By("Waiting for DNS to see that external-dns and skipper route to service and pod works")
 		err = waitForResponse(hostName, "https", waitTime, isSuccess, false)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// Test that we get content from the default ingress
 		By("By checking the content of the reply we see that the ingress stack works")
@@ -400,11 +400,11 @@ var ___ = describe("Ingress tests paths", func() {
 		}()
 		url := "https://" + hostName + "/"
 		req, err := http.NewRequest("GET", url, nil)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		resp, err := rt.RoundTrip(req)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		s, err := getBody(resp)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(s).To(Equal(backendContent))
 
 		// Start actual ingress tests
@@ -421,35 +421,35 @@ var ___ = describe("Ingress tests paths", func() {
 			port,
 		)
 		ingressUpdate, err := cs.NetworkingV1().Ingresses(ingressCreate.ObjectMeta.Namespace).Update(context.TODO(), updatedIng, metav1.UpdateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		// wait 20 seconds to ensure the ingress change is applied by
 		// all skippers
 		time.Sleep(20 * time.Second)
 
 		By(fmt.Sprintf("Testing for ingress %s/%s we want to get a 404 for path /", ingressUpdate.Namespace, ingressUpdate.Name))
 		resp, err = getAndWaitResponse(rt, req, 10*time.Second, http.StatusNotFound)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
 
 		By(fmt.Sprintf("Testing for ingress %s/%s we want to get a 200 for path %s", ingressUpdate.Namespace, ingressUpdate.Name, bepath))
 		beurl := "https://" + hostName + bepath
 		bereq, err := http.NewRequest("GET", beurl, nil)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		resp, err = getAndWaitResponse(rt, bereq, 10*time.Second, http.StatusOK)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 		s, err = getBody(resp)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(s).To(Equal(backendContent))
 
 		// Test ingress with 2 paths
 		bepath2 := "/bar"
 		beurl2 := "https://" + hostName + bepath2
 		bereq2, err := http.NewRequest("GET", beurl2, nil)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		By(fmt.Sprintf("Testing for ingress %s/%s we want to get a 404 for path %s", ingressUpdate.Namespace, ingressUpdate.Name, bepath2))
 		resp, err = getAndWaitResponse(rt, bereq2, 10*time.Second, http.StatusNotFound)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
 		By(fmt.Sprintf("Testing for ingress %s/%s we want to get a 200 for path %s", ingressUpdate.Namespace, ingressUpdate.Name, bepath2))
 		updatedIng = addPathIngressV1(updatedIng,
@@ -465,25 +465,25 @@ var ___ = describe("Ingress tests paths", func() {
 			},
 		)
 		ingressUpdate, err = cs.NetworkingV1().Ingresses(ingressCreate.ObjectMeta.Namespace).Update(context.TODO(), updatedIng, metav1.UpdateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		// wait 20 seconds to ensure the ingress change is applied by
 		// all skippers
 		time.Sleep(20 * time.Second)
 		resp, err = getAndWaitResponse(rt, bereq2, 10*time.Second, http.StatusOK)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 		s, err = getBody(resp)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(s).To(Equal(backendContent2))
 
 		By(fmt.Sprintf("Testing for ingress %s/%s we want to get a 200 for path %s without change from the other path", ingressUpdate.Namespace, ingressUpdate.Name, bepath))
 		beurl = "https://" + hostName + bepath
 		bereq, _ = http.NewRequest("GET", beurl, nil)
 		resp, err = getAndWaitResponse(rt, bereq, 10*time.Second, http.StatusOK)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 		s, err = getBody(resp)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(s).To(Equal(backendContent))
 	})
 })
@@ -517,38 +517,38 @@ var ____ = describe("Ingress tests custom routes", func() {
 		By("Creating a deployment with " + serviceName + " in namespace " + ns)
 		depl := createSkipperBackendDeployment(serviceName, ns, route, labels, int32(targetPort), replicas)
 		_, err := cs.AppsV1().Deployments(ns).Create(context.TODO(), depl, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		By("Creating service " + serviceName + " in namespace " + ns)
 		service := createServiceTypeClusterIP(serviceName, labels, port, targetPort)
 		_, err = cs.CoreV1().Services(ns).Create(context.TODO(), service, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		By("Creating ingress " + serviceName + " in namespace " + ns + "with hostname " + hostName)
 		ing := createIngress(serviceName, hostName, ns, "/", netv1.PathTypeImplementationSpecific, labels, nil, port)
 		ingressCreate, err := cs.NetworkingV1().Ingresses(ns).Create(context.TODO(), ing, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		addr, err := jig.WaitForIngressAddress(context.TODO(), cs, ns, ingressCreate.Name, waitTime)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		_, err = cs.NetworkingV1().Ingresses(ns).Get(context.TODO(), ing.Name, metav1.GetOptions{ResourceVersion: "0"})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// skipper http -> https redirect
 		By("Waiting for skipper route to default redirect from http to https, to see that our ingress-controller and skipper works")
 		err = waitForResponse(addr, "http", waitTime, isRedirect, true)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// ALB ready
 		By("Waiting for ALB to create endpoint " + addr + " and skipper route, to see that our ingress-controller and skipper works")
 		err = waitForResponse(addr, "https", waitTime, isNotFound, true)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// DNS ready
 		By("Waiting for DNS to see that external-dns and skipper route to service and pod works")
 		err = waitForResponse(hostName, "https", waitTime, isSuccess, false)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// Test that we get content from the default ingress
 		By("By checking the content of the reply we see that the ingress stack works")
@@ -558,11 +558,11 @@ var ____ = describe("Ingress tests custom routes", func() {
 		}()
 		url := "https://" + hostName + "/"
 		req, err := http.NewRequest("GET", url, nil)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		resp, err := rt.RoundTrip(req)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		s, err := getBody(resp)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(s).To(Equal(backendContent))
 
 		// Start actual ingress tests
@@ -586,16 +586,16 @@ var ____ = describe("Ingress tests custom routes", func() {
 			port,
 		)
 		ingressUpdate, err := cs.NetworkingV1().Ingresses(ingressCreate.ObjectMeta.Namespace).Update(context.TODO(), updatedIng, metav1.UpdateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		// wait 20 seconds to ensure the ingress change is applied by
 		// all skippers
 		time.Sleep(20 * time.Second)
 
 		By(fmt.Sprintf("Testing for ingress %s/%s we want to get a 307 for path %s", ingressUpdate.Namespace, ingressUpdate.Name, redirectPath))
 		req, err = http.NewRequest("GET", redirectURL, nil)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		resp, err = getAndWaitResponse(rt, req, 10*time.Second, http.StatusTemporaryRedirect)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(resp.StatusCode).To(Equal(http.StatusTemporaryRedirect))
 
 		reqRedirectURL := resp.Header.Get("Location")
@@ -603,10 +603,10 @@ var ____ = describe("Ingress tests custom routes", func() {
 		Expect(redirectDestinationURL).To(Equal(reqRedirectURL))
 		redirectreq, _ := http.NewRequest("GET", reqRedirectURL, nil)
 		resp, err = getAndWaitResponse(rt, redirectreq, 10*time.Second, http.StatusOK)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 		s, err = getBody(resp)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(s).To(Equal(backendContent))
 	})
 })
@@ -646,47 +646,47 @@ var _____ = describe("Ingress tests paths", func() {
 		By("Creating a deployment with " + serviceName + " in namespace " + ns)
 		depl := createSkipperBackendDeployment(serviceName, ns, route, labels, int32(targetPort), replicas)
 		_, err := cs.AppsV1().Deployments(ns).Create(context.TODO(), depl, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		By("Creating a 2nd deployment with " + serviceName2 + " in namespace " + ns)
 		depl2 := createSkipperBackendDeployment(serviceName2, ns, route2, labels2, int32(targetPort), replicas)
 		_, err = cs.AppsV1().Deployments(ns).Create(context.TODO(), depl2, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		By("Creating service " + serviceName + " in namespace " + ns)
 		service := createServiceTypeClusterIP(serviceName, labels, port, targetPort)
 		_, err = cs.CoreV1().Services(ns).Create(context.TODO(), service, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		By("Creating service " + serviceName2 + " in namespace " + ns)
 		service2 := createServiceTypeClusterIP(serviceName2, labels2, port, targetPort)
 		_, err = cs.CoreV1().Services(ns).Create(context.TODO(), service2, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		By("Creating ingress " + serviceName + " in namespace " + ns + "with hostname " + hostName)
 		ing := createIngress(serviceName, hostName, ns, "/", netv1.PathTypeImplementationSpecific, labels, nil, port)
 		ingressCreate, err := cs.NetworkingV1().Ingresses(ns).Create(context.TODO(), ing, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		addr, err := jig.WaitForIngressAddress(context.TODO(), cs, ns, ingressCreate.Name, waitTime)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		_, err = cs.NetworkingV1().Ingresses(ns).Get(context.TODO(), ing.Name, metav1.GetOptions{ResourceVersion: "0"})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// skipper http -> https redirect
 		By("Waiting for skipper route to default redirect from http to https, to see that our ingress-controller and skipper works")
 		err = waitForResponse(addr, "http", waitTime, isRedirect, true)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// ALB ready
 		By("Waiting for ALB to create endpoint " + addr + " and skipper route, to see that our ingress-controller and skipper works")
 		err = waitForResponse(addr, "https", waitTime, isNotFound, true)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// DNS ready
 		By("Waiting for DNS to see that external-dns and skipper route to service and pod works")
 		err = waitForResponse(hostName, "https", waitTime, isSuccess, false)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// Test that we get content from the default ingress
 		By("By checking the content of the reply we see that the ingress stack works")
@@ -696,11 +696,11 @@ var _____ = describe("Ingress tests paths", func() {
 		}()
 		url := "https://" + hostName + "/"
 		req, err := http.NewRequest("GET", url, nil)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		resp, err := rt.RoundTrip(req)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		s, err := getBody(resp)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(s).To(Equal(backendContent))
 
 		// Start actual ingress tests
@@ -717,41 +717,41 @@ var _____ = describe("Ingress tests paths", func() {
 			port,
 		)
 		ingressUpdate, err := cs.NetworkingV1().Ingresses(ingressCreate.ObjectMeta.Namespace).Update(context.TODO(), updatedIng, metav1.UpdateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		// wait 20 seconds to ensure the ingress change is applied by
 		// all skippers
 		time.Sleep(20 * time.Second)
 
 		By(fmt.Sprintf("Testing for ingress %s/%s we want to get a 404 for path /", ingressUpdate.Namespace, ingressUpdate.Name))
 		resp, err = getAndWaitResponse(rt, req, 10*time.Second, http.StatusNotFound)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
 
 		By(fmt.Sprintf("Testing for ingress %s/%s we want to get a 404 for pathType: Exact and path %s/bar", ingressUpdate.Namespace, ingressUpdate.Name, bepath))
 		req.URL.Path = req.URL.Path + "/bar"
 		resp, err = getAndWaitResponse(rt, req, 10*time.Second, http.StatusNotFound)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
 
 		By(fmt.Sprintf("Testing for ingress %s/%s we want to get a 200 for pathType: Exact and matching path %s", ingressUpdate.Namespace, ingressUpdate.Name, bepath))
 		beurl := "https://" + hostName + bepath
 		bereq, err := http.NewRequest("GET", beurl, nil)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		resp, err = getAndWaitResponse(rt, bereq, 10*time.Second, http.StatusOK)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 		s, err = getBody(resp)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(s).To(Equal(backendContent))
 
 		// Test ingress with 2 paths
 		bepath2 := "/bar"
 		beurl2 := "https://" + hostName + bepath2
 		bereq2, err := http.NewRequest("GET", beurl2, nil)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		By(fmt.Sprintf("Testing for ingress %s/%s we want to get a 404 for path %s", ingressUpdate.Namespace, ingressUpdate.Name, bepath2))
 		resp, err = getAndWaitResponse(rt, bereq2, 10*time.Second, http.StatusNotFound)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
 		By(fmt.Sprintf("Testing for ingress %s/%s we want to get a 200 for path %s", ingressUpdate.Namespace, ingressUpdate.Name, bepath2))
 		updatedIng = addPathIngressV1(updatedIng,
@@ -767,35 +767,35 @@ var _____ = describe("Ingress tests paths", func() {
 			},
 		)
 		ingressUpdate, err = cs.NetworkingV1().Ingresses(ingressCreate.ObjectMeta.Namespace).Update(context.TODO(), updatedIng, metav1.UpdateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		// wait 20 seconds to ensure the ingress change is applied by
 		// all skippers
 		time.Sleep(20 * time.Second)
 		resp, err = getAndWaitResponse(rt, bereq2, 10*time.Second, http.StatusOK)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 		s, err = getBody(resp)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(s).To(Equal(backendContent2))
 
 		By(fmt.Sprintf("Testing for ingress %s/%s we want to get a 200 for path %s without change from the other path", ingressUpdate.Namespace, ingressUpdate.Name, bepath))
 		beurl = "https://" + hostName + bepath
 		bereq, _ = http.NewRequest("GET", beurl, nil)
 		resp, err = getAndWaitResponse(rt, bereq, 10*time.Second, http.StatusOK)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 		s, err = getBody(resp)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(s).To(Equal(backendContent))
 
 		By(fmt.Sprintf("Testing for ingress %s/%s we want to get a 200 for path %s/path/prefix/match and pathType Prefix", ingressUpdate.Namespace, ingressUpdate.Name, bepath2))
 		beurl = "https://" + hostName + bepath2 + "/path/prefix/match"
 		bereq, _ = http.NewRequest("GET", beurl, nil)
 		resp, err = getAndWaitResponse(rt, bereq, 10*time.Second, http.StatusOK)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 		s, err = getBody(resp)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(s).To(Equal(backendContent2))
 	})
 })
@@ -829,38 +829,38 @@ var ______ = describe("Ingress tests custom routes", func() {
 		By("Creating a deployment with " + serviceName + " in namespace " + ns)
 		depl := createSkipperBackendDeployment(serviceName, ns, route, labels, int32(targetPort), replicas)
 		_, err := cs.AppsV1().Deployments(ns).Create(context.TODO(), depl, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		By("Creating service " + serviceName + " in namespace " + ns)
 		service := createServiceTypeClusterIP(serviceName, labels, port, targetPort)
 		_, err = cs.CoreV1().Services(ns).Create(context.TODO(), service, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		By("Creating ingress " + serviceName + " in namespace " + ns + "with hostname " + hostName)
 		ing := createIngress(serviceName, hostName, ns, "/", netv1.PathTypeImplementationSpecific, labels, nil, port)
 		ingressCreate, err := cs.NetworkingV1().Ingresses(ns).Create(context.TODO(), ing, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		addr, err := jig.WaitForIngressAddress(context.TODO(), cs, ns, ingressCreate.Name, waitTime)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		_, err = cs.NetworkingV1().Ingresses(ns).Get(context.TODO(), ing.Name, metav1.GetOptions{ResourceVersion: "0"})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// skipper http -> https redirect
 		By("Waiting for skipper route to default redirect from http to https, to see that our ingress-controller and skipper works")
 		err = waitForResponse(addr, "http", waitTime, isRedirect, true)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// ALB ready
 		By("Waiting for ALB to create endpoint " + addr + " and skipper route, to see that our ingress-controller and skipper works")
 		err = waitForResponse(addr, "https", waitTime, isNotFound, true)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// DNS ready
 		By("Waiting for DNS to see that external-dns and skipper route to service and pod works")
 		err = waitForResponse(hostName, "https", waitTime, isSuccess, false)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// Test that we get content from the default ingress
 		By("By checking the content of the reply we see that the ingress stack works")
@@ -870,11 +870,11 @@ var ______ = describe("Ingress tests custom routes", func() {
 		}()
 		url := "https://" + hostName + "/"
 		req, err := http.NewRequest("GET", url, nil)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		resp, err := rt.RoundTrip(req)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		s, err := getBody(resp)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(s).To(Equal(backendContent))
 
 		// Start actual ingress tests
@@ -898,16 +898,16 @@ var ______ = describe("Ingress tests custom routes", func() {
 			port,
 		)
 		ingressUpdate, err := cs.NetworkingV1().Ingresses(ingressCreate.ObjectMeta.Namespace).Update(context.TODO(), updatedIng, metav1.UpdateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		// wait 20 seconds to ensure the ingress change is applied by
 		// all skippers
 		time.Sleep(20 * time.Second)
 
 		By(fmt.Sprintf("Testing for ingress %s/%s we want to get a 307 for path %s", ingressUpdate.Namespace, ingressUpdate.Name, redirectPath))
 		req, err = http.NewRequest("GET", redirectURL, nil)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		resp, err = getAndWaitResponse(rt, req, 10*time.Second, http.StatusTemporaryRedirect)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(resp.StatusCode).To(Equal(http.StatusTemporaryRedirect))
 
 		reqRedirectURL := resp.Header.Get("Location")
@@ -915,10 +915,10 @@ var ______ = describe("Ingress tests custom routes", func() {
 		Expect(redirectDestinationURL).To(Equal(reqRedirectURL))
 		redirectreq, _ := http.NewRequest("GET", reqRedirectURL, nil)
 		resp, err = getAndWaitResponse(rt, redirectreq, 10*time.Second, http.StatusOK)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 		s, err = getBody(resp)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(s).To(Equal(backendContent))
 	})
 })
@@ -963,37 +963,37 @@ var _______ = describe("Ingress tests simple NLB", func() {
 		By("Creating a deployment with " + serviceName + " in namespace " + ns)
 		depl := createSkipperBackendDeployment(serviceName, ns, route, labels, int32(targetPort), replicas)
 		_, err := cs.AppsV1().Deployments(ns).Create(context.TODO(), depl, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		By("Creating service " + serviceName + " in namespace " + ns)
 		service := createServiceTypeClusterIP(serviceName, labels, port, targetPort)
 		_, err = cs.CoreV1().Services(ns).Create(context.TODO(), service, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		ing := createIngress(serviceName, hostName, ns, "/", netv1.PathTypeImplementationSpecific, labels, annotations, port)
 		ingressCreate, err := cs.NetworkingV1().Ingresses(ns).Create(context.TODO(), ing, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		addr, err := jig.WaitForIngressAddress(context.TODO(), cs, ns, ingressCreate.Name, waitTime)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		_, err = cs.NetworkingV1().Ingresses(ns).Get(context.TODO(), ing.Name, metav1.GetOptions{ResourceVersion: "0"})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// skipper http -> https redirect
 		By("Waiting for skipper route to default redirect from http to https, to see that our ingress-controller and skipper works")
 		err = waitForResponse(addr, "http", waitTime, isRedirect, true)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// NLB ready
 		By("Waiting for NLB to create endpoint " + addr + " and skipper route, to see that our ingress-controller and skipper works")
 		err = waitForResponse(addr, "https", waitTime, isNotFound, true)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// DNS ready
 		By("Waiting for DNS to see that external-dns and skipper route to service and pod works")
 		err = waitForResponse(hostName, "https", waitTime, isSuccess, false)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// Test that we get content from the default ingress
 		By("By checking the content of the reply we see that the ingress stack works")
@@ -1003,27 +1003,27 @@ var _______ = describe("Ingress tests simple NLB", func() {
 		}()
 		url := "https://" + hostName + "/"
 		req, err := http.NewRequest("GET", url, nil)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		resp, err := rt.RoundTrip(req)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		s, err := getBody(resp)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(s).To(Equal(backendContent))
 
 		By("Checking request X-Forwarded-* headers")
 		req, err = http.NewRequest("GET", "https://"+hostName+"/", nil)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		resp, err = waitForResponseReturnResponse(req, 10*time.Second, isSuccess, false)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(resp.Header.Get("Request-X-Forwarded-For")).NotTo(Equal(""))
 		Expect(resp.Header.Get("Request-X-Forwarded-Port")).To(Equal("443"))
 		Expect(resp.Header.Get("Request-X-Forwarded-Proto")).To(Equal("https"))
 
 		By("Checking request with trailing dot in the hostname is normalized")
 		req, err = http.NewRequest("GET", "https://"+hostName+"./", nil)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		resp, err = waitForResponseReturnResponse(req, 10*time.Second, isSuccess, false)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(resp.Header.Get("Request-Host")).To(Equal(hostName))
 	})
 })

--- a/test/e2e/kube_metrics_adapter_test.go
+++ b/test/e2e/kube_metrics_adapter_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	rgclient "github.com/szuecs/routegroup-client"
 	rgv1 "github.com/szuecs/routegroup-client/apis/zalando.org/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -44,14 +43,14 @@ var _ = describe("[HPA] Horizontal pod autoscaling (scale resource: Custom Metri
 
 		// setup RouteGroup clientset
 		config, err := framework.LoadConfig()
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		config.QPS = f.Options.ClientQPS
 		config.Burst = f.Options.ClientBurst
 		if f.Options.GroupVersion != nil {
 			config.GroupVersion = f.Options.GroupVersion
 		}
 		rgcs, err = rgclient.NewClientset(config)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 	})
 
 	It("should scale down with Custom Metric of type Pod from kube-metrics-adapter [CustomMetricsAutoscaling] [Zalando]", func() {
@@ -190,13 +189,13 @@ func (tc *CustomMetricTestCase) Run() {
 
 	// Create a MetricsExporter deployment
 	_, err := tc.kubeClient.AppsV1().Deployments(ns).Create(context.TODO(), tc.deployment, metav1.CreateOptions{})
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 	// Wait for the deployment to run
 	waitForReplicas(tc.deployment.ObjectMeta.Name, tc.framework.Namespace.ObjectMeta.Name, tc.kubeClient, 15*time.Minute, tc.initialReplicas)
 
 	for _, deployment := range tc.auxDeployments {
 		_, err := tc.kubeClient.AppsV1().Deployments(ns).Create(context.TODO(), deployment, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		// Wait for the deployment to run
 		waitForReplicas(deployment.ObjectMeta.Name, tc.framework.Namespace.ObjectMeta.Name, tc.kubeClient, 15*time.Minute, int(*(deployment.Spec.Replicas)))
 	}
@@ -205,14 +204,14 @@ func (tc *CustomMetricTestCase) Run() {
 	if tc.ingress != nil {
 		// Create a Service for the Ingress
 		_, err = tc.kubeClient.CoreV1().Services(ns).Create(context.TODO(), tc.service, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// Create an Ingress since RPS based scaling relies on it
 		ingressCreate, err := tc.kubeClient.NetworkingV1().Ingresses(ns).Create(context.TODO(), tc.ingress, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		_, err = tc.jig.WaitForIngressAddress(context.TODO(), tc.kubeClient, ns, ingressCreate.Name, 10*time.Minute)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 	}
 
@@ -220,19 +219,19 @@ func (tc *CustomMetricTestCase) Run() {
 	if tc.routegroup != nil {
 		// Create a Service for the RouteGroup
 		_, err = tc.kubeClient.CoreV1().Services(ns).Create(context.TODO(), tc.service, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// Create a RouteGroup since RPS based scaling relies on it
 		rgCreate, err := tc.rgClient.ZalandoV1().RouteGroups(ns).Create(context.TODO(), tc.routegroup, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		_, err = waitForRouteGroup(tc.rgClient, rgCreate.Name, rgCreate.Namespace, 10*time.Minute)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 	}
 
 	// Autoscale the deployment
 	_, err = tc.kubeClient.AutoscalingV2().HorizontalPodAutoscalers(ns).Create(context.TODO(), tc.hpa, metav1.CreateOptions{})
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 
 	waitForReplicas(tc.deployment.ObjectMeta.Name, tc.framework.Namespace.ObjectMeta.Name, tc.kubeClient, 15*time.Minute, tc.scaledReplicas)
 }

--- a/test/e2e/psp.go
+++ b/test/e2e/psp.go
@@ -50,12 +50,12 @@ var _ = describe("PSP use", func() {
 				Name: ns,
 			},
 		}, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// create SA
 		saObj := createServiceAccount(ns, privilegedSA)
 		_, err = cs.CoreV1().ServiceAccounts(ns).Create(context.TODO(), saObj, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		label := map[string]string{
 			"app": "psp",
@@ -69,7 +69,7 @@ var _ = describe("PSP use", func() {
 			defer GinkgoRecover()
 
 			err = cs.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 		}()
 		_, err = cs.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
 		Expect(err).To(HaveOccurred())
@@ -82,12 +82,12 @@ var _ = describe("PSP use", func() {
 				Name: ns,
 			},
 		}, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// create SA
 		saObj := createServiceAccount(ns, privilegedSA)
 		_, err = cs.CoreV1().ServiceAccounts(ns).Create(context.TODO(), saObj, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		label := map[string]string{
 			"app": "psp",
@@ -102,14 +102,14 @@ var _ = describe("PSP use", func() {
 			By(msg)
 			defer GinkgoRecover()
 			err := cs.CoreV1().Pods(ns).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 
 			err = cs.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 		}()
 
 		_, err = cs.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(context.TODO(), f.ClientSet, pod.Name, pod.Namespace))
 	})
@@ -121,12 +121,12 @@ var _ = describe("PSP use", func() {
 				Name: ns,
 			},
 		}, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// create SA
 		saObj := createServiceAccount(ns, privilegedSA)
 		_, err = cs.CoreV1().ServiceAccounts(ns).Create(context.TODO(), saObj, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		label := map[string]string{
 			"app": "psp",
@@ -145,29 +145,29 @@ var _ = describe("PSP use", func() {
 			By(fmt.Sprintf("Delete a deployment that creates a privileged POD as %s", privilegedSA))
 			defer GinkgoRecover()
 			err := cs.AppsV1().Deployments(ns).Delete(context.TODO(), d.Name, metav1.DeleteOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 
 			err = cs.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 		}()
 
 		deploy, err := cs.AppsV1().Deployments(ns).Create(context.TODO(), d, metav1.CreateOptions{})
 
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// Wait for it to be updated to revision 1
 		err = deploymentframework.WaitForDeploymentRevisionAndImage(cs, ns, deploy.Name, "1", d.Spec.Template.Spec.Containers[0].Image)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		err = deploymentframework.WaitForDeploymentComplete(cs, deploy)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		deployment, err := cs.AppsV1().Deployments(ns).Get(context.TODO(), deploy.Name, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		rs, err := deploymentutil.GetNewReplicaSet(deployment, cs)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		By(fmt.Sprintf("Got rs: %s, from deployment: %s", rs.Name, deploy.Name))
 
 		pods, err := e2epod.PodsCreatedByLabel(context.TODO(), f.ClientSet, ns, rs.Name, replicas, labelSelector)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		By(fmt.Sprintf("Ensuring each pod is running for rs: %s, pod: %s", rs.Name, pods.Items[0].Name))
 		// Wait for the pods to enter the running state. Waiting loops until the pods
 		// are running so non-running pods cause a timeout for this test.
@@ -176,7 +176,7 @@ var _ = describe("PSP use", func() {
 				continue
 			}
 			err = e2epod.WaitForPodNameRunningInNamespace(context.TODO(), f.ClientSet, pod.Name, pod.Namespace)
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 		}
 	})
 })

--- a/test/e2e/routegroup.go
+++ b/test/e2e/routegroup.go
@@ -39,14 +39,14 @@ var _ = describe("RouteGroup ALB creation", func() {
 	BeforeEach(func() {
 		By("Creating an rgclient Clientset")
 		config, err := framework.LoadConfig()
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		config.QPS = f.Options.ClientQPS
 		config.Burst = f.Options.ClientBurst
 		if f.Options.GroupVersion != nil {
 			config.GroupVersion = f.Options.GroupVersion
 		}
 		cs, err = rgclient.NewClientset(config)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 	})
 
 	It("Should create valid https and http ALB endpoint [RouteGroup] [Zalando]", func() {
@@ -65,7 +65,7 @@ var _ = describe("RouteGroup ALB creation", func() {
 		By("Creating service " + serviceName + " in namespace " + ns)
 		service := createServiceTypeClusterIP(serviceName, labels, port, targetPort)
 		_, err := cs.CoreV1().Services(ns).Create(context.TODO(), service, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// POD
 		By("Creating a POD with prefix " + nameprefix + " in namespace " + ns)
@@ -73,7 +73,7 @@ var _ = describe("RouteGroup ALB creation", func() {
 		pod := createSkipperPod(nameprefix, ns, fmt.Sprintf(`r0: * -> inlineContent("%s") -> <shunt>`, expectedResponse), labels, targetPort)
 
 		_, err = cs.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(context.TODO(), f.ClientSet, pod.Name, pod.Namespace))
 
 		// RouteGroup
@@ -82,36 +82,36 @@ var _ = describe("RouteGroup ALB creation", func() {
 			PathSubtree: "/",
 		})
 		rgCreate, err := cs.ZalandoV1().RouteGroups(ns).Create(context.TODO(), rg, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		addr, err := waitForRouteGroup(cs, rgCreate.Name, rgCreate.Namespace, 10*time.Minute)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		rgGot, err := cs.ZalandoV1().RouteGroups(ns).Get(context.TODO(), rg.Name, metav1.GetOptions{ResourceVersion: "0"})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		By(fmt.Sprintf("ALB endpoint from routegroup status: %s", rgGot.Status.LoadBalancer.RouteGroup[0].Hostname))
 
 		//  skipper http -> https redirect
 		By("Waiting for skipper route to default redirect from http to https, to see that our routegroup-controller and skipper works")
 		err = waitForResponse(addr, "http", 10*time.Minute, isRedirect, true)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// ALB ready
 		By("Waiting for ALB to create endpoint " + addr + " and skipper route, to see that our routegroup-controller and skipper works")
 		err = waitForResponse(addr, "https", 10*time.Minute, isNotFound, true)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// DNS ready
 		By("Waiting for DNS to see that external-dns and skipper route to service and pod works")
 		err = waitForResponse(hostName, "https", 10*time.Minute, isSuccess, false)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// response is from our backend
 		By("checking the response body we know, if we got the response from our backend")
 		req, err := http.NewRequest("GET", "https://"+hostName+"/", nil)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		resp, err = waitForResponseReturnResponse(req, 10*time.Minute, isSuccess, false)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		s, err := getBody(resp)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(s).To(Equal(expectedResponse))
 	})
 
@@ -131,7 +131,7 @@ var _ = describe("RouteGroup ALB creation", func() {
 		By("Creating service " + serviceName + " in namespace " + ns)
 		service := createServiceTypeClusterIP(serviceName, labels, port, targetPort)
 		_, err := cs.CoreV1().Services(ns).Create(context.TODO(), service, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// POD
 		By("Creating a POD with prefix " + nameprefix + " in namespace " + ns)
@@ -146,7 +146,7 @@ rBackend: Path("/backend") -> inlineContent("%s") -> <shunt>;`,
 			targetPort)
 
 		_, err = cs.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(context.TODO(), f.ClientSet, pod.Name, pod.Namespace))
 
 		// RouteGroup
@@ -157,30 +157,30 @@ rBackend: Path("/backend") -> inlineContent("%s") -> <shunt>;`,
 			Predicates:  []string{`Header("Foo", "bar")`},
 		})
 		rgCreate, err := cs.ZalandoV1().RouteGroups(ns).Create(context.TODO(), rg, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		_, err = waitForRouteGroup(cs, rgCreate.Name, rgCreate.Namespace, 10*time.Minute)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		rgGot, err := cs.ZalandoV1().RouteGroups(ns).Get(context.TODO(), rg.Name, metav1.GetOptions{ResourceVersion: "0"})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		By(fmt.Sprintf("ALB endpoint from routegroup status: %s", rgGot.Status.LoadBalancer.RouteGroup[0].Hostname))
 
 		// DNS ready
 		By("Waiting for ALB, DNS and skipper route to service and pod works")
 		err = waitForResponse(hostName, "https", 10*time.Minute, isNotFound, false)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// checking backend route with predicates
 		By("checking the response for a request to /backend we know if we got the correct route")
 		err = waitForResponse("https://"+hostName+"/backend", "https", 10*time.Minute, isNotFound, false)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		By("checking the response for a request with headers to /backend we know if we got the correct route")
 		req, err := http.NewRequest("GET", "https://"+hostName+"/backend", nil)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		req.Header.Set("Foo", "bar")
 		resp, err = waitForResponseReturnResponse(req, 10*time.Minute, isSuccess, false)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		s, err := getBody(resp)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(s).To(Equal(expectedResponse))
 	})
 
@@ -200,7 +200,7 @@ rBackend: Path("/backend") -> inlineContent("%s") -> <shunt>;`,
 		By("Creating service " + serviceName + " in namespace " + ns)
 		service := createServiceTypeClusterIP(serviceName, labels, port, targetPort)
 		_, err := cs.CoreV1().Services(ns).Create(context.TODO(), service, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// POD
 		By("Creating a POD with prefix " + nameprefix + " in namespace " + ns)
@@ -218,7 +218,7 @@ rBackend4: Path("/router-response") -> inlineContent("NOT OK") -> <shunt>;
 			targetPort)
 
 		_, err = cs.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(context.TODO(), f.ClientSet, pod.Name, pod.Namespace))
 
 		// RouteGroup
@@ -255,23 +255,23 @@ rBackend4: Path("/router-response") -> inlineContent("NOT OK") -> <shunt>;
 			},
 		})
 		rgCreate, err := cs.ZalandoV1().RouteGroups(ns).Create(context.TODO(), rg, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		_, err = waitForRouteGroup(cs, rgCreate.Name, rgCreate.Namespace, 10*time.Minute)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		rgGot, err := cs.ZalandoV1().RouteGroups(ns).Get(context.TODO(), rg.Name, metav1.GetOptions{ResourceVersion: "0"})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		By(fmt.Sprintf("ALB endpoint from routegroup status: %s", rgGot.Status.LoadBalancer.RouteGroup[0].Hostname))
 
 		// DNS ready
 		By("Waiting for ALB, DNS and skipper route to service and pod works")
 		err = waitForResponse(hostName+"/", "https", 10*time.Minute, isNotFound, false)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// response for / is from our backend
 		By("checking the response code of a request without required request header, we can check if predicate match works correctly")
 		req, _ := http.NewRequest("GET", "https://"+hostName+"/backend", nil)
 		resp, err = waitForResponseReturnResponse(req, 10*time.Minute, isNotFound, false)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		resp.Body.Close()
 
 		// checking backend route with predicates and filters
@@ -279,41 +279,41 @@ rBackend4: Path("/router-response") -> inlineContent("NOT OK") -> <shunt>;
 		waitForResponse("https://"+hostName+"/backend", "https", 10*time.Minute, isNotFound, false)
 		By("checking the response for a request to /backend with the right header we know if we got the correct route")
 		req, err = http.NewRequest("GET", "https://"+hostName+"/backend", nil)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		req.Header.Set("Foo", "bar")
 		resp, err = waitForResponseReturnResponse(req, 10*time.Minute, func(code int) bool {
 			return code == http.StatusCreated
 		}, false)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		s, err := getBody(resp)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(s).To(Equal(expectedResponse))
 
 		By("checking /no-match1 unexpected method should lead to 404")
 		err = waitForResponse("https://"+hostName+"/no-match1", "https", 10*time.Minute, isNotFound, false)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		By("checking /no-match2 unexpected predicate should lead to 404")
 		err = waitForResponse("https://"+hostName+"/no-match2", "https", 10*time.Minute, isNotFound, false)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		By("checking /multi-methods matches correctly")
 		req, err = http.NewRequest("GET", "https://"+hostName+"/multi-methods", nil)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		resp, err = waitForResponseReturnResponse(req, 10*time.Minute, isSuccess, false)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		resp.Body.Close()
 		req, err = http.NewRequest("HEAD", "https://"+hostName+"/multi-methods", nil)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		resp, err = waitForResponseReturnResponse(req, 10*time.Minute, isSuccess, false)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		resp.Body.Close()
 
 		By("checking /router-response matches correctly and response with shunted route")
 		err = waitForResponse("https://"+hostName+"/router-response", "https", 10*time.Minute, func(code int) bool {
 			return code == http.StatusTeapot
 		}, false)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 	})
 
 	It("Should create routes with ratelimit filters and shunt backend [Ratelimits] [RouteGroup] [Zalando]", func() {
@@ -332,7 +332,7 @@ rBackend4: Path("/router-response") -> inlineContent("NOT OK") -> <shunt>;
 		By("Creating service " + serviceName + " in namespace " + ns)
 		service := createServiceTypeClusterIP(serviceName, labels, port, targetPort)
 		_, err := cs.CoreV1().Services(ns).Create(context.TODO(), service, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// POD
 		By("Creating a POD with prefix " + nameprefix + " in namespace " + ns)
@@ -347,7 +347,7 @@ rBackend: Path("/backend") -> inlineContent("%s") -> <shunt>;
 			targetPort)
 
 		_, err = cs.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(context.TODO(), f.ClientSet, pod.Name, pod.Namespace))
 
 		// RouteGroup
@@ -361,35 +361,35 @@ rBackend: Path("/backend") -> inlineContent("%s") -> <shunt>;
 			},
 		})
 		rgCreate, err := cs.ZalandoV1().RouteGroups(ns).Create(context.TODO(), rg, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		_, err = waitForRouteGroup(cs, rgCreate.Name, rgCreate.Namespace, 10*time.Minute)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		rgGot, err := cs.ZalandoV1().RouteGroups(ns).Get(context.TODO(), rg.Name, metav1.GetOptions{ResourceVersion: "0"})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		By(fmt.Sprintf("ALB endpoint from routegroup status: %s", rgGot.Status.LoadBalancer.RouteGroup[0].Hostname))
 
 		// DNS ready
 		By("Waiting for ALB, DNS and skipper route to service and pod works")
 		err = waitForResponse(hostName+"/", "https", 5*time.Minute, isNotFound, false)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// checking backend route with predicates and filters
 		By("checking the response for a request to /backend with the right header we know if we got the correct route")
 		req, err := http.NewRequest("GET", "https://"+hostName+"/backend", nil)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		resp, err = waitForResponseReturnResponse(req, 5*time.Minute, isSuccess, false)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		s, err := getBody(resp)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(s).To(Equal(expectedResponse))
 
 		By("checking the response is for a request to /backend with the right header we know if we got the correct route but get ratelimited")
 		req, err = http.NewRequest("GET", "https://"+hostName+"/backend", nil)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		resp, err = waitForResponseReturnResponse(req, 5*time.Minute, func(code int) bool {
 			return code == http.StatusTooManyRequests
 		}, false)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(resp).NotTo(BeNil())
 		Expect(resp.StatusCode).To(Equal(http.StatusTooManyRequests))
 	})
@@ -410,7 +410,7 @@ rBackend: Path("/backend") -> inlineContent("%s") -> <shunt>;
 		By("Creating service " + serviceName + " in namespace " + ns)
 		service := createServiceTypeClusterIP(serviceName, labels, port, targetPort)
 		_, err := cs.CoreV1().Services(ns).Create(context.TODO(), service, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// POD
 		By("Creating a POD with prefix " + nameprefix + " in namespace " + ns)
@@ -425,7 +425,7 @@ rBackend: Path("/backend") -> inlineContent("%s") -> <shunt>;`,
 			targetPort)
 
 		_, err = cs.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(context.TODO(), f.ClientSet, pod.Name, pod.Namespace))
 
 		// RouteGroup
@@ -461,38 +461,38 @@ rBackend: Path("/backend") -> inlineContent("%s") -> <shunt>;`,
 			},
 		})
 		rgCreate, err := cs.ZalandoV1().RouteGroups(ns).Create(context.TODO(), rg, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		_, err = waitForRouteGroup(cs, rgCreate.Name, rgCreate.Namespace, 10*time.Minute)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		rgGot, err := cs.ZalandoV1().RouteGroups(ns).Get(context.TODO(), rg.Name, metav1.GetOptions{ResourceVersion: "0"})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		By(fmt.Sprintf("ALB endpoint from routegroup status: %s", rgGot.Status.LoadBalancer.RouteGroup[0].Hostname))
 
 		// DNS ready
 		By("Waiting for ALB, DNS and skipper route to service and pod works")
 		err = waitForResponse(hostName, "https", 10*time.Minute, isSuccess, false)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// response for / is from our backend
 		By("checking the response body we know, if we got the response from our backend")
 		req, err := http.NewRequest("GET", "https://"+hostName+"/", nil)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		resp, err = waitForResponseReturnResponse(req, 10*time.Minute, func(code int) bool {
 			return code == 200
 		}, false)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		s, err := getBody(resp)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(s).To(Equal("OK"))
 
 		// checking blue-green routes are ~50/50 match
 		By("checking the response for a request to /blue-green we know if we got the correct route")
 		req, err = http.NewRequest("GET", "https://"+hostName+"/blue-green", nil)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		resp, err = waitForResponseReturnResponse(req, 10*time.Minute, func(code int) bool {
 			return code > 200 && code < 203
 		}, false)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(resp.StatusCode).To(Or(Equal(201), Equal(202)))
 		resp.Body.Close()
 
@@ -504,7 +504,7 @@ rBackend: Path("/backend") -> inlineContent("%s") -> <shunt>;`,
 			resp, err = waitForResponseReturnResponse(req, 10*time.Minute, func(code int) bool {
 				return code > 200 && code < 203
 			}, false)
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 			resp.Body.Close()
 			cnt[resp.StatusCode]++
 		}
@@ -537,9 +537,9 @@ rBackend: Path("/backend") -> inlineContent("%s") -> <shunt>;`,
 		By("Creating service2 " + serviceName2 + " in namespace " + ns)
 		service2 := createServiceTypeClusterIP(serviceName2, labels2, port, targetPort)
 		_, err := cs.CoreV1().Services(ns).Create(context.TODO(), service, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		_, err = cs.CoreV1().Services(ns).Create(context.TODO(), service2, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// POD
 		By("Creating 2 PODs with prefix " + nameprefix + " and " + nameprefix + " in namespace " + ns)
@@ -564,9 +564,9 @@ rBackend: Path("/blue-green") -> status(202) -> inlineContent("%s") -> <shunt>;`
 			targetPort)
 
 		_, err = cs.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		_, err = cs.CoreV1().Pods(ns).Create(context.TODO(), pod2, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(context.TODO(), f.ClientSet, pod.Name, pod.Namespace))
 		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(context.TODO(), f.ClientSet, pod2.Name, pod2.Namespace))
 
@@ -615,30 +615,30 @@ rBackend: Path("/blue-green") -> status(202) -> inlineContent("%s") -> <shunt>;`
 				},
 			})
 		rgCreate, err := cs.ZalandoV1().RouteGroups(ns).Create(context.TODO(), rg, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		_, err = waitForRouteGroup(cs, rgCreate.Name, rgCreate.Namespace, 10*time.Minute)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		rgGot, err := cs.ZalandoV1().RouteGroups(ns).Get(context.TODO(), rg.Name, metav1.GetOptions{ResourceVersion: "0"})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		By(fmt.Sprintf("ALB endpoint from routegroup status: %s", rgGot.Status.LoadBalancer.RouteGroup[0].Hostname))
 
 		// DNS and backend to /blue-green ready
 		By("Waiting for ALB, DNS and skipper route to service and pod works")
 		req, err := http.NewRequest("GET", "https://"+hostName+"/blue-green", nil)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		resp, err = waitForResponseReturnResponse(req, 10*time.Minute, func(code int) bool {
 			return code > 200 && code < 203
 		}, false)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(resp.StatusCode).To(Or(Equal(201), Equal(202)))
 		s, err := getBody(resp)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		Expect(s).To(Or(Equal("blue"), Equal("green")))
 
 		// checking blue-green routes are ~80/20 match
 		By("checking the response for a request to /blue-green we know if we got the correct weights for our backends")
 		req, err = http.NewRequest("GET", "https://"+hostName+"/blue-green", nil)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		cnt := map[int]int{
 			201: 0,
 			202: 0,
@@ -647,7 +647,7 @@ rBackend: Path("/blue-green") -> status(202) -> inlineContent("%s") -> <shunt>;`
 			resp, err = waitForResponseReturnResponse(req, 10*time.Minute, func(code int) bool {
 				return code > 200 && code < 203
 			}, false)
-			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(err)
 			resp.Body.Close()
 			cnt[resp.StatusCode]++
 		}
@@ -675,7 +675,7 @@ rBackend: Path("/blue-green") -> status(202) -> inlineContent("%s") -> <shunt>;`
 		By("Creating service " + serviceName + " in namespace " + ns)
 		service := createServiceTypeClusterIP(serviceName, labels, port, targetPort)
 		_, err := cs.CoreV1().Services(ns).Create(context.TODO(), service, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// POD
 		By("Creating a POD with prefix " + nameprefix + " in namespace " + ns)
@@ -687,7 +687,7 @@ rBackend: Path("/blue-green") -> status(202) -> inlineContent("%s") -> <shunt>;`
 			targetPort)
 
 		_, err = cs.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(context.TODO(), f.ClientSet, pod.Name, pod.Namespace))
 
 		// RouteGroup
@@ -696,17 +696,17 @@ rBackend: Path("/blue-green") -> status(202) -> inlineContent("%s") -> <shunt>;`
 			PathSubtree: "/",
 		})
 		rgCreate, err := cs.ZalandoV1().RouteGroups(ns).Create(context.TODO(), rg, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		_, err = waitForRouteGroup(cs, rgCreate.Name, rgCreate.Namespace, 10*time.Minute)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		rgGot, err := cs.ZalandoV1().RouteGroups(ns).Get(context.TODO(), rg.Name, metav1.GetOptions{ResourceVersion: "0"})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		By(fmt.Sprintf("NLB endpoint from routegroup status: %s", rgGot.Status.LoadBalancer.RouteGroup[0].Hostname))
 
 		// DNS ready
 		By("Waiting for NLB, DNS and skipper route to service and pod works")
 		err = waitForResponse(hostName, "https", 10*time.Minute, isSuccess, false)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 	})
 
 	It("Should create ALB routegroup with 2 hostnames [RouteGroup] [Zalando]", func() {
@@ -724,7 +724,7 @@ rBackend: Path("/blue-green") -> status(202) -> inlineContent("%s") -> <shunt>;`
 		By("Creating service " + serviceName + " in namespace " + ns)
 		service := createServiceTypeClusterIP(serviceName, labels, port, targetPort)
 		_, err := cs.CoreV1().Services(ns).Create(context.TODO(), service, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 
 		// POD
 		By("Creating a POD with prefix " + nameprefix + " in namespace " + ns)
@@ -736,7 +736,7 @@ rBackend: Path("/blue-green") -> status(202) -> inlineContent("%s") -> <shunt>;`
 			targetPort)
 
 		_, err = cs.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(context.TODO(), f.ClientSet, pod.Name, pod.Namespace))
 
 		// RouteGroup
@@ -746,19 +746,19 @@ rBackend: Path("/blue-green") -> status(202) -> inlineContent("%s") -> <shunt>;`
 		})
 		rg.Spec.Hosts = append(rg.Spec.Hosts, hostName2) // add second hostname
 		rgCreate, err := cs.ZalandoV1().RouteGroups(ns).Create(context.TODO(), rg, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		_, err = waitForRouteGroup(cs, rgCreate.Name, rgCreate.Namespace, 10*time.Minute)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		rgGot, err := cs.ZalandoV1().RouteGroups(ns).Get(context.TODO(), rg.Name, metav1.GetOptions{ResourceVersion: "0"})
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		By(fmt.Sprintf("ALB endpoint from routegroup status: %s", rgGot.Status.LoadBalancer.RouteGroup[0].Hostname))
 
 		// DNS ready for both endpoints
 		By("Waiting for ALB, DNS and skipper route to service and pod works")
 		err = waitForResponse(hostName, "https", 10*time.Minute, isSuccess, false)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 		err = waitForResponse(hostName2, "https", 10*time.Minute, isSuccess, false)
-		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(err)
 	})
 
 })

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/utils/ptr"
 
 	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	rgclient "github.com/szuecs/routegroup-client"
 	rgv1 "github.com/szuecs/routegroup-client/apis/zalando.org/v1"
 	zv1 "github.com/zalando-incubator/kube-aws-iam-controller/pkg/apis/zalando.org/v1"
@@ -945,7 +944,7 @@ func deleteDeployment(cs clientset.Interface, ns string, deployment *appsv1.Depl
 	By(fmt.Sprintf("Delete a compliant deployment: %s", deployment.Name))
 	defer GinkgoRecover()
 	err := cs.AppsV1().Deployments(ns).Delete(context.TODO(), deployment.Name, metav1.DeleteOptions{})
-	Expect(err).NotTo(HaveOccurred())
+	framework.ExpectNoError(err)
 }
 
 func createHTTPRoundTripper() (http.RoundTripper, chan<- struct{}) {


### PR DESCRIPTION
The recommended method for making assertions for errors in upstream kubernetes is `framework.ExpectNoError`, from the e2e best practices guide
https://www.kubernetes.dev/blog/2023/04/12/e2e-testing-best-practices-reloaded/#debuggability

> Compared to gomega.Expect(err).NotTo(gomega.HaveOccurred()), framework.ExpectNoError(err) is shorter and produces better failure messages because it logs the full error and then includes only the shorter err.Error() in the failure message.

Let's use this in our setup