### PR TITLE
skipper: Fix formatting of flags

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -182,7 +182,7 @@ spec:
           - "-wait-for-healthcheck-interval={{ .Cluster.ConfigItems.skipper_wait_for_healthcheck_interval }}"
 {{ if ne .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
           - "-kubernetes-east-west-range-domains=ingress.cluster.local"
-          - "-kubernetes-east-west-range-predicates=ClientIP(\"{{ .cluster_internal_cidrs | join `\",\"` }}\")"
+          - '-kubernetes-east-west-range-predicates=ClientIP("{{ .cluster_internal_cidrs | join `","` }}")'
           - '-kubernetes-annotation-predicates={{ .Cluster.ConfigItems.skipper_kubernetes_annotation_predicates }}'
           - '-kubernetes-east-west-range-annotation-predicates={{ .Cluster.ConfigItems.skipper_kubernetes_east_west_range_annotation_predicates }}'
           - "-reverse-source-predicate"
@@ -316,7 +316,7 @@ spec:
 {{ end }}
 {{ if or (eq .Cluster.ConfigItems.nlb_switch "pre") (eq .Cluster.ConfigItems.nlb_switch "exec") }}
           - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
-          - "-forwarded-headers-exclude-cidrs={{ .cluster_internal_cidrs | join "," }}"
+          - '-forwarded-headers-exclude-cidrs={{ .cluster_internal_cidrs | join "," }}'
 {{ end }}
 {{ if .Cluster.ConfigItems.skipper_ingress_inline_routes }}
           - "-inline-routes={{ .Cluster.ConfigItems.skipper_ingress_inline_routes }}"
@@ -554,7 +554,7 @@ spec:
           - "-whitelisted-healthcheck-cidr={{ .Values.subnet_ipv6_cidrs }}"
 {{- end }}
           - "-kubernetes-east-west-range-domains=ingress.cluster.local"
-          - "-kubernetes-east-west-range-predicates=ClientIP(\"{{ $cluster_internal_cidrs | join `\",\"` }}\")"
+          - '-kubernetes-east-west-range-predicates=ClientIP("{{ $cluster_internal_cidrs | join `","` }}")'
           - '-kubernetes-annotation-predicates={{ .Cluster.ConfigItems.skipper_kubernetes_annotation_predicates }}'
           - '-kubernetes-east-west-range-annotation-predicates={{ .Cluster.ConfigItems.skipper_kubernetes_east_west_range_annotation_predicates }}'
           - "-reverse-source-predicate"
@@ -579,7 +579,7 @@ spec:
 {{ end }}
 {{ if or (eq .Cluster.ConfigItems.nlb_switch "pre") (eq .Cluster.ConfigItems.nlb_switch "exec") }}
           - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
-          - "-forwarded-headers-exclude-cidrs={{ $cluster_internal_cidrs | join "," }}"
+          - '-forwarded-headers-exclude-cidrs={{ $cluster_internal_cidrs | join "," }}'
 {{ end }}
           - >-
             -opentracing=lightstep


### PR DESCRIPTION
The formatting of the skipper flags causes an issue in EKS clusters. Simplify by using `'` around the whole flag value and only use `"` for the eskip notation.