### PR TITLE
docs: Add field descriptions to sandbox CRD spec

### DIFF
--- a/cluster/manifests/sandbox-controller/10-sandbox_crd.yaml
+++ b/cluster/manifests/sandbox-controller/10-sandbox_crd.yaml
@@ -28,11 +28,16 @@ spec:
                 - target
               properties:
                 testContext:
+                  description: |-
+                    Specifies the value used to identify requests that can be routed to the sandbox target.
+                    The format of the incoming `X-Zalando-Client-Id` header should be: `test:$testContext:.*`.
                   type: string
                 sourceHosts:
+                  description: Traffic to these hosts will be rerouted to the targetHost if testContext matches.
                   type: array
                   items:
                     type: string
                 target:
+                  description: The target host of the sandboxed traffic.
                   type: string
 {{ end }}


### PR DESCRIPTION
Enhanced the sandbox Custom Resource Definition by adding descriptions for the testContext, sourceHosts, and target fields. The descriptions clarify how testContext is used for request routing with X-Zalando-Client-Id headers, explain that sourceHosts defines which traffic gets rerouted when testContext matches, and specify that target represents the destination host for sandboxed traffic.