### PR TITLE
Increase resources for kube-node-decommissioner and make configurable

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -414,6 +414,8 @@ kube_proxy_verbose_level: "2"
 
 # kube-node-decommissioner
 kube_node_decommissioner_enabled: "true"
+kube_node_decommissioner_cpu: "100m"
+kube_node_decommissioner_memory: "1Gi"
 
 # flannel settings
 flannel_cpu: "25m"

--- a/cluster/manifests/kube-node-decommissioner/cronjob.yaml
+++ b/cluster/manifests/kube-node-decommissioner/cronjob.yaml
@@ -32,9 +32,9 @@ spec:
             image: container-registry.zalando.net/teapot/kube-node-decommissioner:main-2
             resources:
               limits:
-                cpu: 100m
-                memory: 100Mi
+                cpu: "{{.Cluster.ConfigItems.kube_node_decommissioner_cpu}}"
+                memory: "{{.Cluster.ConfigItems.kube_node_decommissioner_memory}}"
               requests:
-                cpu: 100m
-                memory: 100Mi
+                cpu: "{{.Cluster.ConfigItems.kube_node_decommissioner_cpu}}"
+                memory: "{{.Cluster.ConfigItems.kube_node_decommissioner_memory}}"
 # {{ end }}


### PR DESCRIPTION
Increase resources for `kube-node-decommissioner` cronjob and make them configurable.

The cronjob is crashing in big clusters hence the need to increase the resources. 