### PR TITLE
[hotfix-stable] update aws-cloud-controller-manager to 1.31.0

### DIFF
--- a/cluster/manifests/aws-cloud-controller-manager/daemonset.yaml
+++ b/cluster/manifests/aws-cloud-controller-manager/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
         - --cloud-provider=aws
         - --use-service-account-credentials=true
         - --configure-cloud-routes=false
-        image: container-registry.zalando.net/teapot/aws-cloud-controller-manager-internal:v1.30.2-master-126
+        image: container-registry.zalando.net/teapot/aws-cloud-controller-manager-internal:v1.31.0-master-127
         name: aws-cloud-controller-manager
         resources:
           requests:


### PR DESCRIPTION
Hotfixing the patch in #8121 in stable.