### PR TITLE
[e2e] re-enable skipped e2e tests

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -601,7 +601,7 @@ teapot_admission_controller_namespace_delete_protection_enabled: "false"
 teapot_admission_controller_resolve_vanity_images: "true"
 
 {{if eq .Cluster.Environment "e2e"}}
-teapot_admission_controller_ignore_namespaces: "^kube-system|((downward-api|kubectl|projected|statefulset|pod-network|scope-selectors|resourcequota|limitrange|sysctl|node-tests|e2e-kubelet-etc-hosts|csiinlinevolumes|dns)-.*)$"
+teapot_admission_controller_ignore_namespaces: "^kube-system|((downward-api|kubectl|projected|statefulset|pod-network|scope-selectors|resourcequota|limitrange|sysctl|node-tests|e2e-kubelet-etc-hosts|csiinlinevolumes|dns|sched-pred)-.*)$"
 teapot_admission_controller_crd_ensure_no_resources_on_delete: "false"
 {{else}}
 teapot_admission_controller_ignore_namespaces: "^kube-system$"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -601,7 +601,7 @@ teapot_admission_controller_namespace_delete_protection_enabled: "false"
 teapot_admission_controller_resolve_vanity_images: "true"
 
 {{if eq .Cluster.Environment "e2e"}}
-teapot_admission_controller_ignore_namespaces: "^kube-system|((downward-api|kubectl|projected|statefulset|pod-network|scope-selectors|resourcequota|limitrange|sysctl|node-tests|e2e-kubelet-etc-hosts|csiinlinevolumes)-.*)$"
+teapot_admission_controller_ignore_namespaces: "^kube-system|((downward-api|kubectl|projected|statefulset|pod-network|scope-selectors|resourcequota|limitrange|sysctl|node-tests|e2e-kubelet-etc-hosts|csiinlinevolumes|dns|hostport)-.*)$"
 teapot_admission_controller_crd_ensure_no_resources_on_delete: "false"
 {{else}}
 teapot_admission_controller_ignore_namespaces: "^kube-system$"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -601,7 +601,7 @@ teapot_admission_controller_namespace_delete_protection_enabled: "false"
 teapot_admission_controller_resolve_vanity_images: "true"
 
 {{if eq .Cluster.Environment "e2e"}}
-teapot_admission_controller_ignore_namespaces: "^kube-system|((downward-api|kubectl|projected|statefulset|pod-network|scope-selectors|resourcequota|limitrange|sysctl|node-tests|e2e-kubelet-etc-hosts|csiinlinevolumes|dns|sched-pred)-.*)$"
+teapot_admission_controller_ignore_namespaces: "^kube-system|((downward-api|kubectl|projected|statefulset|pod-network|scope-selectors|resourcequota|limitrange|sysctl|node-tests|e2e-kubelet-etc-hosts|csiinlinevolumes|dns)-.*)$"
 teapot_admission_controller_crd_ensure_no_resources_on_delete: "false"
 {{else}}
 teapot_admission_controller_ignore_namespaces: "^kube-system$"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -601,7 +601,7 @@ teapot_admission_controller_namespace_delete_protection_enabled: "false"
 teapot_admission_controller_resolve_vanity_images: "true"
 
 {{if eq .Cluster.Environment "e2e"}}
-teapot_admission_controller_ignore_namespaces: "^kube-system|((downward-api|kubectl|projected|statefulset|pod-network|scope-selectors|resourcequota|limitrange|sysctl|node-tests|e2e-kubelet-etc-hosts|csiinlinevolumes|dns|hostport)-.*)$"
+teapot_admission_controller_ignore_namespaces: "^kube-system|((downward-api|kubectl|projected|statefulset|pod-network|scope-selectors|resourcequota|limitrange|sysctl|node-tests|e2e-kubelet-etc-hosts|csiinlinevolumes|dns)-.*)$"
 teapot_admission_controller_crd_ensure_no_resources_on_delete: "false"
 {{else}}
 teapot_admission_controller_ignore_namespaces: "^kube-system$"

--- a/test/e2e/routegroup.go
+++ b/test/e2e/routegroup.go
@@ -542,7 +542,7 @@ rBackend: Path("/backend") -> inlineContent("%s") -> <shunt>;`,
 		framework.ExpectNoError(err)
 
 		// POD
-		By("Creating 2 PODs with prefix " + nameprefix + " and " + nameprefix + " in namespace " + ns)
+		By("Creating 2 PODs with prefix " + nameprefix + " and " + nameprefix2 + " in namespace " + ns)
 		expectedResponse := "blue"
 		pod := createSkipperPod(
 			nameprefix,
@@ -654,8 +654,8 @@ rBackend: Path("/blue-green") -> status(202) -> inlineContent("%s") -> <shunt>;`
 		// +/- 5 for 80/20
 		res201 := cnt[201] > 75 && cnt[201] < 85
 		res202 := cnt[202] > 15 && cnt[202] < 25
-		Expect(res201).To(BeTrue())
-		Expect(res202).To(BeTrue())
+		Expect(res201).To(BeTrue(), "201 count should be between 75 and 85, got %d", cnt[201])
+		Expect(res202).To(BeTrue(), "202 count should be between 15 and 25, got %d", cnt[202])
 	})
 
 	It("Should create NLB routegroup [RouteGroup] [Zalando]", func() {

--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -204,7 +204,6 @@ if [ "$e2e" = true ]; then
     mkdir -p junit_reports
     ginkgo -procs=25 -flake-attempts=2 \
         -focus="(\[Conformance\]|\[StatefulSetBasic\]|\[Feature:StatefulSet\]\s\[Slow\].*mysql|\[Zalando\])" \
-        -skip="(should.resolve.DNS.of.partial.qualified.names.for.the.cluster|should.resolve.DNS.of.partial.qualified.names.for.services|should.be.able.to.change.the.type.from.ExternalName.to.NodePort|should.be.able.to.create.a.functioning.NodePort.service|should.have.session.affinity.work.for.NodePort.service|should.have.session.affinity.timeout.work.for.NodePort.service|should.be.able.to.switch.session.affinity.for.NodePort.service|validates.that.there.is.no.conflict.between.pods.with.same.hostPort.but.different.hostIP.and.protocol|\[Serial\]|Should.create.gradual.traffic.routes|Should.create.blue-green.routes)" \
         "e2e.test" -- \
         -delete-namespace-on-failure=false \
         -non-blocking-taints=node.kubernetes.io/role,nvidia.com/gpu,dedicated \

--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -164,36 +164,13 @@ if [ "$e2e" = true ]; then
     # * statefulset tests
     # * custom 'zalando' tests
     #
-    # Disable DNS tests covering DNS names of format: <name>.<namespace>.svc which
-    # we don't support with the ndots:2 configuration:
-    #
-    # * "should resolve DNS of partial qualified names for the cluster [DNS] [Conformance]"
-    #   https://github.com/kubernetes/kubernetes/blob/66049e3b21efe110454d67df4fa62b08ea79a19b/test/e2e/network/dns.go#L71-L98
-    #
-    # * "should resolve DNS of partial qualified names for services [LinuxOnly]"
-    #   https://github.com/kubernetes/kubernetes/blob/06ad960bfd03b39c8310aaf92d1e7c12ce618213/test/e2e/network/dns.go#L181-L234
-
     # Disable Tests for setups which we don't support
     #
-    # These are disabled because they assume nodePorts are reachable via the public
-    # IP of the node, we don't currently support that.
-    #
-    # * "[Fail] [sig-network] Services [It] should be able to change the type from ExternalName to NodePort [Conformance]"
-    #   https://github.com/kubernetes/kubernetes/blob/224be7bdce5a9dd0c2fd0d46b83865648e2fe0ba/test/e2e/network/service.go#L1037
-    # * "[Fail] [sig-network] Services [It] should be able to create a functioning NodePort service [Conformance]"
-    #   https://github.com/kubernetes/kubernetes/blob/224be7bdce5a9dd0c2fd0d46b83865648e2fe0ba/test/e2e/network/service.go#L551
-    # * "[Fail] [sig-network] Services [It] should have session affinity work for NodePort service [LinuxOnly] [Conformance]"
-    #   https://github.com/kubernetes/kubernetes/blob/v1.19.2/test/e2e/network/service.go#L1813
-    # * "[Fail] [sig-network] Services [It] should have session affinity timeout work for NodePort service [LinuxOnly] [Conformance]"
-    #   https://github.com/kubernetes/kubernetes/blob/v1.19.2/test/e2e/network/service.go#L2522
-    # * "[Fail] [sig-network] Services [It] should be able to switch session affinity for NodePort service [LinuxOnly] [Conformance]"
-    #   https://github.com/kubernetes/kubernetes/blob/v1.19.2/test/e2e/network/service.go#L2538
-    #
-    # These are disabled because the hostPort are not supported in our
-    # clusters yet. Currently there's no need to support them and
+    # These are disabled because hostPort is not supported in our
+    # clusters yet. Currently there's no need to support it and
     # portMapping is not enabled in the Flannel CNI configmap.
     # * "[Fail] [sig-network] HostPort [It] validates that there is no conflict between pods with same hostPort but different hostIP and protocol [LinuxOnly] [Conformance]"
-    #   https://github.com/kubernetes/kubernetes/blob/v1.21.5/test/e2e/network/hostport.go#L61
+    #   https://github.com/kubernetes/kubernetes/blob/v1.31.0/test/e2e/network/hostport.go#L63
     set +e
 
     # TODO(linki): re-introduce the broken DNS record test after ExternalDNS handles it better
@@ -204,6 +181,7 @@ if [ "$e2e" = true ]; then
     mkdir -p junit_reports
     ginkgo -procs=25 -flake-attempts=2 \
         -focus="(\[Conformance\]|\[StatefulSetBasic\]|\[Feature:StatefulSet\]\s\[Slow\].*mysql|\[Zalando\])" \
+        -skip="(validates.that.there.is.no.conflict.between.pods.with.same.hostPort.but.different.hostIP.and.protocol)" \
         "e2e.test" -- \
         -delete-namespace-on-failure=false \
         -non-blocking-taints=node.kubernetes.io/role,nvidia.com/gpu,dedicated \

--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -181,7 +181,7 @@ if [ "$e2e" = true ]; then
     mkdir -p junit_reports
     ginkgo -procs=25 -flake-attempts=2 \
         -focus="(\[Conformance\]|\[StatefulSetBasic\]|\[Feature:StatefulSet\]\s\[Slow\].*mysql|\[Zalando\])" \
-        -skip="(validates.that.there.is.no.conflict.between.pods.with.same.hostPort.but.different.hostIP.and.protocol)" \
+        -skip="(\[Serial\]|validates.that.there.is.no.conflict.between.pods.with.same.hostPort.but.different.hostIP.and.protocol)" \
         "e2e.test" -- \
         -delete-namespace-on-failure=false \
         -non-blocking-taints=node.kubernetes.io/role,nvidia.com/gpu,dedicated \


### PR DESCRIPTION
We skip some e2e tests in our setup and this is to debug those to see if they're easily fixable to improve our e2e coverage.

## Summary of Changes
1. Add `dns-*` namespace to ignore list of the admission controller so it can allow the test pod to use `hostNetwork`. See the e2e test [here](https://github.com/kubernetes/kubernetes/blob/v1.31.0/test/e2e/network/dns.go#L642).
2. Add `sched-pred-*` namespace to ignore list to allow `hostPort` based test pod. See the e2e test [here](https://github.com/kubernetes/kubernetes/blob/v1.31.0/test/e2e/scheduling/predicates.go#L705)
3. Update route-group gradual traffic test where assertions are missing annotations making it hard to debug. Also fix a typo.
4. Allow some skipped tests to run that now pass in our infrastructure. (detail below)
5. Update the comments in `test/e2e/run_e2e.sh` with the current status of the skipped tests.

## Tests Re-Enabled
The following tests have been re-enabled and they now pass in our setup
1. should resolve DNS of partial qualified names for the cluster
2. should resolve DNS of partial qualified names for services
3. should be able to change the type from ExternalName to NodePort
4. should be able to create a functioning NodePort service
6. should have session affinity work for NodePort service
7. should have session affinity timeout work for NodePort service
8. should be able to switch session affinity for NodePort service
9. should create gradual traffic routes
10. should create blue-green routes

## Tests We Continue to Skip

1. validates that there is no conflict between pods with same hostPort but different hostIP and protocol. This didn't work. Because it attempts to access a hostPort from a public endpoint, which we don't yet support.
2. [Serial] e2e tests.

