### PR TITLE
fix wrong indentation in stack template

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -294,7 +294,7 @@ Resources:
       - zalando:administrator
       Type: "STANDARD"
 {{- else }}
-   EKSAccessEntryManualAuth:
+  EKSAccessEntryManualAuth:
     Type: "AWS::EKS::AccessEntry"
     Properties:
       ClusterName: !Ref EKSCluster


### PR DESCRIPTION
That was missed in e2e tests because it's in the `else` branch.