### PR TITLE
[EKS] switch to generic deny-all admitter, match conditions and fail policy

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -677,9 +677,9 @@ teapot_admission_controller_configmap_deletion_protection_factories_enabled: "tr
 # enable the rolebinding admission-controller webhook which validates rolebindings and clusterrolebindings
 teapot_admission_controller_enable_rolebinding_webhook: "true"
 
-# enable the generic admission-controller webhook which catches all resources
-teapot_admission_controller_enable_generic_webhook: "true"
-# prevent write operations for non-admin users in protected namespaces
+# enable the generic deny-all admission webhook which rejects all requests it receives
+teapot_admission_controller_enable_write_protection_webhook: "true"
+# configure the behaviour of the deny-all admission webhook, `true` blocks everything, `false` allows everything
 teapot_admission_controller_prevent_write_operations: "true"
 
 # Enable and configure Pod Security Policy rules implemented in admission-controller.

--- a/cluster/manifests/02-admission-control/deployment.yaml
+++ b/cluster/manifests/02-admission-control/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
       - name: admission-controller
-        image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-225
+        image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-226
         lifecycle:
           preStop:
             exec:

--- a/cluster/manifests/02-admission-control/teapot.yaml
+++ b/cluster/manifests/02-admission-control/teapot.yaml
@@ -480,21 +480,20 @@ webhooks:
         apiVersions: ["v1"]
         resources: ["rolebindings", "clusterrolebindings"]
 {{- end }}
-{{- if eq .Cluster.ConfigItems.teapot_admission_controller_enable_generic_webhook "true" }}
-  - name: generic-namespaced-admitter.teapot.zalan.do
+{{- if eq .Cluster.ConfigItems.teapot_admission_controller_enable_write_protection_webhook "true" }}
+  - name: namespaced-deny-admitter.teapot.zalan.do
     clientConfig:
       {{- if eq .Cluster.Provider "zalando-eks"}}
       service:
         name: "admission-controller"
         namespace: "kube-system"
-        path: "/generic"
+        path: "/deny"
       {{- else }}
-      url: "https://localhost:8085/generic"
+      url: "https://localhost:8085/deny"
       {{- end }}
       caBundle: "{{ .Cluster.ConfigItems.ca_cert_decompressed }}"
     admissionReviewVersions: ["v1beta1"]
-    # TODO: Switch back to Fail once we have solved the chicken and egg problem
-    failurePolicy: Ignore # Fail
+    failurePolicy: Fail
     sideEffects: "NoneOnDryRun"
     matchPolicy: Equivalent
     namespaceSelector:
@@ -502,29 +501,28 @@ webhooks:
         - key: kubernetes.io/metadata.name
           operator: In
           values: [ "kube-system", "visibility", "kubenurse" ]
-    {{- if eq .Cluster.Provider "zalando-eks"}}
-    # avoid admission-control applying to the admission-controller components (🐔🥚)
-    objectSelector:
-      matchExpressions:
-        - key: component
-          operator: NotIn
-          values: ["admission-controller"]
-    {{- end }}
     rules:
       - operations: [ "*" ]
         apiGroups: ["*"]
         apiVersions: ["*"]
         resources: ["*/*"]
         scope: "Namespaced"
-  - name: generic-cluster-admitter.teapot.zalan.do
+    matchConditions:
+      - name: 'exclude-privileged-groups'
+        expression: 'request.userInfo.groups.all(g, !(g in ["system:masters", "system:nodes", "system:serviceaccounts:kube-system", "okta:common/administrator", "zalando:administrator"]))'
+      - name: 'exclude-privileged-usernames'
+        expression: '!(request.userInfo.username in ["system:kube-controller-manager", "system:kube-scheduler", "zalando-iam:zalando:service:k8sapi_credentials-provider"])'
+      - name: 'exclude-eks-components'
+        expression: '!request.userInfo.username.startsWith("eks:")'
+  - name: global-deny-admitter.teapot.zalan.do
     clientConfig:
       {{- if eq .Cluster.Provider "zalando-eks"}}
       service:
         name: "admission-controller"
         namespace: "kube-system"
-        path: "/generic"
+        path: "/deny"
       {{- else }}
-      url: "https://localhost:8085/generic"
+      url: "https://localhost:8085/deny"
       {{- end }}
       caBundle: "{{ .Cluster.ConfigItems.ca_cert_decompressed }}"
     admissionReviewVersions: ["v1beta1"]
@@ -534,17 +532,17 @@ webhooks:
     objectSelector:
       matchLabels:
         admission.zalando.org/infrastructure-component: "true"
-      {{- if eq .Cluster.Provider "zalando-eks"}}
-      # avoid admission-control applying to the admission-controller components (🐔🥚)
-      matchExpressions:
-        - key: component
-          operator: NotIn
-          values: ["admission-controller"]
-      {{- end }}
     rules:
       - operations: [ "*" ]
         apiGroups: ["*"]
         apiVersions: ["*"]
         resources: ["*/*"]
         scope: "Cluster"
+    matchConditions:
+      - name: 'exclude-privileged-groups'
+        expression: 'request.userInfo.groups.all(g, !(g in ["system:masters", "system:nodes", "system:serviceaccounts:kube-system", "okta:common/administrator", "zalando:administrator"]))'
+      - name: 'exclude-privileged-usernames'
+        expression: '!(request.userInfo.username in ["system:kube-controller-manager", "system:kube-scheduler", "zalando-iam:zalando:service:k8sapi_credentials-provider"])'
+      - name: 'exclude-eks-components'
+        expression: '!request.userInfo.username.startsWith("eks:")'
 {{- end }}


### PR DESCRIPTION
Using `matchConditions` we can prevent the webhooks from being called for privileged components in the first place. This should solve the chicken and egg problem.