### PR TITLE
Add string docs for RBAC read-only testing

### DIFF
--- a/test/e2e/authorization.go
+++ b/test/e2e/authorization.go
@@ -130,6 +130,10 @@ var _ = g.Describe("Authorization [RBAC] [Zalando]", func() {
 		})
 	})
 
+    // NOTE: The read-only role is restricted by RBAC to non-mutating operations.
+    // Such requests bypass the admission controller, which only processes
+    // mutating requests. Admission controller tests for this role are unnecessary,
+    // as access control is fully enforced at the RBAC authorization stage.
 	g.Context("For ReadOnly group", func() {
 		var tc testCase
 		g.BeforeEach(func() {

--- a/test/e2e/authorization.go
+++ b/test/e2e/authorization.go
@@ -134,6 +134,10 @@ var _ = g.Describe("Authorization [RBAC] [Zalando]", func() {
     // Such requests bypass the admission controller, which only processes
     // mutating requests. Admission controller tests for this role are unnecessary,
     // as access control is fully enforced at the RBAC authorization stage.
+    // Flow example:
+    // 1. Request Received → RBAC checks role permissions.
+    // 2. Read-Only Role (`GET`) → Allowed by RBAC, **skips** admission controller.
+    // 3. Read-Only Role (`DELETE`) → Blocked by RBAC, so never reaches admission controller.
 	g.Context("For ReadOnly group", func() {
 		var tc testCase
 		g.BeforeEach(func() {


### PR DESCRIPTION
Adds a docstring to the RBAC read-only role tests explaining that non-mutating requests bypass the admission controller and are enforced solely by RBAC. This clarifies why admission controller testing is unnecessary for this role.