### PR TITLE
add role-sync-controller cronjob

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1155,3 +1155,6 @@ sysctl_settings: ""
 # scheduling_controls
 teapot_admission_controller_scheduling_controls_enabled: "false"
 teapot_admission_controller_scheduling_controls_default_architecture: "amd64"
+
+# role-sync-controller configs
+role_sync_controller_enabled: "false"

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -320,3 +320,15 @@ post_apply:
   kind: Service
   namespace: kube-system
 {{- end }}
+{{- if ne .Cluster.ConfigItems.role_sync_controller_enabled "true" }}
+- name: role-sync-controller
+  kind: CronJob
+  namespace: kube-system
+- name: role-sync-controller
+  kind: ClusterRole
+- name: role-sync-controller
+  kind: ClusterRoleBinding
+- name: role-sync-controller
+  kind: ServiceAccount
+  namespace: kube-system
+{{- end }}

--- a/cluster/manifests/role-sync-controller/cronjob.yaml
+++ b/cluster/manifests/role-sync-controller/cronjob.yaml
@@ -1,0 +1,21 @@
+{{ if .Cluster.ConfigItems.role_sync_controller_enabled "true" }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: role-sync-controller
+  labels:
+    application: kubernetes
+    component: role-sync-controller
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      backoffLimit: 3
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: role-sync-controller
+            image: container-registry.zalando.net/teapot/role-sync-controller:main-1
+            imagePullPolicy: IfNotPresent
+{{ end }}

--- a/cluster/manifests/role-sync-controller/cronjob.yaml
+++ b/cluster/manifests/role-sync-controller/cronjob.yaml
@@ -3,6 +3,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: role-sync-controller
+  namespace: kube-system
   labels:
     application: kubernetes
     component: role-sync-controller
@@ -17,5 +18,4 @@ spec:
           containers:
           - name: role-sync-controller
             image: container-registry.zalando.net/teapot/role-sync-controller:main-1
-            imagePullPolicy: IfNotPresent
 {{ end }}

--- a/cluster/manifests/role-sync-controller/cronjob.yaml
+++ b/cluster/manifests/role-sync-controller/cronjob.yaml
@@ -1,4 +1,4 @@
-{{ if .Cluster.ConfigItems.role_sync_controller_enabled "true" }}
+{{ if eq .Cluster.ConfigItems.role_sync_controller_enabled "true" }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:

--- a/cluster/manifests/role-sync-controller/rbac.yaml
+++ b/cluster/manifests/role-sync-controller/rbac.yaml
@@ -1,4 +1,4 @@
-{{ if .Cluster.ConfigItems.role_sync_controller_enabled "true" }}
+{{ if eq .Cluster.ConfigItems.role_sync_controller_enabled "true" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/cluster/manifests/role-sync-controller/rbac.yaml
+++ b/cluster/manifests/role-sync-controller/rbac.yaml
@@ -1,0 +1,32 @@
+{{ if .Cluster.ConfigItems.role_sync_controller_enabled "true" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: role-sync-controller
+  labels:
+    application: kubernetes
+    component: role-sync-controller
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["rolebindings"]
+  verbs: ["get", "create", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: role-sync-controller
+  labels:
+    application: kubernetes
+    component: role-sync-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: role-sync-controller
+subjects:
+- kind: ServiceAccount
+  name: role-sync-controller
+  namespace: kube-system
+{{ end }}

--- a/cluster/manifests/role-sync-controller/service-account.yaml
+++ b/cluster/manifests/role-sync-controller/service-account.yaml
@@ -1,0 +1,10 @@
+{{ if .Cluster.ConfigItems.role_sync_controller_enabled "true" }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: role-sync-controller
+  namespace: kube-system
+  labels:
+    application: kubernetes
+    component: role-sync-controller
+{{ end }}

--- a/cluster/manifests/role-sync-controller/service-account.yaml
+++ b/cluster/manifests/role-sync-controller/service-account.yaml
@@ -1,4 +1,4 @@
-{{ if .Cluster.ConfigItems.role_sync_controller_enabled "true" }}
+{{ if eq .Cluster.ConfigItems.role_sync_controller_enabled "true" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
This introduces the CronJob we need for RBAC resource synchronisation required by the new RBAC setup to replace the Authz webhook in the api-server.

This is introduced behind a feature flag with the default value of `false`.