### PR TITLE
Drop eks_fis_namespaces config-item

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1304,7 +1304,6 @@ eks_zalando_iam_aws_proxy_hpa_cpu_target: "80"
 eks_zalando_iam_aws_proxy_hpa_memory_target: "80"
 eks_okta_identity_provider: "true"
 eks_fis_support_enabled: "false"
-eks_fis_namespaces: "default"
 
 # prefix delegation can only be configured for ipv4. For ipv6 it can only be true.
 aws_vpc_cni_prefix_delegation: "false"

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -15,11 +15,6 @@ post_apply:
   kind: ClusterRoleBinding
 - name: fis-experiment
   kind: ClusterRole
-# {{ range $namespace := split .Cluster.ConfigItems.eks_fis_namespaces "," }}
-- name: fis-experiment
-  kind: ServiceAccount
-  namespace: "{{ $namespace }}"
-# {{ end }}
 {{- end }}
 {{- end }}
 {{ if eq .Cluster.ConfigItems.teapot_admission_controller_process_resources "true" }}


### PR DESCRIPTION
Follow up to #9817

Drop the unused config-item `eks_fis_namespaces` which is no longer needed with the EKS FIS v2 implementation.