### PR TITLE
Use local endpoint for deployment-controller to status-service

### DIFF
--- a/cluster/manifests/deployment-service/01-config.yaml
+++ b/cluster/manifests/deployment-service/01-config.yaml
@@ -15,6 +15,7 @@ data:
   oidc-subject-key: "{{.Cluster.LocalID}}.{{.Cluster.Alias}}.zalan.do:sub"
   s3-bucket-name: "zalando-deployment-service-{{accountID .Cluster.InfrastructureAccount}}-{{.Cluster.LocalID}}"
   status-service-url: "https://deployment-status-svc-{{.Cluster.Alias}}.{{.Values.hosted_zone}}"
+  status-service-url-local: "http://deployment-status-service.ingress.cluster.local."
   deployment-role-arn: "arn:aws:iam::{{accountID .Cluster.InfrastructureAccount}}:role/{{.Cluster.LocalID}}-deployment-service-deployment"
 {{- if eq .Cluster.ConfigItems.deployment_service_ml_experiments_enabled "true"}}
   ml-experiment-deployment-role-arn: "arn:aws:iam::{{accountID .Cluster.InfrastructureAccount}}:role/{{.Cluster.LocalID}}-deployment-service-ml-experiment-deployment"

--- a/cluster/manifests/deployment-service/controller-statefulset.yaml
+++ b/cluster/manifests/deployment-service/controller-statefulset.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
         - name: "deployment-service-controller"
-          image: "container-registry.zalando.net/teapot/deployment-controller:master-229"
+          image: "container-registry.zalando.net/teapot/deployment-controller:master-230"
           args:
             - "--config-namespace=kube-system"
             - "--decrypt-kms-alias-arn=arn:aws:kms:{{ .Cluster.Region }}:{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:alias/deployment-secret"

--- a/cluster/manifests/deployment-service/status-service-deployment.yaml
+++ b/cluster/manifests/deployment-service/status-service-deployment.yaml
@@ -1,4 +1,4 @@
-# {{ $image   := "container-registry.zalando.net/teapot/deployment-status-service:master-229" }}
+# {{ $image   := "container-registry.zalando.net/teapot/deployment-status-service:master-230" }}
 # {{ $version := index (split $image ":") 1 }}
 
 apiVersion: apps/v1

--- a/cluster/manifests/deployment-service/status-service-ingress.yaml
+++ b/cluster/manifests/deployment-service/status-service-ingress.yaml
@@ -9,6 +9,7 @@ metadata:
 spec:
   hosts:
     - deployment-status-svc-{{ .Cluster.Alias }}.{{ .Values.hosted_zone }}
+    - deployment-status-service.ingress.cluster.local
   backends:
     - name: deployment-service-status-service
       type: service


### PR DESCRIPTION
This adds a cluster local endpoint for status-service-url which can be used by the deployment-controller so it doesn't have to connect via the ingress NLB as illustrated below

![image](https://github.com/user-attachments/assets/5096aab5-eefb-4ea0-aa91-b6e2c1518157)

Before it was using the red path and with this change it communicates internally via the green path.
The `status-service-url` is still kept in the config-map because this is used by the central `deployment-service` to get the public address.