### PR TITLE
fix: skipper-ingress eks migration svc skipper-internal-eks health check

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -87,7 +87,7 @@ Resources:
           FromPort: 9998
           IpProtocol: tcp
           ToPort: 9999
-        - CidrIp: {{ if eq .Cluster.ConfigItems.kube_aws_ingress_controller_nlb_enabled "true" }}"::/0"{{else}}"{{.Values.vpc_ipv6_cidr}}"{{end}}
+        - CidrIp: {{ if eq .Cluster.ConfigItems.kube_aws_ingress_controller_nlb_enabled "true" }}"::/0"{{else}}"{{.Values.vpc_ipv6_cidrs}}"{{end}}
           FromPort: 9998
           IpProtocol: tcp
           ToPort: 9999

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -87,6 +87,10 @@ Resources:
           FromPort: 9998
           IpProtocol: tcp
           ToPort: 9999
+        - CidrIp: {{ if eq .Cluster.ConfigItems.kube_aws_ingress_controller_nlb_enabled "true" }}"::/0"{{else}}"{{.Values.vpc_ipv6_cidr}}"{{end}}
+          FromPort: 9998
+          IpProtocol: tcp
+          ToPort: 9999
 {{- if eq .Cluster.ConfigItems.skipper_ingress_redis_swim_enabled "true" }}
         - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
           FromPort: 9990

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -87,7 +87,7 @@ Resources:
           FromPort: 9998
           IpProtocol: tcp
           ToPort: 9999
-        - CidrIp: {{ if eq .Cluster.ConfigItems.kube_aws_ingress_controller_nlb_enabled "true" }}"::/0"{{else}}"{{.Values.vpc_ipv6_cidrs}}"{{end}}
+        - CidrIpv6: {{ if eq .Cluster.ConfigItems.kube_aws_ingress_controller_nlb_enabled "true" }}"::/0"{{else}}"{{.Values.vpc_ipv6_cidrs}}"{{end}}
           FromPort: 9998
           IpProtocol: tcp
           ToPort: 9999


### PR DESCRIPTION
fix: skipper-ingress eks migration svc skipper-internal-eks reqiuires to allow ipv6 access for TG health check