### PR TITLE
Enable deletion protection on EKS cluster resource

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -206,6 +206,7 @@ Resources:
 {{- else }}
           EnabledTypes: []
 {{- end }}
+      DeletionProtection: {{ .Cluster.ConfigItems.eks_deletion_protection_enabled }}
       # Tags:
       # - Key: "application"
       #   Value: "kubernetes"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1312,7 +1312,7 @@ eks_zalando_iam_aws_proxy_hpa_cpu_target: "80"
 eks_zalando_iam_aws_proxy_hpa_memory_target: "80"
 eks_okta_identity_provider: "true"
 eks_fis_support_enabled: "false"
-eks_deletion_protection_enabled: "false"
+eks_deletion_protection_enabled: "true"
 
 # prefix delegation can only be configured for ipv4. For ipv6 it can only be true.
 aws_vpc_cni_prefix_delegation: "false"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1312,6 +1312,7 @@ eks_zalando_iam_aws_proxy_hpa_cpu_target: "80"
 eks_zalando_iam_aws_proxy_hpa_memory_target: "80"
 eks_okta_identity_provider: "true"
 eks_fis_support_enabled: "false"
+eks_deletion_protection_enabled: "false"
 
 # prefix delegation can only be configured for ipv4. For ipv6 it can only be true.
 aws_vpc_cni_prefix_delegation: "false"

--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -36,7 +36,7 @@ case "$COMMAND" in
         exit 1
 esac
 
-E2E_SKIP_CLUSTER_UPDATE="${E2E_SKIP_CLUSTER_UPDATE:-"false"}"
+E2E_SKIP_CLUSTER_UPDATE="${E2E_SKIP_CLUSTER_UPDATE:-"true"}"
 
 # variables set for making it possible to run script locally
 CDP_BUILD_VERSION="${CDP_BUILD_VERSION:-"local-1"}"


### PR DESCRIPTION
New feature that allows to enable deletion protection on EKS cluster resources. Trying it out for now.

**Rational**: For most clusters, especially the important ones, there's rarely a reason to be able to delete it via an API call or a click of a button. If we ever need to really delete it, then it's OK to go through one extra step. Whether that has to be done manually in the UI or via setting an accompanying config item (similar to deletion protection for Postgres clusters) is to be decided.

Before merging there are a couple of things that need to be clarified:
1. how to keep deleting e2e clusters
2. how to work seamlessly with pet clusters
3. how to configure playground for its weekly decommissioning
4. how to handle intended cluster deletions on protected clusters

Proposals:
1. disable for e2e clusters
2. disable for pet clusters
3. disable for playground or let cluster-cleaner lift the protection (as a reference on how it can work)
4. change it manually in the UI or set a config item with the date for CLM to disable it (it's also possible to switch the config item introduced here, but the date approach used by postgres-operator is safer)

Once this is merged update documentation on how to delete clusters if there are any additional steps required.