### PR TITLE
eks: Fix disabling control plane logging

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -171,15 +171,17 @@ Resources:
         EndpointPublicAccess: true
         EndpointPrivateAccess: true
         # PublicAccessCidrs: [ "1.1.1.2/32" ]
-{{- if eq .Cluster.ConfigItems.eks_control_plane_logging "true" }}
       Logging:
         ClusterLogging:
+{{- if eq .Cluster.ConfigItems.eks_control_plane_logging "true" }}
           EnabledTypes:
             - Type: api
             - Type: audit
             - Type: authenticator
             - Type: controllerManager
             - Type: scheduler
+{{- else }}
+          EnabledTypes: []
 {{- end }}
       # Tags:
       # - Key: "application"


### PR DESCRIPTION
This fixes turning off `eks_control_plane_logging` after it has been enabled.

Without this the CF stack update fails because it's not allowed to remove the whole `Logging` section after it has been defined in the template once.