### PR TITLE
kube-node-decommissioner: fix image

### DIFF
--- a/cluster/manifests/kube-node-decommissioner/cronjob.yaml
+++ b/cluster/manifests/kube-node-decommissioner/cronjob.yaml
@@ -29,9 +29,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: kube-node-decommissioner
-            image: container-registry.zalando.net/teapot/kube-node-decommissioner:main-1
-            args:
-              - --debug
+            image: container-registry.zalando.net/teapot/kube-node-decommissioner:main-2
             resources:
               limits:
                 cpu: 100m


### PR DESCRIPTION
Follow up to #8891 

Fixes two issues:

* Built image was wrong so the cronjob didn't succeed in pulling and running
* Drop `--debug` flag which is not implemented (was copied from another cronjob).