### PR TITLE
skipper-canary-controller: update cronjob lightstep enviroment variables

### DIFF
--- a/cluster/manifests/skipper-canary-controller/canary-cronjob.yaml
+++ b/cluster/manifests/skipper-canary-controller/canary-cronjob.yaml
@@ -36,10 +36,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: _PLATFORM_OBSERVABILITY_ACCESS_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: skipper-ingress
-                  key: lightstep-token
+              value: "{{ .Cluster.ConfigItems.lightstep_token }}"
             - name: _PLATFORM_OBSERVABILITY_COLLECTOR_SCHEME
               value: "{{ .Cluster.ConfigItems.observability_collector_scheme }}"
             - name: _PLATFORM_OBSERVABILITY_COLLECTOR_PORT
@@ -54,6 +51,16 @@ spec:
               value: "{{ .Cluster.Alias }}"
             - name: _PLATFORM_OBSERVABILITY_COMMON_ATTRIBUTE_CLOUD__ACCOUNT__ID
               value: "{{ .Cluster.Alias }}"
+            - name: _PLATFORM_CLUSTER_ID
+              value: "{{ .Cluster.ID }}"
+            - name: _PLATFORM_OPENTRACING_TAG_ACCOUNT
+              value: "{{ .Cluster.Alias }}"
+            - name: _PLATFORM_OPENTRACING_LIGHTSTEP_COLLECTOR_PORT
+              value: "8443"
+            - name: _PLATFORM_OPENTRACING_LIGHTSTEP_COLLECTOR_HOST
+              value: "{{ .Cluster.ConfigItems.tracing_collector_host }}"
+            - name: _PLATFORM_OPENTRACING_LIGHTSTEP_ACCESS_TOKEN
+              value: "{{ .Cluster.ConfigItems.lightstep_token }}"
             - name: LIGHTSTEP_DEBUG
               value: "true"
             args:


### PR DESCRIPTION
use observability token instead of skipper access token and match pod injector as jobs outside `kube-system` were able to push metrics.