### PR TITLE
e2e: remove EoL g3 instances from e2e pool

### DIFF
--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -131,8 +131,6 @@ clusters:
       taints: dedicated=node-tests:NoSchedule
   - discount_strategy: spot
     instance_types:
-    - "g3s.xlarge"
-    - "g3.4xlarge"
     - "g4dn.xlarge"
     - "g4dn.2xlarge"
     - "g4dn.4xlarge"


### PR DESCRIPTION
As per the email received from AWS for the e2e account:

> You are expected to migrate to newer generation G instances by October 31, 2025. Newer generation instances typically offer better price-performance than older generation instances.

As we already use newer generation instances in our e2e pool, will simply drop the older ones.