### PR TITLE
[EKS] Manage kube-proxy as an addon

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -295,6 +295,12 @@ Resources:
     Properties:
       AddonName: eks-pod-identity-agent
       ClusterName: !Ref EKSCluster
+  EKSAddonKubeProxy:
+    Type: AWS::EKS::Addon
+    Properties:
+      AddonName: kube-proxy
+      AddonVersion: "v1.33.3-eksbuild.6"
+      ClusterName: !Ref EKSCluster
   {{ if eq .Cluster.Environment "e2e" }}
   E2EEKSIAMTestRoleReadOnly:
     Properties:

--- a/cluster/manifests/02-admission-control/teapot.yaml
+++ b/cluster/manifests/02-admission-control/teapot.yaml
@@ -139,6 +139,14 @@ webhooks:
         apiVersions: ["v1"]
         resources: ["nodes"]
   - name: configmap-admitter.teapot.zalan.do
+{{- if eq .Cluster.Provider "zalando-eks"}}
+    # avoid admission-control applying to the admission-controller components (🐔🥚)
+    objectSelector:
+      matchExpressions:
+        - key: eks.amazonaws.com/component
+          operator: NotIn
+          values: ["kube-proxy"]
+{{- end }}
     clientConfig:
       {{- if eq .Cluster.Provider "zalando-eks"}}
       service:


### PR DESCRIPTION
Manage `kube-proxy` as an EKS addon.

The motivation for this is that currently `kube-proxy` is not managed on EKS meaning it's set up when the cluster is created by EKS, but afterwards it's not updated. We currently run v1.31 in some v1.33 clusters.

By adding it as an addon we can update the version over time.

The change in the admission controller config is needed to allow EKS to delete the addon during cluster deletion.