### PR TITLE
Skipper open policy agent data preprocessing optimization enabled by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -394,7 +394,7 @@ skipper_ingress_routegroup_crd_require_hosts: "true"
 # Set defaults values that would enable Open Policy Agent in a skipper filter
 skipper_open_policy_agent_enabled: "false"
 skipper_open_policy_agent_styra_token: ""
-skipper_open_policy_agent_data_preprocessing_optimization_enabled: "false"
+skipper_open_policy_agent_data_preprocessing_optimization_enabled: "true"
 
 # Default timeout value in seconds for outgoing http calls from Open Policy Agent in a skipper filter
 skipper_open_policy_agent_styra_response_header_timeout: "2"


### PR DESCRIPTION
Configuration of Skipper open policy agent data preprocessing optimization should be enabled by default for all the clusters that are having OPA enabled.  The decision was made after successful experimental phase when it was enabled for some clusters. 