### PR TITLE
[1/2] remove k8s dashboard resources

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -458,6 +458,9 @@ prometheus_ui_users: ""
 dashboard_metrics_scraper_cpu_min: "50m"
 dashboard_metrics_scraper_mem_min: "200Mi"
 
+# config-item to toggle dashboard in a cluster
+k8s_dashboard_enabled: "false"
+
 metrics_service_cpu: "100m"
 metrics_service_mem_max: "4Gi"
 metrics_server_metric_resolution: "15s"

--- a/cluster/manifests/dashboard/deployment.yaml
+++ b/cluster/manifests/dashboard/deployment.yaml
@@ -1,3 +1,4 @@
+{{ if eq .Cluster.ConfigItems.k8s_dashboard_enabled "true" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -113,3 +114,4 @@ metadata:
   labels:
     application: kubernetes
     component: dashboard
+{{ end }}

--- a/cluster/manifests/dashboard/rbac.yaml
+++ b/cluster/manifests/dashboard/rbac.yaml
@@ -1,3 +1,4 @@
+{{ if eq .Cluster.ConfigItems.k8s_dashboard_enabled "true" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -107,3 +108,4 @@ subjects:
 - kind: ServiceAccount
   name: kubernetes-dashboard
   namespace: kube-system
+{{ end }}

--- a/cluster/manifests/dashboard/scraper-vpa.yaml
+++ b/cluster/manifests/dashboard/scraper-vpa.yaml
@@ -1,3 +1,4 @@
+{{ if eq .Cluster.ConfigItems.k8s_dashboard_enabled "true" }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
@@ -19,3 +20,4 @@ spec:
         minAllowed:
           memory: {{ .Cluster.ConfigItems.dashboard_metrics_scraper_mem_min }}
           cpu: {{ .Cluster.ConfigItems.dashboard_metrics_scraper_cpu_min }}
+{{ end }}

--- a/cluster/manifests/dashboard/scraper.yaml
+++ b/cluster/manifests/dashboard/scraper.yaml
@@ -1,3 +1,4 @@
+{{ if eq .Cluster.ConfigItems.k8s_dashboard_enabled "true" }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -74,3 +75,4 @@ spec:
       volumes:
       - name: tmp-volume
         emptyDir: {}
+{{ end }}

--- a/cluster/manifests/dashboard/service.yaml
+++ b/cluster/manifests/dashboard/service.yaml
@@ -1,3 +1,4 @@
+{{ if eq .Cluster.ConfigItems.k8s_dashboard_enabled "true" }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -14,3 +15,4 @@ spec:
   - port: 80
     targetPort: 9090
     protocol: TCP
+{{ end }}

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -295,3 +295,36 @@ post_apply:
 - name: deployment-service-status-service
   kind: Ingress
   namespace: kube-system
+
+{{ if ne .Cluster.ConfigItems.k8s_dashboard_enabled "true" }}
+- name: kubernetes-dashboard
+  namespace: kube-system
+  kind: Deployment
+- name: kubernetes-dashboard
+  namespace: kube-system
+  kind: Service
+- name: dashboard-metrics-scraper
+  namespace: kube-system
+  kind: Service
+- name: dashboard-metrics-scraper
+  namespace: kube-system
+  kind: Deployment
+- name: kubernetes-dashboard
+  namespace: kube-system
+  kind: Role
+- name: kubernetes-dashboard
+  namespace: kube-system
+  kind: RoleBinding
+- name: kubernetes-dashboard
+  kind: ClusterRole
+- name: kubernetes-dashboard-internal
+  kind: ClusterRoleBinding
+- name: kubernetes-dashboard-readonly
+  kind: ClusterRoleBinding
+- name: dashboard-metrics-scraper-vpa
+  namespace: kube-system
+  kind: VerticalPodAutoscaler
+- name: kubernetes-dashboard
+  namespace: kube-system
+  kind: ServiceAccount
+{{ end }}

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -324,7 +324,8 @@ post_apply:
 - name: dashboard-metrics-scraper-vpa
   namespace: kube-system
   kind: VerticalPodAutoscaler
-- name: kubernetes-dashboard
-  namespace: kube-system
-  kind: ServiceAccount
+# clean this up in another step after the above resources have been cleaned-up
+# - name: kubernetes-dashboard
+#   namespace: kube-system
+#   kind: ServiceAccount
 {{ end }}


### PR DESCRIPTION
As the next step to decommissioning the Kubernetes Dashboard UI from our clusters, this sets a toggle which we can use to reliably remove it from our clusters step by step.

As a final clean-up item, we will remove this along with any other config-items related to the dashboard.