### PR TITLE
Toggle Emergency Access Service

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -250,6 +250,14 @@ skipper_pod_deletion_cost_controller_resync_interval: "1h"
 # polarsignals - only enabled for testing teapot
 polarsignals_enabled: "false"
 
+# Emergency Access Service
+# Control whether the emergency access service is enabled or not.
+{{ if and (eq .Cluster.Environment "production") (eq .Cluster.Provider "zalando-aws") }}
+emergency_access_service_enabled: "true"
+{{else}}
+emergency_access_service_enabled: "false"
+{{end}}
+
 # Kube-Metrics-Adapter
 ## Scheduled scaling metrics: ramp up/down over this period of time
 kube_metrics_adapter_default_scaling_window: "10m"

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -415,3 +415,29 @@ post_apply:
   kind: ServiceAccount
   namespace: kube-system
 {{- end}}
+{{- if ne .Cluster.ConfigItems.emergency_access_service_enabled "true" }}
+- name: emergency-access-service
+  kind: Deployment
+  namespace: kube-system
+- name: emergency-access-service
+  kind: PlatformCredentialsSet
+  namespace: kube-system
+- name: emergency-access-service
+  kind: Ingress
+  namespace: kube-system
+- name: emergency-access-service
+  kind: Service
+  namespace: kube-system
+- name: emergency-access-service
+  kind: Secret
+  namespace: kube-system
+- name: emergency-access-service
+  namespace: kube-system
+  kind: RoleBinding
+- name: emergency-access-service
+  namespace: kube-system
+  kind: Role
+- kind: ServiceAccount
+  name: emergency-access-service
+  namespace: kube-system
+{{- end}}

--- a/cluster/manifests/emergency-access-service/01-rbac.yaml
+++ b/cluster/manifests/emergency-access-service/01-rbac.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Cluster.Environment "production" }}
+{{- if eq .Cluster.ConfigItems.emergency_access_service_enabled "true" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -34,4 +34,4 @@ subjects:
 - kind: ServiceAccount
   name: emergency-access-service
   namespace: kube-system
-{{ end }}
+{{- end }}

--- a/cluster/manifests/emergency-access-service/credentials.yaml
+++ b/cluster/manifests/emergency-access-service/credentials.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Cluster.Environment "production" }}
+{{- if eq .Cluster.ConfigItems.emergency_access_service_enabled "true" }}
 apiVersion: "zalando.org/v1"
 kind: PlatformCredentialsSet
 metadata:
@@ -13,4 +13,4 @@ spec:
        privileges:
      emergency-service:
        privileges:
-{{ end }}
+{{- end }}

--- a/cluster/manifests/emergency-access-service/deployment.yaml
+++ b/cluster/manifests/emergency-access-service/deployment.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Cluster.Environment "production" }}
+{{- if eq .Cluster.ConfigItems.emergency_access_service_enabled "true" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -111,4 +111,4 @@ spec:
       - name: platform-iam-credentials
         secret:
           secretName: "emergency-access-service"
-{{ end }}
+{{- end }}

--- a/cluster/manifests/emergency-access-service/ingress.yaml
+++ b/cluster/manifests/emergency-access-service/ingress.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Cluster.Environment "production" }}
+{{- if eq .Cluster.ConfigItems.emergency_access_service_enabled "true" }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -20,4 +20,4 @@ spec:
             port:
               name: http
         pathType: ImplementationSpecific
-{{ end }}
+{{- end }}

--- a/cluster/manifests/emergency-access-service/service.yaml
+++ b/cluster/manifests/emergency-access-service/service.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Cluster.Environment "production" }}
+{{- if eq .Cluster.ConfigItems.emergency_access_service_enabled "true" }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -15,4 +15,4 @@ spec:
       targetPort: 8080
       protocol: TCP
       name: http
-{{ end }}
+{{- end }}


### PR DESCRIPTION
Add toggle to disable emergency-access-service

The motivation for this is twofold:

1. It doesn't work in EKS cluster, so simply disable it there
2. We intend to soon decommission it. This adds the toggle to disable it gradually.