### PR TITLE
move  credprov rollout date config  to the default configs

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -890,6 +890,9 @@ allow_external_service_accounts: "false"
 # issue tokens with a long expiration time in order to detect applications that don't refresh tokens.
 rotate_service_account_tokens_extended_expiration: "true"
 
+# date of rollout for the credentials provider v2
+credentials_provider_v2_clients_rollout_date: "2025-08-22T14:00:00+02:00"
+
 # Comma separated list of dimensions to include in the Prometheus metrics
 # exposed by audittrail-adapter.
 # Adding more dimensions can help detect which clients are calling the


### PR DESCRIPTION
This config item does not need to be change and it can be in the default with current date