### PR TITLE
e2e: Increase instance-type choices

### DIFF
--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -84,14 +84,20 @@ EOFF
   fi)
   - discount_strategy: spot
     instance_types:
-    - "c6i.large"
-    - "m6i.large"
-    - "r6i.large"
-    - "c7i.large"
-    - "m7i.large"
-    - "r7i.large"
+    - "c6i.xlarge"
+    - "m6i.xlarge"
+    - "r6i.xlarge"
+    - "c7i.xlarge"
+    - "m7i.xlarge"
+    - "r7i.xlarge"
+    - "c6i.2xlarge"
+    - "m6i.2xlarge"
+    - "r6i.2xlarge"
+    - "c7i.2xlarge"
+    - "m7i.2xlarge"
+    - "r7i.2xlarge"
     config_items:
-      availability_zones: "eu-central-1a"
+      availability_zones: "eu-central-1c"
       labels: dedicated=worker-limit-az
       taints: dedicated=worker-limit-az:NoSchedule
     name: worker-limit-az


### PR DESCRIPTION
Follow up to #9119 (originally used for testing the update path)

* Increase the instance-type choices for e2e pool
* Use `eu-central-1c` for AZ test as `1c` historically has more capacity.