### PR TITLE
fix: canary controller cronjob name

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -304,3 +304,6 @@ post_apply:
   kind: RoleBinding
   namespace: kube-system
 {{ end }}
+- name: skipper-canary-conrtroller
+  kind: CronJob
+  namespace: kube-system

--- a/cluster/manifests/skipper-canary-controller/canary-cronjob.yaml
+++ b/cluster/manifests/skipper-canary-controller/canary-cronjob.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: skipper-canary-conrtroller
+  name: skipper-canary-controller
   namespace: kube-system
   labels:
     application: skipper-ingress


### PR DESCRIPTION
fix: canary controller cronjob name