### PR TITLE
Fix forwarded headers exclude cirds for IPv6

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -9,7 +9,7 @@
 {{ $cluster_internal_cidrs := list "10.2.0.0/15" .Values.vpc_ipv4_cidr }}
 {{ if eq .Cluster.Provider "zalando-eks" }}
 {{ if eq .Cluster.ConfigItems.eks_ip_family "ipv6" }}
-{{ $cluster_internal_cidrs = .Values.vpc_ipv6_cidrs }}
+{{ $cluster_internal_cidrs = append .Values.vpc_ipv6_cidrs .Values.vpc_ipv4_cidr }}
 {{ else }}
 {{ $cluster_internal_cidrs = list .Values.vpc_ipv4_cidr }}
 {{ end }}


### PR DESCRIPTION
In EKS IPv6 clusters the ingress is both IPv6 and IPv4 enabled. Therefore we need to make skipper-ingress aware of the IPv4 VPC CIDR range for the `--forwarded-headers-exclude-cirds` flag.

* [x] depends on: https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/841