### PR TITLE
skipper/hostname-credentials-controller: fix ttlSecondsAfterFinished

### DIFF
--- a/cluster/manifests/skipper/hostname-credentials-controller.yaml
+++ b/cluster/manifests/skipper/hostname-credentials-controller.yaml
@@ -106,10 +106,13 @@ spec:
   schedule: "* * * * *"
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 600
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
   jobTemplate:
     spec:
       activeDeadlineSeconds: 30
       backoffLimit: 0
+      ttlSecondsAfterFinished: 300
       template:
         metadata:
           labels:


### PR DESCRIPTION
ttlSecondsAfterFinished should be in the job spec.

Follow up on #9964