### PR TITLE
external-dns: Drop --debug flag

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -37,7 +37,6 @@ spec:
         args:
         - --source=service
         - --source=ingress
-        # TODO: support routegroup with eks ipv6
         - --source=skipper-routegroup
 {{- range split .Cluster.ConfigItems.external_dns_domain_filter "," }}
         - --domain-filter={{ . }}
@@ -53,7 +52,6 @@ spec:
         - --aws-zones-cache-duration={{ .Cluster.ConfigItems.external_dns_zones_cache_duration }}
         - --annotation-filter=external-dns.alpha.kubernetes.io/exclude notin (true)
         - --policy={{ .Cluster.ConfigItems.external_dns_policy }}
-        - --log-level=debug
         resources:
           requests:
             cpu: 50m


### PR DESCRIPTION
Was introduced with #7808 but is not really needed.

Also drop TODO that is not valid anymore