### PR TITLE
Add permissions to list lambda for zmon role

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1726,6 +1726,9 @@ Resources:
               - Action: 'kinesis:Describe*'
                 Effect: Allow
                 Resource: '*'
+              - Action: 'lambda:List*'
+                Effect: Allow
+                Resource: '*'
               - Action: 'opsworks:Describe*'
                 Effect: Allow
                 Resource: '*'


### PR DESCRIPTION
adds permissions to list lambda functions and their tags for zmon role


with this zmon-aws-agent can query information to create entities used in zmon