### PR TITLE
set karpenter_pools_enabled to true by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -30,7 +30,7 @@ cluster_autoscaler_max_usnchedulable_pods_considered: "1000"
 # karpenter settings
 # DO NOT SET TO FALSE IF THE CLUSTER HAS KARPENTER POOLS OR NODES. REFER TO TEAPOT DOCS  FOR HOW TO ROLLBACK KARPENTER
 # https://teapot.docs.zalando.net/howtos/karpenter-operations/
-karpenter_pools_enabled: "false"
+karpenter_pools_enabled: "true"
 
 karpenter_controller_cpu: "25m"
 karpenter_controller_memory: "256Mi"


### PR DESCRIPTION
This is required as a pre-condition to dropping the config-item altogether in #9127 . We have this enabled everywhere already, so we can set it `true` now.