### PR TITLE
use resolved image name for CoreDNS

### DIFF
--- a/cluster/manifests/01-coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/01-coredns-local/daemonset-coredns.yaml
@@ -28,11 +28,7 @@ spec:
       terminationGracePeriodSeconds: 40
       initContainers:
       - name: ensure-apiserver
-{{- if eq .Cluster.Provider "zalando-eks" }}
         image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/ensure-apiserver:master-6
-{{- else }}
-        image: container-registry.zalando.net/teapot/ensure-apiserver:master-6
-{{- end }}
         resources:
           requests:
             cpu: 1m
@@ -43,11 +39,7 @@ spec:
             memory: 50Mi
       containers:
       - name: unbound
-{{- if eq .Cluster.Provider "zalando-eks" }}
         image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/unbound:1.24.1-master-14
-{{- else }}
-        image: container-registry.zalando.net/teapot/unbound:1.24.1-master-14
-{{- end }}
         args:
         - -d
         - -c
@@ -119,11 +111,7 @@ spec:
           name: unbound-socket
           readOnly: false
       - name: coredns
-        {{- if eq .Cluster.Provider "zalando-eks" }}
         image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/coredns:1.12.4-master-29
-        {{- else }}
-        image: container-registry.zalando.net/teapot/coredns:1.12.4-master-29
-        {{- end }}
         args: [ "-conf", "/etc/coredns/Corefile" ]
         env:
         - name: ZONE


### PR DESCRIPTION
Always use the long image name for CoreDNS

When we introduced EKS we needed to use the resolved image name to let CoreDNS run _before_ admission-controller. We conditioned this to only EKS because on non-EKS admission-controller run before CoreDNS and thus can resolve the images during pod creation.

However, this setup means we always need multiple PRs to update an image and it adds no value to split it like this. So simply use the resolved name in all environments.