### PR TITLE
coredns: Fix overlapping port names

### DIFF
--- a/cluster/manifests/01-coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/01-coredns-local/daemonset-coredns.yaml
@@ -46,10 +46,10 @@ spec:
         - /etc/unbound/unbound.conf
         ports:
         - containerPort: 53
-          name: dns-udp
+          name: dns-cache-udp
           protocol: UDP
         - containerPort: 53
-          name: dns-tcp
+          name: dns-cache-tcp
           protocol: TCP
 {{- if eq .Cluster.ConfigItems.expirimental_dns_unbound_liveness_probe "true" }}
         livenessProbe:


### PR DESCRIPTION
The port name `dns-tcp` was defined both for the `unbound` container and for `coredns` container.

This produces a warning.

Change it for `unbound` as the service already selects on the name for coredns