### PR TITLE
make kube-janitor opt-in for production clusters

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1170,7 +1170,13 @@ control_plane_load_balancer_internal: "none"
 #  fs.inotify.max_user_watches = 100000
 sysctl_settings: ""
 
-
+# kube-janitor configuration
+{{if eq .Cluster.Environment "production"}}
+# This makes kube-janitor opt-in for production clusters
+kube_janitor_enabled: "false"
+{{else}}
+kube_janitor_enabled: "true"
+{{end}}
 
 # scheduling_controls
 teapot_admission_controller_scheduling_controls_enabled: "false"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1173,6 +1173,17 @@ sysctl_settings: ""
 # kube-janitor configuration
 {{if eq .Cluster.Environment "production"}}
 # This makes kube-janitor opt-in for production clusters
+
+# IMPORTANT:
+# Please note that before enabling kube-janitor for a production cluster, you
+# must ensure that no existing resources should be annotated with a TTL.
+# This can happen in the case where a test deployment is deployed to production
+# as is. Currently, it's a no-op since kube-janitor doesn't run in production.
+# 
+# This is needed until we can implement namespace prefix matching to reduce
+# the scope of kube-janitor to a set of namespace names that aren't known
+# at the time of enaling kube-janitor. Once the feature is in place, it would
+# be easier to limit the scope.
 kube_janitor_enabled: "false"
 {{else}}
 kube_janitor_enabled: "true"

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -330,3 +330,21 @@ post_apply:
   kind: ServiceAccount
   namespace: kube-system
 {{- end }}
+{{- if ne .Cluster.ConfigItems.kube_janitor_enabled "true" }}
+- name: kube-janitor
+  kind: Deployment
+  namespace: kube-system
+- name: kube-janitor
+  kind: ConfigMap
+  namespace: kube-system
+- name: kube-janitor
+  kind: VerticalPodAutoscaler
+  namespace: kube-system
+- name: kube-janitor
+  kind: ServiceAccount
+  namespace: kube-system
+- name: kube-janitor
+  kind: ClusterRole
+- name: kube-janitor
+  kind: ClusterRoleBinding
+{{- end }}

--- a/cluster/manifests/kube-janitor/deployment.yaml
+++ b/cluster/manifests/kube-janitor/deployment.yaml
@@ -1,4 +1,4 @@
-# {{ if ne .Cluster.Environment "production" }}
+# {{ if eq .Cluster.ConfigItems "kube_janitor_enabled" "true" }}
 # {{ $image := "container-registry.zalando.net/teapot/kube-janitor:23.7.0-main-2" }}
 # {{ $version := index (split (index (split $image ":") 1) "-") 0 }}
 apiVersion: apps/v1

--- a/cluster/manifests/kube-janitor/deployment.yaml
+++ b/cluster/manifests/kube-janitor/deployment.yaml
@@ -1,4 +1,4 @@
-# {{ if eq .Cluster.ConfigItems "kube_janitor_enabled" "true" }}
+# {{ if eq .Cluster.ConfigItems.kube_janitor_enabled "true" }}
 # {{ $image := "container-registry.zalando.net/teapot/kube-janitor:23.7.0-main-2" }}
 # {{ $version := index (split (index (split $image ":") 1) "-") 0 }}
 apiVersion: apps/v1

--- a/cluster/manifests/kube-janitor/rbac.yaml
+++ b/cluster/manifests/kube-janitor/rbac.yaml
@@ -1,4 +1,4 @@
-{{ if ne .Cluster.Environment "production" }}
+{{ if eq .Cluster.ConfigItems "kube_janitor_enabled" "true" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/cluster/manifests/kube-janitor/rbac.yaml
+++ b/cluster/manifests/kube-janitor/rbac.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Cluster.ConfigItems "kube_janitor_enabled" "true" }}
+{{ if eq .Cluster.ConfigItems.kube_janitor_enabled "true" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/cluster/manifests/kube-janitor/rules-config.yaml
+++ b/cluster/manifests/kube-janitor/rules-config.yaml
@@ -1,4 +1,4 @@
-# {{ if eq .Cluster.ConfigItems "kube_janitor_enabled" "true" }}
+# {{ if eq .Cluster.ConfigItems.kube_janitor_enabled "true" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cluster/manifests/kube-janitor/rules-config.yaml
+++ b/cluster/manifests/kube-janitor/rules-config.yaml
@@ -1,4 +1,4 @@
-# {{ if ne .Cluster.Environment "production" }}
+# {{ if eq .Cluster.ConfigItems "kube_janitor_enabled" "true" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cluster/manifests/kube-janitor/vpa.yaml
+++ b/cluster/manifests/kube-janitor/vpa.yaml
@@ -1,4 +1,4 @@
-{{ if ne .Cluster.Environment "production" }}
+{{ if eq .Cluster.ConfigItems "kube_janitor_enabled" "true" }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:

--- a/cluster/manifests/kube-janitor/vpa.yaml
+++ b/cluster/manifests/kube-janitor/vpa.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Cluster.ConfigItems "kube_janitor_enabled" "true" }}
+{{ if eq .Cluster.ConfigItems.kube_janitor_enabled "true" }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:


### PR DESCRIPTION
This is required to address some support requests where we need to enable kube-janitor in some production clusters. This keeps the default behavior intact, so it's a no-op.

In a follow-up, we probably need to expose some kube-janitor configuration as config-items as well, to better control its behavior per-cluster.