### PR TITLE
exclude g6f instance family from Karpenter nodepools

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -51,6 +51,11 @@ karpenter_in_transit_support_required: "false"
 # t type instances have burstable CPU, which can be undesirable in production
 karpenter_instance_family_t_enabled: "false"
 
+# configure whether we allow g6f instance family for Karpenter nodes
+# g6f has fractional GPU count which is also mislabeled by Karpenter and causes
+# scheduling issues, we need to properly test and support it later if needed
+karpenter_instance_family_g6f_enabled: "false"
+
 # configure whether spot instances should be enabled in Karpenter's capacity-types
 karpenter_enable_spot: "true"
 

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -164,6 +164,10 @@ spec:
             - "t3"
             - "t2"
 #{{ end }}
+#{{ if eq .NodePool.ConfigItems.karpenter_instance_family_g6f_enabled "false"}}
+              # g6f has fractional GPU count which is also mislabeled by Karpenter and causes scheduling issues
+            - "g6f"
+#{{ end }}
 #{{ if eq .NodePool.ConfigItems.karpenter_in_transit_support_required "true" }}
         - key: karpenter.k8s.aws/instance-encryption-in-transit-supported
           operator: In


### PR DESCRIPTION
The `g6f` instance family has issues when scheduling workloads, we need to disable it by default and test it properly before we can make it generally available. For now, adding the config-item so we can block provisioning these instances.