### PR TITLE
expose-opa-ast-optimization-configuration-per-cluster

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -372,6 +372,7 @@ skipper_ingress_routegroup_crd_require_hosts: "true"
 # Set defaults values that would enable Open Policy Agent in a skipper filter
 skipper_open_policy_agent_enabled: "false"
 skipper_open_policy_agent_styra_token: ""
+skipper_open_policy_agent_data_preprocessing_optimization_enabled: "false"
 
 # Default timeout value in seconds for outgoing http calls from Open Policy Agent in a skipper filter
 skipper_open_policy_agent_styra_response_header_timeout: "2"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -317,6 +317,7 @@ spec:
           - "-enable-open-policy-agent"
           - "-open-policy-agent-config-template=/etc/skipper/open-policy-agent/opaconfig.yaml"
           - "-open-policy-agent-envoy-metadata=/etc/skipper/open-policy-agent/envoymetadata.json"
+          - "-enable-open-policy-agent-data-preprocessing-optimization={{ .Cluster.ConfigItems.skipper_open_policy_agent_data_preprocessing_optimization_enabled }}"
 {{ end }}
 {{ if or (eq .Cluster.ConfigItems.nlb_switch "pre") (eq .Cluster.ConfigItems.nlb_switch "exec") }}
           - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"


### PR DESCRIPTION
Exposing OPA optimization configuration.

New configuration should be disabled by default and it should be possible to enable it per cluster. Enabling should only be possible if `skipper_open_policy_agent_enabled` is enabled.