### PR TITLE
allow excluding t type instances from Karpenter node-pools

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -47,6 +47,10 @@ karpenter_instance_storage_raid0: "true"
 # Can be set cluster wide or per node pool
 karpenter_in_transit_support_required: "false"
 
+# configure whether we allow t instance families for Karpenter nodes
+# t type instances have burstable CPU, which can be undesirable in production
+karpenter_instance_family_t_enabled: "false"
+
 # ALB config created by kube-aws-ingress-controller
 kube_aws_ingress_controller_ssl_policy: "ELBSecurityPolicy-TLS-1-2-2017-01"
 kube_aws_ingress_controller_idle_timeout: "1m"

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -157,6 +157,13 @@ spec:
           values:
               # the ARM architecture is too old and flannel breaks
             - "a1"
+#{{ if eq .Cluster.ConfigItems.karpenter_instance_family_t_enabled "false"}}
+              # t type instances have burstable CPU, undesired in production
+            - "t4g"
+            - "t3a"
+            - "t3"
+            - "t2"
+#{{ end }}
 #{{ if eq .NodePool.ConfigItems.karpenter_in_transit_support_required "true" }}
         - key: karpenter.k8s.aws/instance-encryption-in-transit-supported
           operator: In


### PR DESCRIPTION
The `t` type instances have burstable CPU which makes them unpredicable to use in production environments. This allows to toggle the usage of these instances. The default behavior will be to exlude them, but we will allow them in test environment.