### PR TITLE
update deployment-service components

### DIFF
--- a/cluster/manifests/deployment-service/controller-statefulset.yaml
+++ b/cluster/manifests/deployment-service/controller-statefulset.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
         - name: "deployment-service-controller"
-          image: "container-registry.zalando.net/teapot/deployment-controller:master-230"
+          image: "container-registry.zalando.net/teapot/deployment-controller:master-232"
           args:
             - "--config-namespace=kube-system"
             - "--decrypt-kms-alias-arn=arn:aws:kms:{{ .Cluster.Region }}:{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:alias/deployment-secret"

--- a/cluster/manifests/deployment-service/status-service-deployment.yaml
+++ b/cluster/manifests/deployment-service/status-service-deployment.yaml
@@ -1,4 +1,4 @@
-# {{ $image   := "container-registry.zalando.net/teapot/deployment-status-service:master-230" }}
+# {{ $image   := "container-registry.zalando.net/teapot/deployment-status-service:master-232" }}
 # {{ $version := index (split $image ":") 1 }}
 
 apiVersion: apps/v1


### PR DESCRIPTION
Updating it manually as both automated PRs have conflicts, we can just close them.

This fixes the issue where cluster scoped resources have a namespace assigned to them in the deployment-service.