### PR TITLE
Add config item to require FabricGateway versioning

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -366,6 +366,7 @@ fabric_gateway_controller_memory: "150Mi"
 fabric_gateway_controller_allow_all_filters: "false"
 fabric_gateway_controller_snapshots_history_limit: "3"
 fabric_gateway_controller_enable_versioning: "true"
+fabric_gateway_controller_require_versioning: "false"
 fabric_gateway_controller_ssl_policy: ""
 fabric_gateway_controller_log_level: "INFO"
 

--- a/cluster/manifests/fabric-gateway/fabricgateway_crd.yaml
+++ b/cluster/manifests/fabric-gateway/fabricgateway_crd.yaml
@@ -464,6 +464,9 @@ spec:
                 required:
                 - hosts
                 - stackSetName
+                {{ if eq .Cluster.ConfigItems.fabric_gateway_controller_require_versioning "true" }}
+                - stackVersion
+                {{ end }}
                 type: object
               x-fabric-admins:
                 description: |-


### PR DESCRIPTION
The versioned FabricGateway is tested enough to be sure it is safe to use for newly created FabricGateway's with external service provider. So this config item is introduced to eventually require such FabricGateway versioning on all clusters.