### PR TITLE
Make internal subnet control associate-public-ip

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -44,9 +44,6 @@ karpenter_max_pods_per_node: "32"
 # legacy => 0.36.2-main-25.patched
 karpenter_version: "current"
 
-# Configure whether to associate public ip when launching instances.
-associate_public_ip_on_launch: "true"
-
 # ALB config created by kube-aws-ingress-controller
 kube_aws_ingress_controller_ssl_policy: "ELBSecurityPolicy-TLS-1-2-2017-01"
 kube_aws_ingress_controller_idle_timeout: "1m"
@@ -1157,7 +1154,13 @@ control_plane_load_balancer_internal: "none"
 
 # Optionally use internal subnets for running the nodes. This can be configured
 # a node pool level to only run a subset of nodes in the internal subnets.
+# If this is true then `associate_public_ip_on_launch` is automatically treated
+# as false.
 internal_node_subnets_enabled: "false"
+
+# Configure whether to associate public ip when launching instances.
+# This is only relevant when `internal_node_subnets_enabled` is false.
+associate_public_ip_on_launch: "true"
 
 # This allows setting custom sysctl settings. The config-item is intended to be
 # used on node-pools rather being set globally.

--- a/cluster/node-pools/master-default/stack.yaml
+++ b/cluster/node-pools/master-default/stack.yaml
@@ -85,7 +85,7 @@ Resources:
             VolumeType: gp3
         NetworkInterfaces:
         - DeviceIndex: 0
-          # {{ if eq .NodePool.ConfigItems.associate_public_ip_on_launch "true" }}
+          # {{ if and (eq .NodePool.ConfigItems.associate_public_ip_on_launch "true") (ne .NodePool.ConfigItems.internal_node_subnets_enabled "true") }}
           AssociatePublicIpAddress: true
           # {{ end }}
           Groups:

--- a/cluster/node-pools/worker-combined/stack.yaml
+++ b/cluster/node-pools/worker-combined/stack.yaml
@@ -154,7 +154,9 @@ Resources:
             VolumeType: gp3
         NetworkInterfaces:
         - DeviceIndex: 0
+          # {{ if and (eq .NodePool.ConfigItems.associate_public_ip_on_launch "true") (ne .NodePool.ConfigItems.internal_node_subnets_enabled "true") }}
           AssociatePublicIpAddress: true
+          # {{ end }}
           Groups:
           - !ImportValue '{{ .Cluster.ID }}:worker-security-group'
         EbsOptimized: false

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -25,7 +25,7 @@ spec:
   securityGroupSelectorTerms:
     - tags:
         karpenter.sh/discovery: "{{ .Cluster.ID }}/WorkerNodeSecurityGroup"
-  # {{ if eq .NodePool.ConfigItems.associate_public_ip_on_launch "true" }}
+  # {{ if and (eq .NodePool.ConfigItems.associate_public_ip_on_launch "true") (ne .NodePool.ConfigItems.internal_node_subnets_enabled "true") }}
   associatePublicIPAddress: true
   # {{ end }}
   instanceProfile: "{{ .Cluster.ID | awsValidID }}-WorkerKarpenter-InstanceProfile"

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -159,7 +159,7 @@ Resources:
             VolumeType: gp3
         NetworkInterfaces:
         - DeviceIndex: 0
-          # {{ if eq .NodePool.ConfigItems.associate_public_ip_on_launch "true" }}
+          # {{ if and (eq .NodePool.ConfigItems.associate_public_ip_on_launch "true") (ne .NodePool.ConfigItems.internal_node_subnets_enabled "true") }}
           AssociatePublicIpAddress: true
           # {{ end }}
           Groups:


### PR DESCRIPTION
When `internal_node_subnets_enabled: true` setting `associate_public_ip_on_launch: true` doesn't make any sense. So ignore `associate_public_ip_on_launch` when `internal_node_subnets_enabled: true` to avoid needing to set both config items always.

Follow up to #8742 and #8758 