### PR TITLE
Fix aws-node-decommissioner image

### DIFF
--- a/cluster/manifests/aws-node-decommissioner/cronjob.yaml
+++ b/cluster/manifests/aws-node-decommissioner/cronjob.yaml
@@ -28,7 +28,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: aws-node-decommissioner
-            image: container-registry.zalando.net/cloud-platform/aws-node-decommissioner:main-4
+            image: container-registry.zalando.net/cloud-platform/aws-node-decommissioner:main-5
             env:
             - name: AWS_REGION
               value: "{{.Cluster.Region}}"


### PR DESCRIPTION
Fixes the image as the `main-4` version had a typo in the built image `decommisioner` -> `decommissioner`