### PR TITLE
Re-enable EKS Control Plane logging in e2es

### DIFF
--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -56,7 +56,6 @@ clusters:
     consolidate_after: "5m"
     wiz_api_client_id: "${WIZ_API_CLIENT_ID}"
     wiz_api_client_token: "${WIZ_API_CLIENT_TOKEN}"
-    eks_control_plane_logging: "false"
   criticality_level: 1
   environment: e2e
   id: ${CLUSTER_ID}


### PR DESCRIPTION
This PR Re-enables EKS Control Plane logging in e2es, additional context from the previous PR https://github.com/zalando-incubator/kubernetes-on-aws/pull/9805:

> This change also temporarily stops the control plane logging in e2e clusters to solve the issue of the Cluster Stack attempting to create a conflicting Resource. Currently, on the first parse of the create-cluster-eks step, the EKS Cluster is created as well as the Control Plane Log Group, however the Log Group is not part of the Stack. Upon applying the PR changes, the Log Group resource fails to create as a Log Group with the same name (created on the first parse) already exists but was never imported. A follow up PR will be created to re-enable the logging in e2e. This issue will then be avoided as the Log Group will not exist in new e2e clusters on the first parse and will only be created upon the PR changes being applied. From then on, the Log Group will already be part of the Cluster Stack.