### PR TITLE
Fix ingress.cluster.local feature for eks

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -3,9 +3,17 @@
 {{ $main_image := print "container-registry.zalando.net/teapot/skipper-internal:" "v0.21.211-1033" }}
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.21.216-1038" }}
 
-
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}
 {{ $canary_args := "" }}
+
+{{ $cluster_internal_cidrs := stringSlice "10.2.0.0/15" .Values.vpc_ipv4_cidr }}
+{{ if eq .Cluster.Provider "zalando-eks" }}
+{{ if eq .Cluster.ConfigItems.eks_ip_family "ipv6" }}
+{{ $cluster_internal_cidrs := .Values.vpc_ipv6_cidrs }}
+{{ else }}
+{{ $cluster_internal_cidrs := stringSlice .Values.vpc_ipv4_cidr }}
+{{ end }}
+{{ end }}
 
 {{ template "skipper-ingress" dict
   "name" "skipper-ingress"
@@ -13,6 +21,7 @@
 
   "Cluster" .Cluster
   "Values" .Values
+  "cluster_internal_cidrs" $cluster_internal_cidrs
 }}
 
 {{ if eq .Cluster.ConfigItems.skipper_ingress_canary_enabled "true" }}
@@ -24,6 +33,7 @@
 
   "Cluster" .Cluster
   "Values" .Values
+  "cluster_internal_cidrs" $cluster_internal_cidrs
 }}
 {{ end }}
 
@@ -172,7 +182,7 @@ spec:
           - "-wait-for-healthcheck-interval={{ .Cluster.ConfigItems.skipper_wait_for_healthcheck_interval }}"
 {{ if ne .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
           - "-kubernetes-east-west-range-domains=ingress.cluster.local"
-          - "-kubernetes-east-west-range-predicates=ClientIP({{ if eq .Cluster.Provider "zalando-eks" }}{{if eq .Cluster.ConfigItems.eks_ip_family "ipv4"}}\"{{ .Values.vpc_ipv4_cidr }}\"{{else}}\"{{join .Values.vpc_ipv6_cidrs `\",\"`}}\"{{end}}{{else}}\"10.2.0.0/15\", \"{{ .Values.vpc_ipv4_cidr }}\"{{end}})"
+          - "-kubernetes-east-west-range-predicates=ClientIP(\"{{ join .cluster_internal_cidrs `\",\"` }}\")"
           - "-reverse-source-predicate"
 {{ end }}
           - "-proxy-preserve-host"
@@ -304,15 +314,7 @@ spec:
 {{ end }}
 {{ if or (eq .Cluster.ConfigItems.nlb_switch "pre") (eq .Cluster.ConfigItems.nlb_switch "exec") }}
           - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
-          {{ if eq .Cluster.Provider "zalando-eks" }}
-            {{ if eq .Cluster.ConfigItems.eks_ip_family "ipv6" }}
-          - "-forwarded-headers-exclude-cidrs={{ join .Values.vpc_ipv6_cidrs "," }}"
-            {{ else }}
-          - "-forwarded-headers-exclude-cidrs={{ .Values.vpc_ipv4_cidr }}"
-            {{ end }}
-          {{ else }}
-          - "-forwarded-headers-exclude-cidrs=10.2.0.0/15,{{ .Values.vpc_ipv4_cidr}}"
-          {{ end }}
+          - "-forwarded-headers-exclude-cidrs={{ join .cluster_internal_cidrs "," }}"
 {{ end }}
 {{ if .Cluster.ConfigItems.skipper_ingress_inline_routes }}
           - "-inline-routes={{ .Cluster.ConfigItems.skipper_ingress_inline_routes }}"
@@ -550,7 +552,7 @@ spec:
           - "-whitelisted-healthcheck-cidr={{ .Values.subnet_ipv6_cidrs }}"
 {{- end }}
           - "-kubernetes-east-west-range-domains=ingress.cluster.local"
-          - "-kubernetes-east-west-range-predicates=ClientIP({{ if eq .Cluster.Provider "zalando-eks" }}{{if eq .Cluster.ConfigItems.eks_ip_family "ipv4"}}\"{{ .Values.vpc_ipv4_cidr }}\"{{else}}\"{{join .Values.vpc_ipv6_cidrs `\",\"`}}\"{{end}}{{else}}\"10.2.0.0/15\", \"{{ .Values.vpc_ipv4_cidr }}\"{{end}})"
+          - "-kubernetes-east-west-range-predicates=ClientIP(\"{{ join $cluster_internal_cidrs `\",\"` }}\")"
           - "-reverse-source-predicate"
           - "-default-filters-dir=/etc/config/default-filters"
           - '-default-filters-prepend={{ .Cluster.ConfigItems.skipper_default_filters }}'
@@ -573,15 +575,7 @@ spec:
 {{ end }}
 {{ if or (eq .Cluster.ConfigItems.nlb_switch "pre") (eq .Cluster.ConfigItems.nlb_switch "exec") }}
           - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
-          {{ if eq .Cluster.Provider "zalando-eks" }}
-            {{ if eq .Cluster.ConfigItems.eks_ip_family "ipv6" }}
-          - "-forwarded-headers-exclude-cidrs={{ join .Values.vpc_ipv6_cidrs "," }}"
-            {{ else }}
-          - "-forwarded-headers-exclude-cidrs={{ .Values.vpc_ipv4_cidr }}"
-            {{ end }}
-          {{ else }}
-          - "-forwarded-headers-exclude-cidrs=10.2.0.0/15,{{ .Values.vpc_ipv4_cidr}}"
-          {{ end }}
+          - "-forwarded-headers-exclude-cidrs={{ join $cluster_internal_cidrs "," }}"
 {{ end }}
           - >-
             -opentracing=lightstep

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -6,12 +6,12 @@
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}
 {{ $canary_args := "" }}
 
-{{ $cluster_internal_cidrs := stringSlice "10.2.0.0/15" .Values.vpc_ipv4_cidr }}
+{{ $cluster_internal_cidrs := list "10.2.0.0/15" .Values.vpc_ipv4_cidr }}
 {{ if eq .Cluster.Provider "zalando-eks" }}
 {{ if eq .Cluster.ConfigItems.eks_ip_family "ipv6" }}
-{{ $cluster_internal_cidrs := .Values.vpc_ipv6_cidrs }}
+{{ $cluster_internal_cidrs = .Values.vpc_ipv6_cidrs }}
 {{ else }}
-{{ $cluster_internal_cidrs := stringSlice .Values.vpc_ipv4_cidr }}
+{{ $cluster_internal_cidrs = list .Values.vpc_ipv4_cidr }}
 {{ end }}
 {{ end }}
 

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -182,7 +182,7 @@ spec:
           - "-wait-for-healthcheck-interval={{ .Cluster.ConfigItems.skipper_wait_for_healthcheck_interval }}"
 {{ if ne .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
           - "-kubernetes-east-west-range-domains=ingress.cluster.local"
-          - "-kubernetes-east-west-range-predicates=ClientIP(\"{{ join .cluster_internal_cidrs `\",\"` }}\")"
+          - "-kubernetes-east-west-range-predicates=ClientIP(\"{{ .cluster_internal_cidrs | join `\",\"` }}\")"
           - "-reverse-source-predicate"
 {{ end }}
           - "-proxy-preserve-host"
@@ -314,7 +314,7 @@ spec:
 {{ end }}
 {{ if or (eq .Cluster.ConfigItems.nlb_switch "pre") (eq .Cluster.ConfigItems.nlb_switch "exec") }}
           - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
-          - "-forwarded-headers-exclude-cidrs={{ join .cluster_internal_cidrs "," }}"
+          - "-forwarded-headers-exclude-cidrs={{ .cluster_internal_cidrs | join "," }}"
 {{ end }}
 {{ if .Cluster.ConfigItems.skipper_ingress_inline_routes }}
           - "-inline-routes={{ .Cluster.ConfigItems.skipper_ingress_inline_routes }}"
@@ -552,7 +552,7 @@ spec:
           - "-whitelisted-healthcheck-cidr={{ .Values.subnet_ipv6_cidrs }}"
 {{- end }}
           - "-kubernetes-east-west-range-domains=ingress.cluster.local"
-          - "-kubernetes-east-west-range-predicates=ClientIP(\"{{ join $cluster_internal_cidrs `\",\"` }}\")"
+          - "-kubernetes-east-west-range-predicates=ClientIP(\"{{ $cluster_internal_cidrs | join `\",\"` }}\")"
           - "-reverse-source-predicate"
           - "-default-filters-dir=/etc/config/default-filters"
           - '-default-filters-prepend={{ .Cluster.ConfigItems.skipper_default_filters }}'
@@ -575,7 +575,7 @@ spec:
 {{ end }}
 {{ if or (eq .Cluster.ConfigItems.nlb_switch "pre") (eq .Cluster.ConfigItems.nlb_switch "exec") }}
           - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
-          - "-forwarded-headers-exclude-cidrs={{ join $cluster_internal_cidrs "," }}"
+          - "-forwarded-headers-exclude-cidrs={{ $cluster_internal_cidrs | join "," }}"
 {{ end }}
           - >-
             -opentracing=lightstep

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -172,7 +172,7 @@ spec:
           - "-wait-for-healthcheck-interval={{ .Cluster.ConfigItems.skipper_wait_for_healthcheck_interval }}"
 {{ if ne .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
           - "-kubernetes-east-west-range-domains=ingress.cluster.local"
-          - "-kubernetes-east-west-range-predicates=ClientIP(\"10.2.0.0/15\", \"{{ .Values.vpc_ipv4_cidr }}\")"
+          - "-kubernetes-east-west-range-predicates=ClientIP({{ if eq .Cluster.Provider "zalando-eks" }}{{if eq .Cluster.ConfigItems.eks_ip_family "ipv4"}}\"{{ .Values.vpc_ipv4_cidr }}\"{{else}}\"{{join .Values.vpc_ipv6_cidrs `\",\"`}}\"{{end}}{{else}}\"10.2.0.0/15\", \"{{ .Values.vpc_ipv4_cidr }}\"{{end}})"
           - "-reverse-source-predicate"
 {{ end }}
           - "-proxy-preserve-host"
@@ -304,7 +304,15 @@ spec:
 {{ end }}
 {{ if or (eq .Cluster.ConfigItems.nlb_switch "pre") (eq .Cluster.ConfigItems.nlb_switch "exec") }}
           - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
+          {{ if eq .Cluster.Provider "zalando-eks" }}
+            {{ if eq .Cluster.ConfigItems.eks_ip_family "ipv6" }}
+          - "-forwarded-headers-exclude-cidrs={{ join .Values.vpc_ipv6_cidrs "," }}"
+            {{ else }}
+          - "-forwarded-headers-exclude-cidrs={{ .Values.vpc_ipv4_cidr }}"
+            {{ end }}
+          {{ else }}
           - "-forwarded-headers-exclude-cidrs=10.2.0.0/15,{{ .Values.vpc_ipv4_cidr}}"
+          {{ end }}
 {{ end }}
 {{ if .Cluster.ConfigItems.skipper_ingress_inline_routes }}
           - "-inline-routes={{ .Cluster.ConfigItems.skipper_ingress_inline_routes }}"
@@ -542,7 +550,7 @@ spec:
           - "-whitelisted-healthcheck-cidr={{ .Values.subnet_ipv6_cidrs }}"
 {{- end }}
           - "-kubernetes-east-west-range-domains=ingress.cluster.local"
-          - "-kubernetes-east-west-range-predicates=ClientIP(\"10.2.0.0/15\", \"{{ .Values.vpc_ipv4_cidr }}\")"
+          - "-kubernetes-east-west-range-predicates=ClientIP({{ if eq .Cluster.Provider "zalando-eks" }}{{if eq .Cluster.ConfigItems.eks_ip_family "ipv4"}}\"{{ .Values.vpc_ipv4_cidr }}\"{{else}}\"{{join .Values.vpc_ipv6_cidrs `\",\"`}}\"{{end}}{{else}}\"10.2.0.0/15\", \"{{ .Values.vpc_ipv4_cidr }}\"{{end}})"
           - "-reverse-source-predicate"
           - "-default-filters-dir=/etc/config/default-filters"
           - '-default-filters-prepend={{ .Cluster.ConfigItems.skipper_default_filters }}'
@@ -565,7 +573,15 @@ spec:
 {{ end }}
 {{ if or (eq .Cluster.ConfigItems.nlb_switch "pre") (eq .Cluster.ConfigItems.nlb_switch "exec") }}
           - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
+          {{ if eq .Cluster.Provider "zalando-eks" }}
+            {{ if eq .Cluster.ConfigItems.eks_ip_family "ipv6" }}
+          - "-forwarded-headers-exclude-cidrs={{ join .Values.vpc_ipv6_cidrs "," }}"
+            {{ else }}
+          - "-forwarded-headers-exclude-cidrs={{ .Values.vpc_ipv4_cidr }}"
+            {{ end }}
+          {{ else }}
           - "-forwarded-headers-exclude-cidrs=10.2.0.0/15,{{ .Values.vpc_ipv4_cidr}}"
+          {{ end }}
 {{ end }}
           - >-
             -opentracing=lightstep


### PR DESCRIPTION
This changes CIDR ranges config used for the skipper-ingress east-west feature based on the cluster setup.

For EKS the CIDR range is either the VPC ipv4 or ipv6 CIDR range and for non EKS it stays as it is.

@AlexanderYastrebov Let me know if these conditions are too complex or if they are readable 😅

* [x] Depends on `vpc_ipv6_cidrs` exposed in CLM: https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/825