### PR TITLE
skipper-internal: Update main fleet to version v0.22.43-1150

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,6 +1,6 @@
 {{/* image-updater-bot detects *image variables so use print to disable it for main image */}}
 
-{{ $main_image := print "container-registry.zalando.net/teapot/skipper-internal:" "v0.22.31-1138" }}
+{{ $main_image := print "container-registry.zalando.net/teapot/skipper-internal:" "v0.22.43-1150" }}
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.22.43-1150" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}


### PR DESCRIPTION
* https://github.com/zalando/skipper/pull/3500
* https://github.com/zalando/skipper/pull/3501
* https://github.com/zalando/skipper/pull/3502
* https://github.com/zalando/skipper/pull/3503
* https://github.com/zalando/skipper/pull/3504
* https://github.com/zalando/skipper/pull/3509
* https://github.com/zalando/skipper/pull/3508
* https://github.com/zalando/skipper/pull/3505
* https://github.com/zalando/skipper/pull/3515
* https://github.com/zalando/skipper/pull/3516
* https://github.com/zalando/skipper/pull/3517
* https://github.com/zalando/skipper/pull/3518
* https://github.com/zalando/skipper/pull/3519
* https://github.com/zalando/skipper/pull/3520

- [x] follow up and depends on https://github.com/zalando-incubator/kubernetes-on-aws/pull/9486