### PR TITLE
Configure associate Public IP at node Pool level

### DIFF
--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -81,7 +81,7 @@ Resources:
             VolumeType: gp3
         NetworkInterfaces:
         - DeviceIndex: 0
-          # {{ if eq .Cluster.ConfigItems.associate_public_ip_on_launch "true" }}
+          # {{ if eq .NodePool.ConfigItems.associate_public_ip_on_launch "true" }}
           AssociatePublicIpAddress: true
           # {{ end }}
           Groups:

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -21,7 +21,7 @@ spec:
   securityGroupSelectorTerms:
     - tags:
         karpenter.sh/discovery: "{{ .Cluster.ID }}/WorkerNodeSecurityGroup"
-  # {{ if eq .Cluster.ConfigItems.associate_public_ip_on_launch "true" }}
+  # {{ if eq .NodePool.ConfigItems.associate_public_ip_on_launch "true" }}
   associatePublicIPAddress: true
   # {{ end }}
   instanceProfile: "{{ .Cluster.ID | awsValidID }}-WorkerKarpenter-InstanceProfile"

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -155,7 +155,7 @@ Resources:
             VolumeType: gp3
         NetworkInterfaces:
         - DeviceIndex: 0
-          # {{ if eq .Cluster.ConfigItems.associate_public_ip_on_launch "true" }}
+          # {{ if eq .NodePool.ConfigItems.associate_public_ip_on_launch "true" }}
           AssociatePublicIpAddress: true
           # {{ end }}
           Groups:


### PR DESCRIPTION
Follow up to #8733 

Allow configuring the associatePublicIP setting at node pool level. It can still be configured cluster wide as before.