### PR TITLE
[e2e] Improvements on the RBAC e2es

### DIFF
--- a/test/e2e/authorization.go
+++ b/test/e2e/authorization.go
@@ -207,10 +207,18 @@ var _ = g.Describe("Authorization [RBAC] [Zalando]", func() {
 				tc.data.resources = namespacedResources
 				tc.data.verbs = writeOperations
 			})
-			// These should be covered by the admission-controller tests.
-			// They're written here for completeness.
-			g.It("should deny write access in kube-system and visibility namespaces", func() {})
-			g.It("should allow write access in namespaces other than kube-system and visibility", func() {})
+			// These should be covered by the admission-controller tests. They will
+			// be skipped here. Later when we cover everything with RBAC, we can run them again.
+			g.It("should deny write access in kube-system and visibility namespaces", func() {
+				tc.data.namespaces = []string{"kube-system", "visibility"}
+				tc.run(context.TODO(), cs, false)
+				gomega.Expect(tc.output.passed).To(gomega.BeTrue(), tc.output.String())
+			})
+			g.It("should allow write access in namespaces other than kube-system and visibility", func() {
+				tc.data.namespaces = []string{"", "teapot"}
+				tc.run(context.TODO(), cs, true)
+				gomega.Expect(tc.output.passed).To(gomega.BeTrue(), tc.output.String())
+			})
 		})
 		g.When("the resource is a global resource", func() {
 			g.BeforeEach(func() {
@@ -279,6 +287,8 @@ var _ = g.Describe("Authorization [RBAC] [Zalando]", func() {
 			tc.run(context.TODO(), cs, true)
 			gomega.Expect(tc.output.passed).To(gomega.BeTrue(), tc.output.String())
 		})
+		// This should be covered by the admission-controller tests. It will
+		// be skipped here. Later when we cover everything with RBAC, we can run it again.
 		g.It("should deny deletion of kube-system or visibility namespaces", func() {
 			tc.data.resources = []string{"namespaces"}
 			tc.data.names = []string{"kube-system", "visibility"}
@@ -292,9 +302,13 @@ var _ = g.Describe("Authorization [RBAC] [Zalando]", func() {
 				tc.data.resources = namespacedResources
 				tc.data.verbs = writeOperations
 			})
-			// This should be covered by the admission-controller tests.
-			// It's written here for completeness.
-			g.It("should deny write access in kube-system namespace", func() {})
+			// This should be covered by the admission-controller tests. It will
+			// be skipped here. Later when we cover everything with RBAC, we can run it again.
+			g.It("should deny write access in kube-system namespace", func() {
+				tc.data.namespaces = []string{"kube-system"}
+				tc.run(context.TODO(), cs, false)
+				gomega.Expect(tc.output.passed).To(gomega.BeTrue(), tc.output.String())
+			})
 			g.It("should allow write access in namespaces other than kube-system", func() {
 				tc.data.namespaces = []string{"", "teapot"}
 				tc.run(context.TODO(), cs, true)

--- a/test/e2e/authorization.go
+++ b/test/e2e/authorization.go
@@ -503,6 +503,11 @@ var _ = g.Describe("Authorization [RBAC] [Zalando]", func() {
 					tc.run(context.TODO(), cs, true)
 					gomega.Expect(tc.output.passed).To(gomega.BeTrue(), tc.output.String())
 				})
+				g.It("should allow write access", func() {
+					tc.data.verbs = writeOperations
+					tc.run(context.TODO(), cs, true)
+					gomega.Expect(tc.output.passed).To(gomega.BeTrue(), tc.output.String())
+				})
 			})
 
 			g.When("the resource is not a Secret", func() {

--- a/test/e2e/authorization.go
+++ b/test/e2e/authorization.go
@@ -32,7 +32,6 @@ var (
 		"apps/deployments/scale",
 		"apps/statefulsets/scale",
 		"services",
-		"persistentvolumes",
 		"persistentvolumeclaims",
 		"configmaps",
 	}
@@ -42,6 +41,7 @@ var (
 		"namespaces",
 		"rbac.authorization.k8s.io/clusterroles",
 		"storage.k8s.io/storageclasses",
+		"storage.k8s.io/persistentvolumes",
 		"apiextensions.k8s.io/customresourcedefinitions",
 	}
 	// a slice of "get", "list", "watch" verbs
@@ -54,11 +54,11 @@ var (
 	allOperations = append(readOperations, writeOperations...)
 
 	// a slice representing all namespaces with respect to the test cases
-	// "" represents the default namespace
+	// "default" is the default namespace
 	// "teapot" is a random namespace
 	// "visibility" is a namespace where collaborators will have access
 	// "kube-system" is a namespace where only administrators will have access
-	allNamespaces = []string{"", "teapot", "visibility", "kube-system"}
+	allNamespaces = []string{"default", "teapot", "visibility", "kube-system"}
 )
 
 var _ = g.Describe("Authorization [RBAC] [Zalando]", func() {
@@ -226,7 +226,7 @@ var _ = g.Describe("Authorization [RBAC] [Zalando]", func() {
 				gomega.Expect(tc.output.passed).To(gomega.BeTrue(), tc.output.String())
 			})
 			g.It("should allow write access in namespaces other than kube-system and visibility", func() {
-				tc.data.namespaces = []string{"", "teapot"}
+				tc.data.namespaces = []string{"default", "teapot"}
 				tc.run(context.TODO(), cs, true)
 				gomega.Expect(tc.output.passed).To(gomega.BeTrue(), tc.output.String())
 			})
@@ -321,7 +321,7 @@ var _ = g.Describe("Authorization [RBAC] [Zalando]", func() {
 				gomega.Expect(tc.output.passed).To(gomega.BeTrue(), tc.output.String())
 			})
 			g.It("should allow write access in namespaces other than kube-system", func() {
-				tc.data.namespaces = []string{"", "teapot"}
+				tc.data.namespaces = []string{"default", "teapot"}
 				tc.run(context.TODO(), cs, true)
 				gomega.Expect(tc.output.passed).To(gomega.BeTrue(), tc.output.String())
 			})

--- a/test/e2e/authorization.go
+++ b/test/e2e/authorization.go
@@ -184,6 +184,14 @@ var _ = g.Describe("Authorization [RBAC] [Zalando]", func() {
 			gomega.Expect(tc.output.passed).To(gomega.BeTrue(), tc.output.String())
 		})
 
+		g.It("should allow read access to Secrets in namespaces other than kube-system and visibility", func() {
+			tc.data.resources = []string{"secrets"}
+			tc.data.namespaces = []string{"default", "teapot"}
+			tc.data.verbs = readOperations
+			tc.run(context.TODO(), cs, true)
+			gomega.Expect(tc.output.passed).To(gomega.BeTrue(), tc.output.String())
+		})
+
 		g.It("should deny write access to Nodes", func() {
 			tc.data.resources = []string{"nodes"}
 			tc.data.verbs = writeOperations

--- a/test/e2e/authorization.go
+++ b/test/e2e/authorization.go
@@ -372,21 +372,9 @@ var _ = g.Describe("Authorization [RBAC] [Zalando]", func() {
 			// g.It("should allow to create Pods", func() {})
 		})
 
-		g.When("the default service account is in default namespace", func() {
+		g.When("the service account is the default service account", func() {
 			g.BeforeEach(func() {
-				tc.data.users = []string{"system:serviceaccount:default:default"}
-			})
-			g.It("should deny to list StatefulSets", func() {
-				tc.data.resources = []string{"apps/statefulsets"}
-				tc.data.verbs = []string{"list"}
-				tc.run(context.TODO(), cs, false)
-				gomega.Expect(tc.output.passed).To(gomega.BeTrue(), tc.output.String())
-			})
-		})
-
-		g.When("the default service account is in non-default namespace", func() {
-			g.BeforeEach(func() {
-				tc.data.users = []string{"system:serviceaccount:non-default:default"}
+				tc.data.users = []string{"system:serviceaccount:default:default", "system:serviceaccount:non-default:default"}
 			})
 			g.It("should deny to list StatefulSets", func() {
 				tc.data.resources = []string{"apps/statefulsets"}

--- a/test/e2e/authorization.go
+++ b/test/e2e/authorization.go
@@ -41,7 +41,6 @@ var (
 		"namespaces",
 		"rbac.authorization.k8s.io/clusterroles",
 		"storage.k8s.io/storageclasses",
-		"storage.k8s.io/persistentvolumes",
 		"apiextensions.k8s.io/customresourcedefinitions",
 	}
 	// a slice of "get", "list", "watch" verbs

--- a/test/e2e/authorization.go
+++ b/test/e2e/authorization.go
@@ -225,17 +225,11 @@ var _ = g.Describe("Authorization [RBAC] [Zalando]", func() {
 				tc.data.resources = namespacedResources
 				tc.data.verbs = writeOperations
 			})
-			// These should be covered by the admission-controller tests. They will
-			// be skipped here. Later when we cover everything with RBAC, we can run them again.
 			g.It("should deny write access in kube-system and visibility namespaces", func() {
-				tc.data.namespaces = []string{"kube-system", "visibility"}
-				tc.run(context.TODO(), cs, false)
-				gomega.Expect(tc.output.passed).To(gomega.BeTrue(), tc.output.String())
+				g.Skip("handled by admission-controller")
 			})
 			g.It("should allow write access in namespaces other than kube-system and visibility", func() {
-				tc.data.namespaces = []string{"default", "teapot"}
-				tc.run(context.TODO(), cs, true)
-				gomega.Expect(tc.output.passed).To(gomega.BeTrue(), tc.output.String())
+				g.Skip("handled by admission-controller")
 			})
 		})
 		g.When("the resource is a global resource", func() {
@@ -305,14 +299,8 @@ var _ = g.Describe("Authorization [RBAC] [Zalando]", func() {
 			tc.run(context.TODO(), cs, true)
 			gomega.Expect(tc.output.passed).To(gomega.BeTrue(), tc.output.String())
 		})
-		// This should be covered by the admission-controller tests. It will
-		// be skipped here. Later when we cover everything with RBAC, we can run it again.
 		g.It("should deny deletion of kube-system or visibility namespaces", func() {
-			tc.data.resources = []string{"namespaces"}
-			tc.data.names = []string{"kube-system", "visibility"}
-			tc.data.verbs = []string{"delete"}
-			tc.run(context.TODO(), cs, false)
-			gomega.Expect(tc.output.passed).To(gomega.BeTrue(), tc.output.String())
+			g.Skip("handled by admission-controller")
 		})
 
 		g.When("the resource is a namespaced resource", func() {
@@ -320,12 +308,8 @@ var _ = g.Describe("Authorization [RBAC] [Zalando]", func() {
 				tc.data.resources = namespacedResources
 				tc.data.verbs = writeOperations
 			})
-			// This should be covered by the admission-controller tests. It will
-			// be skipped here. Later when we cover everything with RBAC, we can run it again.
 			g.It("should deny write access in kube-system namespace", func() {
-				tc.data.namespaces = []string{"kube-system"}
-				tc.run(context.TODO(), cs, false)
-				gomega.Expect(tc.output.passed).To(gomega.BeTrue(), tc.output.String())
+				g.Skip("handled by admission-controller")
 			})
 			g.It("should allow write access in namespaces other than kube-system", func() {
 				tc.data.namespaces = []string{"default", "teapot"}

--- a/test/e2e/authorization.go
+++ b/test/e2e/authorization.go
@@ -449,11 +449,16 @@ var _ = g.Describe("Authorization [RBAC] [Zalando]", func() {
 		g.When("the user is k8sapi_credentials-provider", func() {
 			g.BeforeEach(func() {
 				tc.data.users = []string{"zalando-iam:zalando:service:k8sapi_credentials-provider"}
-			})
-			g.It("should allow to get Secrets in kube-system namespace", func() {
 				tc.data.resources = []string{"secrets"}
 				tc.data.namespaces = []string{"kube-system"}
-				tc.data.verbs = []string{"get"}
+			})
+			g.It("should not allow to delete secrets in kube-system namespace", func() {
+				tc.data.verbs = []string{"delete"}
+				tc.run(context.TODO(), cs, false)
+				gomega.Expect(tc.output.passed).To(gomega.BeTrue(), tc.output.String())
+			})
+			g.It("should allow all non-delete operations on secrets in kube-system namespace", func() {
+				tc.data.verbs = []string{"get", "list", "watch", "create", "update", "patch"}
 				tc.run(context.TODO(), cs, true)
 				gomega.Expect(tc.output.passed).To(gomega.BeTrue(), tc.output.String())
 			})

--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -185,7 +185,6 @@ if [ "$e2e" = true ]; then
     ginkgo -procs=25 -flake-attempts=2 \
         -focus="(\[Conformance\]|\[StatefulSetBasic\]|\[Feature:StatefulSet\]\s\[Slow\].*mysql|\[Zalando\])" \
         -skip="(\[Serial\]|validates.that.there.is.no.conflict.between.pods.with.same.hostPort.but.different.hostIP.and.protocol|Should.create.gradual.traffic.routes)" \
-        -skip="should.deny.write.access.in.kube-system.and.visibility.namespaces|should.allow.write.access.in.namespaces.other.than.kube-system.and.visibility|should.deny.write.access.in.kube-system.namespace|should.deny.deletion.of.kube-system.or.visibility.namespaces" \
         "e2e.test" -- \
         -delete-namespace-on-failure=false \
         -non-blocking-taints=node.kubernetes.io/role,nvidia.com/gpu,dedicated \

--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -185,6 +185,7 @@ if [ "$e2e" = true ]; then
     ginkgo -procs=25 -flake-attempts=2 \
         -focus="(\[Conformance\]|\[StatefulSetBasic\]|\[Feature:StatefulSet\]\s\[Slow\].*mysql|\[Zalando\])" \
         -skip="(\[Serial\]|validates.that.there.is.no.conflict.between.pods.with.same.hostPort.but.different.hostIP.and.protocol|Should.create.gradual.traffic.routes)" \
+        -skip="should.deny.write.access.in.kube-system.and.visibility.namespaces|should.allow.write.access.in.namespaces.other.than.kube-system.and.visibility|should.deny.write.access.in.kube-system.namespace|should.deny.deletion.of.kube-system.or.visibility.namespaces" \
         "e2e.test" -- \
         -delete-namespace-on-failure=false \
         -non-blocking-taints=node.kubernetes.io/role,nvidia.com/gpu,dedicated \


### PR DESCRIPTION
This addresses the review comments on the RBAC e2e PR #8532.

Also adds a missing test case for testing `poweruser` read access to `secrets` in non-system namespaces.