### PR TITLE
Use external cluster endpoint that understands platformcredentialssets

### DIFF
--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -32,7 +32,7 @@ spec:
       - name: controller
         image: container-registry.zalando.net/teapot/kube-static-egress-controller:v0.4.0-master-56
         args:
-        - "--master={{ .Cluster.APIServerURL }}"
+        - "--master={{ .Cluster.LocalID }}.{{ .Values.hosted_zone }}"
         - "--provider=aws"
         - "--vpc-id={{.Cluster.ConfigItems.vpc_id}}"
         - "--cf-template-bucket=cluster-lifecycle-manager-{{.Cluster.InfrastructureAccountID}}-{{.Cluster.Region}}"


### PR DESCRIPTION
Although these values should be the same (according to the API), the `.APIServerURL` field is actually rewritten on-the-fly when rendering the manifests. So let's construct the value ourselves.