### PR TITLE
skipper: increase skipper_pod_deletion_cost_controller_poll_timeout

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -227,7 +227,7 @@ skipper_pod_deletion_cost_controller_cpu_min: 25m
 skipper_pod_deletion_cost_controller_log_v: "0"
 # pod informer sync config
 skipper_pod_deletion_cost_controller_poll_interval: "10s"
-skipper_pod_deletion_cost_controller_poll_timeout: "10s"
+skipper_pod_deletion_cost_controller_poll_timeout: "60s"
 # enable re-sync
 skipper_pod_deletion_cost_controller_resync_enable: "false"
 skipper_pod_deletion_cost_controller_resync_interval: "1h"


### PR DESCRIPTION
Increase skipper_pod_deletion_cost_controller_poll_timeout which configures initial informer cache sync timeout.

Current low value occasionally triggers controller pod restarts.