### PR TITLE
Allow kubernetes-resource-analyzer to read secrets

### DIFF
--- a/cluster/manifests/roles/kubernetes-resource-analyzer.yaml
+++ b/cluster/manifests/roles/kubernetes-resource-analyzer.yaml
@@ -13,3 +13,36 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
   name: zalando-iam:zalando:service:stups_kubernetes
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubernetes-resource-analyzer-secrets
+  labels:
+    application: kubernetes
+    application: resource-analyzer
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubernetes-resource-analyzer-secrets
+  labels:
+    application: kubernetes
+    application: resource-analyzer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubernetes-resource-analyzer-secrets
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: zalando-iam:zalando:service:stups_kubernetes

--- a/cluster/manifests/roles/kubernetes-resource-analyzer.yaml
+++ b/cluster/manifests/roles/kubernetes-resource-analyzer.yaml
@@ -20,7 +20,7 @@ metadata:
   name: kubernetes-resource-analyzer-secrets
   labels:
     application: kubernetes
-    application: resource-analyzer
+    component: resource-analyzer
 rules:
 - apiGroups:
   - ""
@@ -37,7 +37,7 @@ metadata:
   name: kubernetes-resource-analyzer-secrets
   labels:
     application: kubernetes
-    application: resource-analyzer
+    component: resource-analyzer
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
Follow up to #9653 giving the `kubernetes-resource-analyzer` access to also read secrets. It reads the secret resources to determine dependency on PlatformCredenetialsSet and postgres cluster.