### PR TITLE
Fix permissions for kube-node-decommissioner

### DIFF
--- a/cluster/manifests/kube-node-decommissioner/01-rbac.yaml
+++ b/cluster/manifests/kube-node-decommissioner/01-rbac.yaml
@@ -17,8 +17,11 @@ metadata:
     component: kube-node-decommissioner
 rules:
 - apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["list"]
+- apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["list", "patch"]
+  verbs: ["list", "update"]
 ---
 # This role binding allows service-account "kube-node-decommissioner" to
 # list and patch nodes.


### PR DESCRIPTION
Fixes permission issues in `kube-node-decommissioner`.

```
2025/02/18 10:22:01 failed to retire nodes: failed to map nodes to pods: pods is forbidden: User "system:serviceaccount:kube-system:kube-node-decommissioner" cannot list resource "pods" in API group "" at  the cluster scope: access undecided system:serviceaccount:kube-system:kube-node-decommissioner/[system:serviceaccounts system:serviceaccounts:kube-system system:authenticated]
```

[edit] also changed nodes `patch` to `update` to match the function call in the code.