### PR TITLE
Config Item to require instance types with in-transit encryption support

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -47,6 +47,12 @@ karpenter_instance_storage_raid0: "true"
 # Require support for the Nitro hypervisor for Karpenter NodePools.
 karpenter_nitro_support_required: "true"
 
+# configure whether karpenter node pools only allow instances supporting
+# in-transit encryption
+# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/data-protection.html#encryption-transit
+# Can be set cluster wide or per node pool
+karpenter_in_transit_support_required: "false"
+
 # ALB config created by kube-aws-ingress-controller
 kube_aws_ingress_controller_ssl_policy: "ELBSecurityPolicy-TLS-1-2-2017-01"
 kube_aws_ingress_controller_idle_timeout: "1m"

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -158,7 +158,7 @@ spec:
             - nitro
 #{{ end }}
 #{{ end }}
-#{{ if eq .NodePool.ConfigItems.karpenter_in_transit_support_required "true") }}
+#{{ if eq .NodePool.ConfigItems.karpenter_in_transit_support_required "true" }}
         - key: karpenter.k8s.aws/instance-encryption-in-transit-supported
           operator: Exists
 #{{ end }}

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -158,6 +158,10 @@ spec:
             - nitro
 #{{ end }}
 #{{ end }}
+#{{ if eq .NodePool.ConfigItems.karpenter_in_transit_support_required "true") }}
+        - key: karpenter.k8s.aws/instance-encryption-in-transit-supported
+          operator: Exists
+#{{ end }}
 #{{ if $taints }}
 #  {{ range $taints }}
 #    {{ $taint := . }}


### PR DESCRIPTION
This adds a config-item: `karpenter_in_transit_support_required` which, when set set a requirement on Karpenter node pools to restrict to instances with in-transit encryption support

The idea is that this can be set in clusters where this is a requirement.

ref: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/data-protection.html#encryption-transit