### PR TITLE
Disable egress controller in EKS by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -452,7 +452,11 @@ aws_efa_device_plugin_cpu: "10m"
 aws_efa_device_plugin_memory: "20Mi"
 
 # static egress controller settings
+{{- if eq .Cluster.Provider "zalando-eks" }}
+static_egress_controller_enabled: "false"
+{{- else }}
 static_egress_controller_enabled: "true"
+{{- end }}
 
 # journald reader settings
 journald_reader_enabled: "true"


### PR DESCRIPTION
The egress controller is not designed to run multiple times per AWS region as it only makes sense to have a single NAT setup per VPC.

Disable the controller by default in EKS clusters such that it doesn't run in the second cluster during migration phase.

This is a simple way to reduce risk, we need to think about how to make the migration work in respect to egress-controller.