### PR TITLE
Add retention policies to the SSM-SessionManagerRunShell Document

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -2130,6 +2130,8 @@ Resources:
 
   SessionManagerPreferencesDocument:
     Type: AWS::SSM::Document
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       Tags:
         - Key: InfrastructureComponent
@@ -2146,14 +2148,6 @@ Resources:
         schemaVersion: '1.0'
         description: Document to hold regional settings for Session Manager
         sessionType: Standard_Stream
-        inputs:
-          cloudWatchLogGroupName: !Ref SessionManagerLogGroup
-          cloudWatchEncryptionEnabled: false
-          cloudWatchStreamingEnabled: true
-          runAsEnabled: false
-          idleSessionTimeout: '20'
-          shellProfile:
-            linux: 'bash'
 
 {{- if eq .Cluster.Region "eu-central-1"}}
   SessionManagerSubscriptionFilter:


### PR DESCRIPTION
Update the `DeletionPolicy` / `UpdateReplacePolicy` for the default `SSM-SessionManagerRunShell` SSM Document. Due to upcoming changes to create Documents per cluster, we want to retain the default Document in each account but remove the Document content.