### PR TITLE
[HOTFIX/beta] Give api-monitoring-controller access to kube-system configmap

### DIFF
--- a/cluster/manifests/02-admission-control/teapot.yaml
+++ b/cluster/manifests/02-admission-control/teapot.yaml
@@ -552,6 +552,13 @@ webhooks:
         expression: '!(request.userInfo.username in ["system:kube-controller-manager", "system:kube-scheduler", "zalando-iam:zalando:service:k8sapi_credentials-provider"])'
       - name: 'exclude-eks-components'
         expression: '!request.userInfo.username.startsWith("eks:")'
+      - name: 'allow-api-monitoring-controller-access'
+        expression: |
+          !(
+            request.userInfo.username == "system:serviceaccount:api-infrastructure:api-monitoring-controller" &&
+            object.kind == "ConfigMap" &&
+            object.metadata.name == "skipper-default-filters"
+          )
   - name: collaborator-deny-admitter.teapot.zalan.do
     clientConfig:
       {{- if eq .Cluster.Provider "zalando-eks"}}


### PR DESCRIPTION
Hotfix of https://github.com/zalando-incubator/kubernetes-on-aws/pull/9106 to beta