### PR TITLE
Allow Manual role Admin access in e2e clusters

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -252,6 +252,21 @@ Resources:
       KubernetesGroups:
       - zalando:administrator
       Type: "STANDARD"
+{{- if eq .Cluster.Environment "e2e" }}
+  EKSAccessEntryManualAdministratorAuth:
+    Type: "AWS::EKS::AccessEntry"
+    Properties:
+      AccessPolicies:
+      - AccessScope:
+          Type: "cluster"
+        PolicyArn: "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+      ClusterName: !Ref EKSCluster
+      PrincipalArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/Manual"
+      Username: !Sub "arn:aws:sts::${AWS::AccountId}:assumed-role/Manual/{{`{{SessionName}}`}}"
+      KubernetesGroups:
+      - zalando:administrator
+      Type: "STANDARD"
+{{- end }}
   EKSAddonPodIdentityAgent:
     Type: AWS::EKS::Addon
     Properties:


### PR DESCRIPTION
Hack to give `Manual` role Admin access in e2e clusters

Right now, we don't have a simple way to grant admin access to a single cluster, so simple use Manual in e2e clusters as a special work-around.