### PR TITLE
Allow powerusers to use the subjectaccessreviews API

### DIFF
--- a/cluster/manifests/roles/poweruser-role.yaml
+++ b/cluster/manifests/roles/poweruser-role.yaml
@@ -221,6 +221,12 @@ rules:
   - patch
   - update
 - apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
   - scheduling.k8s.io
   resources:
   - priorityclasses


### PR DESCRIPTION
Allow power users to use the `subjectaccessreviews` API in order to check what different identities has access to do.