### PR TITLE
fix: parca-agent restart oom

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -262,7 +262,7 @@ skipper_pod_deletion_cost_controller_resync_interval: "1h"
 # right now only installed on skipper-ingress nodes
 polarsignals_enabled: "false"
 polarsignals_apikey: ""
-polarsignals_memory: 200Mi
+polarsignals_memory: 400Mi
 polarsignals_cpu: 50m
 
 # Kube-Metrics-Adapter

--- a/cluster/manifests/polarsignals/daemonset.yaml
+++ b/cluster/manifests/polarsignals/daemonset.yaml
@@ -17,6 +17,10 @@ spec:
       application: polarsignals
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: 7071
+        prometheus.io/scrape: "true"
       labels:
         component: agent
         application: polarsignals


### PR DESCRIPTION
fix: parca-agent restart oom
fix: parca-agent was not scraped by prometheus