### PR TITLE
Handle secret read clusterroles

### DIFF
--- a/cluster/manifests/02-admission-control/teapot.yaml
+++ b/cluster/manifests/02-admission-control/teapot.yaml
@@ -583,4 +583,33 @@ webhooks:
         expression: '!(request.userInfo.username in ["system:kube-controller-manager", "system:kube-scheduler", "zalando-iam:zalando:service:k8sapi_credentials-provider"])'
       - name: 'exclude-eks-components'
         expression: '!request.userInfo.username.startsWith("eks:")'
+  {{- if eq .Cluster.ConfigItems.role_sync_controller_enabled "true" }}
+  - name: clusterrole-admitter.teapot.zalan.do
+    clientConfig:
+      {{- if eq .Cluster.Provider "zalando-eks"}}
+      service:
+        name: "admission-controller"
+        namespace: "kube-system"
+        path: "/node"
+      {{- else }}
+      url: "https://localhost:8085/clusterrole"
+      {{- end }}
+      caBundle: "{{ .Cluster.ConfigItems.ca_cert_decompressed }}"
+    admissionReviewVersions: ["v1beta1"]
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    sideEffects: "None"
+    rules:
+      - operations: [ "CREATE", "UPDATE" ]
+        apiGroups: ["rbac.authorization.k8s.io"]
+        apiVersions: ["v1"]
+        resources: ["clusterroles"]
+    matchConditions:
+      - name: 'exclude-privileged-groups'
+        expression: 'request.userInfo.groups.all(g, !(g in ["system:masters", "system:nodes", "system:serviceaccounts:kube-system", "okta:common/administrator", "zalando:administrator"]))'
+      {{- if eq .Cluster.Provider "zalando-eks"}}
+      - name: 'exclude-eks-components'
+        expression: '!request.userInfo.username.startsWith("eks:")'
+      {{- end }}
+  {{- end }}
 {{- end }}

--- a/cluster/manifests/02-admission-control/teapot.yaml
+++ b/cluster/manifests/02-admission-control/teapot.yaml
@@ -590,7 +590,7 @@ webhooks:
       service:
         name: "admission-controller"
         namespace: "kube-system"
-        path: "/node"
+        path: "/clusterrole"
       {{- else }}
       url: "https://localhost:8085/clusterrole"
       {{- end }}

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -308,6 +308,11 @@ post_apply:
 - name: role-sync-controller
   kind: ServiceAccount
   namespace: kube-system
+# secret-read role/bindings
+- name: cdp-deployer-poweruser-secret-read
+  kind: ClusterRoleBinding
+- name: deployment-service-executor-poweruser-secret-read
+  kind: ClusterRoleBinding
 {{- end }}
 {{- if ne .Cluster.ConfigItems.kube_janitor_enabled "true" }}
 - name: kube-janitor

--- a/cluster/manifests/deployment-service/controller-rbac.yaml
+++ b/cluster/manifests/deployment-service/controller-rbac.yaml
@@ -123,6 +123,29 @@ subjects:
     name: "deployment-service-controller"
     namespace: "kube-system"
   # {{ end }}
+# {{ if eq .Cluster.ConfigItems.role_sync_controller_enabled "true" }}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "deployment-service-executor-poweruser-secret-read"
+  labels:
+    application: "deployment-service"
+    component: "controller"
+roleRef:
+  kind: ClusterRole
+  name: poweruser-secret-read
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: zalando-iam:zalando:service:k8sapi-local_deployment-service-executor
+  # {{ if eq .Cluster.Provider "zalando-eks" }}
+  - kind: ServiceAccount
+    name: "deployment-service-controller"
+    namespace: "kube-system"
+  # {{ end }}
+# {{ end }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cluster/manifests/roles/cdp-deployer-binding.yaml
+++ b/cluster/manifests/roles/cdp-deployer-binding.yaml
@@ -10,3 +10,18 @@ subjects:
 - kind: ServiceAccount
   name: cdp
   namespace: default
+# {{ if eq .Cluster.ConfigItems.role_sync_controller_enabled "true" }}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cdp-deployer-poweruser-secret-read
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: poweruser-secret-read
+subjects:
+- kind: ServiceAccount
+  name: cdp
+  namespace: default
+# {{ end }}

--- a/cluster/manifests/roles/poweruser-role.yaml
+++ b/cluster/manifests/roles/poweruser-role.yaml
@@ -58,6 +58,7 @@ rules:
   - services/proxy
   verbs:
   - get
+# {{ if ne .Cluster.ConfigItems.role_sync_controller_enabled "true" }}
 - apiGroups:
   - ''
   resources:
@@ -66,6 +67,7 @@ rules:
   - get
   - list
   - watch
+# {{ end }}
 - apiGroups:
   - ''
   - extensions
@@ -248,3 +250,19 @@ rules:
   - update
   - patch
   - delete
+# {{ if eq .Cluster.ConfigItems.role_sync_controller_enabled "true" }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: poweruser-secret-read
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+# {{ end }}

--- a/cluster/manifests/roles/poweruser-role.yaml
+++ b/cluster/manifests/roles/poweruser-role.yaml
@@ -58,21 +58,14 @@ rules:
   - services/proxy
   verbs:
   - get
-{{ if ne .Cluster.ConfigItems.role_sync_controller_enabled "true" }}
 - apiGroups:
   - ''
   resources:
   - secrets
   verbs:
-  - create
-  - delete
-  - deletecollection
   - get
   - list
-  - patch
-  - update
   - watch
-{{ end }}
 - apiGroups:
   - ''
   - extensions


### PR DESCRIPTION
Improves handling of secret read cluster roles in EKS clusters

The implementation is described as follows:

1. Extend admission-controller with a clusterrole admitter which detects clusterroles that defined secret read permissions `({ApiGroups: [""], Resources:["secrets"],Verbs:["get|list|watch"]}`). If detected, it extracts the permissions from the role and moves them to an annotation: `clusterroles.admission-controller.zalando.org/secret-read-verbs: "get,list,watch"`. This achieves two things 1) Users can't deploy clusterroles with secret read permissions because those permissions will be removed during admission. 2) The role gets annotated such that it can be detected if the users intended to have read secret permissions. This is implemented in https://github.com/zalando-incubator/kubernetes-on-aws/pull/8987
2. Extend the role-sync-controller to look for clusterroles withs the annotation: `clusterroles.admission-controller.zalando.org/secret-read-verbs: "get,list,watch"` and resolve the clusterrolebindings binding to those roles. With the bindings we get a list of subjects that want read secret permissions at cluster level and those subjects can be added to the per namespace secrets role bindings. This is implemented in https://github.com/zalando-incubator/kubernetes-on-aws/pull/8986
3. Allow read secret permissions at the cluster level for poweruser/CDP. This effectively allows users to apply a clusterrole with read secret permissions, but because of 1 and 2, the clusterrole is not applied in that way but the subject(s) binding to the clusterrole will instead bind to the per namespace secret reader roles and the users get effectively the same permissions as in non-EKS, without changing their manifests.
4. Lastly, to prevent powerusers from reading from kube-system we remove secret read permissions from the cluster-role and only attach those permissions to the cdp/deployment-service service accounts. This means a poweruser, user, e.g. Manual access, can't create a cluster-role with read secret permissions. This is however still possible via CDP.


## TODO

* [ ] ~Add e2e covering this feature.~