### PR TITLE
skipper-internal: Update main to version v0.22.24-1131

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,6 +1,6 @@
 {{/* image-updater-bot detects *image variables so use print to disable it for main image */}}
 
-{{ $main_image := print "container-registry.zalando.net/teapot/skipper-internal:" "v0.22.21-1130" }}
+{{ $main_image := print "container-registry.zalando.net/teapot/skipper-internal:" "v0.22.24-1131" }}
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.22.24-1131" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}


### PR DESCRIPTION
* https://github.com/zalando/skipper/pull/3467
* https://github.com/zalando/skipper/pull/3472
* https://github.com/zalando/skipper/pull/3465
* https://github.com/zalando/skipper/pull/3464
* https://github.com/zalando/skipper/pull/3487
* https://github.com/zalando/skipper/pull/3490

Changes: https://github.com/zalando/skipper/compare/v0.22.7...v0.22.21

Canary Update : https://github.com/zalando-incubator/kubernetes-on-aws/pull/9362