### PR TITLE
fix: skipper topologySpreadConstraints.labelSelector

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -79,7 +79,8 @@ spec:
           whenUnsatisfiable: DoNotSchedule
           labelSelector:
             matchLabels:
-              deployment: skipper-ingress
+              component: ingress
+              application: skipper-ingress
 {{- end }}
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       serviceAccountName: skipper-ingress


### PR DESCRIPTION
we have 2 deployments and component=ingress identifies the data-plane