### PR TITLE
skipper-ingress-redis: update image

### DIFF
--- a/cluster/manifests/skipper/skipper-redis.yaml
+++ b/cluster/manifests/skipper/skipper-redis.yaml
@@ -49,7 +49,7 @@ spec:
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       terminationGracePeriodSeconds: 45
       containers:
-      - image: container-registry.zalando.net/library/redis-7-alpine:7-alpine-20240226
+      - image: container-registry.zalando.net/library/redis-7-alpine:7.2-alpine-20250805
         name: skipper-ingress-redis
         args:
         - /usr/local/bin/docker-entrypoint.sh


### PR DESCRIPTION
use image built from GHEC