### PR TITLE
Excempt wiz namespace from being downscaled in test clusters

### DIFF
--- a/cluster/manifests/kube-downscaler/deployment.yaml
+++ b/cluster/manifests/kube-downscaler/deployment.yaml
@@ -32,7 +32,7 @@ spec:
         image: container-registry.zalando.net/teapot/kube-downscaler:22.7.1-master-13
         args:
           - --interval=30
-          - --exclude-namespaces=kube-system,visibility,tracing
+          - --exclude-namespaces=kube-system,visibility,tracing,wiz
           # do not downscale ourselves, also keep Postgres Operator so excluded DBs can be managed
           - --exclude-deployments=kube-downscaler,postgres-operator
           - "--default-uptime={{ .Cluster.ConfigItems.downscaler_default_uptime }}"


### PR DESCRIPTION
The Wiz broker is currently getting downscaled in test clusters, casing health issues to spawn. This adds the namespace to the exemption list to prevent this behavior.