### PR TITLE
Revert "aws-mountpoint-s3-csi-driver: Update to version v2.0.0-master-32"

### DIFF
--- a/cluster/manifests/s3-csi-driver/daemonset.yaml
+++ b/cluster/manifests/s3-csi-driver/daemonset.yaml
@@ -48,7 +48,7 @@ spec:
               fieldPath: spec.nodeName
         - name: HOST_PLUGIN_DIR
           value: /opt/podruntime/kubelet/plugins/s3.csi.aws.com/
-        image: container-registry.zalando.net/teapot/aws-mountpoint-s3-csi-driver:v2.0.0-master-32
+        image: container-registry.zalando.net/teapot/aws-mountpoint-s3-csi-driver:v1.14.1-master-30
         resources:
           requests:
             cpu: 1m
@@ -134,7 +134,7 @@ spec:
         env:
         - name: MOUNTPOINT_INSTALL_DIR
           value: /target
-        image: container-registry.zalando.net/teapot/aws-mountpoint-s3-csi-driver:v2.0.0-master-32
+        image: container-registry.zalando.net/teapot/aws-mountpoint-s3-csi-driver:v1.14.1-master-30
         imagePullPolicy: IfNotPresent
         name: install-mountpoint
         resources:


### PR DESCRIPTION
Reverts zalando-incubator/kubernetes-on-aws#9865

Revert until version v2.0.0 is properly tested, currently it doesn't work.