### PR TITLE
Exclude kubenurse from being considered for a node to get ready

### DIFF
--- a/cluster/manifests/kubenurse/daemonset.yaml
+++ b/cluster/manifests/kubenurse/daemonset.yaml
@@ -7,6 +7,8 @@ metadata:
   labels:
     application: kubernetes
     component: kubenurse
+  annotations:
+    node-ready.cluster.zalando.org/exclude: "true"
   name: kubenurse
   namespace: kubenurse
 spec:


### PR DESCRIPTION
Don't treat `kubenurse` as a critical daemonset that must be ready before a node is ready. This way if kubenurse it failing for whatever reason, nodes will still be ready for user workloads.

depends on #8576 