### PR TITLE
Make WIZ Connector default config items conditional to cluster provider

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1265,6 +1265,8 @@ wiz_sensor_memory: "300Mi"
 wiz_connector_cpu: "50m"
 wiz_connector_memory: "150Mi"
 wiz_priority: "true"
+wiz_api_client_id: ""
+wiz_api_client_token: ""
 # Please note when this is set to true it allows the use of the node selector feature
 # to deploy the sensor and connector on specific nodes, by manually setting the node selector label on the nodes.
 # This is useful when you want to deploy the sensor and connector on specific nodes.

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1252,9 +1252,14 @@ role_sync_controller_enabled: "false"
 # When wiz_enable_runtime_sensor and wiz_enable_runtime_connector are set to true,
 # this enables WIZ runtime monitoring. A DaemonSet called Sensor and a Deployment
 # called Connector will be deployed into the cluster.
-wiz_enable_runtime_sensor: "false"
+{{ if eq .Cluster.Provider "zalando-eks" }}
 wiz_enable_runtime_connector: "false"
 wiz_enable_runtime_connector_broker: "false"
+{{ else }}
+wiz_enable_runtime_connector: "true"
+wiz_enable_runtime_connector_broker: "true"
+{{ end }}
+wiz_enable_runtime_sensor: "false"
 wiz_sensor_cpu: "200m"
 wiz_sensor_memory: "300Mi"
 wiz_connector_cpu: "50m"


### PR DESCRIPTION
makes the default config items conditional to prevent deployment of the broker and its associated resources to eks clusters. Neither broker nor connector should be needed with those, as access to Wiz is granted using [access entries](https://docs.aws.amazon.com/eks/latest/userguide/access-entries.html)