### PR TITLE
Update to platform-iam-tokeninfo built from GHEC

### DIFF
--- a/cluster/manifests/zalando-iam-aws-proxy/deployment.yaml
+++ b/cluster/manifests/zalando-iam-aws-proxy/deployment.yaml
@@ -49,7 +49,7 @@ spec:
             sleep:
               seconds: 20
       - name: tokeninfo
-        image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/foundation/platform-iam-tokeninfo:master-154
+        image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/foundation/platform-iam-tokeninfo:master-156
         env:
         - name: OPENID_PROVIDER_CONFIGURATION_URL
           value: https://identity.zalando.com/.well-known/openid-configuration
@@ -79,7 +79,7 @@ spec:
             memory: 100Mi
       # {{- if ne .Cluster.Environment "production"}}
       - name: tokeninfo-sandbox
-        image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/foundation/platform-iam-tokeninfo:master-154
+        image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/foundation/platform-iam-tokeninfo:master-156
         env:
         - name: OPENID_PROVIDER_CONFIGURATION_URL
           value: https://sandbox.identity.zalando.com/.well-known/openid-configuration

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -370,7 +370,7 @@ write_files:
           - mountPath: /etc/kubernetes/k8s-authnz-webhook-kubeconfig
             name: k8s-authnz-webhook-kubeconfig
             readOnly: true
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/foundation/platform-iam-tokeninfo:master-154
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/foundation/platform-iam-tokeninfo:master-156
           name: tokeninfo
           ports:
             - containerPort: 9021
@@ -401,7 +401,7 @@ write_files:
               value: {{ .Cluster.ConfigItems.apiserver_business_partner_ids }}
 {{ if ne .Cluster.Environment "production" }}
         - name: tokeninfo-sandbox
-          image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/foundation/platform-iam-tokeninfo:master-154
+          image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/foundation/platform-iam-tokeninfo:master-156
           ports:
           - containerPort: 9022
           lifecycle:


### PR DESCRIPTION
Updates to the latest `platform-iam-tokeninfo` built from GHEC and without CVEs.