### PR TITLE
Enable OAuth2 UI login in e2e environment

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -372,12 +372,7 @@ skipper_tokeninfo_cache_ttl: "30s"
 # skipper-ingress ingress OAuth2 grant flow
 #
 # oauth2 UI login - grant flow
-{{if eq .Cluster.Environment "e2e"}}
-skipper_oauth2_ui_login: "false"
-skipper_ingress_encryption_key: ""
-{{else}}
 skipper_oauth2_ui_login: "true"
-{{end}}
 
 # Comma-separated list of tokeninfo keys to retain
 skipper_oauth2_ui_login_tokeninfo_keys: ""


### PR DESCRIPTION
The ~~production~~playground configuration suffers from a chicken-and-egg problem wrt to the encryption key. Let's see if it makes sense / is possible to reproduce it in e2e tests.

[EDIT] Actually, it's fine. It found it eventually. But let's see what e2e says about `skipper_oauth2_ui_login: true` in e2e tests anyways.