### PR TITLE
skipper-internal: Update main fleet to version v0.22.115-1222

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,6 +1,7 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.22.103-1210" }}
+{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.22.115-1222" }}
+)
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.22.115-1222" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,7 +1,6 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
 {{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.22.115-1222" }}
-)
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.22.115-1222" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}


### PR DESCRIPTION
* https://github.com/zalando/skipper/pull/3610
* https://github.com/zalando/skipper/pull/3613
* https://github.com/zalando/skipper/pull/3614
* https://github.com/zalando/skipper/pull/3618
* https://github.com/zalando/skipper/pull/3616
* https://github.com/zalando/skipper/pull/3617
* https://github.com/zalando/skipper/pull/3615
* https://github.com/zalando/skipper/pull/3619
* https://github.com/zalando/skipper/pull/3603
* https://github.com/zalando/skipper/pull/3623
* https://github.com/zalando/skipper/pull/3626
* https://github.com/zalando/skipper/pull/3622
* https://github.com/zalando/skipper/pull/3624
* https://github.com/zalando/skipper/pull/3625

follow up on https://github.com/zalando-incubator/kubernetes-on-aws/pull/9912