### PR TITLE
Disable emergency-access-service by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -254,11 +254,7 @@ polarsignals_enabled: "false"
 
 # Emergency Access Service
 # Control whether the emergency access service is enabled or not.
-{{ if and (eq .Cluster.Environment "production") (eq .Cluster.Provider "zalando-aws") }}
-emergency_access_service_enabled: "true"
-{{else}}
 emergency_access_service_enabled: "false"
-{{end}}
 
 # Kube-Metrics-Adapter
 ## Scheduled scaling metrics: ramp up/down over this period of time


### PR DESCRIPTION
Disable Emergency-access-Service by default

This service is replaced by Okta/Savyint so there is no need to run it anymore. A handful of users are still connecting to in in the last month, will send communication to them and inform about using Okta instead.