### PR TITLE
feat: Update Sandbox CRD with the generated one

### DIFF
--- a/cluster/manifests/sandbox-controller/10-sandbox_crd.yaml
+++ b/cluster/manifests/sandbox-controller/10-sandbox_crd.yaml
@@ -2,42 +2,69 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: sandboxes.zalando.org
 spec:
   group: zalando.org
   names:
+    categories:
+    - all
     kind: Sandbox
+    listKind: SandboxList
     plural: sandboxes
-    singular: sandbox
     shortNames:
-      - sb
+    - sb
+    singular: sandbox
   scope: Namespaced
   versions:
-    - name: v1
-      served: true
-      storage: true
-      schema:
-        openAPIV3Schema:
-          type: object
-          properties:
-            spec:
-              type: object
-              required:
-                - testContext
-                - sourceHosts
-                - target
-              properties:
-                testContext:
-                  description: |-
-                    Specifies the value used to identify requests that can be routed to the sandbox target.
-                    The format of the incoming `X-Zalando-Client-Id` header should be: `test:$testContext:.*`.
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              sourceHosts:
+                description: Traffic to these hosts will be rerouted to the targetHost
+                  if testContext matches.
+                items:
                   type: string
-                sourceHosts:
-                  description: Traffic to these hosts will be rerouted to the targetHost if testContext matches.
-                  type: array
-                  items:
-                    type: string
-                target:
-                  description: The target host of the sandboxed traffic.
-                  type: string
+                minItems: 1
+                type: array
+              target:
+                description: The target host of the sandboxed traffic.
+                type: string
+              testContext:
+                description: |-
+                  Specifies the value used to identify requests that can be routed to the sandbox target.
+                  The format of the incoming `X-Zalando-Client-Id` header should be: `test:$testContext:.*`.
+                type: string
+            required:
+            - sourceHosts
+            - target
+            - testContext
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
 {{ end }}


### PR DESCRIPTION
Replacing Sandbox CRD with the one generated from the Go sources.
https://github.com/zalando-build/sandbox-controller/pull/23
https://github.com/zalando-build/sandbox-controller/pull/24