### PR TITLE
exclude a1 instance family from Karpenter pools

### DIFF
--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -152,6 +152,11 @@ spec:
           operator: In
           values:
             - nitro
+        - key: "karpenter.k8s.aws/instance-family"
+          operator: NotIn
+          values:
+              # the ARM architecture is too old and flannel breaks
+            - "a1"
 #{{ if eq .NodePool.ConfigItems.karpenter_in_transit_support_required "true" }}
         - key: karpenter.k8s.aws/instance-encryption-in-transit-supported
           operator: In


### PR DESCRIPTION
The `a1` instance family has an ARM architecture that is too old and flannel-tc container crashes on the node:

```bash
Fatal glibc error: This version of Amazon Linux requires a newer ARM64 processor
                   compliant with at least ARM architecture 8.2-a with Cryptographic
                   extensions. On EC2 this is Graviton 2 or later.
```

We have to exclude this from Karpenter pools so these instances aren't used.
