### PR TITLE
Configure egress-controller to use platform credentials

### DIFF
--- a/cluster/manifests/kube-static-egress-controller/01-rbac.yaml
+++ b/cluster/manifests/kube-static-egress-controller/01-rbac.yaml
@@ -24,6 +24,18 @@ roleRef:
   kind: ClusterRole
   name: kube-static-egress-controller
 subjects:
-- kind: ServiceAccount
-  name: kube-static-egress-controller
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: zalando-iam:zalando:service:stups_kubernetes
+---
+apiVersion: zalando.org/v1
+kind: PlatformCredentialsSet
+metadata:
+  name: kube-static-egress-controller-credentials
   namespace: kube-system
+spec:
+  application: kubernetes
+  token_version: v2
+  tokens:
+    kube-static-egress-controller:
+      privileges: []

--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: kube-static-egress-controller
       containers:
       - name: controller
-        image: container-registry.zalando.net/teapot/kube-static-egress-controller:v0.3.5-master-54
+        image: container-registry.zalando.net/teapot/kube-static-egress-controller:v0.3.6-master-55
         args:
         - "--provider=aws"
         - "--vpc-id={{.Cluster.ConfigItems.vpc_id}}"
@@ -53,6 +53,7 @@ spec:
         - "--additional-stack-tags=InfrastructureComponent=true"
         - "--additional-stack-tags=application=kubernetes"
         - "--additional-stack-tags=component=kube-static-egress-controller"
+        - "--use-platform-credentials"
         env:
         - name: AWS_REGION
           value: {{ .Cluster.Region }}
@@ -66,3 +67,11 @@ spec:
         ports:
           - containerPort: 8000
             protocol: TCP
+        volumeMounts:
+        - name: platform-iam-credentials
+          mountPath: /meta/credentials
+          readOnly: true
+      volumes:
+      - name: platform-iam-credentials
+        secret:
+          secretName: kube-static-egress-controller-credentials


### PR DESCRIPTION
Roll out v0.3.6 of egress-controller: https://github.com/szuecs/kube-static-egress-controller/tree/v0.3.6 that includes https://github.com/szuecs/kube-static-egress-controller/pull/60. Configure it to use platform credentials instead of service account tokens.