### PR TITLE
Allow Powerusers to patch pods/ephemeralcontainers

### DIFF
--- a/cluster/manifests/roles/poweruser-role.yaml
+++ b/cluster/manifests/roles/poweruser-role.yaml
@@ -46,6 +46,12 @@ rules:
 - apiGroups:
   - ''
   resources:
+  - pods/ephemeralcontainers
+  verbs:
+  - patch
+- apiGroups:
+  - ''
+  resources:
   - pods/exec
   - pods/portforward
   - pods/proxy


### PR DESCRIPTION
Extend the poweruser role to have access to `patch` `pods/ephemeralcontainers` which is needed for attaching a debug container via `kubectl debug`.