### PR TITLE
Fix AWS permissions for aws-cloud-controller-manager

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -2249,6 +2249,7 @@ Resources:
             - "autoscaling:DescribeLaunchConfigurations"
             - "autoscaling:DescribeTags"
             - "ec2:DescribeInstances"
+            - "ec2:DescribeInstanceTopology"
             - "ec2:DescribeRegions"
             - "ec2:DescribeRouteTables"
             - "ec2:DescribeSecurityGroups"

--- a/cluster/manifests/aws-cloud-controller-manager/daemonset.yaml
+++ b/cluster/manifests/aws-cloud-controller-manager/daemonset.yaml
@@ -30,6 +30,9 @@ spec:
         - --configure-cloud-routes=false
         image: container-registry.zalando.net/teapot/aws-cloud-controller-manager-internal:v1.32.3-master-149
         name: aws-cloud-controller-manager
+        env:
+        - name: AWS_REGION
+          value: "{{ .Cluster.Region }}"
         resources:
           requests:
             cpu: "{{ .Cluster.ConfigItems.aws_cloud_controller_manager_cpu }}"


### PR DESCRIPTION
This fixes a couple of issues with the `aws-cloud-controller-manager`

* Set `AWS_REGION` which is _sometimes_? required as it's using aws-sdk-go v2 since v1.32.0.
* Add permission for `ec2:DescribeInstanceTopology` which is required since v1.32.2

These issues was identified in logs:

```
Error describing instance topology: "operation error EC2: DescribeInstanceTopology, get identity: get credentials: failed to refresh cached credentials, failed to retrieve credentials, operation error STS: AssumeRoleWithWebIdentity, failed to resolve service endpoint, endpoint rule error, Invalid Configuration: Missing Region"
```

```
Not authorized to perform: ec2:DescribeInstanceTopology, permission missing: "operation error EC2: DescribeInstanceTopology
```