### PR TITLE
Revert "enable egress-controller on EKS when it's the only cluster in the account"

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -488,8 +488,7 @@ aws_efa_device_plugin_cpu: "10m"
 aws_efa_device_plugin_memory: "20Mi"
 
 # static egress controller settings
-# by default static egress controller is enabled on legacy clusters and disabled on zalando-eks clusters with multiple clusters
-{{- if and (eq .Cluster.Provider "zalando-eks") (gt (len .Cluster.AccountClusters) 1) }}
+{{- if eq .Cluster.Provider "zalando-eks" }}
 static_egress_controller_enabled: "false"
 {{- else }}
 static_egress_controller_enabled: "true"


### PR DESCRIPTION
Reverts zalando-incubator/kubernetes-on-aws#10084

This logic doesn't work because `.AccountClusters` _does_ include decommissioned clusters (I thought it didn't - for trust relationship these are filtered out in CLM).

This means that "single" clusters are not detected as such when there was an old cluster that is now decommissioned. This leads to egress-controller not running when it should.

Let's go back to the "simple" manual approach and find a better way based on that.