### PR TITLE
drop deprecated annotation from skipper-ingress Service

### DIFF
--- a/cluster/manifests/skipper/service-internal.yaml
+++ b/cluster/manifests/skipper/service-internal.yaml
@@ -2,10 +2,6 @@ kind: Service
 apiVersion: v1
 metadata:
   annotations:
-    # Kubernetes version 1.23 - 1.26
-    # TODO(sszuecs): cleanup later, because it was renamed in Kube-1.27
-    service.kubernetes.io/topology-aware-hints: auto
-    # Kubernetes version >=1.27
     service.kubernetes.io/topology-mode: auto
   name: skipper-internal
   namespace: kube-system


### PR DESCRIPTION
We see warnings reported in CLM for the deprecated annotation:
```
time="2024-10-08T14:13:59Z" level=error msg="Warning: annotation service.kubernetes.io/topology-aware-hints is deprecated, please use service.kubernetes.io/topology-mode instead" cluster=experimentation-platform module=main/skipper worker=7

```

I see it's already marked as a TODO, so just dropping it now.