### PR TITLE
prometheus: ipv6 pod support

### DIFF
--- a/cluster/manifests/prometheus/configmap.yaml
+++ b/cluster/manifests/prometheus/configmap.yaml
@@ -265,10 +265,18 @@ data:
         action: replace
         target_label: __metrics_path__
         regex: (.+)
+      # If __address__ is ipv6, update ipv6 adress with []
+      # https://github.com/prometheus/prometheus/issues/14656
+      - source_labels: [__address__]
+        regex: '\[?([0-9a-fA-F:]+:[0-9a-fA-F:]+)\]?(:\d+)?'
+        action: replace
+        target_label: __address__
+        replacement: '[$1]$2'
       - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
         action: replace
-        regex: ([^:]+)(?::\d+)?;(\d+)
-        replacement: $1:$2
+        # match both ipv6 and ipv4
+        regex: ([0-9.]+|\[?[0-9a-fA-F:]+\]?)(:?\d+)?;(\d+)
+        replacement: $1:$3
         target_label: __address__
       - action: replace
         source_labels: ['__meta_kubernetes_pod_ip']


### PR DESCRIPTION
Handle both ipv4 and ipv6 addresses when scraping for the `kubernetes-pods` job.

The motivation for this is to make it work with EKS ipv6 clusters, but it should be backwards compatible with non-eks/ipv4 clusters.