### PR TITLE
Test enabling rolling of flannel

### DIFF
--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     component: flannel
 spec:
   updateStrategy:
-    type: OnDelete
+    type: RollingUpdate
   selector:
     matchLabels:
       daemonset: kube-flannel
@@ -20,6 +20,7 @@ spec:
         daemonset: kube-flannel
         application: kubernetes
         component: flannel
+        test: rolling
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
         config/hash: {{"configmap.yaml" | manifestHash}}


### PR DESCRIPTION
This validates that updating the flannel image as done in #9371 will not fail the e2e introduced in #9315 validating that the updated flannel image has a fix for dropping traffic when pods are being rotated.