### PR TITLE
Default e2e pools to amd64

### DIFF
--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -108,15 +108,6 @@ EOFF
     profile: worker-splitaz
     min_size: 0
     max_size: 21
-  - name: default-karpenter
-    profile: worker-karpenter
-    discount_strategy: none
-    max_size: 0
-    min_size: 0
-    instance_types:
-    - default-for-karpenter
-    config_items:
-      scaling_priority: "100"
   - name: karpenter-arm
     profile: worker-karpenter
     discount_strategy: none
@@ -188,7 +179,6 @@ EOFF
       scaling_priority: "2"
       taints: nvidia.com/gpu=present:NoSchedule,zalando.org/dedicated=dedicated:NoSchedule
     discount_strategy: none
-    instance_type: not-specified
     instance_types:
     - not-specified
     max_size: 0
@@ -200,9 +190,8 @@ EOFF
       scaling_priority: "1"
       taints: zalando.org/dedicated=dedicated:NoSchedule
     discount_strategy: none
-    instance_type: not-specified
     instance_types:
-    - not-specified
+    - default-for-karpenter
     max_size: 0
     min_size: 0
     name: karpenter-catch-all-dedicated
@@ -212,7 +201,6 @@ EOFF
       scaling_priority: "3"
       taints: nvidia.com/gpu=present:NoSchedule
     discount_strategy: none
-    instance_type: not-specified
     instance_types:
     - not-specified
     max_size: 0
@@ -222,9 +210,8 @@ EOFF
   - config_items:
       scaling_priority: "2"
     discount_strategy: none
-    instance_type: not-specified
     instance_types:
-    - not-specified
+    - default-for-karpenter
     max_size: 0
     min_size: 0
     name: karpenter-catch-all


### PR DESCRIPTION
In #9642 we introduced `karpenter-catch-all` and `karpenter-catch-all-dedicated` pools to the e2e setup to enable skipper-ingress-redis running on `dedicated` nodes.

However, this had the side-effect that now other e2e pods can land on arm64 instances as this is what `karpenter-catch-all` allows.

This is normally not possible because admission-controller injects `amd64` nodeSelector unless users opts for amd64 via scaling annotations, however, in e2e we disable various admission-controller settings as they are not always compatible with the upstream e2e framework. (e.g. we can't enforce resource requests on e2e pods).

In practice we see e2e pods fail from time to time with `CrashLoopBackoff` I found a case of the upstream `mysql` test where pods are only `amd64` compatible and thus the e2e test fails om `arm64`.

This is a quick fix to the issue by limiting the `karpenter-catch-all` pools to `default-for-karpenter` which right now is a list of only `amd64` instances.
The longer term fix is likely to enable some of the admission-controller features for e2e pods like the runtime policy logic.