### PR TITLE
validation: migrate to skipper binary

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -342,6 +342,8 @@ routegroups_validation: "enabled"
 # disabled|enabled ingress validation via skipper webhook
 ingresses_validation: "enabled"
 
+enable_advanced_validation: "false"
+
 # tokeninfo
 {{if eq .Cluster.Environment "production"}}
 # production|bridge|disabled

--- a/cluster/manifests/02-skipper-validation-webhook/deployment.yaml
+++ b/cluster/manifests/02-skipper-validation-webhook/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Cluster.Provider "zalando-eks"}}
+# {{- if eq .Cluster.Provider "zalando-eks"}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -34,10 +34,12 @@ spec:
       - name: skipper-admission-webhook
         image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/skipper:v0.22.142
         args:
-          - webhook
-          - --address=:9085
-          - --tls-cert-file=/etc/tls-certs/skipper-validation-webhook.pem
-          - --tls-key-file=/etc/tls-certs/skipper-validation-webhook-key.pem
+          - skipper
+          - --validation-webhook-enabled=true
+          - --validation-webhook-address=:9085
+          - --validation-webhook-cert-file=/etc/tls-certs/skipper-validation-webhook.pem
+          - --validation-webhook-key-file=/etc/tls-certs/skipper-validation-webhook-key.pem
+          - "--enable-advanced-validation={{ .Cluster.ConfigItems.enable_advanced_validation }}"
         lifecycle:
           preStop:
             sleep:
@@ -63,4 +65,4 @@ spec:
       - name: tls-certs
         secret:
           secretName: skipper-validation-webhook-tls-certs
-{{- end }}
+# {{- end }}

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -260,12 +260,14 @@ write_files:
               name: admission-controller-kubeconfig
               readOnly: true
         - name: skipper-admission-webhook
-          image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/skipper:v0.22.127
+          image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/skipper:v0.22.142
           args:
-            - webhook
-            - --address=:9085
-            - --tls-cert-file=/etc/kubernetes/ssl/admission-controller.pem
-            - --tls-key-file=/etc/kubernetes/ssl/admission-controller-key.pem
+            - skipper
+            - --validation-webhook-enabled=true
+            - --validation-webhook-address=:9085
+            - --validation-webhook-cert-file=/etc/kubernetes/ssl/admission-controller.pem
+            - --validation-webhook-key-file=/etc/kubernetes/ssl/admission-controller-key.pem
+            - "--enable-advanced-validation={{ .Cluster.ConfigItems.enable_advanced_validation }}"
           lifecycle:
             preStop:
               sleep:


### PR DESCRIPTION
use skipper in validation mode to deprecate `webhook` binary later and to enable more advanced validations