### PR TITLE
Use AccountName field to infer default Okta client ID

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -974,7 +974,7 @@ stackset_pcs_support_enabled: "true"
 enable_control_plane_profiling: "false"
 
 okta_auth_issuer_url: ""
-okta_auth_client_id: "kubernetes.cluster.{{.Cluster.Alias}}"
+okta_auth_client_id: "kubernetes.cluster.{{.Cluster.AccountName}}"
 
 # Deploy
 # This section contains config items to enable and disable the the

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -45,7 +45,6 @@ clusters:
     stackset_ingress_source_switch_ttl: "1m"
     teapot_admission_controller_daemonset_reserved_cpu: "518m"
     karpenter_pools_enabled: "true"
-    okta_auth_client_id: "kubernetes.cluster.teapot-e2e"
     teapot_admission_controller_validate_pod_images_soft_fail_namespaces: "^kube-system$"
   criticality_level: 1
   environment: e2e
@@ -199,4 +198,5 @@ clusters:
   provider: zalando-aws
   region: ${REGION}
   owner: '${OWNER}'
+  account_name: teapot-e2e
 EOF


### PR DESCRIPTION
With [CLM adding the account name to the cluster struct](https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/816), we can use it to calculate the right Client ID for Okta.
