### PR TITLE
Make audittrail bucket configurable

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -2943,7 +2943,7 @@ Resources:
     Type: AWS::S3::Bucket
     DeletionPolicy: Delete
     Properties:
-      BucketName: "zalando-audittrail-{{accountID .Cluster.InfrastructureAccount}}-{{.Cluster.LocalID}}"
+      BucketName: "{{ .Cluster.ConfigItems.audittrail_bucket_name }}"
       LifecycleConfiguration:
         Rules:
           - AbortIncompleteMultipartUpload:

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -801,6 +801,7 @@ audittrail_adapter_cpu: "50m"
 audittrail_adapter_memory: "200Mi"
 
 audittrail_adapter_timeout: "2s"
+audittrail_bucket_name: "zalando-audittrail-{{ .Cluster.InfrastructureAccount | getAWSAccountID }}-{{ .Cluster.LocalID }}"
 
 # When enabled, any read-only events are added to the metrics, but are dropped
 # before being sent to audittrail-api.

--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -47,7 +47,7 @@ spec:
         - --cluster-alias={{ .Cluster.Alias }}
         - --nakadi-url={{ .Cluster.ConfigItems.audittrail_nakadi_url }}
         - --audittrail-url={{ .Cluster.ConfigItems.audittrail_url }}
-        - --s3-fallback-bucket-name=zalando-audittrail-{{accountID .Cluster.InfrastructureAccount}}-{{ .Cluster.LocalID }}
+        - --s3-fallback-bucket-name={{ .Cluster.ConfigItems.audittrail_bucket_name }}
         - --address=:8889
         - --metrics-address=:7980
         - --audittrail-timeout={{ .Cluster.ConfigItems.audittrail_adapter_timeout }}


### PR DESCRIPTION
Configure and deduplicate audittrail bucket name. This will also allow to shorten it.