### PR TITLE
update: skipper-ingress main fleet

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,6 +1,6 @@
 {{/* image-updater-bot detects *image variables so use print to disable it for main image */}}
 
-{{ $main_image := print "container-registry.zalando.net/teapot/skipper-internal:v0.22.88-1195" }}
+{{ $main_image := print "container-registry.zalando.net/teapot/skipper-internal:v0.22.102-1209" }}
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.22.102-1209" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}


### PR DESCRIPTION
update: skipper-ingress main fleet
[performance optimization](https://github.com/zalando/skipper/releases/tag/v0.22.97) of a predicate used in all fabricgateways per lookup of 100x times faster per route

ref canary https://github.com/zalando-incubator/kubernetes-on-aws/pull/9781