### PR TITLE
Update dcgm-exporter to 3.3.9-3.6.1 release

### DIFF
--- a/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
+++ b/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
@@ -79,7 +79,7 @@ spec:
           mountPath: /var/lib/kubelet/device-plugins
 {{- if eq .Cluster.ConfigItems.nvidia_dcgm_exporter_enabled "true" }}
       - name: dcgm-exporter
-        image: container-registry.zalando.net/teapot/nvidia-dcgm-exporter:v3.3.6-3.4.2-ubuntu22.04-master-15
+        image: container-registry.zalando.net/teapot/nvidia-dcgm-exporter:v3.3.9-3.6.1-ubuntu22.04-master-16
         args:
         - --kubernetes
         - --address=:9400


### PR DESCRIPTION
Update the `dcgm-exporter` image to the latest `3.3.9-3.6.1` release.

https://github.com/NVIDIA/dcgm-exporter/releases/tag/3.3.9-3.6.1