### PR TITLE
Update aws-node-decommissioner pipeline

### DIFF
--- a/cluster/manifests/aws-node-decommissioner/cronjob.yaml
+++ b/cluster/manifests/aws-node-decommissioner/cronjob.yaml
@@ -28,7 +28,10 @@ spec:
           restartPolicy: Never
           containers:
           - name: aws-node-decommissioner
-            image: container-registry.zalando.net/teapot/aws-node-decommissioner:master-690846a9-master-19
+            image: container-registry.zalando.net/cloud-platform/aws-node-decommissioner:main-4
+            env:
+            - name: AWS_REGION
+              value: "{{.Cluster.Region}}"
             args:
               - --debug
             resources:


### PR DESCRIPTION
Updates the aws-node-decommissioner image to the new internal pipeline. This change includes

* Update the build and use static base image to reduce possible CVEs
* Update to aws-sdk-go v2
* Pass AWS_REGION as needed by aws-sdk-go v2 and make it work in regions other than `eu-central-1`.