### PR TITLE
[e2e] minor improvements to build

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -21,7 +21,7 @@ pipeline:
   commands:
   - desc: install deps
     cmd: |
-      apt-get update && apt-get install -y rsync
+      apt-get update -qq && apt-get install -qq rsync
   - desc: build and push
     cmd: |
       cd ./test/e2e/

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -1,5 +1,5 @@
 # builder image
-FROM golang:1.22 as builder
+FROM golang:1.22 AS builder
 
 RUN CGO_ENABLED=0 go install github.com/onsi/ginkgo/v2/ginkgo@v2.15.0
 
@@ -10,14 +10,9 @@ FROM container-registry.zalando.net/library/python-3.12-slim:latest
 
 ARG TARGETARCH
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-  bc \
-  curl \
-  git \
-  jq \
-  pwgen \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -qq bc curl git jq pwgen \
   && rm -rf /var/lib/apt/lists/* \
-  && pip3 install awscli --no-cache-dir
+  && pip3 install awscli --no-cache-dir -q
 
 ARG KUBE_VERSION
 ADD https://storage.googleapis.com/kubernetes-release/release/$KUBE_VERSION/bin/linux/$TARGETARCH/kubectl /usr/bin/kubectl
@@ -31,9 +26,9 @@ COPY --from=container-registry.zalando.net/teapot/aws-account-creator:latest /aw
 
 ADD . /workdir
 
-ENV KUBECTL_PATH /usr/bin/kubectl
-ENV KUBERNETES_PROVIDER skeleton
-ENV KUBERNETES_CONFORMANCE_TEST Y
+ENV KUBECTL_PATH=/usr/bin/kubectl
+ENV KUBERNETES_PROVIDER=skeleton
+ENV KUBERNETES_CONFORMANCE_TEST=Y
 
 WORKDIR /workdir/test/e2e
 

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -48,7 +48,7 @@ build.push: build.docker
 build.push.multiarch: build.linux.amd64 #build.linux.arm64
 	docker buildx create --config /etc/cdp-buildkitd.toml --driver-opt network=host --bootstrap --use
 	# docker buildx build --rm --build-arg KUBE_VERSION=$(KUBE_VERSION) -t "$(IMAGE):$(TAG)" --platform linux/amd64,linux/arm64 --push -f $(DOCKERFILE) ../..
-	docker buildx build --rm --build-arg KUBE_VERSION=$(KUBE_VERSION) -t "$(IMAGE):$(TAG)" --platform linux/amd64 --push -f $(DOCKERFILE) ../..
+	docker buildx build --quiet --rm --build-arg KUBE_VERSION=$(KUBE_VERSION) -t "$(IMAGE):$(TAG)" --platform linux/amd64 --push -f $(DOCKERFILE) ../..
 
 clean:
 	rm -rf e2e.test


### PR DESCRIPTION
Minor improvements to e2e `build` step from looking at the existing logs
1. use quiet mode where available to suppress verbose logging but keep warnings/errors etc.
2. address warnings in Dockerfile