### PR TITLE
skipper-internal: Update main fleet to version v0.21.268-1090

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,6 +1,6 @@
 {{/* image-updater-bot detects *image variables so use print to disable it for main image */}}
 
-{{ $main_image := print "container-registry.zalando.net/teapot/skipper-internal:" "v0.21.257-1079" }}
+{{ $main_image := print "container-registry.zalando.net/teapot/skipper-internal:" "v0.21.268-1090" }}
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.21.268-1090" }}
 
 


### PR DESCRIPTION
* https://github.com/zalando/skipper/pull/3377
* https://github.com/zalando/skipper/pull/3382
* https://github.com/zalando/skipper/pull/3384
* https://github.com/zalando/skipper/pull/3385
* https://github.com/zalando/skipper/pull/3386
* https://github.com/zalando/skipper/pull/3387
* https://github.com/zalando/skipper/pull/3390
* https://github.com/zalando/skipper/pull/3395
* https://github.com/zalando/skipper/pull/3394
* https://github.com/zalando/skipper/pull/3393
* https://github.com/zalando/skipper/pull/3392
* https://github.com/zalando/skipper/pull/3396
* https://github.com/zalando/skipper/pull/3315
* https://github.com/zalando/skipper/pull/3400
* https://github.com/zalando/skipper/pull/3399
* https://github.com/zalando/skipper/pull/3401
* https://github.com/zalando/skipper/pull/3402
* https://github.com/zalando/skipper/pull/3403

follow up on https://github.com/zalando-incubator/kubernetes-on-aws/pull/8864