### PR TITLE
skipper-internal: Update main fleet to version v0.21.224-1047

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -127,6 +127,8 @@ skipper_edit_route_placeholders: ""
 skipper_ingress_inline_routes: ""
 skipper_ingress_refuse_payload: ""
 skipper_endpointslices_enabled: "true"
+skipper_kubernetes_annotation_predicates: ''
+skipper_kubernetes_east_west_range_annotation_predicates: ''
 
 skipper_compress_encodings: "gzip,deflate,br"
 

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,6 +1,6 @@
 {{/* image-updater-bot detects *image variables so use print to disable it for main image */}}
 
-{{ $main_image := print "container-registry.zalando.net/teapot/skipper-internal:" "v0.21.220-1043" }}
+{{ $main_image := print "container-registry.zalando.net/teapot/skipper-internal:" "v0.21.224-1047" }}
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.21.224-1047" }}
 
 
@@ -173,6 +173,8 @@ spec:
 {{ if ne .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
           - "-kubernetes-east-west-range-domains=ingress.cluster.local"
           - "-kubernetes-east-west-range-predicates=ClientIP(\"10.2.0.0/15\", \"{{ .Values.vpc_ipv4_cidr }}\")"
+          - '-kubernetes-annotation-predicates={{ .Cluster.ConfigItems.skipper_kubernetes_annotation_predicates }}'
+          - '-kubernetes-east-west-range-annotation-predicates={{ .Cluster.ConfigItems.skipper_kubernetes_east_west_range_annotation_predicates }}'
           - "-reverse-source-predicate"
 {{ end }}
           - "-proxy-preserve-host"
@@ -540,6 +542,8 @@ spec:
           - "-wait-for-healthcheck-interval={{ .Cluster.ConfigItems.skipper_wait_for_healthcheck_interval }}"
           - "-kubernetes-east-west-range-domains=ingress.cluster.local"
           - "-kubernetes-east-west-range-predicates=ClientIP(\"10.2.0.0/15\", \"{{ .Values.vpc_ipv4_cidr }}\")"
+          - '-kubernetes-annotation-predicates={{ .Cluster.ConfigItems.skipper_kubernetes_annotation_predicates }}'
+          - '-kubernetes-east-west-range-annotation-predicates={{ .Cluster.ConfigItems.skipper_kubernetes_east_west_range_annotation_predicates }}'
           - "-reverse-source-predicate"
           - "-default-filters-dir=/etc/config/default-filters"
           - '-default-filters-prepend={{ .Cluster.ConfigItems.skipper_default_filters }}'


### PR DESCRIPTION
* https://github.com/zalando/skipper/pull/3271
* https://github.com/zalando/skipper/pull/3283
* https://github.com/zalando/skipper/pull/3284
* https://github.com/zalando/skipper/pull/3285
* https://github.com/zalando/skipper/pull/3281
* https://github.com/zalando/skipper/pull/3282
* https://github.com/zalando/skipper/pull/3294
* https://github.com/zalando/skipper/pull/3293
* https://github.com/zalando/skipper/pull/3292
* https://github.com/zalando/skipper/pull/3291
* https://github.com/zalando/skipper/pull/3288
* https://github.com/zalando/skipper/pull/3300
* https://github.com/zalando/skipper/pull/3301
* https://github.com/zalando/skipper/pull/3290
* https://github.com/zalando/skipper/pull/3328
* https://github.com/zalando/skipper/pull/3319
* https://github.com/zalando/skipper/pull/3325
* https://github.com/zalando/skipper/pull/3310
* https://github.com/zalando/skipper/pull/3307
* https://github.com/zalando/skipper/pull/3322
* https://github.com/zalando/skipper/pull/3326
* https://github.com/zalando/skipper/pull/3289

https://github.com/zalando/skipper/compare/v0.21.220...v0.21.224

follow up on https://github.com/zalando-incubator/kubernetes-on-aws/pull/8574