### PR TITLE
static-egress upload CF template to s3

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1640,6 +1640,12 @@ Resources:
               - Action: 'ec2:DescribeVpcs'
                 Effect: Allow
                 Resource: '*'
+              - Action:
+                - "s3:PutObject"
+                - "s3:GetObject"
+                - "s3:GetObjectVersion"
+                Effect: Allow
+                Resource: "arn:aws:s3:::cluster-lifecycle-manager-{{accountID .Cluster.InfrastructureAccount}}-{{.Cluster.Region}}/*"
             Version: 2012-10-17
           PolicyName: root
       RoleName: "{{.Cluster.LocalID}}-static-egress-controller"

--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -30,10 +30,11 @@ spec:
       serviceAccountName: kube-static-egress-controller
       containers:
       - name: controller
-        image: container-registry.zalando.net/teapot/kube-static-egress-controller:v0.3.1-master-50
+        image: container-registry.zalando.net/teapot/kube-static-egress-controller:v0.3.2-master-51
         args:
         - "--provider=aws"
         - "--vpc-id={{.Cluster.ConfigItems.vpc_id}}"
+        - "--cf-template-bucket=cluster-lifecycle-manager-{{accountID .Cluster.InfrastructureAccount}}-{{.Cluster.Region}}"
 {{- range $subnet := stupsNATSubnets .Values.vpc_ipv4_cidr }}
         - "--aws-nat-cidr-block={{ $subnet }}"
 {{- end }}


### PR DESCRIPTION
This updates the kube-static-egress-controller to a version that supports passing a s3 bucket for cf template upload when the template is too big for embedding in Cloudformation.

This PR is simply using the existing cluster-lifecycle-manager bucket which is managed by CLM in each account as the place to store the templates. This is also where CLM stores templates for the cluster stacks.
The benefit is that we don't have to handle the lifecycle of the bucket in the egress-controller, the downside is that it's maybe a bit weird to piggy-back on the CLM bucket with this use case.

The alternative is to create a dedicated bucket, but then we need to consider the lifecycle when decommissioning a cluster as the bucket deletion would fail if it's not empty :/

See https://github.com/szuecs/kube-static-egress-controller/pull/56