### PR TITLE
Avoid userdata change

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -3,9 +3,6 @@ write_files:
   - owner: root:root
     path: /etc/kubernetes/secrets.env
     content: |
-{{- if eq .NodePool.ConfigItems.kuberuntu_ami_version "old" }}
-      NODEPOOL_TAINTS=node.kubernetes.io/role=master:NoSchedule{{if index .NodePool.ConfigItems "taints"}},{{.NodePool.ConfigItems.taints}}{{end}}
-{{- end }}
       NODE_LABELS=master=true,node.kubernetes.io/exclude-from-external-load-balancers,node.kubernetes.io/distro=ubuntu,cluster-lifecycle-controller.zalan.do/decommission-priority=999,lifecycle-status=ready{{if index .NodePool.ConfigItems "labels"}},{{.NodePool.ConfigItems.labels}}{{end}}
       NODEPOOL_NAME={{ .NodePool.Name }}
       KUBELET_ROLE=master
@@ -78,7 +75,6 @@ write_files:
       # variables are replaced on instance start-up.
       providerID: __PROVIDER_ID__
       clusterDNS: [__CLUSTER_DNS__]
-{{- if eq .NodePool.ConfigItems.kuberuntu_ami_version "new" }}
       registerWithTaints:
         - key: node.kubernetes.io/role
           value: master
@@ -88,7 +84,6 @@ write_files:
           effect: {{$taint.Effect}}
 {{- if $taint.Value }}
           value: {{$taint.Value }}
-{{- end }}
 {{- end }}
 {{- end }}
 
@@ -938,25 +933,7 @@ write_files:
       {{index $cfg 0}} = {{index $cfg 1}}
       {{- end}}
 {{- end}}
-{{ if eq .NodePool.ConfigItems.kuberuntu_ami_version "old" }}
-  # TODO: Remove this once all nodes are running an AMI compatible with /etc/cni/net.d/10-flannel.conflist
-  - owner: root:root
-    path: /etc/kubernetes/cni/net.d/10-flannel.conflist
-    content: |
-      {
-        "name": "podnet",
-        "cniVersion": "0.3.1",
-        "plugins": [
-          {
-            "type": "flannel",
-            "delegate": {
-              "isDefaultGateway": true,
-              "hairpinMode": true
-            }
-          }
-        ]
-      }
-{{ end }}
+
   - owner: root:root
     path: /etc/cni/net.d/10-flannel.conflist
     content: |

--- a/cluster/node-pools/worker-splitaz/userdata.yaml
+++ b/cluster/node-pools/worker-splitaz/userdata.yaml
@@ -7,9 +7,6 @@ write_files:
   - owner: root:root
     path: /etc/kubernetes/secrets.env
     content: |
-{{- if eq .NodePool.ConfigItems.kuberuntu_ami_version "old" }}
-      NODEPOOL_TAINTS={{if index .NodePool.ConfigItems "taints"}}{{.NodePool.ConfigItems.taints}}{{end}}
-{{- end }}
       NODE_LABELS=node.kubernetes.io/profile={{ .NodePool.Profile }},lifecycle-status=ready,node.kubernetes.io/distro=ubuntu{{if index .NodePool.ConfigItems "labels"}},{{.NodePool.ConfigItems.labels}}{{end}}{{if or (eq .NodePool.Profile "worker-splitaz") (eq .NodePool.Profile "worker-combined")}},asg-lifecycle-hook=true{{end}}
       NODEPOOL_NAME={{ .NodePool.Name }}
       KUBELET_ROLE=worker
@@ -141,7 +138,6 @@ write_files:
       # variables are replaced on instance start-up.
       providerID: __PROVIDER_ID__
       clusterDNS: [__CLUSTER_DNS__]
-{{- if eq .NodePool.ConfigItems.kuberuntu_ami_version "new" }}
 {{- if or (.NodePool.Taints) (eq .NodePool.Profile "worker-karpenter") }}
       registerWithTaints:
 {{- range $taint := .NodePool.Taints }}
@@ -154,7 +150,6 @@ write_files:
 {{- if eq .NodePool.Profile "worker-karpenter" }}
         - key: karpenter.sh/unregistered
           effect: NoExecute
-{{-  end }}
 {{-  end }}
 {{-  end }}
 
@@ -174,27 +169,7 @@ write_files:
       {{index $cfg 0}} = {{index $cfg 1}}
       {{- end}}
 {{- end}}
-
-{{- if ne .Cluster.Provider "zalando-eks" }}
-{{ if eq .NodePool.ConfigItems.kuberuntu_ami_version "old" }}
-  # TODO: Remove this once all nodes are running an AMI compatible with /etc/cni/net.d/10-flannel.conflist
-  - owner: root:root
-    path: /etc/kubernetes/cni/net.d/10-flannel.conflist
-    content: |
-      {
-        "name": "podnet",
-        "cniVersion": "0.3.1",
-        "plugins": [
-          {
-            "type": "flannel",
-            "delegate": {
-              "isDefaultGateway": true,
-              "hairpinMode": true
-            }
-          }
-        ]
-      }
-{{ end }}
+{{if ne .Cluster.Provider "zalando-eks" }}
   - owner: root:root
     path: /etc/cni/net.d/10-flannel.conflist
     content: |


### PR DESCRIPTION
In #9181 we changed the value of `kuberuntu_ami_version` from `old|new` to `aws|eks`. This had the side effect of changing the userdata which was not intended.

This fixes it by removing the use of `kuberuntu_ami_version` inside the userdata and ensuring that the userdata renders exactly the same as before to avoid rolling nodes even just for a whitespace in the userdata.