### PR TITLE
efa-plugin: use label selector: vpc.amazonaws.com/efa: enabled

### DIFF
--- a/cluster/manifests/aws-efa-device-plugin/daemonset.yaml
+++ b/cluster/manifests/aws-efa-device-plugin/daemonset.yaml
@@ -34,6 +34,8 @@ spec:
       # be rescheduled after a failure.
       # See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
       priorityClassName: "system-node-critical"
+      nodeSelector:
+        vpc.amazonaws.com/efa: enabled
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
This adds a nodeSelector to the efa plugin:

```
vpc.amazonaws.com/efa: enabled
```

This means node-pools that intend to run with EFA enabled instances should set this label. The reason for this is that even if an instance has the capability to attach EFA, it might not do it. If it doesn't then the efa-plugion daemonset pod just exits and the pod and node never gets ready.

This is a mitigation to that problem. Ideally the plugin would behave more graceful.