### PR TITLE
admission-control: allow routesrv proxy

### DIFF
--- a/cluster/manifests/02-admission-control/teapot.yaml
+++ b/cluster/manifests/02-admission-control/teapot.yaml
@@ -575,6 +575,16 @@ webhooks:
             object.kind == "ConfigMap" &&
             object.metadata.name == "skipper-default-filters"
           )
+      - name: 'allow-routesrv-routes-access'
+        expression: |
+          !(
+            "okta:common/engineer" in request.userInfo.groups &&
+            request.name == "skipper-ingress-routesrv" &&
+            request.resource.resource == "services" &&
+            request.subResource == "proxy" &&
+            request.operation == "CONNECT"
+          )
+
   - name: collaborator-deny-admitter.teapot.zalan.do
     clientConfig:
       {{- if eq .Cluster.Provider "zalando-eks"}}


### PR DESCRIPTION
Allow engineers to read routes from routesrv service proxy.
The access level should be the same as for listing Ingresses and RouteGroups (because one can technically generate the same by running routesrv locally against api server)

See also
* #6497
* #9106