### PR TITLE
Disable egress-controller in EKS clusters by default for the time being

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -452,7 +452,11 @@ aws_efa_device_plugin_cpu: "10m"
 aws_efa_device_plugin_memory: "20Mi"
 
 # static egress controller settings
+{{ if eq .Cluster.Provider "zalando-eks" }}
+static_egress_controller_enabled: "false"
+{{ else }}
 static_egress_controller_enabled: "true"
+{{ end }}
 
 # journald reader settings
 journald_reader_enabled: "true"


### PR DESCRIPTION
Egress controller currently doesn't work well with EKS. Let's disable it by default.