### PR TITLE
Pass Account Name to to deployment-service

### DIFF
--- a/cluster/manifests/deployment-service/01-config.yaml
+++ b/cluster/manifests/deployment-service/01-config.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: kube-system
 data:
   aws-account-id: "{{accountID .Cluster.InfrastructureAccount}}"
+  aws-account-name: "{{.Cluster.AccountName}}"
   cluster-alias: "{{.Cluster.Alias}}"
   cluster-vpc-id: "{{.Cluster.ConfigItems.vpc_id}}"
   scalyr-team-token: "{{.Cluster.ConfigItems.scalyr_team_token}}"


### PR DESCRIPTION
Pass the AWS Account name to the deployment-service such that it can be expected as template variable `CDP_TARGET_AWS_ACCOUNT`