### PR TITLE
master-node-autoscaler: add config-item to disable instance generation downgrade

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1207,7 +1207,7 @@ teapot_admission_controller_scheduling_controls_default_architecture: "amd64"
 # Ignore recommendations for downgrading the instance generation of the master nodes
 # This is required to persist the upgrade of instance generation for master nodes
 # in a cluster.
-master_node_autoscaler_instance_downgrade_disabled: "false"
+master_node_autoscaler_instance_generation_downgrade_disabled: "false"
 
 # role-sync-controller configs
 # Enabled by default only on Zalando EKS clusters

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1202,6 +1202,13 @@ kube_janitor_enabled: "true"
 teapot_admission_controller_scheduling_controls_enabled: "false"
 teapot_admission_controller_scheduling_controls_default_architecture: "amd64"
 
+# master-node-autoscaler configuration
+
+# Ignore recommendations for downgrading the instance generation of the master nodes
+# This is required to persist the upgrade of instance generation for master nodes
+# in a cluster.
+master_node_autoscaler_instance_downgrade_disabled: "false"
+
 # role-sync-controller configs
 # Enabled by default only on Zalando EKS clusters
 {{ if eq .Cluster.Provider "zalando-eks" }}


### PR DESCRIPTION
We need this config item to control the master-node-autoscaler behaviour on a cluster level. There are use-cases where we don't want to downgrade the instance generation once upgraded.