### PR TITLE
Update Karpenter to v1.5.0

### DIFF
--- a/cluster/manifests/z-karpenter/07-karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/cluster/manifests/z-karpenter/07-karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: ec2nodeclasses.karpenter.k8s.aws
 spec:
   group: karpenter.k8s.aws
@@ -195,6 +195,17 @@ spec:
                               Valid Range: Minimum value of 125. Maximum value of 1000.
                             format: int64
                             type: integer
+                          volumeInitializationRate:
+                            description: |-
+                              VolumeInitializationRate specifies the Amazon EBS Provisioned Rate for Volume Initialization,
+                              in MiB/s, at which to download the snapshot blocks from Amazon S3 to the volume. This is also known as volume
+                              initialization. Specifying a volume initialization rate ensures that the volume is initialized at a
+                              predictable and consistent rate after creation. Only allowed if SnapshotID is set.
+                              Valid Range: Minimum value of 100. Maximum value of 300.
+                            format: int32
+                            maximum: 300
+                            minimum: 100
+                            type: integer
                           volumeSize:
                             description: |-
                               VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or
@@ -228,6 +239,8 @@ spec:
                         x-kubernetes-validations:
                           - message: snapshotID or volumeSize must be defined
                             rule: has(self.snapshotID) || has(self.volumeSize)
+                          - message: snapshotID must be set when volumeInitializationRate is set
+                            rule: '!has(self.volumeInitializationRate) || (has(self.snapshotID) && self.snapshotID != '''')'
                       rootVolume:
                         description: |-
                           RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can

--- a/cluster/manifests/z-karpenter/08-karpenter.sh_nodeclaims.yaml
+++ b/cluster/manifests/z-karpenter/08-karpenter.sh_nodeclaims.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: nodeclaims.karpenter.sh
 spec:
   group: karpenter.sh

--- a/cluster/manifests/z-karpenter/09-karpenter.sh_nodepools.yaml
+++ b/cluster/manifests/z-karpenter/09-karpenter.sh_nodepools.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: nodepools.karpenter.sh
 spec:
   group: karpenter.sh

--- a/cluster/manifests/z-karpenter/deployment.yaml
+++ b/cluster/manifests/z-karpenter/deployment.yaml
@@ -30,16 +30,19 @@ spec:
         prometheus.io/scheme: "http"
         prometheus.io/scrape: "true"
     spec:
-      dnsPolicy: Default
       automountServiceAccountToken: true
       serviceAccountName: karpenter
       securityContext:
         fsGroup: 65532
+        runAsNonRoot: false
+        seccompProfile:
+          type: RuntimeDefault
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       dnsPolicy: ClusterFirst
       containers:
         - name: controller
           securityContext:
+            privileged: false
             runAsUser: 65532
             runAsGroup: 65532
             runAsNonRoot: true
@@ -50,11 +53,11 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
-          image: "container-registry.zalando.net/teapot/karpenter:1.4.0-main-38.patched"
+          image: "container-registry.zalando.net/teapot/karpenter:1.5.0-main-39.patched"
           imagePullPolicy: IfNotPresent
           env:
             - name: KUBERNETES_MIN_VERSION
-              value: 1.22.0-0
+              value: 1.19.0-0
             - name: AWS_REGION
               value: "{{ .Cluster.Region }}"
             - name: CLUSTER_ENDPOINT
@@ -88,13 +91,11 @@ spec:
                   divisor: "0"
                   resource: limits.memory
             - name: FEATURE_GATES
-              value: "Drift=false,SpotToSpotConsolidation=true,NodeRepair=false"
+              value: "ReservedCapacity=false,SpotToSpotConsolidation=true,NodeRepair=false"
             - name: BATCH_MAX_DURATION
               value: "10s"
             - name: BATCH_IDLE_DURATION
               value: "1s"
-            - name: ASSUME_ROLE_DURATION
-              value: "15m"
             - name: PREFERENCE_POLICY
               value: "Respect"
             - name: CLUSTER_NAME
@@ -153,13 +154,6 @@ spec:
               matchLabels:
                 deployment: karpenter
             topologyKey: kubernetes.io/hostname
-#      topologySpreadConstraints:
-#        - labelSelector:
-#            matchLabels:
-#              deployment: karpenter
-#          maxSkew: 1
-#          topologyKey: topology.kubernetes.io/zone
-#          whenUnsatisfiable: ScheduleAnyway
       tolerations:
         - key: CriticalAddonsOnly
           operator: Exists


### PR DESCRIPTION
This updates Karpenter to `v1.5.0`. This is also required for support of `i7i` instance type that has been requested by teams.


## Summary of Changes

- [x] Updating the CRDs
- [x] Updating `provisioners.yaml` to reflect any breaking CRD changes
- [x] Updating of controller manifests