### PR TITLE
skipper-canary-controller: remove `LIGHTSTEP_DEBUG`

### DIFF
--- a/cluster/manifests/skipper-canary-controller/canary-cronjob.yaml
+++ b/cluster/manifests/skipper-canary-controller/canary-cronjob.yaml
@@ -61,8 +61,6 @@ spec:
               value: "{{ .Cluster.ConfigItems.tracing_collector_host }}"
             - name: _PLATFORM_OPENTRACING_LIGHTSTEP_ACCESS_TOKEN
               value: "{{ .Cluster.ConfigItems.lightstep_token }}"
-            - name: LIGHTSTEP_DEBUG
-              value: "true"
             args:
               - "--dry-mode=true"
               - "--prometheus-url=http://prometheus.kube-system.svc.cluster.local"


### PR DESCRIPTION
`LIGHTSTEP_DEBUG` env will make the sdk push metrics to stdout only