### PR TITLE
Leverage new IAM properties on CLM's cluster object

### DIFF
--- a/cluster/manifests/deployment-service/01-config.yaml
+++ b/cluster/manifests/deployment-service/01-config.yaml
@@ -12,7 +12,10 @@ data:
   scalyr-team-token: "{{.Cluster.ConfigItems.scalyr_team_token}}"
   create-namespaces: "true"
   aws-available: "true"
-  worker-role-arn: "arn:aws:iam::{{accountID .Cluster.InfrastructureAccount}}:role/{{.Cluster.LocalID}}-worker"
+  worker-role-arn: "{{.Cluster.WorkerRoleARN}}"
+  oidc-provider-arn: "{{.Cluster.OIDCProviderARN}}"
+  oidc-subject-key: "{{.Cluster.OIDCSubjectKey}}"
+  iam-role-trust-relationship-template: '{{.Cluster.IAMRoleTrustRelationshipTemplate}}'
 {{- if eq .Cluster.Provider "zalando-eks" }}
   {{ $oidc_issuer_aws := printf "%s.%s" .Cluster.ConfigItems.eks_legacy_cluster_local_id .Values.hosted_zone }}
   {{ $oidc_issuer_eks := index (split .Cluster.ConfigItems.eks_oidc_issuer_url "//") 1 }}
@@ -20,8 +23,6 @@ data:
   {{ $oidc_provider_arn_eks := printf "arn:aws:iam::%s:oidc-provider/%s" (accountID .Cluster.InfrastructureAccount) $oidc_issuer_eks }}
   {{ $oidc_subject_key_aws := printf "%s:sub" $oidc_issuer_aws }}
   {{ $oidc_subject_key_eks := printf "%s:sub" $oidc_issuer_eks }}
-  oidc-provider-arn: "{{$oidc_provider_arn_eks}}"
-  oidc-subject-key: "{{$oidc_subject_key_eks}}"
   {{- if ne .Cluster.ConfigItems.eks_legacy_cluster_local_id "" }}
   oidc-trust-relationship-template: '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Federated":"{{$oidc_provider_arn_aws}}"},"Action":"sts:AssumeRoleWithWebIdentity","Condition":{"StringLike":{"{{$oidc_subject_key_aws}}":"system:serviceaccount:${SERVICE_ACCOUNT}"}}},{"Effect":"Allow","Principal":{"Federated":"{{$oidc_provider_arn_eks}}"},"Action":"sts:AssumeRoleWithWebIdentity","Condition":{"StringLike":{"{{$oidc_subject_key_eks}}":"system:serviceaccount:${SERVICE_ACCOUNT}"}}}]}'
   {{- else }}
@@ -34,8 +35,6 @@ data:
   {{ $oidc_provider_arn_eks := printf "arn:aws:iam::%s:oidc-provider/%s" (accountID .Cluster.InfrastructureAccount) $oidc_issuer_eks }}
   {{ $oidc_subject_key_aws := printf "%s:sub" $oidc_issuer_aws }}
   {{ $oidc_subject_key_eks := printf "%s:sub" $oidc_issuer_eks }}
-  oidc-provider-arn: "{{$oidc_provider_arn_aws}}"
-  oidc-subject-key: "{{$oidc_subject_key_aws}}"
   {{- if ne $oidc_issuer_eks "" }}
   oidc-trust-relationship-template: '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Federated":"{{$oidc_provider_arn_aws}}"},"Action":"sts:AssumeRoleWithWebIdentity","Condition":{"StringLike":{"{{$oidc_subject_key_aws}}":"system:serviceaccount:${SERVICE_ACCOUNT}"}}},{"Effect":"Allow","Principal":{"Federated":"{{$oidc_provider_arn_eks}}"},"Action":"sts:AssumeRoleWithWebIdentity","Condition":{"StringLike":{"{{$oidc_subject_key_eks}}":"system:serviceaccount:${SERVICE_ACCOUNT}"}}}]}'
   {{- else }}


### PR DESCRIPTION
Use new member variables on cluster objects provided by CLM to improve combined trust relationship. The old trust relationship is left in place until all applications have migrated away from it.