### PR TITLE
Update to image container-registry-test.zalando.net/teapot/skipper-test:pr-3562-59

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,7 +1,7 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.22.103-1210" }}
-{{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.22.115-1222" }}
+{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-test:pr-3562-59" }}
+{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-test:pr-3562-59" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}
 {{ $canary_args := "" }}


### PR DESCRIPTION
To test pre-loading feature for OPA filters