### PR TITLE
Polarsignals ds fixes

### DIFF
--- a/cluster/manifests/polarsignals/daemonset.yaml
+++ b/cluster/manifests/polarsignals/daemonset.yaml
@@ -37,7 +37,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: container-registry.zalando.net/gwproxy/parca-agent:v0.41.0
+          image: container-registry.zalando.net/gwproxy/parca-agent:v0.41.0-main-1
           name: polarsignals-agent
           ports:
             - containerPort: 7071

--- a/cluster/manifests/polarsignals/daemonset.yaml
+++ b/cluster/manifests/polarsignals/daemonset.yaml
@@ -23,7 +23,6 @@ spec:
     spec:
       containers:
         - args:
-            - /bin/parca-agent
             - --log-level=info
             - --node=$(NODE_NAME)
             - --http-address=:7071

--- a/cluster/manifests/polarsignals/daemonset.yaml
+++ b/cluster/manifests/polarsignals/daemonset.yaml
@@ -41,10 +41,6 @@ spec:
           ports:
             - containerPort: 7071
               name: http
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: http
           resources:
             limits:
               cpu: "{{ .Cluster.ConfigItems.polarsignals_cpu}}"

--- a/cluster/manifests/polarsignals/daemonset.yaml
+++ b/cluster/manifests/polarsignals/daemonset.yaml
@@ -85,8 +85,6 @@ spec:
         - effect: NoSchedule
           key: dedicated
           value: skipper-ingress
-        - effect: NoExecute
-          operator: Exists
       volumes:
         - emptyDir: {}
           name: tmp


### PR DESCRIPTION
This adds some fixes for the polarsignals daemonset instroduced in #9783 

1. Fix image name (was missing `main-1` suffix in version)
2. Drop NoExecute toleration which our admission-controller doesn't allow as it would mean the DS _could_ run on master nodes. The DS is deployed in a non-system namespace `polarsignals` and therefore not allowed. Alternative solution is to make polarsignals namespace a system namespace. This requires a change in admission-controller.
3. Drop the `/bin/parca-agent` from `args` it's already defined as command in the dockerfile
4. Remove Readiness Probe which fails and is also not defined upstream: https://www.parca.dev/docs/kubernetes/#setting-up-parca-agent