### PR TITLE
OPA JWT cache configuration enabled by default 

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -404,7 +404,7 @@ skipper_open_policy_agent_decision_logs_buffer_type_event_enable: "false"
 skipper_open_policy_agent_decision_logs_buffer_type_event_limit: "10000"
 
 # Open Policy Agent JWT cache configuration
-skipper_open_policy_agent_jwt_cache_enable: "false"
+skipper_open_policy_agent_jwt_cache_enable: "true"
 # Sets default value for maximum number of entries in the Open Policy Agent JWT cache
 skipper_open_policy_agent_jwt_cache_max_num_entries: "1000"
 


### PR DESCRIPTION
Enabling Open Policy Agent JWT cache configuration by default. for all the clusters