### PR TITLE
Optional internal control plane LB

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -52,6 +52,78 @@ Resources:
           Value: owned
       ToPort: 10250
     Type: 'AWS::EC2::SecurityGroupIngress'
+{{- if or (eq .Cluster.ConfigItems.control_plane_load_balancer_internal "pre") (eq .Cluster.ConfigItems.control_plane_load_balancer_internal "serving") (eq .Cluster.ConfigItems.control_plane_load_balancer_internal "active") }}
+  ControlPlaneInternalLB:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: "{{.Cluster.LocalID}}-nlb-internal"
+      LoadBalancerAttributes:
+        - Key: load_balancing.cross_zone.enabled
+          Value: true
+      Scheme: internal
+      Subnets:
+  {{ with $values := .Values }}
+  {{ range $az := $values.availability_zones }}
+        - "{{ index $values.lb_subnets $az }}"
+  {{ end }}
+  {{ end }}
+      Tags:
+        - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
+          Value: owned
+        - Key: "component"
+          Value: "kube-apiserver"
+      Type: network
+  ControlPlaneInternalLBTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckIntervalSeconds: 10
+      HealthCheckPort: 8443
+      HealthCheckProtocol: HTTPS
+      HealthCheckPath: "/readyz"
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 2
+      Name: "{{.Cluster.LocalID}}-nlb-internal"
+      Port: 8443
+      Protocol: TLS
+      Tags:
+        - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
+          Value: owned
+        - Key: "component"
+          Value: "kube-apiserver"
+      VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
+      TargetGroupAttributes:
+        - Key: deregistration_delay.timeout_seconds
+          Value: 60
+        - Key: preserve_client_ip.enabled
+          Value: "false"
+  ControlPlaneInternalLBListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      AlpnPolicy:
+        - {{ if eq .Cluster.ConfigItems.experimental_nlb_alpn_h2_enabled "true" }}HTTP2Preferred{{else}}None{{end}}
+      SslPolicy: "ELBSecurityPolicy-TLS-1-2-2017-01"
+      Certificates:
+        - CertificateArn: "{{.Values.load_balancer_certificate}}"
+      DefaultActions:
+      - Type: forward
+        TargetGroupArn: !Ref ControlPlaneInternalLBTargetGroup
+      LoadBalancerArn: !Ref ControlPlaneInternalLB
+      Port: 443
+      Protocol: TLS
+  ControlPlaneInternalLBVersionDomain:
+    Properties:
+      AliasTarget:
+        DNSName: !GetAtt
+          - ControlPlaneInternalLB
+          - DNSName
+        HostedZoneId: !GetAtt
+          - ControlPlaneInternalLB
+          - CanonicalHostedZoneID
+      HostedZoneName: "{{.Values.hosted_zone}}."
+      Name: "{{.Cluster.LocalID}}-internal.{{.Values.hosted_zone}}."
+      Type: A
+    Type: 'AWS::Route53::RecordSet'
+{{- end  }}
   MasterLoadBalancerNLB:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
@@ -2503,6 +2575,12 @@ Outputs:
     Export:
       Name: '{{.Cluster.ID}}:master-load-balancer-nlb-target-group'
     Value: !Ref MasterLoadBalancerNLBTargetGroup
+{{- if or (eq .Cluster.ConfigItems.control_plane_load_balancer_internal "pre") (eq .Cluster.ConfigItems.control_plane_load_balancer_internal "serving") (eq .Cluster.ConfigItems.control_plane_load_balancer_internal "active") }}
+  ControlPlaneInternalLBTargetGroup:
+    Export:
+      Name: '{{.Cluster.ID}}:control-plane-internal-lb-target-group'
+    Value: !Ref ControlPlaneInternalLBTargetGroup
+{{- end }}
   MasterSecurityGroup:
     Export:
       Name: '{{.Cluster.ID}}:master-security-group'

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1136,6 +1136,18 @@ control_plane_asg_lifecycle_hook: "false"
 # enable graceful shutdown on the control_plane nodes
 control_plane_graceful_shutdown: "true"
 
+# Optionally enable an internal load balancer for the control plane nodes
+# additionally to the public load balancer.
+#
+# Possible values:
+# none - Load Balancer is not created
+# pre - Load Balancer is created but not attached to control plane nodes
+# serving - Load Balancer is created and attached to control plane nodes.
+# active - Load Balancer is being actively used by worker nodes.
+#
+# For rolling back it needs to be done in multiple stages: active -> serving -> pre -> none
+control_plane_load_balancer_internal: "none"
+
 # This allows setting custom sysctl settings. The config-item is intended to be
 # used on node-pools rather being set globally.
 #

--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -44,6 +44,9 @@ Resources:
 {{ end }}
       TargetGroupARNs:
       - !ImportValue '{{ .Cluster.ID }}:master-load-balancer-nlb-target-group'
+{{- if or (eq .Cluster.ConfigItems.control_plane_load_balancer_internal "serving") (eq .Cluster.ConfigItems.control_plane_load_balancer_internal "active") }}
+      - !ImportValue '{{ .Cluster.ID }}:control-plane-internal-lb-target-group'
+{{- end}}
     Type: 'AWS::AutoScaling::AutoScalingGroup'
   LaunchTemplate:
     Properties:

--- a/cluster/node-pools/worker-splitaz/userdata.yaml
+++ b/cluster/node-pools/worker-splitaz/userdata.yaml
@@ -34,7 +34,11 @@ write_files:
       clusters:
       - name: local
         cluster:
+{{- if eq .Cluster.ConfigItems.control_plane_load_balancer_internal "active" }}
+          server: "https://{{.Cluster.LocalID}}-internal.{{.Values.hosted_zone}}"
+{{- else }}
           server: {{ .Cluster.APIServerURL }}
+{{- end }}
       users:
       - name: kubelet
         user:


### PR DESCRIPTION
This adds optional support for adding an internal Load balancer for the control plane nodes. That is, it will allow workers to connect to the control plane inside the VPC and not go through the public LB used by external users. This is illustrated in the diagram below:

![image](https://github.com/user-attachments/assets/2ba9d5e6-b853-49b1-88e1-d85c1415175e)

This is helpful if the cluster/account has custom egress routing to the internet which doesn't work well if something inside the VPC calls an NLB in the VPC via the internet.

The feature is controller via the config-item: `control_plane_load_balancer_internal` and is disabled by default.