### PR TITLE
drop subdomain_max_length config for stups-test

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1130,11 +1130,7 @@ open_sg_ingress_ranges: ""
 
 # Each DNS label (subdomain) can be 63 octets or less (https://datatracker.ietf.org/doc/html/rfc1035#section-2.3.4)
 # This custom value sets the subdomain max allowed length taking into consideration the 'cname-' prefix added by external-dns
-{{ if eq .Cluster.Alias "stups-test" }}
-subdomain_max_length: "100"
-{{ else }}
 subdomain_max_length: "57"
-{{ end }}
 
 # Network monitoring
 network_monitoring_enabled: "false"


### PR DESCRIPTION
We decided to shorten the subdomain names instead. So, this change introduced in #9573 can be dropped. 
If it's really needed in the future, we can set it per cluster instead, instead of doing it here.