### PR TITLE
[experiment] Switch from LocalID to Alias

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -556,7 +556,7 @@ Resources:
                 Resource: '*'
             Version: 2012-10-17
           PolicyName: root
-      RoleName: "{{.Cluster.LocalID}}-app-autoscaler"
+      RoleName: "cluster-autoscaler-{{ .Cluster.Alias }}"
     Type: 'AWS::IAM::Role'
   KarpenterNodeInstanceProfile: # instance profile for worker nodes spawn by karpenter controller
     Type: "AWS::IAM::InstanceProfile"
@@ -813,7 +813,7 @@ Resources:
                 }
               ]
             }
-      RoleName: "{{.Cluster.LocalID}}-app-karpenter"
+      RoleName: "karpenter-{{ .Cluster.Alias }}"
     Type: 'AWS::IAM::Role'
   KarpenterInterruptionQueue:
     Type: AWS::SQS::Queue
@@ -1120,7 +1120,7 @@ Resources:
                 Resource: '*'
             Version: 2012-10-17
           PolicyName: root
-      RoleName: "{{.Cluster.LocalID}}-app-external-dns"
+      RoleName: "external-dns-{{ .Cluster.Alias }}"
     Type: 'AWS::IAM::Role'
   IngressControllerIAMRole:
     Properties:
@@ -1234,7 +1234,7 @@ Resources:
                 Resource: '*'
             Version: 2012-10-17
           PolicyName: root
-      RoleName: "{{.Cluster.LocalID}}-app-ingr-ctrl"
+      RoleName: "ingress-controller-{{ .Cluster.Alias }}"
     Type: 'AWS::IAM::Role'
 {{ if eq .Cluster.ConfigItems.skipper_open_policy_agent_enabled "true" }}
   # Note: this is not strictly specific to Open Policy Agent and can be extend
@@ -1263,7 +1263,7 @@ Resources:
                   - "{{ .Cluster.ConfigItems.skipper_open_policy_agent_bucket_arn }}/*"
             Version: 2012-10-17
           PolicyName: read-opa-bundles
-      RoleName: "{{.Cluster.LocalID}}-app-skipper-ingress"
+      RoleName: "skipper-ingress-{{ .Cluster.Alias }}"
     Type: 'AWS::IAM::Role'
 {{ end }}
   ClusterLifecycleControllerIAMRole:
@@ -1318,7 +1318,7 @@ Resources:
             Resource: '*'
           Version: 2012-10-17
         PolicyName: root
-      RoleName: "{{.Cluster.LocalID}}-cluster-lifecycle-controller"
+      RoleName: "cluster-lifecycle-controller-{{ .Cluster.Alias }}"
     Type: 'AWS::IAM::Role'
   KubeReadyIAMRole:
     Properties:
@@ -1356,7 +1356,7 @@ Resources:
                 Resource: '*'
             Version: 2012-10-17
           PolicyName: root
-      RoleName: "{{.Cluster.LocalID}}-kube-node-ready"
+      RoleName: "kube-node-ready-{{ .Cluster.Alias }}"
     Type: 'AWS::IAM::Role'
   MasterIAMRole:
     Properties:
@@ -1515,7 +1515,7 @@ Resources:
             - "*"
           Version: 2012-10-17
         PolicyName: root
-      RoleName: "{{.Cluster.LocalID}}-cloud-controller-manager"
+      RoleName: "cloud-controller-manager-{{ .Cluster.Alias }}"
     Type: "AWS::IAM::Role"
   ETCDS3BackupIAMRole:
     Properties:
@@ -1558,7 +1558,7 @@ Resources:
                     arn:aws:s3:::{{.Cluster.ConfigItems.etcd_s3_backup_bucket}}/*
             Version: 2012-10-17
           PolicyName: root
-      RoleName: "{{.Cluster.LocalID}}-etcd-backup"
+      RoleName: "etcd-backup-{{ .Cluster.Alias }}"
     Type: 'AWS::IAM::Role'
   StaticEgressControllerIAMRole:
     Properties:
@@ -1642,7 +1642,7 @@ Resources:
                 Resource: '*'
             Version: 2012-10-17
           PolicyName: root
-      RoleName: "{{.Cluster.LocalID}}-static-egress-controller"
+      RoleName: "static-egress-controller-{{ .Cluster.Alias }}"
     Type: 'AWS::IAM::Role'
   ZmonIAMRole:
     Properties:
@@ -1886,7 +1886,7 @@ Resources:
                 Resource: '*'
             Version: 2012-10-17
           PolicyName: root
-      RoleName: "{{.Cluster.LocalID}}-kube-metrics-adapter"
+      RoleName: "kube-metrics-adapter-{{ .Cluster.Alias }}"
     Type: 'AWS::IAM::Role'
 
   EBSCSIControllerIAMRole:
@@ -1987,7 +1987,7 @@ Resources:
                     ec2:ResourceTag/ebs.csi.aws.com/cluster: 'true'
             Version: 2012-10-17
           PolicyName: root
-      RoleName: "{{.Cluster.LocalID}}-ebs-csi-controller"
+      RoleName: "ebs-csi-controller-{{.Cluster.Alias}}"
     Type: 'AWS::IAM::Role'
 
   {{ if eq .Cluster.Environment "e2e" }}
@@ -2194,7 +2194,7 @@ Resources:
   AWSNodeDecommissionerIAMRole:
     Type: 'AWS::IAM::Role'
     Properties:
-      RoleName: "{{.Cluster.LocalID}}-aws-node-decommissioner"
+      RoleName: "aws-node-decommissioner-{{ .Cluster.Alias }}"
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -2249,7 +2249,7 @@ Resources:
                     - BucketArn: !GetAtt AuditTrailBucket.Arn
             Version: 2012-10-17
           PolicyName: root
-      RoleName: "{{.Cluster.LocalID}}-emergency-access-service"
+      RoleName: "emergency-access-service-{{ .Cluster.Alias }}"
     Type: 'AWS::IAM::Role'
   AudittrailAdapterIAMRole:
     Properties:
@@ -2283,7 +2283,7 @@ Resources:
                     - BucketArn: !GetAtt AuditTrailBucket.Arn
             Version: 2012-10-17
           PolicyName: root
-      RoleName: "{{.Cluster.LocalID}}-audittrail-adapter"
+      RoleName: "audittrail-adapter-{{ .Cluster.Alias }}"
     Type: 'AWS::IAM::Role'
   RemoteFilesEncryptionKey:
     Type: "AWS::KMS::Key"

--- a/cluster/manifests/03-ebs-csi/serviceaccount-csi-controller.yaml
+++ b/cluster/manifests/03-ebs-csi/serviceaccount-csi-controller.yaml
@@ -7,4 +7,4 @@ metadata:
     application: kubernetes
     component: ebs-csi-driver
   annotations:
-    iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-ebs-csi-controller"
+    iam.amazonaws.com/role: "ebs-csi-controller-{{ .Cluster.Alias }}"

--- a/cluster/manifests/audittrail-adapter/01-rbac.yaml
+++ b/cluster/manifests/audittrail-adapter/01-rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: audittrail-adapter
   namespace: kube-system
   annotations:
-    iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-audittrail-adapter"
+    iam.amazonaws.com/role: "audittrail-adapter-{{ .Cluster.Alias }}"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/cluster/manifests/aws-cloud-controller-manager/rbac.yaml
+++ b/cluster/manifests/aws-cloud-controller-manager/rbac.yaml
@@ -8,7 +8,7 @@ metadata:
     application: kubernetes
     component: aws-cloud-controller-manager
   annotations:
-    iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-cloud-controller-manager"
+    iam.amazonaws.com/role: "cloud-controller-manager-{{ .Cluster.Alias }}"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/cluster/manifests/aws-node-decommissioner/01-rbac.yaml
+++ b/cluster/manifests/aws-node-decommissioner/01-rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     application: kubernetes
     component: aws-node-decommissioner
-    iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-aws-node-decommissioner"
+    iam.amazonaws.com/role: "aws-node-decommissioner-{{ .Cluster.Alias }}"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/cluster/manifests/cluster-lifecycle-controller/01-rbac.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/01-rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cluster-lifecycle-controller
   namespace: kube-system
   annotations:
-    iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-cluster-lifecycle-controller"
+    iam.amazonaws.com/role: "cluster-lifecycle-controller-{{ .Cluster.Alias }}"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/cluster/manifests/emergency-access-service/01-rbac.yaml
+++ b/cluster/manifests/emergency-access-service/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   name: emergency-access-service
   namespace: kube-system
   annotations:
-    iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-emergency-access-service"
+    iam.amazonaws.com/role: "emergency-access-service-{{ .Cluster.Alias }}"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/cluster/manifests/etcd-backup/01-rbac.yaml
+++ b/cluster/manifests/etcd-backup/01-rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: etcd-backup
   namespace: kube-system
   annotations:
-    iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-etcd-backup"
+    iam.amazonaws.com/role: "etcd-backup-{{ .Cluster.Alias }}"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/cluster/manifests/external-dns/01-rbac.yaml
+++ b/cluster/manifests/external-dns/01-rbac.yaml
@@ -8,7 +8,7 @@ metadata:
     application: kubernetes
     component: external-dns
   annotations:
-    iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-app-external-dns"
+    iam.amazonaws.com/role: "external-dns-{{ .Cluster.Alias }}"
 ---
 # allows to list services and ingresses
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cluster/manifests/ingress-controller/01-rbac.yaml
+++ b/cluster/manifests/ingress-controller/01-rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kube-ingress-aws-controller
   namespace: kube-system
   annotations:
-    iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-app-ingr-ctrl"
+    iam.amazonaws.com/role: "ingress-controller-{{ .Cluster.Alias }}"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/cluster/manifests/kube-cluster-autoscaler/01-rbac.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/01-rbac.yaml
@@ -7,7 +7,7 @@ metadata:
     application: kubernetes
     component: kube-cluster-autoscaler
   annotations:
-    iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-app-autoscaler"
+    iam.amazonaws.com/role: "cluster-autoscaler-{{ .Cluster.Alias }}"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/cluster/manifests/kube-metrics-adapter/01-rbac.yaml
+++ b/cluster/manifests/kube-metrics-adapter/01-rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: custom-metrics-apiserver
   namespace: kube-system
   annotations:
-    iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-kube-metrics-adapter"
+    iam.amazonaws.com/role: "kube-metrics-adapter-{{ .Cluster.Alias }}"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/cluster/manifests/kube-node-ready/01-rbac.yaml
+++ b/cluster/manifests/kube-node-ready/01-rbac.yaml
@@ -4,4 +4,4 @@ metadata:
   name: kube-node-ready
   namespace: kube-system
   annotations:
-    iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-kube-node-ready"
+    iam.amazonaws.com/role: "kube-node-ready-{{ .Cluster.Alias }}"

--- a/cluster/manifests/kube-static-egress-controller/01-rbac.yaml
+++ b/cluster/manifests/kube-static-egress-controller/01-rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kube-static-egress-controller
   namespace: kube-system
   annotations:
-    iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-static-egress-controller"
+    iam.amazonaws.com/role: "static-egress-controller-{{ .Cluster.Alias }}"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/cluster/manifests/skipper/rbac.yaml
+++ b/cluster/manifests/skipper/rbac.yaml
@@ -9,7 +9,7 @@ metadata:
 {{ if eq .Cluster.ConfigItems.skipper_open_policy_agent_enabled "true" }}
   # Note: if the role extends beyond OPA use, this condition can be removed
   annotations:
-    iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-app-skipper-ingress"
+    iam.amazonaws.com/role: "skipper-ingress-{{ .Cluster.Alias }}"
 {{ end }}
 ---
 apiVersion: v1

--- a/cluster/manifests/z-karpenter/01-serviceaccount.yaml
+++ b/cluster/manifests/z-karpenter/01-serviceaccount.yaml
@@ -10,5 +10,5 @@ metadata:
     application: kubernetes
     component: karpenter
   annotations:
-    iam.amazonaws.com/role: '{{ .Cluster.LocalID }}-app-karpenter'
+    iam.amazonaws.com/role: "karpenter-{{ .Cluster.Alias }}"
 {{end}}


### PR DESCRIPTION
This is an attempt to overcome the sometimes cryptic use of `Cluster.LocalID`.

In the past we didn't parametrize our cluster-wide resources (such as IAM roles) because there was no need for it since the Kubernetes stack was only created once per account. The introduction of multiple e2e clusters in the very same e2e account changed that and let to the need to occasionally add the `Cluster.LocalID` parameter to the resource names. However, the list grew and with the outlook of having multiple clusters in many accounts will only intensify.

Unfamiliar users, such as new team members or other platform teams, are even more surprised by the need of this parameter as they haven't been exposed to multiple clusters in the accounts up until now.

In order to make this concept more clear and understandable, this PR changes it to use the `Cluster.Alias`. The alias is globally unique and hence will also be unique in the same account, like `Cluster.LocalID`. In addition, the more familiar alias value is easier to understand and unforeseen future name conflicts are avoided proactively by making the alias part of each AWS resource name.