### PR TITLE
sandbox crd: testContext rename and URL validation

### DIFF
--- a/cluster/manifests/sandbox-controller/10-sandbox_crd.yaml
+++ b/cluster/manifests/sandbox-controller/10-sandbox_crd.yaml
@@ -43,7 +43,7 @@ spec:
             properties:
               sourceHosts:
                 description: Traffic to these hosts will be rerouted to the targetHost
-                  if testContext matches.
+                  if testProject matches.
                 items:
                   type: string
                 minItems: 1
@@ -51,15 +51,21 @@ spec:
               target:
                 description: The target host of the sandboxed traffic.
                 type: string
-              testContext:
+                x-kubernetes-validations:
+                - message: target has to be a valid URL, http scheme is only allowed
+                    for *.cluster.local domains
+                  rule: 'isURL(self) && ((url(self).getHostname().endsWith(''cluster.local'')
+                    && url(self).getScheme() ==''http'') || url(self).getScheme()
+                    ==''https'') '
+              testProject:
                 description: |-
                   Specifies the value used to identify requests that can be routed to the sandbox target.
-                  The format of the incoming `X-Zalando-Client-Id` header should be: `test:$testContext:.*`.
+                  The format of the incoming `X-Zalando-Client-Id` header should be: `test:$testProject:.*`.
                 type: string
             required:
             - sourceHosts
             - target
-            - testContext
+            - testProject
             type: object
         required:
         - metadata


### PR DESCRIPTION
Rename testContext -> testProject to match the TDD.
Also add URL validation for the target field to ensure it uses a valid URL with http scheme only allowed for cluster.local domains and https for all others.

see:
- https://github.com/zalando-build/sandbox-controller/pull/50
- https://github.com/zalando-build/sandbox-controller/pull/45