### PR TITLE
Update Tokeninfo to latest version

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -357,7 +357,7 @@ write_files:
           - mountPath: /etc/kubernetes/k8s-authnz-webhook-kubeconfig
             name: k8s-authnz-webhook-kubeconfig
             readOnly: true
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/foundation/platform-iam-tokeninfo:master-113
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/foundation/platform-iam-tokeninfo:master-124
           name: tokeninfo
           ports:
             - containerPort: 9021
@@ -388,7 +388,7 @@ write_files:
               value: {{ .Cluster.ConfigItems.apiserver_business_partner_ids }}
 {{ if ne .Cluster.Environment "production" }}
         - name: tokeninfo-sandbox
-          image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/foundation/platform-iam-tokeninfo:master-113
+          image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/foundation/platform-iam-tokeninfo:master-124
           ports:
           - containerPort: 9022
           lifecycle:

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -418,6 +418,8 @@ write_files:
             value: "https://sandbox.identity.zalando.com"
           - name: LISTEN_ADDRESS
             value: ":9022"
+          - name: METRICS_LISTEN_ADDRESS
+            value: ":9023"
           - name: BUSINESS_PARTNERS
             value: {{ .Cluster.ConfigItems.apiserver_business_partner_ids }}
 {{ end }}


### PR DESCRIPTION
Similar to #8165 but adds configuration of METRICS_LISTEN_ADDRESS for the sandbox tokeninfo to avoid it overlapping with the port used by the tokeninfo container.