### PR TITLE
Give api-monitoring-controller access to kube-system configmap

### DIFF
--- a/cluster/manifests/02-admission-control/teapot.yaml
+++ b/cluster/manifests/02-admission-control/teapot.yaml
@@ -568,6 +568,13 @@ webhooks:
         expression: '!(request.userInfo.username in ["system:kube-controller-manager", "system:kube-scheduler", "zalando-iam:zalando:service:k8sapi_credentials-provider"])'
       - name: 'exclude-eks-components'
         expression: '!request.userInfo.username.startsWith("eks:")'
+      - name: 'allow-api-monitoring-controller-access'
+        expression: |
+          !(
+            request.userInfo.username == "system:serviceaccount:api-infrastructure:api-monitoring-controller" &&
+            object.kind == "ConfigMap" &&
+            object.metadata.name == "skipper-default-filters"
+          )
   - name: collaborator-deny-admitter.teapot.zalan.do
     clientConfig:
       {{- if eq .Cluster.Provider "zalando-eks"}}


### PR DESCRIPTION
The api-monitoring-controller needs access to write to a specific configmap in `kube-system`. Exclude it from namespaced-deny admission-controller to allow write access.

The errors from the controller illustrate the issue:

```
%!q(*model.ErrorSummary=&{FATAL failed to update config map k8s gateway [resource=replace configmaps, status-code=400, message={"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"admission webhook \"namespaced-deny-admitter.teapot.zalan.do\" denied the request: write operations are forbidden","code":400}] 1 []})] interval="30s" status="FAILED"

```