### PR TITLE
Test the upgrade path of EKS clusters in e2e tests

### DIFF
--- a/test/e2e/apply/config.yaml
+++ b/test/e2e/apply/config.yaml
@@ -38,4 +38,3 @@ metadata:
   name: "{{{APPLICATION}}}-{{{COMPONENT}}}-config-provider-eks"
 data:
   CLUSTER_PROVIDER: "zalando-eks"
-  E2E_SKIP_CLUSTER_UPDATE: "true"

--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -102,7 +102,7 @@ if [ "$create_cluster" = true ]; then
         fi
 
         # generate the cluster certificates
-        aws-account-creator refresh-certificates --registry-file base_cluster.yaml --create-ca
+        aws-account-creator refresh-certificates --registry-file base_cluster.yaml --create-ca --provider "${CLUSTER_PROVIDER}"
 
         # Create cluster
         clm provision \


### PR DESCRIPTION
Similar to legacy clusters, test the upgrade path as well, now that it's possible.