### PR TITLE
rename function that detects the main cluster for egress-controller

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -508,7 +508,7 @@ aws_efa_device_plugin_cpu: "10m"
 aws_efa_device_plugin_memory: "20Mi"
 
 # static egress controller settings
-{{- if .Cluster.IsOldestReadyCluster }}
+{{- if .Cluster.IsOldestReadyClusterInTheRegion }}
 static_egress_controller_enabled: "true"
 {{- else }}
 static_egress_controller_enabled: "false"


### PR DESCRIPTION
Use the more correct function name so we can phase out the other one.