### PR TITLE
Support open policy agent buffer type event for decision logging

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -377,6 +377,11 @@ skipper_open_policy_agent_data_preprocessing_optimization_enabled: "false"
 # Default timeout value in seconds for outgoing http calls from Open Policy Agent in a skipper filter
 skipper_open_policy_agent_styra_response_header_timeout: "2"
 
+# Decision logging use event buffer type
+skipper_open_policy_agent_decision_logs_buffer_type_event_enable: "false"
+# Decision logging sets the maximum number of decision log events that can be buffered before being dropped
+skipper_open_policy_agent_decision_logs_buffer_type_event_limit: "1000"
+
 #
 # FabricGateway controller config
 #

--- a/cluster/manifests/skipper/configmap-open-policy-agent.yaml
+++ b/cluster/manifests/skipper/configmap-open-policy-agent.yaml
@@ -31,6 +31,12 @@ data:
             session_name: open-policy-agent-instance
       name: styra-bundles
       url: "{{ .Cluster.ConfigItems.skipper_open_policy_agent_bundles_url }}"
+    {{ if eq .Cluster.ConfigItems.skipper_open_policy_agent_decision_logs_buffer_type_event_enable "true" }}
+    decision_logs:
+      reporting:
+        buffer_type: "event"
+        buffer_size_limit_events: {{ .Cluster.ConfigItems.skipper_open_policy_agent_decision_logs_buffer_type_event_limit }}
+    {{ end }}
   envoymetadata.json: |-
     {
       "filter_metadata": {


### PR DESCRIPTION
# Description
The new event-based buffer is for OPA decision logging designed to reduce lock contention and improve performance at high loads, but sacrifices the memory footprint guarantees of the default buffer.
This PR allows clusters to use this new buffer type with a default buffer size of 1000 events.
