### PR TITLE
Provide AWS credentials to aws-node via eks-pod-identity

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -212,6 +212,11 @@ Resources:
       PrincipalArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/Administrator"
       Username: !Sub "arn:aws:sts::${AWS::AccountId}:assumed-role/Administrator/{{`{{SessionName}}`}}"
       Type: "STANDARD"
+  EKSAddonPodIdentityAgent:
+    Type: AWS::EKS::Addon
+    Properties:
+      AddonName: eks-pod-identity-agent
+      ClusterName: !Ref EKSCluster
   # TODO: IAM POLICY
   EKSCNIIPv6Policy:
     Type: AWS::IAM::ManagedPolicy
@@ -237,9 +242,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       RoleName: "{{.Cluster.LocalID}}-aws-node"
-      AssumeRolePolicyDocument: !Sub
-        - |
-          {
+      AssumeRolePolicyDocument: {
             "Version": "2012-10-17",
             "Statement": [
               {
@@ -254,24 +257,18 @@ Resources:
                 ]
               },
               {
+                "Sid": "AllowEksAuthToAssumeRoleForPodIdentity",
                 "Effect": "Allow",
                 "Principal": {
-                  "Federated": [
-                    "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
-                  ]
+                    "Service": "pods.eks.amazonaws.com"
                 },
                 "Action": [
-                  "sts:AssumeRoleWithWebIdentity"
-                ],
-                "Condition": {
-                  "StringEquals": {
-                    "${OIDC}:sub": "system:serviceaccount:kube-system:aws-node"
-                  }
-                }
+                    "sts:AssumeRole",
+                    "sts:TagSession"
+                ]
               }
             ]
           }
-        - OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
       Path: /
       ManagedPolicyArns:
 {{- if eq .Cluster.ConfigItems.eks_ip_family "ipv4" }}
@@ -279,6 +276,13 @@ Resources:
 {{- else }}
       - !Ref EKSCNIIPv6Policy
 {{- end }}
+  EKSAWSNodePodIdentity:
+    Type: "AWS::EKS::PodIdentityAssociation"
+    Properties:
+      ClusterName: !Ref EKSCluster
+      Namespace: kube-system
+      RoleArn: !GetAtt EKSAWSNodeIAMRole.Arn
+      ServiceAccount: aws-node
   EKSZalandoIAMProxyIAMRole:
     Type: AWS::IAM::Role
     Properties:

--- a/cluster/manifests/01-aws-node/sa.yaml
+++ b/cluster/manifests/01-aws-node/sa.yaml
@@ -8,6 +8,4 @@ metadata:
   labels:
     application: kubernetes
     component: aws-node
-  annotations:
-    eks.amazonaws.com/role-arn: "arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/{{.Cluster.LocalID}}-aws-node"
 {{- end}}


### PR DESCRIPTION
Proof of Concept using the newer [eks-pod-identity feature](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) to provide AWS credentials to the aws-node daemonset.

This both showcases how to use it, and it potentially resolves a race-condition on cluster creation where aws-node pods would start before the aws-node serviceacount had the aws role annotation (via [IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)) leading to the pod starting without AWS permissions and failing to get ready. Via eks-pod-identity the race should not happen.

~This currently does _not_ work with eks v1.31. I have created a support case with AWS as this seem like an EKS bug. Successfully tested on eks v1.30.~
This was fixed by AWS.