### PR TITLE
Read only k8s group readonly

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -302,6 +302,14 @@ Resources:
       Type: "STANDARD"
       KubernetesGroups:
         - zalando:readonly
+  EKSAccessEntryReadOnlyAuth:
+    Type: "AWS::EKS::AccessEntry"
+    Properties:
+      ClusterName: !Ref EKSCluster
+      PrincipalArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/ReadOnly"
+      Type: "STANDARD"
+      KubernetesGroups:
+        - zalando:readonly
   EKSAddonPodIdentityAgent:
     Type: AWS::EKS::Addon
     Properties:


### PR DESCRIPTION
This diff adds a new EKS access entry for a ReadOnly IAM role. The new `EKSAccessEntryReadOnlyAuth` resource grants the `ReadOnly` role access to the EKS cluster with the same `zalando:readonly` Kubernetes group permissions as the existing access entry above it.

Key points:
- Creates access for `arn:aws:iam::${AWS::AccountId}:role/ReadOnly`
- Uses STANDARD access entry type
- Maps to `zalando:readonly` Kubernetes group
- Follows the same pattern as the existing access entry