### PR TITLE
fix RBAC for role-sync-controller

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -325,8 +325,6 @@ post_apply:
   kind: CronJob
   namespace: kube-system
 - name: role-sync-controller
-  kind: ClusterRole
-- name: role-sync-controller
   kind: ClusterRoleBinding
 - name: role-sync-controller
   kind: ServiceAccount

--- a/cluster/manifests/role-sync-controller/rbac.yaml
+++ b/cluster/manifests/role-sync-controller/rbac.yaml
@@ -1,20 +1,5 @@
 {{ if eq .Cluster.ConfigItems.role_sync_controller_enabled "true" }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: role-sync-controller
-  labels:
-    application: kubernetes
-    component: role-sync-controller
-rules:
-- apiGroups: [""]
-  resources: ["namespaces"]
-  verbs: ["list"]
-- apiGroups: ["rbac.authorization.k8s.io"]
-  resources: ["rolebindings"]
-  verbs: ["get", "create", "update"]
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: role-sync-controller
@@ -24,7 +9,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: role-sync-controller
+  name: poweruser
 subjects:
 - kind: ServiceAccount
   name: role-sync-controller


### PR DESCRIPTION
The CronJob itself needs `poweruser` role to be able to bind the role to `okta:common/engineer`.

I deleted the `deletions.yaml` entry as well since we haven't rolled the feature out yet, so there are no `ClusterRoles` in place.