### PR TITLE
OPA JWT cache configuration

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -407,7 +407,7 @@ skipper_open_policy_agent_decision_logs_buffer_type_event_limit: "10000"
 # Open Policy Agent JWT cache configuration
 skipper_open_policy_agent_jwt_cache_enable: false
 # Sets default value for maximum number of entries in the Open Policy Agent JWT cache
-skipper_open_policy_agent_jwt_cache_max_num_entries: "5000"
+skipper_open_policy_agent_jwt_cache_max_num_entries: "1000"
 
 #
 # FabricGateway controller config

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -405,7 +405,7 @@ skipper_open_policy_agent_decision_logs_buffer_type_event_enable: "false"
 skipper_open_policy_agent_decision_logs_buffer_type_event_limit: "10000"
 
 # Open Policy Agent JWT cache configuration
-skipper_open_policy_agent_jwt_cache_enable: false
+skipper_open_policy_agent_jwt_cache_enable: "false"
 # Sets default value for maximum number of entries in the Open Policy Agent JWT cache
 skipper_open_policy_agent_jwt_cache_max_num_entries: "1000"
 

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -404,6 +404,8 @@ skipper_open_policy_agent_decision_logs_buffer_type_event_enable: "false"
 # Decision logging sets the maximum number of decision log events that can be buffered before being dropped
 skipper_open_policy_agent_decision_logs_buffer_type_event_limit: "10000"
 
+# Open Policy Agent JWT cache configuration
+skipper_open_policy_agent_jwt_cache_enable: false
 # Sets default value for maximum number of entries in the Open Policy Agent JWT cache
 skipper_open_policy_agent_jwt_cache_max_num_entries: "5000"
 

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -404,6 +404,9 @@ skipper_open_policy_agent_decision_logs_buffer_type_event_enable: "false"
 # Decision logging sets the maximum number of decision log events that can be buffered before being dropped
 skipper_open_policy_agent_decision_logs_buffer_type_event_limit: "10000"
 
+# Sets default value for maximum number of entries in the Open Policy Agent JWT cache
+skipper_open_policy_agent_jwt_cache_max_num_entries: "5000"
+
 #
 # FabricGateway controller config
 #

--- a/cluster/manifests/skipper/configmap-open-policy-agent.yaml
+++ b/cluster/manifests/skipper/configmap-open-policy-agent.yaml
@@ -36,6 +36,8 @@ data:
       reporting:
         buffer_type: "event"
         buffer_size_limit_events: {{ .Cluster.ConfigItems.skipper_open_policy_agent_decision_logs_buffer_type_event_limit }}
+    {{ end }}
+    {{ if eq .Cluster.ConfigItems.skipper_open_policy_agent_jwt_cache_enable "true" }}
     caching: 
       inter_query_builtin_value_cache:
         named:

--- a/cluster/manifests/skipper/configmap-open-policy-agent.yaml
+++ b/cluster/manifests/skipper/configmap-open-policy-agent.yaml
@@ -36,6 +36,11 @@ data:
       reporting:
         buffer_type: "event"
         buffer_size_limit_events: {{ .Cluster.ConfigItems.skipper_open_policy_agent_decision_logs_buffer_type_event_limit }}
+    caching: 
+      inter_query_builtin_value_cache:
+        named:
+          io_jwt:
+            max_num_entries: {{ .Cluster.ConfigItems.skipper_open_policy_agent_jwt_cache_max_num_entries }}
     {{ end }}
   envoymetadata.json: |-
     {


### PR DESCRIPTION
Open Policy Agent JWT cache configuration. 
- adding configuration to opaconfig.yaml
- setting default max number entries for 1000. 

The configuration is disabled by default.