### PR TITLE
eks: Enable control plane logging by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1251,7 +1251,7 @@ wiz_priority: "false"
 wiz_node_feature_rollout : "false"
 
 # EKS specific configuration
-eks_control_plane_logging: "false"
+eks_control_plane_logging: "true"
 eks_ip_family: "ipv4"
 eks_zalando_iam_aws_proxy_cpu: "100m"
 eks_zalando_iam_aws_proxy_memory: "512Mi"


### PR DESCRIPTION
Enable control plane logging by default in EKS.