### PR TITLE
Enable primary IPv6 address on legacy node pools

### DIFF
--- a/cluster/node-pools/worker-splitaz/stack.yaml
+++ b/cluster/node-pools/worker-splitaz/stack.yaml
@@ -170,6 +170,7 @@ Resources:
           # {{ end }}
           # {{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6") }}
           Ipv6AddressCount: 1
+          PrimaryIpv6: true
           # {{- end}}
           Groups:
           - !ImportValue '{{ .Cluster.ID }}:worker-security-group'


### PR DESCRIPTION
Seed worker nodes currently don't have a "primary" IPv6 address set. This breaks AWS load balancer controller in instance-mode.

```bash
$ aws ec2 describe-instances --instance-id i-xxx | jq '.Reservations[].Instances[].NetworkInterfaces[0].Ipv6Addresses'
[
  {
    "Ipv6Address": "2a05:...::ce1b",
    "IsPrimaryIpv6": false
  }
]
```

An IPv6 IP can be made primary, only then it's possible to use it in a instance-based TargetGroup. Normally, seed workers don't need to be added to LB target groups but it looks like the AWS LB controller needs all instances to work or it doesn't add one _at all_. All Karpenter nodes set their IPv6 address as primary already.

Since skipper migrated to karpenter, this only applies to seed workers.