### PR TITLE
Allow to separate subnets for LBs and nodes

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -63,7 +63,7 @@ Resources:
       Subnets:
   {{ with $values := .Values }}
   {{ range $az := $values.availability_zones }}
-        - "{{ index $values.subnets $az }}"
+        - "{{ index $values.lb_subnets $az }}"
   {{ end }}
   {{ end }}
       Tags:


### PR DESCRIPTION
* [x] Depends on https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/827

Allows to have separate subnets for LBs and for nodes which enables different rules for ingress and egress.

Existing clusters will continue to use the same subnets for both. A migration is needed to split it.