### PR TITLE
kube2iam: Fix for EKS ipv6

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -777,14 +777,18 @@ tracing_coredns_local_zone_traces_endpoint: ""
 # AMI id given the image name and the Image AWS account owner.
 #
 # [0]: https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/8a9bd1cb2d094038a9e23e646421f8146b48886a/provisioner/template.go#L116
-kuberuntu_image_v1_31_old_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.31.4-amd64-master-359" "861068367966" }}
-kuberuntu_image_v1_31_old_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.31.4-arm64-master-359" "861068367966" }}
-kuberuntu_image_v1_31_new_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.31.6-amd64-master-368" "861068367966" }}
-kuberuntu_image_v1_31_new_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.31.6-arm64-master-368" "861068367966" }}
+kuberuntu_image_v1_31_aws_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.31.6-amd64-master-368" "861068367966" }}
+kuberuntu_image_v1_31_aws_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.31.6-arm64-master-368" "861068367966" }}
+kuberuntu_image_v1_31_eks_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.31.7-amd64-master-371" "861068367966" }}
+kuberuntu_image_v1_31_eks_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.31.7-arm64-master-371" "861068367966" }}
 
 # This is used to determine which AMI to use for the cluster or individual node
-# pools. Possible values are 'new' or 'old'
-kuberuntu_ami_version: "new"
+# pools. Possible values are 'aws' or 'eks'
+{{if eq .Cluster.Provider "zalando-eks"}}
+kuberuntu_ami_version: "eks"
+{{else}}
+kuberuntu_ami_version: "aws"
+{{end}}
 
 # Feature toggle for auditing events
 audit_pod_events: "true"

--- a/cluster/manifests/02-admission-control/config.yaml
+++ b/cluster/manifests/02-admission-control/config.yaml
@@ -45,6 +45,10 @@ data:
   pod.env-inject.variable._PLATFORM_OBSERVABILITY_METRICS_PORT: "{{ .Cluster.ConfigItems.observability_metrics_port }}"
   pod.env-inject.variable._PLATFORM_OBSERVABILITY_ACCESS_TOKEN: "{{ .Cluster.ConfigItems.lightstep_token }}"
   pod.env-inject.variable._PLATFORM_OBSERVABILITY_COMMON_ATTRIBUTE_CLOUD__ACCOUNT__ID : "{{ .Cluster.Alias }}"
+{{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6")}}
+  pod.env-inject.variable.AWS_EC2_METADATA_SERVICE_ENDPOINT: "http://[fd00:ec2::254]"
+  pod.env-inject.variable.AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE: "IPv6"
+{{- end }}
 {{- if eq .Cluster.Environment "e2e" }}
   pod.env-inject.variable._PLATFORM_E2E: "injected"
 {{- end }}

--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -38,7 +38,7 @@ spec:
         effect: NoExecute
       hostNetwork: true
       containers:
-      - image: container-registry.zalando.net/teapot/kube2iam:0.12.0-master-19.patched
+      - image: container-registry.zalando.net/teapot/kube2iam:0.12.0-master-22.patched
         name: kube2iam
         args:
         - --auto-discover-base-arn

--- a/cluster/node-pools/worker-combined/stack.yaml
+++ b/cluster/node-pools/worker-combined/stack.yaml
@@ -132,6 +132,11 @@ Resources:
     Properties:
       LaunchTemplateName: '{{.Cluster.LocalID}}-{{ .NodePool.Name }}'
       LaunchTemplateData:
+{{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6") }}
+        MetadataOptions:
+          HttpEndpoint: enabled
+          HttpProtocolIpv6: enabled
+{{- end }}
         TagSpecifications:
         - ResourceType: "volume"
           Tags:

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -11,7 +11,11 @@ spec:
     - id: {{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_31_" .NodePool.ConfigItems.kuberuntu_ami_version "_arm64") }}
   metadataOptions:
     httpEndpoint: enabled
+    # {{ if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6") }}
+    httpProtocolIPv6: enabled
+    # {{ else }}
     httpProtocolIPv6: disabled
+    # {{ end }}
     httpPutResponseHopLimit: 2
     httpTokens: optional
   subnetSelectorTerms:

--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -137,6 +137,11 @@ Resources:
     Properties:
       LaunchTemplateName: '{{ .Cluster.LocalID }}-{{ .NodePool.Name }}'
       LaunchTemplateData:
+{{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6") }}
+        MetadataOptions:
+          HttpEndpoint: enabled
+          HttpProtocolIpv6: enabled
+{{- end }}
         TagSpecifications:
         - ResourceType: "volume"
           Tags:

--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -214,7 +214,6 @@ if [ "$e2e" = true ]; then
             "Mirror pods should be created for the main Kubernetes components \[Zalando\]"
             "Should audit API calls to create, update, patch, delete pods. \[Audit\] \[Zalando\]"
             "should validate permissions for \[Authorization\] \[RBAC\] \[Zalando\]" # TODO: Remains skipped until we remove the older RBAC setup
-            "Should NOT get AWS IAM credentials" # Disabled on IPv6 as kube2iam is not compatible in current config.
             "should creating a working mysql cluster" # upstream test which does not work with IPv6
             "Should create DNS entry via Service \[Zalando\]" # Depends on service Type LoadBalancer which doesn't work with IPv6.
         )


### PR DESCRIPTION
Make kube2iam work on EKS with IPv6

This is done in the following way:

* Enable IPv6 EC2 metadata endpoint `http://[fd00:ec2::254]` (`HttpProtocolIpv6: enabled`) (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html)
* Update AMI to a version which create an `ip6tables` rule for routing traffic targeting `http://[fd00:ec2::254]` to kube2iam.
* Update kube2iam to fix handling IPv6 addresses (https://github.com/jtblin/kube2iam/pull/389)
* Inject `AWS_EC2_METADATA_SERVICE_ENDPOINT=http://[fd00:ec2::254]` and `AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE=IPv6` envars into pods to ensure the AWS SDKs uses the IPv6 endpoint (https://docs.aws.amazon.com/sdkref/latest/guide/feature-imds-credentials.html).