### PR TITLE
skipper: make hostname-credentials-controller resources configurable

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -336,6 +336,9 @@ skipper_oauth2_ui_login: "true"
 # Comma-separated list of tokeninfo keys to retain
 skipper_oauth2_ui_login_tokeninfo_keys: ""
 
+skipper_hostname_credentials_controller_cpu: 10m
+skipper_hostname_credentials_controller_memory: 50Mi
+
 # ClusterScalingSchedules
 # One or multiple cluster scaling schedules can be configured as a
 # comma-separated list of <cluster schedule name>=<target value> pairs.

--- a/cluster/manifests/skipper/hostname-credentials-controller.yaml
+++ b/cluster/manifests/skipper/hostname-credentials-controller.yaml
@@ -138,9 +138,9 @@ spec:
                 - -combined-secret-labels=application=skipper-ingress,component=hostname-credentials-combined
               resources:
                 limits:
-                  cpu: 10m
-                  memory: 50Mi
+                  cpu: "{{ .Cluster.ConfigItems.skipper_hostname_credentials_controller_cpu }}"
+                  memory: "{{ .Cluster.ConfigItems.skipper_hostname_credentials_controller_memory }}"
                 requests:
-                  cpu: 10m
-                  memory: 50Mi
+                  cpu: "{{ .Cluster.ConfigItems.skipper_hostname_credentials_controller_cpu }}"
+                  memory: "{{ .Cluster.ConfigItems.skipper_hostname_credentials_controller_memory }}"
 # {{ end }}


### PR DESCRIPTION
This is useful in case CronJob is OOMKilled.