### PR TITLE
Make the IAM proxy's endpoint available via the alias

### DIFF
--- a/cluster/manifests/zalando-iam-aws-proxy/routegroup.yaml
+++ b/cluster/manifests/zalando-iam-aws-proxy/routegroup.yaml
@@ -9,7 +9,7 @@ metadata:
     component: zalando-iam-aws-proxy
 spec:
   hosts:
-    - {{.Cluster.LocalID}}.{{ .Values.hosted_zone }}
+    - {{.Cluster.Alias}}.{{ .Values.hosted_zone }}
   backends:
     - name: zalando-iam-aws-proxy
       type: service


### PR DESCRIPTION
If `Alias != LocalID`, let's use the Alias for zalando-iam-proxy's endpoint.