### PR TITLE
Switch deployment targets from `stups-test` to `stups-euc1-test`

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -42,7 +42,7 @@ pipeline:
   - build
   type: process
   desc: "Create cluster for Kubernetes e2e tests"
-  target: stups-test
+  target: stups-euc1-test
   process: microservice_standard_test
   config:
     apply_manifests:
@@ -99,7 +99,7 @@ pipeline:
   - create-cluster-aws
   type: process
   desc: "Kubernetes e2e tests"
-  target: stups-test
+  target: stups-euc1-test
   process: microservice_standard_test
   config:
     apply_manifests:
@@ -137,7 +137,7 @@ pipeline:
   - create-cluster-aws
   type: process
   desc: "Kubernetes e2e load tests"
-  target: stups-test
+  target: stups-euc1-test
   process: microservice_standard_test
   config:
     apply_manifests:
@@ -175,7 +175,7 @@ pipeline:
   - create-cluster-aws
   type: process
   desc: "StackSet e2e tests"
-  target: stups-test
+  target: stups-euc1-test
   process: microservice_standard_test
   config:
     apply_manifests:
@@ -215,7 +215,7 @@ pipeline:
   - e2e-load-test-result-aws
   type: process
   desc: "Decommission cluster used for Kubernetes e2e tests"
-  target: stups-test
+  target: stups-euc1-test
   process: microservice_standard_test
   config:
     apply_manifests:
@@ -253,7 +253,7 @@ pipeline:
   - build
   type: process
   desc: "Create cluster for Kubernetes e2e tests"
-  target: stups-test
+  target: stups-euc1-test
   process: microservice_standard_test
   config:
     apply_manifests:
@@ -297,7 +297,7 @@ pipeline:
   - create-cluster-eks
   type: process
   desc: "Kubernetes e2e tests"
-  target: stups-test
+  target: stups-euc1-test
   process: microservice_standard_test
   config:
     apply_manifests:
@@ -335,7 +335,7 @@ pipeline:
   - create-cluster-eks
   type: process
   desc: "Kubernetes e2e load tests"
-  target: stups-test
+  target: stups-euc1-test
   process: microservice_standard_test
   config:
     apply_manifests:
@@ -373,7 +373,7 @@ pipeline:
   - create-cluster-eks
   type: process
   desc: "StackSet e2e tests"
-  target: stups-test
+  target: stups-euc1-test
   process: microservice_standard_test
   config:
     apply_manifests:
@@ -413,7 +413,7 @@ pipeline:
   - e2e-load-test-result-eks
   type: process
   desc: "Decommission cluster used for Kubernetes e2e tests"
-  target: stups-test
+  target: stups-euc1-test
   process: microservice_standard_test
   config:
     apply_manifests:

--- a/test/e2e/apply/pcs.yaml
+++ b/test/e2e/apply/pcs.yaml
@@ -2,6 +2,9 @@ apiVersion: zalando.org/v1
 kind: PlatformCredentialsSet
 metadata:
   name: "{{{APPLICATION}}}-{{{COMPONENT}}}-credentials"
+  labels:
+    application: "{{{APPLICATION}}}"
+    component: "{{{COMPONENT}}}"
 spec:
   application: "{{{APPLICATION}}}"
   token_version: "v2"

--- a/test/e2e/apply/pdb.yaml
+++ b/test/e2e/apply/pdb.yaml
@@ -2,6 +2,9 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: "{{{APPLICATION}}}-{{{COMPONENT}}}"
+  labels:
+    application: "{{{APPLICATION}}}"
+    component: "{{{COMPONENT}}}"
 spec:
   maxUnavailable: 0
   selector:


### PR DESCRIPTION
Runs e2e tests on `stups-euc1-test` instead of `stups-test`.