### PR TITLE
Enable Zalando AWS IAM e2e test

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -730,8 +730,8 @@ tracing_coredns_local_zone_traces_endpoint: ""
 # AMI id given the image name and the Image AWS account owner.
 #
 # [0]: https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/8a9bd1cb2d094038a9e23e646421f8146b48886a/provisioner/template.go#L116
-kuberuntu_image_v1_31_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.31.0-amd64-master-354" "861068367966" }}
-kuberuntu_image_v1_31_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.31.0-arm64-master-354" "861068367966" }}
+kuberuntu_image_v1_31_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.31.1-amd64-master-357" "861068367966" }}
+kuberuntu_image_v1_31_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.31.1-arm64-master-357" "861068367966" }}
 
 # Which distro from the previous config items should be used. Valid options are only `jammy` for now. Can be set for each node pool.
 kuberuntu_distro_master: "jammy"

--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -205,7 +205,6 @@ if [ "$e2e" = true ]; then
             "Mirror pods should be created for the main Kubernetes components \[Zalando\]"
             "Should audit API calls to create, update, patch, delete pods. \[Audit\] \[Zalando\]"
             "should validate permissions for \[Authorization\] \[RBAC\] \[Zalando\]" # TODO: temporary disabled because feature is missing
-            "Should NOT get AWS IAM credentials \[AWS-IAM\] \[Zalando\]" # TODO: check why this doesn't work
             "Should create DNS entry \[Zalando\]" # TODO: broken because type: LoadBalancer doesn't work
         )
     fi


### PR DESCRIPTION
* Update AMI to a version that correctly sets iptables rules for kube2iam with aws-cni
* Enable the AWS IAM e2e test previously disabled for EKS (kube-aws-iam-controller).
* Add additional e2e test to test kube2iam