### PR TITLE
lifecycle-metrics: Reduce pod rescheduling

### DIFF
--- a/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
@@ -18,6 +18,7 @@ spec:
         application: kubernetes
         component: lifecycle-metrics
       annotations:
+        karpenter.sh/do-not-disrupt: "true"
         prometheus.io/path: /metrics
         prometheus.io/port: "9090"
         prometheus.io/scrape: "true"


### PR DESCRIPTION
The `kubernetes-lifecycle-metrics` component has a bug where it can count the scheduling time of pods multiple times whenever it's rescheduled/restarted. This happens because the pods are only tracked in memory and retracked if the pods is restarted and the pod scheduling events are still to be found.

With karpenter there is a bigger chance of the pod being rescheduled, thus a bigger chance of multi counting pod scheduling times.

The proper fix is to store the pod scheduling time state somewhere else than memory. For a quick mitigation, however, add the `karpenter.sh/do-not-disrupt: "true"` annotation to reduce the amount of rescheduling for `kubernetes-lifecycle-metrics` to see if this has a positive effect on the Pod Scheduling SLO.

We use the karpenter native annotation, instead of the abstracted annotation because this pod is in `kube-system` where we don't do the runtime abstraction logic.