### PR TITLE
Optional support for AWS Fault Injection Service with EKS

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -9,6 +9,37 @@ Metadata:
 
 Resources:
 {{ if eq .Cluster.Provider "zalando-eks" }}
+  # https://aws.amazon.com/blogs/containers/aws-fault-injection-simulator-supports-chaos-engineering-experiments-on-amazon-eks-pods/
+  {{- if eq .Cluster.ConfigItems.eks_fis_support_enabled "true" }}
+  FISEKSClusterRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: "{{.Cluster.LocalID}}-eks-fis-experiment-executor"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+            - fis.amazonaws.com
+          Action:
+          - sts:AssumeRole
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/service-role/AWSFaultInjectionSimulatorEKSAccess
+      Policies:
+      - PolicyDocument:
+          Statement:
+            - Action:
+              - "logs:CreateLogDelivery"
+              - "logs:PutResourcePolicy"
+              - "logs:DescribeResourcePolicies"
+              - "logs:DescribeLogGroups"
+              Effect: Allow
+              Resource: "*"
+          Version: 2012-10-17
+        PolicyName: root
+  {{- end }}
+
   EKSClusterRole:
     Type: AWS::IAM::Role
     Properties:
@@ -190,6 +221,15 @@ Resources:
       KubernetesGroups:
       - zalando:administrator
       Type: "STANDARD"
+  {{- if eq .Cluster.ConfigItems.eks_fis_support_enabled "true" }}
+  EKSAccessEntryFISEKSRole:
+    Type: "AWS::EKS::AccessEntry"
+    Properties:
+      ClusterName: !Ref EKSCluster
+      PrincipalArn: !GetAtt FISEKSClusterRole.Arn
+      Username: "fis-experiment-executor"
+      Type: "STANDARD"
+  {{- end }}
   EKSAccessEntryZalandoIAMAuth:
     Type: "AWS::EKS::AccessEntry"
     Properties:

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1253,6 +1253,8 @@ eks_zalando_iam_aws_proxy_hpa_max_replicas: "10"
 eks_zalando_iam_aws_proxy_hpa_cpu_target: "80"
 eks_zalando_iam_aws_proxy_hpa_memory_target: "80"
 eks_okta_identity_provider: "true"
+eks_fis_support_enabled: "false"
+eks_fis_namespaces: "default"
 
 # prefix delegation can only be configured for ipv4. For ipv6 it can only be true.
 aws_vpc_cni_prefix_delegation: "false"

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -10,6 +10,17 @@ post_apply:
 - name: coredns
   kind: ConfigMap
   namespace: kube-system
+{{- if ne .Cluster.ConfigItems.eks_fis_support_enabled "true" }}
+- name: fis-experiment
+  kind: ClusterRoleBinding
+- name: fis-experiment
+  kind: ClusterRole
+# {{ range $namespace := split .Cluster.ConfigItems.eks_fis_namespaces "," }}
+- name: fis-experiment
+  kind: ServiceAccount
+  namespace: "{{ $namespace }}"
+# {{ end }}
+{{- end }}
 {{- end }}
 {{ if eq .Cluster.ConfigItems.teapot_admission_controller_process_resources "true" }}
 - name: limits

--- a/cluster/manifests/eks-fis/01-rbac.yaml
+++ b/cluster/manifests/eks-fis/01-rbac.yaml
@@ -1,0 +1,48 @@
+{{- if eq .Cluster.ConfigItems.eks_fis_support_enabled "true" }}
+# {{ range $namespace := split .Cluster.ConfigItems.eks_fis_namespaces "," }}
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  namespace: "{{ $namespace }}"
+  name: fis-experiment-executor
+---
+# {{ end }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: fis-experiment-executor
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "create", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["create", "get", "delete", "deletecollection", "list"]
+- apiGroups: [""]
+  resources: ["pods/ephemeralcontainers"]
+  verbs: ["update"]
+- apiGroups: [""]
+  resources: ["pods/exec"]
+  verbs: ["create"]
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: fis-experiment-executor
+subjects:
+# {{ range $namespace := split .Cluster.ConfigItems.eks_fis_namespaces "," }}
+- kind: ServiceAccount
+  name: fis-experiment-executor
+  namespace: "{{ $namespace }}"
+# {{ end }}
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: fis-experiment-executor
+roleRef:
+  kind: ClusterRole
+  name: fis-experiment-executor
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}


### PR DESCRIPTION
This implements the foundation for integrating AWS Fault Injection Service (FIS) with EKS

It basically creates an IAM role to be used in FIS which has access to create a FIS executor pod in the target namespace.

![image](https://github.com/user-attachments/assets/65df0c32-e190-4094-ba94-99afac8f91d2)

This is the very first version of adding support, there are several complexities not yet solved, however having this in the EKS branch makes it simpler to enable and test in clusters.

https://docs.aws.amazon.com/fis/latest/userguide/eks-pod-actions.html

https://aws.amazon.com/blogs/containers/aws-fault-injection-simulator-supports-chaos-engineering-experiments-on-amazon-eks-pods/