### PR TITLE
Make deployment-service's S3 bucket name configurable

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1528,7 +1528,7 @@ Resources:
     Type: AWS::S3::Bucket
     DeletionPolicy: Delete
     Properties:
-      BucketName: "zalando-deployment-service-{{accountID .Cluster.InfrastructureAccount}}-{{.Cluster.LocalID}}"
+      BucketName: "{{ .Cluster.ConfigItems.deployment_service_bucket_name }}"
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1044,6 +1044,7 @@ deployment_service_cf_auto_expand_enabled: "false"
 deployment_service_cf_update_source_branch_changes: "true"
 deployment_service_executor_cdp_permissions: "false"
 deployment_service_skip_mustache_rendering: "true"
+deployment_service_bucket_name: "zalando-deployment-service-{{ .Cluster.InfrastructureAccount | getAWSAccountID }}-{{ .Cluster.LocalID }}"
 {{- if eq .Cluster.Environment "test" }}
 # disable CF update of source branch changes in test to avoid updating CF stacks
 # on any PR.

--- a/cluster/manifests/deployment-service/01-config.yaml
+++ b/cluster/manifests/deployment-service/01-config.yaml
@@ -42,7 +42,7 @@ data:
   oidc-trust-relationship-template: '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Federated":"{{$oidc_provider_arn_aws}}"},"Action":"sts:AssumeRoleWithWebIdentity","Condition":{"StringLike":{"{{$oidc_subject_key_aws}}":"system:serviceaccount:${SERVICE_ACCOUNT}"}}}]}'
   {{- end }}
 {{- end }}
-  s3-bucket-name: "zalando-deployment-service-{{accountID .Cluster.InfrastructureAccount}}-{{.Cluster.LocalID}}"
+  s3-bucket-name: "{{ .Cluster.ConfigItems.deployment_service_bucket_name }}"
   status-service-url: "https://depl-status-{{.Cluster.Alias}}.{{.Values.hosted_zone}}"
   status-service-url-local: "http://deployment-status-service.ingress.cluster.local."
   deployment-role-arn: "arn:aws:iam::{{accountID .Cluster.InfrastructureAccount}}:role/{{.Cluster.LocalID}}-deployment-service-deployment"


### PR DESCRIPTION
Adds a config item for deployment-service's S3 bucket name. The default is the current value.

In order to shorten it in the future, we can configure the current value for all existing clusters in cluster-registry and then change the default for all clusters going forward. We could also do the opposite and only configure the value if the default exceeds the length limit.