### PR TITLE
flannel-awaiter: Optionally check only older nodes

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -442,6 +442,10 @@ flannel_awaiter_cpu: "25m"
 flannel_awaiter_memory_request: "50Mi"
 flannel_awaiter_memory_limit: "50Mi"
 
+# configure flannel-awaiter to only check for nodes older than the current node
+# and set timeout for nodes being reachable to 30s (down from the default of 2m).
+flannel_awaiter_check_only_older_nodes: "true"
+
 # nvidia device plugin
 nvidia_device_plugin_cpu: "10m"
 nvidia_device_plugin_memory: "50Mi"

--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -39,9 +39,19 @@ spec:
             memory: 50Mi
       containers:
       - name: delayed-install-cni
-        image: container-registry.zalando.net/teapot/flannel-awaiter:master-15
+        image: container-registry.zalando.net/teapot/flannel-awaiter:master-16
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         command:
         - /await
+        {{- if eq .Cluster.ConfigItems.flannel_awaiter_check_only_older_nodes "true" }}
+        args:
+        - "--own-node-name=$(NODE_NAME)"
+        - "--timeout=30s"
+        {{- end }}
         stdin: true
         resources:
           requests:


### PR DESCRIPTION
This updates flannel-awaiter to a version that has a flag `--own-node-name`, which when passed, will use the node name to find the node where it's running and use the creationTime of the node to only check reachability to other nodes older than itself.

The purpose of this is to avoid a situation where new nodes constantly come up and it continuously tries to check reachability to all new nodes, never finalizing. In that situation it eventually times out after 2 min. and proceeds with starting flannel, but this means a node startup is increased by 2 min.

The feature is behind the flag: `flannel_awaiter_check_only_older_nodes`, enabled by default. This also reduces the timeout from 2 min (default) to 30 seconds as there is no point in waiting too long if nodes anyway are not becoming reachable, to then just proceed anyway.

The main goal of this change is to speed up node boot and thereby improve pod scheduling time without impact reliability.