### PR TITLE
add appropriate RBAC for the role-sync-controller

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -314,6 +314,8 @@ post_apply:
   kind: CronJob
   namespace: kube-system
 - name: role-sync-controller
+  kind: ClusterRole
+- name: role-sync-controller
   kind: ClusterRoleBinding
 - name: role-sync-controller
   kind: ServiceAccount

--- a/cluster/manifests/role-sync-controller/rbac.yaml
+++ b/cluster/manifests/role-sync-controller/rbac.yaml
@@ -1,5 +1,40 @@
 {{ if eq .Cluster.ConfigItems.role_sync_controller_enabled "true" }}
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: role-sync-controller
+  labels:
+    application: kubernetes
+    component: role-sync-controller
+rules:
+  # Allow the controller to list namespaces
+  - apiGroups:
+    - ""
+    resources:
+    - "namespaces"
+    verbs:
+    - "list"
+  # Allow the controller to manage Roles and Rolebindings
+  - apiGroups:
+    - rbac.authorization.k8s.io
+    resources:
+    - roles
+    - rolebindings
+    verbs:
+    - "get"
+    - "create"
+    - "update"
+  # Allow the controller to manage roles based on reading Secrets
+  - apiGroups:
+    - ""
+    resources:
+    - secrets
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: role-sync-controller
@@ -9,7 +44,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: poweruser
+  name: role-sync-controller
 subjects:
 - kind: ServiceAccount
   name: role-sync-controller

--- a/test/e2e/authorization.go
+++ b/test/e2e/authorization.go
@@ -185,7 +185,9 @@ var _ = g.Describe("Authorization [RBAC] [Zalando]", func() {
 
 		g.It("should allow read access to Secrets in namespaces other than kube-system and visibility", func() {
 			tc.data.resources = []string{"secrets"}
-			tc.data.namespaces = []string{"default", "teapot"}
+			// The namespace must exist for the test case to pass, otherwise access
+			// remains undecided.
+			tc.data.namespaces = []string{"default"}
 			tc.data.verbs = readOperations
 			tc.run(context.TODO(), cs, true)
 			gomega.Expect(tc.output.passed).To(gomega.BeTrue(), tc.output.String())


### PR DESCRIPTION
Since we removed the permissions to read `Secret` objects from the `poweruser` `ClusterRole` in #8537 , we can no longer bind this `ClusterRole` to the role-sync-controller `ServiceAccount`. This doesn't work anymore:

```golang
time="2024-12-09T08:53:00Z" level=error msg="error reconcile Role 'secrets-reader' for Namespace 'authorization-219': failed to create Role 'secrets-reader' in Namespace 'authorization-219': roles.rbac.authorization.k8s.io \"secrets-reader\" is forbidden: user \"system:serviceaccount:kube-system:role-sync-controller\" (groups=[\"system:serviceaccounts\" \"system:serviceaccounts:kube-system\" \"system:authenticated\"]) is attempting to grant RBAC permissions not currently held:\n{APIGroups:[\"\"], Resources:[\"secrets\"], Verbs:[\"get\" \"list\" \"watch\"]}"
```

This introduces a new `ClusterRole` intended to be used by the role-sync-controller` and only provides the permissions it needs for syncing `secrets-reader` Role in each namespace.