### PR TITLE
kube-proxy: Use livez instead of healthz

### DIFF
--- a/cluster/manifests/kube-proxy/daemonset.yaml
+++ b/cluster/manifests/kube-proxy/daemonset.yaml
@@ -58,7 +58,7 @@ spec:
           httpGet:
             host: 127.0.0.1
             port: 10256
-            path: /healthz
+            path: /livez
         resources:
           requests:
             cpu: {{.Cluster.ConfigItems.kube_proxy_cpu}}


### PR DESCRIPTION
The semantics of `/healthz` for `kube-proxy` changed as part of: https://github.com/kubernetes/kubernetes/pull/116470 (Kubernetes v1.28)

The change is that if a node is draining for deletion then `/healthz` of `kube-proxy` starts to return 503 even if kube-proxy itself is healthy.

This effectively means in our setup, since we use `/healthz` for readiness probe, that kube-proxy gets unready if the node it is running on is draining. This can take a long time meaning kube-proxy can be unready for a long time and this can block e.g. update of kube-proxy daemonset across nodes as the daemonset pods are rolled one by one and stop if not all pods are ready.

The fix is to change to use `/livez` for the readiness probe which doesn't include the _node is draining_ logic of `/healthz` and is the same a `/healthz` before the upstream change introduced in v1.28. 