### PR TITLE
skipper: disable basicAuth filter

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -121,7 +121,7 @@ skipper_default_filters: 'disableAccessLog(2,3,404,429) -> fifo(2000,20,"1s")'
 # skipper_default_filters_authentication defines filters that implement default request authentication
 skipper_default_filters_authentication: ''
 skipper_default_filters_append: 'stateBagToTag("auth-user", "client.uid")'
-skipper_disabled_filters: "static,bearerinjector,setRequestHeaderFromSecret"
+skipper_disabled_filters: "static,bearerinjector,setRequestHeaderFromSecret,basicAuth"
 skipper_lua_sources: "file"
 skipper_edit_route_placeholders: ""
 skipper_ingress_inline_routes: ""
@@ -1171,7 +1171,7 @@ sysctl_settings: ""
 # must ensure that no existing resources should be annotated with a TTL.
 # This can happen in the case where a test deployment is deployed to production
 # as is. Currently, it's a no-op since kube-janitor doesn't run in production.
-# 
+#
 # This is needed until we can implement namespace prefix matching to reduce
 # the scope of kube-janitor to a set of namespace names that aren't known
 # at the time of enaling kube-janitor. Once the feature is in place, it would


### PR DESCRIPTION
[basicAuth](https://github.com/zalando/skipper/blob/master/docs/reference/filters.md#basicauth) filter requires htpasswd file that is not available in the ingress setup.

See related https://github.com/zalando/skipper/issues/3327