### PR TITLE
Drop additional EKS control plane log config item after migration

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -159,9 +159,7 @@ Resources:
   EKSCluster:
     Type: AWS::EKS::Cluster
 {{- if eq .Cluster.ConfigItems.eks_control_plane_logging "true" }}
-{{- if eq .Cluster.ConfigItems.eks_control_plane_logging_migration "true" }}
     DependsOn: ControlPlaneLogGroup
-{{- end }}
 {{- end }}
     Properties:
       Name: "{{.Cluster.Name}}"
@@ -2337,8 +2335,8 @@ Resources:
             Version: 2012-10-17
           PolicyName: root
       RoleName: "{{.Cluster.LocalID}}-etcd-backup"
-{{- end }}
     Type: 'AWS::IAM::Role'
+{{- end }}
   StaticEgressControllerIAMRole:
     Properties:
       AssumeRolePolicyDocument: !Sub
@@ -3035,13 +3033,11 @@ Resources:
 {{- end }}
 
 {{- if eq .Cluster.ConfigItems.eks_control_plane_logging "true" }}
-{{- if eq .Cluster.ConfigItems.eks_control_plane_logging_migration "true" }}
   ControlPlaneLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: "/aws/eks/{{.Cluster.LocalID}}/cluster"
+      LogGroupName: "/aws/eks/{{.Cluster.Name}}/cluster"
       RetentionInDays: 545
-{{- end }}
 {{- end }}
 
 {{- if index .Cluster.ConfigItems "session_manager_destination_arn" }}

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -156,6 +156,13 @@ Resources:
       GroupDescription: EKS worker to EFS sg
       VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
     Type: 'AWS::EC2::SecurityGroup'
+{{- if eq .Cluster.ConfigItems.eks_control_plane_logging "true" }}
+  ControlPlaneLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: "/aws/eks/{{.Cluster.Name}}/cluster"
+      RetentionInDays: 545
+{{- end }}
   EKSCluster:
     Type: AWS::EKS::Cluster
 {{- if eq .Cluster.ConfigItems.eks_control_plane_logging "true" }}
@@ -3030,14 +3037,6 @@ Resources:
               - !Sub
                 - "${BucketArn}/*"
                 - BucketArn: !GetAtt AuditTrailBucket.Arn
-{{- end }}
-
-{{- if eq .Cluster.ConfigItems.eks_control_plane_logging "true" }}
-  ControlPlaneLogGroup:
-    Type: AWS::Logs::LogGroup
-    Properties:
-      LogGroupName: "/aws/eks/{{.Cluster.Name}}/cluster"
-      RetentionInDays: 545
 {{- end }}
 
 {{- if index .Cluster.ConfigItems "session_manager_destination_arn" }}

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1287,7 +1287,6 @@ wiz_node_feature_rollout : "false"
 
 # EKS specific configuration
 eks_control_plane_logging: "true"
-eks_control_plane_logging_migration: "false"
 eks_ip_family: "ipv4"
 eks_zalando_iam_aws_proxy_cpu: "100m"
 eks_zalando_iam_aws_proxy_memory: "512Mi"

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -56,6 +56,7 @@ clusters:
     consolidate_after: "5m"
     wiz_api_client_id: "${WIZ_API_CLIENT_ID}"
     wiz_api_client_token: "${WIZ_API_CLIENT_TOKEN}"
+    eks_control_plane_logging: "false"
   criticality_level: 1
   environment: e2e
   id: ${CLUSTER_ID}


### PR DESCRIPTION
Follow up to https://github.com/zalando-incubator/kubernetes-on-aws/pull/9777

Now that the Log Groups have been imported into the Cluster Stacks, we can drop the helper config item: `eks_control_plane_logging_migration`. Also update the template variable for the LogGroupName to `Cluster.Name`.

This change also temporarily stops the control plane logging in e2e clusters to solve the issue of the Cluster Stack attempting to create a conflicting Resource. Currently, on the first parse of the create-cluster-eks step, the EKS Cluster is created as well as the Control Plane Log Group, however the Log Group is not part of the Stack. Upon applying the PR changes, the Log Group resource fails to create as a Log Group with the same name (created on the first parse) already exists but was never imported. A follow up PR will be created to re-enable the logging in e2e. This issue will then be avoided as the Log Group will not exist in new e2e clusters on the first parse and will only be created upon the PR changes being applied. From then on, the Log Group will already be part of the Cluster Stack.

