### PR TITLE
Add RBAC for kubernetes-unit-costs

### DIFF
--- a/cluster/manifests/roles/kubernetes-unit-costs.yaml
+++ b/cluster/manifests/roles/kubernetes-unit-costs.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubernetes-unit-costs
+  labels:
+    application: kubernetes-unit-costs
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubernetes-unit-costs
+  labels:
+    application: kubernetes-unit-costs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubernetes-unit-costs
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: zalando-iam:zalando:service:stups_kubernetes-unit-costs


### PR DESCRIPTION
Add RBAC permission for the `kubernetes-unit-costs` application which needs to get pods and nodes of all clusters to estimate unit costs.