### PR TITLE
update aws-cloud-controller-manager to 1.31.0

### DIFF
--- a/cluster/manifests/aws-cloud-controller-manager/daemonset.yaml
+++ b/cluster/manifests/aws-cloud-controller-manager/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
         - --cloud-provider=aws
         - --use-service-account-credentials=true
         - --configure-cloud-routes=false
-        image: container-registry.zalando.net/teapot/aws-cloud-controller-manager-internal:v1.30.2-master-126
+        image: container-registry.zalando.net/teapot/aws-cloud-controller-manager-internal:v1.31.0-master-127
         name: aws-cloud-controller-manager
         resources:
           requests:


### PR DESCRIPTION
This important update to the AWS cloud provider was missed when rolling out the update. From the [official docs](https://github.com/kubernetes/cloud-provider-aws?tab=readme-ov-file#compatibility-with-kubernetes), compatibility is ONLY guaranteed for the same versions of the provider and k8s and this update id MANDATORY

> Currently, for a given cloud provider release version, compatibility is ONLY guaranteed between that release and the corresponding Kubernetes version, meaning you need to upgrade the cloud provider components every time you upgrade Kubernetes, just like you would do for the kube controller manager.

We can apply this as a quick hotfix patch to try and mediate the networking issue that is most exacerbated in clusters that operate a lot of load balancers based workloads. This is a requirement and a faster change to rollout than attempting a k8s upgrade rollback. Let's try this first.