### PR TITLE
skipper/hostname-credentials-controller: configure ttlSecondsAfterFinished

### DIFF
--- a/cluster/manifests/skipper/hostname-credentials-controller.yaml
+++ b/cluster/manifests/skipper/hostname-credentials-controller.yaml
@@ -106,6 +106,9 @@ spec:
   schedule: "* * * * *"
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 600
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  ttlSecondsAfterFinished: 300
   jobTemplate:
     spec:
       activeDeadlineSeconds: 30


### PR DESCRIPTION
Configure ttlSecondsAfterFinished to clean up failed jobs earlier (failed job pods are collected by generic-garbage-collector) such that sporadic failures (e.g. due to k8s API ratelimit) which trigger pods-not-running alert resolve faster.

Also configure default failedJobsHistoryLimit and successfulJobsHistoryLimit explicitly.