### PR TITLE
security: update Control Plane default ssl policy to `ELBSecurityPolicy-TLS13-1-2-2021-06`

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -681,7 +681,7 @@ Resources:
     Properties:
       AlpnPolicy:
         - {{ if eq .Cluster.ConfigItems.experimental_nlb_alpn_h2_enabled "true" }}HTTP2Preferred{{else}}None{{end}}
-      SslPolicy: "ELBSecurityPolicy-TLS-1-2-2017-01"
+      SslPolicy: "ELBSecurityPolicy-TLS13-1-2-2021-06"
       Certificates:
         - CertificateArn: "{{.Values.load_balancer_certificate}}"
       DefaultActions:

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -614,7 +614,7 @@ Resources:
     Properties:
       AlpnPolicy:
         - {{ if eq .Cluster.ConfigItems.experimental_nlb_alpn_h2_enabled "true" }}HTTP2Preferred{{else}}None{{end}}
-      SslPolicy: "ELBSecurityPolicy-TLS-1-2-2017-01"
+      SslPolicy: "ELBSecurityPolicy-TLS13-1-2-2021-06"
       Certificates:
         - CertificateArn: "{{.Values.load_balancer_certificate}}"
       DefaultActions:


### PR DESCRIPTION
updates the default ssl policy from ELBSecurityPolicy-TLS-1-2-2017-01 to ELBSecurityPolicy-TLS13-1-2-2021-06 for the control plane

Outdated ssl-policy can lead to low level attacks like MitM to break TLS connections. Also TLS ranking tools show us not to be best in class, so we should take care to make it best in class.

Ingress update was done here : https://github.com/zalando-incubator/kubernetes-on-aws/pull/9314