### PR TITLE
Test custom AMI for EFA support

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -760,7 +760,7 @@ kuberuntu_image_v1_31_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernet
 kuberuntu_image_v1_31_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.31.4-arm64-master-359" "861068367966" }}
 
 # FOR TESTING ONLY:
-kuberuntu_image_v1_31_jammy_with_gpu_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-test-v1.31.4-amd64-pr-380-14" "861068367966" }}
+kuberuntu_image_v1_31_jammy_with_gpu_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-test-v1.31.4-amd64-pr-380-22" "861068367966" }}
 kuberuntu_image_v1_31_jammy_with_gpu_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.31.4-arm64-master-359" "861068367966" }}
 
 # set to false on a node pool to enable ssm access for non Administrator users.

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -759,6 +759,13 @@ tracing_coredns_local_zone_traces_endpoint: ""
 kuberuntu_image_v1_31_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.31.4-amd64-master-359" "861068367966" }}
 kuberuntu_image_v1_31_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.31.4-arm64-master-359" "861068367966" }}
 
+# FOR TESTING ONLY:
+kuberuntu_image_v1_31_jammy_with_gpu_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-test-v1.31.4-amd64-pr-380-14" "861068367966" }}
+kuberuntu_image_v1_31_jammy_with_gpu_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.31.4-arm64-master-359" "861068367966" }}
+
+# set to false on a node pool to enable ssm access for non Administrator users.
+tag_instance_infrastructure_component: "true"
+
 # Which distro from the previous config items should be used. Valid options are only `jammy` for now. Can be set for each node pool.
 kuberuntu_distro_master: "jammy"
 kuberuntu_distro_worker: "jammy"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -760,7 +760,7 @@ kuberuntu_image_v1_31_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernet
 kuberuntu_image_v1_31_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.31.4-arm64-master-359" "861068367966" }}
 
 # FOR TESTING ONLY:
-kuberuntu_image_v1_31_jammy_with_gpu_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-test-v1.31.4-amd64-pr-380-22" "861068367966" }}
+kuberuntu_image_v1_31_jammy_with_gpu_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.31.5-amd64-master-364" "861068367966" }}
 kuberuntu_image_v1_31_jammy_with_gpu_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.31.4-arm64-master-359" "861068367966" }}
 
 # set to false on a node pool to enable ssm access for non Administrator users.

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -63,7 +63,9 @@ spec:
       memory: "{{ .Cluster.ConfigItems.kubelet_kube_reserved_memory }}"
   tags:
     Name: "{{ .NodePool.Name }} ({{ .Cluster.ID }})"
+    # {{ if eq .NodePool.ConfigItems.tag_instance_infrastructure_component "true" }}
     InfrastructureComponent: 'true'
+    # {{ end }}
     application: kubernetes
     component: shared-resource
     environment: "{{ .Cluster.Environment }}"


### PR DESCRIPTION
This PR is purely for enabling testing of an in-progress AMI to enable support for EFA on `g5` and `p5` instances.

The idea is that a cluster switched to this PR branch will be able to run a node-pool like this:

```yaml
- config_items:
    labels: dedicated=gpu-g5-efa,zalando.org/nvidia-gpu=nvidia-a10g,efa=enabled
    taints: dedicated=gpu-g5-efa:NoSchedule
    kuberuntu_distro_worker: "jammy_with_gpu"
    tag_instance_infrastructure_component: "false"
    internal_node_subnets_enabled: "true"
  discount_strategy: none
  instance_types:
  - g5.8xlarge
  - g5.12xlarge
  - g5.16xlarge
  - g5.24xlarge
  - g5.48xlarge
  max_size: 30
  min_size: 0
  name: gpu-g5-efa
  profile: worker-karpenter
```

With will run the special AMI defined as: `kuberuntu_image_v1_31_jammy_with_gpu_amd64`. To change the AMI to test, only that config-item needs to be changed in this PR and the node pool will be updated.