### PR TITLE
Enable primary IPv6 address on legacy node pools

### DIFF
--- a/cluster/node-pools/worker-combined/stack.yaml
+++ b/cluster/node-pools/worker-combined/stack.yaml
@@ -165,6 +165,7 @@ Resources:
           # {{ end }}
           {{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6") }}
           Ipv6AddressCount: 1
+          PrimaryIpv6: true
           {{- end}}
           Groups:
           - !ImportValue '{{ .Cluster.ID }}:worker-security-group'


### PR DESCRIPTION
Same as https://github.com/zalando-incubator/kubernetes-on-aws/pull/10082 but for the right node pool profile: `worker-combined`.