### PR TITLE
Enable  skipper-ingress aws role for reading opa bundles by default

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1967,7 +1967,6 @@ Resources:
           PolicyName: root
       RoleName: "{{.Cluster.LocalID}}-app-ingr-ctrl"
     Type: 'AWS::IAM::Role'
-{{ if eq .Cluster.ConfigItems.skipper_open_policy_agent_enabled "true" }}
   # Note: this is not strictly specific to Open Policy Agent and can be extend
   # if Skipper Ingress needs to access other AWS resources
   SkipperIngressIAMRole:
@@ -2013,7 +2012,6 @@ Resources:
           PolicyName: read-opa-bundles
       RoleName: "{{.Cluster.LocalID}}-app-skipper-ingress"
     Type: 'AWS::IAM::Role'
-{{ end }}
   ClusterLifecycleControllerIAMRole:
     Properties:
       AssumeRolePolicyDocument: !Sub


### PR DESCRIPTION
Enable  skipper-ingress aws role for reading opa bundles by default