### PR TITLE
[STABLE] Allow update of pods/ephemeralcontainers

### DIFF
--- a/cluster/manifests/roles/poweruser-role.yaml
+++ b/cluster/manifests/roles/poweruser-role.yaml
@@ -49,6 +49,7 @@ rules:
   - pods/ephemeralcontainers
   verbs:
   - patch
+  - update
 - apiGroups:
   - ''
   resources:


### PR DESCRIPTION
Cherry-pick https://github.com/zalando-incubator/kubernetes-on-aws/pull/9619 to stable to not wait for e2e.