### PR TITLE
Revert "skipper/hostname-credentials-controller: configure ttlSecondsAfterFinished

### DIFF
--- a/cluster/manifests/skipper/hostname-credentials-controller.yaml
+++ b/cluster/manifests/skipper/hostname-credentials-controller.yaml
@@ -106,9 +106,6 @@ spec:
   schedule: "* * * * *"
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 600
-  failedJobsHistoryLimit: 1
-  successfulJobsHistoryLimit: 3
-  ttlSecondsAfterFinished: 300
   jobTemplate:
     spec:
       activeDeadlineSeconds: 30


### PR DESCRIPTION
This reverts commit 36b671ea8421d8c9d8e111bfc69b51c18dca205d (#9964).
```
The request is invalid: patch: Invalid value ... strict decoding error: unknown field "spec.ttlSecondsAfterFinished"
```

