### PR TITLE
Set unbound as default dns_cache

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -929,7 +929,7 @@ external_dns_zones_cache_duration: "1h"
 external_dns_mem: "4Gi"
 
 # select which cache to use for Cluster DNS: unbound or dnsmasq.
-dns_cache: "dnsmasq"
+dns_cache: "unbound"
 
 expirimental_dns_unbound_liveness_probe: "true"
 


### PR DESCRIPTION
Make `unbound` the default dns_cache.

Clusters currently running dnsmasq has the config-item set explicitly.