### PR TITLE
Configure egress-controller to use external API server endpoint

### DIFF
--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -32,6 +32,7 @@ spec:
       - name: controller
         image: container-registry.zalando.net/teapot/kube-static-egress-controller:v0.4.0-master-56
         args:
+        - "--master={{ .Cluster.APIServerURL }}"
         - "--provider=aws"
         - "--vpc-id={{.Cluster.ConfigItems.vpc_id}}"
         - "--cf-template-bucket=cluster-lifecycle-manager-{{.Cluster.InfrastructureAccountID}}-{{.Cluster.Region}}"


### PR DESCRIPTION
In order to actually use PCS against the API server consistently in both environments (`zalando-aws`, `zalando-eks`) let's switch to using the external API server URL.