### PR TITLE
Enable previously disabled e2e tests for authz

### DIFF
--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -204,6 +204,7 @@ if [ "$e2e" = true ]; then
         SKIPPED_TESTS+=(
             "Mirror pods should be created for the main Kubernetes components \[Zalando\]"
             "Should audit API calls to create, update, patch, delete pods. \[Audit\] \[Zalando\]"
+            "should validate permissions for \[Authorization\] \[RBAC\] \[Zalando\]" # TODO: Remains skipped until we remove the older RBAC setup
         )
     fi
 

--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -204,7 +204,6 @@ if [ "$e2e" = true ]; then
         SKIPPED_TESTS+=(
             "Mirror pods should be created for the main Kubernetes components \[Zalando\]"
             "Should audit API calls to create, update, patch, delete pods. \[Audit\] \[Zalando\]"
-            "should validate permissions for \[Authorization\] \[RBAC\] \[Zalando\]" # TODO: temporary disabled because feature is missing
         )
     fi
 


### PR DESCRIPTION
Enable previously disabled authz related e2e tests now that it should be working via #8571 