### PR TITLE
Allow update of pods/ephemeralcontainers

### DIFF
--- a/cluster/manifests/roles/poweruser-role.yaml
+++ b/cluster/manifests/roles/poweruser-role.yaml
@@ -49,6 +49,7 @@ rules:
   - pods/ephemeralcontainers
   verbs:
   - patch
+  - update
 - apiGroups:
   - ''
   resources:


### PR DESCRIPTION
Allow `update` on `pods/ephemeralcontainers` which is the verb needed when calling [UpdateEphemeralContainers](https://github.com/kubernetes/client-go/blob/c2ce9a8b31709226bab8585d0e7211cebdb221b1/kubernetes/typed/core/v1/pod.go#L54)