### PR TITLE
Exclude kube-proxy in admission config

### DIFF
--- a/cluster/manifests/02-admission-control/teapot.yaml
+++ b/cluster/manifests/02-admission-control/teapot.yaml
@@ -339,6 +339,9 @@ webhooks:
         - key: component
           operator: NotIn
           values: ["admission-controller", "aws-node", "coredns"]
+        - key: k8s-app
+          operator: NotIn
+          values: ["kube-proxy"]
 {{- end }}
     clientConfig:
       {{- if eq .Cluster.Provider "zalando-eks"}}


### PR DESCRIPTION
Follow up to #9840 

We need to also exclude `kube-proxy` service account from the admission-controller, otherwise the kube-proxy addon fails to delete during cluster deletion and thus the CF Stack deletion fails.