### PR TITLE
Add bucket policies to Kubernetes infra s3 buckets

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1041,7 +1041,6 @@ Resources:
                   - "{{.Cluster.ConfigItems.deployment_service_api_role_arn}}"
 {{- end }}
                   - !Sub "arn:aws:iam::${AWS::AccountId}:role/cluster-lifecycle-manager-entrypoint"
-                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/Shibboleth-Administrator"
                   - !Sub "arn:aws:iam::${AWS::AccountId}:role/Administrator"
   DeploymentControllerRole:
     Type: AWS::IAM::Role
@@ -2218,6 +2217,19 @@ Resources:
               - !Sub
                 - "${BucketArn}/*"
                 - BucketArn: !GetAtt AuditTrailBucket.Arn
+          - Action: "s3:*"
+            Effect: Deny
+            Resource:
+              - !Sub "arn:aws:s3:::${AuditTrailBucket}/*"
+              - !Sub "arn:aws:s3:::${AuditTrailBucket}"
+            Principal: "*"
+            Condition:
+              ArnNotEquals:
+                aws:PrincipalArn:
+                  - !GetAtt EmergencyAccessServiceIAMRole.Arn
+                  - !GetAtt AudittrailAdapterIAMRole.Arn
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/cluster-lifecycle-manager-entrypoint"
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/Administrator"
 
 {{- if .Cluster.ConfigItems.audittrail_root_account_role }}
           # Central access
@@ -2420,7 +2432,6 @@ Resources:
             Principal:
               AWS:
                 - !Sub "arn:aws:iam::${AWS::AccountId}:role/cluster-lifecycle-manager-entrypoint"
-                - !Sub "arn:aws:iam::${AWS::AccountId}:role/Shibboleth-Administrator"
                 - !Sub "arn:aws:iam::${AWS::AccountId}:role/Administrator"
             Action:
             - "kms:*"
@@ -2458,7 +2469,6 @@ Resources:
             Effect: "Allow"
             Principal:
               AWS:
-              - !Sub "arn:aws:iam::${AWS::AccountId}:role/Shibboleth-Administrator"
               - !Sub "arn:aws:iam::${AWS::AccountId}:role/Administrator"
             Action:
             - "kms:*"
@@ -2496,7 +2506,6 @@ Resources:
             Principal:
               AWS:
                 - !Sub "arn:aws:iam::${AWS::AccountId}:role/cluster-lifecycle-manager-entrypoint"
-                - !Sub "arn:aws:iam::${AWS::AccountId}:role/Shibboleth-Administrator"
                 - !Sub "arn:aws:iam::${AWS::AccountId}:role/Administrator"
             Action:
             - "kms:*"
@@ -2533,7 +2542,6 @@ Resources:
             Principal:
               AWS:
                 - !Sub "arn:aws:iam::${AWS::AccountId}:role/cluster-lifecycle-manager-entrypoint"
-                - !Sub "arn:aws:iam::${AWS::AccountId}:role/Shibboleth-Administrator"
                 - !Sub "arn:aws:iam::${AWS::AccountId}:role/Administrator"
             Action:
             - "kms:*"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -718,6 +718,16 @@ etcd_scalyr_key: ""
 
 etcd_ami: {{ amiID "zalando-ubuntu-etcd-production-v3.5.13-amd64-main-34" "861068367966"}}
 
+# Enable/Disable bucket policy on the etcd bucket to limit access to the local
+# cluster.
+# This can be disabled in environments where multiple clusters share a single
+# etcd instance e.g. e2e and dev environments.
+{{if eq .Cluster.Environment "e2e"}}
+etcd_backup_bucket_policy: "false"
+{{else}}
+etcd_backup_bucket_policy: "true"
+{{end}}
+
 cluster_dns: "coredns"
 coredns_log_svc_names: "true"
 coredns_log_forward: "false"

--- a/cluster/etcd/stack.yaml
+++ b/cluster/etcd/stack.yaml
@@ -206,6 +206,55 @@ Resources:
             Status: Enabled
       VersioningConfiguration:
         Status: Suspended
+{{- if eq .Cluster.ConfigItems.etcd_backup_bucket_policy "true" }}
+  EtcdBackupBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref EtcdBackupBucket
+      PolicyDocument:
+        Statement:
+          # In-cluster access
+          - Action:
+              - s3:ListBucket
+            Effect: Allow
+            Principal:
+              AWS:
+              - "arn:aws:iam::${AWS::AccountId}:role/{{.Cluster.LocalID}}-etcd-backup"
+            Resource:
+              - !GetAtt EtcdBackupBucket.Arn
+          - Action:
+              - s3:PutObject
+            Effect: Allow
+            Principal:
+              AWS:
+              - "arn:aws:iam::${AWS::AccountId}:role/{{.Cluster.LocalID}}-etcd-backup"
+            Resource:
+              - !Sub
+                - "${BucketArn}/*"
+                - BucketArn: !GetAtt EtcdBackupBucket.Arn
+          - Action:
+            - s3:ListObjects
+            - s3:PutObject
+            Effect: Allow
+            Principal:
+              AWS:
+              - "arn:aws:iam::${AWS::AccountId}:role/{{.Cluster.LocalID}}-etcd-backup"
+            Resource:
+              - !Sub
+                - "${BucketArn}/*"
+                - BucketArn: !GetAtt EtcdBackupBucket.Arn
+          - Action: "s3:*"
+            Effect: Deny
+            Resource:
+              - !Sub "arn:aws:s3:::${EtcdBackupBucket}/*"
+              - !Sub "arn:aws:s3:::${EtcdBackupBucket}"
+            Principal: "*"
+            Condition:
+              ArnNotEquals:
+                aws:PrincipalArn:
+                  - "arn:aws:iam::${AWS::AccountId}:role/{{.Cluster.LocalID}}-etcd-backup"
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/Administrator"
+{{- end }}
   EtcdRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
This adds bucket policies to the s3 buckets that are part of the Kubernetes core infra. The policies prevent users who shouldn't have access from tampering with objects.

Only Administrator and respective service roles should have access to the bucket contents.

This also removes the legacy `Shibboleth-Administrator` role in a few places.

## TODO

* [ ] Validate that etcd backup/restore script works with the policy in place.