### PR TITLE
skipper-ingress: disable automated healthcheck routes

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -558,6 +558,7 @@ spec:
           - "-enable-profile"
           - "-kubernetes"
           - "-kubernetes-in-cluster"
+          - "-kubernetes-healthcheck=false" # see -inline-routes of skipper pods
           - "-kubernetes-path-mode=path-prefix"
           - "-kubernetes-backend-traffic-algorithm={{ .Cluster.ConfigItems.skipper_ingress_backend_traffic_algorithm }}"
           - "-kubernetes-default-lb-algorithm={{ .Cluster.ConfigItems.skipper_ingress_default_lb_algorithm }}"
@@ -574,7 +575,6 @@ spec:
           - '-kubernetes-annotation-filters-append={{ .Cluster.ConfigItems.skipper_kubernetes_annotation_filters_append }}'
           - '-kubernetes-east-west-range-annotation-predicates={{ .Cluster.ConfigItems.skipper_kubernetes_east_west_range_annotation_predicates }}'
           - '-kubernetes-east-west-range-annotation-filters-append={{ .Cluster.ConfigItems.skipper_kubernetes_east_west_range_annotation_filters_append }}'
-          - "-reverse-source-predicate"
           - "-default-filters-dir=/etc/config/default-filters"
           - '-default-filters-prepend={{ .Cluster.ConfigItems.skipper_default_filters }}'
           - '-default-filters-append={{ .Cluster.ConfigItems.skipper_default_filters_authentication }}'

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -326,11 +326,17 @@ spec:
           - |
             kube__healthz_down: Path("/kube-system/healthz") && Shutdown()
               && SourceFromLast("{{ .cluster_internal_cidrs | join `","` }}", "10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8", "fd00::/8", "::1/128")
+{{ if ne .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
+              -> annotate("iam.zalando.org/public", "Healthcheck route access is restricted by IP")
+{{ end }}
               -> disableAccessLog()
               -> status(503)
               -> <shunt>;
             kube__healthz_up: Path("/kube-system/healthz")
               && SourceFromLast("{{ .cluster_internal_cidrs | join `","` }}", "10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8", "fd00::/8", "::1/128")
+{{ if ne .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
+              -> annotate("iam.zalando.org/public", "Healthcheck route access is restricted by IP")
+{{ end }}
               -> disableAccessLog()
               -> status(200)
               -> <shunt>;

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -566,9 +566,6 @@ spec:
           - "-enable-kubernetes-endpointslices={{ .Cluster.ConfigItems.skipper_endpointslices_enabled }}"
           - "-address=:9990"
           - "-wait-for-healthcheck-interval={{ .Cluster.ConfigItems.skipper_wait_for_healthcheck_interval }}"
-{{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6")}}
-          - "-whitelisted-healthcheck-cidr={{ .Values.subnet_ipv6_cidrs }}"
-{{- end }}
           - "-kubernetes-east-west-range-domains=ingress.cluster.local"
           - '-kubernetes-east-west-range-predicates=ClientIP("{{ $cluster_internal_cidrs | join `","` }}")'
           - '-kubernetes-annotation-predicates={{ .Cluster.ConfigItems.skipper_kubernetes_annotation_predicates }}'

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -326,17 +326,13 @@ spec:
           - |
             kube__healthz_down: Path("/kube-system/healthz") && Shutdown()
               && SourceFromLast("{{ .cluster_internal_cidrs | join `","` }}", "10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8", "fd00::/8", "::1/128")
-{{ if ne .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
               -> annotate("iam.zalando.org/public", "Healthcheck route access is restricted by IP")
-{{ end }}
               -> disableAccessLog()
               -> status(503)
               -> <shunt>;
             kube__healthz_up: Path("/kube-system/healthz")
               && SourceFromLast("{{ .cluster_internal_cidrs | join `","` }}", "10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8", "fd00::/8", "::1/128")
-{{ if ne .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
               -> annotate("iam.zalando.org/public", "Healthcheck route access is restricted by IP")
-{{ end }}
               -> disableAccessLog()
               -> status(200)
               -> <shunt>;


### PR DESCRIPTION
Skipper provides two flags to control kubernetes healthcheck routes:
`-kubernetes-healthcheck` (true by default) that enables automatic healthcheck routes
and `-reverse-source-predicate` to select source predicate type.

Currently when routesrv is enabled (default state) it adds
automatic healthcheck routes and appends default filters to 
all routes including healthcheck routes.

We want  to avoid adding default filters to healthcheck routes. The explicit inlined checks were created in [this PR](https://github.com/zalando-incubator/kubernetes-on-aws/pull/9206). 
This change disables automatic healthcheck routes provided by routesrv.

Additionally this PR add an iam anotation to these healhcheck routes to opt-out them from the authentication.

- [x] ~This PR should be merged only after [this one](https://github.com/zalando-incubator/kubernetes-on-aws/pull/9206) is deployed.~
