### PR TITLE
introduce config-items to control kubelet image qps

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -787,6 +787,22 @@ ebs_csi_controller_sidecar_cpu: "10m"
 # pull images in parallel
 serialize_image_pulls: "false"
 
+# rate of image pull in the kubelet, see
+# see https://github.com/kubernetes/kubernetes/blob/v1.30.0/staging/src/k8s.io/kubelet/config/v1beta1/types.go#L200-L212
+#
+# registryPullQPS is the limit of registry pulls per second.
+# The value must not be a negative number.
+# Setting it to 0 means no limit.
+# Default: 5
+kubelet_registry_pull_qps : "20"
+
+# registryBurst is the maximum size of bursty pulls, temporarily allows
+# pulls to burst to this number, while still not exceeding registryPullQPS.
+# The value must not be a negative number.
+# Only used if registryPullQPS is greater than 0.
+# Default: 10
+kubelet_registry_burst: "40"
+
 # Version of the scheduler or controller-manager used by the master nodes.
 # Supported values:
 #  - upstream: official Kubernetes version

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -17,7 +17,7 @@ write_files:
   - owner: root:root
     path: /etc/kubernetes/config/kubelet.yaml.template
     content: |
-      # https://github.com/kubernetes/kubernetes/blob/v1.13.6/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+      # https://github.com/kubernetes/kubernetes/blob/v1.30.0/staging/src/k8s.io/kubelet/config/v1beta1/types.go
       apiVersion: kubelet.config.k8s.io/v1beta1
       kind: KubeletConfiguration
       cgroupDriver: systemd
@@ -35,6 +35,8 @@ write_files:
 {{- if ne .Cluster.ConfigItems.serialize_image_pulls "true" }}
       serializeImagePulls: false
 {{- end }}
+      registryPullQPS: {{ .Cluster.ConfigItems.kubelet_registry_pull_qps }}
+      registryBurst: {{ .Cluster.ConfigItems.kubelet_registry_burst }}
       healthzPort: 10248
       healthzBindAddress: "0.0.0.0"
       tlsCertFile: "/etc/kubernetes/ssl/worker.pem"

--- a/cluster/node-pools/worker-splitaz/userdata.yaml
+++ b/cluster/node-pools/worker-splitaz/userdata.yaml
@@ -77,6 +77,8 @@ write_files:
 {{- if ne .Cluster.ConfigItems.serialize_image_pulls "true" }}
       serializeImagePulls: false
 {{- end }}
+      registryPullQPS: {{ .Cluster.ConfigItems.kubelet_registry_pull_qps }}
+      registryBurst: {{ .Cluster.ConfigItems.kubelet_registry_burst }}
       healthzPort: 10248
       healthzBindAddress: "0.0.0.0"
       tlsCertFile: "/etc/kubernetes/ssl/worker.pem"


### PR DESCRIPTION
## Background
It was reported recently in a support ticket that there are intermittent ImagePullBackoff errors for various images.
Upon looking deeper into this, it turns out the backoff is triggered by the kubelet, and not the ECR service.
```
E0903 10:30:03.291420    1088 pod_workers.go:1298] "Error syncing pod, skipping" err="failed to \"StartContainer\" for \"<CONTAINER_NAME>\" with ErrImagePull: \"pull QPS exceeded\"" pod="<POD_NAME>" podUID="<POD_ID>"
```
The default value of the QPS is 5. This is not sufficient, as we often initiate to run more than 5 containers on a node at a time, and so we run into this limit quite often.

## Summary
This introduces the config-items in the kubelet config userdata so we configure this value to a higher value, alongside a burst that can help temporarily increase this value to avoid QPS issues. The configuration items can be seen [here](https://github.com/kubernetes/kubernetes/blob/v1.30.0/staging/src/k8s.io/kubelet/config/v1beta1/types.go#L200-L212).