### PR TITLE
Drop dnsmasq as dns cache option

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -921,16 +921,9 @@ external_dns_zones_cache_duration: "1h"
 # resource configuration
 external_dns_mem: "4Gi"
 
-# select which cache to use for Cluster DNS: unbound or dnsmasq.
-dns_cache: "unbound"
-
 expirimental_dns_unbound_liveness_probe: "true"
 
 # DNS container resources
-dns_dnsmasq_cpu: "100m"
-dns_dnsmasq_mem: "50Mi"
-dns_dnsmasq_sidecar_cpu: "10m"
-dns_dnsmasq_sidecar_mem: "45Mi"
 dns_unbound_cpu: "100m"
 dns_unbound_mem: "50Mi"
 dns_unbound_exporter_cpu: "10m"

--- a/cluster/manifests/01-coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/01-coredns-local/daemonset-coredns.yaml
@@ -42,7 +42,6 @@ spec:
             cpu: 1m
             memory: 50Mi
       containers:
-{{ if eq .Cluster.ConfigItems.dns_cache "unbound" }}
       - name: unbound
 {{- if eq .Cluster.Provider "zalando-eks" }}
         image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/unbound:1.22.0-master-10
@@ -119,95 +118,6 @@ spec:
         - mountPath: /run/unbound
           name: unbound-socket
           readOnly: false
-{{ end }}
-{{ if eq .Cluster.ConfigItems.dns_cache "dnsmasq" }}
-      - name: dnsmasq
-        {{- if eq .Cluster.Provider "zalando-eks" }}
-        image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/k8s-dns-dnsmasq-nanny:1.17.4-master-15
-        {{- else }}
-        image: container-registry.zalando.net/teapot/k8s-dns-dnsmasq-nanny:1.17.4-master-15
-        {{- end }}
-        securityContext:
-          privileged: true
-        livenessProbe:
-          httpGet:
-            path: /healthcheck/dnsmasq
-            port: 9054
-            scheme: HTTP
-          initialDelaySeconds: 60
-          timeoutSeconds: 5
-          successThreshold: 1
-          failureThreshold: 5
-        args:
-        - -v=2
-        - -logtostderr
-        - -configDir=/etc/k8s/dns/dnsmasq-nanny
-        - -restartDnsmasq=true
-        - --
-        - --no-resolv
-        - --keep-in-foreground
-        - --log-facility=-
-        - --cache-size=50000
-        - --dns-forward-max=500
-        - --neg-ttl=60
-        # send requests to the last server first, only fallback to the previous ones if it's unreachable
-        - --strict-order
-        - --server=10.5.0.11#53 # TODO: fix this for ipv6
-        - --server={{ if eq .Cluster.ConfigItems.eks_ip_family "ipv4" }}127.0.0.1{{else}}::1{{end}}#9254
-        ports:
-        - containerPort: 53
-          name: dns
-          protocol: UDP
-        - containerPort: 53
-          name: dns-tcp
-          protocol: TCP
-        resources:
-          requests:
-            ephemeral-storage: 256Mi
-          limits:
-            cpu: {{.Cluster.ConfigItems.dns_dnsmasq_cpu}}
-            memory: {{.Cluster.ConfigItems.dns_dnsmasq_mem}}
-        lifecycle:
-          preStop:
-            sleep:
-              seconds: 35
-      - name: sidecar
-        {{- if eq .Cluster.Provider "zalando-eks" }}
-        image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/k8s-dns-sidecar:1.17.4-master-15
-        {{- else }}
-        image: container-registry.zalando.net/teapot/k8s-dns-sidecar:1.17.4-master-15
-        {{- end }}
-        securityContext:
-          privileged: true
-        livenessProbe:
-          httpGet:
-            path: /metrics
-            port: 9054
-            scheme: HTTP
-          initialDelaySeconds: 60
-          timeoutSeconds: 5
-          successThreshold: 1
-          failureThreshold: 5
-        args:
-        - --v=2
-        - --logtostderr
-        - --probe=dnsmasq,127.0.0.1:9254,ec2.amazonaws.com,5,A
-        - --prometheus-port=9054
-        ports:
-        - containerPort: 9054
-          name: metrics
-          protocol: TCP
-        resources:
-          requests:
-            ephemeral-storage: 256Mi
-          limits:
-            cpu: {{.Cluster.ConfigItems.dns_dnsmasq_sidecar_cpu}}
-            memory: {{.Cluster.ConfigItems.dns_dnsmasq_sidecar_mem}}
-        lifecycle:
-          preStop:
-            sleep:
-              seconds: 35
-{{ end }}
       - name: coredns
         {{- if eq .Cluster.Provider "zalando-eks" }}
         image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/coredns:1.12.1-master-26
@@ -299,7 +209,5 @@ spec:
             path: Corefile
           - key: unbound.conf
             path: unbound.conf
-{{- if eq .Cluster.ConfigItems.dns_cache "unbound" }}
       - name: unbound-socket
         emptyDir: {}
-{{- end }}


### PR DESCRIPTION
Drops `dnsmasq` as option for `dns_cache` and drops the `dns_cache` config-item, making `unbound` the only DNS cache option.

`unbound` is already the default in all clusters so this is just a cleanup to get rid of dnsmasq.