### PR TITLE
eks: Support dynamic IPv4 service CIDR

### DIFF
--- a/cluster/manifests/01-coredns-local/configmap-local.yaml
+++ b/cluster/manifests/01-coredns-local/configmap-local.yaml
@@ -71,8 +71,8 @@ data:
 {{ end }}
         template IN A {
             match "^.*[.]ingress[.]cluster[.]local"
-            {{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6")}}
-            answer "{{"{{"}} .Name {{"}}"}} 60 IN AAAA {{ addressNFromIPv6CIDR .Cluster.ConfigItems.service_ipv6_cidr 50 }}"
+            {{- if eq .Cluster.Provider "zalando-eks" }}
+            answer "{{"{{"}} .Name {{"}}"}} 60 IN AAAA {{ nthAddressFromCIDR .Cluster.ConfigItems.service_cidr 50 }}"
             {{- else}}
             answer "{{"{{"}} .Name {{"}}"}} 60 IN A 10.5.99.99"
             {{- end}}

--- a/cluster/manifests/skipper/service-internal.yaml
+++ b/cluster/manifests/skipper/service-internal.yaml
@@ -14,7 +14,7 @@ metadata:
     component: ingress
 spec:
   type: ClusterIP
-{{- if eq .Cluster.Provider "zalando-eks") }}
+{{- if eq .Cluster.Provider "zalando-eks" }}
   clusterIP: {{ nthAddressFromCIDR .Cluster.ConfigItems.service_cidr 50 }}
 {{- else}}
   clusterIP: 10.5.99.99

--- a/cluster/manifests/skipper/service-internal.yaml
+++ b/cluster/manifests/skipper/service-internal.yaml
@@ -14,8 +14,8 @@ metadata:
     component: ingress
 spec:
   type: ClusterIP
-{{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6") }}
-  clusterIP: {{ addressNFromIPv6CIDR .Cluster.ConfigItems.service_ipv6_cidr 50 }}
+{{- if eq .Cluster.Provider "zalando-eks") }}
+  clusterIP: {{ nthAddressFromCIDR .Cluster.ConfigItems.service_cidr 50 }}
 {{- else}}
   clusterIP: 10.5.99.99
 {{- end}}


### PR DESCRIPTION
Allow handling of dynamic eks IPv4 CIDR in the same way as was implemented for IPv6.

Depends on the related changes to CLM: https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/824