### PR TITLE
[EKS] Add an admitter that validates that unprivileged users cannot exec into postgres pods

### DIFF
--- a/cluster/manifests/02-admission-control/deployment.yaml
+++ b/cluster/manifests/02-admission-control/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
       - name: admission-controller
-        image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-226
+        image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-227
         lifecycle:
           preStop:
             exec:

--- a/cluster/manifests/02-admission-control/teapot.yaml
+++ b/cluster/manifests/02-admission-control/teapot.yaml
@@ -490,6 +490,37 @@ webhooks:
         resources: ["rolebindings", "clusterrolebindings"]
 {{- end }}
 {{- if eq .Cluster.ConfigItems.teapot_admission_controller_enable_write_protection_webhook "true" }}
+  - name: pod-exec-admitter.teapot.zalan.do
+    clientConfig:
+      {{- if eq .Cluster.Provider "zalando-eks"}}
+      service:
+        name: "admission-controller"
+        namespace: "kube-system"
+        path: "/pod/exec"
+      {{- else }}
+      url: "https://localhost:8085/pod/exec"
+      {{- end }}
+      caBundle: "{{ .Cluster.ConfigItems.ca_cert_decompressed }}"
+    admissionReviewVersions: ["v1beta1"]
+    failurePolicy: Fail
+    sideEffects: "NoneOnDryRun"
+    matchPolicy: Equivalent
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values: [ "kube-system", "visibility", "kubenurse" ]
+    rules:
+      - operations: [ "CONNECT" ]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods/exec"]
+        scope: "Namespaced"
+    matchConditions:
+      - name: 'exclude-privileged-groups'
+        expression: 'request.userInfo.groups.all(g, !(g in ["okta:common/administrator", "zalando:administrator"]))'
+      - name: 'exclude-postgres-admins'
+        expression: 'request.userInfo.groups.all(g, !(g in ["okta:common/postgres-admin"]))'
   - name: namespaced-deny-admitter.teapot.zalan.do
     clientConfig:
       {{- if eq .Cluster.Provider "zalando-eks"}}


### PR DESCRIPTION
This uses a new admitter and endpoint (`pod/exec`) that is designed to capture exec requests. Upon receiving such a request the admitter will reject the request if it's for a postgres (`application=spilo`) pod, otherwise it allows it.

This is configured to only run for non-privileged namespaces (userland) [1]. It's also _not_ run for admins as well as postgres-admins. This has the effect that admins and postgres-admins can exec into any userland pod. Normal users will trigger the admitter which then allows the request for any pod (in userland) that isn't a postgres pod, hence only admins and postgres-admins can exec into postgres pods in userland. Note, that postgres-admins _cannot_ exec into postgres pods in privileged namespaces. Also note, that anyone who _only_ has the postgres-admin role can exec into postgres pods as well as any other pod in a non-privileged names. In other words, the exec permission for postgres-admins is not limited to just postgres pods.

[1] exec requests in privileged namespaces are handled by the `namespaced-deny-admitter.teapot.zalan.do` admitter and only allows admins and internal components to exec.