### PR TITLE
cluster/manifests: disable loading routing table

### DIFF
--- a/cluster/manifests/02-skipper-validation-webhook/deployment.yaml
+++ b/cluster/manifests/02-skipper-validation-webhook/deployment.yaml
@@ -68,6 +68,7 @@ spec:
           - "-serve-method-metric={{ .Cluster.ConfigItems.skipper_serve_method_metric }}"
           - "-serve-status-code-metric={{ .Cluster.ConfigItems.skipper_serve_status_code_metric }}"
           - "-serve-host-counter"
+          - "-source-poll-timeout=9223372036854775807" # Disable loading routing table in dataclient
           - "-combined-response-metrics={{ .Cluster.ConfigItems.skipper_combined_response_metrics }}"
           - "-backend-host-metrics={{ .Cluster.ConfigItems.skipper_backend_host_metrics }}"
           - "-disable-metrics-compat"


### PR DESCRIPTION
Set the `source-poll-timeout` flag to the max int64 value to disable loading the routing table for the data client. The routing table loads by default whenever a data-client config is present. In this case, the config is only needed, so the filters get added to the registry for validation