### PR TITLE
remove the unused karpenter_pools_enabled config-item

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -28,9 +28,6 @@ cluster_autoscaler_max_graceful_termination_sec: "1209600" # 2 weeks
 cluster_autoscaler_max_usnchedulable_pods_considered: "1000"
 
 # karpenter settings
-# DO NOT SET TO FALSE IF THE CLUSTER HAS KARPENTER POOLS OR NODES. REFER TO TEAPOT DOCS  FOR HOW TO ROLLBACK KARPENTER
-# https://teapot.docs.zalando.net/howtos/karpenter-operations/
-karpenter_pools_enabled: "true"
 
 karpenter_controller_cpu: "25m"
 karpenter_controller_memory: "256Mi"


### PR DESCRIPTION
As a final step to cleaning up the `karpenter_pools_enabled` config-item, drop it as it's no longer used anywhere in the templates.

Follow-up to https://github.com/zalando-incubator/kubernetes-on-aws/pull/9127