### PR TITLE
[RBAC] drop secret read permission from poweruser ClusterRole

### DIFF
--- a/cluster/manifests/roles/collaborator-roles.yaml
+++ b/cluster/manifests/roles/collaborator-roles.yaml
@@ -14,6 +14,14 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cluster/manifests/roles/collaborator-roles.yaml
+++ b/cluster/manifests/roles/collaborator-roles.yaml
@@ -14,6 +14,7 @@ rules:
   - update
   - patch
   - delete
+{{ if eq .Cluster.ConfigItems.role_sync_controller_enabled "true" }}
 - apiGroups:
   - ""
   resources:
@@ -22,6 +23,7 @@ rules:
   - get
   - list
   - watch
+{{ end }}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cluster/manifests/roles/poweruser-role.yaml
+++ b/cluster/manifests/roles/poweruser-role.yaml
@@ -60,19 +60,6 @@ rules:
   - get
 - apiGroups:
   - ''
-  resources:
-  - secrets
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ''
   - extensions
   resources:
   - replicationcontrollers

--- a/cluster/manifests/roles/poweruser-role.yaml
+++ b/cluster/manifests/roles/poweruser-role.yaml
@@ -58,6 +58,21 @@ rules:
   - services/proxy
   verbs:
   - get
+{{ if ne .Cluster.ConfigItems.role_sync_controller_enabled "true" }}
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+{{ end }}
 - apiGroups:
   - ''
   - extensions


### PR DESCRIPTION
This drops the permissions to read `Secrets` from the RBAC `ClusterRole` of poweruser. The write permissions dropped are redundant here, as another rule above this one allows for them. We also extend the `collaborator` Role to include permissions to read Secrets in the `visibility` Namespace, as the e2e test otherwise fails for it.

This is done because:
1. In the current Authz setup which relies on a combination of RBAC and Authz-Webhook, even though we allow these permission in the RBAC, they are blocked by the webhook, so having them here is of no affect.
2. In the future Authz setup, which relies on a combination of per-namespace RBAC and admission-controller, these are still not needed. This is since the permission to read Secrets is provided through a per-namespace `RoleBinding` for different users; through the `role-sync-controller`. Therefore, we can simply drop these permission from this definition here.

This patch is also needed to fully rollout the Authz system we need for EKS.