### PR TITLE
Dummy PR to test RoleBinding admitter during cluster creation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,5 @@
+Dummy trigger
+
 =================
 Kubernetes on AWS
 =================


### PR DESCRIPTION
Follow up for https://github.com/zalando-incubator/kubernetes-on-aws/pull/8504

This tests that the new rolebinding admitter doesn't interfere with cluster creation.