### PR TITLE
fabric-gateway: remove namespace for validation

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -32,10 +32,8 @@ post_apply:
 {{ end }}
 {{ if ne .Cluster.ConfigItems.fabric_gateway_custom_validation_enabled "true" }}
 - name: "fabricgateway-policy.zalando.org"
-  namespace: default
   kind: ValidatingAdmissionPolicy
 - name: "fabricgateway-policy.zalando.org"
-  namespace: default
   kind: ValidatingAdmissionPolicyBinding
 {{ end }}
 {{ if ne .Cluster.ConfigItems.polarsignals_enabled "true" }}


### PR DESCRIPTION
The resource shouldn't be namespaced.