### PR TITLE
Add c8i instance family to default-for-karpenter

### DIFF
--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -209,6 +209,7 @@ spec:
             - "c7i"
             - "m7i"
             - "r7i"
+            - "c8i"
             - "m8i"
             - "r8i"
 #{{ else if (eq .NodePool.KarpenterInstanceTypeStrategy "custom" ) }}


### PR DESCRIPTION
Follow up to https://github.com/zalando-incubator/kubernetes-on-aws/pull/9929.

Add the `c8i` instance family to the `default-for-karpenter` list now that it has been released.