### PR TITLE
Make e2e more stable via retries

### DIFF
--- a/test/e2e/apiserver.go
+++ b/test/e2e/apiserver.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/job"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
@@ -262,12 +263,19 @@ var _ = describe("Image Policy Tests (Pods Update Path)", func() {
 
 		By("Updating pod " + namePrefix + " in namespace " + namespace)
 
-		pod, err = cs.CoreV1().Pods(namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			// Get the latest version of the resource
+			pod, err = cs.CoreV1().Pods(namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
 
-		pod.Spec.Containers[0].Image = compliantImage4
+			pod.Spec.Containers[0].Image = compliantImage4
 
-		_, err = cs.CoreV1().Pods(namespace).Update(context.TODO(), pod, metav1.UpdateOptions{})
+			// Try to update
+			_, err = cs.CoreV1().Pods(namespace).Update(context.TODO(), pod, metav1.UpdateOptions{})
+			return err
+		})
 		framework.ExpectNoError(err)
 
 		_, err = e2epod.WaitForPodsWithLabelRunningReady(context.TODO(), cs, namespace, appLabelSelector(appLabel), 1, waitForPodTimeout)
@@ -295,14 +303,21 @@ var _ = describe("Image Policy Tests (Pods Update Path)", func() {
 		_, err = e2epod.WaitForPodsWithLabelRunningReady(context.TODO(), cs, namespace, appLabelSelector(appLabel), 1, waitForPodTimeout)
 		framework.ExpectNoError(err)
 
-		pod, err = cs.CoreV1().Pods(namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
-
 		By("Updating pod " + namePrefix + " in namespace " + namespace)
 
-		pod.Spec.Containers[0].Image = nonCompliantImage5
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			// Get the latest version of the resource
+			pod, err = cs.CoreV1().Pods(namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
 
-		_, err = cs.CoreV1().Pods(namespace).Update(context.TODO(), pod, metav1.UpdateOptions{})
+			pod.Spec.Containers[0].Image = nonCompliantImage5
+
+			// Try to update
+			_, err = cs.CoreV1().Pods(namespace).Update(context.TODO(), pod, metav1.UpdateOptions{})
+			return err
+		})
 		Expect(err).To(HaveOccurred())
 	})
 })
@@ -337,14 +352,21 @@ var _ = describe("Image Policy Tests (Pods Update Path) (when disabled)", func()
 		_, err = e2epod.WaitForPodsWithLabelRunningReady(context.TODO(), cs, namespace, appLabelSelector(appLabel), 1, waitForPodTimeout)
 		framework.ExpectNoError(err)
 
-		pod, err = cs.CoreV1().Pods(namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
-
 		By("Updating pod " + namePrefix + " in namespace " + namespace)
 
-		pod.Spec.Containers[0].Image = nonCompliantImage6
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			// Get the latest version of the resource
+			pod, err = cs.CoreV1().Pods(namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
 
-		_, err = cs.CoreV1().Pods(namespace).Update(context.TODO(), pod, metav1.UpdateOptions{})
+			pod.Spec.Containers[0].Image = nonCompliantImage6
+
+			// Try to update
+			_, err = cs.CoreV1().Pods(namespace).Update(context.TODO(), pod, metav1.UpdateOptions{})
+			return err
+		})
 		framework.ExpectNoError(err)
 
 		_, err = e2epod.WaitForPodsWithLabelRunningReady(context.TODO(), cs, namespace, appLabelSelector(appLabel), 1, waitForPodTimeout)


### PR DESCRIPTION
Some e2e tests can fail because of trying to update a pod which was updated in the meantime:

```
  I1001 13:14:09.178537 29 apiserver.go:271] Unexpected error: 
      <*errors.StatusError | 0xc000919b80>: 
      Operation cannot be fulfilled on pods "image-policy-test-compliant-a1dc085a-1ac8-4bb9-9fcb-813dcb5c075c": the object has been modified; please apply your changes to the latest version and try again
      {
          ErrStatus: 
              code: 409
              details:
                kind: pods
                name: image-policy-test-compliant-a1dc085a-1ac8-4bb9-9fcb-813dcb5c075c
              message: 'Operation cannot be fulfilled on pods "image-policy-test-compliant-a1dc085a-1ac8-4bb9-9fcb-813dcb5c075c":
                the object has been modified; please apply your changes to the latest version and
                try again'
              metadata: {}
              reason: Conflict
              status: Failure,
      }
  STEP: Delete a pod: image-policy-test-compliant-a1dc085a-1ac8-4bb9-9fcb-813dcb5c075c @ 10/01/25 13:14:09.178
  [FAILED] in [It] - /workspace/test/e2e/apiserver.go:271 @ 10/01/25 13:14:09.258
```

Make those tests more robust with a retry on conflict error