### PR TITLE
Beta to stable manual

### DIFF
--- a/cluster/manifests/03-kube-aws-iam-controller/deployment.yaml
+++ b/cluster/manifests/03-kube-aws-iam-controller/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       hostNetwork: true
       containers:
       - name: kube-aws-iam-controller
-        image: container-registry.zalando.net/teapot/kube-aws-iam-controller:v0.3.0-74-g62d552b
+        image: container-registry.zalando.net/teapot/kube-aws-iam-controller:v0.3.0-76-g1a28806
         env:
         - name: AWS_DEFAULT_REGION
           value: "{{.Cluster.Region}}"

--- a/cluster/manifests/deployment-service/status-service-deployment.yaml
+++ b/cluster/manifests/deployment-service/status-service-deployment.yaml
@@ -1,4 +1,4 @@
-# {{ $image   := "container-registry.zalando.net/teapot/deployment-status-service:master-239" }}
+# {{ $image   := "container-registry.zalando.net/teapot/deployment-status-service:master-240" }}
 # {{ $version := index (split $image ":") 1 }}
 
 apiVersion: apps/v1

--- a/cluster/manifests/fabric-gateway/deployment.yaml
+++ b/cluster/manifests/fabric-gateway/deployment.yaml
@@ -1,4 +1,4 @@
-# {{ $image := "container-registry.zalando.net/gwproxy/fabric-gateway:master-319" }}
+# {{ $image := "container-registry.zalando.net/gwproxy/fabric-gateway:master-320" }}
 # {{ $version := index (split $image ":") 1 }}
 apiVersion: apps/v1
 kind: Deployment

--- a/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
+++ b/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
@@ -60,7 +60,7 @@ spec:
 {{- end}}
       containers:
       - name: nvidia-gpu-device-plugin
-        image: container-registry.zalando.net/teapot/nvidia-gpu-device-plugin:v0.17.1-master-17
+        image: container-registry.zalando.net/teapot/nvidia-gpu-device-plugin:v0.17.1-master-18
         args:
         - --pass-device-specs
         resources:


### PR DESCRIPTION
Manual beta to stable to address merge conflict because of fabric gateway revert in stable.

* **nvidia-gpu-device-plugin: Update to version v0.17.1-master-18** ([#&#x2060;9264](https://github.com/zalando-incubator/kubernetes-on-aws/pull/9264)) - https://github.com/zalando-incubator/kubernetes-on-aws/labels/minor
* **kube-aws-iam-controller: Update to version v0.3.0-76-g1a28806** ([#&#x2060;9267](https://github.com/zalando-incubator/kubernetes-on-aws/pull/9267)) - https://github.com/zalando-incubator/kubernetes-on-aws/labels/dependencies
* **fabric-gateway: Update to version master-320** ([#&#x2060;9266](https://github.com/zalando-incubator/kubernetes-on-aws/pull/9266)) - https://github.com/zalando-incubator/kubernetes-on-aws/labels/bugfix
* **deployment-status-service: Update to version master-240** ([#&#x2060;9268](https://github.com/zalando-incubator/kubernetes-on-aws/pull/9268)) - https://github.com/zalando-incubator/kubernetes-on-aws/labels/minor