### PR TITLE
Use default kube-controller-manager image

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -599,11 +599,7 @@ write_files:
           effect: NoSchedule
         containers:
         - name: kube-controller-manager
-{{- if eq .Cluster.ConfigItems.kubernetes_controller_manager_image "zalando" }}
-          image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/kube-controller-manager-internal:v1.31.3-master-133
-{{- else }}
-          image: nonexistent.zalan.do/teapot/kube-controller-manager:fixed
-{{- end }}
+          image: nonexistent.zalan.do/teapot/{{if eq .Cluster.ConfigItems.kubernetes_controller_manager_image "zalando" }}kube-controller-manager-internal{{else}}kube-controller-manager{{end}}:fixed
           args:
           - --kubeconfig=/etc/kubernetes/controller-manager-kubeconfig
           - --leader-elect=true


### PR DESCRIPTION
This reverts #8395 to use the latest version of the kube-controller-manager image which includes the fix that was the original motivation for pinning the version.

This is possible after Kubernetes v1.31.4 which includes the fix: https://github.com/zalando-incubator/kubernetes-on-aws/pull/8639