### PR TITLE
Add an admitter that validates that unprivileged users cannot exec into postgres pods

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -677,9 +677,9 @@ teapot_admission_controller_configmap_deletion_protection_factories_enabled: "tr
 # enable the rolebinding admission-controller webhook which validates rolebindings and clusterrolebindings
 teapot_admission_controller_enable_rolebinding_webhook: "true"
 
-# enable the generic admission-controller webhook which catches all resources
-teapot_admission_controller_enable_generic_webhook: "false"
-# prevent write operations for non-admin users in protected namespaces
+# enable the generic deny-all admission webhook which rejects all requests it receives
+teapot_admission_controller_enable_write_protection_webhook: "false"
+# configure the behaviour of the deny-all admission webhook, `true` blocks everything, `false` allows everything
 teapot_admission_controller_prevent_write_operations: "false"
 
 # Enable and configure Pod Security Policy rules implemented in admission-controller.

--- a/cluster/manifests/01-admission-control/teapot.yaml
+++ b/cluster/manifests/01-admission-control/teapot.yaml
@@ -267,10 +267,10 @@ webhooks:
         apiVersions: ["v1"]
         resources: ["rolebindings", "clusterrolebindings"]
 {{- end }}
-{{- if eq .Cluster.ConfigItems.teapot_admission_controller_enable_generic_webhook "true" }}
-  - name: generic-namespaced-admitter.teapot.zalan.do
+{{- if eq .Cluster.ConfigItems.teapot_admission_controller_enable_write_protection_webhook "true" }}
+  - name: namespaced-deny-admitter.teapot.zalan.do
     clientConfig:
-      url: "https://localhost:8085/generic"
+      url: "https://localhost:8085/deny"
       caBundle: "{{ .Cluster.ConfigItems.ca_cert_decompressed }}"
     admissionReviewVersions: ["v1beta1"]
     failurePolicy: Fail
@@ -287,9 +287,16 @@ webhooks:
         apiVersions: ["*"]
         resources: ["*/*"]
         scope: "Namespaced"
-  - name: generic-cluster-admitter.teapot.zalan.do
+    matchConditions:
+      - name: 'exclude-privileged-groups'
+        expression: 'request.userInfo.groups.all(g, !(g in ["system:masters", "system:nodes", "system:serviceaccounts:kube-system", "okta:common/administrator", "zalando:administrator"]))'
+      - name: 'exclude-privileged-usernames'
+        expression: '!(request.userInfo.username in ["system:kube-controller-manager", "system:kube-scheduler", "zalando-iam:zalando:service:k8sapi_credentials-provider"])'
+      - name: 'exclude-eks-components'
+        expression: '!request.userInfo.username.startsWith("eks:")'
+  - name: global-deny-admitter.teapot.zalan.do
     clientConfig:
-      url: "https://localhost:8085/generic"
+      url: "https://localhost:8085/deny"
       caBundle: "{{ .Cluster.ConfigItems.ca_cert_decompressed }}"
     admissionReviewVersions: ["v1beta1"]
     failurePolicy: Fail
@@ -304,4 +311,11 @@ webhooks:
         apiVersions: ["*"]
         resources: ["*/*"]
         scope: "Cluster"
+    matchConditions:
+      - name: 'exclude-privileged-groups'
+        expression: 'request.userInfo.groups.all(g, !(g in ["system:masters", "system:nodes", "system:serviceaccounts:kube-system", "okta:common/administrator", "zalando:administrator"]))'
+      - name: 'exclude-privileged-usernames'
+        expression: '!(request.userInfo.username in ["system:kube-controller-manager", "system:kube-scheduler", "zalando-iam:zalando:service:k8sapi_credentials-provider"])'
+      - name: 'exclude-eks-components'
+        expression: '!request.userInfo.username.startsWith("eks:")'
 {{- end }}

--- a/cluster/manifests/01-admission-control/teapot.yaml
+++ b/cluster/manifests/01-admission-control/teapot.yaml
@@ -268,6 +268,30 @@ webhooks:
         resources: ["rolebindings", "clusterrolebindings"]
 {{- end }}
 {{- if eq .Cluster.ConfigItems.teapot_admission_controller_enable_write_protection_webhook "true" }}
+  - name: pod-exec-admitter.teapot.zalan.do
+    clientConfig:
+      url: "https://localhost:8085/pod/exec"
+      caBundle: "{{ .Cluster.ConfigItems.ca_cert_decompressed }}"
+    admissionReviewVersions: ["v1beta1"]
+    failurePolicy: Fail
+    sideEffects: "NoneOnDryRun"
+    matchPolicy: Equivalent
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values: [ "kube-system", "visibility", "kubenurse" ]
+    rules:
+      - operations: [ "CONNECT" ]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods/exec"]
+        scope: "Namespaced"
+    matchConditions:
+      - name: 'exclude-privileged-groups'
+        expression: 'request.userInfo.groups.all(g, !(g in ["okta:common/administrator", "zalando:administrator"]))'
+      - name: 'exclude-postgres-admins'
+        expression: 'request.userInfo.groups.all(g, !(g in ["okta:common/postgres-admin"]))'
   - name: namespaced-deny-admitter.teapot.zalan.do
     clientConfig:
       url: "https://localhost:8085/deny"

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -206,7 +206,7 @@ write_files:
             limits:
               memory: {{ .Values.InstanceInfo.MemoryFraction (parseInt64 .Cluster.ConfigItems.apiserver_memory_limit_percent)}}
 {{- end }}
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-226
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-227
           name: admission-controller
           lifecycle:
             preStop:

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -206,7 +206,7 @@ write_files:
             limits:
               memory: {{ .Values.InstanceInfo.MemoryFraction (parseInt64 .Cluster.ConfigItems.apiserver_memory_limit_percent)}}
 {{- end }}
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-224
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-226
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
This uses a new admitter and endpoint (`pod/exec`) that is designed to capture exec requests. Upon receiving such a request the admitter will reject the request if it's for a postgres (`application=spilo`) pod, otherwise it allows it.

This is configured to only run for non-privileged namespaces (userland) [1]. It's also _not_ run for admins as well as postgres-admins. This has the effect that admins and postgres-admins can exec into any userland pod. Normal users will trigger the admitter which then allows the request for any pod (in userland) that isn't a postgres pod, hence only admins and postgres-admins can exec into postgres pods in userland. Note, that postgres-admins _cannot_ exec into postgres pods in privileged namespaces. Also note, that anyone who _only_ has the postgres-admin role can exec into postgres pods as well as any other pod in a non-privileged names. In other words, the exec permission for postgres-admins is not limited to just postgres pods.

[1] exec requests in privileged namespaces are handled by the `namespaced-deny-admitter.teapot.zalan.do` admitter and only allows admins and internal components to exec.