### PR TITLE
fabric-gateway: update CRD to support zero ratelimit for custom routes

### DIFF
--- a/cluster/manifests/fabric-gateway/fabricgateway_crd.yaml
+++ b/cluster/manifests/fabric-gateway/fabricgateway_crd.yaml
@@ -174,9 +174,10 @@ spec:
                               properties:
                                 default-rate:
                                   description: |-
-                                    Non user specific value to apply to the route. If a client makes more requests than this
+                                    Non-user specific value to apply to the route. If a client makes more requests than this
                                     value within the defined period, then they will start getting HTTP 429 responses.
-                                  minimum: 1
+                                    Setting `default-rate` to 0 will cause all requests matching the rate limit configuration to be denied.
+                                  minimum: 0
                                   type: integer
                                 period:
                                   description: |-
@@ -330,9 +331,10 @@ spec:
                         properties:
                           default-rate:
                             description: |-
-                              Non user specific value to apply to the route. If a client makes more requests than this
+                              Non-user specific value to apply to the route. If a client makes more requests than this
                               value within the defined period, then they will start getting HTTP 429 responses.
-                            minimum: 1
+                              Setting `default-rate` to 0 will cause all requests matching the rate limit configuration to be denied.
+                            minimum: 0
                             type: integer
                           period:
                             description: |-


### PR DESCRIPTION
- Update CRD to allow zero ratelimit for custom routes  