### PR TITLE
add nitro requirement for Karpenter pools

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -44,6 +44,9 @@ karpenter_max_pods_per_node: "32"
 # Our AMI configured RAID0 at boot.
 karpenter_instance_storage_raid0: "true"
 
+# Require support for the Nitro hypervisor for Karpenter NodePools.
+karpenter_nitro_support_required: "true"
+
 # ALB config created by kube-aws-ingress-controller
 kube_aws_ingress_controller_ssl_policy: "ELBSecurityPolicy-TLS-1-2-2017-01"
 kube_aws_ingress_controller_idle_timeout: "1m"

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -150,6 +150,14 @@ spec:
           values:
             - nitro
 #{{ end }}
+#{{ if eq .Cluster.ConfigItems.karpenter_nitro_support_required "true" }}
+#{{ if and (eq .Cluster.Provider "zalando-aws") (eq .NodePool.KarpenterInstanceTypeStrategy "not-specified") }}
+        - key: karpenter.k8s.aws/instance-hypervisor
+          operator: in
+          values:
+            - nitro
+#{{ end }}
+#{{ end }}
 #{{ if $taints }}
 #  {{ range $taints }}
 #    {{ $taint := . }}


### PR DESCRIPTION
For Karpenter node-pools that use the instance type strategy of `not-specified`, we want to restrict the usage of Nitro hypervisor as this will be required for all nodes when running EKS with IPv6.

This adds this behind a toggle so it's easier to rollback in case we see issues when rolling this out.  Once the rollout is complete, the toggle will be dropped.

This is only relevant for clusters that have the scheduling controls enabled, since only in those clusters we have Karpenter based node-pools with `instance-types: not-specified`.