### PR TITLE
Only attach skipper nodes to NLB in e2e

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -113,11 +113,7 @@ skipper_ingress_binpack: "false"
 
 # skipper node-pool
 enable_dedicate_nodepool_skipper: "true"
-{{if eq .Cluster.Environment "e2e"}}
-skipper_attach_only_to_skipper_node_pool: "false"
-{{else}}
 skipper_attach_only_to_skipper_node_pool: "true"
-{{end}}
 
 skipper_suppress_route_update_logs: "true"
 skipper_validate_query: "true"


### PR DESCRIPTION
We run with a dedicated skipper-ingress pool in e2e as in all other clusters, so only attach instances of that pool to the NLB(s) in e2e.