### PR TITLE
Enable postgresql owning-application annotation check in prod

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -605,6 +605,7 @@ teapot_admission_controller_validate_pod_template_resources: "true"
 teapot_admission_controller_preemption_enabled: "true"
 teapot_admission_controller_postgresql_delete_protection_enabled: "true"
 teapot_admission_controller_namespace_delete_protection_enabled: "true"
+teapot_admission_controller_postgresql_owning_application_check_enabled: "true"
 {{else if eq .Cluster.Environment "e2e"}}
 teapot_admission_controller_validate_application_label: "false"
 teapot_admission_controller_validate_base_images: "false"
@@ -616,6 +617,7 @@ teapot_admission_controller_validate_pod_template_resources: "false"
 teapot_admission_controller_preemption_enabled: "true"
 teapot_admission_controller_postgresql_delete_protection_enabled: "false"
 teapot_admission_controller_namespace_delete_protection_enabled: "false"
+teapot_admission_controller_postgresql_owning_application_check_enabled: "false"
 {{else}}
 teapot_admission_controller_validate_application_label: "false"
 teapot_admission_controller_validate_base_images: "false"
@@ -627,6 +629,7 @@ teapot_admission_controller_validate_pod_template_resources: "true"
 teapot_admission_controller_preemption_enabled: "false"
 teapot_admission_controller_postgresql_delete_protection_enabled: "false"
 teapot_admission_controller_namespace_delete_protection_enabled: "false"
+teapot_admission_controller_postgresql_owning_application_check_enabled: "false"
 {{end}}
 
 # Enable automatic replacement of vanity images with ECR images

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -617,7 +617,6 @@ teapot_admission_controller_validate_pod_template_resources: "false"
 teapot_admission_controller_preemption_enabled: "true"
 teapot_admission_controller_postgresql_delete_protection_enabled: "false"
 teapot_admission_controller_namespace_delete_protection_enabled: "false"
-teapot_admission_controller_postgresql_owning_application_check_enabled: "false"
 {{else}}
 teapot_admission_controller_validate_application_label: "false"
 teapot_admission_controller_validate_base_images: "false"

--- a/cluster/manifests/01-admission-control/config.yaml
+++ b/cluster/manifests/01-admission-control/config.yaml
@@ -173,6 +173,7 @@ data:
   priorityclass.preemption.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_preemption_enabled }}"
 
   postgresql.delete-protection.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_postgresql_delete_protection_enabled }}"
+  postgresql.owning-application-check.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_postgresql_owning_application_check_enabled }}"
 
   namespace.delete-protection.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_namespace_delete_protection_enabled }}"
 

--- a/cluster/manifests/01-admission-control/teapot.yaml
+++ b/cluster/manifests/01-admission-control/teapot.yaml
@@ -222,7 +222,7 @@ webhooks:
     sideEffects: "NoneOnDryRun"
     matchPolicy: Equivalent
     rules:
-      - operations: [ "CREATE", "DELETE" ]
+      - operations: [ "CREATE", "DELETE", "UPDATE" ]
         apiGroups: ["acid.zalan.do"]
         apiVersions: ["v1"]
         resources: ["postgresqls"]


### PR DESCRIPTION
Block production CREATEs and UPDATEs of a postgresql resource without `zalando.org/owning-application `annotation specified in the manifest or when its value is a non-existent/inactive application.