### PR TITLE
Open up worker-to-worker communication

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -143,6 +143,14 @@ Resources:
       IpProtocol: tcp
       SourceSecurityGroupId: !Ref EKSWorkerSecurityGroup
       ToPort: 443
+  EKSWorkerSecurityGroupIngressFromWorkerToWorkerSteadyBit:
+    Properties:
+      FromPort: 8085
+      GroupId: !Ref EKSWorkerSecurityGroup
+      IpProtocol: tcp
+      SourceSecurityGroupId: !Ref EKSWorkerSecurityGroup
+      ToPort: 8087
+    Type: 'AWS::EC2::SecurityGroupIngress'
   EKSCluster:
     Type: AWS::EKS::Cluster
     Properties:
@@ -930,6 +938,14 @@ Resources:
       IpProtocol: tcp
       SourceSecurityGroupId: !Ref WorkerSecurityGroup
       ToPort: 10250 # Kubelet
+    Type: 'AWS::EC2::SecurityGroupIngress'
+  WorkerSecurityGroupIngressFromWorkerToWorkerSteadyBit:
+    Properties:
+      FromPort: 8085
+      GroupId: !Ref WorkerSecurityGroup
+      IpProtocol: tcp
+      SourceSecurityGroupId: !Ref WorkerSecurityGroup
+      ToPort: 8087
     Type: 'AWS::EC2::SecurityGroupIngress'
   WorkerSecurityGroupIngressFromWorkerToWorkerSkipperMetrics:
     Properties:

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -143,16 +143,6 @@ Resources:
       IpProtocol: tcp
       SourceSecurityGroupId: !Ref EKSWorkerSecurityGroup
       ToPort: 443
-{{- if eq .Cluster.ConfigItems.open_sg_for_steadybit "true" }}
-  EKSWorkerSecurityGroupIngressFromWorkerToWorkerSteadyBit:
-    Properties:
-      FromPort: 8085
-      GroupId: !Ref EKSWorkerSecurityGroup
-      IpProtocol: tcp
-      SourceSecurityGroupId: !Ref EKSWorkerSecurityGroup
-      ToPort: 8087
-    Type: 'AWS::EC2::SecurityGroupIngress'
-{{- end }}
   EKSCluster:
     Type: AWS::EKS::Cluster
     Properties:
@@ -925,56 +915,12 @@ Resources:
       SourceSecurityGroupId: !Ref MasterSecurityGroup
       ToPort: 10250
     Type: 'AWS::EC2::SecurityGroupIngress'
-  WorkerSecurityGroupIngressFromWorkerToFlannel:
+  WorkerSecurityGroupWorkerToWorker:
+    Type: AWS::EC2::SecurityGroupIngress
     Properties:
-      FromPort: 8472
+      IpProtocol: "-1"
       GroupId: !Ref WorkerSecurityGroup
-      IpProtocol: udp
       SourceSecurityGroupId: !Ref WorkerSecurityGroup
-      ToPort: 8472
-    Type: 'AWS::EC2::SecurityGroupIngress'
-  WorkerSecurityGroupIngressFromWorkerToWorkerKubeletAndKubeProxy:
-    Properties:
-      FromPort: 10249 # KubeProxy
-      GroupId: !Ref WorkerSecurityGroup
-      IpProtocol: tcp
-      SourceSecurityGroupId: !Ref WorkerSecurityGroup
-      ToPort: 10250 # Kubelet
-    Type: 'AWS::EC2::SecurityGroupIngress'
-{{- if eq .Cluster.ConfigItems.open_sg_for_steadybit "true" }}
-  WorkerSecurityGroupIngressFromWorkerToWorkerSteadyBit:
-    Properties:
-      FromPort: 8085
-      GroupId: !Ref WorkerSecurityGroup
-      IpProtocol: tcp
-      SourceSecurityGroupId: !Ref WorkerSecurityGroup
-      ToPort: 8087
-    Type: 'AWS::EC2::SecurityGroupIngress'
-{{- end }}
-  WorkerSecurityGroupIngressFromWorkerToWorkerSkipperMetrics:
-    Properties:
-      FromPort: 9911
-      GroupId: !Ref WorkerSecurityGroup
-      IpProtocol: tcp
-      SourceSecurityGroupId: !Ref WorkerSecurityGroup
-      ToPort: 9911
-    Type: 'AWS::EC2::SecurityGroupIngress'
-  WorkerSecurityGroupIngressFromWorkerToWorkerSkipperTokeninfoMetrics:
-    Properties:
-      FromPort: 9022
-      GroupId: !Ref WorkerSecurityGroup
-      IpProtocol: tcp
-      SourceSecurityGroupId: !Ref WorkerSecurityGroup
-      ToPort: 9022
-    Type: 'AWS::EC2::SecurityGroupIngress'
-  WorkerSecurityGroupIngressFromWorkerToNodeMonitor:
-    Properties:
-      FromPort: 9100
-      ToPort: 9101
-      GroupId: !Ref WorkerSecurityGroup
-      IpProtocol: tcp
-      SourceSecurityGroupId: !Ref WorkerSecurityGroup
-    Type: 'AWS::EC2::SecurityGroupIngress'
   EFSSecurityGroupIngressFromWorkerSecurityGroup:
     Properties:
       FromPort: 2049

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -143,6 +143,7 @@ Resources:
       IpProtocol: tcp
       SourceSecurityGroupId: !Ref EKSWorkerSecurityGroup
       ToPort: 443
+{{- if eq .Cluster.ConfigItems.open_sg_for_steadybit "true" }}
   EKSWorkerSecurityGroupIngressFromWorkerToWorkerSteadyBit:
     Properties:
       FromPort: 8085
@@ -151,6 +152,7 @@ Resources:
       SourceSecurityGroupId: !Ref EKSWorkerSecurityGroup
       ToPort: 8087
     Type: 'AWS::EC2::SecurityGroupIngress'
+{{- end }}
   EKSCluster:
     Type: AWS::EKS::Cluster
     Properties:
@@ -939,6 +941,7 @@ Resources:
       SourceSecurityGroupId: !Ref WorkerSecurityGroup
       ToPort: 10250 # Kubelet
     Type: 'AWS::EC2::SecurityGroupIngress'
+{{- if eq .Cluster.ConfigItems.open_sg_for_steadybit "true" }}
   WorkerSecurityGroupIngressFromWorkerToWorkerSteadyBit:
     Properties:
       FromPort: 8085
@@ -947,6 +950,7 @@ Resources:
       SourceSecurityGroupId: !Ref WorkerSecurityGroup
       ToPort: 8087
     Type: 'AWS::EC2::SecurityGroupIngress'
+{{- end }}
   WorkerSecurityGroupIngressFromWorkerToWorkerSkipperMetrics:
     Properties:
       FromPort: 9911

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1129,6 +1129,9 @@ enable_statefulset_autodelete_pvc: "true"
 # Source for the template function: sgIngressRanges: https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/42695865a251fef58e22ce612d6549e75fa5d103/provisioner/template.go#L336-L417
 open_sg_ingress_ranges: ""
 
+# open ports 8085-8087 between worker nodes for steadybit components
+open_sg_for_steadybit: "false"
+
 # Each subdomain can reach a max of 63 bytes on Route53
 # This custom value sets the subdomain max allowed length taking into consideration the 'cname-' prefix added by external-dns
 subdomain_max_length: "57"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1129,9 +1129,6 @@ enable_statefulset_autodelete_pvc: "true"
 # Source for the template function: sgIngressRanges: https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/42695865a251fef58e22ce612d6549e75fa5d103/provisioner/template.go#L336-L417
 open_sg_ingress_ranges: ""
 
-# open ports 8085-8087 between worker nodes for steadybit components
-open_sg_for_steadybit: "false"
-
 # Each subdomain can reach a max of 63 bytes on Route53
 # This custom value sets the subdomain max allowed length taking into consideration the 'cname-' prefix added by external-dns
 subdomain_max_length: "57"


### PR DESCRIPTION
For https://github.com/zalando-build/zooport/issues/5703.

Similar to the EKS setup, enables all nodes using the worker security group to connect to each other.