### PR TITLE
feature: add OTel backend address in proxy span [2/2]

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,6 +1,6 @@
 {{/* image-updater-bot detects *image variables so use print to disable it for main image */}}
 
-{{ $main_image := print "container-registry.zalando.net/teapot/skipper-internal:" "v0.22.24-1131" }}
+{{ $main_image := print "container-registry.zalando.net/teapot/skipper-internal:" "v0.22.31-1138" }}
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.22.31-1138" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}


### PR DESCRIPTION
main fleet deployment, canary was https://github.com/zalando-incubator/kubernetes-on-aws/pull/9424