### PR TITLE
Add permissions in zmon role for lambda functions

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1726,6 +1726,12 @@ Resources:
               - Action: 'kinesis:Describe*'
                 Effect: Allow
                 Resource: '*'
+              - Action: 'lambda:ListFunctions'
+                Effect: Allow
+                Resource: '*'
+              - Action: 'lambda:ListTags'
+                Effect: Allow
+                Resource: '*'
               - Action: 'opsworks:Describe*'
                 Effect: Allow
                 Resource: '*'


### PR DESCRIPTION
allow zmon role to list lambda functions and their tags