### PR TITLE
Remove region conditional for SSM resource creation

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -2151,7 +2151,6 @@ Resources:
           shellProfile:
             linux: 'bash'
 
-{{- if eq .Cluster.Region "eu-central-1"}}
   SessionManagerSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
     Properties:
@@ -2185,7 +2184,6 @@ Resources:
                 Resource:
                   - !GetAtt SessionManagerLogGroup.Arn
       RoleName: "SessionManager-{{.Cluster.Alias}}"
-{{- end }}
 
   AWSNodeDecommissionerIAMRole:
     Type: 'AWS::IAM::Role'


### PR DESCRIPTION
A `Destination` resource has been created in `eu-north-1` allowing SSM logs from this region to be centrally collected. This PR removes the cluster region conditional that restricted the Log Group's Subscription Filter and relevant IAM Role from only be created for clusters in `eu-central-1`.