### PR TITLE
skipper-ingress: explicit healthcheck routes on the pod level

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -323,20 +323,22 @@ spec:
           - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
           - '-forwarded-headers-exclude-cidrs={{ .cluster_internal_cidrs | join "," }}'
 {{ end }}
-          - "-inline-routes"
-          - |
-            kube__healthz_down: Path("/kube-system/healthz")
-              && Shutdown()
-              && SourceFromLast("10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8", "fd00::/8", "::1/128")
-              -> disableAccessLog()
-              -> status(503)
-              -> <shunt>;
-            kube__healthz_up: Path("/kube-system/healthz")
-              && SourceFromLast("10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8", "fd00::/8", "::1/128")
-              -> disableAccessLog()
-              -> status(200)
-              -> <shunt>;
-            {{ .Cluster.ConfigItems.skipper_ingress_inline_routes }};
+          - >-
+            -inline-routes=
+            kube__healthz_down:
+            Path("/kube-system/healthz") &&
+            Shutdown() &&
+            SourceFromLast("10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8", "fd00::/8", "::1/128"{{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6")}}{{ range $ip := split .Values.subnet_ipv6_cidrs "," }},"{{ $ip }}"{{ end }}{{- end }})
+            -> disableAccessLog()
+            -> status(503)
+            -> <shunt>;
+            kube__healthz_up:
+            Path("/kube-system/healthz") &&
+            SourceFromLast("10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8", "fd00::/8", "::1/128"{{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6")}}{{ range $ip := split .Values.subnet_ipv6_cidrs "," }},"{{ $ip }}"{{ end }}{{- end }})
+            -> disableAccessLog()
+            -> status(200)
+            -> <shunt>;
+            {{ .Cluster.ConfigItems.skipper_ingress_inline_routes }}
 
 {{ if .Cluster.ConfigItems.skipper_ingress_health_check_options }}
           - "-passive-health-check={{ .Cluster.ConfigItems.skipper_ingress_health_check_options }}"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -171,6 +171,7 @@ spec:
 {{ else }}
           - "-kubernetes"
           - "-kubernetes-in-cluster"
+          - "-kubernetes-healthcheck=false" # see -inline-routes
           - "-kubernetes-path-mode=path-prefix"
           - "-kubernetes-backend-traffic-algorithm={{ .Cluster.ConfigItems.skipper_ingress_backend_traffic_algorithm }}"
           - "-kubernetes-default-lb-algorithm={{ .Cluster.ConfigItems.skipper_ingress_default_lb_algorithm }}"
@@ -190,7 +191,6 @@ spec:
           - '-kubernetes-annotation-filters-append={{ .Cluster.ConfigItems.skipper_kubernetes_annotation_filters_append }}'
           - '-kubernetes-east-west-range-annotation-predicates={{ .Cluster.ConfigItems.skipper_kubernetes_east_west_range_annotation_predicates }}'
           - '-kubernetes-east-west-range-annotation-filters-append={{ .Cluster.ConfigItems.skipper_kubernetes_east_west_range_annotation_filters_append }}'
-          - "-reverse-source-predicate"
 {{ end }}
           - "-proxy-preserve-host"
           - "-compress-encodings={{ .Cluster.ConfigItems.skipper_compress_encodings }}"
@@ -323,9 +323,21 @@ spec:
           - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
           - '-forwarded-headers-exclude-cidrs={{ .cluster_internal_cidrs | join "," }}'
 {{ end }}
-{{ if .Cluster.ConfigItems.skipper_ingress_inline_routes }}
-          - "-inline-routes={{ .Cluster.ConfigItems.skipper_ingress_inline_routes }}"
-{{ end }}
+          - "-inline-routes"
+          - |
+            kube__healthz_down: Path("/kube-system/healthz")
+              && Shutdown()
+              && SourceFromLast("10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8", "fd00::/8", "::1/128")
+              -> disableAccessLog()
+              -> status(503)
+              -> <shunt>;
+            kube__healthz_up: Path("/kube-system/healthz")
+              && SourceFromLast("10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8", "fd00::/8", "::1/128")
+              -> disableAccessLog()
+              -> status(200)
+              -> <shunt>;
+            {{ .Cluster.ConfigItems.skipper_ingress_inline_routes }};
+
 {{ if .Cluster.ConfigItems.skipper_ingress_health_check_options }}
           - "-passive-health-check={{ .Cluster.ConfigItems.skipper_ingress_health_check_options }}"
 {{ end }}
@@ -548,6 +560,7 @@ spec:
           - "-enable-profile"
           - "-kubernetes"
           - "-kubernetes-in-cluster"
+          - "-kubernetes-healthcheck=false" # see -inline-routes of skipper pods
           - "-kubernetes-path-mode=path-prefix"
           - "-kubernetes-backend-traffic-algorithm={{ .Cluster.ConfigItems.skipper_ingress_backend_traffic_algorithm }}"
           - "-kubernetes-default-lb-algorithm={{ .Cluster.ConfigItems.skipper_ingress_default_lb_algorithm }}"
@@ -564,7 +577,6 @@ spec:
           - '-kubernetes-annotation-filters-append={{ .Cluster.ConfigItems.skipper_kubernetes_annotation_filters_append }}'
           - '-kubernetes-east-west-range-annotation-predicates={{ .Cluster.ConfigItems.skipper_kubernetes_east_west_range_annotation_predicates }}'
           - '-kubernetes-east-west-range-annotation-filters-append={{ .Cluster.ConfigItems.skipper_kubernetes_east_west_range_annotation_filters_append }}'
-          - "-reverse-source-predicate"
           - "-default-filters-dir=/etc/config/default-filters"
           - '-default-filters-prepend={{ .Cluster.ConfigItems.skipper_default_filters }}'
           - '-default-filters-append={{ .Cluster.ConfigItems.skipper_default_filters_authentication }}'

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -328,13 +328,13 @@ spec:
             kube__healthz_down:
             Path("/kube-system/healthz") &&
             Shutdown() &&
-            SourceFromLast("10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8"{{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6")}}{{ range $ip := split .Values.subnet_ipv6_cidrs "," }},"{{ $ip }}"{{ end }}{{- else }}, "fd00::/8", "::1/128"{{- end }})
+            SourceFromLast("10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8", "::1/128"{{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6")}}{{ range $ip := split .Values.subnet_ipv6_cidrs "," }},"{{ $ip }}"{{ end }}{{- else }}, "fd00::/8"{{- end }})
             -> disableAccessLog()
             -> status(503)
             -> <shunt>;
             kube__healthz_up:
             Path("/kube-system/healthz") &&
-            SourceFromLast("10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8"{{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6")}}{{ range $ip := split .Values.subnet_ipv6_cidrs "," }},"{{ $ip }}"{{ end }}{{- else }}, "fd00::/8", "::1/128"{{- end }})
+            SourceFromLast("10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8", "::1/128"{{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6")}}{{ range $ip := split .Values.subnet_ipv6_cidrs "," }},"{{ $ip }}"{{ end }}{{- else }}, "fd00::/8"{{- end }})
             -> disableAccessLog()
             -> status(200)
             -> <shunt>;

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -328,13 +328,13 @@ spec:
             kube__healthz_down:
             Path("/kube-system/healthz") &&
             Shutdown() &&
-            SourceFromLast("10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8", "fd00::/8", "::1/128"{{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6")}}{{ range $ip := split .Values.subnet_ipv6_cidrs "," }},"{{ $ip }}"{{ end }}{{- end }})
+            SourceFromLast("10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8"{{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6")}}{{ range $ip := split .Values.subnet_ipv6_cidrs "," }},"{{ $ip }}"{{ end }}{{- else }}, "fd00::/8", "::1/128"{{- end }})
             -> disableAccessLog()
             -> status(503)
             -> <shunt>;
             kube__healthz_up:
             Path("/kube-system/healthz") &&
-            SourceFromLast("10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8", "fd00::/8", "::1/128"{{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6")}}{{ range $ip := split .Values.subnet_ipv6_cidrs "," }},"{{ $ip }}"{{ end }}{{- end }})
+            SourceFromLast("10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8"{{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6")}}{{ range $ip := split .Values.subnet_ipv6_cidrs "," }},"{{ $ip }}"{{ end }}{{- else }}, "fd00::/8", "::1/128"{{- end }})
             -> disableAccessLog()
             -> status(200)
             -> <shunt>;

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -562,7 +562,6 @@ spec:
           - "-enable-profile"
           - "-kubernetes"
           - "-kubernetes-in-cluster"
-          - "-kubernetes-healthcheck=false" # see -inline-routes of skipper pods
           - "-kubernetes-path-mode=path-prefix"
           - "-kubernetes-backend-traffic-algorithm={{ .Cluster.ConfigItems.skipper_ingress_backend_traffic_algorithm }}"
           - "-kubernetes-default-lb-algorithm={{ .Cluster.ConfigItems.skipper_ingress_default_lb_algorithm }}"
@@ -579,6 +578,7 @@ spec:
           - '-kubernetes-annotation-filters-append={{ .Cluster.ConfigItems.skipper_kubernetes_annotation_filters_append }}'
           - '-kubernetes-east-west-range-annotation-predicates={{ .Cluster.ConfigItems.skipper_kubernetes_east_west_range_annotation_predicates }}'
           - '-kubernetes-east-west-range-annotation-filters-append={{ .Cluster.ConfigItems.skipper_kubernetes_east_west_range_annotation_filters_append }}'
+          - "-reverse-source-predicate"
           - "-default-filters-dir=/etc/config/default-filters"
           - '-default-filters-prepend={{ .Cluster.ConfigItems.skipper_default_filters }}'
           - '-default-filters-append={{ .Cluster.ConfigItems.skipper_default_filters_authentication }}'


### PR DESCRIPTION
Skipper provides two flags to control kubernetes healthcheck routes:
`-kubernetes-healthcheck` (true by default) that enables automatic healthcheck routes
and `-reverse-source-predicate` to select source predicate type.

Currently when routesrv is enabled (default state) it adds
automatic healthcheck routes and appends default filters to
all routes including healthcheck routes.

This change defines healthcheck routes in skipper pods to avoid adding default
filters to them and enable further modifications. 


The automated healthcheck routes are still enabled on the routesrv level, to 
make it possible to deploy the change and avoid the situation when the skipper
pod without inlined routes consumes data from the routerrv with healthchecks
 disabled. These routes are disabled in the [following PR](https://github.com/zalando-incubator/kubernetes-on-aws/pull/9241). 

When routesrv is disabled though skipper will add default filters
to explicitly-defined healthcheck routes like it happens currently.
In this case default filters should be configured to not hinder
healthchecks.

