### PR TITLE
Make ssm session logging optional

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -2125,6 +2125,7 @@ Resources:
                 - BucketArn: !GetAtt AuditTrailBucket.Arn
 {{- end }}
 
+{{- if index .Cluster.ConfigItems "session_manager_destination_arn" }}
   SessionManagerLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
@@ -2184,6 +2185,7 @@ Resources:
                 Resource:
                   - !GetAtt SessionManagerLogGroup.Arn
       RoleName: "SessionManager-{{.Cluster.Alias}}"
+{{- end }}
 
   AWSNodeDecommissionerIAMRole:
     Type: 'AWS::IAM::Role'


### PR DESCRIPTION
Make ssm session logging configuration optional based on the config-item: `session_manager_destination_arn`.

This way we don't need to enable it in pet clusters. It will be enabled in all other clusters which have a value set for `session_manager_destination_arn`