### PR TITLE
Use cluster's member function instead of template functions

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1050,7 +1050,7 @@ Resources:
                 Effect: Allow
                 Resource:
                 - >-
-                  arn:aws:s3:::zalando-e2e-test-{{accountID .Cluster.InfrastructureAccount}}-{{.Cluster.LocalID}}
+                  arn:aws:s3:::zalando-e2e-test-{{.Cluster.InfrastructureAccountID}}-{{.Cluster.LocalID}}
               - Action:
                 - 's3:PutObject'
                 - 's3:GetObject'
@@ -1058,7 +1058,7 @@ Resources:
                 Effect: Allow
                 Resource:
                 - >-
-                  arn:aws:s3:::zalando-e2e-test-{{accountID .Cluster.InfrastructureAccount}}-{{.Cluster.LocalID}}/*
+                  arn:aws:s3:::zalando-e2e-test-{{.Cluster.InfrastructureAccountID}}-{{.Cluster.LocalID}}/*
 {{ end }}
             Version: 2012-10-17
           PolicyName: root
@@ -2417,7 +2417,7 @@ Resources:
                 - "s3:GetObject"
                 - "s3:GetObjectVersion"
                 Effect: Allow
-                Resource: "arn:aws:s3:::cluster-lifecycle-manager-{{accountID .Cluster.InfrastructureAccount}}-{{.Cluster.Region}}/*"
+                Resource: "arn:aws:s3:::cluster-lifecycle-manager-{{.Cluster.InfrastructureAccountID}}-{{.Cluster.Region}}/*"
             Version: 2012-10-17
           PolicyName: root
       RoleName: "{{.Cluster.LocalID}}-static-egress-controller"
@@ -2612,7 +2612,7 @@ Resources:
                 Resource: '*'
               - Action: 'secretsmanager:GetSecretValue'
                 Effect: Allow
-                Resource: "arn:aws:secretsmanager:{{.Cluster.Region}}:{{.Cluster.InfrastructureAccount | getAWSAccountID}}:secret:*.zmon-db-user.credentials*"
+                Resource: "arn:aws:secretsmanager:{{.Cluster.Region}}:{{.Cluster.InfrastructureAccountID}}:secret:*.zmon-db-user.credentials*"
             Version: 2012-10-17
           PolicyName: root
       RoleName: "{{.Cluster.LocalID}}-app-zmon"
@@ -2909,7 +2909,7 @@ Resources:
             Effect: Allow
             Resource:
             - >-
-              arn:aws:s3:::zalando-e2e-test-{{accountID .Cluster.InfrastructureAccount}}-{{.Cluster.LocalID}}
+              arn:aws:s3:::zalando-e2e-test-{{.Cluster.InfrastructureAccountID}}-{{.Cluster.LocalID}}
           - Action:
             - 's3:PutObject'
             - 's3:GetObject'
@@ -2917,7 +2917,7 @@ Resources:
             Effect: Allow
             Resource:
             - >-
-              arn:aws:s3:::zalando-e2e-test-{{accountID .Cluster.InfrastructureAccount}}-{{.Cluster.LocalID}}/*
+              arn:aws:s3:::zalando-e2e-test-{{.Cluster.InfrastructureAccountID}}-{{.Cluster.LocalID}}/*
           Version: 2012-10-17
         PolicyName: root
       RoleName: "{{.Cluster.LocalID}}-e2e-aws-iam-test"
@@ -2926,7 +2926,7 @@ Resources:
     Type: AWS::S3::Bucket
     DeletionPolicy: Delete
     Properties:
-      BucketName: "zalando-e2e-test-{{accountID .Cluster.InfrastructureAccount}}-{{.Cluster.LocalID}}"
+      BucketName: "zalando-e2e-test-{{.Cluster.InfrastructureAccountID}}-{{.Cluster.LocalID}}"
       LifecycleConfiguration:
         Rules:
         - AbortIncompleteMultipartUpload:

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -470,7 +470,7 @@ journald_reader_cpu: "1m"
 journald_reader_memory: "30Mi"
 
 # Logging settings
-logging_s3_bucket: "zalando-logging-{{ .Cluster.InfrastructureAccount | getAWSAccountID}}-{{ .Cluster.Region }}"
+logging_s3_bucket: "zalando-logging-{{ .Cluster.InfrastructureAccountID }}-{{ .Cluster.Region }}"
 scalyr_team_token: ""
 log_destination_infra: "scalyr/stups"
 log_destination_both: "scalyr/main+stups"
@@ -801,7 +801,7 @@ audittrail_adapter_cpu: "50m"
 audittrail_adapter_memory: "200Mi"
 
 audittrail_adapter_timeout: "2s"
-audittrail_bucket_name: "zalando-audittrail-{{ .Cluster.InfrastructureAccount | getAWSAccountID }}-{{ .Cluster.LocalID }}"
+audittrail_bucket_name: "zalando-audittrail-{{ .Cluster.InfrastructureAccountID }}-{{ .Cluster.LocalID }}"
 
 # When enabled, any read-only events are added to the metrics, but are dropped
 # before being sent to audittrail-api.
@@ -1044,7 +1044,7 @@ deployment_service_cf_auto_expand_enabled: "false"
 deployment_service_cf_update_source_branch_changes: "true"
 deployment_service_executor_cdp_permissions: "false"
 deployment_service_skip_mustache_rendering: "true"
-deployment_service_bucket_name: "zalando-deployment-service-{{ .Cluster.InfrastructureAccount | getAWSAccountID }}-{{ .Cluster.LocalID }}"
+deployment_service_bucket_name: "zalando-deployment-service-{{ .Cluster.InfrastructureAccountID }}-{{ .Cluster.LocalID }}"
 {{- if eq .Cluster.Environment "test" }}
 # disable CF update of source branch changes in test to avoid updating CF stacks
 # on any PR.

--- a/cluster/manifests/02-admission-control/config.yaml
+++ b/cluster/manifests/02-admission-control/config.yaml
@@ -30,7 +30,7 @@ data:
   pod.default.dns-ndots: "{{ .Cluster.ConfigItems.teapot_admission_controller_ndots }}"
   pod.parent-resource-hash.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_parent_resource_hash }}"
   pod.service-account-iam.enable: "true"
-  pod.service-account-iam.base-aws-account-id: "{{ accountID .Cluster.InfrastructureAccount }}"
+  pod.service-account-iam.base-aws-account-id: "{{ .Cluster.InfrastructureAccountID }}"
 {{- if eq .Cluster.ConfigItems.teapot_admission_controller_inject_aws_waiter "true" }}
   pod.aws-waiter.image: "926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/automata/aws-credentials-waiter:master-266"
 {{- end }}

--- a/cluster/manifests/aws-load-balancer-controller/serviceaccount.yaml
+++ b/cluster/manifests/aws-load-balancer-controller/serviceaccount.yaml
@@ -8,5 +8,5 @@ metadata:
     application: kubernetes
     component: aws-load-balancer-controller
   annotations:
-    eks.amazonaws.com/role-arn: "arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/aws-load-balancer-controller-{{.Cluster.Name}}"
+    eks.amazonaws.com/role-arn: "arn:aws:iam::{{.Cluster.InfrastructureAccountID}}:role/aws-load-balancer-controller-{{.Cluster.Name}}"
 # {{- end }}

--- a/cluster/manifests/aws-node-decommissioner/01-rbac.yaml
+++ b/cluster/manifests/aws-node-decommissioner/01-rbac.yaml
@@ -8,7 +8,7 @@ metadata:
     component: aws-node-decommissioner
   annotations:
 {{- if eq .Cluster.Provider "zalando-eks"}}
-    eks.amazonaws.com/role-arn: "arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/{{ .Cluster.LocalID }}-aws-node-decommissioner"
+    eks.amazonaws.com/role-arn: "arn:aws:iam::{{.Cluster.InfrastructureAccountID}}:role/{{ .Cluster.LocalID }}-aws-node-decommissioner"
 {{- else}}
     iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-aws-node-decommissioner"
 {{- end}}

--- a/cluster/manifests/deployment-service/01-config.yaml
+++ b/cluster/manifests/deployment-service/01-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: deployment-config
   namespace: kube-system
 data:
-  aws-account-id: "{{accountID .Cluster.InfrastructureAccount}}"
+  aws-account-id: "{{.Cluster.InfrastructureAccountID}}"
   aws-account-name: "{{.Cluster.AccountName}}"
   cluster-alias: "{{.Cluster.Alias}}"
   cluster-provider: "{{.Cluster.Provider}}"
@@ -19,9 +19,9 @@ data:
   s3-bucket-name: "{{ .Cluster.ConfigItems.deployment_service_bucket_name }}"
   status-service-url: "https://depl-status-{{.Cluster.Alias}}.{{.Values.hosted_zone}}"
   status-service-url-local: "http://deployment-status-service.ingress.cluster.local."
-  deployment-role-arn: "arn:aws:iam::{{accountID .Cluster.InfrastructureAccount}}:role/{{.Cluster.LocalID}}-deployment-service-deployment"
+  deployment-role-arn: "arn:aws:iam::{{.Cluster.InfrastructureAccountID}}:role/{{.Cluster.LocalID}}-deployment-service-deployment"
 {{- if eq .Cluster.ConfigItems.deployment_service_ml_experiments_enabled "true"}}
-  ml-experiment-deployment-role-arn: "arn:aws:iam::{{accountID .Cluster.InfrastructureAccount}}:role/{{ .Cluster.ConfigItems.deployment_service_ml_experiments_role_name }}"
+  ml-experiment-deployment-role-arn: "arn:aws:iam::{{.Cluster.InfrastructureAccountID}}:role/{{ .Cluster.ConfigItems.deployment_service_ml_experiments_role_name }}"
 {{- end }}
   cloudformation-enable-auto-expand: "{{.Cluster.ConfigItems.deployment_service_cf_auto_expand_enabled}}"
   cloudformation-update-source-branch-changes: "{{.Cluster.ConfigItems.deployment_service_cf_update_source_branch_changes}}"

--- a/cluster/manifests/deployment-service/controller-rbac.yaml
+++ b/cluster/manifests/deployment-service/controller-rbac.yaml
@@ -8,7 +8,7 @@ metadata:
     component: "controller"
   annotations:
     {{- if eq .Cluster.Provider "zalando-eks" }}
-    eks.amazonaws.com/role-arn: "arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/{{.Cluster.LocalID}}-deployment-service-controller"
+    eks.amazonaws.com/role-arn: "arn:aws:iam::{{.Cluster.InfrastructureAccountID}}:role/{{.Cluster.LocalID}}-deployment-service-controller"
     {{- else }}
     iam.amazonaws.com/role: "{{.Cluster.LocalID}}-deployment-service-controller"
     {{- end }}

--- a/cluster/manifests/deployment-service/controller-statefulset.yaml
+++ b/cluster/manifests/deployment-service/controller-statefulset.yaml
@@ -32,7 +32,7 @@ spec:
           image: "container-registry.zalando.net/teapot/deployment-controller:master-263"
           args:
             - "--config-namespace=kube-system"
-            - "--decrypt-kms-alias-arn=arn:aws:kms:{{ .Cluster.Region }}:{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:alias/deployment-secret"
+            - "--decrypt-kms-alias-arn=arn:aws:kms:{{ .Cluster.Region }}:{{ .Cluster.InfrastructureAccountID }}:alias/deployment-secret"
             # {{ if eq .Cluster.Provider "zalando-eks" }}
             - --use-service-account
             # {{ end }}

--- a/cluster/manifests/deployment-service/status-service-rbac.yaml
+++ b/cluster/manifests/deployment-service/status-service-rbac.yaml
@@ -8,7 +8,7 @@ metadata:
     component: "status-service"
   annotations:
     {{- if eq .Cluster.Provider "zalando-eks" }}
-    eks.amazonaws.com/role-arn: "arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/{{.Cluster.LocalID}}-deployment-service-status-service"
+    eks.amazonaws.com/role-arn: "arn:aws:iam::{{.Cluster.InfrastructureAccountID}}:role/{{.Cluster.LocalID}}-deployment-service-status-service"
     {{- else }}
     iam.amazonaws.com/role: "{{.Cluster.LocalID}}-deployment-service-status-service"
     {{- end }}

--- a/cluster/manifests/external-dns/01-rbac.yaml
+++ b/cluster/manifests/external-dns/01-rbac.yaml
@@ -9,7 +9,7 @@ metadata:
     component: external-dns
   annotations:
 {{- if eq .Cluster.Provider "zalando-eks"}}
-    eks.amazonaws.com/role-arn: "arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/{{ .Cluster.LocalID }}-app-external-dns"
+    eks.amazonaws.com/role-arn: "arn:aws:iam::{{.Cluster.InfrastructureAccountID}}:role/{{ .Cluster.LocalID }}-app-external-dns"
 {{- else}}
     iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-app-external-dns"
 {{- end}}

--- a/cluster/manifests/ingress-controller/01-rbac.yaml
+++ b/cluster/manifests/ingress-controller/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   annotations:
 {{- if eq .Cluster.Provider "zalando-eks"}}
-    eks.amazonaws.com/role-arn: "arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/{{ .Cluster.LocalID }}-app-ingr-ctrl"
+    eks.amazonaws.com/role-arn: "arn:aws:iam::{{.Cluster.InfrastructureAccountID}}:role/{{ .Cluster.LocalID }}-app-ingr-ctrl"
 {{- else}}
     iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-app-ingr-ctrl"
 {{- end}}

--- a/cluster/manifests/kube-cluster-autoscaler/01-rbac.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/01-rbac.yaml
@@ -8,7 +8,7 @@ metadata:
     component: kube-cluster-autoscaler
   annotations:
 {{- if eq .Cluster.Provider "zalando-eks"}}
-    eks.amazonaws.com/role-arn: "arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/{{ .Cluster.LocalID }}-app-autoscaler"
+    eks.amazonaws.com/role-arn: "arn:aws:iam::{{.Cluster.InfrastructureAccountID}}:role/{{ .Cluster.LocalID }}-app-autoscaler"
 {{- else}}
     iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-app-autoscaler"
 {{- end}}

--- a/cluster/manifests/kube-metrics-adapter/01-rbac.yaml
+++ b/cluster/manifests/kube-metrics-adapter/01-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   annotations:
     {{- if eq .Cluster.Provider "zalando-eks" }}
-    eks.amazonaws.com/role-arn: "arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/{{ .Cluster.LocalID }}-kube-metrics-adapter"
+    eks.amazonaws.com/role-arn: "arn:aws:iam::{{.Cluster.InfrastructureAccountID}}:role/{{ .Cluster.LocalID }}-kube-metrics-adapter"
     {{- else }}
     iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-kube-metrics-adapter"
     {{- end }}

--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -34,7 +34,7 @@ spec:
         args:
         - "--provider=aws"
         - "--vpc-id={{.Cluster.ConfigItems.vpc_id}}"
-        - "--cf-template-bucket=cluster-lifecycle-manager-{{accountID .Cluster.InfrastructureAccount}}-{{.Cluster.Region}}"
+        - "--cf-template-bucket=cluster-lifecycle-manager-{{.Cluster.InfrastructureAccountID}}-{{.Cluster.Region}}"
 {{- range $subnet := stupsNATSubnets .Values.vpc_ipv4_cidr }}
         - "--aws-nat-cidr-block={{ $subnet }}"
 {{- end }}

--- a/cluster/manifests/skipper/01-rbac.yaml
+++ b/cluster/manifests/skipper/01-rbac.yaml
@@ -10,7 +10,7 @@ metadata:
   # Note: if the role extends beyond OPA use, this condition can be removed
   annotations:
     {{- if eq .Cluster.Provider "zalando-eks" }}
-    eks.amazonaws.com/role-arn: "arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/{{ .Cluster.LocalID }}-app-skipper-ingress"
+    eks.amazonaws.com/role-arn: "arn:aws:iam::{{.Cluster.InfrastructureAccountID}}:role/{{ .Cluster.LocalID }}-app-skipper-ingress"
     {{- else}}
     iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-app-skipper-ingress"
     {{- end}}

--- a/cluster/manifests/skipper/configmap-open-policy-agent.yaml
+++ b/cluster/manifests/skipper/configmap-open-policy-agent.yaml
@@ -16,7 +16,7 @@ data:
     labels:
       environment: {{ .Cluster.Environment }}
       kubernetes-cluster-alias: {{ .Cluster.Alias }}
-      aws-account-id: "{{ accountID .Cluster.InfrastructureAccount }}"
+      aws-account-id: "{{ .Cluster.InfrastructureAccountID }}"
     services:
     - credentials:
         bearer:

--- a/cluster/manifests/z-karpenter/01-serviceaccount.yaml
+++ b/cluster/manifests/z-karpenter/01-serviceaccount.yaml
@@ -10,7 +10,7 @@ metadata:
     component: karpenter
   annotations:
 {{- if eq .Cluster.Provider "zalando-eks"}}
-    eks.amazonaws.com/role-arn: "arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/{{ .Cluster.LocalID }}-app-karpenter"
+    eks.amazonaws.com/role-arn: "arn:aws:iam::{{.Cluster.InfrastructureAccountID}}:role/{{ .Cluster.LocalID }}-app-karpenter"
 {{- else}}
     iam.amazonaws.com/role: '{{ .Cluster.LocalID }}-app-karpenter'
 {{- end}}

--- a/cluster/manifests/zalando-iam-aws-proxy/deployment.yaml
+++ b/cluster/manifests/zalando-iam-aws-proxy/deployment.yaml
@@ -32,7 +32,7 @@ spec:
         - "--apiserver-url=https://kubernetes.default.svc.cluster.local"
         - "--ca-file-path=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
         - "--cluster-id={{.Cluster.Name}}"
-        - "--role-arn=arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/{{.Cluster.LocalID}}-zalando-iam"
+        - "--role-arn=arn:aws:iam::{{.Cluster.InfrastructureAccountID}}:role/{{.Cluster.LocalID}}-zalando-iam"
         - "--tokeninfo-url=https://identity.zalando.com=http://:9021/oauth2/tokeninfo"
         # {{- if ne .Cluster.Environment "production"}}
         - "--tokeninfo-url=https://sandbox.identity.zalando.com=http://:9022/oauth2/tokeninfo"

--- a/cluster/manifests/zalando-iam-aws-proxy/rbac.yaml
+++ b/cluster/manifests/zalando-iam-aws-proxy/rbac.yaml
@@ -8,5 +8,5 @@ metadata:
     application: kubernetes
     component: zalando-iam-aws-proxy
   annotations:
-    eks.amazonaws.com/role-arn: "arn:aws:iam::{{.Cluster.InfrastructureAccount | getAWSAccountID}}:role/{{ .Cluster.LocalID }}-zalando-iam-aws-proxy"
+    eks.amazonaws.com/role-arn: "arn:aws:iam::{{.Cluster.InfrastructureAccountID}}:role/{{ .Cluster.LocalID }}-zalando-iam-aws-proxy"
 # {{ end }}

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -313,7 +313,7 @@ write_files:
               memory: 50Mi
           args:
             - --node-auth-cluster-id={{.Cluster.ID}}
-            - "--node-auth-role-arn=arn:aws:iam::{{accountID .Cluster.InfrastructureAccount}}:role/{{.Cluster.LocalID}}-worker"
+            - "--node-auth-role-arn=arn:aws:iam::{{.Cluster.InfrastructureAccountID}}:role/{{.Cluster.LocalID}}-worker"
             - "--node-auth-rate-limit={{.Cluster.ConfigItems.node_auth_rate_limit}}"
             - --cluster-alias={{.Cluster.Alias}}
 
@@ -549,7 +549,7 @@ write_files:
           image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/aws-encryption-provider:87537492279066f5ddc94bf0cf3667f38f3f6328-main-3.custom
           command:
           - /aws-encryption-provider
-          - --key=arn:aws:kms:{{ .Cluster.Region }}:{{ .Cluster.InfrastructureAccount | getAWSAccountID }}:key/{{ .Values.ClusterStackOutputs.EtcdEncryptionKey }}
+          - --key=arn:aws:kms:{{ .Cluster.Region }}:{{ .Cluster.InfrastructureAccountID }}:key/{{ .Values.ClusterStackOutputs.EtcdEncryptionKey }}
           - --region={{ .Cluster.Region }}
           - --listen=/var/run/kmsplugin/socket.sock
           - --health-port=:8086


### PR DESCRIPTION
Replaces the various ways we use to get to the account ID by a single method.