### PR TITLE
kube-proxy: verbose level 1

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -438,7 +438,7 @@ kube_proxy_cpu: "50m"
 kube_proxy_memory_request: "200Mi"
 kube_proxy_memory_limit: "200Mi"
 kube_proxy_sync_period: "15m0s"
-kube_proxy_verbose_level: "2"
+kube_proxy_verbose_level: "1"
 
 # kube-node-decommissioner
 kube_node_decommissioner_enabled: "true"


### PR DESCRIPTION
In Kubernetes v1.33, kube-proxy has new verbose 2 level logging introduced: https://github.com/kubernetes/kubernetes/blob/74cdb4273add43f53ddcad2de8ea9fd93c810dc4/pkg/proxy/topology.go#L192-L195

This leads to high (top 10) log volume after rolling out to test clusters.

Set the default to verbose: 1 to reduce the log volume.