### PR TITLE
Allow powerusers to also delete leases

### DIFF
--- a/cluster/manifests/roles/poweruser-role.yaml
+++ b/cluster/manifests/roles/poweruser-role.yaml
@@ -246,3 +246,4 @@ rules:
   - create
   - update
   - patch
+  - delete


### PR DESCRIPTION
The `leases` API can be useful for building leader election/distributed locks via the Kubernetes API.

Also allow powerusers and thereby services to `delete` leases` if needed (delete is not much different than updating).