### PR TITLE
Do not allow Karpenter to disrupt nodes due to Drift

### DIFF
--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -278,6 +278,9 @@ spec:
     # limit the maximum number of nodes that can be removed from the NodePool at once to 10 nodes for clusters with gte 200 nodes
     budgets:
       - nodes: "5%"
+        reasons: 
+        - "Empty"
+        - "Underutilized"
       - nodes: "10"
         reasons: 
         - "Empty"

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -279,6 +279,13 @@ spec:
     budgets:
       - nodes: "5%"
       - nodes: "10"
+        reasons: 
+        - "Empty"
+        - "Underutilized"
+      # Do not allow nodes to be disrupted due to Drift.
+      - nodes: "0"
+        reasons: 
+        - "Drifted"
     # Describes which types of Nodes Karpenter should consider for consolidation
     # If using 'WhenEmptyOrUnderutilized', Karpenter will consider all nodes for consolidation and attempt to remove or replace Nodes when it discovers that the Node is underutilized and could be changed to reduce cost
     # If using `WhenEmpty`, Karpenter will only consider nodes for consolidation that contain no workload pods


### PR DESCRIPTION
We rely on internal components to implement the same logic as Drift disruption by Karpenter. Additionally, Karpenter does not respect our internal features (e.g. to block node disruption during cluster updates) and SLAs for forced node rotations.

This PR configures the Karpenter disruption budget to disable node disruption due to Drift.