### PR TITLE
Use small seed node

### DIFF
--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -69,9 +69,9 @@ cat <<EOFF
       taints: dedicated=cluster-seed:NoSchedule
     discount_strategy: none
     instance_types:
-    - "m6i.xlarge"
-    max_size: 99
-    min_size: 2
+    - "c7g.large"
+    max_size: 2
+    min_size: 1
     name: seed-worker
     profile: worker-combined
 EOFF


### PR DESCRIPTION
Follow up to #10117 

Use a small seed node for e2e EKS clusters to validate that this works continously.

This depends on #10117 being fully rolled out first

* [x] #10117
* [x] alpha
* [x] beta
* [x] stable