### PR TITLE
update to etcd v3.5.18

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -734,7 +734,7 @@ etcd_instance_type: "t3.medium"
 
 etcd_scalyr_key: ""
 
-etcd_ami: {{ amiID "zalando-ubuntu-etcd-production-v3.5.13-amd64-main-34" "861068367966"}}
+etcd_ami: {{ amiID "zalando-ubuntu-etcd-production-v3.5.18-amd64-main-35" "861068367966"}}
 
 cluster_dns: "coredns"
 coredns_log_svc_names: "true"


### PR DESCRIPTION
Update the etcd version to `v3.5.18`, will follow with node rotations to rollout the new version.