### PR TITLE
Run e2e tests for both `zalando-aws` and `zalando-eks` providers.

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -330,7 +330,7 @@ Resources:
             AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
         Version: 2012-10-17
       Path: /
-      RoleName: "{{.Cluster.LocalID}}-e2e-eks-iam-test-postgres-administrator-role"
+      RoleName: "{{.Cluster.LocalID}}-e2e-eks-iam-test-postgres-admin-role"
     Type: 'AWS::IAM::Role'
   E2EEKSIAMTestAccessEntryPostgresAdministrator:
     Type: "AWS::EKS::AccessEntry"

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -35,7 +35,7 @@ pipeline:
       IMAGE=container-registry-test.zalando.net/teapot/kubernetes-on-aws-e2e
       IMAGE=$IMAGE VERSION=$CDP_BUILD_VERSION make build.push.multiarch
 
-- id: create-cluster
+- id: create-cluster-aws
   when:
     event: pull_request
   depends_on:
@@ -46,7 +46,7 @@ pipeline:
   process: microservice_standard_test
   config:
     apply_manifests:
-      env: &apply_env
+      env: &apply_env_aws
       - name: DEPLOYMENT_PATH
         value: test/e2e
       - name: IAM_ROLE_ARN
@@ -55,6 +55,10 @@ pipeline:
         value: kubernetes
       - name: COMPONENT
         value: e2e
+      - name: CLUSTER_PROVIDER
+        value: zalando-aws
+      - name: E2E_SKIP_CLUSTER_UPDATE
+        value: "false"
     end2end_tests:
       metadata:
         name: e2e
@@ -81,9 +85,15 @@ pipeline:
           - name: ETCD_ENDPOINTS
             value: "https://etcd-server.etcd.teapot-e2e.zalan.do:2479"
           - name: CLUSTER_PROVIDER
-            value: "zalando-eks"
+            valueFrom:
+              configMapKeyRef:
+                name: kubernetes-e2e-config
+                key: "CLUSTER_PROVIDER"
           - name: E2E_SKIP_CLUSTER_UPDATE
-            value: "true"
+            valueFrom:
+              configMapKeyRef:
+                name: kubernetes-e2e-config
+                key: "E2E_SKIP_CLUSTER_UPDATE"
           - name: SKIPPER_OPA_ENABLED
             value: "true"
           - name: HOSTED_ZONE
@@ -199,18 +209,18 @@ pipeline:
               cpu: 500m
               memory: 2Gi
 
-- id: e2e-tests
+- id: e2e-tests-aws
   when:
     event: pull_request
   depends_on:
-  - create-cluster
+  - create-cluster-aws
   type: process
   desc: "Kubernetes e2e tests"
   target: stups-test
   process: microservice_standard_test
   config:
     apply_manifests:
-      env: *apply_env
+      env: *apply_env_aws
     end2end_tests:
       metadata:
         name: e2e
@@ -236,18 +246,18 @@ pipeline:
               cpu: 2
               memory: 8Gi
 
-- id: e2e-load-test-result
+- id: e2e-load-test-result-aws
   when:
     event: pull_request
   depends_on:
-  - create-cluster
+  - create-cluster-aws
   type: process
   desc: "Kubernetes e2e load tests"
   target: stups-test
   process: microservice_standard_test
   config:
     apply_manifests:
-      env: *apply_env
+      env: *apply_env_aws
     end2end_tests:
       metadata:
         name: e2e
@@ -273,18 +283,18 @@ pipeline:
               cpu: 1000m
               memory: 1000Mi
 
-- id: stackset-e2e-tests
+- id: stackset-e2e-tests-aws
   when:
     event: pull_request
   depends_on:
-  - create-cluster
+  - create-cluster-aws
   type: process
   desc: "StackSet e2e tests"
   target: stups-test
   process: microservice_standard_test
   config:
     apply_manifests:
-      env: *apply_env
+      env: *apply_env_aws
     end2end_tests:
       metadata:
         name: e2e
@@ -310,20 +320,219 @@ pipeline:
               cpu: 2
               memory: 1Gi
 
-- id: decommission-cluster
+- id: decommission-cluster-aws
   when:
     event: pull_request
   depends_on:
-  - e2e-tests
-  - stackset-e2e-tests
-  - e2e-load-test-result
+  - e2e-tests-aws
+  - stackset-e2e-tests-aws
+  - e2e-load-test-result-aws
   type: process
   desc: "Decommission cluster used for Kubernetes e2e tests"
   target: stups-test
   process: microservice_standard_test
   config:
     apply_manifests:
-      env: *apply_env
+      env: *apply_env_aws
+    end2end_tests:
+      metadata:
+        name: e2e
+        labels:
+          application: kubernetes
+          component: e2e
+        annotations:
+          zalando.org/runtime-policy: require-on-demand
+      spec:
+        serviceAccountName: kubernetes-e2e
+        restartPolicy: Never
+        containers:
+        - name: e2e
+          image: "container-registry-test.zalando.net/teapot/kubernetes-on-aws-e2e:#{CDP_BUILD_VERSION}"
+          args:
+          - decommission-cluster
+          env: *e2e_env
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 500m
+              memory: 1Gi
+
+- id: create-cluster-eks
+  when:
+    event: pull_request
+  depends_on:
+  - build
+  type: process
+  desc: "Create cluster for Kubernetes e2e tests"
+  target: stups-test
+  process: microservice_standard_test
+  config:
+    apply_manifests:
+      env: &apply_env_eks
+      - name: DEPLOYMENT_PATH
+        value: test/e2e
+      - name: IAM_ROLE_ARN
+        value: "arn:aws:iam::925511348110:role/cluster-lifecycle-manager-entrypoint"
+      - name: APPLICATION
+        value: kubernetes
+      - name: COMPONENT
+        value: e2e
+      - name: CLUSTER_PROVIDER
+        value: zalando-eks
+      - name: E2E_SKIP_CLUSTER_UPDATE
+        value: "true"
+    end2end_tests:
+      metadata:
+        name: e2e
+        labels:
+          application: kubernetes
+          component: e2e
+        annotations:
+          zalando.org/runtime-policy: require-on-demand
+      spec:
+        serviceAccountName: kubernetes-e2e
+        restartPolicy: Never
+        containers:
+        - name: e2e
+          image: "container-registry-test.zalando.net/teapot/kubernetes-on-aws-e2e:#{CDP_BUILD_VERSION}"
+          args:
+          - create-cluster
+          env: *e2e_env
+          resources:
+            limits:
+              cpu: 500m
+              memory: 2Gi
+            requests:
+              cpu: 500m
+              memory: 2Gi
+
+- id: e2e-tests-eks
+  when:
+    event: pull_request
+  depends_on:
+  - create-cluster-eks
+  type: process
+  desc: "Kubernetes e2e tests"
+  target: stups-test
+  process: microservice_standard_test
+  config:
+    apply_manifests:
+      env: *apply_env_eks
+    end2end_tests:
+      metadata:
+        name: e2e
+        labels:
+          application: kubernetes
+          component: e2e
+        annotations:
+          zalando.org/runtime-policy: require-on-demand
+      spec:
+        serviceAccountName: kubernetes-e2e
+        restartPolicy: Never
+        containers:
+        - name: e2e
+          image: "container-registry-test.zalando.net/teapot/kubernetes-on-aws-e2e:#{CDP_BUILD_VERSION}"
+          args:
+          - e2e
+          env: *e2e_env
+          resources:
+            limits:
+              cpu: 2
+              memory: 8Gi
+            requests:
+              cpu: 2
+              memory: 8Gi
+
+- id: e2e-load-test-result-eks
+  when:
+    event: pull_request
+  depends_on:
+  - create-cluster-eks
+  type: process
+  desc: "Kubernetes e2e load tests"
+  target: stups-test
+  process: microservice_standard_test
+  config:
+    apply_manifests:
+      env: *apply_env_eks
+    end2end_tests:
+      metadata:
+        name: e2e
+        labels:
+          application: kubernetes
+          component: e2e
+        annotations:
+          zalando.org/runtime-policy: require-on-demand
+      spec:
+        serviceAccountName: kubernetes-e2e
+        restartPolicy: Never
+        containers:
+        - name: e2e
+          image: "container-registry-test.zalando.net/teapot/kubernetes-on-aws-e2e:#{CDP_BUILD_VERSION}"
+          args:
+          - loadtest-e2e
+          env: *e2e_env
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1000Mi
+            requests:
+              cpu: 1000m
+              memory: 1000Mi
+
+- id: stackset-e2e-tests-eks
+  when:
+    event: pull_request
+  depends_on:
+  - create-cluster-eks
+  type: process
+  desc: "StackSet e2e tests"
+  target: stups-test
+  process: microservice_standard_test
+  config:
+    apply_manifests:
+      env: *apply_env_eks
+    end2end_tests:
+      metadata:
+        name: e2e
+        labels:
+          application: kubernetes
+          component: e2e
+        annotations:
+          zalando.org/runtime-policy: require-on-demand
+      spec:
+        serviceAccountName: kubernetes-e2e
+        restartPolicy: Never
+        containers:
+        - name: e2e
+          image: "container-registry-test.zalando.net/teapot/kubernetes-on-aws-e2e:#{CDP_BUILD_VERSION}"
+          args:
+          - stackset-e2e
+          env: *e2e_env
+          resources:
+            limits:
+              cpu: 2
+              memory: 1Gi
+            requests:
+              cpu: 2
+              memory: 1Gi
+
+- id: decommission-cluster-eks
+  when:
+    event: pull_request
+  depends_on:
+  - e2e-tests-eks
+  - stackset-e2e-tests-eks
+  - e2e-load-test-result-eks
+  type: process
+  desc: "Decommission cluster used for Kubernetes e2e tests"
+  target: stups-test
+  process: microservice_standard_test
+  config:
+    apply_manifests:
+      env: *apply_env_eks
     end2end_tests:
       metadata:
         name: e2e

--- a/test/e2e/apply/config.yaml
+++ b/test/e2e/apply/config.yaml
@@ -8,3 +8,5 @@ metadata:
 data:
   HOSTED_ZONE: "teapot-e2e.zalan.do"
   REGION: "eu-central-1"
+  CLUSTER_PROVIDER: "{{{CLUSTER_PROVIDER}}}"
+  E2E_SKIP_CLUSTER_UPDATE: "{{{E2E_SKIP_CLUSTER_UPDATE}}}"

--- a/test/e2e/authorization.go
+++ b/test/e2e/authorization.go
@@ -813,7 +813,7 @@ func getUnprivilegedClient(cluster *types.Cluster, awsAccountID string) (*kubern
 
 // getPostgresAdministratorClient returns a client with the `zalando:postgres-admin` group.
 func getPostgresAdministratorClient(cluster *types.Cluster, awsAccountID string) (*kubernetes.Clientset, error) {
-	return newClientWithRole(cluster, fmt.Sprintf("arn:aws:iam::%s:role/%s-e2e-eks-iam-test-postgres-administrator-role", awsAccountID, aws.ToString(cluster.Name)))
+	return newClientWithRole(cluster, fmt.Sprintf("arn:aws:iam::%s:role/%s-e2e-eks-iam-test-postgres-admin-role", awsAccountID, aws.ToString(cluster.Name)))
 }
 
 // newClientWithRole returns a new Kubernetes client with the specified IAM role and its associated AccessEntries.

--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -45,12 +45,12 @@ CDP_TARGET_COMMIT_ID="${CDP_TARGET_COMMIT_ID:-"dev"}"
 CDP_HEAD_COMMIT_ID="${CDP_HEAD_COMMIT_ID:-"$(git describe --tags --always)"}"
 RESULT_BUCKET="${RESULT_BUCKET:-""}"
 
-export CLUSTER_ALIAS="${CLUSTER_ALIAS:-"e2e-${CDP_BUILD_VERSION}"}"
-export LOCAL_ID="${LOCAL_ID:-"e2e-${CDP_BUILD_VERSION}"}"
+export CLUSTER_PROVIDER="${CLUSTER_PROVIDER:-"zalando-aws"}"
+export CLUSTER_ALIAS="${CLUSTER_ALIAS:-"e2e-${CDP_BUILD_VERSION}-${CLUSTER_PROVIDER#zalando-}"}"
+export LOCAL_ID="${LOCAL_ID:-"e2e-${CDP_BUILD_VERSION}-${CLUSTER_PROVIDER#zalando-}"}"
 export API_SERVER_URL="https://${LOCAL_ID}.${HOSTED_ZONE}"
 export INFRASTRUCTURE_ACCOUNT="aws:${AWS_ACCOUNT}"
 export CLUSTER_ID="${INFRASTRUCTURE_ACCOUNT}:${REGION}:${LOCAL_ID}"
-export CLUSTER_PROVIDER="${CLUSTER_PROVIDER:-"zalando-aws"}"
 
 if [ "$CLUSTER_PROVIDER" == "zalando-aws" ]; then
     # create kubeconfig
@@ -146,9 +146,11 @@ if [ "$create_cluster" = true ]; then
         --registry=head_cluster.yaml \
         --manage-etcd-stack
 
-    aws eks --region "${REGION}" update-kubeconfig --name "${LOCAL_ID}" --kubeconfig kubeconfig
-    KUBECONFIG="$(pwd)/kubeconfig"
-    export KUBECONFIG="$KUBECONFIG"
+    if [ "$CLUSTER_PROVIDER" == "zalando-eks" ]; then
+        aws eks --region "${REGION}" update-kubeconfig --name "${LOCAL_ID}" --kubeconfig kubeconfig
+        KUBECONFIG="$(pwd)/kubeconfig"
+        export KUBECONFIG="$KUBECONFIG"
+    fi
 
     # rotate nodes with old daemonset pods and update strategy onDelete
     # This is important to ensure we e2e test against e.g. latest coredns daemonset
@@ -198,6 +200,13 @@ if [ "$e2e" = true ]; then
         "validates.that.there.is.no.conflict.between.pods.with.same.hostPort.but.different.hostIP.and.protocol"
         "Should.create.gradual.traffic.routes"
     )
+
+    if [ "$CLUSTER_PROVIDER" == "zalando-aws" ]; then
+        # some tests are skipped for zalando-aws because they only apply to zalando-eks
+        SKIPPED_TESTS+=(
+            "Authorization via admission-controller \[RBAC\] \[Zalando\]"
+        )
+    fi
 
     if [ "$CLUSTER_PROVIDER" == "zalando-eks" ]; then
         # some tests are skipped for eks because they test part of the control plane which is part of EKS


### PR DESCRIPTION
Run e2e tests for both `zalando-aws` and `zalando-eks` providers.

Combination of both https://github.com/zalando-incubator/kubernetes-on-aws/pull/9001 and https://github.com/zalando-incubator/kubernetes-on-aws/pull/9002