### PR TITLE
Set AWS_DEFAULT_REGION for kube2iam

### DIFF
--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -45,6 +45,8 @@ spec:
         - --verbose
         - --node=$(NODE_NAME)
         env:
+        - name: AWS_DEFAULT_REGION
+          value: "{{.Cluster.Region}}"
         - name: NODE_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
Follow up to #8427 

Since kube2iam was upgraded to use aws-go-sdk-v2 we need to set `AWS_DEFAULT_REGION` or we get errors like:

```
"Error assuming role operation error EC2: DescribeRegions, failed to resolve service endpoint, endpoint rule error, Invalid Configuration: Missing Region"
```