### PR TITLE
Update e2es to use region-based DNS for etcd [1/2]

### DIFF
--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -19,7 +19,8 @@ clusters:
     etcd_client_ca_cert: "${ETCD_CLIENT_CA_CERT}"
     etcd_client_ca_key: "${ETCD_CLIENT_CA_KEY}"
     etcd_scalyr_key: "${ETCD_SCALYR_KEY}"
-    etcd_dns_record_prefixes: "etcd-server.etcd"
+    etcd_dns_record_prefixes: "etcd-server.etcd,etcd-server.eu-central-1"
+    etcd_additional_endpoints: "https://etcd-server.eu-central-1.teapot-e2e.zalan.do:2479"
     docker_meta_url: https://docker-meta.stups-test.zalan.do
     vpa_enabled: "true"
     lightstep_token: "${LIGHTSTEP_TOKEN}"

--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -125,11 +125,15 @@ if [ "$create_cluster" = true ]; then
     "./cluster_config.sh" "${CDP_HEAD_COMMIT_ID}" "ready" > head_cluster.yaml
 
     # either copy the certificates from the already created cluster or regenerate them from scratch
-    if [ -f base_cluster.yaml ]; then
-      ./copy-certificates.py base_cluster.yaml head_cluster.yaml
-    else
-      aws-account-creator refresh-certificates --registry-file head_cluster.yaml --create-ca
-    fi
+    # NOTE: while migrating to region-based etcd, ensure certiciates are refreshed
+    # if [ -f base_cluster.yaml ]; then
+    #   ./copy-certificates.py base_cluster.yaml head_cluster.yaml
+    # else
+    aws-account-creator refresh-certificates --registry-file head_cluster.yaml --create-ca
+    # fi
+
+    echo "head_cluster.yaml:"
+    cat head_cluster.yaml
 
     # Update cluster
     echo "Updating cluster ${CLUSTER_ID}: ${API_SERVER_URL}"


### PR DESCRIPTION
Update e2e cluster creation etcd config items as part of migrating to region-based etcd DNS.

- add `eu-central-1` `etcd_additional_endpoints` config item to generate an updated `etcd_client_server_cert`
- update `etcd_dns_record_prefixes` to create the additional region-based Route53 DNS record
- ensure aws-account-creator refreshes certificates during the migration