### PR TITLE
[e2] refactor external-dns test to use `service.TestJig`

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -558,25 +558,6 @@ func createServiceTypeClusterIP(serviceName string, labels map[string]string, po
 	}
 }
 
-func createServiceTypeLoadbalancer(serviceName, hostName string, labels map[string]string, port int) *v1.Service {
-	return &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: serviceName,
-			Annotations: map[string]string{
-				externalDNSAnnotation: hostName,
-			},
-		},
-		Spec: v1.ServiceSpec{
-			Type:     v1.ServiceTypeLoadBalancer,
-			Selector: labels,
-			Ports: []v1.ServicePort{{
-				Port:       int32(port),
-				TargetPort: intstr.FromInt(port),
-			}},
-		},
-	}
-}
-
 func waitForSuccessfulResponse(hostname string, timeout time.Duration) error {
 	client := http.Client{
 		Transport: &http.Transport{},


### PR DESCRIPTION
This is to resolve a TODO in `test/e2e/external_dns.go` where we have to refactor the code to use `service.TestJig` from `k8s.io/kubernetes/test/e2e/framework/service` pkg to create the Service.
I used [this upstream e2e test](https://github.com/kubernetes/kubernetes/blob/v1.31.0/test/e2e/network/service.go#L3829) as a reference.

Also added annotations to the error assertions.
