### PR TITLE
skipper-internal: update main to v0.22.62

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,6 +1,6 @@
 {{/* image-updater-bot detects *image variables so use print to disable it for main image */}}
 
-{{ $main_image := print "container-registry.zalando.net/teapot/skipper-internal:" "v0.22.59-1166" }}
+{{ $main_image := print "container-registry.zalando.net/teapot/skipper-internal:" "v0.22.62-1169" }}
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.22.62-1169" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}


### PR DESCRIPTION
Changes: https://github.com/zalando/skipper/compare/v0.22.59...v0.22.62

* https://github.com/zalando/skipper/pull/3544
* https://github.com/zalando/skipper/pull/3543
* https://github.com/zalando/skipper/pull/3536

Canary update: #9657