### PR TITLE
Set increased WIZ Priority as default 

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1255,7 +1255,7 @@ wiz_sensor_cpu: "200m"
 wiz_sensor_memory: "300Mi"
 wiz_connector_cpu: "50m"
 wiz_connector_memory: "150Mi"
-wiz_priority: "false"
+wiz_priority: "true"
 # Please note when this is set to true it allows the use of the node selector feature
 # to deploy the sensor and connector on specific nodes, by manually setting the node selector label on the nodes.
 # This is useful when you want to deploy the sensor and connector on specific nodes.


### PR DESCRIPTION
The initial rollout of WIZ is now complete and there are no longer any Pending WIZ Pods in our environment. This PR changes the default WIZ priority to `system-node-critical`, which is inline with the rest of our core DaemonSet pods.