### PR TITLE
Drop legacy skipper probe url

### DIFF
--- a/cluster/manifests/skipper/routegroup-probe.yaml
+++ b/cluster/manifests/skipper/routegroup-probe.yaml
@@ -13,7 +13,6 @@ spec:
   defaultBackends:
   - backendName: simulation
   hosts:
-  - cluster-health.{{ .Values.hosted_zone }}
   - cluster-health-{{ .Cluster.Alias }}.{{ .Values.hosted_zone }}
   routes:
   - pathSubtree: /


### PR DESCRIPTION
Follow up to #8981 drop the legacy url which is not used anymore.