### PR TITLE
fix: update skipper validation webhook version to enable forward backend

### DIFF
--- a/cluster/manifests/02-skipper-validation-webhook/deployment.yaml
+++ b/cluster/manifests/02-skipper-validation-webhook/deployment.yaml
@@ -32,7 +32,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
       - name: skipper-admission-webhook
-        image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/skipper:v0.22.102
+        image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/skipper:v0.22.119
         args:
           - webhook
           - --address=:9085

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -260,7 +260,7 @@ write_files:
               name: admission-controller-kubeconfig
               readOnly: true
         - name: skipper-admission-webhook
-          image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/skipper:v0.22.103
+          image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/skipper:v0.22.119
           args:
             - webhook
             - --address=:9085
@@ -437,7 +437,7 @@ write_files:
             value: {{ .Cluster.ConfigItems.apiserver_business_partner_ids }}
 {{ end }}
         - name: skipper-proxy
-          image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/skipper:v0.22.103
+          image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/skipper:v0.22.119
           args:
           - skipper
           - -access-log-strip-query


### PR DESCRIPTION
fix: update skipper validation webhook version to enable `<forward>`  backend