### PR TITLE
clean up leftover k8s dashboard RBAC resources

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -297,34 +297,10 @@ post_apply:
   namespace: kube-system
 
 {{ if ne .Cluster.ConfigItems.k8s_dashboard_enabled "true" }}
-- name: kubernetes-dashboard
-  namespace: kube-system
-  kind: Deployment
-- name: kubernetes-dashboard
-  namespace: kube-system
-  kind: Service
-- name: dashboard-metrics-scraper
-  namespace: kube-system
-  kind: Service
-- name: dashboard-metrics-scraper
-  namespace: kube-system
-  kind: Deployment
-- name: kubernetes-dashboard
-  namespace: kube-system
+- name: readonly-dashboard
   kind: Role
-- name: kubernetes-dashboard
   namespace: kube-system
+- name: readonly-dashboard
   kind: RoleBinding
-- name: kubernetes-dashboard
-  kind: ClusterRole
-- name: kubernetes-dashboard-internal
-  kind: ClusterRoleBinding
-- name: kubernetes-dashboard-readonly
-  kind: ClusterRoleBinding
-- name: dashboard-metrics-scraper-vpa
   namespace: kube-system
-  kind: VerticalPodAutoscaler
-- name: kubernetes-dashboard
-  namespace: kube-system
-  kind: ServiceAccount
 {{ end }}

--- a/cluster/manifests/roles/readonly-binding.yaml
+++ b/cluster/manifests/roles/readonly-binding.yaml
@@ -19,6 +19,7 @@ subjects:
   - kind: Group
     name: "okta:common/read-only"
     apiGroup: rbac.authorization.k8s.io
+{{ if ne .Cluster.ConfigItems.k8s_dashboard_enabled "true" }}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -42,6 +43,7 @@ subjects:
   - kind: Group
     name: "okta:common/read-only"
     apiGroup: rbac.authorization.k8s.io
+{{ end }}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cluster/manifests/roles/readonly-dashboard.yaml
+++ b/cluster/manifests/roles/readonly-dashboard.yaml
@@ -1,3 +1,4 @@
+{{ if ne .Cluster.ConfigItems.k8s_dashboard_enabled "true" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -8,3 +9,4 @@ rules:
     resources: [ "services/proxy" ]
     verbs: [ "get" ]
     resourceNames: [ "kubernetes-dashboard" ]
+{{ end }}


### PR DESCRIPTION
These RBAC resources were missed during cleanup in #8092 and #8105 . This puts these resources behind the toggle and add `deletions.yaml` entry to clean them up from all clusters.