### PR TITLE
eks-pod-identity-agent: Update to latest version

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -294,6 +294,7 @@ Resources:
     Type: AWS::EKS::Addon
     Properties:
       AddonName: eks-pod-identity-agent
+      AddonVersion: "v1.3.8-eksbuild.2"
       ClusterName: !Ref EKSCluster
   {{ if eq .Cluster.Environment "e2e" }}
   E2EEKSIAMTestRoleReadOnly:


### PR DESCRIPTION
Update to latest version of the `eks-pod-identity-agent` addon. Without this the version stays at the version which was available when the cluster was created.