### PR TITLE
pod-metric: adds availability zone label to pod metrics

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1070,7 +1070,7 @@ observability_metrics_pods_labels: "application,component,version,environment,st
 
 observability_metrics_ingresses_labels: ""
 
-observability_metrics_pods_annotations: "zalando.org/zmon-job-metric-stored"
+observability_metrics_pods_annotations: "zalando.org/zmon-job-metric-stored,topology.kubernetes.io/zone"
 
 # opentelemetry collector
 observability_otel_collector_enabled: "true"


### PR DESCRIPTION
## Description

This change will result in otel-collectors to get the `topology.kubernetes.io/zone:<availability-zone>` pod annotation and push it along with the pod metrics into Lightstep as an attribute of those metrics.