### PR TITLE
Disable gr6f instance-types

### DIFF
--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -167,6 +167,7 @@ spec:
 #{{ if eq .NodePool.ConfigItems.karpenter_instance_family_g6f_enabled "false"}}
               # g6f has fractional GPU count which is also mislabeled by Karpenter and causes scheduling issues
             - "g6f"
+            - "gr6f"
 #{{ end }}
 #{{ if eq .NodePool.ConfigItems.karpenter_in_transit_support_required "true" }}
         - key: karpenter.k8s.aws/instance-encryption-in-transit-supported


### PR DESCRIPTION
Disable `gr6f` instance types because:

1. Has the same karpenter scheduling issue as `g6f`
2. Doesn't work on our AMI because of no available tesla driver (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/install-nvidia-driver.html#nvidia-driver-types)
3. Documented use case is video encoding, not the common use case for GPUs at Zalando (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/install-nvidia-driver.html#nvidia-driver-types)