### PR TITLE
HOTFIX: reducing the autoscaler tolerance to 9% alpha

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -510,7 +510,7 @@ downscaler_enabled: "false"
 
 # HPA settings (defaults from https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/)
 horizontal_pod_autoscaler_sync_period: "30s"
-horizontal_pod_autoscaler_tolerance: "0.1"
+horizontal_pod_autoscaler_tolerance: "0.09"
 horizontal_pod_downscale_stabilization: "5m0s"
 
 # Vertical pod autoscaler version for controlling roll-out, can be "current" or "legacy"


### PR DESCRIPTION
changing the default value of the horizontal_pod_autoscaler_tolerance to 9%