### PR TITLE
sandbox-controller: add status field to Sandbox CRD

### DIFF
--- a/cluster/manifests/sandbox-controller/10-sandbox_crd.yaml
+++ b/cluster/manifests/sandbox-controller/10-sandbox_crd.yaml
@@ -67,6 +67,16 @@ spec:
             - target
             - testProject
             type: object
+          status:
+            description: |-
+              SandboxStatus is the current state of the Sandbox.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              problems:
+                items:
+                  type: string
+                type: array
+            type: object
         required:
         - metadata
         - spec


### PR DESCRIPTION
Introduces a status subresource with a problems array to track the current state of Sandbox resources according to Kubernetes API conventions.