### PR TITLE
Configure response header timeouts for styra calls

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -378,6 +378,9 @@ skipper_ingress_routegroup_crd_require_hosts: "true"
 skipper_open_policy_agent_enabled: "false"
 skipper_open_policy_agent_styra_token: ""
 
+# Default timeout value in seconds for outgoing http calls from Open Policy Agent in a skipper filter
+skipper_open_policy_agent_styra_response_header_timeout: 2
+
 #
 # FabricGateway controller config
 #

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -379,7 +379,7 @@ skipper_open_policy_agent_enabled: "false"
 skipper_open_policy_agent_styra_token: ""
 
 # Default timeout value in seconds for outgoing http calls from Open Policy Agent in a skipper filter
-skipper_open_policy_agent_styra_response_header_timeout: 2
+skipper_open_policy_agent_styra_response_header_timeout: "2"
 
 #
 # FabricGateway controller config

--- a/cluster/manifests/skipper/configmap-open-policy-agent.yaml
+++ b/cluster/manifests/skipper/configmap-open-policy-agent.yaml
@@ -23,7 +23,7 @@ data:
           token: "{{ `{{ .Env.STYRA_TOKEN }}` }}"
       name: styra
       url: "{{ .Cluster.ConfigItems.skipper_open_policy_agent_observability_url }}"
-      response_header_timeout_seconds: 2
+      response_header_timeout_seconds: {{ .Cluster.ConfigItems.skipper_open_policy_agent_styra_response_header_timeout }}
     - credentials:
         s3_signing:
           web_identity_credentials:

--- a/cluster/manifests/skipper/configmap-open-policy-agent.yaml
+++ b/cluster/manifests/skipper/configmap-open-policy-agent.yaml
@@ -23,6 +23,7 @@ data:
           token: "{{ `{{ .Env.STYRA_TOKEN }}` }}"
       name: styra
       url: "{{ .Cluster.ConfigItems.skipper_open_policy_agent_observability_url }}"
+      response_header_timeout_seconds: 2
     - credentials:
         s3_signing:
           web_identity_credentials:

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -52,7 +52,6 @@ clusters:
     skipper_open_policy_agent_bucket_arn: "${SKIPPER_OPA_BUCKET_ARN}"
     skipper_open_policy_agent_observability_url: "${SKIPPER_OPA_OBSERVABILITY_URL}"
     skipper_open_policy_agent_bundles_url: "${SKIPPER_OPA_BUNDLES_URL}"
-    skipper_open_policy_agent_styra_response_header_timeout: 2
     eks_ip_family: "ipv6"
   criticality_level: 1
   environment: e2e

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -52,6 +52,7 @@ clusters:
     skipper_open_policy_agent_bucket_arn: "${SKIPPER_OPA_BUCKET_ARN}"
     skipper_open_policy_agent_observability_url: "${SKIPPER_OPA_OBSERVABILITY_URL}"
     skipper_open_policy_agent_bundles_url: "${SKIPPER_OPA_BUNDLES_URL}"
+    skipper_open_policy_agent_styra_response_header_timeout: 2
     eks_ip_family: "ipv6"
   criticality_level: 1
   environment: e2e


### PR DESCRIPTION
Configure response header timeouts for styra API calls

This configuration will make sure any outgoing calls to styra will timeout after 2 seconds. The default timeout is 10 seconds. Our Styra endpoints has p999 below 1s and it makes sense the calls do not have to wait longer in case there's a service degradation. 