### PR TITLE
skipper-ingress: update canary to v0.21.211

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,7 +1,7 @@
 {{/* image-updater-bot detects *image variables so use print to disable it for main image */}}
 
 {{ $main_image := print "container-registry.zalando.net/teapot/skipper-internal:" "v0.21.208-1027" }}
-{{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.21.208-1027" }}
+{{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.21.211-1033" }}
 
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}


### PR DESCRIPTION
* https://github.com/zalando/skipper/pull/3250
* https://github.com/zalando/skipper/pull/3251
* https://github.com/zalando/skipper/pull/3252
* https://github.com/zalando/skipper/pull/3253
* https://github.com/zalando/skipper/pull/3255
* https://github.com/zalando/skipper/pull/3254
* https://github.com/zalando/skipper/pull/3256

https://github.com/zalando/skipper/compare/v0.21.208...v0.21.211