### PR TITLE
Reduce WIZ resources

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1252,10 +1252,10 @@ role_sync_controller_enabled: "false"
 wiz_enable_runtime_sensor: "false"
 wiz_enable_runtime_connector: "false"
 wiz_enable_runtime_connector_broker: "false"
-wiz_sensor_cpu: "300m"
+wiz_sensor_cpu: "200m"
 wiz_sensor_memory: "300Mi"
-wiz_connector_cpu: "300m"
-wiz_connector_memory: "300Mi"
+wiz_connector_cpu: "50m"
+wiz_connector_memory: "150Mi"
 wiz_priority: "false"
 # Please note when this is set to true it allows the use of the node selector feature
 # to deploy the sensor and connector on specific nodes, by manually setting the node selector label on the nodes.


### PR DESCRIPTION
Post WIZ rollout we have now been able to observe and build a more realistic picture of the required resources of the Sensor and Connector components. This PR reduces the requests/limits to be more fitting to the actual usage.