### PR TITLE
Exclude kube-proxy from admission-controller

### DIFF
--- a/cluster/manifests/02-admission-control/teapot.yaml
+++ b/cluster/manifests/02-admission-control/teapot.yaml
@@ -537,6 +537,9 @@ webhooks:
         - key: component
           operator: NotIn
           values: ["admission-controller"]
+        - key: eks.amazonaws.com/component
+          operator: NotIn
+          values: ["kube-proxy"]
 {{- end }}
     clientConfig:
       {{- if eq .Cluster.Provider "zalando-eks"}}


### PR DESCRIPTION
Similar to #9919 extending to one more admission endpoint which can fail during update:

<img width="1454" height="140" alt="image" src="https://github.com/user-attachments/assets/882d2268-7bae-4a78-87c9-c9de5b115ee5" />
