### PR TITLE
Drop unused eks config-item

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1196,7 +1196,7 @@ teapot_admission_controller_scheduling_controls_default_architecture: "amd64"
 # role-sync-controller configs
 role_sync_controller_enabled: "false"
 
-eks: "false"
+# EKS specific configuration
 eks_control_plane_logging: "false"
 eks_ip_family: "ipv4"
 eks_zalando_iam_aws_proxy_cpu: "100m"


### PR DESCRIPTION
Drops the unused `eks` config-item which we no longer use as we use `.Cluster.Provider == "zalando-eks"` to enable EKS specific configuration.