### PR TITLE
Update to Vertical Pod Autoscaler v1.5.1

### DIFF
--- a/cluster/manifests/02-vertical-pod-autoscaler/01-crd.yaml
+++ b/cluster/manifests/02-vertical-pod-autoscaler/01-crd.yaml
@@ -458,6 +458,7 @@ spec:
                     - "Off"
                     - Initial
                     - Recreate
+                    - InPlaceOrRecreate
                     - Auto
                     type: string
                 type: object

--- a/cluster/manifests/02-vertical-pod-autoscaler/admission-controller-deployment.yaml
+++ b/cluster/manifests/02-vertical-pod-autoscaler/admission-controller-deployment.yaml
@@ -26,9 +26,9 @@ spec:
       containers:
       - name: admission-controller
         {{if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "current"}}
-        image: container-registry.zalando.net/teapot/vpa-admission-controller:v1.3.1-main-10-custom
+        image: container-registry.zalando.net/teapot/vpa-admission-controller:v1.5.1-main-11-custom
         {{else if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "legacy"}}
-        image: container-registry.zalando.net/teapot/vpa-admission-controller:v1.3.0-main-8-custom
+        image: container-registry.zalando.net/teapot/vpa-admission-controller:v1.3.1-main-10-custom
         {{end}}
         command:
           - /admission-controller

--- a/cluster/manifests/02-vertical-pod-autoscaler/recommender-deployment.yaml
+++ b/cluster/manifests/02-vertical-pod-autoscaler/recommender-deployment.yaml
@@ -24,9 +24,9 @@ spec:
       containers:
       - name: recommender
         {{if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "current"}}
-        image: container-registry.zalando.net/teapot/vpa-recommender:v1.3.1-main-10-custom
+        image: container-registry.zalando.net/teapot/vpa-recommender:v1.5.1-main-11-custom
         {{else if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "legacy"}}
-        image: container-registry.zalando.net/teapot/vpa-recommender:v1.3.0-main-8-custom
+        image: container-registry.zalando.net/teapot/vpa-recommender:v1.3.1-main-10-custom
         {{end}}
         args:
         - --logtostderr

--- a/cluster/manifests/02-vertical-pod-autoscaler/updater-deployment.yaml
+++ b/cluster/manifests/02-vertical-pod-autoscaler/updater-deployment.yaml
@@ -24,9 +24,9 @@ spec:
       containers:
       - name: updater
         {{if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "current"}}
-        image: container-registry.zalando.net/teapot/vpa-updater:v1.3.1-main-10-custom
+        image: container-registry.zalando.net/teapot/vpa-updater:v1.5.1-main-11-custom
         {{else if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "legacy"}}
-        image: container-registry.zalando.net/teapot/vpa-updater:v1.3.0-main-8-custom
+        image: container-registry.zalando.net/teapot/vpa-updater:v1.3.1-main-10-custom
         {{end}}
         command:
           - ./updater


### PR DESCRIPTION
This updates the VPA components from v1.3.1 to the latest v1.5.1: https://github.com/kubernetes/autoscaler/releases/tag/vertical-pod-autoscaler-1.5.0

It's possible to switch back to the previous version by setting: `vertical_pod_autoscaler_version: legacy`

### TODO

* [x] Update to production images