### PR TITLE
[e2e] use p4 instead of old p3 instances

### DIFF
--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -131,7 +131,6 @@ clusters:
       taints: dedicated=node-tests:NoSchedule
   - discount_strategy: spot
     instance_types:
-    - "p4d.24xlarge"
     - "g3s.xlarge"
     - "g3.4xlarge"
     - "g4dn.xlarge"
@@ -142,6 +141,9 @@ clusters:
     - "g5.4xlarge"
     - "g5.8xlarge"
     - "g5.16xlarge"
+    - "g6.xlarge"
+    - "g6.2xlarge"
+    - "g6.4xlarge"
     name: worker-gpu
     profile: worker-splitaz
     min_size: 0

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -131,7 +131,7 @@ clusters:
       taints: dedicated=node-tests:NoSchedule
   - discount_strategy: spot
     instance_types:
-    - "p3.2xlarge"
+    - "p4d.24xlarge"
     - "g3s.xlarge"
     - "g3.4xlarge"
     - "g4dn.xlarge"


### PR DESCRIPTION
We got notified in the e2e account to migrate away from `p3` instance type as AWS is decommissioning it in the upcoming months. This updates it to use `p4` instead, as suggested by AWS.

> Please migrate to newer generation EC2 G or P instances by December 20, 2025