### PR TITLE
fix: use resync as default in pod deletion cost controller

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -239,7 +239,7 @@ skipper_pod_deletion_cost_controller_log_v: "0"
 skipper_pod_deletion_cost_controller_poll_interval: "10s"
 skipper_pod_deletion_cost_controller_poll_timeout: "60s"
 # enable re-sync
-skipper_pod_deletion_cost_controller_resync_enable: "false"
+skipper_pod_deletion_cost_controller_resync_enable: "true"
 skipper_pod_deletion_cost_controller_resync_interval: "1h"
 
 # polarsignals - only enabled for testing teapot


### PR DESCRIPTION
fix: use resync as default in pod deletion cost controller