### PR TITLE
Fail nvidia-plugin on initialization error

### DIFF
--- a/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
+++ b/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
@@ -62,7 +62,6 @@ spec:
       - name: nvidia-gpu-device-plugin
         image: container-registry.zalando.net/teapot/nvidia-gpu-device-plugin:v0.16.2-master-14
         args:
-        - --fail-on-init-error=false
         - --pass-device-specs
         resources:
           requests:


### PR DESCRIPTION
We have observed that the plugin can fail at startup like this:

```
Defaulted container "nvidia-gpu-device-plugin" out of: nvidia-gpu-device-plugin, dcgm-exporter
I1023 10:14:11.984927       1 main.go:199] Starting FS watcher.
I1023 10:14:11.985034       1 main.go:206] Starting OS watcher.
I1023 10:14:11.985244       1 main.go:221] Starting Plugins.
I1023 10:14:11.985269       1 main.go:278] Loading configuration.
I1023 10:14:11.986215       1 main.go:303] Updating config with default resource matching patterns.
I1023 10:14:11.986423       1 main.go:314]
Running with config:
{
  "version": "v1",
  "flags": {
    "migStrategy": "none",
    "failOnInitError": false,
    "mpsRoot": "",
    "nvidiaDriverRoot": "/",
    "nvidiaDevRoot": "/",
    "gdsEnabled": false,
    "mofedEnabled": false,
    "useNodeFeatureAPI": null,
    "deviceDiscoveryStrategy": "auto",
    "plugin": {
      "passDeviceSpecs": true,
      "deviceListStrategy": [
        "envvar"
      ],
      "deviceIDStrategy": "uuid",
      "cdiAnnotationPrefix": "cdi.k8s.io/",
      "nvidiaCTKPath": "/usr/bin/nvidia-ctk",
      "containerDriverRoot": "/driver-root"
    }
  },
  "resources": {
    "gpus": [
      {
        "pattern": "*",
        "name": "nvidia.com/gpu"
      }
    ]
  },
  "sharing": {
    "timeSlicing": {}
  }
}
I1023 10:14:11.986441       1 main.go:317] Retrieving plugins.
E1023 10:14:11.996661       1 factory.go:68] Failed to initialize NVML: Unknown Error.
E1023 10:14:11.996689       1 factory.go:69] If this is a GPU node, did you set the docker default runtime to `nvidia`?
E1023 10:14:11.996693       1 factory.go:70] You can check the prerequisites at: https://github.com/NVIDIA/k8s-device-plugin#prerequisites
E1023 10:14:11.996703       1 factory.go:71] You can learn how to set the runtime at: https://github.com/NVIDIA/k8s-device-plugin#quick-start
E1023 10:14:11.996707       1 factory.go:72] If this is not a GPU node, you should set up a toleration or nodeSelector to only deploy this plugin on GPU nodes
W1023 10:14:11.996711       1 factory.go:76] nvml init failed: Unknown Error
I1023 10:14:11.996718       1 main.go:346] No devices found. Waiting indefinitely.
```

In this case it was just stuck not working never marking a GPU node ready. This issue was fixed by deleting the nvidia-device-plugin pod and the replacement worked. Therefore set `fail-on-init-error=true` (default) such that it can auto-recover by restarting the container if it fails initially.