### PR TITLE
skipper-internal: Update main to version v0.22.52-1159

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,6 +1,6 @@
 {{/* image-updater-bot detects *image variables so use print to disable it for main image */}}
 
-{{ $main_image := print "container-registry.zalando.net/teapot/skipper-internal:" "v0.22.43-1150" }}
+{{ $main_image := print "container-registry.zalando.net/teapot/skipper-internal:" "v0.22.52-1159" }}
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.22.52-1159" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}


### PR DESCRIPTION
* https://github.com/zalando/skipper/pull/3521
* https://github.com/zalando/skipper/pull/3525
* https://github.com/zalando/skipper/pull/3447
* https://github.com/zalando/skipper/pull/3524
* https://github.com/zalando/skipper/pull/3527
* https://github.com/zalando/skipper/pull/3506
* https://github.com/zalando/skipper/pull/3529
* https://github.com/zalando/skipper/pull/3532
* https://github.com/zalando/skipper/pull/3533
* https://github.com/zalando/skipper/pull/3512
* https://github.com/zalando/skipper/pull/3514

Changes: https://github.com/zalando/skipper/compare/v0.22.43...v0.22.52

Canary Update: https://github.com/zalando-incubator/kubernetes-on-aws/pull/9578