### PR TITLE
Allow configuring associatePublicIp on instance launch

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -44,6 +44,9 @@ karpenter_max_pods_per_node: "32"
 # legacy => 0.36.2-main-25.patched
 karpenter_version: "current"
 
+# Configure whether to associate public ip when launching instances.
+associate_public_ip_on_launch: "true"
+
 # ALB config created by kube-aws-ingress-controller
 kube_aws_ingress_controller_ssl_policy: "ELBSecurityPolicy-TLS-1-2-2017-01"
 kube_aws_ingress_controller_idle_timeout: "1m"

--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -81,7 +81,9 @@ Resources:
             VolumeType: gp3
         NetworkInterfaces:
         - DeviceIndex: 0
+          # {{ if eq .Cluster.ConfigItems.associate_public_ip_on_launch "true" }}
           AssociatePublicIpAddress: true
+          # {{ end }}
           Groups:
           - !ImportValue '{{ .Cluster.ID }}:master-security-group'
         EbsOptimized: false

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -21,7 +21,9 @@ spec:
   securityGroupSelectorTerms:
     - tags:
         karpenter.sh/discovery: "{{ .Cluster.ID }}/WorkerNodeSecurityGroup"
+  # {{ if eq .Cluster.ConfigItems.associate_public_ip_on_launch "true" }}
   associatePublicIPAddress: true
+  # {{ end }}
   instanceProfile: "{{ .Cluster.ID | awsValidID }}-WorkerKarpenter-InstanceProfile"
   blockDeviceMappings:
     - deviceName: /dev/sda1

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -155,7 +155,9 @@ Resources:
             VolumeType: gp3
         NetworkInterfaces:
         - DeviceIndex: 0
+          # {{ if eq .Cluster.ConfigItems.associate_public_ip_on_launch "true" }}
           AssociatePublicIpAddress: true
+          # {{ end }}
           Groups:
           - !ImportValue '{{ .Cluster.ID }}:worker-security-group'
         EbsOptimized: false


### PR DESCRIPTION
By default we configure AssociatePublicIPAddress on the launch templates of the node pools such that an IP address is added at instance launch.

For some special usage cases e.g. what is being tested in #8729 we need to launch instances with multiple network interfaces. This is not supported with AssociatePublicIPAddress in EC2 as you get the error:

```
 InvalidParameterCombination: The associatePublicIPAddress parameter cannot be specified when launching with multiple network interfaces
```

See also this for more details on the problem: https://github.com/aws/karpenter-provider-aws/pull/5666

The workaround for this problem is to set MapPublicIPOnLaunch on the subnets and not set associatePublicIPAddress on the launch template. This PR puts the config behind a config-item so it can be disabled per cluster.