### PR TITLE
clean up minor k8s 1.30 references

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -724,9 +724,6 @@ tracing_coredns_local_zone_traces_endpoint: ""
 # AMI id given the image name and the Image AWS account owner.
 #
 # [0]: https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/8a9bd1cb2d094038a9e23e646421f8146b48886a/provisioner/template.go#L116
-kuberuntu_image_v1_30_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.30.2-amd64-master-341" "861068367966" }}
-kuberuntu_image_v1_30_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.30.2-arm64-master-341" "861068367966" }}
-
 kuberuntu_image_v1_31_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.31.0-amd64-master-347" "861068367966" }}
 kuberuntu_image_v1_31_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.31.0-arm64-master-347" "861068367966" }}
 
@@ -799,7 +796,7 @@ ebs_csi_controller_sidecar_cpu: "10m"
 serialize_image_pulls: "false"
 
 # rate of image pull in the kubelet, see
-# see https://github.com/kubernetes/kubernetes/blob/v1.30.0/staging/src/k8s.io/kubelet/config/v1beta1/types.go#L200-L212
+# see https://github.com/kubernetes/kubernetes/blob/v1.31.0/staging/src/k8s.io/kubelet/config/v1beta1/types.go#L200-L212
 #
 # registryPullQPS is the limit of registry pulls per second.
 # The value must not be a negative number.


### PR DESCRIPTION
As a follow-up to #7965 , clean up some leftover references of `v1.30`.