### PR TITLE
Loadtest prometheus ipv6 pod support 

### DIFF
--- a/test/e2e/loadtest/client/prom-configmap.yaml
+++ b/test/e2e/loadtest/client/prom-configmap.yaml
@@ -57,10 +57,18 @@ data:
         action: replace
         target_label: __metrics_path__
         regex: (.+)
+      # If __address__ is ipv6, update ipv6 adress with []
+      # https://github.com/prometheus/prometheus/issues/14656
+      - source_labels: [__address__]
+        regex: '\[?([0-9a-fA-F:]+:[0-9a-fA-F:]+)\]?(:\d+)?'
+        action: replace
+        target_label: __address__
+        replacement: '[$1]$2'
       - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
         action: replace
-        regex: ([^:]+)(?::\d+)?;(\d+)
-        replacement: $1:$2
+        # match both ipv6 and ipv4
+        regex: ([0-9.]+|\[?[0-9a-fA-F:]+\]?)(:?\d+)?;(\d+)
+        replacement: $1:$3
         target_label: __address__
       - action: replace
         source_labels: ['__meta_kubernetes_pod_ip']


### PR DESCRIPTION
Fixes the target configuration for the prometheus used during the load test. Similar to https://github.com/zalando-incubator/kubernetes-on-aws/commit/ce6f3fe518322115196cb422554844f3a1512355