### PR TITLE
Only update flannel OnDelete

### DIFF
--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     component: flannel
 spec:
   updateStrategy:
-    type: RollingUpdate
+    type: OnDelete
   selector:
     matchLabels:
       daemonset: kube-flannel

--- a/test/e2e/daemonset-updated/main.go
+++ b/test/e2e/daemonset-updated/main.go
@@ -192,11 +192,19 @@ func onDeleteDaemonsets(ctx context.Context, client kubernetes.Interface) (map[d
 
 	for _, ds := range daemonsets.Items {
 		if ds.Spec.UpdateStrategy.Type == appsv1.OnDeleteDaemonSetStrategyType {
+			var templateGeneration int64
+			if genStr, ok := ds.Annotations["deprecated.daemonset.template.generation"]; ok {
+				templateGeneration, err = strconv.ParseInt(genStr, 10, 64)
+				if err != nil {
+					templateGeneration = 0
+				}
+
+			}
 			onDeleteDaemonsets[dsID{
 				Name:      ds.Name,
 				Namespace: ds.Namespace,
 				UID:       ds.UID,
-			}] = ds.Generation
+			}] = templateGeneration
 		}
 	}
 


### PR DESCRIPTION
Change the updateStrategy to OnDelete to only update flannel pods when nodes rotate.

The motivation is that shutdown of a flannel pod can lead to temporary unavailability of pod network on the node because flannel [cleans up iptables during shutdown](https://github.com/flannel-io/flannel/blob/986fc24fc75619160bb0ad9a104790e585462ed0/pkg/trafficmngr/iptables/iptables.go#L59-L62).

This avoids issues if we accidentally update flannel until we have a proper fix.