### PR TITLE
Make kube-node-ready optional

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -484,6 +484,9 @@ kubernetes_lifecycle_metrics_mem_min: "120Mi"
 kube_node_ready_controller_cpu: "50m"
 kube_node_ready_controller_memory: "200Mi"
 
+# Enable kube-node-ready ASG lifecycle hook feature.
+kube_node_ready_enabled: "true"
+
 # Enable deployment of aws-cloud-controller-manager
 aws_cloud_controller_manager_enabled: "true"
 aws_cloud_controller_manager_cpu: "125m"

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -309,3 +309,14 @@ post_apply:
   kind: DaemonSet
   namespace: kube-system
 {{- end }}
+{{- if ne .Cluster.ConfigItems.kube_node_ready_enabled "true" }}
+- name: kube-node-ready
+  kind: DaemonSet
+  namespace: kube-system
+- name: kube-node-ready
+  kind: ServiceAccount
+  namespace: kube-system
+- name: kube-node-ready
+  kind: Service
+  namespace: kube-system
+{{- end }}

--- a/cluster/manifests/kube-node-ready/01-rbac.yaml
+++ b/cluster/manifests/kube-node-ready/01-rbac.yaml
@@ -1,3 +1,4 @@
+# {{ if eq .Cluster.ConfigItems.kube_node_ready_enabled "true" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -5,3 +6,4 @@ metadata:
   namespace: kube-system
   annotations:
     iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-kube-node-ready"
+# {{ end }}

--- a/cluster/manifests/kube-node-ready/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready/daemonset.yaml
@@ -1,3 +1,4 @@
+# {{ if eq .Cluster.ConfigItems.kube_node_ready_enabled "true" }}
 # {{ $image := "container-registry.zalando.net/teapot/kube-node-ready:master-34" }}
 # {{ $version := index (split $image ":") 1 }}
 
@@ -65,3 +66,4 @@ spec:
           runAsUser: 1000
       securityContext:
         fsGroup: 65534
+# {{ end }}

--- a/cluster/manifests/kube-node-ready/service.yaml
+++ b/cluster/manifests/kube-node-ready/service.yaml
@@ -1,3 +1,4 @@
+# {{ if eq .Cluster.ConfigItems.kube_node_ready_enabled "true" }}
 kind: Service
 apiVersion: v1
 metadata:
@@ -16,3 +17,4 @@ spec:
       protocol: TCP
   selector:
     component: kube-node-ready
+# {{ end }}

--- a/cluster/node-pools/worker-combined/stack.yaml
+++ b/cluster/node-pools/worker-combined/stack.yaml
@@ -174,6 +174,7 @@ Resources:
       Roles:
       - !ImportValue '{{ .Cluster.ID }}:worker-iam-role'
     Type: 'AWS::IAM::InstanceProfile'
+# {{ if eq .Cluster.ConfigItems.kube_node_ready_enabled "true" }}
   AutoscalingLifecycleHook:
     Properties:
       AutoScalingGroupName: !Ref AutoScalingGroup
@@ -182,3 +183,4 @@ Resources:
       HeartbeatTimeout: '600'
       LifecycleTransition: 'autoscaling:EC2_INSTANCE_LAUNCHING'
     Type: 'AWS::AutoScaling::LifecycleHook'
+# {{ end }}

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -125,6 +125,7 @@ Resources:
       VPCZoneIdentifier:
         - "{{ index $data.Values.subnets $az }}"
     Type: 'AWS::AutoScaling::AutoScalingGroup'
+# {{ if eq $data.Cluster.ConfigItems.kube_node_ready_enabled "true" }}
   AutoscalingLifecycleHook{{$azID}}:
     Properties:
       AutoScalingGroupName: !Ref AutoScalingGroup{{$azID}}
@@ -133,6 +134,7 @@ Resources:
       HeartbeatTimeout: '600'
       LifecycleTransition: 'autoscaling:EC2_INSTANCE_LAUNCHING'
     Type: 'AWS::AutoScaling::LifecycleHook'
+# {{ end }}
 {{ end }}
 {{ end }}
 {{ end }}


### PR DESCRIPTION
`kube-node-ready` has lost its usefulness for several reasons:

* Karpenter nodes don't run it which is the majority of nodes in most clusters
* `kube-node-ready` was introduced at a time where we had a problem that ASGs could be automatically AZ reblanced, terminating nodes before the replacements had a chance to startup. Having nodes only marked ready in the ASG once the kube-node-ready pod was running slowed this rebalancing down. We no longer have AZ rebalance enabled, so not relevant.
* We used it as a pseudo way to check pod network functionality, but we now have kubenurse which does a better job at this.

This PR introduces a config-item `kube_node_ready_enabled` which lets us disable it. The intention is to first disable in test clusters and later in all clusters.

This is indirectly motivated by switching to IMDSv2 for which `kube-node-ready` is not compatible with.