### PR TITLE
skipper-internal: update main fleet to version v0.21.240-1063

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,6 +1,6 @@
 {{/* image-updater-bot detects *image variables so use print to disable it for main image */}}
 
-{{ $main_image := print "container-registry.zalando.net/teapot/skipper-internal:" "v0.21.224-1047" }}
+{{ $main_image := print "container-registry.zalando.net/teapot/skipper-internal:" "v0.21.240-1063" }}
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.21.240-1063" }}
 
 


### PR DESCRIPTION
* https://github.com/zalando/skipper/pull/3323
* https://github.com/zalando/skipper/pull/3334
* https://github.com/zalando/skipper/pull/3330
* https://github.com/zalando/skipper/pull/3341
* https://github.com/zalando/skipper/pull/3344
* https://github.com/zalando/skipper/pull/3348
* https://github.com/zalando/skipper/pull/3318
* https://github.com/zalando/skipper/pull/3347
* https://github.com/zalando/skipper/pull/3345
* https://github.com/zalando/skipper/pull/3337
* https://github.com/zalando/skipper/pull/3342
* https://github.com/zalando/skipper/pull/3351
* https://github.com/zalando/skipper/pull/3335
* https://github.com/zalando/skipper/pull/3338

follow up on https://github.com/zalando-incubator/kubernetes-on-aws/pull/8587