### PR TITLE
update flannel DaemonSet strategy to RollingUpdate

### DIFF
--- a/cluster/manifests/flannel/daemonset.yaml
+++ b/cluster/manifests/flannel/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     component: flannel
 spec:
   updateStrategy:
-    type: OnDelete
+    type: RollingUpdate
   selector:
     matchLabels:
       daemonset: kube-flannel


### PR DESCRIPTION
This is needed to affirm rolling out the fix for the network disruption during node rotation.