### PR TITLE
skipper-validation: fix cluster bootstrapping

### DIFF
--- a/cluster/manifests/02-skipper-validation-webhook/deployment.yaml
+++ b/cluster/manifests/02-skipper-validation-webhook/deployment.yaml
@@ -141,8 +141,8 @@ spec:
           - "-oauth2-auth-url={{ .Cluster.ConfigItems.skipper_oauth2_auth_url }}"
           - "-oauth2-token-url={{ .Cluster.ConfigItems.skipper_oauth2_token_url }}"
           - "-oauth2-secret-file=/etc/skipper/secret/encryption-key"
-          - "-oauth2-client-id-file=/etc/skipper/hostname-credentials/{host}-grant-credentials-employee-client-id"
-          - "-oauth2-client-secret-file=/etc/skipper/hostname-credentials/{host}-grant-credentials-employee-client-secret"
+          - "-oauth2-client-id=dummyvalue"
+          - "-oauth2-client-secret=dummyvalue"
           - "-credentials-update-interval=1m"
           - "-oauth2-token-cookie-name={{ .Cluster.ConfigItems.skipper_oauth2_cookie_name }}"
           - "-oauth2-token-cookie-remove-subdomains=0"
@@ -191,9 +191,6 @@ spec:
             readOnly: true
 {{ end }}
 {{ if eq .Cluster.ConfigItems.skipper_oauth2_ui_login "true"}}
-          - name: hostname-credentials
-            mountPath: /etc/skipper/hostname-credentials
-            readOnly: true
           - name: encryption-key
             mountPath: /etc/skipper/secret
             readOnly: true
@@ -218,12 +215,9 @@ spec:
           optional: true
 {{ end }}
 {{ if eq .Cluster.ConfigItems.skipper_oauth2_ui_login "true"}}
-      - name: hostname-credentials
-        secret:
-          secretName: hostname-credentials
       - name: encryption-key
         secret:
-          secretName: skipper-ingress
+          secretName: skipper-validation-webhook-tls-certs
 {{ end }}
 {{ if eq .Cluster.ConfigItems.skipper_open_policy_agent_enabled "true" }}
       - name: open-policy-agent-config

--- a/cluster/manifests/02-skipper-validation-webhook/secret.yaml
+++ b/cluster/manifests/02-skipper-validation-webhook/secret.yaml
@@ -10,3 +10,5 @@ type: Opaque
 data:
   skipper-validation-webhook.pem: "{{ .Cluster.ConfigItems.skipper_validation_webhook_cert }}"
   skipper-validation-webhook-key.pem: "{{ .Cluster.ConfigItems.skipper_validation_webhook_key }}"
+  encryption-key: {{ printf "dummy_value" | base64 }}
+

--- a/cluster/manifests/skipper/hostname-credentials-controller.yaml
+++ b/cluster/manifests/skipper/hostname-credentials-controller.yaml
@@ -124,12 +124,6 @@ spec:
               [{"container": "controller", "parser": "keyValue"}]
             logging/destination: "{{ .Cluster.ConfigItems.log_destination_both }}"
         spec:
-          # {{- if eq .Cluster.Provider "zalando-eks"}}
-          tolerations:
-          - key: dedicated
-            value: cluster-seed
-            effect: NoSchedule
-          # {{ end }}
           serviceAccountName: hostname-credentials-controller
           restartPolicy: Never
           containers:


### PR DESCRIPTION
We don't need the full setup for oauthGrant to work so I move hostname-credentials-provider back to skipper and we can use some dummy values as a place holder for filter to work