### PR TITLE
Experimental support for ipv6

### DIFF
--- a/cluster/manifests/01-coredns-local/configmap-local.yaml
+++ b/cluster/manifests/01-coredns-local/configmap-local.yaml
@@ -71,7 +71,11 @@ data:
 {{ end }}
         template IN A {
             match "^.*[.]ingress[.]cluster[.]local"
+            {{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6")}}
+            answer "{{"{{"}} .Name {{"}}"}} 60 IN AAAA {{ addressNFromIPv6CIDR .Cluster.ConfigItems.service_ipv6_cidr 50 }}"
+            {{- else}}
             answer "{{"{{"}} .Name {{"}}"}} 60 IN A 10.5.99.99"
+            {{- end}}
             fallthrough
         }
         template IN AAAA {
@@ -83,7 +87,7 @@ data:
 
     # Defines that this server is authority for reverse
     # lookups for these ranges.
-    cluster.local:9254 10.2.0.0/15:9254 10.5.0.0/16:9254 {{ if eq .Cluster.ConfigItems.tracing_coredns_route_traces_to_local_zone "true"}}{{ range $src := split .Cluster.ConfigItems.tracing_coredns_global_traces_endpoint  "," }}{{ $src }}:9254 {{ end }} {{ end }} {
+    cluster.local:9254 {{if eq .Cluster.Provider "zalando-eks"}}in-addr.arpa:9254 ip6.arpa:9254{{else}}10.2.0.0/15:9254 10.5.0.0/16:9254{{end}} {{ if eq .Cluster.ConfigItems.tracing_coredns_route_traces_to_local_zone "true"}}{{ range $src := split .Cluster.ConfigItems.tracing_coredns_global_traces_endpoint  "," }}{{ $src }}:9254 {{ end }} {{ end }} {
         errors
         {{ if eq .Cluster.ConfigItems.tracing_coredns_route_traces_to_local_zone "true"}}
           {{- with $cluster := .Cluster }}
@@ -94,6 +98,9 @@ data:
         {{ end }}
         kubernetes {
             pods insecure
+            {{- if eq .Cluster.Provider "zalando-eks"}}
+            fallthrough in-addr.arpa ip6.arpa
+            {{- end}}
         }
         cache 30
 {{ if eq .Cluster.ConfigItems.coredns_log_svc_names "true"}}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -537,8 +537,7 @@ spec:
           - "-address=:9990"
           - "-wait-for-healthcheck-interval={{ .Cluster.ConfigItems.skipper_wait_for_healthcheck_interval }}"
 {{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6")}}
-          # TODO: dynamically get the subnet range (or figure out if these are known internal addresses?)
-          - "-whitelisted-healthcheck-cidr=2a05:d014:09c0:bf00:0:0:0:0/64,2a05:d014:09c0:bf01:0:0:0:0/64,2a05:d014:09c0:bf02:0:0:0:0/64"
+          - "-whitelisted-healthcheck-cidr={{ .Values.subnet_ipv6_cidrs }}"
 {{- end }}
           - "-kubernetes-east-west-range-domains=ingress.cluster.local"
           - "-kubernetes-east-west-range-predicates=ClientIP(\"10.2.0.0/15\", \"{{ .Values.vpc_ipv4_cidr }}\")"

--- a/cluster/manifests/skipper/service-internal.yaml
+++ b/cluster/manifests/skipper/service-internal.yaml
@@ -14,10 +14,9 @@ metadata:
     component: ingress
 spec:
   type: ClusterIP
-{{- if ne .Cluster.Provider "zalando-eks"}}
-# TODO: how to do internal-ingress?
-# function to derive IP from range?
-# Can be hardcoded for ipv4, must be dynamic for ipv6
+{{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6") }}
+  clusterIP: {{ addressNFromIPv6CIDR .Cluster.ConfigItems.service_ipv6_cidr 50 }}
+{{- else}}
   clusterIP: 10.5.99.99
 {{- end}}
   ports:

--- a/cluster/manifests/z-karpenter/07-karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/cluster/manifests/z-karpenter/07-karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -242,6 +242,11 @@ spec:
                 enum:
                 - RAID0
                 type: string
+              ipv6AddressCount:
+                description: IPv6AddressCount controls the number of IPv6 addresses
+                  assigned to instances that are launched with the nodeclass.
+                format: int64
+                type: integer
               metadataOptions:
                 default:
                   httpEndpoint: enabled

--- a/cluster/manifests/z-karpenter/deployment.yaml
+++ b/cluster/manifests/z-karpenter/deployment.yaml
@@ -51,7 +51,7 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
           {{if eq .Cluster.ConfigItems.karpenter_version "current"}}
-          image: "container-registry.zalando.net/teapot/karpenter:0.37.0-main-26.patched"
+          image: "container-registry.zalando.net/teapot/karpenter:0.37.0-main-27.patched"
           {{else if eq .Cluster.ConfigItems.karpenter_version "legacy"}}
           image: "container-registry.zalando.net/teapot/karpenter:0.36.2-main-25.patched"
           {{end}}

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -22,7 +22,9 @@ spec:
     - tags:
         karpenter.sh/discovery: "{{ .Cluster.ID }}/WorkerNodeSecurityGroup"
   associatePublicIPAddress: true
-  # TODO: eks: ipv6
+  {{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6") }}
+  ipv6AddressCount: 1
+  {{- end }}
   instanceProfile: "{{ .Cluster.ID | awsValidID }}-WorkerKarpenter-InstanceProfile"
   blockDeviceMappings:
     - deviceName: /dev/sda1


### PR DESCRIPTION
This PR adds some missing features to get a fully working EKS ipv6 cluster.

1. Custom version of Karpenter which has support for setting `ipv6AddressCount` on instances at launch
2. Provide IPv6 subnet addresses to skipper-ingress such that skipper-ingress can detect internal vs. external traffic.
3. Configure a static IPv6 address (based on EKS ipv6 service CIDR) for the skipper-internal service and corresponding coredns config to make `ingress.cluster.local` hostnames work.

These changes depend on the related changes in CLM: https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/822