### PR TITLE
Add kube-node-decommissioner CronJob

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -417,6 +417,9 @@ kube_proxy_memory_limit: "200Mi"
 kube_proxy_sync_period: "15m0s"
 kube_proxy_verbose_level: "2"
 
+# kube-node-decommissioner
+kube_node_decommissioner_enabled: "true"
+
 # flannel settings
 flannel_cpu: "25m"
 flannel_memory_request: "100Mi"

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -410,3 +410,15 @@ post_apply:
   kind: ServiceAccount
   namespace: kube-system
 {{- end}}
+{{- if ne .Cluster.ConfigItems.kube_node_decommissioner_enabled "true"}}
+- name: kube-node-decommissioner
+  kind: CronJob
+  namespace: kube-system
+- name: kube-node-decommissioner
+  kind: ClusterRole
+- name: kube-node-decommissioner
+  kind: ClusterRoleBinding
+- name: kube-node-decommissioner
+  kind: ServiceAccount
+  namespace: kube-system
+{{- end}}

--- a/cluster/manifests/kube-node-decommissioner/01-rbac.yaml
+++ b/cluster/manifests/kube-node-decommissioner/01-rbac.yaml
@@ -1,0 +1,40 @@
+# {{ if eq .Cluster.ConfigItems.kube_node_decommissioner_enabled "true" }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "kube-node-decommissioner"
+  namespace: "kube-system"
+  annotations:
+    application: kubernetes
+    component: kube-node-decommissioner
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-node-decommissioner
+  labels:
+    application: kubernetes
+    component: kube-node-decommissioner
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["list", "patch"]
+---
+# This role binding allows service-account "kube-node-decommissioner" to
+# list and patch nodes.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-node-decommissioner
+  labels:
+    application: kubernetes
+    component: kube-node-decommissioner
+roleRef:
+  kind: ClusterRole
+  name: kube-node-decommissioner
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: "kube-node-decommissioner"
+  namespace: "kube-system"
+# {{ end }}

--- a/cluster/manifests/kube-node-decommissioner/cronjob.yaml
+++ b/cluster/manifests/kube-node-decommissioner/cronjob.yaml
@@ -1,0 +1,42 @@
+# {{ if eq .Cluster.ConfigItems.kube_node_decommissioner_enabled "true" }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: kube-node-decommissioner
+  namespace: "kube-system"
+  labels:
+    application: kubernetes
+    component: kube-node-decommissioner
+spec:
+  schedule: "*/1 * * * *"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 300
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 300
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            application: kubernetes
+            component: kube-node-decommissioner
+          annotations:
+            logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
+        spec:
+          serviceAccountName: kube-node-decommissioner
+          restartPolicy: Never
+          containers:
+          - name: kube-node-decommissioner
+            image: container-registry.zalando.net/teapot/kube-node-decommissioner:main-1
+            args:
+              - --debug
+            resources:
+              limits:
+                cpu: 100m
+                memory: 100Mi
+              requests:
+                cpu: 100m
+                memory: 100Mi
+# {{ end }}


### PR DESCRIPTION
This adds a simple cronJob which checks all nodes in a cluster and sees if the node should be replaced for some reason.

Currently it only implements checking for nodes in an unresponsive state where all pods are in terminating state.

This is intended as a simple mitigation to that problem. E.g. auto detect the condition and automatically mark the node for decommissioning. This is both faster than having an on-call person get paged and do it manually, and it's additionally less toil for 24x7.

It's enabled by default but can be turned off by setting `kube_node_decommissioner_enabled: false`