### PR TITLE
admission: use builtin preStop sleep

### DIFF
--- a/cluster/manifests/02-admission-control/deployment.yaml
+++ b/cluster/manifests/02-admission-control/deployment.yaml
@@ -36,8 +36,8 @@ spec:
         image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-257
         lifecycle:
           preStop:
-            exec:
-              command: ["/bin/sh", "-c",  "sleep 60"]
+            sleep:
+              seconds: 60
         readinessProbe:
           httpGet:
             scheme: HTTPS

--- a/cluster/manifests/02-admission-control/deployment.yaml
+++ b/cluster/manifests/02-admission-control/deployment.yaml
@@ -37,7 +37,7 @@ spec:
         lifecycle:
           preStop:
             sleep:
-              seconds: 60
+              seconds: 20
         readinessProbe:
           httpGet:
             scheme: HTTPS

--- a/cluster/manifests/02-skipper-validation-webhook/deployment.yaml
+++ b/cluster/manifests/02-skipper-validation-webhook/deployment.yaml
@@ -41,7 +41,7 @@ spec:
         lifecycle:
           preStop:
             sleep:
-              seconds: 60
+              seconds: 20
         readinessProbe:
           httpGet:
             scheme: HTTPS

--- a/cluster/manifests/02-skipper-validation-webhook/deployment.yaml
+++ b/cluster/manifests/02-skipper-validation-webhook/deployment.yaml
@@ -40,8 +40,8 @@ spec:
           - --tls-key-file=/etc/tls-certs/skipper-validation-webhook-key.pem
         lifecycle:
           preStop:
-            exec:
-              command: ["/bin/sh", "-c",  " sleep 60"]
+            sleep:
+              seconds: 60
         readinessProbe:
           httpGet:
             scheme: HTTPS


### PR DESCRIPTION
We already use it in other manifests and these two are the last ones using shell sleep.

See https://github.com/kubernetes/enhancements/issues/3960