### PR TITLE
add startupProbe to metrics-server Pod to protect against race condition

### DIFF
--- a/cluster/manifests/metrics-server/deployment.yaml
+++ b/cluster/manifests/metrics-server/deployment.yaml
@@ -52,6 +52,17 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+        # This is needed to fix the issue where when a new metrics-server Pod comes up at
+        # the same time when many nodes are Terminated, it will get stuck and not be marked
+        # Ready for a long time. This provides a failsafe where the kubelet can kill the Pod
+        # and it can be restarted.
+        startupProbe:
+          periodSeconds: 10
+          failureThreshold: 12 #120s = 2min startup timeout
+          httpGet:
+            path: /healthz
+            port: https
+            scheme: HTTPS
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true


### PR DESCRIPTION
We have a race condition when a new metrics-server Pod comes up, between the time that the server updates the node informer cache and it scrapes the nodes in the cache, Karpenter can terminate many nodes at the same time. This leads to the scraper stuck in a loop attempting to connect to the kubelet on terminated/terminating nodes and not progressing from NotReady state for up-to 30mins and we get paged for a kube-system Pod not running. There is no way to configure the `max-retries` to a kubelet, so there is no straight-forward way to configure this in the metrics-server itself.

```go
E0303 15:51:02.423322       1 scraper.go:149] "Failed to scrape node" err="Get \"https://ip-10-151-1-173.eu-central-1.compute.internal:10250/metrics/resource\": dial tcp 10.151.1.173:10250: connect: connection refused" node="ip-10-151-1-173.eu-central-1.compute.internal"
```

This introduces a `startupProbe` on the container where we can have the kubelet kill and restart the container after `2mins` if it's stuck like this, and the restarted Pod should have an updated node informer cache, and proceed to `Ready` state.

