### PR TITLE
Fix typo in wiz-sensor service account name

### DIFF
--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -116,7 +116,7 @@ data:
   pod.pod-security-policy.privileged-service-accounts.{{ $sa }}: ""
 {{- end}}
 {{- if eq .Cluster.ConfigItems.wiz_enable_runtime_sensor "true" }}
-  pod.pod-security-policy.privileged-service-accounts.wiz_wiz_sensor: ""
+  pod.pod-security-policy.privileged-service-accounts.wiz_wiz-sensor: ""
 {{- end }}
 
   pod.pod-security-policy.allowed-restricted-capabilities.AUDIT_WRITE: ""


### PR DESCRIPTION
Fix typo in the `wiz-sensor` service account name. Otherwise it's not treated as privileged.