### PR TITLE
Exclude *5d.large instances in karpenter

### DIFF
--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -164,6 +164,8 @@ spec:
           operator: "NotIn"
           values:
             - "c5d.large"
+            - "m5d.large"
+            - "r5d.large"
 #{{ else }}
         - key: "node.kubernetes.io/instance-type"
           operator: In


### PR DESCRIPTION
Similar to https://github.com/zalando-incubator/kubernetes-on-aws/pull/6887 add also m and r instance types to be excluded from Karpenter default instance types because they are slow to start with instance storage.

For some reason these instance types are often the first choice on spot so it's common to get these slow to startup nodes in pet clusters which is annoying.