### PR TITLE
use upgraded instance types in default-for-karpenter

### DIFF
--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -128,9 +128,6 @@ spec:
         - key: "karpenter.k8s.aws/instance-family"
           operator: In
           values:
-            - "c5"
-            - "m5"
-            - "r5"
             - "c5d"
             - "m5d"
             - "r5d"


### PR DESCRIPTION
We decided to perform instance type upgrades:

| Instance Type | Replacement |
|---------------|-------------|
| c5            | c6i         |
| m5            | m6i         |
| r5            | r6i         |
| ~c6g~           | ~c7g~         |

For the `default-for-karpenter` type, we can simply drop the older types as we already have the new ones in the list. `c6g` is not in the list so no replacement is needed.