### PR TITLE
role-sync: Add missing RBAC permissions

### DIFF
--- a/cluster/manifests/role-sync-controller/rbac.yaml
+++ b/cluster/manifests/role-sync-controller/rbac.yaml
@@ -24,6 +24,14 @@ rules:
     - "get"
     - "create"
     - "update"
+  # Allow the controller to list clusterrolebindings
+  - apiGroups:
+    - rbac.authorization.k8s.io
+    resources:
+    - "clusterrolebindings"
+    - "clusterroles"
+    verbs:
+    - "list"
   # Allow the controller to manage roles based on reading Secrets
   - apiGroups:
     - ""


### PR DESCRIPTION
Add missing permissions needed after the role-sync-controller was updated in https://github.com/zalando-incubator/kubernetes-on-aws/pull/8986