### PR TITLE
Correctly exclude wiz from node readiness check

### DIFF
--- a/cluster/manifests/wiz/sensor-daemonset.yaml
+++ b/cluster/manifests/wiz/sensor-daemonset.yaml
@@ -10,6 +10,8 @@ metadata:
     application: "wiz"
     component: "sensor"
     daemonset: "wiz-sensor"
+  annotations:
+    node-ready.cluster.zalando.org/exclude: "true"
   namespace: wiz
 spec:
   selector:
@@ -27,7 +29,6 @@ spec:
       annotations:
         container.apparmor.security.beta.kubernetes.io/wiz-sensor: unconfined
         cluster-autoscaler.kubernetes.io/enable-ds-eviction: "true"
-        node-ready.cluster.zalando.org/exclude: "true"
     spec:
       serviceAccountName: wiz-sensor
       nodeSelector:


### PR DESCRIPTION
Follow up to #8679 

Moves the annotation: `node-ready.cluster.zalando.org/exclude: "true"` to the right place (daemonset level) to have the intended effect of not marking nodes unready if wiz fails to run.