### PR TITLE
Give deployment-controller the permission to create deployment tasks

### DIFF
--- a/cluster/manifests/deployment-service/controller-rbac.yaml
+++ b/cluster/manifests/deployment-service/controller-rbac.yaml
@@ -32,6 +32,9 @@ rules:
       - get
       - list
       - watch
+      # {{ if eq .Cluster.Provider "zalando-eks" }}
+      - create
+      # {{ end }}
       - update
       - patch
       - delete


### PR DESCRIPTION
Since https://github.com/zalando-incubator/kubernetes-on-aws/commit/be1fd06dc91931da396ec29e94f0e62bf95c86ae the ServiceAccount is used on EKS. When [running e2e tests for Deployment Service itself](https://sunrise.zalando.net/cdp/ghe/teapot/deployment-service/l-p8h7wft7s393gsgyk74nhhzgf/steps/1/deployment_status), the cluster's deployment-controller needs permission to create CDPDeploymentTasks which it could do before (actually, it needs to create a ClusterRole for testing that has this permission). Using the ServiceAccount it misses the respective permission. So let's add it.