### PR TITLE
Optionally Audit controller-manager node changes

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -726,6 +726,9 @@ kuberuntu_distro_worker: "jammy"
 
 # Feature toggle for auditing events
 audit_pod_events: "true"
+# Whether to log audit event for node changes by kube-controller-manager. Useful
+# to see if kube-controller-manager is setting overlapping podCIDRs.
+audit_kube_controller_manager_node_changes: "false"
 {{if eq .Cluster.Environment "production"}}
 audittrail_url: "https://audittrail.cloud.zalando.com"
 {{else}}

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -767,6 +767,14 @@ write_files:
             - group: "" # core
               resources: ["pods"]
         {{ end }}
+{{- if eq .Cluster.ConfigItems.audit_kube_controller_manager_node_changes "true"}}
+        - level: Request
+          users: ["system:kube-controller-manager"]
+          verbs: ["patch", "update"]
+          resources:
+            - group: "" # core
+              resources: ["nodes"]
+{{- end}}
         # don't audit any kube-controller-manager events
         - level: None
           users: ["system:kube-controller-manager"]


### PR DESCRIPTION
Add a flag to optionally enable logging of audit events for kube-controller-manager patching/updating node resources. This is disabled by default.

The context for this is that we're investigating a potential bug in Kubernetes v1.31 where an already allocated podCIDR can be allocated to a second node in the cluster. These logs can help verify if this is done by kube-controller-manager or not.