### PR TITLE
karpenter: Only allow nitro instances

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -44,9 +44,6 @@ karpenter_max_pods_per_node: "32"
 # Our AMI configured RAID0 at boot.
 karpenter_instance_storage_raid0: "true"
 
-# Require support for the Nitro hypervisor for Karpenter NodePools.
-karpenter_nitro_support_required: "true"
-
 # configure whether karpenter node pools only allow instances supporting
 # in-transit encryption
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/data-protection.html#encryption-transit

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -144,20 +144,10 @@ spec:
       # Operators { In, NotIn, Exists, DoesNotExist, Gt, and Lt } are supported.
       # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#operators
       requirements:
-#{{ if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6") }}
         - key: karpenter.k8s.aws/instance-hypervisor
           operator: In
           values:
             - nitro
-#{{ end }}
-#{{ if eq .Cluster.ConfigItems.karpenter_nitro_support_required "true" }}
-#{{ if and (eq .Cluster.Provider "zalando-aws") (eq .NodePool.KarpenterInstanceTypeStrategy "not-specified") }}
-        - key: karpenter.k8s.aws/instance-hypervisor
-          operator: In
-          values:
-            - nitro
-#{{ end }}
-#{{ end }}
 #{{ if eq .NodePool.ConfigItems.karpenter_in_transit_support_required "true" }}
         - key: karpenter.k8s.aws/instance-encryption-in-transit-supported
           operator: In


### PR DESCRIPTION
Only allow nitro instances in general and drop the complexity of a config-item and eks ipv6 conditions.