### PR TITLE
skipper: disable setRequestHeaderFromSecret filter

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -121,7 +121,7 @@ skipper_default_filters: 'disableAccessLog(2,3,404,429) -> fifo(2000,20,"1s")'
 # skipper_default_filters_authentication defines filters that implement default request authentication
 skipper_default_filters_authentication: ''
 skipper_default_filters_append: 'stateBagToTag("auth-user", "client.uid")'
-skipper_disabled_filters: "static,bearerinjector"
+skipper_disabled_filters: "static,bearerinjector,setRequestHeaderFromSecret"
 skipper_lua_sources: "file"
 skipper_edit_route_placeholders: ""
 skipper_ingress_inline_routes: ""


### PR DESCRIPTION
It is similar to disabled `bearerinjector`,
see https://github.com/zalando/skipper/blob/master/docs/reference/filters.md#setrequestheaderfromsecret