### PR TITLE
Kube proxy config cleanup

### DIFF
--- a/cluster/manifests/kube-proxy/configmap.yaml
+++ b/cluster/manifests/kube-proxy/configmap.yaml
@@ -40,4 +40,3 @@ data:
     mode: iptables
     oomScoreAdj: -999
     portRange: ""
-    udpIdleTimeout: 250ms

--- a/cluster/manifests/kube-proxy/configmap.yaml
+++ b/cluster/manifests/kube-proxy/configmap.yaml
@@ -40,5 +40,4 @@ data:
     mode: iptables
     oomScoreAdj: -999
     portRange: ""
-    resourceContainer: /kube-proxy
     udpIdleTimeout: 250ms


### PR DESCRIPTION
Remove legacy fields from kube-proxy config

* Remove `resourceContainer` dropped since v1.16: https://github.com/kubernetes/kubernetes/pull/78294
* Remove `udpIdleTimeout` dropped since v1.26: https://github.com/kubernetes/kubernetes/pull/112133

Found when looking at kube-proxy logs printing this at startup:

```
I0304 09:05:19.643699       1 options.go:480] "Using lenient decoding as strict decoding failed" err="strict decoding error: unknown field \"resourceContainer\", unknown field \"udpIdleTimeout\"
```