### PR TITLE
upgrade e2e to go 1.24

### DIFF
--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -1,8 +1,6 @@
 module github.com/zalando-incubator/kubernetes-on-aws/tests/e2e
 
-go 1.23.0
-
-toolchain go1.23.4
+go 1.24.0
 
 require (
 	github.com/evanphx/json-patch v5.6.0+incompatible


### PR DESCRIPTION
Updates the e2e module to use golang version `1.24`.