### PR TITLE
Fix *ingress.cluster.local. on IPv6

### DIFF
--- a/cluster/manifests/01-coredns-local/configmap-local.yaml
+++ b/cluster/manifests/01-coredns-local/configmap-local.yaml
@@ -70,16 +70,26 @@ data:
         log
 {{ end }}
         template IN A {
+            {{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6") }}
+            rcode NOERROR
+            {{- else}}
             match "^.*[.]ingress[.]cluster[.]local"
             {{- if eq .Cluster.Provider "zalando-eks" }}
-            answer "{{"{{"}} .Name {{"}}"}} 60 IN AAAA {{ nthAddressFromCIDR .Cluster.ConfigItems.service_cidr 50 }}"
+            answer "{{"{{"}} .Name {{"}}"}} 60 IN A {{ nthAddressFromCIDR .Cluster.ConfigItems.service_cidr 50 }}"
             {{- else}}
             answer "{{"{{"}} .Name {{"}}"}} 60 IN A 10.5.99.99"
             {{- end}}
             fallthrough
+            {{- end}}
         }
         template IN AAAA {
+            {{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6") }}
+            match "^.*[.]ingress[.]cluster[.]local"
+            answer "{{"{{"}} .Name {{"}}"}} 60 IN AAAA {{ nthAddressFromCIDR .Cluster.ConfigItems.service_cidr 50 }}"
+            fallthrough
+            {{- else}}
             rcode NOERROR
+            {{- end}}
         }
         prometheus :9153
         ready :9155


### PR DESCRIPTION
The DNS config for the "magic" `*.ingress.cluster.local.` address was wrongly configured such that it responded with `AAAA` on an `A` record query in IPv6 clusters.

This made it not work in Go applications as they would get an error like:

```
lookup deployment-status-service.ingress.cluster.local. on [2a05:d014:b94:3404::c4c3]:53: no such host
```

Somehow `curl` was able to handle this misconfiguration and use the IPv6 address responded on `A` query, this is why the issue was not noticed in the initial implementation :shrug:

This fixes the issue by replying with AAAA record if the query is for AAAA in IPv6 mode and no reply with anything on A query in IPv6 mode and vice versa.