### PR TITLE
skipper: update main to v0.22.76

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,6 +1,6 @@
 {{/* image-updater-bot detects *image variables so use print to disable it for main image */}}
 
-{{ $main_image := print "container-registry.zalando.net/teapot/skipper-internal:" "v0.22.62-1169" }}
+{{ $main_image := print "container-registry.zalando.net/teapot/skipper-internal:" "v0.22.76-1183" }}
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.22.76-1183" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}


### PR DESCRIPTION
Compare changes: https://github.com/zalando/skipper/compare/v0.22.62...v0.22.76
Canary update: #9674

* https://github.com/zalando/skipper/pull/3555
* https://github.com/zalando/skipper/pull/3558
* https://github.com/zalando/skipper/pull/3556
* https://github.com/zalando/skipper/pull/3538
* https://github.com/zalando/skipper/pull/3553
* https://github.com/zalando/skipper/pull/3557
* https://github.com/zalando/skipper/pull/3550
* https://github.com/zalando/skipper/pull/3560
* https://github.com/zalando/skipper/pull/3564
* https://github.com/zalando/skipper/pull/3568
* https://github.com/zalando/skipper/pull/3566
* https://github.com/zalando/skipper/pull/3561
* https://github.com/zalando/skipper/pull/3569
* https://github.com/zalando/skipper/pull/3563