### PR TITLE
Don't display cluster-scoped CRDs in `kubectl get all`

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/cluster_scaling_schedules_crd.yaml
+++ b/cluster/manifests/kube-metrics-adapter/cluster_scaling_schedules_crd.yaml
@@ -8,8 +8,6 @@ metadata:
 spec:
   group: zalando.org
   names:
-    categories:
-    - all
     kind: ClusterScalingSchedule
     listKind: ClusterScalingScheduleList
     plural: clusterscalingschedules


### PR DESCRIPTION
`ClusterScalingSchedule` is the only global CRD that is displayed as part of `kubectl get all`. This is fairly confusing when you want to see "all" resources in a namespace (knowing that all is not really everything) but you constantly _also_ see the `ClusterScalingSchedule` everytime.

This was recently introduced by a bug fix but turns out the old (bugged) behaviour was actually better.