### PR TITLE
Allow collaborators write access in collaborator namespaces

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -318,6 +318,37 @@ Resources:
       KubernetesGroups:
       - zalando:administrator
       Type: "STANDARD"
+  E2EEKSIAMTestRoleCollaborator:
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Action:
+          - 'sts:AssumeRole'
+          - 'sts:SetSourceIdentity'
+          Effect: Allow
+          Principal:
+            AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+        Version: 2012-10-17
+      Path: /
+      RoleName: "{{.Cluster.LocalID}}-e2e-eks-iam-test-collaborator-role"
+    Type: 'AWS::IAM::Role'
+  E2EEKSIAMTestAccessEntryCollaborator:
+    Type: "AWS::EKS::AccessEntry"
+    Properties:
+      AccessPolicies:
+      - AccessScope:
+          Type: "cluster"
+        PolicyArn: "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+      ClusterName: !Ref EKSCluster
+      PrincipalArn: !GetAtt E2EEKSIAMTestRoleCollaborator.Arn
+      Username: !Join
+          - ''
+          - - !Sub 'arn:aws:sts::${AWS::AccountId}:assumed-role/'
+            - !Ref E2EEKSIAMTestRoleCollaborator
+            - '/{{`{{SessionName}}`}}'
+      KubernetesGroups:
+      - zalando:collaborator
+      Type: "STANDARD"
   E2EEKSIAMTestRolePostgresAdministrator:
     Properties:
       AssumeRolePolicyDocument:

--- a/cluster/manifests/02-admission-control/teapot.yaml
+++ b/cluster/manifests/02-admission-control/teapot.yaml
@@ -538,7 +538,7 @@ webhooks:
       matchExpressions:
         - key: kubernetes.io/metadata.name
           operator: In
-          values: [ "kube-system", "visibility", "kubenurse" ]
+          values: [ "kube-system", "kubenurse" ]
     rules:
       - operations: [ "*" ]
         apiGroups: ["*"]
@@ -548,6 +548,39 @@ webhooks:
     matchConditions:
       - name: 'exclude-privileged-groups'
         expression: 'request.userInfo.groups.all(g, !(g in ["system:masters", "system:nodes", "system:serviceaccounts:kube-system", "okta:common/administrator", "zalando:administrator"]))'
+      - name: 'exclude-privileged-usernames'
+        expression: '!(request.userInfo.username in ["system:kube-controller-manager", "system:kube-scheduler", "zalando-iam:zalando:service:k8sapi_credentials-provider"])'
+      - name: 'exclude-eks-components'
+        expression: '!request.userInfo.username.startsWith("eks:")'
+  - name: collaborator-deny-admitter.teapot.zalan.do
+    clientConfig:
+      {{- if eq .Cluster.Provider "zalando-eks"}}
+      service:
+        name: "admission-controller"
+        namespace: "kube-system"
+        path: "/deny"
+      {{- else }}
+      url: "https://localhost:8085/deny"
+      {{- end }}
+      caBundle: "{{ .Cluster.ConfigItems.ca_cert_decompressed }}"
+    admissionReviewVersions: ["v1beta1"]
+    failurePolicy: Fail
+    sideEffects: "NoneOnDryRun"
+    matchPolicy: Equivalent
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values: [ "visibility" ]
+    rules:
+      - operations: [ "*" ]
+        apiGroups: ["*"]
+        apiVersions: ["*"]
+        resources: ["*/*"]
+        scope: "Namespaced"
+    matchConditions:
+      - name: 'exclude-privileged-groups'
+        expression: 'request.userInfo.groups.all(g, !(g in ["system:masters", "system:nodes", "system:serviceaccounts:kube-system", "okta:common/administrator", "zalando:administrator", "okta:common/collaborator", "zalando:collaborator"]))'
       - name: 'exclude-privileged-usernames'
         expression: '!(request.userInfo.username in ["system:kube-controller-manager", "system:kube-scheduler", "zalando-iam:zalando:service:k8sapi_credentials-provider"])'
       - name: 'exclude-eks-components'

--- a/test/e2e/authorization.go
+++ b/test/e2e/authorization.go
@@ -590,12 +590,14 @@ var _ = g.Describe("Authorization via admission-controller [RBAC] [Zalando]", fu
 
 	g.Context("for namespaced resources", func() {
 		var (
-			systemResource    *corev1.Pod
-			nonSystemResource *corev1.Pod
+			systemResource       *corev1.Pod
+			collaboratorResource *corev1.Pod
+			nonSystemResource    *corev1.Pod
 		)
 
 		g.BeforeEach(func() {
 			systemResource = examplePod("kube-system", nil)
+			collaboratorResource = examplePod("visibility", nil)
 			nonSystemResource = examplePod(f.Namespace.Name, nil)
 		})
 
@@ -614,9 +616,40 @@ var _ = g.Describe("Authorization via admission-controller [RBAC] [Zalando]", fu
 				framework.ExpectNoError(err, "failed to create pod: %s in namespace: %s", nonSystemResource.Name, nonSystemResource.Namespace)
 			})
 
+			g.It("should allow write access in collaborator namespace", func() {
+				_, err := client.CoreV1().Pods(collaboratorResource.Namespace).Create(context.Background(), collaboratorResource, metav1.CreateOptions{DryRun: []string{"All"}})
+				framework.ExpectNoError(err, "failed to create pod: %s in namespace: %s", collaboratorResource.Name, collaboratorResource.Namespace)
+			})
+
 			g.It("should allow write access in system namespace", func() {
 				_, err := client.CoreV1().Pods(systemResource.Namespace).Create(context.Background(), systemResource, metav1.CreateOptions{DryRun: []string{"All"}})
 				framework.ExpectNoError(err, "failed to create pod: %s in namespace: %s", systemResource.Name, systemResource.Namespace)
+			})
+		})
+
+		g.Context("as collaborator user", func() {
+			var client *kubernetes.Clientset
+
+			g.BeforeEach(func() {
+				var err error
+
+				client, err = getCollaboratorClient(eksCluster, awsAccountID)
+				framework.ExpectNoError(err)
+			})
+
+			g.It("should allow write access in user namespace", func() {
+				_, err := client.CoreV1().Pods(nonSystemResource.Namespace).Create(context.Background(), nonSystemResource, metav1.CreateOptions{DryRun: []string{"All"}})
+				framework.ExpectNoError(err, "failed to create pod: %s in namespace: %s", nonSystemResource.Name, nonSystemResource.Namespace)
+			})
+
+			g.It("should allow write access in collaborator namespace", func() {
+				_, err := client.CoreV1().Pods(collaboratorResource.Namespace).Create(context.Background(), collaboratorResource, metav1.CreateOptions{DryRun: []string{"All"}})
+				framework.ExpectNoError(err, "failed to create pod: %s in namespace: %s", collaboratorResource.Name, collaboratorResource.Namespace)
+			})
+
+			g.It("should deny write access in system namespace", func() {
+				_, err := client.CoreV1().Pods(systemResource.Namespace).Create(context.Background(), systemResource, metav1.CreateOptions{DryRun: []string{"All"}})
+				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
 			})
 		})
 
@@ -633,6 +666,11 @@ var _ = g.Describe("Authorization via admission-controller [RBAC] [Zalando]", fu
 			g.It("should allow write access in user namespace", func() {
 				_, err := client.CoreV1().Pods(nonSystemResource.Namespace).Create(context.Background(), nonSystemResource, metav1.CreateOptions{DryRun: []string{"All"}})
 				framework.ExpectNoError(err, "failed to create pod: %s in namespace: %s", nonSystemResource.Name, nonSystemResource.Namespace)
+			})
+
+			g.It("should deny write access in collaborator namespace", func() {
+				_, err := client.CoreV1().Pods(collaboratorResource.Namespace).Create(context.Background(), collaboratorResource, metav1.CreateOptions{DryRun: []string{"All"}})
+				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
 			})
 
 			g.It("should deny write access in system namespace", func() {
@@ -804,6 +842,11 @@ var _ = g.Describe("Authorization via admission-controller [RBAC] [Zalando]", fu
 // getPrivilegedClient returns a client with the `zalando:administrator` group.
 func getPrivilegedClient(cluster *types.Cluster, awsAccountID string) (*kubernetes.Clientset, error) {
 	return newClientWithRole(cluster, fmt.Sprintf("arn:aws:iam::%s:role/%s-e2e-eks-iam-test-privileged-role", awsAccountID, aws.ToString(cluster.Name)))
+}
+
+// getCollaboratorClient returns a client with the `zalando:collaborator` group.
+func getCollaboratorClient(cluster *types.Cluster, awsAccountID string) (*kubernetes.Clientset, error) {
+	return newClientWithRole(cluster, fmt.Sprintf("arn:aws:iam::%s:role/%s-e2e-eks-iam-test-collaborator-role", awsAccountID, aws.ToString(cluster.Name)))
 }
 
 // getUnprivilegedClient returns a client with the `zalando:readonly` group.


### PR DESCRIPTION
Collaborators should have access in a subset of the (currently marked as) privileged namespaces. This includes visibility and kubenurse based on the old configuration.