### PR TITLE
Add e2e admission-controller role access tests

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -285,7 +285,7 @@ Resources:
             AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
         Version: 2012-10-17
       Path: /
-      RoleName: "{{.Cluster.LocalID}/-e2e-eks-iam-test-read-only-role"
+      RoleName: "{{.Cluster.LocalID}}-e2e-eks-iam-test-read-only-role"
     Type: 'AWS::IAM::Role'
   E2EEKSIAMTestAccessEntryReadOnly:
     Type: "AWS::EKS::AccessEntry"

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -273,7 +273,7 @@ Resources:
       AddonName: eks-pod-identity-agent
       ClusterName: !Ref EKSCluster
   {{ if eq .Cluster.Environment "e2e" }}
-  E2EEKSIAMTestRoleUnprivileged:
+  E2EEKSIAMTestRoleReadOnly:
     Properties:
       AssumeRolePolicyDocument:
         Statement:
@@ -285,9 +285,9 @@ Resources:
             AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
         Version: 2012-10-17
       Path: /
-      RoleName: "{{.Cluster.LocalID}}-e2e-eks-iam-test-unprivileged-role"
+      RoleName: "{{.Cluster.LocalID}/-e2e-eks-iam-test-read-only-role"
     Type: 'AWS::IAM::Role'
-  E2EEKSIAMTestAccessEntryUnprivileged:
+  E2EEKSIAMTestAccessEntryReadOnly:
     Type: "AWS::EKS::AccessEntry"
     Properties:
       AccessPolicies:
@@ -295,16 +295,16 @@ Resources:
           Type: "cluster"
         PolicyArn: "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
       ClusterName: !Ref EKSCluster
-      PrincipalArn: !GetAtt E2EEKSIAMTestRoleUnprivileged.Arn
+      PrincipalArn: !GetAtt E2EEKSIAMTestRoleReadOnly.Arn
       Username: !Join
           - ''
           - - !Sub 'arn:aws:sts::${AWS::AccountId}:assumed-role/'
-            - !Ref E2EEKSIAMTestRoleUnprivileged
+            - !Ref E2EEKSIAMTestRoleReadOnly
             - '/{{`{{SessionName}}`}}'
       KubernetesGroups:
       - zalando:readonly
       Type: "STANDARD"
-  E2EEKSIAMTestRolePrivileged:
+  E2EEKSIAMTestRoleAdministrator:
     Properties:
       AssumeRolePolicyDocument:
         Statement:
@@ -316,9 +316,9 @@ Resources:
             AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
         Version: 2012-10-17
       Path: /
-      RoleName: "{{.Cluster.LocalID}}-e2e-eks-iam-test-privileged-role"
+      RoleName: "{{.Cluster.LocalID}}-e2e-eks-iam-test-administrator-role"
     Type: 'AWS::IAM::Role'
-  E2EEKSIAMTestAccessEntryPrivileged:
+  E2EEKSIAMTestAccessEntryAdministrator:
     Type: "AWS::EKS::AccessEntry"
     Properties:
       AccessPolicies:
@@ -326,11 +326,11 @@ Resources:
           Type: "cluster"
         PolicyArn: "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
       ClusterName: !Ref EKSCluster
-      PrincipalArn: !GetAtt E2EEKSIAMTestRolePrivileged.Arn
+      PrincipalArn: !GetAtt E2EEKSIAMTestRoleAdministrator.Arn
       Username: !Join
           - ''
           - - !Sub 'arn:aws:sts::${AWS::AccountId}:assumed-role/'
-            - !Ref E2EEKSIAMTestRolePrivileged
+            - !Ref E2EEKSIAMTestRoleAdministrator
             - '/{{`{{SessionName}}`}}'
       KubernetesGroups:
       - zalando:administrator

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -366,6 +366,37 @@ Resources:
       KubernetesGroups:
       - zalando:collaborator
       Type: "STANDARD"
+  E2EEKSIAMTestRoleEngineer:
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Action:
+          - 'sts:AssumeRole'
+          - 'sts:SetSourceIdentity'
+          Effect: Allow
+          Principal:
+            AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+        Version: 2012-10-17
+      Path: /
+      RoleName: "{{.Cluster.LocalID}}-e2e-eks-iam-test-engineer-role"
+    Type: 'AWS::IAM::Role'
+  E2EEKSIAMTestAccessEntryEngineer:
+    Type: "AWS::EKS::AccessEntry"
+    Properties:
+      AccessPolicies:
+      - AccessScope:
+          Type: "cluster"
+        PolicyArn: "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+      ClusterName: !Ref EKSCluster
+      PrincipalArn: !GetAtt E2EEKSIAMTestRoleEngineer.Arn
+      Username: !Join
+          - ''
+          - - !Sub 'arn:aws:sts::${AWS::AccountId}:assumed-role/'
+            - !Ref E2EEKSIAMTestRoleEngineer
+            - '/{{`{{SessionName}}`}}'
+      KubernetesGroups:
+      - zalando:engineer
+      Type: "STANDARD"
   E2EEKSIAMTestRolePostgresAdministrator:
     Properties:
       AssumeRolePolicyDocument:

--- a/cluster/manifests/02-visibility/01-namespace.yaml
+++ b/cluster/manifests/02-visibility/01-namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: visibility
+  labels:
+    admission.zalando.org/infrastructure-component: "true"

--- a/cluster/manifests/02-visibility/01-namespace.yaml
+++ b/cluster/manifests/02-visibility/01-namespace.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: visibility
   labels:
-    admission.zalando.org/infrastructure-component: "true"
+    admission.zalando.org/infrastructure-component: "true" # This label flags the resource as protected

--- a/test/e2e/authorization.go
+++ b/test/e2e/authorization.go
@@ -596,35 +596,41 @@ var _ = g.Describe("Authorization via admission-controller [RBAC] [Zalando]", fu
 		)
 
 		g.BeforeEach(func() {
-			systemResource = examplePod("kube-system", nil)
-			collaboratorResource = examplePod("visibility", nil)
-			nonSystemResource = examplePod(f.Namespace.Name, nil)
+			var err error
+
+			nonSystemResource, err = createPod(context.Background(), f.ClientSet, f.Namespace.Name, nil)
+			framework.ExpectNoError(err)
+
+			collaboratorResource, err = createPod(context.Background(), f.ClientSet, "visibility", nil)
+			framework.ExpectNoError(err)
+
+			systemResource, err = createPod(context.Background(), f.ClientSet, "kube-system", map[string]string{"admission.zalando.org/infrastructure-component": "true"})
+			framework.ExpectNoError(err)
 		})
 
-		// TODO: see remarks below about privileged acceess / engineer role. Let's rename this to "admin" access to avoid any confusion.
-		g.Context("as privileged user", func() {
+		g.Context("as admin user", func() {
 			var client *kubernetes.Clientset
 
 			g.BeforeEach(func() {
 				var err error
 
-				client, err = getPrivilegedClient(eksCluster, awsAccountID)
+				client, err = getAdminClient(eksCluster, awsAccountID)
 				framework.ExpectNoError(err)
 			})
 
 			g.It("should allow write access in user namespace", func() {
-				_, err := client.CoreV1().Pods(nonSystemResource.Namespace).Create(context.Background(), nonSystemResource, metav1.CreateOptions{DryRun: []string{"All"}})
-				framework.ExpectNoError(err, "failed to create pod: %s in namespace: %s", nonSystemResource.Name, nonSystemResource.Namespace)
+				err := client.CoreV1().Pods(nonSystemResource.Namespace).Delete(context.Background(), nonSystemResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
+				framework.ExpectNoError(err, "failed to delete pod: %s in namespace: %s", nonSystemResource.Name, nonSystemResource.Namespace)
 			})
 
 			g.It("should allow write access in collaborator namespace", func() {
-				_, err := client.CoreV1().Pods(collaboratorResource.Namespace).Create(context.Background(), collaboratorResource, metav1.CreateOptions{DryRun: []string{"All"}})
-				framework.ExpectNoError(err, "failed to create pod: %s in namespace: %s", collaboratorResource.Name, collaboratorResource.Namespace)
+				err := client.CoreV1().Pods(collaboratorResource.Namespace).Delete(context.Background(), collaboratorResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
+				framework.ExpectNoError(err, "failed to delete pod: %s in namespace: %s", collaboratorResource.Name, collaboratorResource.Namespace)
 			})
 
 			g.It("should allow write access in system namespace", func() {
-				_, err := client.CoreV1().Pods(systemResource.Namespace).Create(context.Background(), systemResource, metav1.CreateOptions{DryRun: []string{"All"}})
-				framework.ExpectNoError(err, "failed to create pod: %s in namespace: %s", systemResource.Name, systemResource.Namespace)
+				err := client.CoreV1().Pods(systemResource.Namespace).Delete(context.Background(), systemResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
+				framework.ExpectNoError(err, "failed to delete pod: %s in namespace: %s", systemResource.Name, systemResource.Namespace)
 			})
 		})
 
@@ -639,42 +645,21 @@ var _ = g.Describe("Authorization via admission-controller [RBAC] [Zalando]", fu
 			})
 
 			g.It("should allow write access in user namespace", func() {
-				_, err := client.CoreV1().Pods(nonSystemResource.Namespace).Create(context.Background(), nonSystemResource, metav1.CreateOptions{DryRun: []string{"All"}})
-				framework.ExpectNoError(err, "failed to create pod: %s in namespace: %s", nonSystemResource.Name, nonSystemResource.Namespace)
+				err := client.CoreV1().Pods(nonSystemResource.Namespace).Delete(context.Background(), nonSystemResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
+				framework.ExpectNoError(err, "failed to delete pod: %s in namespace: %s", nonSystemResource.Name, nonSystemResource.Namespace)
 			})
 
-			// Not needed actually
-			// // TODO: need to create resource before deleting it
-			// g.It("should deny delete access in collaborator namespace", func() {
-			// 	err := client.CoreV1().Pods(collaboratorResource.Namespace).Delete(context.Background(), collaboratorResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
-			// 	gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("delete operations are forbidden")))
-			// })
-
-			// Should allow visibility ns deletion?
-			// g.It("should allow delete access in collaborator namespace", func() {
-			// 	err := client.CoreV1().Pods(collaboratorResource.Namespace).Delete(context.Background(), collaboratorResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
-			// 	framework.ExpectNoError(err, "failed to delete pod: %s in namespace: %s", collaboratorResource.Name, collaboratorResource.Namespace)
-			// })
-
 			g.It("should allow write access in collaborator namespace", func() {
-				_, err := client.CoreV1().Pods(collaboratorResource.Namespace).Create(context.Background(), collaboratorResource, metav1.CreateOptions{DryRun: []string{"All"}})
-				framework.ExpectNoError(err, "failed to create pod: %s in namespace: %s", collaboratorResource.Name, collaboratorResource.Namespace)
+				err := client.CoreV1().Pods(collaboratorResource.Namespace).Delete(context.Background(), collaboratorResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
+				framework.ExpectNoError(err, "failed to delete pod: %s in namespace: %s", collaboratorResource.Name, collaboratorResource.Namespace)
 			})
 
 			g.It("should deny write access in system namespace", func() {
-				_, err := client.CoreV1().Pods(systemResource.Namespace).Create(context.Background(), systemResource, metav1.CreateOptions{DryRun: []string{"All"}})
+				err := client.CoreV1().Pods(systemResource.Namespace).Delete(context.Background(), systemResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
 				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
 			})
-
-			// Not needed actually
-			// // TODO: need to create resource before deleting it
-			// g.It("should deny delete access in system namespace", func() {
-			// 	err := client.CoreV1().Pods(systemResource.Namespace).Delete(context.Background(), systemResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
-			// 	gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("delete operations are forbidden")))
-			// })
 		})
 
-		// TODO: this is for manual/ememergency access (to be consistent let's rename it to "privleged" because this si now called "privielegd access" by the IAM team)
 		g.Context("as engineer user", func() {
 			var client *kubernetes.Clientset
 
@@ -685,46 +670,44 @@ var _ = g.Describe("Authorization via admission-controller [RBAC] [Zalando]", fu
 				framework.ExpectNoError(err)
 			})
 
-			// these tests are similar to the ones for unprivileged (let's think about that) (also see remarks of the first test in the block below)
 			g.It("should allow write access in user namespace", func() {
-				_, err := client.CoreV1().Pods(nonSystemResource.Namespace).Create(context.Background(), nonSystemResource, metav1.CreateOptions{DryRun: []string{"All"}})
-				framework.ExpectNoError(err, "failed to create pod: %s in namespace: %s", nonSystemResource.Name, nonSystemResource.Namespace)
+				err := client.CoreV1().Pods(nonSystemResource.Namespace).Delete(context.Background(), nonSystemResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
+				framework.ExpectNoError(err, "failed to delete pod: %s in namespace: %s", nonSystemResource.Name, nonSystemResource.Namespace)
 			})
 
 			g.It("should deny write access in collaborator namespace", func() {
-				_, err := client.CoreV1().Pods(collaboratorResource.Namespace).Create(context.Background(), collaboratorResource, metav1.CreateOptions{DryRun: []string{"All"}})
+				err := client.CoreV1().Pods(collaboratorResource.Namespace).Delete(context.Background(), collaboratorResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
 				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
 			})
 
 			g.It("should deny write access in system namespace", func() {
-				_, err := client.CoreV1().Pods(systemResource.Namespace).Create(context.Background(), systemResource, metav1.CreateOptions{DryRun: []string{"All"}})
+				err := client.CoreV1().Pods(systemResource.Namespace).Delete(context.Background(), systemResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
 				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
 			})
 		})
 
-		g.Context("as unprivileged user", func() {
+		g.Context("as read-only user", func() {
 			var client *kubernetes.Clientset
 
 			g.BeforeEach(func() {
 				var err error
 
-				client, err = getUnprivilegedClient(eksCluster, awsAccountID)
+				client, err = getReadOnlyClient(eksCluster, awsAccountID)
 				framework.ExpectNoError(err)
 			})
 
-			// TODO: is that correct?? We use "readonly" as the role in the test case, why should this be able to delete something?
-			g.It("should allow write access in user namespace", func() {
-				_, err := client.CoreV1().Pods(nonSystemResource.Namespace).Create(context.Background(), nonSystemResource, metav1.CreateOptions{DryRun: []string{"All"}})
-				framework.ExpectNoError(err, "failed to create pod: %s in namespace: %s", nonSystemResource.Name, nonSystemResource.Namespace)
+			g.It("should deny write access in user namespace", func() {
+				err := client.CoreV1().Pods(nonSystemResource.Namespace).Delete(context.Background(), nonSystemResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
+				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
 			})
 
 			g.It("should deny write access in collaborator namespace", func() {
-				_, err := client.CoreV1().Pods(collaboratorResource.Namespace).Create(context.Background(), collaboratorResource, metav1.CreateOptions{DryRun: []string{"All"}})
+				err := client.CoreV1().Pods(collaboratorResource.Namespace).Delete(context.Background(), collaboratorResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
 				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
 			})
 
 			g.It("should deny write access in system namespace", func() {
-				_, err := client.CoreV1().Pods(systemResource.Namespace).Create(context.Background(), systemResource, metav1.CreateOptions{DryRun: []string{"All"}})
+				err := client.CoreV1().Pods(systemResource.Namespace).Delete(context.Background(), systemResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
 				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
 			})
 		})
@@ -746,19 +729,24 @@ var _ = g.Describe("Authorization via admission-controller [RBAC] [Zalando]", fu
 			framework.ExpectNoError(err)
 		})
 
-		g.Context("as privileged user", func() {
+		g.Context("as admin user", func() {
 			var client *kubernetes.Clientset
 
 			g.BeforeEach(func() {
 				var err error
 
-				client, err = getPrivilegedClient(eksCluster, awsAccountID)
+				client, err = getAdminClient(eksCluster, awsAccountID)
 				framework.ExpectNoError(err)
 			})
 
 			g.It("should allow write access for non-system resources", func() {
 				err := client.RbacV1().ClusterRoles().Delete(context.Background(), nonSystemResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
 				framework.ExpectNoError(err, "failed to delete cluster role: %s", nonSystemResource.Name)
+			})
+
+			g.It("should allow write access for collaborator resources", func() {
+				err := client.RbacV1().ClusterRoles().Delete(context.Background(), "visibility", metav1.DeleteOptions{DryRun: []string{"All"}})
+				framework.ExpectNoError(err, "failed to delete cluster role: %s", "visibility")
 			})
 
 			g.It("should allow write access for system resources", func() {
@@ -782,21 +770,30 @@ var _ = g.Describe("Authorization via admission-controller [RBAC] [Zalando]", fu
 				framework.ExpectNoError(err, "failed to delete cluster role: %s", nonSystemResource.Name)
 			})
 
+			g.It("should allow write access for collaborator resources", func() {
+				err := client.RbacV1().ClusterRoles().Delete(context.Background(), "visibility", metav1.DeleteOptions{DryRun: []string{"All"}})
+				framework.ExpectNoError(err, "failed to delete cluster role: %s", "visibility")
+			})
+
 			g.It("should deny write access for system resources", func() {
 				err := client.RbacV1().ClusterRoles().Delete(context.Background(), systemResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
 				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
 			})
 
 			// test specific namespaces
-
-			g.It("should deny deletion of kube-system namespace", func() {
-				err := client.CoreV1().Namespaces().Delete(context.Background(), "kube-system", metav1.DeleteOptions{DryRun: []string{"All"}})
-				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("this namespace may not be deleted")))
+			g.It("should allow deletion of non-system namespace", func() {
+				err := client.CoreV1().Namespaces().Delete(context.Background(), nonSystemResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
+				framework.ExpectNoError(err, "failed to delete namespace: %s", nonSystemResource.Name)
 			})
 
 			g.It("should deny deletion of visibility namespace", func() {
 				err := client.CoreV1().Namespaces().Delete(context.Background(), "visibility", metav1.DeleteOptions{DryRun: []string{"All"}})
 				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
+			})
+
+			g.It("should deny deletion of kube-system namespace", func() {
+				err := client.CoreV1().Namespaces().Delete(context.Background(), systemResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
+				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("this namespace may not be deleted")))
 			})
 		})
 
@@ -815,37 +812,47 @@ var _ = g.Describe("Authorization via admission-controller [RBAC] [Zalando]", fu
 				framework.ExpectNoError(err, "failed to delete cluster role: %s", nonSystemResource.Name)
 			})
 
+			g.It("should deny write access for collaborator resources", func() {
+				err := client.RbacV1().ClusterRoles().Delete(context.Background(), "visibility", metav1.DeleteOptions{DryRun: []string{"All"}})
+				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
+			})
+
 			g.It("should deny write access for system resources", func() {
 				err := client.RbacV1().ClusterRoles().Delete(context.Background(), systemResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
 				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
 			})
 
 			// test specific namespaces
-
-			g.It("should deny deletion of kube-system namespace", func() {
-				err := client.CoreV1().Namespaces().Delete(context.Background(), "kube-system", metav1.DeleteOptions{DryRun: []string{"All"}})
-				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("this namespace may not be deleted")))
-			})
-
 			g.It("should deny deletion of visibility namespace", func() {
 				err := client.CoreV1().Namespaces().Delete(context.Background(), "visibility", metav1.DeleteOptions{DryRun: []string{"All"}})
 				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
 			})
+
+			g.It("should deny deletion of kube-system namespace", func() {
+				err := client.CoreV1().Namespaces().Delete(context.Background(), systemResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
+				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("this namespace may not be deleted")))
+			})
 		})
 
-		g.Context("as unprivileged user", func() {
+		g.Context("as read-only user", func() {
 			var client *kubernetes.Clientset
 
 			g.BeforeEach(func() {
 				var err error
 
-				client, err = getUnprivilegedClient(eksCluster, awsAccountID)
+				client, err = getReadOnlyClient(eksCluster, awsAccountID)
 				framework.ExpectNoError(err)
 			})
 
+			// why allow any write acess for read-only user?
 			g.It("should allow write access for non-system resources", func() {
 				err := client.RbacV1().ClusterRoles().Delete(context.Background(), nonSystemResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
 				framework.ExpectNoError(err, "failed to delete cluster role: %s", nonSystemResource.Name)
+			})
+
+			g.It("should deny write access for collaborator resources", func() {
+				err := client.RbacV1().ClusterRoles().Delete(context.Background(), "visibility", metav1.DeleteOptions{DryRun: []string{"All"}})
+				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
 			})
 
 			g.It("should deny write access for system resources", func() {
@@ -901,13 +908,13 @@ var _ = g.Describe("Authorization via admission-controller [RBAC] [Zalando]", fu
 			})
 		})
 
-		g.Context("as privileged user", func() {
+		g.Context("as admin user", func() {
 			var client *kubernetes.Clientset
 
 			g.BeforeEach(func() {
 				var err error
 
-				client, err = getPrivilegedClient(eksCluster, awsAccountID)
+				client, err = getAdminClient(eksCluster, awsAccountID)
 				framework.ExpectNoError(err)
 			})
 
@@ -927,13 +934,13 @@ var _ = g.Describe("Authorization via admission-controller [RBAC] [Zalando]", fu
 			})
 		})
 
-		g.Context("as unprivileged user", func() {
+		g.Context("as read-only user", func() {
 			var client *kubernetes.Clientset
 
 			g.BeforeEach(func() {
 				var err error
 
-				client, err = getUnprivilegedClient(eksCluster, awsAccountID)
+				client, err = getReadOnlyClient(eksCluster, awsAccountID)
 				framework.ExpectNoError(err)
 			})
 
@@ -955,8 +962,8 @@ var _ = g.Describe("Authorization via admission-controller [RBAC] [Zalando]", fu
 	})
 })
 
-// getPrivilegedClient returns a client with the `zalando:administrator` group.
-func getPrivilegedClient(cluster *types.Cluster, awsAccountID string) (*kubernetes.Clientset, error) {
+// getAdminClient returns a client with the `zalando:administrator` group.
+func getAdminClient(cluster *types.Cluster, awsAccountID string) (*kubernetes.Clientset, error) {
 	return newClientWithRole(cluster, fmt.Sprintf("arn:aws:iam::%s:role/%s-e2e-eks-iam-test-privileged-role", awsAccountID, aws.ToString(cluster.Name)))
 }
 
@@ -970,8 +977,8 @@ func getEngineerClient(cluster *types.Cluster, awsAccountID string) (*kubernetes
 	return newClientWithRole(cluster, fmt.Sprintf("arn:aws:iam::%s:role/%s-e2e-eks-iam-test-engineer-role", awsAccountID, aws.ToString(cluster.Name)))
 }
 
-// getUnprivilegedClient returns a client with the `zalando:readonly` group.
-func getUnprivilegedClient(cluster *types.Cluster, awsAccountID string) (*kubernetes.Clientset, error) {
+// getReadOnlyClient returns a client with the `zalando:readonly` group.
+func getReadOnlyClient(cluster *types.Cluster, awsAccountID string) (*kubernetes.Clientset, error) {
 	return newClientWithRole(cluster, fmt.Sprintf("arn:aws:iam::%s:role/%s-e2e-eks-iam-test-unprivileged-role", awsAccountID, aws.ToString(cluster.Name)))
 }
 

--- a/test/e2e/authorization.go
+++ b/test/e2e/authorization.go
@@ -685,32 +685,6 @@ var _ = g.Describe("Authorization via admission-controller [RBAC] [Zalando]", fu
 				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
 			})
 		})
-
-		g.Context("as read-only user", func() {
-			var client *kubernetes.Clientset
-
-			g.BeforeEach(func() {
-				var err error
-
-				client, err = getReadOnlyClient(eksCluster, awsAccountID)
-				framework.ExpectNoError(err)
-			})
-
-			g.It("should deny write access in user namespace", func() {
-				err := client.CoreV1().Pods(nonSystemResource.Namespace).Delete(context.Background(), nonSystemResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
-				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
-			})
-
-			g.It("should deny write access in collaborator namespace", func() {
-				err := client.CoreV1().Pods(collaboratorResource.Namespace).Delete(context.Background(), collaboratorResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
-				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
-			})
-
-			g.It("should deny write access in system namespace", func() {
-				err := client.CoreV1().Pods(systemResource.Namespace).Delete(context.Background(), systemResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
-				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
-			})
-		})
 	})
 
 	g.Context("for global resources", func() {
@@ -811,28 +785,6 @@ var _ = g.Describe("Authorization via admission-controller [RBAC] [Zalando]", fu
 			g.It("should deny deletion of kube-system namespace", func() {
 				err := client.CoreV1().Namespaces().Delete(context.Background(), "kube-system", metav1.DeleteOptions{DryRun: []string{"All"}})
 				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("this namespace may not be deleted")))
-			})
-		})
-
-		g.Context("as read-only user", func() {
-			var client *kubernetes.Clientset
-
-			g.BeforeEach(func() {
-				var err error
-
-				client, err = getReadOnlyClient(eksCluster, awsAccountID)
-				framework.ExpectNoError(err)
-			})
-
-			// why allow any write acess for read-only user?
-			g.It("should allow write access for non-system resources", func() {
-				err := client.RbacV1().ClusterRoles().Delete(context.Background(), nonSystemResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
-				framework.ExpectNoError(err, "failed to delete cluster role: %s", nonSystemResource.Name)
-			})
-
-			g.It("should deny write access for system resources", func() {
-				err := client.RbacV1().ClusterRoles().Delete(context.Background(), systemResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
-				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
 			})
 		})
 	})

--- a/test/e2e/authorization.go
+++ b/test/e2e/authorization.go
@@ -744,11 +744,6 @@ var _ = g.Describe("Authorization via admission-controller [RBAC] [Zalando]", fu
 				framework.ExpectNoError(err, "failed to delete cluster role: %s", nonSystemResource.Name)
 			})
 
-			g.It("should allow write access for collaborator resources", func() {
-				err := client.RbacV1().ClusterRoles().Delete(context.Background(), "visibility", metav1.DeleteOptions{DryRun: []string{"All"}})
-				framework.ExpectNoError(err, "failed to delete cluster role: %s", "visibility")
-			})
-
 			g.It("should allow write access for system resources", func() {
 				err := client.RbacV1().ClusterRoles().Delete(context.Background(), systemResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
 				framework.ExpectNoError(err, "failed to delete cluster role: %s", systemResource.Name)
@@ -770,29 +765,19 @@ var _ = g.Describe("Authorization via admission-controller [RBAC] [Zalando]", fu
 				framework.ExpectNoError(err, "failed to delete cluster role: %s", nonSystemResource.Name)
 			})
 
-			g.It("should allow write access for collaborator resources", func() {
-				err := client.RbacV1().ClusterRoles().Delete(context.Background(), "visibility", metav1.DeleteOptions{DryRun: []string{"All"}})
-				framework.ExpectNoError(err, "failed to delete cluster role: %s", "visibility")
-			})
-
 			g.It("should deny write access for system resources", func() {
 				err := client.RbacV1().ClusterRoles().Delete(context.Background(), systemResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
 				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
 			})
 
 			// test specific namespaces
-			g.It("should allow deletion of non-system namespace", func() {
-				err := client.CoreV1().Namespaces().Delete(context.Background(), nonSystemResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
-				framework.ExpectNoError(err, "failed to delete namespace: %s", nonSystemResource.Name)
-			})
-
 			g.It("should deny deletion of visibility namespace", func() {
 				err := client.CoreV1().Namespaces().Delete(context.Background(), "visibility", metav1.DeleteOptions{DryRun: []string{"All"}})
 				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
 			})
 
 			g.It("should deny deletion of kube-system namespace", func() {
-				err := client.CoreV1().Namespaces().Delete(context.Background(), systemResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
+				err := client.CoreV1().Namespaces().Delete(context.Background(), "kube-system", metav1.DeleteOptions{DryRun: []string{"All"}})
 				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("this namespace may not be deleted")))
 			})
 		})
@@ -812,11 +797,6 @@ var _ = g.Describe("Authorization via admission-controller [RBAC] [Zalando]", fu
 				framework.ExpectNoError(err, "failed to delete cluster role: %s", nonSystemResource.Name)
 			})
 
-			g.It("should deny write access for collaborator resources", func() {
-				err := client.RbacV1().ClusterRoles().Delete(context.Background(), "visibility", metav1.DeleteOptions{DryRun: []string{"All"}})
-				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
-			})
-
 			g.It("should deny write access for system resources", func() {
 				err := client.RbacV1().ClusterRoles().Delete(context.Background(), systemResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
 				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
@@ -829,7 +809,7 @@ var _ = g.Describe("Authorization via admission-controller [RBAC] [Zalando]", fu
 			})
 
 			g.It("should deny deletion of kube-system namespace", func() {
-				err := client.CoreV1().Namespaces().Delete(context.Background(), systemResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
+				err := client.CoreV1().Namespaces().Delete(context.Background(), "kube-system", metav1.DeleteOptions{DryRun: []string{"All"}})
 				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("this namespace may not be deleted")))
 			})
 		})
@@ -848,11 +828,6 @@ var _ = g.Describe("Authorization via admission-controller [RBAC] [Zalando]", fu
 			g.It("should allow write access for non-system resources", func() {
 				err := client.RbacV1().ClusterRoles().Delete(context.Background(), nonSystemResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
 				framework.ExpectNoError(err, "failed to delete cluster role: %s", nonSystemResource.Name)
-			})
-
-			g.It("should deny write access for collaborator resources", func() {
-				err := client.RbacV1().ClusterRoles().Delete(context.Background(), "visibility", metav1.DeleteOptions{DryRun: []string{"All"}})
-				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
 			})
 
 			g.It("should deny write access for system resources", func() {

--- a/test/e2e/authorization.go
+++ b/test/e2e/authorization.go
@@ -601,6 +601,7 @@ var _ = g.Describe("Authorization via admission-controller [RBAC] [Zalando]", fu
 			nonSystemResource = examplePod(f.Namespace.Name, nil)
 		})
 
+		// TODO: see remarks below about privileged acceess / engineer role. Let's rename this to "admin" access to avoid any confusion.
 		g.Context("as privileged user", func() {
 			var client *kubernetes.Clientset
 
@@ -669,6 +670,34 @@ var _ = g.Describe("Authorization via admission-controller [RBAC] [Zalando]", fu
 			})
 		})
 
+		// TODO: this is for manual/ememergency access (to be consistent let's rename it to "privleged" because this si now called "privielegd access" by the IAM team)
+		g.Context("as engineer user", func() {
+			var client *kubernetes.Clientset
+
+			g.BeforeEach(func() {
+				var err error
+
+				client, err = getEngineerClient(eksCluster, awsAccountID)
+				framework.ExpectNoError(err)
+			})
+
+			// these tests are similar to the ones for unprivileged (let's think about that) (also see remarks of the first test in the block below)
+			g.It("should allow write access in user namespace", func() {
+				_, err := client.CoreV1().Pods(nonSystemResource.Namespace).Create(context.Background(), nonSystemResource, metav1.CreateOptions{DryRun: []string{"All"}})
+				framework.ExpectNoError(err, "failed to create pod: %s in namespace: %s", nonSystemResource.Name, nonSystemResource.Namespace)
+			})
+
+			g.It("should deny write access in collaborator namespace", func() {
+				_, err := client.CoreV1().Pods(collaboratorResource.Namespace).Create(context.Background(), collaboratorResource, metav1.CreateOptions{DryRun: []string{"All"}})
+				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
+			})
+
+			g.It("should deny write access in system namespace", func() {
+				_, err := client.CoreV1().Pods(systemResource.Namespace).Create(context.Background(), systemResource, metav1.CreateOptions{DryRun: []string{"All"}})
+				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
+			})
+		})
+
 		g.Context("as unprivileged user", func() {
 			var client *kubernetes.Clientset
 
@@ -679,6 +708,7 @@ var _ = g.Describe("Authorization via admission-controller [RBAC] [Zalando]", fu
 				framework.ExpectNoError(err)
 			})
 
+			// TODO: is that correct?? We use "readonly" as the role in the test case, why should this be able to delete something?
 			g.It("should allow write access in user namespace", func() {
 				_, err := client.CoreV1().Pods(nonSystemResource.Namespace).Create(context.Background(), nonSystemResource, metav1.CreateOptions{DryRun: []string{"All"}})
 				framework.ExpectNoError(err, "failed to create pod: %s in namespace: %s", nonSystemResource.Name, nonSystemResource.Namespace)
@@ -730,6 +760,72 @@ var _ = g.Describe("Authorization via admission-controller [RBAC] [Zalando]", fu
 			g.It("should allow write access for system resources", func() {
 				err := client.RbacV1().ClusterRoles().Delete(context.Background(), systemResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
 				framework.ExpectNoError(err, "failed to delete cluster role: %s", systemResource.Name)
+			})
+		})
+
+		g.Context("as collaborator user", func() {
+			var client *kubernetes.Clientset
+
+			g.BeforeEach(func() {
+				var err error
+
+				client, err = getCollaboratorClient(eksCluster, awsAccountID)
+				framework.ExpectNoError(err)
+			})
+
+			g.It("should allow write access for non-system resources", func() {
+				err := client.RbacV1().ClusterRoles().Delete(context.Background(), nonSystemResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
+				framework.ExpectNoError(err, "failed to delete cluster role: %s", nonSystemResource.Name)
+			})
+
+			g.It("should deny write access for system resources", func() {
+				err := client.RbacV1().ClusterRoles().Delete(context.Background(), systemResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
+				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
+			})
+
+			// test specific namespaces
+
+			g.It("should deny deletion of kube-system namespace", func() {
+				err := client.CoreV1().Namespaces().Delete(context.Background(), "kube-system", metav1.DeleteOptions{DryRun: []string{"All"}})
+				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
+			})
+
+			g.It("should deny deletion of visibility namespace", func() {
+				err := client.CoreV1().Namespaces().Delete(context.Background(), "visibility", metav1.DeleteOptions{DryRun: []string{"All"}})
+				framework.ExpectNoError(err, "failed to delete cluster role: %s", nonSystemResource.Name)
+			})
+		})
+
+		g.Context("as engineer user", func() {
+			var client *kubernetes.Clientset
+
+			g.BeforeEach(func() {
+				var err error
+
+				client, err = getEngineerClient(eksCluster, awsAccountID)
+				framework.ExpectNoError(err)
+			})
+
+			g.It("should allow write access for non-system resources", func() {
+				err := client.RbacV1().ClusterRoles().Delete(context.Background(), nonSystemResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
+				framework.ExpectNoError(err, "failed to delete cluster role: %s", nonSystemResource.Name)
+			})
+
+			g.It("should deny write access for system resources", func() {
+				err := client.RbacV1().ClusterRoles().Delete(context.Background(), systemResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
+				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
+			})
+
+			// test specific namespaces
+
+			g.It("should deny deletion of kube-system namespace", func() {
+				err := client.CoreV1().Namespaces().Delete(context.Background(), "kube-system", metav1.DeleteOptions{DryRun: []string{"All"}})
+				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
+			})
+
+			g.It("should deny deletion of visibility namespace", func() {
+				err := client.CoreV1().Namespaces().Delete(context.Background(), "visibility", metav1.DeleteOptions{DryRun: []string{"All"}})
+				framework.ExpectNoError(err, "failed to delete cluster role: %s", nonSystemResource.Name)
 			})
 		})
 
@@ -863,6 +959,11 @@ func getPrivilegedClient(cluster *types.Cluster, awsAccountID string) (*kubernet
 // getCollaboratorClient returns a client with the `zalando:collaborator` group.
 func getCollaboratorClient(cluster *types.Cluster, awsAccountID string) (*kubernetes.Clientset, error) {
 	return newClientWithRole(cluster, fmt.Sprintf("arn:aws:iam::%s:role/%s-e2e-eks-iam-test-collaborator-role", awsAccountID, aws.ToString(cluster.Name)))
+}
+
+// getEngineerClient returns a client with the `zalando:engineer` group.
+func getEngineerClient(cluster *types.Cluster, awsAccountID string) (*kubernetes.Clientset, error) {
+	return newClientWithRole(cluster, fmt.Sprintf("arn:aws:iam::%s:role/%s-e2e-eks-iam-test-engineer-role", awsAccountID, aws.ToString(cluster.Name)))
 }
 
 // getUnprivilegedClient returns a client with the `zalando:readonly` group.

--- a/test/e2e/authorization.go
+++ b/test/e2e/authorization.go
@@ -964,7 +964,7 @@ var _ = g.Describe("Authorization via admission-controller [RBAC] [Zalando]", fu
 
 // getAdminClient returns a client with the `zalando:administrator` group.
 func getAdminClient(cluster *types.Cluster, awsAccountID string) (*kubernetes.Clientset, error) {
-	return newClientWithRole(cluster, fmt.Sprintf("arn:aws:iam::%s:role/%s-e2e-eks-iam-test-privileged-role", awsAccountID, aws.ToString(cluster.Name)))
+	return newClientWithRole(cluster, fmt.Sprintf("arn:aws:iam::%s:role/%s-e2e-eks-iam-test-administrator-role", awsAccountID, aws.ToString(cluster.Name)))
 }
 
 // getCollaboratorClient returns a client with the `zalando:collaborator` group.
@@ -979,7 +979,7 @@ func getEngineerClient(cluster *types.Cluster, awsAccountID string) (*kubernetes
 
 // getReadOnlyClient returns a client with the `zalando:readonly` group.
 func getReadOnlyClient(cluster *types.Cluster, awsAccountID string) (*kubernetes.Clientset, error) {
-	return newClientWithRole(cluster, fmt.Sprintf("arn:aws:iam::%s:role/%s-e2e-eks-iam-test-unprivileged-role", awsAccountID, aws.ToString(cluster.Name)))
+	return newClientWithRole(cluster, fmt.Sprintf("arn:aws:iam::%s:role/%s-e2e-eks-iam-test-read-only-role", awsAccountID, aws.ToString(cluster.Name)))
 }
 
 // getPostgresAdministratorClient returns a client with the `zalando:postgres-admin` group.

--- a/test/e2e/authorization.go
+++ b/test/e2e/authorization.go
@@ -642,6 +642,17 @@ var _ = g.Describe("Authorization via admission-controller [RBAC] [Zalando]", fu
 				framework.ExpectNoError(err, "failed to create pod: %s in namespace: %s", nonSystemResource.Name, nonSystemResource.Namespace)
 			})
 
+			g.It("should deny delete access in collaborator namespace", func() {
+				err := client.CoreV1().Pods(collaboratorResource.Namespace).Delete(context.Background(), collaboratorResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
+				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("delete operations are forbidden")))
+			})
+
+			// Should allow visibility ns deletion?
+			// g.It("should allow delete access in collaborator namespace", func() {
+			// 	err := client.CoreV1().Pods(collaboratorResource.Namespace).Delete(context.Background(), collaboratorResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
+			// 	framework.ExpectNoError(err, "failed to delete pod: %s in namespace: %s", collaboratorResource.Name, collaboratorResource.Namespace)
+			// })
+
 			g.It("should allow write access in collaborator namespace", func() {
 				_, err := client.CoreV1().Pods(collaboratorResource.Namespace).Create(context.Background(), collaboratorResource, metav1.CreateOptions{DryRun: []string{"All"}})
 				framework.ExpectNoError(err, "failed to create pod: %s in namespace: %s", collaboratorResource.Name, collaboratorResource.Namespace)
@@ -650,6 +661,11 @@ var _ = g.Describe("Authorization via admission-controller [RBAC] [Zalando]", fu
 			g.It("should deny write access in system namespace", func() {
 				_, err := client.CoreV1().Pods(systemResource.Namespace).Create(context.Background(), systemResource, metav1.CreateOptions{DryRun: []string{"All"}})
 				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
+			})
+
+			g.It("should deny delete access in system namespace", func() {
+				err := client.CoreV1().Pods(systemResource.Namespace).Delete(context.Background(), systemResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
+				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("delete operations are forbidden")))
 			})
 		})
 

--- a/test/e2e/authorization.go
+++ b/test/e2e/authorization.go
@@ -643,10 +643,12 @@ var _ = g.Describe("Authorization via admission-controller [RBAC] [Zalando]", fu
 				framework.ExpectNoError(err, "failed to create pod: %s in namespace: %s", nonSystemResource.Name, nonSystemResource.Namespace)
 			})
 
-			g.It("should deny delete access in collaborator namespace", func() {
-				err := client.CoreV1().Pods(collaboratorResource.Namespace).Delete(context.Background(), collaboratorResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
-				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("delete operations are forbidden")))
-			})
+			// Not needed actually
+			// // TODO: need to create resource before deleting it
+			// g.It("should deny delete access in collaborator namespace", func() {
+			// 	err := client.CoreV1().Pods(collaboratorResource.Namespace).Delete(context.Background(), collaboratorResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
+			// 	gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("delete operations are forbidden")))
+			// })
 
 			// Should allow visibility ns deletion?
 			// g.It("should allow delete access in collaborator namespace", func() {
@@ -664,10 +666,12 @@ var _ = g.Describe("Authorization via admission-controller [RBAC] [Zalando]", fu
 				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
 			})
 
-			g.It("should deny delete access in system namespace", func() {
-				err := client.CoreV1().Pods(systemResource.Namespace).Delete(context.Background(), systemResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
-				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("delete operations are forbidden")))
-			})
+			// Not needed actually
+			// // TODO: need to create resource before deleting it
+			// g.It("should deny delete access in system namespace", func() {
+			// 	err := client.CoreV1().Pods(systemResource.Namespace).Delete(context.Background(), systemResource.Name, metav1.DeleteOptions{DryRun: []string{"All"}})
+			// 	gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("delete operations are forbidden")))
+			// })
 		})
 
 		// TODO: this is for manual/ememergency access (to be consistent let's rename it to "privleged" because this si now called "privielegd access" by the IAM team)
@@ -787,12 +791,12 @@ var _ = g.Describe("Authorization via admission-controller [RBAC] [Zalando]", fu
 
 			g.It("should deny deletion of kube-system namespace", func() {
 				err := client.CoreV1().Namespaces().Delete(context.Background(), "kube-system", metav1.DeleteOptions{DryRun: []string{"All"}})
-				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
+				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("this namespace may not be deleted")))
 			})
 
 			g.It("should deny deletion of visibility namespace", func() {
 				err := client.CoreV1().Namespaces().Delete(context.Background(), "visibility", metav1.DeleteOptions{DryRun: []string{"All"}})
-				framework.ExpectNoError(err, "failed to delete cluster role: %s", nonSystemResource.Name)
+				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
 			})
 		})
 
@@ -820,12 +824,12 @@ var _ = g.Describe("Authorization via admission-controller [RBAC] [Zalando]", fu
 
 			g.It("should deny deletion of kube-system namespace", func() {
 				err := client.CoreV1().Namespaces().Delete(context.Background(), "kube-system", metav1.DeleteOptions{DryRun: []string{"All"}})
-				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
+				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("this namespace may not be deleted")))
 			})
 
 			g.It("should deny deletion of visibility namespace", func() {
 				err := client.CoreV1().Namespaces().Delete(context.Background(), "visibility", metav1.DeleteOptions{DryRun: []string{"All"}})
-				framework.ExpectNoError(err, "failed to delete cluster role: %s", nonSystemResource.Name)
+				gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("write operations are forbidden")))
 			})
 		})
 


### PR DESCRIPTION
Extend test roles Admission Controller coverage for EKS.

| **User Role \\ Namespace** | **user namespace** | **visibility**     | **kube-system** |
|----------------------------|---------------------|---------------------|------------------|
| **admin**                  | ✅ Write Access     | ✅ Write Access     | ✅ Write Access  |
| **collaborator**           | ✅ Write Access     | ✅ Write Access     |  ❌ No Access    |
| **engineer**               | ✅ Write Access     | ❌ No Access        | ❌ No Access     |
