### PR TITLE
Register generic admitter for write protection behind a feature flag

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -677,6 +677,11 @@ teapot_admission_controller_configmap_deletion_protection_factories_enabled: "tr
 # enable the rolebinding admission-controller webhook which validates rolebindings and clusterrolebindings
 teapot_admission_controller_enable_rolebinding_webhook: "true"
 
+# enable the generic admission-controller webhook which catches all resources
+teapot_admission_controller_enable_generic_webhook: "false"
+# prevent write operations for non-admin users in protected namespaces
+teapot_admission_controller_prevent_write_operations: "false"
+
 # Enable and configure Pod Security Policy rules implemented in admission-controller.
 teapot_admission_controller_pod_security_policy_enabled: "true"
 

--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -12,6 +12,8 @@ data:
 
   dns.default.subdomain-max-length: "{{ .Cluster.ConfigItems.subdomain_max_length }}"
 
+  generic.prevent-write-operations.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_prevent_write_operations }}"
+
   pod.container-resource-control.min-memory-request: "25Mi"
   pod.container-resource-control.default-cpu-request: "{{ .Cluster.ConfigItems.teapot_admission_controller_default_cpu_request }}"
   pod.container-resource-control.default-memory-request: "{{ .Cluster.ConfigItems.teapot_admission_controller_default_memory_request }}"

--- a/cluster/manifests/01-admission-control/teapot.yaml
+++ b/cluster/manifests/01-admission-control/teapot.yaml
@@ -267,3 +267,41 @@ webhooks:
         apiVersions: ["v1"]
         resources: ["rolebindings", "clusterrolebindings"]
 {{- end }}
+{{- if eq .Cluster.ConfigItems.teapot_admission_controller_enable_generic_webhook "true" }}
+  - name: generic-namespaced-admitter.teapot.zalan.do
+    clientConfig:
+      url: "https://localhost:8085/generic"
+      caBundle: "{{ .Cluster.ConfigItems.ca_cert_decompressed }}"
+    admissionReviewVersions: ["v1beta1"]
+    failurePolicy: Fail
+    sideEffects: "NoneOnDryRun"
+    matchPolicy: Equivalent
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values: [ "kube-system", "visibility", "kubenurse" ]
+    rules:
+      - operations: [ "*" ]
+        apiGroups: ["*"]
+        apiVersions: ["*"]
+        resources: ["*/*"]
+        scope: "Namespaced"
+  - name: generic-cluster-admitter.teapot.zalan.do
+    clientConfig:
+      url: "https://localhost:8085/generic"
+      caBundle: "{{ .Cluster.ConfigItems.ca_cert_decompressed }}"
+    admissionReviewVersions: ["v1beta1"]
+    failurePolicy: Fail
+    sideEffects: "NoneOnDryRun"
+    matchPolicy: Equivalent
+    objectSelector:
+      matchLabels:
+        admission.zalando.org/infrastructure-component: "true"
+    rules:
+      - operations: [ "*" ]
+        apiGroups: ["*"]
+        apiVersions: ["*"]
+        resources: ["*/*"]
+        scope: "Cluster"
+{{- end }}

--- a/cluster/manifests/prometheus/rbac.yaml
+++ b/cluster/manifests/prometheus/rbac.yaml
@@ -8,6 +8,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: prometheus
+  labels:
+    admission.zalando.org/infrastructure-component: "true"
 rules:
 - apiGroups: [""]
   resources:
@@ -37,6 +39,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus
+  labels:
+    admission.zalando.org/infrastructure-component: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -206,7 +206,7 @@ write_files:
             limits:
               memory: {{ .Values.InstanceInfo.MemoryFraction (parseInt64 .Cluster.ConfigItems.apiserver_memory_limit_percent)}}
 {{- end }}
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-222
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-224
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
This is the same as https://github.com/zalando-incubator/kubernetes-on-aws/pull/8517 for dev (there are little conflicts that I'll fix in the `dev-to-eks` merge)

This supercedes https://github.com/zalando-incubator/kubernetes-on-aws/pull/8518

The goal is to deploy the latest version of admission-controller in dev, so that we have an up-to-date version. The new features are entirely turned off so **this is a no-op**.