### PR TITLE
fix: connector job and broker deployment

### DIFF
--- a/cluster/manifests/wiz/004-connector-broker-secrets.yaml
+++ b/cluster/manifests/wiz/004-connector-broker-secrets.yaml
@@ -1,4 +1,4 @@
-{{ if or (eq .Cluster.ConfigItems.wiz_enable_runtime_connector "true") (eq .Cluster.ConfigItems.wiz_enable_runtime_connector_broker "true") }}
+{{ if or (eq .Cluster.ConfigItems.wiz_enable_runtime_connector "true") }}
 ---
 # These are used both in Job and Deployment
 # Create when wiz_enable_runtime_connector or wiz_enable_runtime_connector_broker is true and deleted when wiz_enable_runtime_connector_broker and wiz_enable_runtime_connector is false
@@ -15,6 +15,8 @@ metadata:
 type: Opaque
 data:
   connectorData: "e30="
+{{end}}
+{{ if or (eq .Cluster.ConfigItems.wiz_enable_runtime_connector "true") (eq .Cluster.ConfigItems.wiz_enable_runtime_connector_broker "true") }}
 ---
 # Source: wiz-kubernetes-integration/charts/wiz-kubernetes-connector/templates/service-account-cluster-reader.yaml
 apiVersion: v1

--- a/cluster/manifests/wiz/004-connector-broker-secrets.yaml
+++ b/cluster/manifests/wiz/004-connector-broker-secrets.yaml
@@ -1,4 +1,4 @@
-{{ if or (eq .Cluster.ConfigItems.wiz_enable_runtime_connector "true") }}
+{{ if eq .Cluster.ConfigItems.wiz_enable_runtime_connector "true" }}
 ---
 # These are used both in Job and Deployment
 # Create when wiz_enable_runtime_connector or wiz_enable_runtime_connector_broker is true and deleted when wiz_enable_runtime_connector_broker and wiz_enable_runtime_connector is false


### PR DESCRIPTION
- This will enable wiz-connector-connector to be created when wiz_enable_runtime_connector set to true and will avoid re applying via CLM 

Fixes: 
- Crashloopback of broker pod when wiz_enable_runtime_connector set to false 
- Duplicate broker connections by re applying the connector job every time CLM runs as wiz_enable_runtime_connector set to true