### PR TITLE
EKS: Optimize seed node usage

### DIFF
--- a/cluster/manifests/02-admission-control/deployment.yaml
+++ b/cluster/manifests/02-admission-control/deployment.yaml
@@ -21,6 +21,22 @@ spec:
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                deployment: teapot-admission-controller
+            topologyKey: kubernetes.io/hostname
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                - key: dedicated
+                  operator: In
+                  values:
+                  - cluster-seed
       tolerations:
       - key: dedicated
         value: cluster-seed

--- a/cluster/manifests/02-skipper-validation-webhook/deployment.yaml
+++ b/cluster/manifests/02-skipper-validation-webhook/deployment.yaml
@@ -21,10 +21,6 @@ spec:
       annotations:
         logging/destination: "{{.Cluster.ConfigItems.log_destination_infra}}"
     spec:
-      tolerations:
-      - key: dedicated
-        value: cluster-seed
-        effect: NoSchedule
       dnsConfig:
         options:
           - name: ndots

--- a/cluster/manifests/audittrail-adapter/daemonset.yaml
+++ b/cluster/manifests/audittrail-adapter/daemonset.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Cluster.Provider "zalando-aws" }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -23,13 +24,8 @@ spec:
     spec:
       serviceAccountName: audittrail-adapter
       priorityClassName: system-node-critical
-{{- if eq .Cluster.Provider "zalando-eks"}}
-      nodeSelector:
-        dedicated: cluster-seed
-{{- else}}
       nodeSelector:
         node.kubernetes.io/role: master
-{{- end}}
       tolerations:
       - operator: Exists
         effect: NoSchedule
@@ -97,3 +93,4 @@ spec:
         secret:
           secretName: audittrail-adapter-nakadi
       {{- end }}
+{{- end }}

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -72,9 +72,3 @@ spec:
         env:
         - name: AWS_REGION
           value: "{{ .Cluster.Region }}"
-{{- if eq .Cluster.Provider "zalando-eks"}}
-      tolerations:
-        - key: dedicated
-          value: cluster-seed
-          effect: NoSchedule
-{{- end}}

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -75,9 +75,3 @@ spec:
             requests:
               cpu: 50m
               memory: 4Gi
-      # {{ if eq .Cluster.Provider "zalando-eks" }}
-      tolerations:
-        - key: dedicated
-          value: cluster-seed
-          effect: NoSchedule
-      # {{ end }}

--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -74,14 +74,7 @@ spec:
         env:
           - name: AWS_REGION
             value: "{{ .Cluster.Region }}"
-{{- if eq .Cluster.Provider "zalando-eks"}}
-      nodeSelector:
-        dedicated: cluster-seed
-      tolerations:
-      - key: dedicated
-        value: cluster-seed
-        effect: NoSchedule
-{{- else}}
+{{- if ne .Cluster.Provider "zalando-eks"}}
       nodeSelector:
         node.kubernetes.io/role: master
       tolerations:

--- a/cluster/manifests/kube-node-ready-controller/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready-controller/daemonset.yaml
@@ -17,6 +17,8 @@ spec:
 {{- if ne .Cluster.Provider "zalando-eks"}}
   updateStrategy:
     type: RollingUpdate
+{{- else }}
+  replicas: 2
 {{- end}}
   template:
     metadata:
@@ -45,8 +47,22 @@ spec:
             cpu: {{.Cluster.ConfigItems.kube_node_ready_controller_cpu}}
             memory: {{.Cluster.ConfigItems.kube_node_ready_controller_memory}}
 {{- if eq .Cluster.Provider "zalando-eks"}}
-      nodeSelector:
-        dedicated: cluster-seed
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                daemonset: kube-node-ready-controller
+            topologyKey: kubernetes.io/hostname
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                - key: dedicated
+                  operator: In
+                  values:
+                  - cluster-seed
       tolerations:
       - key: dedicated
         value: cluster-seed

--- a/cluster/manifests/z-karpenter/deployment.yaml
+++ b/cluster/manifests/z-karpenter/deployment.yaml
@@ -147,6 +147,15 @@ spec:
                 matchExpressions:
                 - key: karpenter.sh/nodepool
                   operator: DoesNotExist
+{{- if eq .Cluster.Provider "zalando-eks"}}
+            - weight: 100
+              preference:
+                matchExpressions:
+                - key: dedicated
+                  operator: In
+                  values:
+                  - cluster-seed
+{{- else }}
             - weight: 100
               preference:
                 matchExpressions:
@@ -154,6 +163,7 @@ spec:
                   operator: In
                   values:
                   - master
+{{- end }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:

--- a/cluster/manifests/zalando-iam-aws-proxy/deployment.yaml
+++ b/cluster/manifests/zalando-iam-aws-proxy/deployment.yaml
@@ -114,8 +114,4 @@ spec:
             cpu: 50m
             memory: 100Mi
       # {{- end}}
-      tolerations:
-        - key: dedicated
-          value: cluster-seed
-          effect: NoSchedule
 # {{ end }}


### PR DESCRIPTION
This PR aims to optimize, e.g. reduce, the capacity needed for the cluster-seed nodes in EKS clusters. Currently we run 2 x `r7g.large` in production clusters, but in reality the seed nodes are _only_ supposed to bootstrap the cluster and enable karpenter to scale new nodes. Thus we only really need to run a couple of components on the seed node.
Since the seed nodes are static, we want them to be as small as possible and let karpenter find the optimized space for the majority of workloads.

The changes are described below

| component | seed node | reasoning |
|----------|----------|----------|
| `admission-controller` | ✅ | Needed to bootstrap all other components. Runs with 2 replicas, one on seed and one on another node |
| `karpenter` | ✅ | Needed to scale out all other nodes, runs with 2 replicas, one on seed and one on another node |
| `kube-node-ready-controller` | ✅ | Needed to mark new nodes ready, runs with 2 replicas, one on seed and one on another node |
| `skipper-validation-webhook` | 🛑 | Not critical for cluster bootstrap so let it run on Karpenter managed capacity |
| `external-dns` | 🛑 | Not critical for cluster bootstrap so let it run on Karpenter managed capacity |
| `kube-ingress-aws-controller` | 🛑 | Not critical for cluster bootstrap so let it run on Karpenter managed capacity |
| `kube-cluster-autoscaler` | 🛑 | No longer critical for cluster bootstrap so let it run on Karpenter managed capacity, this currently means Karpenter is an implicit dependency for `skipper-ingress` capacity |
| `zalando-iam-aws-proxy` | 🛑 | Not critical for cluster bootstrap to let it run on Karpenter managed capacity |
| `audittrail-adapter`  | 🛑 | Removed from EKS clusters as it's not used so we can safe some resources by not running it. |

For `admission-controller`, `karpenter`, `kube-node-ready-controller` they all run with 2 replicas for high availability and they run with a pod anti-affinity rule to not run two pods on the same node. Additionally they have a `preferredDuringSchedulingIgnoredDuringExecution` nodeAffinity such that always one of the replicas prefer to run on the seed node and thus we always ensure to have one on a seed node.

With these changes we can switch from 2 x r.large to 1 x c.large and we likely can even run this reasonably safe on a spot seed node, because if the seed node goes down there will be a replica to take over for the most time critical components.

### Security considerations

Isolating some components on master/seed nodes had an implicit safety aspect in that, exploiting a node from a user workload would not exploit the most critical components. But 1) we never applied this logic consistently and 2) there are likely extremely critical user workloads where you could make the same argument. We already prevent user pods from running privileged as a safety measure to prevent container break outs.


#### Availability considerations

By running more critical components on Karpenter managed nodes, we expose those to the "disruptions" of Karpenter. However, this is an issue affecting all workloads which should be solved at the core instead of making workarounds just for _our_ components. 