### PR TITLE
Revert "Update to Karpenter v1.3.0"

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -668,8 +668,7 @@ Resources:
                     "arn:${AWS::Partition}:ec2:${AWS::Region}::image/*",
                     "arn:${AWS::Partition}:ec2:${AWS::Region}::snapshot/*",
                     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:security-group/*",
-                    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:subnet/*",
-                    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:capacity-reservation/*"
+                    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:subnet/*"
                   ],
                   "Action": [
                     "ec2:RunInstances",
@@ -702,8 +701,7 @@ Resources:
                     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
                     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*",
                     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*",
-                    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*",
-                    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:capacity-reservation/*"
+                    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*"
                   ],
                   "Action": [
                     "ec2:RunInstances",
@@ -797,7 +795,6 @@ Resources:
                   "Resource": "*",
                   "Action": [
                     "ec2:DescribeAvailabilityZones",
-                    "ec2:DescribeCapacityReservations",
                     "ec2:DescribeImages",
                     "ec2:DescribeInstances",
                     "ec2:DescribeInstanceTypeOfferings",

--- a/cluster/manifests/z-karpenter/02-role.yaml
+++ b/cluster/manifests/z-karpenter/02-role.yaml
@@ -1,4 +1,5 @@
 {{ if eq .Cluster.ConfigItems.karpenter_pools_enabled "true"}}
+
 ---
 # Source: karpenter/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cluster/manifests/z-karpenter/07-karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/cluster/manifests/z-karpenter/07-karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.17.1
   name: ec2nodeclasses.karpenter.k8s.aws
 spec:
   group: karpenter.k8s.aws
@@ -237,39 +237,6 @@ spec:
                   x-kubernetes-validations:
                     - message: must have only one blockDeviceMappings with rootVolume
                       rule: self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1
-                capacityReservationSelectorTerms:
-                  description: |-
-                    CapacityReservationSelectorTerms is a list of capacity reservation selector terms. Each term is ORed together to
-                    determine the set of eligible capacity reservations.
-                  items:
-                    properties:
-                      id:
-                        description: ID is the capacity reservation id in EC2
-                        pattern: ^cr-[0-9a-z]+$
-                        type: string
-                      ownerID:
-                        description: Owner is the owner id for the ami.
-                        pattern: ^[0-9]{12}$
-                        type: string
-                      tags:
-                        additionalProperties:
-                          type: string
-                        description: |-
-                          Tags is a map of key/value tags used to select capacity reservations.
-                          Specifying '*' for a value selects all values for a given tag key.
-                        maxProperties: 20
-                        type: object
-                        x-kubernetes-validations:
-                          - message: empty tag keys or values aren't supported
-                            rule: self.all(k, k != '' && self[k] != '')
-                    type: object
-                  maxItems: 30
-                  type: array
-                  x-kubernetes-validations:
-                    - message: expected at least one, got none, ['tags', 'id']
-                      rule: self.all(x, has(x.tags) || has(x.id))
-                    - message: '''id'' is mutually exclusive, cannot be set along with tags in a capacity reservation selector term'
-                      rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.ownerID)))'
                 context:
                   description: |-
                     Context is a Reserved field in EC2 APIs
@@ -500,7 +467,7 @@ spec:
                     - message: immutable field changed
                       rule: self == oldSelf
                 securityGroupSelectorTerms:
-                  description: SecurityGroupSelectorTerms is a list of security group selector terms. The terms are ORed.
+                  description: SecurityGroupSelectorTerms is a list of or security group selector terms. The terms are ORed.
                   items:
                     description: |-
                       SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.
@@ -534,12 +501,12 @@ spec:
                       rule: self.size() != 0
                     - message: expected at least one, got none, ['tags', 'id', 'name']
                       rule: self.all(x, has(x.tags) || has(x.id) || has(x.name))
-                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in a security group selector term'
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
                       rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))'
-                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in a security group selector term'
+                    - message: '''name'' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms'
                       rule: '!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))'
                 subnetSelectorTerms:
-                  description: SubnetSelectorTerms is a list of subnet selector terms. The terms are ORed.
+                  description: SubnetSelectorTerms is a list of or subnet selector terms. The terms are ORed.
                   items:
                     description: |-
                       SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.
@@ -568,7 +535,7 @@ spec:
                       rule: self.size() != 0
                     - message: expected at least one, got none, ['tags', 'id']
                       rule: self.all(x, has(x.tags) || has(x.id))
-                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in a subnet selector term'
+                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in subnetSelectorTerms'
                       rule: '!self.all(x, has(x.id) && has(x.tags))'
                 tags:
                   additionalProperties:
@@ -669,46 +636,6 @@ spec:
                     required:
                       - id
                       - requirements
-                    type: object
-                  type: array
-                capacityReservations:
-                  description: |-
-                    CapacityReservations contains the current capacity reservation values that are available to this NodeClass under the
-                    CapacityReservation selectors.
-                  items:
-                    properties:
-                      availabilityZone:
-                        description: The availability zone the capacity reservation is available in.
-                        type: string
-                      endTime:
-                        description: |-
-                          The time at which the capacity reservation expires. Once expired, the reserved capacity is released and Karpenter
-                          will no longer be able to launch instances into that reservation.
-                        format: date-time
-                        type: string
-                      id:
-                        description: The id for the capacity reservation.
-                        pattern: ^cr-[0-9a-z]+$
-                        type: string
-                      instanceMatchCriteria:
-                        description: Indicates the type of instance launches the capacity reservation accepts.
-                        enum:
-                          - open
-                          - targeted
-                        type: string
-                      instanceType:
-                        description: The instance type for the capacity reservation.
-                        type: string
-                      ownerID:
-                        description: The ID of the AWS account that owns the capacity reservation.
-                        pattern: ^[0-9]{12}$
-                        type: string
-                    required:
-                      - availabilityZone
-                      - id
-                      - instanceMatchCriteria
-                      - instanceType
-                      - ownerID
                     type: object
                   type: array
                 conditions:

--- a/cluster/manifests/z-karpenter/08-karpenter.sh_nodeclaims.yaml
+++ b/cluster/manifests/z-karpenter/08-karpenter.sh_nodeclaims.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.17.1
   name: nodeclaims.karpenter.sh
 spec:
   group: karpenter.sh
@@ -135,7 +135,7 @@ spec:
                           - message: label "kubernetes.io/hostname" is restricted
                             rule: self != "kubernetes.io/hostname"
                           - message: label domain "karpenter.k8s.aws" is restricted
-                            rule: self in ["karpenter.k8s.aws/capacity-reservation-id", "karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                            rule: self in ["karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
                       minValues:
                         description: |-
                           This field is ALPHA and can be dropped or replaced at any time

--- a/cluster/manifests/z-karpenter/09-karpenter.sh_nodepools.yaml
+++ b/cluster/manifests/z-karpenter/09-karpenter.sh_nodepools.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.17.1
   name: nodepools.karpenter.sh
 spec:
   group: karpenter.sh
@@ -208,7 +208,7 @@ spec:
                             - message: label "kubernetes.io/hostname" is restricted
                               rule: self.all(x, x != "kubernetes.io/hostname")
                             - message: label domain "karpenter.k8s.aws" is restricted
-                              rule: self.all(x, x in ["karpenter.k8s.aws/capacity-reservation-id", "karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
+                              rule: self.all(x, x in ["karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !x.find("^([^/]+)").endsWith("karpenter.k8s.aws"))
                       type: object
                     spec:
                       description: |-
@@ -281,7 +281,7 @@ spec:
                                   - message: label "kubernetes.io/hostname" is restricted
                                     rule: self != "kubernetes.io/hostname"
                                   - message: label domain "karpenter.k8s.aws" is restricted
-                                    rule: self in ["karpenter.k8s.aws/capacity-reservation-id", "karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
+                                    rule: self in ["karpenter.k8s.aws/ec2nodeclass", "karpenter.k8s.aws/instance-encryption-in-transit-supported", "karpenter.k8s.aws/instance-category", "karpenter.k8s.aws/instance-hypervisor", "karpenter.k8s.aws/instance-family", "karpenter.k8s.aws/instance-generation", "karpenter.k8s.aws/instance-local-nvme", "karpenter.k8s.aws/instance-size", "karpenter.k8s.aws/instance-cpu", "karpenter.k8s.aws/instance-cpu-manufacturer", "karpenter.k8s.aws/instance-cpu-sustained-clock-speed-mhz", "karpenter.k8s.aws/instance-memory", "karpenter.k8s.aws/instance-ebs-bandwidth", "karpenter.k8s.aws/instance-network-bandwidth", "karpenter.k8s.aws/instance-gpu-name", "karpenter.k8s.aws/instance-gpu-manufacturer", "karpenter.k8s.aws/instance-gpu-count", "karpenter.k8s.aws/instance-gpu-memory", "karpenter.k8s.aws/instance-accelerator-name", "karpenter.k8s.aws/instance-accelerator-manufacturer", "karpenter.k8s.aws/instance-accelerator-count"] || !self.find("^([^/]+)").endsWith("karpenter.k8s.aws")
                               minValues:
                                 description: |-
                                   This field is ALPHA and can be dropped or replaced at any time

--- a/cluster/manifests/z-karpenter/deployment.yaml
+++ b/cluster/manifests/z-karpenter/deployment.yaml
@@ -32,7 +32,6 @@ spec:
         prometheus.io/scrape: "true"
     spec:
       dnsPolicy: Default
-      automountServiceAccountToken: true
       serviceAccountName: karpenter
       securityContext:
         fsGroup: 65532
@@ -51,7 +50,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
-          image: "container-registry.zalando.net/teapot/karpenter:1.3.0-main-32.patched"
+          image: "container-registry.zalando.net/teapot/karpenter:1.2.0-main-30.patched"
           imagePullPolicy: IfNotPresent
           env:
             - name: KUBERNETES_MIN_VERSION


### PR DESCRIPTION
Reverts zalando-incubator/kubernetes-on-aws#9012

There are issues with new code in karpenter 1.3.0: https://github.com/aws/karpenter-provider-aws/blob/v1.3.0/pkg/controllers/nodeclass/validation.go#L240

```
{"level":"ERROR","time":"2025-03-04T16:49:06.464Z","logger":"controller","caller":"controller/controller.go:288","message":"Reconciler error","commit":"ff59416-dirty","controller":"nodeclass","controllerGroup":"karpenter.k8s.aws","controllerKind":"EC2NodeClass","EC2NodeClass":{"name":"default-karpenter"},"namespace":"","name":"default-karpenter","reconcileID":"51320baf-e975-41b8-87c0-15d46b600cef","error":"validating ec2:RunInstances authorization, operation error EC2: RunInstances, https response error StatusCode: 400, RequestID: REDACTED, api error MissingInput: No subnets found for the default VPC 'vpc-dadxxxx'. Please specify a subnet."}
```