### PR TITLE
Fix indentation to make template valid

### DIFF
--- a/cluster/manifests/deployment-service/controller-rbac.yaml
+++ b/cluster/manifests/deployment-service/controller-rbac.yaml
@@ -210,11 +210,11 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
   name: zalando-iam:zalando:service:k8sapi-local_deployment-service-executor
-  # {{ if eq .Cluster.Provider "zalando-eks" }}
-  - kind: ServiceAccount
-    name: "deployment-service-controller"
-    namespace: "kube-system"
-  # {{ end }}
+# {{ if eq .Cluster.Provider "zalando-eks" }}
+- kind: ServiceAccount
+  name: "deployment-service-controller"
+  namespace: "kube-system"
+# {{ end }}
 ---
 {{- end }}
 kind: Role


### PR DESCRIPTION
Fix indentation to make template valid.

Without this fix we get the error:

```
error remarshaling manifest main/cluster/manifests/deployment-service/controller-rbac.yaml: yaml: line 208: did not find expected key
```

When `deployment_service_executor_cdp_permissions: "true"`