### PR TITLE
Add option to bump wiz sensor daemonset priority class

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1244,6 +1244,7 @@ wiz_sensor_cpu: "300m"
 wiz_sensor_memory: "300Mi"
 wiz_connector_cpu: "300m"
 wiz_connector_memory: "300Mi"
+wiz_priority: "false"
 # Please note when this is set to true it allows the use of the node selector feature
 # to deploy the sensor and connector on specific nodes, by manually setting the node selector label on the nodes.
 # This is useful when you want to deploy the sensor and connector on specific nodes.

--- a/cluster/manifests/wiz/sensor-daemonset.yaml
+++ b/cluster/manifests/wiz/sensor-daemonset.yaml
@@ -31,6 +31,9 @@ spec:
         cluster-autoscaler.kubernetes.io/enable-ds-eviction: "true"
     spec:
       serviceAccountName: wiz-sensor
+      {{- if eq .Cluster.ConfigItems.wiz_priority "true" }}
+      priorityClassName: system-node-critical
+      {{- end }}
       nodeSelector:
         {{ if eq .Cluster.ConfigItems.wiz_node_feature_rollout "true" }}
         node-feature.zalando.org/wiz: enabled


### PR DESCRIPTION
Add a config item to enable the increased priority class: `system-node-critical` for the WIZ Sensor component. This will be enabled individually for clusters to avoid disruption to existing workloads and can eventually be removed after the WIZ rollout is complete.