### PR TITLE
Remove unused config item to simplify configuration

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -83,11 +83,11 @@ Resources:
           ToPort: {{ $element.ToPort }}
 {{- end }}
 {{- end }}
-        - CidrIp: {{ if eq .Cluster.ConfigItems.kube_aws_ingress_controller_nlb_enabled "true" }}"0.0.0.0/0"{{else}}"{{.Values.vpc_ipv4_cidr}}"{{end}}
+        - CidrIp: "0.0.0.0/0"
           FromPort: 9998
           IpProtocol: tcp
           ToPort: 9999
-        - CidrIpv6: {{ if eq .Cluster.ConfigItems.kube_aws_ingress_controller_nlb_enabled "true" }}"::/0"{{else}}"{{.Values.vpc_ipv6_cidrs}}"{{end}}
+        - CidrIpv6: "::/0"
           FromPort: 9998
           IpProtocol: tcp
           ToPort: 9999
@@ -886,7 +886,7 @@ Resources:
           ToPort: {{ $element.ToPort }}
 {{- end }}
 {{- end }}
-        - CidrIp: {{ if eq .Cluster.ConfigItems.kube_aws_ingress_controller_nlb_enabled "true" }}"0.0.0.0/0"{{else}}"{{.Values.vpc_ipv4_cidr}}"{{end}}
+        - CidrIp: "0.0.0.0/0"
           FromPort: 9998
           IpProtocol: tcp
           ToPort: 9999

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -64,8 +64,6 @@ kube_aws_ingress_controller_ssl_policy: "ELBSecurityPolicy-TLS13-1-2-Res-2021-06
 kube_aws_ingress_controller_idle_timeout: "1m"
 kube_aws_ingress_controller_deregistration_delay_timeout: "10s"
 # allow using NLBs for ingress
-# This opens skipper-ingress ports 9998 and 9999 on all worker nodes
-kube_aws_ingress_controller_nlb_enabled: "true"
 kube_aws_ingress_controller_nlb_cross_zone: "true"
 kube_aws_ingress_controller_nlb_zone_affinity: "any_availability_zone"
 kube_aws_ingress_controller_cert_polling_interval: "2m"

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -34,7 +34,6 @@ clusters:
     skipper_ingress_refuse_payload: "refused-pattern-1[cf724afc]refused-pattern-2"
     efs_id: ${EFS_ID}
     webhook_id: ${INFRASTRUCTURE_ACCOUNT}:${REGION}:kube-aws-test
-    kube_aws_ingress_controller_nlb_enabled: "true"
     nlb_switch: "pre"
     vm_dirty_bytes: 134217728
     vm_dirty_background_bytes: 67108864


### PR DESCRIPTION
This config item defaults to true everywhere. Let's get rid of it to avoid testing/maintaining the `else` branches.