### PR TITLE
Add taint to arm64 pool

### DIFF
--- a/cluster/manifests/e2e-resources/pool-reserve.yaml
+++ b/cluster/manifests/e2e-resources/pool-reserve.yaml
@@ -48,6 +48,11 @@ spec:
           key: dedicated
           value: {{$pool}}
       {{ end }}
+      {{ if eq $pool "worker-arm64" }}
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          value: arm64
+      {{ end }}
       terminationGracePeriodSeconds: 0
       containers:
       - name: pause

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -124,6 +124,7 @@ EOFF
     config_items:
       requirements: "- key: kubernetes.io/arch\n  operator: In\n  values:\n  - arm64\n"
       consolidate_after: "5m"
+      taints: kubernetes.io/arch=arm64:NoSchedule
   - discount_strategy: spot
     instance_types:
     - "c7g.large"


### PR DESCRIPTION
Add taint to ARM e2e pool to avoid e2e test containers that are only amd64 compatible gets scheduled on an ARM node with empty space. 