### PR TITLE
increase subdomain_max_length for stups-test

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1133,7 +1133,11 @@ open_sg_ingress_ranges: ""
 
 # Each DNS label (subdomain) can be 63 octets or less (https://datatracker.ietf.org/doc/html/rfc1035#section-2.3.4)
 # This custom value sets the subdomain max allowed length taking into consideration the 'cname-' prefix added by external-dns
+{{ if eq .Cluster.Alias "stups-test" }}
+subdomain_max_length: "100"
+{{ else }}
 subdomain_max_length: "57"
+{{ end }}
 
 # Network monitoring
 network_monitoring_enabled: "false"


### PR DESCRIPTION
After #9479 , e2e tests in the `stackset-controller` broke as the hostnames there exceed this default limit of `57` for subdomain length. 

```go
time="2025-06-13T12:40:22Z" level=error msg="Unable to reconcile stack resources: admission webhook \"routegroup-admitter.teapot.zalan.do\" denied the request: subdomain 'd-9owpufu1wutzdgxfdrpytgzw1-stackset-update-add-routegroup' is too long, keep each subdomain at a max of 57 characters" controller=stackset namespace=d-9owpufu1wutzdgxfdrpytgzw1 stack=stackset-update-add-routegroup-v2 stackset=stackset-update-add-routegroup
```

It's tricky to change the domain names and since it's just an e2e test environment, it's easier to enable this limit to a higher value, to make the e2e tests work like they worked before enforcing this limit in the admission-controller. 