### PR TITLE
Set application/component label on eks-pod-identity-agent

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -314,8 +314,15 @@ Resources:
     Type: AWS::EKS::Addon
     Properties:
       AddonName: eks-pod-identity-agent
-      AddonVersion: "v1.3.8-eksbuild.2"
+      AddonVersion: "v1.3.10-eksbuild.1"
       ClusterName: !Ref EKSCluster
+      ConfigurationValues: |
+        {
+          "podLabels": {
+            "application": "kubernetes",
+            "component": "eks-pod-identity-agent"
+          }
+        }
   EKSAddonKubeProxy:
     Type: AWS::EKS::Addon
     Properties:


### PR DESCRIPTION
Set `application` and `component` labels on the eks-pod-identity-agent EKS addon.

This is now possible after the upstream bug was fixed: https://github.com/aws/containers-roadmap/issues/2684