### PR TITLE
skipper-canary-controller: add preStop for the cronjob

### DIFF
--- a/cluster/manifests/skipper-canary-controller/canary-cronjob.yaml
+++ b/cluster/manifests/skipper-canary-controller/canary-cronjob.yaml
@@ -30,6 +30,10 @@ spec:
           - name: skipper-canary-controller
             terminationMessagePolicy: FallbackToLogsOnError
             image: container-registry.zalando.net/gwproxy/skipper-canary-controller:main-29
+            lifecycle:
+              preStop:
+                sleep:
+                  seconds: 30
             env:
             - name: POD_NAME
               valueFrom:


### PR DESCRIPTION
Give time for the controller to push metrics to lightstep