### PR TITLE
Export worker security group ID

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -3653,7 +3653,7 @@ Outputs:
   EKSWorkerSecurityGroupId:
     Export:
       Name: "{{.Cluster.ID}}:eks-worker-security-group-id"
-    Value: !GetAtt EKSCluster.EKSWorkerSecurityGroup.Id
+    Value: !GetAtt EKSWorkerSecurityGroup.Id
   # Too big for Cloudformation output?
   # EKSCertificateAuthorityData:
   #   Export:

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -3650,6 +3650,10 @@ Outputs:
     Export:
       Name: "{{.Cluster.ID}}:worker-security-group"
     Value: !Ref EKSWorkerSecurityGroup
+  EKSWorkerSecurityGroupId:
+    Export:
+      Name: "{{.Cluster.ID}}:eks-worker-security-group-id"
+    Value: !GetAtt EKSCluster.EKSWorkerSecurityGroupId
   # Too big for Cloudformation output?
   # EKSCertificateAuthorityData:
   #   Export:
@@ -3683,6 +3687,10 @@ Outputs:
     Export:
       Name: '{{.Cluster.ID}}:worker-security-group'
     Value: !Ref WorkerSecurityGroup
+  WorkerSecurityGroupId:
+    Export:
+      Name: "{{.Cluster.ID}}:worker-security-group-id"
+    Value: !GetAtt WorkerSecurityGroupId
 {{- end }}
   EtcdEncryptionKey:
     Export:

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -3653,7 +3653,7 @@ Outputs:
   EKSWorkerSecurityGroupId:
     Export:
       Name: "{{.Cluster.ID}}:eks-worker-security-group-id"
-    Value: !GetAtt EKSCluster.EKSWorkerSecurityGroupId
+    Value: !GetAtt EKSCluster.EKSWorkerSecurityGroup.Id
   # Too big for Cloudformation output?
   # EKSCertificateAuthorityData:
   #   Export:

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -3690,7 +3690,7 @@ Outputs:
   WorkerSecurityGroupId:
     Export:
       Name: "{{.Cluster.ID}}:worker-security-group-id"
-    Value: !GetAtt WorkerSecurityGroupId
+    Value: !GetAtt WorkerSecurityGroup.Id
 {{- end }}
   EtcdEncryptionKey:
     Export:


### PR DESCRIPTION
When importing the K8s security group in external projects it might only work via it's id.