### PR TITLE
fix requirement for encryption in-transit

### DIFF
--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -160,7 +160,9 @@ spec:
 #{{ end }}
 #{{ if eq .NodePool.ConfigItems.karpenter_in_transit_support_required "true" }}
         - key: karpenter.k8s.aws/instance-encryption-in-transit-supported
-          operator: Exists
+          operator: In
+          values:
+            - "true"
 #{{ end }}
 #{{ if $taints }}
 #  {{ range $taints }}


### PR DESCRIPTION
This was added in https://github.com/zalando-incubator/kubernetes-on-aws/pull/9143. The label exists on all Karpenter nodes, so we need to check for a value of `true` instead of checking if it exists.
