### PR TITLE
Allow access to secretsmanager:GetSecretValue for ZMON role

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1938,6 +1938,9 @@ Resources:
               - Action: 'states:ListExecutions'
                 Effect: Allow
                 Resource: '*'
+              - Action: 'secretsmanager:GetSecretValue'
+                Effect: Allow
+                Resource: "arn:aws:secretsmanager:{{.Cluster.Region}}:{{.Cluster.InfrastructureAccount | getAWSAccountID}}:secret:*.zmon-db-user.credentials*"
             Version: 2012-10-17
           PolicyName: root
       RoleName: "{{.Cluster.LocalID}}-app-zmon"


### PR DESCRIPTION
This PR allows access to secretsmanager:GetSecretValue for ZMON role following the support request