### PR TITLE
Allow downscaling statefulsets

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -554,6 +554,8 @@ downscaler_default_uptime: "always"
 downscaler_default_downtime: "never"
 downscaler_enabled: "false"
 {{end}}
+# optionally enable downscaling of statefulsets
+downscaler_scale_statefulsets: "false"
 
 # HPA settings (defaults from https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/)
 horizontal_pod_autoscaler_sync_period: "30s"

--- a/cluster/manifests/kube-downscaler/deployment.yaml
+++ b/cluster/manifests/kube-downscaler/deployment.yaml
@@ -34,10 +34,10 @@ spec:
           - --interval=30
           - --exclude-namespaces=kube-system,visibility,tracing,wiz
           # do not downscale ourselves, also keep Postgres Operator so excluded DBs can be managed
-          - --exclude-deployments=kube-downscaler,postgres-operator
+          - --exclude-deployments=kube-downscaler{{if ne .Cluster.ConfigItems.downscaler_scale_statefulsets "true"}},postgres-operator{{end}}
           - "--default-uptime={{ .Cluster.ConfigItems.downscaler_default_uptime }}"
           - "--default-downtime={{ .Cluster.ConfigItems.downscaler_default_downtime }}"
-          - --include-resources=deployments,stacks
+          - --include-resources=deployments,stacks{{if eq .Cluster.ConfigItems.downscaler_scale_statefulsets "true"}},statefulsets{{end}}
           - --deployment-time-annotation=deployment-time
         resources:
           limits:


### PR DESCRIPTION
Optionally allow downscaling `statefulsets` via `kube-downscaler`.

This was previously disabled in #3179

The intention is to re-visit this and see if there is an opportunity for easy cost savings. It's still disabled by default but can be enabled per cluster.