### PR TITLE
Drop karpenter taint injection via admission-controller

### DIFF
--- a/cluster/manifests/02-admission-control/config.yaml
+++ b/cluster/manifests/02-admission-control/config.yaml
@@ -197,7 +197,6 @@ data:
 {{- end}}
 
   node.node-not-ready-taint.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_node_not_ready_taint }}"
-  node.karpenter-unregistered-taint.enable: "true"
   node.extended-node-restriction.enable: "true"
 
 {{- range $group, $provider := nodeLifeCycleProviderPerNodePoolGroup .Cluster.NodePools }}

--- a/cluster/manifests/02-admission-control/deployment.yaml
+++ b/cluster/manifests/02-admission-control/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
       - name: admission-controller
-        image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-247
+        image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-248
         lifecycle:
           preStop:
             exec:

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -221,7 +221,7 @@ write_files:
             limits:
               memory: {{ .Values.InstanceInfo.MemoryFraction (parseInt64 .Cluster.ConfigItems.apiserver_memory_limit_percent)}}
 {{- end }}
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-247
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-248
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
Drops karpenter taint injeciton via admission-controller as this is now done via kubelet: #8915