### PR TITLE
Add config item for controlling spot in Karpenter capacity-type

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -51,6 +51,9 @@ karpenter_in_transit_support_required: "false"
 # t type instances have burstable CPU, which can be undesirable in production
 karpenter_instance_family_t_enabled: "false"
 
+# configure whether spot instances should be enabled in Karpenter's capacity-types
+karpenter_enable_spot: "true"
+
 # ALB config created by kube-aws-ingress-controller
 kube_aws_ingress_controller_ssl_policy: "ELBSecurityPolicy-TLS13-1-2-2021-06"
 kube_aws_ingress_controller_idle_timeout: "1m"

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -249,7 +249,9 @@ spec:
         - key: "karpenter.sh/capacity-type"
           operator: In
           values:
+#{{ if eq .NodePool.ConfigItems.karpenter_enable_spot "true" }}
             - "spot"
+#{{ end }}
             - "on-demand"
         - key: "kubernetes.io/arch"
           operator: In


### PR DESCRIPTION
This PR adds a config item: `karpenter_enable_spot` (true by default) which allows controlling whether Karpenter nodepools contain `spot` as a `capacity-type`. This config allows us to easily toggle whether Karpenter can provision spot instances alongside on-demand.  