### PR TITLE
skipper: enable backend and response metrics

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -305,6 +305,12 @@ skipper_serve_method_metric: "false"
 # defines if the http response status code is included in the dimension
 # of the skipper_serve_host_duration_seconds_bucket metric.
 skipper_serve_status_code_metric: "false"
+# skipper_combined_response_metrics sets the flag -combined-response-metrics.
+# It enables reporting combined response time metrics
+skipper_combined_response_metrics: "false"
+# skipper_backend_host_metrics sets the flag -backend-host-metrics.
+# It enables reporting total serve time metrics for backend
+skipper_backend_host_metrics: "false"
 
 # disabled|provisioned|enabled routegroup validation via skipper webhook
 # can be one of disabled|provisioned|enabled

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -198,6 +198,8 @@ spec:
           - "-serve-method-metric={{ .Cluster.ConfigItems.skipper_serve_method_metric }}"
           - "-serve-status-code-metric={{ .Cluster.ConfigItems.skipper_serve_status_code_metric }}"
           - "-serve-host-counter"
+          - "-combined-response-metrics={{ .Cluster.ConfigItems.skipper_combined_response_metrics }}"
+          - "-backend-host-metrics={{ .Cluster.ConfigItems.skipper_backend_host_metrics }}"
           - "-disable-metrics-compat"
           - "-enable-profile"
           - "-memory-profile-rate={{ .Cluster.ConfigItems.skipper_memory_profile_rate }}"


### PR DESCRIPTION
This change adds new flags for enabling backend and response metrics for skipper pods.

The defaults are false and this change enables setting these values as true for different clusters and collect metrics when required.