### PR TITLE
Add Log Group with expiring retention period for EKS Control Plane logging

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -158,6 +158,9 @@ Resources:
     Type: 'AWS::EC2::SecurityGroup'
   EKSCluster:
     Type: AWS::EKS::Cluster
+{{- if eq .Cluster.ConfigItems.eks_control_plane_logging "true" }}
+    DependsOn: ControlPlaneLogGroup
+{{- end }}
     Properties:
       Name: "{{.Cluster.Name}}"
       Version: "1.32"

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -159,7 +159,9 @@ Resources:
   EKSCluster:
     Type: AWS::EKS::Cluster
 {{- if eq .Cluster.ConfigItems.eks_control_plane_logging "true" }}
+{{- if eq .Cluster.ConfigItems.eks_control_plane_logging_migration "true" }}
     DependsOn: ControlPlaneLogGroup
+{{- end }}
 {{- end }}
     Properties:
       Name: "{{.Cluster.Name}}"

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -3023,6 +3023,16 @@ Resources:
                 - BucketArn: !GetAtt AuditTrailBucket.Arn
 {{- end }}
 
+{{- if eq .Cluster.ConfigItems.eks_control_plane_logging "true" }}
+{{- if eq .Cluster.ConfigItems.eks_control_plane_logging_migration "true" }}
+  ControlPlaneLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: "/aws/eks/{{.Cluster.LocalID}}/cluster"
+      RetentionInDays: 545
+{{- end }}
+{{- end }}
+
 {{- if index .Cluster.ConfigItems "session_manager_destination_arn" }}
   SessionManagerLogGroup:
     Type: AWS::Logs::LogGroup

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1283,6 +1283,7 @@ wiz_node_feature_rollout : "false"
 
 # EKS specific configuration
 eks_control_plane_logging: "true"
+eks_control_plane_logging_migration: "false"
 eks_ip_family: "ipv4"
 eks_zalando_iam_aws_proxy_cpu: "100m"
 eks_zalando_iam_aws_proxy_memory: "512Mi"


### PR DESCRIPTION
Add a new Log Group `ControlPlaneLogGroup` to the main CF stack which allows us to configure the retention period of the EKS Control Plane logs. The name of the Log Group is fixed by EKS and we cannot point the logs to a new Log Group.

For existing EKS clusters, as the Log Group will first need to be manually imported into the Stack, this PR also introduces a helper config item `eks_control_plane_logging_migration` to control when the resource will be applied by CLM.