### PR TITLE
Set prefix delegation false by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1211,7 +1211,7 @@ eks_zalando_iam_aws_proxy_hpa_memory_target: "80"
 eks_okta_identity_provider: "true"
 
 # prefix delegation can only be configured for ipv4. For ipv6 it can only be true.
-aws_vpc_cni_prefix_delegation: "true"
+aws_vpc_cni_prefix_delegation: "false"
 # enable network policy enforcement in the cluster.
 aws_vpc_cni_enable_network_policy: "false"
 # specify the network policy enforcement mode.


### PR DESCRIPTION
Set Prefix delegation false by default.

Not using prefix delegation gives a better utilization of ipv4 address space without sacrificing pod density on nodes too much in our environment.

We calculated that only 35 nodes would have less density than current usage across all production clusters. 