### PR TITLE
Allow higher memory limit for flannel and kube-proxy

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -402,16 +402,19 @@ node_exporter_experimental_metrics: "false"
 
 # kube-proxy settings
 kube_proxy_cpu: "50m"
-kube_proxy_memory: "200Mi"
+kube_proxy_memory_request: "200Mi"
+kube_proxy_memory_limit: "200Mi"
 kube_proxy_sync_period: "15m0s"
 kube_proxy_verbose_level: "2"
 
 # flannel settings
 flannel_cpu: "25m"
-flannel_memory: "100Mi"
+flannel_memory_request: "100Mi"
+flannel_memory_limit: "100Mi"
 
 flannel_awaiter_cpu: "25m"
-flannel_awaiter_memory: "50Mi"
+flannel_awaiter_memory_request: "50Mi"
+flannel_awaiter_memory_limit: "50Mi"
 
 # nvidia device plugin
 nvidia_device_plugin_cpu: "10m"

--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -44,11 +44,11 @@ spec:
         resources:
           requests:
             cpu: "{{ .Cluster.ConfigItems.flannel_awaiter_cpu }}"
-            memory: "{{ .Cluster.ConfigItems.flannel_awaiter_memory }}"
+            memory: "{{ .Cluster.ConfigItems.flannel_awaiter_memory_request }}"
             ephemeral-storage: 256Mi
           limits:
             cpu: "{{ .Cluster.ConfigItems.flannel_awaiter_cpu }}"
-            memory: "{{ .Cluster.ConfigItems.flannel_awaiter_memory }}"
+            memory: "{{ .Cluster.ConfigItems.flannel_awaiter_memory_limit }}"
         startupProbe:
           exec:
             command:
@@ -78,11 +78,11 @@ spec:
         resources:
           requests:
             cpu: "{{ .Cluster.ConfigItems.flannel_cpu }}"
-            memory: "{{ .Cluster.ConfigItems.flannel_memory }}"
+            memory: "{{ .Cluster.ConfigItems.flannel_memory_request }}"
             ephemeral-storage: 256Mi
           limits:
             cpu: "{{ .Cluster.ConfigItems.flannel_cpu }}"
-            memory: "{{ .Cluster.ConfigItems.flannel_memory }}"
+            memory: "{{ .Cluster.ConfigItems.flannel_memory_limit }}"
         readinessProbe:
           httpGet:
             host: 127.0.0.1

--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -60,11 +60,11 @@ spec:
         resources:
           requests:
             cpu: {{.Cluster.ConfigItems.kube_proxy_cpu}}
-            memory: {{.Cluster.ConfigItems.kube_proxy_memory}}
+            memory: {{.Cluster.ConfigItems.kube_proxy_memory_request}}
             ephemeral-storage: 256Mi
           limits:
             cpu: {{.Cluster.ConfigItems.kube_proxy_cpu}}
-            memory: {{.Cluster.ConfigItems.kube_proxy_memory}}
+            memory: {{.Cluster.ConfigItems.kube_proxy_memory_limit}}
         volumeMounts:
         - name: kube-api-token
           mountPath: /var/run/secrets/kubernetes.io/serviceaccount


### PR DESCRIPTION
This introduces new config-items to control requests and limits of memory for `kube-proxy` and `flannel` independently. The idea behind this is to easy operations of components that scale vertically with the cluster size and let them sometime spike above the requests while still having a limit to prevent complete uncontrolled memory usage.

Apart from this change we also need a change to admission-controller to allow setting this different for daemonset pods in certain namespaces.

([Internal design issue](https://github.bus.zalan.do/teapot/issues/issues/3720
))