### PR TITLE
add exception handling in toggle-scaledown.py

### DIFF
--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -175,8 +175,11 @@ if [ "$e2e" = true ]; then
 
     # TODO(linki): re-introduce the broken DNS record test after ExternalDNS handles it better
     #
-    # # introduce a broken DNS record to mess with ExternalDNS
-    # cat broken-dns-record.yaml | kubectl apply -f -
+    # This is still broken in external-dns:v0.14.2-master-40
+    # InvalidChangeBatch: FATAL problem: DomainLabelEmpty (Domain label is empty) encountered with '_external-dns..teapot-e2e.zalan.do'
+    #
+    # introduce a broken DNS record to mess with ExternalDNS
+    # kubectl apply -f broken-dns-record.yaml
 
     mkdir -p junit_reports
     ginkgo -procs=25 -flake-attempts=2 \


### PR DESCRIPTION
Often when an e2e cluster has been cleaned up, unknowingly retriggering e2e tests gives a cryptic output:

```
E0902 09:14:56.459007      10 memcache.go:265] couldn't get current server API group list: Get "https://e2e-pr-8019-6.teapot-e2e.zalan.do/api?timeout=32s": dial tcp: lookup e2e-pr-8019-6.teapot-e2e.zalan.do on 172.31.6.4:53: no such host
E0902 09:14:56.459791      10 memcache.go:265] couldn't get current server API group list: Get "https://e2e-pr-8019-6.teapot-e2e.zalan.do/api?timeout=32s": dial tcp: lookup e2e-pr-8019-6.teapot-e2e.zalan.do on 172.31.6.4:53: no such host
E0902 09:14:56.461508      10 memcache.go:265] couldn't get current server API group list: Get "https://e2e-pr-8019-6.teapot-e2e.zalan.do/api?timeout=32s": dial tcp: lookup e2e-pr-8019-6.teapot-e2e.zalan.do on 172.31.6.4:53: no such host
E0902 09:14:56.462145      10 memcache.go:265] couldn't get current server API group list: Get "https://e2e-pr-8019-6.teapot-e2e.zalan.do/api?timeout=32s": dial tcp: lookup e2e-pr-8019-6.teapot-e2e.zalan.do on 172.31.6.4:53: no such host
E0902 09:14:56.463765      10 memcache.go:265] couldn't get current server API group list: Get "https://e2e-pr-8019-6.teapot-e2e.zalan.do/api?timeout=32s": dial tcp: lookup e2e-pr-8019-6.teapot-e2e.zalan.do on 172.31.6.4:53: no such host
Unable to connect to the server: dial tcp: lookup e2e-pr-8019-6.teapot-e2e.zalan.do on 172.31.6.4:53: no such host
Traceback (most recent call last):
  File "/workdir/test/e2e/./toggle-scaledown.py", line 53, in <module>
    main()
  File "/workdir/test/e2e/./toggle-scaledown.py", line 49, in main
    toggle_scaledown(enabled)
  File "/workdir/test/e2e/./toggle-scaledown.py", line 9, in toggle_scaledown
    subprocess.check_output(
  File "/usr/local/lib/python3.12/subprocess.py", line 466, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['kubectl', 'get', 'daemonset', '-o', 'json', '-n', 'kube-system', 'kube-cluster-autoscaler']' returned non-zero exit status 1.
```

This adds a bit of exception handling around the code to get a better output in case of failure. Here's what the output looks like now:
```
Running e2e against cluster <CLUSTER>: https://e2e-pr-8020-4.teapot-e2e.zalan.do/
Failed to reach the API server, is the cluster running?
Failed to toggle scale-down.
```