### PR TITLE
Exclude eks-pod-identity-agent from admission-controller to avoid 🐔🥚

### DIFF
--- a/cluster/manifests/02-admission-control/teapot.yaml
+++ b/cluster/manifests/02-admission-control/teapot.yaml
@@ -17,6 +17,9 @@ webhooks:
         - key: k8s-app
           operator: NotIn
           values: ["kube-proxy"]
+        - key: app.kubernetes.io/name
+          operator: NotIn
+          values: ["eks-pod-identity-agent"]
 {{- end }}
     clientConfig:
       {{- if eq .Cluster.Provider "zalando-eks"}}
@@ -49,6 +52,9 @@ webhooks:
         - key: k8s-app
           operator: NotIn
           values: ["kube-proxy"]
+        - key: app.kubernetes.io/name
+          operator: NotIn
+          values: ["eks-pod-identity-agent"]
 {{- end }}
     clientConfig:
       {{- if eq .Cluster.Provider "zalando-eks"}}
@@ -341,6 +347,9 @@ webhooks:
         - key: k8s-app
           operator: NotIn
           values: ["kube-proxy"]
+        - key: app.kubernetes.io/name
+          operator: NotIn
+          values: ["eks-pod-identity-agent"]
 {{- end }}
     clientConfig:
       {{- if eq .Cluster.Provider "zalando-eks"}}


### PR DESCRIPTION
Filter the `eks-pod-identity-agent` daemonset out of the admission-controller as the admission-controller depend on it to run.