### PR TITLE
skipper: whitelist IPv6 CIDR

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -176,6 +176,9 @@ spec:
           - "-kubernetes-default-lb-algorithm={{ .Cluster.ConfigItems.skipper_ingress_default_lb_algorithm }}"
           - "-kubernetes-disable-catchall-routes={{ .Cluster.ConfigItems.skipper_ingress_disable_catchall_routes }}"
           - "-enable-kubernetes-endpointslices={{ .Cluster.ConfigItems.skipper_endpointslices_enabled }}"
+{{ if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6")}}
+          - "-whitelisted-healthcheck-cidr={{ .Values.subnet_ipv6_cidrs }}"
+{{ end }}
 {{ end }}
           - "-address=:9999"
           - "-wait-first-route-load"


### PR DESCRIPTION
Currently we only whitelist IPv6 with RouteSRV running in front of skipper, see https://github.com/zalando-incubator/kubernetes-on-aws/blob/18cb6e0afd46c6244d06ea79fd98fd81a0396b3f/cluster/manifests/skipper/deployment.yaml#L556
If we disable RouteSRV healthchecks will fail.