### PR TITLE
Shorten deployment-status-service url [1/3]

### DIFF
--- a/cluster/manifests/deployment-service/status-service-ingress.yaml
+++ b/cluster/manifests/deployment-service/status-service-ingress.yaml
@@ -8,6 +8,7 @@ metadata:
     component: status-service
 spec:
   hosts:
+    - depl-status-{{ .Cluster.Alias }}.{{ .Values.hosted_zone }}
     - deployment-status-svc-{{ .Cluster.Alias }}.{{ .Values.hosted_zone }}
     - deployment-status-service.ingress.cluster.local
   backends:


### PR DESCRIPTION
This adds a shorter name for the deployment-status-service url. The motivation is that the name, including the cluster alias is too long in some clusters and leads to the following errors in external-dns:

```
time="2025-03-03T19:48:03Z" level=error msg="label cname-deployment-status-svc-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-test in _external-dns.cname-deployment-status-svc-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-test.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-test.zalan.do is longer than 63 characters. Cannot create endpoint"
```

We currently have 2 clusters with this problem. Reducing the prefix allows for the longer cluster alias.