### PR TITLE
Disable resource protection via admission-controller in legacy clusters

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -695,10 +695,15 @@ teapot_admission_controller_configmap_deletion_protection_factories_enabled: "tr
 # enable the rolebinding admission-controller webhook which validates rolebindings and clusterrolebindings
 teapot_admission_controller_enable_rolebinding_webhook: "true"
 
-# enable the generic deny-all admission webhook which rejects all requests it receives
+{{ if eq .Cluster.Provider "zalando-eks" }}
+# enable the resource protection admission webhook which prevents users from accessing system resources
 teapot_admission_controller_enable_write_protection_webhook: "true"
-# configure the behaviour of the deny-all admission webhook, `true` blocks everything, `false` allows everything
+# configure the behaviour of the resource protection admission webhook, `true` blocks everything, `false` allows everything
 teapot_admission_controller_prevent_write_operations: "true"
+{{ else }}
+teapot_admission_controller_enable_write_protection_webhook: "false"
+teapot_admission_controller_prevent_write_operations: "false"
+{{ end }}
 
 # Enable and configure Pod Security Policy rules implemented in admission-controller.
 teapot_admission_controller_pod_security_policy_enabled: "true"


### PR DESCRIPTION
Enable the new resource protection via admission-controller only in EKS clusters where it's actually needed.

This is to unblock the channel propagation here: https://github.com/zalando-incubator/kubernetes-on-aws/pull/9056

Especially this rule has me concerned: https://github.com/zalando-incubator/kubernetes-on-aws/blob/097abfad7096d9345ece1933507813c8920026ef/cluster/manifests/02-admission-control/teapot.yaml#L493-L521

It would block exec calls in user namespaces in production clusters, which is fine. But it would also block in test and cannot be overridden by manual access as far as I can tell. Let's unblock the rollout while figuring this out.