### PR TITLE
Halt terminating unbound

### DIFF
--- a/cluster/manifests/coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/coredns-local/daemonset-coredns.yaml
@@ -63,6 +63,10 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 5
 {{- end }}
+        lifecyle:
+          preStop:
+            sleep:
+              seconds: 25
         resources:
           requests:
             ephemeral-storage: 256Mi


### PR DESCRIPTION
After enabled `unbound` instead of `dnsmasq` as DNS cache in all test clusters we sometime see DNS errors from `logging-agent`. The errors correspond with `logging-agent` doing requests before shutting down when daemonsets are evicted as part of node decommissioning.

The reason we see those errors with `unbound` and not with `dnsmasq` is that `dnsmasq` DOES NOT handle SIGTERM and shut down, but instead waits 30s for terminationGracePeriod and then shuts down with SIGKILL.
`unbound` on the other hand shuts down straight away when it gets the `SIGTERM` making DNS unavailable during other daemonset pod shutdown.

To avoid this, add a sleep preStop hook to the `unbound` container. 