### PR TITLE
Skipper ingress Karpenter scheduling annotations

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -128,6 +128,7 @@ worker_sg_legacy_cluster: ""
 # skipper node-pool
 enable_dedicate_nodepool_skipper: "true"
 skipper_attach_only_to_skipper_node_pool: "true"
+skipper_karpenter_node_pools_enabled: "false"
 
 skipper_suppress_route_update_logs: "true"
 skipper_validate_query: "true"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -85,9 +85,6 @@ spec:
 {{- if eq .Cluster.ConfigItems.skipper_topology_spread_enabled "true" }}
       topologySpreadConstraints:
         - maxSkew: 1
-{{- if eq .Cluster.ConfigItems.skipper_karpenter_node_pools_enabled "true" }}
-          minDomains: 3
-{{- end }}
           topologyKey: topology.kubernetes.io/zone
           whenUnsatisfiable: DoNotSchedule
           labelSelector:

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -85,12 +85,57 @@ spec:
 {{- if eq .Cluster.ConfigItems.skipper_topology_spread_enabled "true" }}
       topologySpreadConstraints:
         - maxSkew: 1
+{{- if eq .Cluster.ConfigItems.skipper_karpenter_node_pools_enabled "true" }}
+          minDomains: 3
+{{- end }}
           topologyKey: topology.kubernetes.io/zone
           whenUnsatisfiable: DoNotSchedule
           labelSelector:
             matchLabels:
               component: ingress
               application: skipper-ingress
+{{- end }}
+{{- if eq .Cluster.ConfigItems.skipper_karpenter_node_pools_enabled "true" }}
+      affinity:
+       podAntiAffinity:
+         requiredDuringSchedulingIgnoredDuringExecution:
+         - labelSelector:
+             matchExpressions:
+             - key: application
+               operator: In
+               values:
+               - skipper-ingress
+             - key: component
+               operator: In
+               values:
+               - ingress
+           topologyKey: kubernetes.io/hostname
+       nodeAffinity:
+         preferredDuringSchedulingIgnoredDuringExecution:
+         - weight: 100
+           preference:
+             matchExpressions:
+             - key: node.kubernetes.io/instance-type
+               operator: In
+               values:
+               - c7g.large
+               - c7g.xlarge
+               - c7g.2xlarge
+               - c7g.4xlarge
+               - c7g.8xlarge
+               - m7g.large
+         - weight: 50
+           preference:
+             matchExpressions:
+             - key: node.kubernetes.io/instance-type
+               operator: In
+               values:
+               - c6g.large
+               - c6g.xlarge
+               - c6g.2xlarge
+               - c6g.4xlarge
+               - c6g.8xlarge
+               - m6g.large
 {{- end }}
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       serviceAccountName: skipper-ingress
@@ -472,12 +517,21 @@ spec:
             name: open-policy-agent-config
 {{ end }}
 {{ if eq .Cluster.ConfigItems.enable_dedicate_nodepool_skipper "true"}}
+{{- if eq .Cluster.ConfigItems.skipper_karpenter_node_pools_enabled "true" }}
+      nodeSelector:
+        zalando.org/dedicated: skipper-ingress
+      tolerations:
+      - key: "zalando.org/dedicated"
+        operator: Exists
+        effect: NoSchedule
+{{ else }}
       nodeSelector:
         dedicated: skipper-ingress
       tolerations:
       - effect: NoSchedule
         key: dedicated
         value: skipper-ingress
+{{ end}}
 {{ end }}
 {{ end }}
 


### PR DESCRIPTION
This implements scheduling annotations for skipper-ingress such that a dedicated node pool is not needed, but it will land on dedicated nodes via dedicated scheduling annotation feature.

(Since kube-system currently is not covered by scheduling annotations, the annotation is not defined, but the nodeSelector/toleration which is normally injected by admission-controller, is defined manually)

The changes includes a few more optimizations:

- Include the instance type priority to prioritize 7th gen instances instead of 6th gen