### PR TITLE
Register `/rolebinding` admitter in order to reject certain rolebindings

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -674,6 +674,9 @@ teapot_admission_controller_configmap_deletion_protection_enabled: "true"
 teapot_admission_controller_configmap_deletion_protection_factories_enabled: "true"
 {{end}}
 
+# enable the rolebinding admission-controller webhook which validates rolebindings and clusterrolebindings
+teapot_admission_controller_enable_rolebinding_webhook: "true"
+
 # Enable and configure Pod Security Policy rules implemented in admission-controller.
 teapot_admission_controller_pod_security_policy_enabled: "true"
 

--- a/cluster/manifests/01-admission-control/teapot.yaml
+++ b/cluster/manifests/01-admission-control/teapot.yaml
@@ -252,3 +252,16 @@ webhooks:
         apiGroups: [""]
         apiVersions: ["v1"]
         resources: ["services"]
+  - name: rolebinding-admitter.teapot.zalan.do
+    clientConfig:
+      url: "https://localhost:8085/rolebinding"
+      caBundle: "{{ .Cluster.ConfigItems.ca_cert_decompressed }}"
+    admissionReviewVersions: ["v1beta1"]
+    failurePolicy: Fail
+    sideEffects: "NoneOnDryRun"
+    matchPolicy: Equivalent
+    rules:
+      - operations: [ "CREATE", "UPDATE" ]
+        apiGroups: ["rbac.authorization.k8s.io"]
+        apiVersions: ["v1"]
+        resources: ["rolebindings", "clusterrolebindings"]

--- a/cluster/manifests/01-admission-control/teapot.yaml
+++ b/cluster/manifests/01-admission-control/teapot.yaml
@@ -252,6 +252,7 @@ webhooks:
         apiGroups: [""]
         apiVersions: ["v1"]
         resources: ["services"]
+{{- if eq .Cluster.ConfigItems.teapot_admission_controller_enable_rolebinding_webhook "true" }}
   - name: rolebinding-admitter.teapot.zalan.do
     clientConfig:
       url: "https://localhost:8085/rolebinding"
@@ -265,3 +266,4 @@ webhooks:
         apiGroups: ["rbac.authorization.k8s.io"]
         apiVersions: ["v1"]
         resources: ["rolebindings", "clusterrolebindings"]
+{{- end }}


### PR DESCRIPTION
This will catch creations and updates of `rolebindings` and `clusterrolebindings` so that they can be inspected by admission-controller and rejected in certain cases.