### PR TITLE
security: update Ingress default ssl policy `ELBSecurityPolicy-TLS13-1-2-2021-06`

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -681,7 +681,7 @@ Resources:
     Properties:
       AlpnPolicy:
         - {{ if eq .Cluster.ConfigItems.experimental_nlb_alpn_h2_enabled "true" }}HTTP2Preferred{{else}}None{{end}}
-      SslPolicy: "ELBSecurityPolicy-TLS13-1-2-2021-06"
+      SslPolicy: "ELBSecurityPolicy-TLS-1-2-2017-01"
       Certificates:
         - CertificateArn: "{{.Values.load_balancer_certificate}}"
       DefaultActions:

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -614,7 +614,7 @@ Resources:
     Properties:
       AlpnPolicy:
         - {{ if eq .Cluster.ConfigItems.experimental_nlb_alpn_h2_enabled "true" }}HTTP2Preferred{{else}}None{{end}}
-      SslPolicy: "ELBSecurityPolicy-TLS-1-2-2017-01"
+      SslPolicy: "ELBSecurityPolicy-TLS13-1-2-2021-06"
       Certificates:
         - CertificateArn: "{{.Values.load_balancer_certificate}}"
       DefaultActions:
@@ -681,7 +681,7 @@ Resources:
     Properties:
       AlpnPolicy:
         - {{ if eq .Cluster.ConfigItems.experimental_nlb_alpn_h2_enabled "true" }}HTTP2Preferred{{else}}None{{end}}
-      SslPolicy: "ELBSecurityPolicy-TLS-1-2-2017-01"
+      SslPolicy: "ELBSecurityPolicy-TLS13-1-2-2021-06"
       Certificates:
         - CertificateArn: "{{.Values.load_balancer_certificate}}"
       DefaultActions:

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -614,7 +614,7 @@ Resources:
     Properties:
       AlpnPolicy:
         - {{ if eq .Cluster.ConfigItems.experimental_nlb_alpn_h2_enabled "true" }}HTTP2Preferred{{else}}None{{end}}
-      SslPolicy: "ELBSecurityPolicy-TLS13-1-2-2021-06"
+      SslPolicy: "ELBSecurityPolicy-TLS-1-2-2017-01"
       Certificates:
         - CertificateArn: "{{.Values.load_balancer_certificate}}"
       DefaultActions:

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -52,7 +52,7 @@ karpenter_in_transit_support_required: "false"
 karpenter_instance_family_t_enabled: "false"
 
 # ALB config created by kube-aws-ingress-controller
-kube_aws_ingress_controller_ssl_policy: "ELBSecurityPolicy-TLS-1-2-2017-01"
+kube_aws_ingress_controller_ssl_policy: "ELBSecurityPolicy-TLS13-1-2-2021-06"
 kube_aws_ingress_controller_idle_timeout: "1m"
 kube_aws_ingress_controller_deregistration_delay_timeout: "10s"
 # allow using NLBs for ingress


### PR DESCRIPTION
updates the default ssl policy from ELBSecurityPolicy-TLS-1-2-2017-01 to ELBSecurityPolicy-TLS13-1-2-2021-06 for ingress

Outdated ssl-policy can lead to low level attacks like MitM to break TLS connections. Also TLS ranking tools show us not to be best in class, so we should take care to make it best in class.