### PR TITLE
Exclude base image validation in kube-system

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -606,6 +606,7 @@ kubelet_image_gc_low_threshold: 40
 {{if eq .Cluster.Environment "production"}}
 teapot_admission_controller_validate_application_label: "true"
 teapot_admission_controller_validate_base_images: "true"
+teapot_admission_controller_validate_base_images_namespaces: "^kube-system$"
 
 # Check container image compliance in production clusters. Be careful when thinking about changing this: Setting it to
 # false will allow any container image to run in production clusters.


### PR DESCRIPTION
To avoid a circular dependency as explained in #9092 exclude the base image validation in kube-system,

This check is disabled in e2e making it different from production. It's tricky to enable in e2e as we have many e2e images that would not pass.