### PR TITLE
Assume RAID0 for instances with local storage

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -44,6 +44,11 @@ karpenter_max_pods_per_node: "32"
 # legacy => 0.36.2-main-25.patched
 karpenter_version: "current"
 
+# configure whether karpenter should assume instances with local storage use
+# RAID0 for ephemeral pod storage.
+# Our AMI configured RAID0 at boot.
+karpenter_instance_storage_raid0: "true"
+
 # ALB config created by kube-aws-ingress-controller
 kube_aws_ingress_controller_ssl_policy: "ELBSecurityPolicy-TLS-1-2-2017-01"
 kube_aws_ingress_controller_idle_timeout: "1m"

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -35,6 +35,9 @@ spec:
         deleteOnTermination: {{ .NodePool.ConfigItems.ebs_root_volume_delete_on_termination }}
         volumeSize: {{ .NodePool.ConfigItems.ebs_root_volume_size }}Gi
         volumeType: gp3
+  # {{ if eq .NodePool.ConfigItems.karpenter_instance_storage_raid0 "true" }}
+  instanceStorePolicy: RAID0
+  # {{ end }}
   # If you enable this option, the Amazon EC2 console displays monitoring graphs with a 1-minute period for the instances that Karpenter launches.
   detailedMonitoring: false
   tags:


### PR DESCRIPTION
Configure Karpenter to assume RAID0 setup for instances with local storage.

This maps to how we configure such instances at boot and is needed to make Karpenter know what ephemeral storage size to expect when choosing instances for a pod requesting ephemeral storage.

This is how it's used when calculating ephemeral storage for an instance type: https://github.com/aws/karpenter-provider-aws/blob/5f55b1d20d26302e9d3a0fc5943416dcfca1688c/pkg/providers/instancetype/types.go#L228-L235

This setting is added behind a config-item, on by default, to make it quick to turn off should it cause unexpected issues. (The change was tested/validated in a pet cluster)