### PR TITLE
Update default-for-karpenter 7th / 8th gen instances

### DIFF
--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -209,12 +209,8 @@ spec:
             - "c7i"
             - "m7i"
             - "r7i"
-            - "c7id"
-            - "m7id"
-            - "r7id"
-            - "c7in"
-            - "m7in"
-            - "r7in"
+            - "m8i"
+            - "r8i"
 #{{ else if (eq .NodePool.KarpenterInstanceTypeStrategy "custom" ) }}
         - key: "node.kubernetes.io/instance-type"
           operator: In


### PR DESCRIPTION
Some instance types included in the `default-for-karpenter` list are non-existent and should be removed. For the intel `i` option instances in the 7th generation, the additional storage `d` and network/EBS `n` specialisations do not exist.

Also add the new 8th gen intel types: 
```
m8i # general purpose
r8i # memory optimised
```

The compute optimised `c8i` is not (yet?) available.