### PR TITLE
Update kube-ingress-aws-controller v0.15.30

### DIFF
--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -1,4 +1,4 @@
-# {{ $image := "container-registry.zalando.net/teapot/kube-ingress-aws-controller:v0.15.27" }}
+# {{ $image := "container-registry.zalando.net/teapot/kube-ingress-aws-controller:v0.15.30" }}
 # {{ $version := index (split $image ":") 1 }}
 
 apiVersion: apps/v1


### PR DESCRIPTION
+ aws: fail on ListCertificatesPages error (#725)
+ Fix staticcheck warning (#726)
+ Bump docker/login-action from 2 to 3 (#717)
+ Bump github.com/zalando/skipper in the all-go-mod-patch-and-minor gro…
+ Bump actions/setup-go from 2 to 5 (#715)
+ Bump docker/metadata-action from 4 to 5 (#716)
+ Bump docker/setup-qemu-action from 2 to 3 (#719)