### PR TITLE
Use newer and recommended TLS 1.3 security policy for NLBs

### DIFF
--- a/cluster/manifests/aws-load-balancer-controller/deployment.yaml
+++ b/cluster/manifests/aws-load-balancer-controller/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         - --feature-gates=ServiceTypeLoadBalancerOnly=true
         - --webhook-cert-file=admission-controller.pem
         - --webhook-key-file=admission-controller-key.pem
+        - --default-ssl-policy=ELBSecurityPolicy-TLS13-1-2-2021-06
         - --default-load-balancer-scheme=internet-facing
         - --default-target-type=ip
         image: container-registry.zalando.net/teapot/aws-load-balancer-controller:v2.12.0-main-2.patched


### PR DESCRIPTION
Let's use the latest and recommended TLS security policy for new Services on EKS clusters. This is the same policy as proposed for Ingresses: https://github.com/zalando-incubator/kubernetes-on-aws/pull/9314

![image](https://github.com/user-attachments/assets/2b8e2d3c-de42-4f59-b528-2f791c8f0264)
