### PR TITLE
Add custom PDB for skipper-ingress covering main and canary deployment

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -113,11 +113,7 @@ skipper_ingress_binpack: "false"
 
 # skipper node-pool
 enable_dedicate_nodepool_skipper: "true"
-{{if eq .Cluster.Environment "e2e"}}
-skipper_attach_only_to_skipper_node_pool: "false"
-{{else}}
 skipper_attach_only_to_skipper_node_pool: "true"
-{{end}}
 
 skipper_suppress_route_update_logs: "true"
 skipper_validate_query: "true"

--- a/cluster/manifests/skipper/pdb.yaml
+++ b/cluster/manifests/skipper/pdb.yaml
@@ -1,0 +1,14 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    application: skipper-ingress
+    component: ingress
+  name: skipper-ingress
+  namespace: kube-system
+spec:
+  maxUnavailable: 1%
+  selector:
+    matchLabels:
+      application: skipper-ingress
+      component: ingress


### PR DESCRIPTION
Since introducing the canary skipper-ingress deployment there is no automatic PodDisruptionBudget created by `pdb-controller` in test and e2e clusters. The reason is that it only creates a PDB for deployments with 2 or more replicas. Since there can be a canary with 1 replica and main deployment with minReplicas: 1 it doesn't create a PDB.
This means that both pods could be unavailable at the same time, making skipper-ingress 100% unavailable without any protection.

This fixes the issue by adding a custom PDB that matches pods across both deployments.

I noticed this when debugging the flakyness of the load tests done as part of e2e and I believe this is causing skipper to be unavailable once in a while during e2e, making the load test fail.