### PR TITLE
Introduce S3 csi driver (disabled by default)

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1103,6 +1103,16 @@ network_monitoring_check_unschedulable_nodes: "true"
 network_monitoring_check_interval: "1m"
 network_monitoring_separate_prometheus: "false"
 
+# Enable/Disable the s3-csi-driver daemonset:
+# https://github.com/awslabs/mountpoint-s3-csi-driver
+s3_csi_driver: "false"
+# When set to true this will add a node-selector `s3-csi-driver: enabled` to the
+# s3-csi-driver daemonset such that only node/node-pools with that label will
+# have the driver running. This allows enabling in a subset of a cluster for
+# testing.
+s3_csi_driver_node_selector_restricted: "true"
+
+
 # Percent of master node instance memory to allocate to the kube-apiserver
 # container. If this value is non-zero it will set the memory limit for the
 # kube-apiserver container in the kube-apiserver pod.

--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -101,6 +101,9 @@ data:
   pod.pod-security-policy.privileged-service-accounts.kube-system_etcd-backup: ""
   pod.pod-security-policy.privileged-service-accounts.kube-system_coredns: ""
   pod.pod-security-policy.privileged-service-accounts.kube-system_efs-provisioner: ""
+{{- if eq .Cluster.ConfigItems.s3_csi_driver "true" }}
+  pod.pod-security-policy.privileged-service-accounts.kube-system_s3-csi-driver: ""
+{{- end }}
   pod.pod-security-policy.privileged-service-accounts.visibility_logging-agent: ""
 {{- range $sa := split .Cluster.ConfigItems.teapot_admission_controller_pod_security_policy_privileged_service_accounts "," }}
   pod.pod-security-policy.privileged-service-accounts.{{ $sa }}: ""

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -299,3 +299,13 @@ post_apply:
 - name: skipper-canary-conrtroller
   kind: CronJob
   namespace: kube-system
+{{- if ne .Cluster.ConfigItems.s3_csi_driver "true" }}
+- name: s3.csi.aws.com
+  kind: CSIDriver
+- name: s3-csi-driver
+  kind: ServiceAccount
+  namespace: kube-system
+- name: s3-csi-node
+  kind: DaemonSet
+  namespace: kube-system
+{{- end }}

--- a/cluster/manifests/s3-csi-driver/csidriver.yaml
+++ b/cluster/manifests/s3-csi-driver/csidriver.yaml
@@ -1,0 +1,16 @@
+{{- if eq .Cluster.ConfigItems.s3_csi_driver "true" }}
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: s3.csi.aws.com
+  labels:
+    application: kubernetes
+    component: aws-mountpoint-s3-csi-driver
+spec:
+  attachRequired: false
+  podInfoOnMount: true
+  tokenRequests:
+    - audience: "sts.amazonaws.com"
+      expirationSeconds: 3600
+  requiresRepublish: true
+{{- end }}

--- a/cluster/manifests/s3-csi-driver/daemonset.yaml
+++ b/cluster/manifests/s3-csi-driver/daemonset.yaml
@@ -1,0 +1,180 @@
+{{- if eq .Cluster.ConfigItems.s3_csi_driver "true" }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    application: kubernetes
+    component: aws-mountpoint-s3-csi-driver
+    app.kubernetes.io/name: aws-mountpoint-s3-csi-driver
+  name: s3-csi-node
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      daemonset: s3-csi-node
+  template:
+    metadata:
+      labels:
+        daemonset: s3-csi-node
+        application: kubernetes
+        component: aws-mountpoint-s3-csi-driver
+    spec:
+      priorityClassName: system-node-critical
+      serviceAccountName: s3-csi-driver
+      nodeSelector:
+        node.kubernetes.io/role: worker
+{{- if eq .Cluster.ConfigItems.s3_csi_driver_node_selector_restricted "true" }}
+        s3-csi-driver: enabled
+{{- end }}
+      tolerations:
+      - operator: Exists
+      containers:
+      - args:
+        - --endpoint=$(CSI_ENDPOINT)
+        - --logtostderr
+        - --v=4
+        env:
+        - name: CSI_ENDPOINT
+          value: unix:/csi/csi.sock
+        - name: PTMX_PATH
+          value: /host/dev/ptmx
+        - name: MOUNT_S3_PATH
+          value: /opt/mountpoint-s3-csi/bin/mount-s3
+        - name: AWS_DEFAULT_REGION
+          value: "{{ .Cluster.Region }}"
+        - name: CSI_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: HOST_PLUGIN_DIR
+          value: /opt/podruntime/kubelet/plugins/s3.csi.aws.com/
+        image: container-registry.zalando.net/teapot/aws-mountpoint-s3-csi-driver:v1.9.0-master-21
+        resources:
+          requests:
+            cpu: 1m
+            memory: 50Mi
+            ephemeral-storage: 256Mi
+          limits:
+            cpu: 1m
+            memory: 50Mi
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 10
+          periodSeconds: 2
+          timeoutSeconds: 3
+        name: s3-plugin
+        ports:
+        - containerPort: 9810
+          name: healthz
+          protocol: TCP
+        securityContext:
+          privileged: false
+        volumeMounts:
+        - mountPath: /opt/podruntime/kubelet
+          name: kubelet-dir
+        - mountPath: /csi
+          name: plugin-dir
+        - mountPath: /run/systemd/private
+          name: systemd-bus
+        - mountPath: /host/dev
+          name: host-dev
+        - mountPath: /host/proc/mounts
+          name: proc-mounts
+      - args:
+        - --csi-address=$(ADDRESS)
+        - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        env:
+        - name: ADDRESS
+          value: /csi/csi.sock
+        - name: DRIVER_REG_SOCK_PATH
+          value: /opt/podruntime/kubelet/plugins/s3.csi.aws.com/csi.sock
+        - name: KUBE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: container-registry.zalando.net/teapot/node-driver-registrar:v2.12.0-eks-1-31-4-master-20
+        imagePullPolicy: IfNotPresent
+        name: node-driver-registrar
+        resources:
+          requests:
+            cpu: 1m
+            memory: 50Mi
+            ephemeral-storage: 256Mi
+          limits:
+            cpu: 1m
+            memory: 50Mi
+        volumeMounts:
+        - mountPath: /csi
+          name: plugin-dir
+        - mountPath: /registration
+          name: registration-dir
+      - args:
+        - --csi-address=/csi/csi.sock
+        - --health-port=9810
+        image: container-registry.zalando.net/teapot/livenessprobe:v2.14.0-eks-1-31-4-master-20
+        imagePullPolicy: IfNotPresent
+        name: liveness-probe
+        resources:
+          requests:
+            cpu: 1m
+            memory: 50Mi
+            ephemeral-storage: 256Mi
+          limits:
+            cpu: 1m
+            memory: 50Mi
+        volumeMounts:
+        - mountPath: /csi
+          name: plugin-dir
+      initContainers:
+      - command:
+        - /bin/install-mp
+        env:
+        - name: MOUNTPOINT_INSTALL_DIR
+          value: /target
+        image: container-registry.zalando.net/teapot/aws-mountpoint-s3-csi-driver:v1.9.0-master-21
+        imagePullPolicy: IfNotPresent
+        name: install-mountpoint
+        resources:
+          requests:
+            cpu: 1m
+            memory: 50Mi
+            ephemeral-storage: 256Mi
+          limits:
+            cpu: 1m
+            memory: 50Mi
+        volumeMounts:
+        - mountPath: /target
+          name: mp-install
+      volumes:
+      - hostPath:
+          path: /dev/
+          type: Directory
+        name: host-dev
+      - hostPath:
+          path: /opt/mountpoint-s3-csi/bin
+          type: DirectoryOrCreate
+        name: mp-install
+      - hostPath:
+          path: /proc/mounts
+          type: File
+        name: proc-mounts
+      - hostPath:
+          path: /run/systemd/private
+          type: Socket
+        name: systemd-bus
+      - hostPath:
+          path: /opt/podruntime/kubelet
+          type: Directory
+        name: kubelet-dir
+      - hostPath:
+          path: /opt/podruntime/kubelet/plugins_registry/
+          type: Directory
+        name: registration-dir
+      - hostPath:
+          path: /opt/podruntime/kubelet/plugins/s3.csi.aws.com/
+          type: DirectoryOrCreate
+        name: plugin-dir
+{{- end }}

--- a/cluster/manifests/s3-csi-driver/rbac.yaml
+++ b/cluster/manifests/s3-csi-driver/rbac.yaml
@@ -1,0 +1,41 @@
+{{- if eq .Cluster.ConfigItems.s3_csi_driver "true" }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: s3-csi-driver
+  namespace: kube-system
+  labels:
+    application: kubernetes
+    component: aws-mountpoint-s3-csi-driver
+    app.kubernetes.io/name: aws-mountpoint-s3-csi-driver
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: s3-csi-driver-cluster-role
+  labels:
+    application: kubernetes
+    component: aws-mountpoint-s3-csi-driver
+    app.kubernetes.io/name: aws-mountpoint-s3-csi-driver
+rules:
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["get"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mountpoint-s3-csi-node-binding
+  labels:
+    application: kubernetes
+    component: aws-mountpoint-s3-csi-driver
+    app.kubernetes.io/name: aws-mountpoint-s3-csi-driver
+roleRef:
+  kind: ClusterRole
+  name: s3-csi-driver-cluster-role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: s3-csi-driver
+    namespace: kube-system
+{{- end }}


### PR DESCRIPTION
This introduces support for the S3 CSI driver: https://github.com/awslabs/mountpoint-s3-csi-driver

It's disabled by default, but in clusters where it's enabled it will allow creation of PVs pointing to an S3 bucket and mount the PVC between multiple pods which can then write to a volume backed by S3.

It's not configured with an IAM role for the driver, meaning users need to define an iam role on the service account of the pods which will be used for the s3 access: https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/docs/CONFIGURATION.md#pod-level-credentials

This implementation has one caveat in our setup. It relies on the EKS annotation on serviceAccounts: `eks.amazonaws.com/role-arn` as opposed to the one we use today: `iam.amazonaws.com/role`. If the pod needs IAM roles for more than s3 driver access then adding both annotations is a workaround.

The intention is to roll this out to select clusters first and evaluate if this should be a promoted GA feature. It comes with daemonset overhead when enabled.