### PR TITLE
Revert "remove hyped articles rbac manifest"

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1108,6 +1108,9 @@ zmon_accessible_s3_buckets: ""
 # disable zmon-appliance worker tracking in Prometheus
 disable_zmon_appliance_worker_tracking: "true"
 
+# Add ClusterRole for clusters required by hyped-article-lifecycle-management controller
+hyped_article_lifecycle_management: "false"
+
 # Add ClusterRole for clusters required by business-partner and config-provider controller
 business_partner_service: "false"
 config_provider_service: "false"

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -174,6 +174,12 @@ post_apply:
   name: open-policy-agent-config
   namespace: kube-system
 {{ end }}
+{{ if eq .Cluster.ConfigItems.hyped_article_lifecycle_management "false" }}
+- name: hyped-articles-lifecycle-management
+  kind: ClusterRole
+- name: hyped-articles-lifecycle-management
+  kind: ClusterRoleBinding
+{{ end }}
 {{ if eq .Cluster.ConfigItems.business_partner_service "false" }}
 - name: business-partner-service
   kind: ClusterRole

--- a/cluster/manifests/roles/hyped-articles-lifecycle-rbac.yaml
+++ b/cluster/manifests/roles/hyped-articles-lifecycle-rbac.yaml
@@ -1,0 +1,34 @@
+{{- if eq .Cluster.ConfigItems.hyped_article_lifecycle_management "true" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hyped-articles-lifecycle-management
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - articles-protection-config
+  - article-protection-config
+  - article-protection-config-invite-only
+  verbs:
+  - get
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hyped-articles-lifecycle-management
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hyped-articles-lifecycle-management
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: zalando-iam:zalando:service:stups_hyped-articles-lifecycle-management
+{{- end }}


### PR DESCRIPTION
Reverts zalando-incubator/kubernetes-on-aws#9973

The `hyped_article_lifecycle_management` is still used, so add it back.