### PR TITLE
Mainly use karpenter pools for e2e

### DIFF
--- a/cluster/manifests/e2e-resources/pool-reserve.yaml
+++ b/cluster/manifests/e2e-resources/pool-reserve.yaml
@@ -1,5 +1,5 @@
 {{ if eq .Cluster.Environment "e2e" }}
-{{ range $pool := split "default-worker-splitaz,worker-limit-az,worker-combined,worker-instance-storage,worker-node-tests,worker-karpenter,worker-arm64" "," }}
+{{ range $pool := split "worker-limit-az,worker-instance-storage,worker-node-tests,worker-arm64" "," }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -20,8 +20,13 @@ spec:
         application: pool-reserve
         pool: "{{$pool}}"
     spec:
+      {{- if eq $pool "worker-arm64" }}
+      nodeSelector:
+        kubernetes.io/arch: arm64
+      {{- else if ne $pool "worker-instance-storage" }}
       nodeSelector:
         node.kubernetes.io/node-pool: "{{$pool}}"
+      {{- end }}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -38,21 +43,6 @@ spec:
           key: dedicated
           value: node-tests
       {{ end }}
-      {{ if eq $pool "worker-combined" }}
-        - effect: NoSchedule
-          key: dedicated
-          value: worker-combined
-      {{ end }}
-      {{ if eq $pool "worker-karpenter" }}
-        - effect: NoSchedule
-          key: dedicated
-          value: worker-karpenter
-      {{ end }}
-      {{ if eq $pool "worker-arm64" }}
-        - effect: NoSchedule
-          key: dedicated
-          value: worker-arm64
-      {{ end }}
       terminationGracePeriodSeconds: 0
       containers:
       - name: pause
@@ -64,6 +54,9 @@ spec:
           requests:
             cpu: 1m
             memory: 50Mi
+            {{- if eq $pool "worker-instance-storage" }}
+            ephemeral-storage: "500Gi"
+            {{- end }}
 ---
 {{ end }}
 {{ end }}

--- a/cluster/manifests/e2e-resources/pool-reserve.yaml
+++ b/cluster/manifests/e2e-resources/pool-reserve.yaml
@@ -43,6 +43,11 @@ spec:
           key: dedicated
           value: node-tests
       {{ end }}
+      {{ if eq $pool "worker-limit-az" }}
+        - effect: NoSchedule
+          key: dedicated
+          value: {{$pool}}
+      {{ end }}
       terminationGracePeriodSeconds: 0
       containers:
       - name: pause

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -39,7 +39,6 @@ clusters:
     vm_dirty_bytes: 134217728
     vm_dirty_background_bytes: 67108864
     coredns_max_upsteam_concurrency: 30
-    ebs_root_volume_size: "550" # required by the limitRanger e2e tests (needs 500Gi ephemoral storage) https://github.com/kubernetes/kubernetes/blob/v1.18.3/test/e2e/scheduling/limit_range.go#L59
     routegroups_validation: "enabled"
     stackset_routegroup_support_enabled: "true"
     stackset_ingress_source_switch_ttl: "1m"
@@ -85,15 +84,6 @@ EOFF
   fi)
   - discount_strategy: none
     instance_types:
-    - "m6i.2xlarge"
-    name: default-worker-splitaz
-    profile: worker-splitaz
-    min_size: 0
-    max_size: 21
-    config_items:
-      cpu_manager_policy: static
-  - discount_strategy: none
-    instance_types:
     - "m6i.xlarge"
     config_items:
       availability_zones: "eu-central-1a"
@@ -102,23 +92,24 @@ EOFF
     profile: worker-splitaz
     min_size: 0
     max_size: 21
-  - discount_strategy: none
-    instance_types:
-    - "m6id.xlarge"
-    name: worker-instance-storage
-    profile: worker-splitaz
+  - name: default-karpenter
+    profile: worker-karpenter
+    discount_strategy: none
+    max_size: 0
     min_size: 0
-    max_size: 21
-  - discount_strategy: none
     instance_types:
-    - "m6i.xlarge"
-    name: worker-combined
-    profile: worker-combined
+    - default-for-karpenter
     config_items:
-      labels: dedicated=worker-combined
-      taints: dedicated=worker-combined:NoSchedule
+      scaling_priority: "100"
+  - name: karpenter-catch-all
+    profile: worker-karpenter
+    discount_strategy: none
+    max_size: 0
     min_size: 0
-    max_size: 21
+    instance_types:
+    - not-specified
+    config_items:
+      scaling_priority: "2"
   - discount_strategy: spot
     instance_types:
     - "c7g.large"
@@ -137,17 +128,10 @@ EOFF
       taints: dedicated=skipper-ingress:NoSchedule
   - discount_strategy: spot
     instance_types:
-    - "m6a.large"
-    - "m6i.large"
-    - "m6a.xlarge"
-    - "m6i.xlarge"
-    - "c6i.large"
-    - "c6i.xlarge"
-    - "c6a.large"
-    - "c6a.xlarge"
+    - "default-for-karpenter"
     min_size: 0
-    max_size: 3
-    profile: worker-splitaz
+    max_size: 0
+    profile: worker-karpenter
     name: worker-node-tests
     config_items:
       labels: dedicated=node-tests
@@ -166,54 +150,22 @@ EOFF
     - "g6.2xlarge"
     - "g6.4xlarge"
     name: worker-gpu
-    profile: worker-splitaz
+    profile: worker-karpenter
     min_size: 0
-    max_size: 6
+    max_size: 0
     config_items:
-      availability_zones: "eu-central-1a,eu-central-1b"
       labels: zalando.org/nvidia-gpu=tesla
       taints: nvidia.com/gpu=present:NoSchedule
-      scaling_priority: "-100"
-  - discount_strategy: none
-    instance_types: ["g4dn.xlarge"]
-    name: worker-gpu-on-demand
-    profile: worker-splitaz
-    min_size: 0
-    max_size: 6
-    config_items:
-      availability_zones: "eu-central-1a,eu-central-1b"
-      labels: zalando.org/nvidia-gpu=tesla
-      taints: nvidia.com/gpu=present:NoSchedule
-      scaling_priority: "-200"
   - discount_strategy: none
     instance_types:
-    - "m6i.xlarge"
+    - "default-for-karpenter"
     min_size: 0
-    max_size: 3
-    profile: worker-splitaz
+    max_size: 0
+    profile: worker-karpenter
     name: node-reboot-tests
     config_items:
       labels: dedicated=node-reboot-tests
       taints: dedicated=node-reboot-tests:NoSchedule
-  - discount_strategy: none
-    instance_types: ["default-for-karpenter"]
-    min_size: 0
-    max_size: 0
-    profile: worker-karpenter
-    name: worker-karpenter
-    config_items:
-      labels: dedicated=worker-karpenter
-      taints: dedicated=worker-karpenter:NoSchedule
-  - discount_strategy: none
-    instance_types:
-    - "m6g.large"
-    min_size: 0
-    max_size: 3
-    profile: worker-splitaz
-    name: worker-arm64
-    config_items:
-      labels: dedicated=worker-arm64
-      taints: dedicated=worker-arm64:NoSchedule
   provider: ${CLUSTER_PROVIDER}
   region: ${REGION}
   owner: '${OWNER}'

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -107,6 +107,7 @@ EOFF
     - default-for-karpenter
     config_items:
       scaling_priority: "100"
+      consolidate_after: "5m"
   - name: karpenter-arm
     profile: worker-karpenter
     discount_strategy: none
@@ -116,6 +117,7 @@ EOFF
     - not-specified
     config_items:
       requirements: "- key: kubernetes.io/arch\n  operator: In\n  values:\n  - arm64\n"
+      consolidate_after: "5m"
   - discount_strategy: spot
     instance_types:
     - "c7g.large"
@@ -142,6 +144,7 @@ EOFF
     config_items:
       labels: dedicated=node-tests
       taints: dedicated=node-tests:NoSchedule
+      consolidate_after: "5m"
   - discount_strategy: spot
     instance_types:
     - "g4dn.xlarge"
@@ -162,6 +165,7 @@ EOFF
     config_items:
       labels: zalando.org/nvidia-gpu=tesla
       taints: nvidia.com/gpu=present:NoSchedule
+      consolidate_after: "5m"
   - discount_strategy: none
     instance_types:
     - "default-for-karpenter"
@@ -172,6 +176,7 @@ EOFF
     config_items:
       labels: dedicated=node-reboot-tests
       taints: dedicated=node-reboot-tests:NoSchedule
+      consolidate_after: "5m"
   provider: ${CLUSTER_PROVIDER}
   region: ${REGION}
   owner: '${OWNER}'

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -156,6 +156,7 @@ EOFF
     config_items:
       labels: zalando.org/nvidia-gpu=tesla
       taints: nvidia.com/gpu=present:NoSchedule
+      scaling_priority: "3"
   - discount_strategy: none
     instance_types:
     - "default-for-karpenter"

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -101,7 +101,7 @@ EOFF
     - default-for-karpenter
     config_items:
       scaling_priority: "100"
-  - name: karpenter-catch-all
+  - name: karpenter-arm
     profile: worker-karpenter
     discount_strategy: none
     max_size: 0
@@ -109,7 +109,7 @@ EOFF
     instance_types:
     - not-specified
     config_items:
-      scaling_priority: "2"
+      requirements: "- key: kubernetes.io/arch\n  operator: In\n  values:\n  - arm64\n"
   - discount_strategy: spot
     instance_types:
     - "c7g.large"
@@ -149,14 +149,13 @@ EOFF
     - "g6.xlarge"
     - "g6.2xlarge"
     - "g6.4xlarge"
-    name: worker-gpu
+    name: karpenter-gpu
     profile: worker-karpenter
     min_size: 0
     max_size: 0
     config_items:
       labels: zalando.org/nvidia-gpu=tesla
       taints: nvidia.com/gpu=present:NoSchedule
-      scaling_priority: "3"
   - discount_strategy: none
     instance_types:
     - "default-for-karpenter"

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -82,12 +82,18 @@ cat <<EOFF
     max_size: 2
 EOFF
   fi)
-  - discount_strategy: none
+  - discount_strategy: spot
     instance_types:
-    - "m6i.xlarge"
+    - "c6i.large"
+    - "m6i.large"
+    - "r6i.large"
+    - "c7i.large"
+    - "m7i.large"
+    - "r7i.large"
     config_items:
       availability_zones: "eu-central-1a"
-      scaling_priority: "-100"
+      labels: dedicated=worker-limit-az
+      taints: dedicated=worker-limit-az:NoSchedule
     name: worker-limit-az
     profile: worker-splitaz
     min_size: 0

--- a/test/e2e/infra.go
+++ b/test/e2e/infra.go
@@ -37,12 +37,9 @@ var _ = describe("Infrastructure tests", func() {
 	It("All node pools should be able to run pods [Zalando]", func() {
 		// When modifying this list, don't forget to modify cluster/manifests/e2e-resources/pool-reserve.yaml
 		nodePools := []string{
-			"default-worker-splitaz",
-			"worker-combined",
 			"worker-limit-az",
 			"worker-instance-storage",
 			"worker-node-tests",
-			"worker-karpenter",
 			"worker-arm64",
 		}
 

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -918,6 +918,9 @@ func createVectorPod(nameprefix, namespace string, labels map[string]string) *v1
 					},
 				},
 			},
+			NodeSelector: map[string]string{
+				"kubernetes.io/arch": "amd64",
+			},
 		},
 	}
 }


### PR DESCRIPTION
Reduce number of ASG based node pools as we constantly hit rate limits on the ASG API in the e2e account

* Replace `default-worker-splitaz` by a `default-karpenter` pool. `worker-splitaz` profile pool is tested by skipper-ingress indirectly.
* Drop dedicated `worker-instance-storage` pool and just rely on karpenter spinning up a right node to satisfy a pod requesting 500Gi ephemeralStorage.
* Drop dedicated `worker-combined` pool. Master pool and EKS Seed pool are both `worker-combined` and we only use this profile in that context, so should be enough to test as part of e2e.
* Switch GPU pools to be karpenter based
* Drop dedicated `worker-karpenter` pool and rely on `default-karpenter` for testing basic karpenter functionality
* Replaced dedicated `worker-arm64` pool with a karpenter-arm pool that can spin up any arm instance based on `kubernetes.io/arch: arm64` nodeSelector.
* Drop the custom setting: `ebs_root_volume_size: "550"` as karpenter can spin up a node with enough ephemeral storage.