### PR TITLE
add EFS SG definition and rule for EKS cluster

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -143,6 +143,19 @@ Resources:
       IpProtocol: tcp
       SourceSecurityGroupId: !Ref EKSWorkerSecurityGroup
       ToPort: 443
+  EKSEFSSecurityGroupIngressFromEKSWorkerSecurityGroup:
+    Properties:
+      FromPort: 2049
+      GroupId: !Ref EKSEFSWorkerSecurityGroup
+      IpProtocol: tcp
+      SourceSecurityGroupId: !Ref EKSWorkerSecurityGroup
+      ToPort: 2049
+    Type: 'AWS::EC2::SecurityGroupIngress'
+  EKSEFSWorkerSecurityGroup:
+    Properties:
+      GroupDescription: EKS worker to EFS sg
+      VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
+    Type: 'AWS::EC2::SecurityGroup'
   EKSCluster:
     Type: AWS::EKS::Cluster
     Properties:


### PR DESCRIPTION
This adds a SecurityGroup definition for EFS traffic and then adds an ingress rule from the EKSWorkerSecurityGroup. This is based on how we do it for legacy non-EKS clusters. This is required to enable EFS backed PersistentVolumes in EKS.

I created a somewhat "duplicate" `EKSEFSWorkerSecurityGroup` so that it's easier to drop support for legacy clusters in the future and we don't have overlapping resource between the two clusters.