### PR TITLE
[2/2] remove k8s dashboard resources

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -324,8 +324,7 @@ post_apply:
 - name: dashboard-metrics-scraper-vpa
   namespace: kube-system
   kind: VerticalPodAutoscaler
-# clean this up in another step after the above resources have been cleaned-up
-# - name: kubernetes-dashboard
-#   namespace: kube-system
-#   kind: ServiceAccount
+- name: kubernetes-dashboard
+  namespace: kube-system
+  kind: ServiceAccount
 {{ end }}


### PR DESCRIPTION
A follow-up to #8092 , this cleans up the `ServiceAccount` for the dashboard. This was done separately as running pods in the e2e cluster was causing e2e to fail complaining that the `ServiceAccount` is in use. This should now just work because dashboard pods won't be running anymore.

The final step will be to remove the toggle alongside the entry in `deletions.yaml`.