### PR TITLE
skipper-internal: Update main version to v0.22.7-1117

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,6 +1,6 @@
 {{/* image-updater-bot detects *image variables so use print to disable it for main image */}}
 
-{{ $main_image := print "container-registry.zalando.net/teapot/skipper-internal:" "v0.22.1-1111" }}
+{{ $main_image := print "container-registry.zalando.net/teapot/skipper-internal:" "v0.22.7-1117" }}
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.22.7-1117" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}


### PR DESCRIPTION
* https://github.com/zalando/skipper/pull/3438
* https://github.com/zalando/skipper/pull/3437
* https://github.com/zalando/skipper/pull/3439
* https://github.com/zalando/skipper/pull/3440
* https://github.com/zalando/skipper/pull/3443
* https://github.com/zalando/skipper/pull/3407
* https://github.com/zalando/skipper/pull/3441

follow up on https://github.com/zalando-incubator/kubernetes-on-aws/pull/9102

diff https://github.com/zalando/skipper/compare/v0.22.1...v0.22.7