### PR TITLE
skipper-ingress: fix main image formatting

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,6 +1,6 @@
 {{/* image-updater-bot detects *image variables so use print to disable it for main image */}}
 
-{{ $main_image := print "container-registry.zalando.net/teapot/skipper-internal:v0.22.103-1210" }}
+{{ $main_image := print "container-registry.zalando.net/teapot/skipper-internal:" "v0.22.103-1210" }}
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.22.103-1210" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}


### PR DESCRIPTION
Main image value formatted via print to prevent image updater bot to update it automatically along with canary image.

This PR restores formatting broken by #9787