### PR TITLE
add manifests for the aws-fsx-csi-driver

### DIFF
--- a/cluster/manifests/aws-fsx-csi-driver/controller-deployment.yaml
+++ b/cluster/manifests/aws-fsx-csi-driver/controller-deployment.yaml
@@ -1,0 +1,112 @@
+# Source: aws-fsx-csi-driver/templates/controller-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fsx-csi-controller
+  namespace: kube-system
+  labels:
+    application: kubernetes
+    component: aws-fsx-csi-driver
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      deployment: fsx-csi-controller
+  template:
+    metadata:
+      labels:
+        deployment: fsx-csi-controller
+        application: kubernetes
+        component: aws-fsx-csi-driver
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: fsx-csi-controller-sa
+      priorityClassName: system-cluster-critical
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+          tolerationSeconds: 300
+      containers:
+        - name: fsx-plugin
+          image: container-registry.zalando.net/teapot/aws-fsx-csi-driver:v1.3.0-master-25
+          imagePullPolicy: IfNotPresent
+          args:
+            - --mode=controller
+            - --endpoint=$(CSI_ENDPOINT)
+            - --logging-format=text
+            - --v=2
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: CSI_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws-secret
+                  key: key_id
+                  optional: true
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws-secret
+                  key: access_key
+                  optional: true
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+          ports:
+            - name: healthz
+              containerPort: 9910
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 2
+            failureThreshold: 5
+        - name: csi-provisioner
+          image: container-registry.zalando.net/teapot/external-provisioner:v5.1.0-eks-1-31-10-master-24
+          args:
+            - --csi-address=$(ADDRESS)
+            - --v=2
+            - --timeout=5m
+            - --extra-create-metadata
+            - --leader-election=true
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-resizer
+          image: container-registry.zalando.net/teapot/external-resizer:v1.12.0-eks-1-31-10-master-24
+          args:
+            - --csi-address=$(ADDRESS)
+            - --v=2
+            - --leader-election=true
+            - --timeout=5m
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: liveness-probe
+          image: container-registry.zalando.net/teapot/livenessprobe:v2.14.0-eks-1-31-10-master-24
+          args:
+            - --csi-address=/csi/csi.sock
+            - --health-port=9910
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+      volumes:
+        - name: socket-dir
+          emptyDir: {}

--- a/cluster/manifests/aws-fsx-csi-driver/csi-driver.yaml
+++ b/cluster/manifests/aws-fsx-csi-driver/csi-driver.yaml
@@ -1,0 +1,8 @@
+# Source: aws-fsx-csi-driver/templates/csidriver.yaml
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: fsx.csi.aws.com
+spec:
+  attachRequired: false
+  fsGroupPolicy: ReadWriteOnceWithFSType

--- a/cluster/manifests/aws-fsx-csi-driver/daemonset.yaml
+++ b/cluster/manifests/aws-fsx-csi-driver/daemonset.yaml
@@ -105,13 +105,13 @@ spec:
       volumes:
         - name: kubelet-dir
           hostPath:
-            path: /var/lib/kubelet
+            path: /opt/podruntime/kubelet
             type: Directory
         - name: registration-dir
           hostPath:
-            path: /var/lib/kubelet/plugins_registry/
+            path: /opt/podruntime/kubelet/plugins_registry/
             type: Directory
         - name: plugin-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/fsx.csi.aws.com/
+            path: /opt/podruntime/kubelet/plugins/fsx.csi.aws.com/
             type: DirectoryOrCreate

--- a/cluster/manifests/aws-fsx-csi-driver/daemonset.yaml
+++ b/cluster/manifests/aws-fsx-csi-driver/daemonset.yaml
@@ -1,0 +1,117 @@
+# Source: aws-fsx-csi-driver/templates/node-daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fsx-csi-node
+  namespace: kube-system
+  labels:
+    application: kubernetes
+    component: aws-fsx-csi-driver
+spec:
+  selector:
+    matchLabels:
+      daemonset: fsx-csi-node
+      application: kubernetes
+      component: aws-fsx-csi-driver
+  template:
+    metadata:
+      labels:
+        daemonset: fsx-csi-node
+        application: kubernetes
+        component: aws-fsx-csi-driver
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      dnsPolicy: ClusterFirst
+      serviceAccountName: fsx-csi-node-sa
+      priorityClassName: system-node-critical
+      tolerations:
+        - operator: Exists
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: eks.amazonaws.com/compute-type
+                operator: NotIn
+                values:
+                - fargate
+      containers:
+        - name: fsx-plugin
+          securityContext:
+            privileged: true
+          image: container-registry.zalando.net/teapot/aws-fsx-csi-driver:v1.3.0-master-25
+          imagePullPolicy: IfNotPresent
+          args:
+            - --mode=node
+            - --endpoint=$(CSI_ENDPOINT)
+            - --logging-format=text
+            - --v=2
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:/csi/csi.sock
+            - name: CSI_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: kubelet-dir
+              mountPath: /var/lib/kubelet
+              mountPropagation: "Bidirectional"
+            - name: plugin-dir
+              mountPath: /csi
+          ports:
+            - name: healthz
+              containerPort: 9810
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 2
+            failureThreshold: 5
+        - name: node-driver-registrar
+          image: container-registry.zalando.net/teapot/node-driver-registrar:v2.12.0-eks-1-31-10-master-24
+          imagePullPolicy: IfNotPresent
+          args:
+            - --csi-address=$(ADDRESS)
+            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+            - --v=2
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/fsx.csi.aws.com/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+        - name: liveness-probe
+          image: container-registry.zalando.net/teapot/livenessprobe:v2.14.0-eks-1-31-10-master-24
+          imagePullPolicy: IfNotPresent
+          args:
+            - --csi-address=/csi/csi.sock
+            - --health-port=9810
+          volumeMounts:
+            - mountPath: /csi
+              name: plugin-dir
+      volumes:
+        - name: kubelet-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: Directory
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/fsx.csi.aws.com/
+            type: DirectoryOrCreate

--- a/cluster/manifests/aws-fsx-csi-driver/rbac.yaml
+++ b/cluster/manifests/aws-fsx-csi-driver/rbac.yaml
@@ -1,0 +1,147 @@
+# Source: aws-fsx-csi-driver/templates/controller-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fsx-csi-controller-sa
+  namespace: kube-system
+  labels:
+    application: kubernetes
+    component: aws-fsx-csi-driver
+---
+# Source: aws-fsx-csi-driver/templates/node-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fsx-csi-node-sa
+  namespace: kube-system
+  labels:
+    application: kubernetes
+    component: aws-fsx-csi-driver
+---
+# Source: aws-fsx-csi-driver/templates/clusterrole-csi-node.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: fsx-csi-node-role
+  labels:
+    application: kubernetes
+    component: aws-fsx-csi-driver
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "patch"]
+---
+# Source: aws-fsx-csi-driver/templates/controller-serviceaccount.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: fsx-csi-external-provisioner-role
+  labels:
+    application: kubernetes
+    component: aws-fsx-csi-driver
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+---
+# Source: aws-fsx-csi-driver/templates/controller-serviceaccount.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: fsx-external-resizer-role
+  labels:
+    application: kubernetes
+    component: aws-fsx-csi-driver
+rules:
+  # The following rule should be uncommented for plugins that require secrets
+  # for provisioning.
+  # - apiGroups: [""]
+  #   resources: ["secrets"]
+  #   verbs: ["get", "list", "watch"]
+  - apiGroups: [ "" ]
+    resources: [ "persistentvolumes" ]
+    verbs: [ "get", "list", "watch", "update", "patch" ]
+  - apiGroups: [ "" ]
+    resources: [ "persistentvolumeclaims" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "" ]
+    resources: [ "persistentvolumeclaims/status" ]
+    verbs: [ "update", "patch" ]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "storageclasses" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "" ]
+    resources: [ "events" ]
+    verbs: [ "list", "watch", "create", "update", "patch" ]
+  - apiGroups: [ "" ]
+    resources: [ "pods" ]
+    verbs: [ "get", "list", "watch" ]
+---
+# Source: aws-fsx-csi-driver/templates/clusterrolebinding-csi-node.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: fsx-csi-node-getter-binding
+  labels:
+    application: kubernetes
+    component: aws-fsx-csi-driver
+subjects:
+  - kind: ServiceAccount
+    name: fsx-csi-node-sa
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: fsx-csi-node-role
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: aws-fsx-csi-driver/templates/controller-serviceaccount.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: fsx-csi-external-provisioner-binding
+  labels:
+    application: kubernetes
+    component: aws-fsx-csi-driver
+subjects:
+  - kind: ServiceAccount
+    name: fsx-csi-controller-sa
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: fsx-csi-external-provisioner-role
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: aws-fsx-csi-driver/templates/controller-serviceaccount.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: fsx-csi-resizer-binding
+  labels:
+    application: kubernetes
+    component: aws-fsx-csi-driver
+subjects:
+  - kind: ServiceAccount
+    name: fsx-csi-controller-sa
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: fsx-external-resizer-role
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Adds manifests needed for support of [AWS FSx CSI Driver](https://docs.aws.amazon.com/eks/latest/userguide/fsx-csi.html) as requested by the data team. The manifest source is: https://github.com/kubernetes-sigs/aws-fsx-csi-driver/tree/master/charts/aws-fsx-csi-driver

Dry-ran helm in the chart directory to render the manifests and then adjusted for our environment:

```bash
$ helm install aws-fsx-csi-driver . --dry-run --debug
```

TODO: 
- [ ] Add an AWS IAM role for the controller, annotate the service account.
- [ ] Put the feature behind a feature flag.

