### PR TITLE
Adding playground poweruser policy to deployment services

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1540,7 +1540,7 @@ Resources:
         - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-DenyDefault"
         - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-AllowPowerUser"
         - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-AllowPowerUserCustom"
-        {{- if or (eq .Cluster.Name "playground") (eq .Cluster.Name "testaccount1")}}
+        {{- if eq .Cluster.Name "playground" }}
         - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-AllowPowerUser-Playground"
         {{- end }}
       RoleName: "{{.Cluster.LocalID}}-deployment"
@@ -1694,7 +1694,7 @@ Resources:
         - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-DenyDefault"
         - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-AllowPowerUser"
         - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-AllowPowerUserCustom"
-        {{- if or (eq .Cluster.Name "playground") (eq .Cluster.Name "testaccount1")}}
+        {{- if eq .Cluster.Name "playground" }}
         - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-AllowPowerUser-Playground"
         {{- end }}
 {{- if eq .Cluster.ConfigItems.deployment_service_ml_experiments_enabled "true"}}

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1540,6 +1540,9 @@ Resources:
         - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-DenyDefault"
         - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-AllowPowerUser"
         - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-AllowPowerUserCustom"
+        {{- if or (eq .Cluster.Name "playground") (eq .Cluster.Name "testaccount1")}}
+        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-AllowPowerUser-Playground"
+        {{- end }}
       RoleName: "{{.Cluster.LocalID}}-deployment"
     Type: 'AWS::IAM::Role'
   DeploymentServiceBucket:
@@ -1691,6 +1694,9 @@ Resources:
         - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-DenyDefault"
         - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-AllowPowerUser"
         - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-AllowPowerUserCustom"
+        {{- if or (eq .Cluster.Name "playground") (eq .Cluster.Name "testaccount1")}}
+        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-AllowPowerUser-Playground"
+        {{- end }}
 {{- if eq .Cluster.ConfigItems.deployment_service_ml_experiments_enabled "true"}}
   DeploymentControllerMLExperimentDeploymentRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
Adding playground poweruser policy to deployment services for CI/CD role to have the same permissions as users.