### PR TITLE
skipper-ingress: main fleet update to canary in stable

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,6 +1,6 @@
 {{/* image-updater-bot detects *image variables so use print to disable it for main image */}}
 
-{{ $main_image := print "container-registry.zalando.net/teapot/skipper-internal:" "v0.22.52-1159" }}
+{{ $main_image := print "container-registry.zalando.net/teapot/skipper-internal:" "v0.22.59-1166" }}
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.22.62-1169" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}


### PR DESCRIPTION
* https://github.com/zalando/skipper/pull/3534
* https://github.com/zalando/skipper/pull/3539
* https://github.com/zalando/skipper/pull/3531
* https://github.com/zalando/skipper/pull/3542
* https://github.com/zalando/skipper/pull/3541
* https://github.com/zalando/skipper/pull/3546
* https://github.com/zalando/skipper/pull/3549
* https://github.com/zalando/skipper/pull/3551