### PR TITLE
Add internal path for loadtest

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -689,7 +689,7 @@ spot_node_rescheduler_cpu: "50m"
 
 # Enable and configure prevent scale down annotation
 teapot_admission_controller_prevent_scale_down_enabled: "true"
-{{if eq .Cluster.Environment "production"}}
+{{if or (eq .Cluster.Environment "production") (eq .Cluster.Environment "e2e")}}
 teapot_admission_controller_prevent_scale_down_allowed: "true"
 {{else}}
 teapot_admission_controller_prevent_scale_down_allowed: "false"

--- a/test/e2e/loadtest/backend/loadtest-target-routegroup.yaml
+++ b/test/e2e/loadtest/backend/loadtest-target-routegroup.yaml
@@ -11,7 +11,7 @@ spec:
   - backendName: simulation
   hosts:
   - %TARGET%.%ZONE%
-  - %TARGET%.ingress.cluster.local
+  - loadtest-e2e.ingress.cluster.local
   routes:
   - pathSubtree: /
     filters:

--- a/test/e2e/loadtest/client/loadtest-config.yaml
+++ b/test/e2e/loadtest/client/loadtest-config.yaml
@@ -8,6 +8,11 @@ metadata:
 data:
   routes.eskip: |
     h: PathSubtree("/healthz") -> status(200) -> inlineContent("OK") -> <shunt>;
-    r: * -> "https://%TARGET%.%ZONE%";
-  get.txt: |
+    e: Host("external.zalan.do") -> "https://%TARGET%.%ZONE%";
+    i: Host("internal.zalan.do") -> "http://loadtest-e2e.ingress.cluster.local";
+  get_external.txt: |
     GET http://127.0.0.1:9090
+    Host: external.zalan.do
+  get_internal.txt: |
+    GET http://127.0.0.1:9090
+    Host: internal.zalan.do

--- a/test/e2e/loadtest/client/loadtest-deployment.yaml
+++ b/test/e2e/loadtest/client/loadtest-deployment.yaml
@@ -20,6 +20,7 @@ spec:
         prometheus.io/path: /metrics
         prometheus.io/port: "9911"
         prometheus.io/scrape: "true"
+        zalando.org/prevent-scale-down: "true"
       labels:
         application: e2e-vegeta
     spec:
@@ -59,10 +60,10 @@ spec:
         resources:
           limits:
             cpu: "1"
-            memory: 1500Mi
+            memory: 4Gi
           requests:
             cpu: "1"
-            memory: 1500Mi
+            memory: 4Gi
         volumeMounts:
         - name: cfg
           mountPath: /load-targets

--- a/test/e2e/loadtest/client/loadtest-deployment.yaml
+++ b/test/e2e/loadtest/client/loadtest-deployment.yaml
@@ -70,7 +70,7 @@ spec:
         - name: RATE
           value: "1000/1s"
         - name: TARGET_VARIANT
-          value: "get.txt"
+          value: "get_external.txt"
         - name: SLEEP_TIME
           value: "10"
         - name: DURATION
@@ -78,6 +78,28 @@ spec:
         image: container-registry.zalando.net/teapot/calibrated-loadtest:master-4
         imagePullPolicy: IfNotPresent
         name: e2e-vegeta
+        resources:
+          limits:
+            cpu: "2"
+            memory: 4Gi
+          requests:
+            cpu: "2"
+            memory: 4Gi
+        volumeMounts:
+        - name: cfg
+          mountPath: /load-targets
+      - env:
+        - name: RATE
+          value: "1000/1s"
+        - name: TARGET_VARIANT
+          value: "get_internal.txt"
+        - name: SLEEP_TIME
+          value: "10"
+        - name: DURATION
+          value: "1h"
+        image: container-registry.zalando.net/teapot/calibrated-loadtest:master-4
+        imagePullPolicy: IfNotPresent
+        name: e2e-vegeta-internal
         resources:
           limits:
             cpu: "2"

--- a/test/e2e/start-load-test.sh
+++ b/test/e2e/start-load-test.sh
@@ -98,7 +98,7 @@ echo "provision namespace: loadtest-e2e"
 kubectl create namespace loadtest-e2e
 
 echo "provision loadtest backend with target https://${TARGET}.${ZONE}"
-kubectl create -f ./loadtest/backend
+kubectl apply -f ./loadtest/backend
 
 # we do not want to fail on failing curl
 set +e
@@ -117,7 +117,7 @@ done
 set -e
 
 echo "provision loadtest client"
-kubectl create -f ./loadtest/client
+kubectl apply -f ./loadtest/client
 
 echo "load test started, waiting ${sleep_seconds} seconds"
 sleep "$sleep_seconds"

--- a/test/e2e/wait-for-update.py
+++ b/test/e2e/wait-for-update.py
@@ -25,8 +25,9 @@ def update_complete(kind, check_fn):
 
 def daemonset_updated(spec, status):
     desired = status.get("desiredNumberScheduled", 0)
+    updated = status.get("updatedNumberScheduled", 0)
     ready = status.get("numberReady", 0)
-    if desired == ready:
+    if desired == ready and desired == updated:
         return None
     else:
         return "{}/{} [{}]".format(ready, desired, condition_messages(status))


### PR DESCRIPTION
This extends the existing load test to test internal path in the cluster e.g. to test the pod network via the path illustrated below:

![image](https://github.com/user-attachments/assets/b4f3d33b-77ea-4565-9c6d-39682d66d52a)

The purpose of this is to test the pod network during a cluster upgrade e.g. during flannel rotation which can cause a short drop of network availability (https://github.com/zalando-incubator/kubernetes-on-aws/pull/9272).

To make the test work it further improves the load test

* Fix checking if daemonset pods are up to date in the `wait-for-update.py` script
* Prevent scale-down of the vegeta/load test client to ensure it always running also when flannel is rotated.
* Use `kubectl apply` instead of `create` to make it simpler to run `start-load-test.sh` locally.

### TODO

* [x] Drop flannel change which is currently there to validate the test would catch it.