### PR TITLE
Filter watched clusters for egress-configs to ready clusters

### DIFF
--- a/cluster/manifests/kube-static-egress-controller/deployment.yaml
+++ b/cluster/manifests/kube-static-egress-controller/deployment.yaml
@@ -33,7 +33,9 @@ spec:
         image: container-registry.zalando.net/teapot/kube-static-egress-controller:v0.4.0-master-56
         args:
         # {{ range $cluster := .Cluster.AccountClusters }}
+        # {{ if eq $cluster.LifecycleStatus "ready" }}
         - "--master=https://{{ $cluster.LocalID }}.{{ $.Values.hosted_zone }}"
+        # {{ end }}
         # {{ end }}
         - "--provider=aws"
         - "--vpc-id={{.Cluster.ConfigItems.vpc_id}}"


### PR DESCRIPTION
We need to manually filter the non-ready clusters because the provided list can contain decommissioned or to-be-provisioned clusters.