### PR TITLE
[e2e] Skip authz test for access handled by admission-controller

### DIFF
--- a/test/e2e/authorization.go
+++ b/test/e2e/authorization.go
@@ -213,11 +213,7 @@ var _ = g.Describe("Authorization [RBAC] [Zalando]", func() {
 		})
 
 		g.It("should deny deleting kube-system or visibility namespaces", func() {
-			tc.data.resources = []string{"namespaces"}
-			tc.data.namespaces = []string{"kube-system", "visibility"}
-			tc.data.verbs = []string{"delete"}
-			tc.run(context.TODO(), cs, false)
-			gomega.Expect(tc.output.passed).To(gomega.BeTrue(), tc.output.String())
+			g.Skip("handled by admission-controller")
 		})
 
 		g.When("the resource is a namespaced resource", func() {


### PR DESCRIPTION
Skipping another test that was previously overlooked and is also covered by admission-controller. It's for  the access for `PowerUser`, `Manual` and `Emergency` groups to delete the `kube-system` or `visibility` namespace.

I updated the internal issue that tracks these, and added this test that has to be implemented in e2e for admission-controller.