### PR TITLE
Update deployment-service to expose PCS resource status

### DIFF
--- a/cluster/manifests/deployment-service/controller-statefulset.yaml
+++ b/cluster/manifests/deployment-service/controller-statefulset.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
         - name: "deployment-service-controller"
-          image: "container-registry.zalando.net/teapot/deployment-controller:master-223"
+          image: "container-registry.zalando.net/teapot/deployment-controller:master-224"
           args:
             - "--config-namespace=kube-system"
             - "--decrypt-kms-alias-arn=arn:aws:kms:{{ .Cluster.Region }}:{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:alias/deployment-secret"

--- a/cluster/manifests/deployment-service/status-service-deployment.yaml
+++ b/cluster/manifests/deployment-service/status-service-deployment.yaml
@@ -1,5 +1,5 @@
 {{ $image   := "container-registry.zalando.net/teapot/deployment-status-service" }}
-{{ $version := "master-220" }}
+{{ $version := "master-224" }}
 
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Update deployment service to the lastest version which correctly tracks versioned PCS.