### PR TITLE
Enable zone-based topology-spread for deployment-service's status component

### DIFF
--- a/cluster/manifests/deployment-service/status-service-deployment.yaml
+++ b/cluster/manifests/deployment-service/status-service-deployment.yaml
@@ -26,6 +26,7 @@ spec:
         prometheus.io/port: "9090"
         prometheus.io/scrape: "true"
         config/hash: '{{"01-config.yaml" | manifestHash}}'
+        zalando.org/topology-spread: 'true'
     spec:
       serviceAccountName: "deployment-service-status-service"
       containers:


### PR DESCRIPTION
Let's make sure the three pods for deployment-service's status component are distributed across zones (and therefore nodes).