### PR TITLE
Enable network policies by default for EKS

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1265,6 +1265,6 @@ eks_fis_namespaces: "default"
 # prefix delegation can only be configured for ipv4. For ipv6 it can only be true.
 aws_vpc_cni_prefix_delegation: "false"
 # enable network policy enforcement in the cluster.
-aws_vpc_cni_enable_network_policy: "false"
+aws_vpc_cni_enable_network_policy: "true"
 # specify the network policy enforcement mode.
 aws_vpc_cni_network_policy_enforcing_mode: "standard"


### PR DESCRIPTION
Enable the NetworkPolicy controller in EKS by default. This will also enable it for all e2e test runs.