### PR TITLE
Fix typo in lifecycle

### DIFF
--- a/cluster/manifests/coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/coredns-local/daemonset-coredns.yaml
@@ -63,7 +63,7 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 5
 {{- end }}
-        lifecyle:
+        lifecycle:
           preStop:
             sleep:
               seconds: 25


### PR DESCRIPTION
Follow up to #8963 

Fix typo `lifecyle` -> `lifecycle`