### PR TITLE
Add config items to control enabling network policies

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1180,12 +1180,16 @@ role_sync_controller_enabled: "false"
 eks: "false"
 eks_control_plane_logging: "false"
 eks_ip_family: "ipv4"
-# prefix delegation can only be configured for ipv4. For ipv6 it can only be
-# true.
-aws_vpc_cni_prefix_delegation: "true"
 eks_zalando_iam_aws_proxy_cpu: "100m"
 eks_zalando_iam_aws_proxy_memory: "512Mi"
 eks_zalando_iam_aws_proxy_hpa_max_replicas: "10"
 eks_zalando_iam_aws_proxy_hpa_cpu_target: "80"
 eks_zalando_iam_aws_proxy_hpa_memory_target: "80"
 eks_okta_identity_provider: "true"
+
+# prefix delegation can only be configured for ipv4. For ipv6 it can only be true.
+aws_vpc_cni_prefix_delegation: "true"
+# enable network policy enforcement in the cluster.
+aws_vpc_cni_enable_network_policy: "false"
+# specify the network policy enforcement mode.
+aws_vpc_cni_network_policy_enforcing_mode: "standard"

--- a/cluster/manifests/01-aws-node/config.yaml
+++ b/cluster/manifests/01-aws-node/config.yaml
@@ -1,0 +1,12 @@
+{{- if eq .Cluster.Provider "zalando-eks" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: amazon-vpc-cni
+  namespace: kube-system
+  labels:
+    application: kubernetes
+    component: aws-node
+data:
+  enable-network-policy-controller: "{{.Cluster.ConfigItems.aws_vpc_cni_enable_network_policy}}"
+{{- end }}

--- a/cluster/manifests/01-aws-node/daemonset.yaml
+++ b/cluster/manifests/01-aws-node/daemonset.yaml
@@ -87,7 +87,7 @@ spec:
         - name: ENABLE_SUBNET_DISCOVERY
           value: "true"
         - name: NETWORK_POLICY_ENFORCING_MODE
-          value: standard
+          value: "{{.Cluster.ConfigItems.aws_vpc_cni_network_policy_enforcing_mode}}"
         - name: VPC_CNI_VERSION
           value: v1.18.1
         - name: VPC_ID
@@ -161,7 +161,7 @@ spec:
           name: xtables-lock
       - args:
         - --enable-ipv6={{ if eq .Cluster.ConfigItems.eks_ip_family "ipv4" }}false{{else}}true{{end}}
-        - --enable-network-policy=false
+        - --enable-network-policy={{.Cluster.ConfigItems.aws_vpc_cni_enable_network_policy}}
         - --enable-cloudwatch-logs=false
         - --enable-policy-event-logs=false
         - --metrics-bind-addr=:8162


### PR DESCRIPTION
This adds the relevant config items to control the enablement of the network policy feature in our self-managed VPC CNI addon.