### PR TITLE
Engineer k8s group manual

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -293,6 +293,15 @@ Resources:
       KubernetesGroups:
       - zalando:administrator
       Type: "STANDARD"
+{{- else }}
+   EKSAccessEntryManualAuth:
+    Type: "AWS::EKS::AccessEntry"
+    Properties:
+      ClusterName: !Ref EKSCluster
+      PrincipalArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/Manual"
+      Type: "STANDARD"
+      KubernetesGroups:
+        - zalando:engineer
 {{- end }}
   EKSAccessEntrySecurityAuth:
     Type: "AWS::EKS::AccessEntry"
@@ -310,14 +319,6 @@ Resources:
       Type: "STANDARD"
       KubernetesGroups:
         - zalando:readonly
-  EKSAccessEntryManualAuth:
-    Type: "AWS::EKS::AccessEntry"
-    Properties:
-      ClusterName: !Ref EKSCluster
-      PrincipalArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/Manual"
-      Type: "STANDARD"
-      KubernetesGroups:
-        - zalando:administrator
   EKSAddonPodIdentityAgent:
     Type: AWS::EKS::Addon
     Properties:

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -310,6 +310,14 @@ Resources:
       Type: "STANDARD"
       KubernetesGroups:
         - zalando:readonly
+  EKSAccessEntryManualAuth:
+    Type: "AWS::EKS::AccessEntry"
+    Properties:
+      ClusterName: !Ref EKSCluster
+      PrincipalArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/Manual"
+      Type: "STANDARD"
+      KubernetesGroups:
+        - zalando:administrator
   EKSAddonPodIdentityAgent:
     Type: AWS::EKS::Addon
     Properties:

--- a/cluster/manifests/02-admission-control/teapot.yaml
+++ b/cluster/manifests/02-admission-control/teapot.yaml
@@ -634,8 +634,10 @@ webhooks:
       - name: 'allow-routesrv-routes-access'
         expression: |
           !(
-            "okta:common/engineer" in request.userInfo.groups ||
-            "zalando:engineer" in request.userInfo.groups &&
+            (
+              "okta:common/engineer" in request.userInfo.groups ||
+              "zalando:engineer" in request.userInfo.groups
+            ) &&
             request.name == "skipper-ingress-routesrv" &&
             request.resource.resource == "services" &&
             request.subResource == "proxy" &&

--- a/cluster/manifests/02-admission-control/teapot.yaml
+++ b/cluster/manifests/02-admission-control/teapot.yaml
@@ -634,8 +634,8 @@ webhooks:
       - name: 'allow-routesrv-routes-access'
         expression: |
           !(
-            ("okta:common/engineer" in request.userInfo.groups) ||
-            ("zalando:engineer" in request.userInfo.groups) &&
+            "okta:common/engineer" in request.userInfo.groups ||
+            "zalando:engineer" in request.userInfo.groups &&
             request.name == "skipper-ingress-routesrv" &&
             request.resource.resource == "services" &&
             request.subResource == "proxy" &&

--- a/cluster/manifests/02-admission-control/teapot.yaml
+++ b/cluster/manifests/02-admission-control/teapot.yaml
@@ -634,7 +634,8 @@ webhooks:
       - name: 'allow-routesrv-routes-access'
         expression: |
           !(
-            "okta:common/engineer" in request.userInfo.groups &&
+            ("okta:common/engineer" in request.userInfo.groups) ||
+            ("zalando:engineer" in request.userInfo.groups) &&
             request.name == "skipper-ingress-routesrv" &&
             request.resource.resource == "services" &&
             request.subResource == "proxy" &&

--- a/cluster/manifests/role-sync-controller/cronjob.yaml
+++ b/cluster/manifests/role-sync-controller/cronjob.yaml
@@ -39,6 +39,7 @@ spec:
               - --subject-group=Manual
               - --subject-group=Emergency
               - --subject-group=okta:common/engineer
+              - --subject-group=zalando:engineer
               - --subject-serviceaccount=default/cdp
               - --subject-user=zalando-iam:zalando:service:k8sapi-local_deployment-service-executor
               {{- if eq .Cluster.Environment "test"}}

--- a/cluster/manifests/roles/cluster-admin-binding.yaml
+++ b/cluster/manifests/roles/cluster-admin-binding.yaml
@@ -10,6 +10,3 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
   name: okta:common/administrator
-- apiGroup: rbac.authorization.k8s.io
-  kind: Group
-  name: zalando:administrator

--- a/cluster/manifests/roles/cluster-admin-binding.yaml
+++ b/cluster/manifests/roles/cluster-admin-binding.yaml
@@ -10,3 +10,6 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
   name: okta:common/administrator
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: zalando:administrator

--- a/cluster/manifests/roles/poweruser-binding.yaml
+++ b/cluster/manifests/roles/poweruser-binding.yaml
@@ -24,3 +24,6 @@ subjects:
 - kind: Group
   name: "okta:common/engineer"
   apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: "zalando:engineer"
+  apiGroup: rbac.authorization.k8s.io

--- a/cluster/manifests/roles/readonly-binding.yaml
+++ b/cluster/manifests/roles/readonly-binding.yaml
@@ -22,6 +22,9 @@ subjects:
   - kind: Group
     name: "zalando:readonly"
     apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "zalando:engineer"
+    apiGroup: rbac.authorization.k8s.io
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -47,4 +50,7 @@ subjects:
     apiGroup: rbac.authorization.k8s.io
   - kind: Group
     name: "zalando:readonly"
+    apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: "zalando:engineer"
     apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
**cluster.yaml changes:**
- Adds a new `EKSAccessEntryManualAuth` resource in an `{{- else }}` block
- Creates an access entry for a manual IAM role (`arn:aws:iam::${AWS::AccountId}:role/Manual`)
- Assigns the `zalando:engineer` Kubernetes group to this role

**poweruser-binding.yaml changes:**
- Adds the `zalando:engineer` group as a subject in the existing RoleBinding/ClusterRoleBinding
- This grants the same permissions that `okta:common/engineer` has to the new `zalando:engineer` group