### PR TITLE
skipper: update main fleet version to v0.21.208

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,6 +1,6 @@
 {{/* image-updater-bot detects *image variables so use print to disable it for main image */}}
 
-{{ $main_image := print "container-registry.zalando.net/teapot/skipper-internal:" "v0.21.198-1017" }}
+{{ $main_image := print "container-registry.zalando.net/teapot/skipper-internal:" "v0.21.208-1027" }}
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.21.208-1027" }}
 
 


### PR DESCRIPTION
+ https://github.com/zalando/skipper/pull/3227
+ https://github.com/zalando/skipper/pull/3225
+ https://github.com/zalando/skipper/pull/3234
+ https://github.com/zalando/skipper/pull/3239
+ https://github.com/zalando/skipper/pull/3240
+ https://github.com/zalando/skipper/pull/3241
+ https://github.com/zalando/skipper/pull/3242
+ https://github.com/zalando/skipper/pull/3245
+ https://github.com/zalando/skipper/pull/3246
+ https://github.com/zalando/skipper/pull/3247
+ https://github.com/zalando/skipper/pull/3249
+ https://github.com/zalando/skipper/pull/3248

FYI https://github.com/zalando/skipper/compare/v0.21.198...v0.21.208

canary was updated https://github.com/zalando-incubator/kubernetes-on-aws/pull/8214