### PR TITLE
[HOTFIX] [STABLE] Update cluster autoscaler version

### DIFF
--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -38,7 +38,7 @@ spec:
       dnsPolicy: Default
       containers:
       - name: cluster-autoscaler
-        image: container-registry.zalando.net/teapot/kube-cluster-autoscaler:v1.18.2-internal.48
+        image: container-registry.zalando.net/teapot/kube-cluster-autoscaler:v1.18.2-internal.50
         command:
           - ./cluster-autoscaler
           - --v={{.Cluster.ConfigItems.autoscaling_autoscaler_log_level}}


### PR DESCRIPTION
Apply CA version hotfix to stable.

dev PR: https://github.com/zalando-incubator/kubernetes-on-aws/pull/9730
changes: https://github.com/zalando-incubator/autoscaler/pull/113