### PR TITLE
update role-sync-controller

### DIFF
--- a/cluster/manifests/role-sync-controller/cronjob.yaml
+++ b/cluster/manifests/role-sync-controller/cronjob.yaml
@@ -26,7 +26,7 @@ spec:
           restartPolicy: OnFailure
           containers:
           - name: role-sync-controller
-            image: container-registry.zalando.net/teapot/role-sync-controller:main-2
+            image: container-registry.zalando.net/teapot/role-sync-controller:main-4
             args:
               - --subject-group=PowerUser
               - --subject-group=Manual


### PR DESCRIPTION
This update includes the refactoring in the controller to not make any bindings for the `poweruser` Role, instead use per-namespace `secrets-reader` Role and RoleBinding.