### PR TITLE
[e2e] upgrade instance types

### DIFF
--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -99,11 +99,8 @@ clusters:
   - discount_strategy: spot
     instance_types:
     - "c7g.large"
-    - "c6g.large"
     - "c6i.large"
     - "c6a.large"
-    - "c5.large"
-    - "m5.large"
     - "m6i.large"
     - "m6a.large"
     - "m6g.large"
@@ -119,8 +116,6 @@ clusters:
     instance_types:
     - "m6a.large"
     - "m6i.large"
-    - "m5.large"
-    - "m5.xlarge"
     - "m6a.xlarge"
     - "m6i.xlarge"
     - "c6i.large"


### PR DESCRIPTION
We decided to upgrade instance types in our setup:

| Instance Type | Replacement |
|---------------|-------------|
| c5            | c6i         |
| m5            | m6i         |
| c6g           | c7g         |


This updates the types for the `e2e` node pools. Since the upgraded replacements are already in the pools, the older instance families are simply dropped.