### PR TITLE
Exclude slow c6id.large instance types

### DIFF
--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -238,6 +238,7 @@ spec:
         - key: "node.kubernetes.io/instance-type"
           operator: "NotIn"
           values:
+            - "c6id.large"
             - "c5d.large"
             - "m5d.large"
             - "r5d.large"


### PR DESCRIPTION
We have had at least 3 cases where scheduling on `c6id.large` takes a long time leading to "pods not scheduled in time alerts". It's always the same pattern of 2-3 `c6id.large` being launched and only the last one getting ready in time.

For this reason, exclude `c6id.large` types by default similar to how we exclude `c5d.large` because of slow SSD.