### PR TITLE
Give kubernetes-resource-analyzer access to read resources

### DIFF
--- a/cluster/manifests/roles/kubernetes-resource-analyzer.yaml
+++ b/cluster/manifests/roles/kubernetes-resource-analyzer.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubernetes-resource-analyzer
+  labels:
+    application: kubernetes
+    application: resource-analyzer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: readonly
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: zalando-iam:zalando:service:stups_kubernetes


### PR DESCRIPTION
This adds a binding intended for the `kubernetes-resource-analyzer` to get read access to all resources.

It uses the `stups_kubernetes` identity to avoid creating a new Application for this use case.