### PR TITLE
[ALPHA] [HOTFIX] Update Cluster Autoscaler version

### DIFF
--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -38,7 +38,7 @@ spec:
       dnsPolicy: Default
       containers:
       - name: cluster-autoscaler
-        image: container-registry.zalando.net/teapot/kube-cluster-autoscaler:v1.18.2-internal.48
+        image: container-registry.zalando.net/teapot/kube-cluster-autoscaler:v1.18.2-internal.50
         command:
           - ./cluster-autoscaler
           - --v={{.Cluster.ConfigItems.autoscaling_autoscaler_log_level}}


### PR DESCRIPTION
dev-to-alpha e2es do not pass as the cluster creation step initially tries to use the old CA image version which does not work.

This PR introduces the CA version update separately.