### PR TITLE
ingress: log into both cluster and infra accounts

### DIFF
--- a/cluster/manifests/fabric-gateway/deployment.yaml
+++ b/cluster/manifests/fabric-gateway/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         kubernetes-log-watcher/scalyr-parser: |
           [{"container": "controller", "parser": "keyValue"}]
-        logging/destination: "{{ .Cluster.ConfigItems.log_destination_infra }}"
+        logging/destination: "{{ .Cluster.ConfigItems.log_destination_both }}"
         prometheus.io/path: /metrics
         prometheus.io/port: "7979"
         prometheus.io/scrape: "true"

--- a/cluster/manifests/skipper/hostname-credentials-controller.yaml
+++ b/cluster/manifests/skipper/hostname-credentials-controller.yaml
@@ -119,7 +119,7 @@ spec:
           annotations:
             kubernetes-log-watcher/scalyr-parser: |
               [{"container": "controller", "parser": "keyValue"}]
-            logging/destination: "{{ .Cluster.ConfigItems.log_destination_infra }}"
+            logging/destination: "{{ .Cluster.ConfigItems.log_destination_both }}"
         spec:
           serviceAccountName: hostname-credentials-controller
           restartPolicy: Never

--- a/cluster/manifests/skipper/pod-deletion-cost-controller.yaml
+++ b/cluster/manifests/skipper/pod-deletion-cost-controller.yaml
@@ -20,6 +20,8 @@ spec:
         application: skipper-ingress
         component: pod-deletion-cost-controller
         deployment: pod-deletion-cost-controller
+      annotations:
+        logging/destination: "{{ .Cluster.ConfigItems.log_destination_both }}"
     spec:
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       serviceAccountName: pod-deletion-cost-controller
@@ -29,12 +31,13 @@ spec:
         - -v={{ .Cluster.ConfigItems.skipper_pod_deletion_cost_controller_log_v }}
         - -poll-interval={{ .Cluster.ConfigItems.skipper_pod_deletion_cost_controller_poll_interval }}
         - -poll-timeout={{ .Cluster.ConfigItems.skipper_pod_deletion_cost_controller_poll_timeout }}
-{{ if eq .Cluster.ConfigItems.skipper_pod_deletion_cost_controller_resync_enable "true" }}
+        # {{ if eq .Cluster.ConfigItems.skipper_pod_deletion_cost_controller_resync_enable "true" }}
         - -resync
         - -resync-interval={{ .Cluster.ConfigItems.skipper_pod_deletion_cost_controller_resync_interval }}
-{{ end }}
+        # {{ end }}
         image: container-registry.zalando.net/gwproxy/pod-deletion-cost-controller:main-27
         name: pod-deletion-cost-controller
+        terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 8080
           name: metrics

--- a/cluster/manifests/skipper/skipper-redis.yaml
+++ b/cluster/manifests/skipper/skipper-redis.yaml
@@ -22,7 +22,7 @@ spec:
         version: v7.2.4
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
-        logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
+        logging/destination: "{{ .Cluster.ConfigItems.log_destination_both }}"
 {{- if eq .Cluster.ConfigItems.skipper_topology_spread_enabled "true" }}
         zalando.org/topology-spread-timeout: 7m
 {{- end }}


### PR DESCRIPTION
It makes sense for ingress components to log into
both cluster and infra accounts:
* cluster logs enable correlation with skipper-ingress access logs and user application logs
* infra logs enable correlation across clusters
* ingress components typically do not produce large amount of logs (unlike skipper-ingress access logs)

For pod-deletion-cost-controller save last chunk of logs into container status on error to simplify debugging.