### PR TITLE
Update to Kubernetes v1.31.4

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -740,8 +740,8 @@ tracing_coredns_local_zone_traces_endpoint: ""
 # AMI id given the image name and the Image AWS account owner.
 #
 # [0]: https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/8a9bd1cb2d094038a9e23e646421f8146b48886a/provisioner/template.go#L116
-kuberuntu_image_v1_31_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.31.0-amd64-master-347" "861068367966" }}
-kuberuntu_image_v1_31_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.31.0-arm64-master-347" "861068367966" }}
+kuberuntu_image_v1_31_jammy_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.31.4-amd64-master-359" "861068367966" }}
+kuberuntu_image_v1_31_jammy_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.31.4-arm64-master-359" "861068367966" }}
 
 # Which distro from the previous config items should be used. Valid options are only `jammy` for now. Can be set for each node pool.
 kuberuntu_distro_master: "jammy"
@@ -833,7 +833,7 @@ kubelet_registry_burst: "40"
 #  - upstream: official Kubernetes version
 #  - zalando:  internal Zalando build with our custom patches
 kubernetes_scheduler_image: "zalando"
-kubernetes_controller_manager_image: "zalando"
+kubernetes_controller_manager_image: "upstream"
 
 # when set to true, service account tokens can be used from outside the cluster
 allow_external_service_accounts: "false"

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -928,8 +928,26 @@ write_files:
       {{- end}}
 {{- end}}
 
+  # TODO: Remove this once all nodes are running an AMI compatible with /etc/cni/net.d/10-flannel.conflist
   - owner: root:root
     path: /etc/kubernetes/cni/net.d/10-flannel.conflist
+    content: |
+      {
+        "name": "podnet",
+        "cniVersion": "0.3.1",
+        "plugins": [
+          {
+            "type": "flannel",
+            "delegate": {
+              "isDefaultGateway": true,
+              "hairpinMode": true
+            }
+          }
+        ]
+      }
+
+  - owner: root:root
+    path: /etc/cni/net.d/10-flannel.conflist
     content: |
       {
         "name": "podnet",

--- a/cluster/node-pools/worker-splitaz/userdata.yaml
+++ b/cluster/node-pools/worker-splitaz/userdata.yaml
@@ -136,8 +136,26 @@ write_files:
       {{- end}}
 {{- end}}
 
+  # TODO: Remove this once all nodes are running an AMI compatible with /etc/cni/net.d/10-flannel.conflist
   - owner: root:root
     path: /etc/kubernetes/cni/net.d/10-flannel.conflist
+    content: |
+      {
+        "name": "podnet",
+        "cniVersion": "0.3.1",
+        "plugins": [
+          {
+            "type": "flannel",
+            "delegate": {
+              "isDefaultGateway": true,
+              "hairpinMode": true
+            }
+          }
+        ]
+      }
+
+  - owner: root:root
+    path: /etc/cni/net.d/10-flannel.conflist
     content: |
       {
         "name": "podnet",


### PR DESCRIPTION
This updates the AMI to Kubernetes v1.31.4: https://github.com/kubernetes/kubernetes/releases/tag/v1.31.4

Additionally it makes the following changes:

* Switch to upstream version of kube-controller-manager. This is possible because the fix for https://github.com/kubernetes/kubernetes/issues/127792 is part of Kubernetes v1.31.4
* Add the CNI config to the standard path `/etc/cni/net.d/` this is following a change in the AMI to expect the config at that path. This is done to be compatible with AWS CNI plugin which is expecting the standard path. We need later a follow up to remove the legacy path from the userdata. Added a TODO comment to cover this.