### PR TITLE
eks: Break circular dependency on bootstrap

### DIFF
--- a/cluster/manifests/02-admission-control/teapot.yaml
+++ b/cluster/manifests/02-admission-control/teapot.yaml
@@ -13,13 +13,21 @@ webhooks:
       matchExpressions:
         - key: component
           operator: NotIn
-          values: ["admission-controller", "coredns", "aws-node"]
+          values:
+            - "admission-controller"
+            - "coredns"
+            - "aws-node"
+            - "external-dns"
+            - "zalando-iam-aws-proxy"
         - key: k8s-app
           operator: NotIn
           values: ["kube-proxy"]
         - key: app.kubernetes.io/name
           operator: NotIn
           values: ["eks-pod-identity-agent"]
+        - key: application
+          operator: NotIn
+          values: ["kube-ingress-aws-controller"]
 {{- end }}
     clientConfig:
       {{- if eq .Cluster.Provider "zalando-eks"}}
@@ -48,13 +56,21 @@ webhooks:
       matchExpressions:
         - key: component
           operator: NotIn
-          values: ["admission-controller", "coredns", "aws-node"]
+          values:
+            - "admission-controller"
+            - "coredns"
+            - "aws-node"
+            - "external-dns"
+            - "zalando-iam-aws-proxy"
         - key: k8s-app
           operator: NotIn
           values: ["kube-proxy"]
         - key: app.kubernetes.io/name
           operator: NotIn
           values: ["eks-pod-identity-agent"]
+        - key: application
+          operator: NotIn
+          values: ["kube-ingress-aws-controller"]
 {{- end }}
     clientConfig:
       {{- if eq .Cluster.Provider "zalando-eks"}}

--- a/cluster/manifests/02-skipper-validation-webhook/skipper-webhook.yaml
+++ b/cluster/manifests/02-skipper-validation-webhook/skipper-webhook.yaml
@@ -13,6 +13,12 @@ webhooks:
         apiGroups: ["zalando.org"]
         apiVersions: ["v1"]
         resources: ["routegroups"]
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
     clientConfig:
       # {{- if eq .Cluster.Provider "zalando-eks"}}
       service:
@@ -34,6 +40,12 @@ webhooks:
         apiGroups: ["networking.k8s.io"]
         apiVersions: ["v1"]
         resources: ["ingresses"]
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
     clientConfig:
       # {{- if eq .Cluster.Provider "zalando-eks"}}
       service:

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: container-registry.zalando.net/teapot/external-dns:v0.15.1-master-42
+        image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/external-dns:v0.15.1-master-42
         args:
         - --source=service
         - --source=ingress
@@ -72,3 +72,9 @@ spec:
         env:
         - name: AWS_REGION
           value: "{{ .Cluster.Region }}"
+{{- if eq .Cluster.Provider "zalando-eks"}}
+      tolerations:
+        - key: dedicated
+          value: cluster-seed
+          effect: NoSchedule
+{{- end}}

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -1,4 +1,4 @@
-# {{ $image := "container-registry.zalando.net/teapot/kube-ingress-aws-controller:v0.15.34" }}
+# {{ $image := "926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/kube-ingress-aws-controller:v0.15.34" }}
 # {{ $version := index (split $image ":") 1 }}
 
 apiVersion: apps/v1
@@ -75,3 +75,9 @@ spec:
             requests:
               cpu: 50m
               memory: 4Gi
+{{- if eq .Cluster.Provider "zalando-eks"}}
+      tolerations:
+        - key: dedicated
+          value: cluster-seed
+          effect: NoSchedule
+{{- end}}

--- a/cluster/manifests/zalando-iam-aws-proxy/deployment.yaml
+++ b/cluster/manifests/zalando-iam-aws-proxy/deployment.yaml
@@ -114,4 +114,8 @@ spec:
             cpu: 50m
             memory: 100Mi
       # {{- end}}
+      tolerations:
+        - key: dedicated
+          value: cluster-seed
+          effect: NoSchedule
 # {{ end }}


### PR DESCRIPTION
When bootstrapping a production EKS cluster we have the following circular dependency

![image](https://github.com/user-attachments/assets/370b428a-8b0c-4bdf-8dc3-4fe3fba5bb75)


Which prevents the majority of pods from starting because the check for production ready images in admission-controller can not execute.

This PR breaks the circular dependency in the following way

1. Exclude components needed for setting up the `<cluster-alias>.<account>.zalan.do` endpoint from admission-controller
   * `zalando-iam-aws-proxy`
   * `external-dns`
   * `kube-ingress-aws-controller`
2. Use the resolved ECR image url for those components as they can't be transformed from the vanity URL when not going through admission-controller
3. Allow those components to run on the cluster-seed nodes such that they can run e.g. before karpenter is running.
4. Exclude `kube-system` from skipper validating webhook ingress/RouteGroup validation.