### PR TITLE
Eks ipv6 e2e

### DIFF
--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -53,6 +53,7 @@ clusters:
     skipper_open_policy_agent_bucket_arn: "${SKIPPER_OPA_BUCKET_ARN}"
     skipper_open_policy_agent_observability_url: "${SKIPPER_OPA_OBSERVABILITY_URL}"
     skipper_open_policy_agent_bundles_url: "${SKIPPER_OPA_BUNDLES_URL}"
+    eks_ip_family: "ipv6"
   criticality_level: 1
   environment: e2e
   id: ${CLUSTER_ID}

--- a/test/e2e/external_dns.go
+++ b/test/e2e/external_dns.go
@@ -19,10 +19,12 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/framework/ingress"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
 	admissionapi "k8s.io/pod-security-admission/api"
@@ -40,16 +42,18 @@ var _ = describe("External DNS creation", func() {
 	f := framework.NewDefaultFramework("external-dns")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelBaseline
 	var (
-		cs  kubernetes.Interface
-		jig *e2eservice.TestJig
+		cs   kubernetes.Interface
+		jigs *e2eservice.TestJig
+		jigi *ingress.TestJig
 	)
 
 	BeforeEach(func() {
 		cs = f.ClientSet
-		jig = e2eservice.NewTestJig(cs, f.Namespace.Name, serviceName)
+		jigs = e2eservice.NewTestJig(cs, f.Namespace.Name, serviceName)
+		jigi = ingress.NewIngressTestJig(f.ClientSet)
 	})
 
-	f.It("Should create DNS entry [Zalando]", f.WithSlow(), func(ctx context.Context) {
+	f.It("Should create DNS entry via Service [Zalando]", f.WithSlow(), func(ctx context.Context) {
 		nameprefix := serviceName + "-"
 		ns := f.Namespace.Name
 		labels := map[string]string{
@@ -65,7 +69,7 @@ var _ = describe("External DNS creation", func() {
 		}()
 
 		hostName := fmt.Sprintf("%s-%d.%s", serviceName, time.Now().UTC().Unix(), E2EHostedZone())
-		_, err := jig.CreateLoadBalancerService(ctx, timeout, func(svc *v1.Service) {
+		_, err := jigs.CreateLoadBalancerService(ctx, timeout, func(svc *v1.Service) {
 			svc.ObjectMeta = metav1.ObjectMeta{
 				Name: serviceName,
 				Annotations: map[string]string{
@@ -91,6 +95,58 @@ var _ = describe("External DNS creation", func() {
 			defer GinkgoRecover()
 			err2 := cs.CoreV1().Pods(ns).Delete(ctx, pod.Name, metav1.DeleteOptions{})
 			framework.ExpectNoError(err2, "failed to delete pod: %s in namespace: %s", pod.Name, ns)
+		}()
+
+		_, err = cs.CoreV1().Pods(ns).Create(ctx, pod, metav1.CreateOptions{})
+		framework.ExpectNoError(err, "failed to create pod: %s in namespace: %s", pod.Name, ns)
+
+		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, pod.Namespace),
+			"failed to wait for pod: %s in namespace: %s", pod.Name, ns)
+
+		// wait for DNS and for pod to be reachable.
+		By("Waiting up to " + timeout.String() + " for " + hostName + " to be reachable")
+		err = waitForSuccessfulResponse(hostName, timeout)
+		framework.ExpectNoError(err, "failed to wait for %s to be reachable", hostName)
+	})
+
+	f.It("Should create DNS entry via Ingress [Zalando]", f.WithSlow(), func(ctx context.Context) {
+		nameprefix := serviceName + "-"
+		ns := f.Namespace.Name
+		labels := map[string]string{
+			"foo": "bar",
+			"baz": "blah",
+		}
+		port := 80
+
+		By("Creating service " + serviceName + " in namespace " + ns)
+		service := createServiceTypeClusterIP(serviceName, labels, port, port)
+		defer func() {
+			err := cs.CoreV1().Services(ns).Delete(ctx, serviceName, metav1.DeleteOptions{})
+			framework.ExpectNoError(err, "failed to delete service: %s in namespace: %s", serviceName, ns)
+		}()
+		_, err := cs.CoreV1().Services(ns).Create(ctx, service, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+
+		hostName := fmt.Sprintf("%s-%d.%s", serviceName, time.Now().UTC().Unix(), E2EHostedZone())
+
+		By("Creating an ingress with name " + serviceName + " in namespace " + ns + " with hostname " + hostName)
+		ing := createIngress(serviceName, hostName, ns, "/", netv1.PathTypeImplementationSpecific, labels, nil, port)
+		defer func() {
+			err := cs.NetworkingV1().Ingresses(ns).Delete(ctx, ing.Name, metav1.DeleteOptions{})
+			framework.ExpectNoError(err, "failed to delete ingress: %s in namespace: %s", serviceName, ns)
+		}()
+		ingressCreate, err := cs.NetworkingV1().Ingresses(ns).Create(ctx, ing, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+
+		_, err = jigi.WaitForIngressAddress(ctx, cs, ns, ingressCreate.Name, 10*time.Minute)
+		framework.ExpectNoError(err)
+
+		By("Submitting the pod to kubernetes")
+		route := fmt.Sprintf(`* -> inlineContent("%s") -> <shunt>`, "OK")
+		pod := createSkipperPod(nameprefix, ns, route, labels, port)
+		defer func() {
+			err := cs.CoreV1().Pods(ns).Delete(ctx, pod.Name, metav1.DeleteOptions{})
+			framework.ExpectNoError(err, "failed to delete pod: %s in namespace: %s", pod.Name, ns)
 		}()
 
 		_, err = cs.CoreV1().Pods(ns).Create(ctx, pod, metav1.CreateOptions{})

--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -205,6 +205,8 @@ if [ "$e2e" = true ]; then
             "Mirror pods should be created for the main Kubernetes components \[Zalando\]"
             "Should audit API calls to create, update, patch, delete pods. \[Audit\] \[Zalando\]"
             "should validate permissions for \[Authorization\] \[RBAC\] \[Zalando\]" # TODO: Remains skipped until we remove the older RBAC setup
+            "Should NOT get AWS IAM credentials" # Disabled on IPv6 as kube2iam is not compatible in current config.
+            "should creating a working mysql cluster" # upstream test which does not work with IPv6
         )
     fi
 

--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -207,6 +207,7 @@ if [ "$e2e" = true ]; then
             "should validate permissions for \[Authorization\] \[RBAC\] \[Zalando\]" # TODO: Remains skipped until we remove the older RBAC setup
             "Should NOT get AWS IAM credentials" # Disabled on IPv6 as kube2iam is not compatible in current config.
             "should creating a working mysql cluster" # upstream test which does not work with IPv6
+            "Should create DNS entry \[Zalando\]" # Depends on service Type LoadBalancer which doesn't work with IPv6.
         )
     fi
 

--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -207,7 +207,7 @@ if [ "$e2e" = true ]; then
             "should validate permissions for \[Authorization\] \[RBAC\] \[Zalando\]" # TODO: Remains skipped until we remove the older RBAC setup
             "Should NOT get AWS IAM credentials" # Disabled on IPv6 as kube2iam is not compatible in current config.
             "should creating a working mysql cluster" # upstream test which does not work with IPv6
-            "Should create DNS entry \[Zalando\]" # Depends on service Type LoadBalancer which doesn't work with IPv6.
+            "Should create DNS entry via Service \[Zalando\]" # Depends on service Type LoadBalancer which doesn't work with IPv6.
         )
     fi
 


### PR DESCRIPTION
* Set IPv6 as default for EKS e2e clusters
* [add separate ExternalDNS test for Ingress, skip Service](https://github.com/zalando-incubator/kubernetes-on-aws/commit/3208596b8aeee44ec6cb8aa4d2ba977c9183bd51)