### PR TITLE
Fix karpenter CRDs for v1.1.1 upgrade

### DIFF
--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -122,6 +122,8 @@ spec:
       expireAfter: Never
       # References the Cloud Provider's NodeClass resource, see your cloud provider specific documentation
       nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
         name: {{ .NodePool.Name }}
 #{{ $taints := .NodePool.Taints }}
 #{{  if $taints }}

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -256,6 +256,7 @@ spec:
     consolidateAfter: {{ or (index .NodePool.ConfigItems "consolidate_after") "10m" }}
 #{{  else }}
     consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: {{ or (index .NodePool.ConfigItems "consolidate_after") "0s" }}
 #{{  end }}
   # Priority given to the NodePool when the scheduler considers which NodePool
   # to select. Higher weights indicate higher priority when comparing NodePools.


### PR DESCRIPTION
Follow up to #8901

Fixes issues with creating the ec2nodeclass in new clusters (issue didn't happen when migration from existing v1beta1 version of the resource).

* Set `consolidateAfter` to 0s which is the same behavior as with v1beta1, but allow configuring this via `consolidate_after`.
* Add `group` and `kind` to nodeClassRef