### PR TITLE
Remove TopologyAwareHints Feature Flag

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -945,9 +945,6 @@ enable_default_sa: "false"
 vm_dirty_background_bytes: "67108864"
 vm_dirty_bytes: "134217728"
 
-# Option to Enable FeatureGate TopologyAwareHints
-enable_topology_aware_hints: "false"
-
 # Enable FeatureGate HPAScaleToZero
 enable_hpa_scale_to_zero: "true"
 

--- a/cluster/manifests/kube-proxy/configmap.yaml
+++ b/cluster/manifests/kube-proxy/configmap.yaml
@@ -23,7 +23,6 @@ data:
       tcpEstablishedTimeout: 24h0m0s
     enableProfiling: false
     featureGates:
-      TopologyAwareHints: {{ .Cluster.ConfigItems.enable_topology_aware_hints }}
       SizeMemoryBackedVolumes: {{ .Cluster.ConfigItems.enable_size_memory_backed_volumes }}
 {{- if eq .Cluster.ConfigItems.enable_image_volumes "true" }}
       ImageVolume: true

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -155,7 +155,7 @@ write_files:
           - "--oidc-username-prefix=okta:"
           - --oidc-groups-claim=groups
           - "--oidc-groups-prefix=okta:"
-          - --feature-gates=HPAScaleToZero={{ .Cluster.ConfigItems.enable_hpa_scale_to_zero }},StatefulSetAutoDeletePVC={{ .Cluster.ConfigItems.enable_statefulset_autodelete_pvc }},TopologyAwareHints={{ .Cluster.ConfigItems.enable_topology_aware_hints }},MaxUnavailableStatefulSet={{.Cluster.ConfigItems.max_unavailable_statefulset_enabled}},KMSv1=true{{if eq .Cluster.ConfigItems.enable_image_volumes "true"}},ImageVolume=true{{end}}
+          - --feature-gates=HPAScaleToZero={{ .Cluster.ConfigItems.enable_hpa_scale_to_zero }},StatefulSetAutoDeletePVC={{ .Cluster.ConfigItems.enable_statefulset_autodelete_pvc }},MaxUnavailableStatefulSet={{.Cluster.ConfigItems.max_unavailable_statefulset_enabled}},KMSv1=true{{if eq .Cluster.ConfigItems.enable_image_volumes "true"}},ImageVolume=true{{end}}
           - --service-account-key-file=/etc/kubernetes/ssl/service-account-public-key.pem
           - --service-account-signing-key-file=/etc/kubernetes/ssl/service-account-private-key.pem
           - --service-account-issuer={{ .Cluster.APIServerURL }}
@@ -620,7 +620,7 @@ write_files:
           - --root-ca-file=/etc/kubernetes/ssl/ca.pem
           - --cloud-provider=external
           - --cloud-config=/etc/kubernetes/cloud-config.ini
-          - --feature-gates=StatefulSetAutoDeletePVC={{ .Cluster.ConfigItems.enable_statefulset_autodelete_pvc }},TopologyAwareHints={{ .Cluster.ConfigItems.enable_topology_aware_hints }},MaxUnavailableStatefulSet={{.Cluster.ConfigItems.max_unavailable_statefulset_enabled}}{{if eq .Cluster.ConfigItems.enable_image_volumes "true"}},ImageVolume=true{{end}}
+          - --feature-gates=StatefulSetAutoDeletePVC={{ .Cluster.ConfigItems.enable_statefulset_autodelete_pvc }},MaxUnavailableStatefulSet={{.Cluster.ConfigItems.max_unavailable_statefulset_enabled}}{{if eq .Cluster.ConfigItems.enable_image_volumes "true"}},ImageVolume=true{{end}}
           - --use-service-account-credentials=true
           - --configure-cloud-routes=false
           - --allocate-node-cidrs=true


### PR DESCRIPTION
This removes the custom config for `TopologyAwareHints` featureflag and default to true which is the only option since Kubernetes v1.33. It's no longer possible to set the Feature flag.

This change must be rolled out _before_ #9523 otherwise `kube-proxy` will not get ready on the new master node during roll out
