### PR TITLE
[e2e] use bigger instance for `default-worker-splitaz` to avoid flake

### DIFF
--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -62,7 +62,7 @@ clusters:
     max_size: 2
   - discount_strategy: none
     instance_types:
-    - "m6i.xlarge"
+    - "m6i.2xlarge"
     name: default-worker-splitaz
     profile: worker-splitaz
     min_size: 0


### PR DESCRIPTION
We have a flake e2e test where a pod remains pending for too long and times out. This increases the instance size so we can avoid that flakey test failure.

Reference: https://github.bus.zalan.do/teapot/issues/issues/3619