### PR TITLE
Include both authentication providers in trust relationship template variable

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1270,6 +1270,8 @@ eks_zalando_iam_aws_proxy_hpa_max_replicas: "10"
 eks_zalando_iam_aws_proxy_hpa_cpu_target: "80"
 eks_zalando_iam_aws_proxy_hpa_memory_target: "80"
 eks_okta_identity_provider: "true"
+eks_legacy_cluster_local_id: "kube-1"
+eks_oidc_issuer_url: "https://"
 eks_fis_support_enabled: "false"
 eks_fis_namespaces: "default"
 

--- a/cluster/manifests/deployment-service/01-config.yaml
+++ b/cluster/manifests/deployment-service/01-config.yaml
@@ -13,17 +13,35 @@ data:
   create-namespaces: "true"
   aws-available: "true"
   worker-role-arn: "arn:aws:iam::{{accountID .Cluster.InfrastructureAccount}}:role/{{.Cluster.LocalID}}-worker"
-  {{ $oidc_issuer := "" }}
 {{- if eq .Cluster.Provider "zalando-eks" }}
-  {{ $oidc_issuer = index (split .Cluster.ConfigItems.eks_oidc_issuer_url "//") 1 }}
+  {{ $oidc_issuer_aws := printf "%s.%s" .Cluster.ConfigItems.eks_legacy_cluster_local_id .Values.hosted_zone }}
+  {{ $oidc_issuer_eks := index (split .Cluster.ConfigItems.eks_oidc_issuer_url "//") 1 }}
+  {{ $oidc_provider_arn_aws := printf "arn:aws:iam::%s:oidc-provider/%s" (accountID .Cluster.InfrastructureAccount) $oidc_issuer_aws }}
+  {{ $oidc_provider_arn_eks := printf "arn:aws:iam::%s:oidc-provider/%s" (accountID .Cluster.InfrastructureAccount) $oidc_issuer_eks }}
+  {{ $oidc_subject_key_aws := printf "%s:sub" $oidc_issuer_aws }}
+  {{ $oidc_subject_key_eks := printf "%s:sub" $oidc_issuer_eks }}
+  oidc-provider-arn: "{{$oidc_provider_arn_eks}}"
+  oidc-subject-key: "{{$oidc_subject_key_eks}}"
+  {{- if ne .Cluster.ConfigItems.eks_legacy_cluster_local_id "" }}
+  oidc-trust-relationship-template: '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Federated":"{{$oidc_provider_arn_aws}}"},"Action":"sts:AssumeRoleWithWebIdentity","Condition":{"StringLike":{"{{$oidc_subject_key_aws}}":"system:serviceaccount:${SERVICE_ACCOUNT}"}}},{"Effect":"Allow","Principal":{"Federated":"{{$oidc_provider_arn_eks}}"},"Action":"sts:AssumeRoleWithWebIdentity","Condition":{"StringLike":{"{{$oidc_subject_key_eks}}":"system:serviceaccount:${SERVICE_ACCOUNT}"}}}]}'
+  {{- else }}
+  oidc-trust-relationship-template: '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Federated":"{{$oidc_provider_arn_eks}}"},"Action":"sts:AssumeRoleWithWebIdentity","Condition":{"StringLike":{"{{$oidc_subject_key_eks}}":"system:serviceaccount:${SERVICE_ACCOUNT}"}}}]}'
+  {{- end }}
 {{- else }}
-  {{ $oidc_issuer = printf "%s.%s" .Cluster.LocalID .Values.hosted_zone }}
+  {{ $oidc_issuer_aws := printf "%s.%s" .Cluster.LocalID .Values.hosted_zone }}
+  {{ $oidc_issuer_eks := index (split .Cluster.ConfigItems.eks_oidc_issuer_url "//") 1 }}
+  {{ $oidc_provider_arn_aws := printf "arn:aws:iam::%s:oidc-provider/%s" (accountID .Cluster.InfrastructureAccount) $oidc_issuer_aws }}
+  {{ $oidc_provider_arn_eks := printf "arn:aws:iam::%s:oidc-provider/%s" (accountID .Cluster.InfrastructureAccount) $oidc_issuer_eks }}
+  {{ $oidc_subject_key_aws := printf "%s:sub" $oidc_issuer_aws }}
+  {{ $oidc_subject_key_eks := printf "%s:sub" $oidc_issuer_eks }}
+  oidc-provider-arn: "{{$oidc_provider_arn_aws}}"
+  oidc-subject-key: "{{$oidc_subject_key_aws}}"
+  {{- if ne $oidc_issuer_eks "" }}
+  oidc-trust-relationship-template: '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Federated":"{{$oidc_provider_arn_aws}}"},"Action":"sts:AssumeRoleWithWebIdentity","Condition":{"StringLike":{"{{$oidc_subject_key_aws}}":"system:serviceaccount:${SERVICE_ACCOUNT}"}}},{"Effect":"Allow","Principal":{"Federated":"{{$oidc_provider_arn_eks}}"},"Action":"sts:AssumeRoleWithWebIdentity","Condition":{"StringLike":{"{{$oidc_subject_key_eks}}":"system:serviceaccount:${SERVICE_ACCOUNT}"}}}]}'
+  {{- else }}
+  oidc-trust-relationship-template: '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Federated":"{{$oidc_provider_arn_aws}}"},"Action":"sts:AssumeRoleWithWebIdentity","Condition":{"StringLike":{"{{$oidc_subject_key_aws}}":"system:serviceaccount:${SERVICE_ACCOUNT}"}}}]}'
+  {{- end }}
 {{- end }}
-  {{ $oidc_provider_arn := printf "arn:aws:iam::%s:oidc-provider/%s" (accountID .Cluster.InfrastructureAccount) $oidc_issuer }}
-  {{ $oidc_subject_key := printf "%s:sub" $oidc_issuer }}
-  oidc-provider-arn: "{{$oidc_provider_arn}}"
-  oidc-subject-key: "{{$oidc_subject_key}}"
-  oidc-trust-relationship-template: '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Federated":"{{$oidc_provider_arn}}"},"Action":"sts:AssumeRoleWithWebIdentity","Condition":{"StringLike":{"{{$oidc_subject_key}}":"system:serviceaccount:${SERVICE_ACCOUNT}"}}}]}'
   s3-bucket-name: "zalando-deployment-service-{{accountID .Cluster.InfrastructureAccount}}-{{.Cluster.LocalID}}"
   status-service-url: "https://depl-status-{{.Cluster.Alias}}.{{.Values.hosted_zone}}"
   status-service-url-local: "http://deployment-status-service.ingress.cluster.local."

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -46,6 +46,7 @@ clusters:
     okta_auth_client_id: "kubernetes.cluster.teapot-e2e"
     teapot_admission_controller_validate_pod_images_soft_fail_namespaces: "^kube-system$"
     eks_okta_identity_provider: "false" # disabled to speed up EKS cluster creation for e2e.
+    eks_legacy_cluster_local_id: "https://e2e-${CDP_BUILD_VERSION}-aws.${HOSTED_ZONE}"
     skipper_open_policy_agent_enabled: "${SKIPPER_OPA_ENABLED}"
     skipper_open_policy_agent_styra_token: "${STYRA_TOKEN}"
     skipper_open_policy_agent_bucket_arn: "${SKIPPER_OPA_BUCKET_ARN}"

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -46,7 +46,7 @@ clusters:
     okta_auth_client_id: "kubernetes.cluster.teapot-e2e"
     teapot_admission_controller_validate_pod_images_soft_fail_namespaces: "^kube-system$"
     eks_okta_identity_provider: "false" # disabled to speed up EKS cluster creation for e2e.
-    eks_legacy_cluster_local_id: "https://e2e-${CDP_BUILD_VERSION}-aws.${HOSTED_ZONE}"
+    eks_legacy_cluster_local_id: "e2e-${CDP_BUILD_VERSION}-aws"
     skipper_open_policy_agent_enabled: "${SKIPPER_OPA_ENABLED}"
     skipper_open_policy_agent_styra_token: "${STYRA_TOKEN}"
     skipper_open_policy_agent_bucket_arn: "${SKIPPER_OPA_BUCKET_ARN}"


### PR DESCRIPTION
Goal: The new variable `oidc-trust-relationship-template` should contain trust relationships for both the `zaland-aws` and `zalando-eks` providers.

CLM runs code for provisioning clusters based on their respective provider. As such, values of some variables will be different, missing and/or new variables exist. Running the EKS provisioner will result in a different outcome than running the provisioner for the legacy provider and it requires different inputs.

If we want to provide both trust relationships to each cluster, the challenge is that the provisioning code for EKS needs to know the logic of that part of the legacy provisioners code and vice versa. That's pretty easy for things were both providers work identical or where one can easily be inferred from the other.

Let's assume the pair of clusters where the legacy cluster is `cloud` and the new EKS cluster is `cloud-euc1`.

For the EKS cluster, the config item `eks_legacy_cluster_local_id` must be set to the local ID of the legacy cluster. This is typically `kube-1` and therefore can usually be left out. There are two exceptions in old clusters which will be set manually once. This is enough for the EKS cluster to construct the URL for the OIDC provider of the legacy cluster.

For the legacy cluster, the config item `eks_oidc_issuer_url` must be set to the URL of the OIDC provider of the EKS cluster. This cannot easily be inferred as there's no connection from the cluster names or accounts to the URL of the OIDC provider. Hence it must be set manually matching the value of the EKS cluster. If this value is left at the default, then it falls back to the current approach where only the legacy provider is part of the trust relationship template. In a future version it might be possible for CLM to do that step but for now we can easily set it via `cluster-config-manager` at any point after the EKS cluster creation.

When running on either cluster type, the config should result in the following:

```yaml
oidc-provider-arn: "{{$oidc_provider_arn_aws or $oidc_provider_arn_eks}}" # the ARN of the current cluster's OIDC provider respectively
oidc-subject-key: "{{$oidc_subject_key_aws or $oidc_subject_key_eks}}" # the subject of the current cluster's OIDC provider respectively
# The trust relationship template will contain both providers on both clusters with a fixed order.
oidc-trust-relationship-template: '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Federated":"{{$oidc_provider_arn_aws}}"},"Action":"sts:AssumeRoleWithWebIdentity","Condition":{"StringLike":{"{{$oidc_subject_key_aws}}":"system:serviceaccount:${SERVICE_ACCOUNT}"}}},{"Effect":"Allow","Principal":{"Federated":"{{$oidc_provider_arn_eks}}"},"Action":"sts:AssumeRoleWithWebIdentity","Condition":{"StringLike":{"{{$oidc_subject_key_eks}}":"system:serviceaccount:${SERVICE_ACCOUNT}"}}}]}'
```

For legacy clusters where the corresponding EKS cluster's OIDC provider URL is not set, the `oidc-trust-relationship-template` will only contain the legacy cluster's trust relationship template.

This would also be the case vice versa but since it's trivial to infer the correct OIDC provider for the legacy cluster from the EKS cluster, this case can be ignored.