### PR TITLE
VPA Auto mode is deprecated, use Recreate instead

### DIFF
--- a/cluster/manifests/04-ebs-csi/vpa.yaml
+++ b/cluster/manifests/04-ebs-csi/vpa.yaml
@@ -12,7 +12,7 @@ spec:
     kind: Deployment
     name: ebs-csi-controller
   updatePolicy:
-    updateMode: Auto
+    updateMode: Recreate
   resourcePolicy:
     containerPolicies:
     - containerName: ebs-plugin

--- a/cluster/manifests/aws-load-balancer-controller/vpa.yaml
+++ b/cluster/manifests/aws-load-balancer-controller/vpa.yaml
@@ -13,7 +13,7 @@ spec:
     kind: Deployment
     name: aws-load-balancer-controller
   updatePolicy:
-    updateMode: Auto
+    updateMode: Recreate
   resourcePolicy:
     containerPolicies:
     - containerName: controller

--- a/cluster/manifests/cronjob-fixer/vpa.yaml
+++ b/cluster/manifests/cronjob-fixer/vpa.yaml
@@ -12,7 +12,7 @@ spec:
     kind: Deployment
     name: cronjob-fixer
   updatePolicy:
-    updateMode: Auto
+    updateMode: Recreate
   resourcePolicy:
     containerPolicies:
     - containerName: cronjob-fixer

--- a/cluster/manifests/deployment-service/status-service-vpa.yaml
+++ b/cluster/manifests/deployment-service/status-service-vpa.yaml
@@ -12,7 +12,7 @@ spec:
     kind: Deployment
     name: "deployment-service-status-service"
   updatePolicy:
-    updateMode: Auto
+    updateMode: Recreate
   resourcePolicy:
     containerPolicies:
     - containerName: "deployment-service-status-service"

--- a/cluster/manifests/event-logger/vpa.yaml
+++ b/cluster/manifests/event-logger/vpa.yaml
@@ -12,7 +12,7 @@ spec:
     kind: StatefulSet
     name: kubernetes-event-logger
   updatePolicy:
-    updateMode: Auto
+    updateMode: Recreate
   resourcePolicy:
     containerPolicies:
     - containerName: logger

--- a/cluster/manifests/external-dns/vpa.yaml
+++ b/cluster/manifests/external-dns/vpa.yaml
@@ -12,7 +12,7 @@ spec:
     kind: Deployment
     name: external-dns
   updatePolicy:
-    updateMode: Auto
+    updateMode: Recreate
   resourcePolicy:
     containerPolicies:
     - containerName: external-dns

--- a/cluster/manifests/ingress-controller/vpa.yaml
+++ b/cluster/manifests/ingress-controller/vpa.yaml
@@ -11,7 +11,7 @@ spec:
     kind: Deployment
     name: kube-ingress-aws-controller
   updatePolicy:
-    updateMode: Auto
+    updateMode: Recreate
   resourcePolicy:
     containerPolicies:
     - containerName: kube-ingress-aws-controller

--- a/cluster/manifests/kube-downscaler/vpa.yaml
+++ b/cluster/manifests/kube-downscaler/vpa.yaml
@@ -13,7 +13,7 @@ spec:
     kind: Deployment
     name: kube-downscaler
   updatePolicy:
-    updateMode: Auto
+    updateMode: Recreate
   resourcePolicy:
     containerPolicies:
     - containerName: downscaler

--- a/cluster/manifests/kube-janitor/vpa.yaml
+++ b/cluster/manifests/kube-janitor/vpa.yaml
@@ -13,7 +13,7 @@ spec:
     kind: Deployment
     name: kube-janitor
   updatePolicy:
-    updateMode: Auto
+    updateMode: Recreate
   resourcePolicy:
     containerPolicies:
     - containerName: janitor

--- a/cluster/manifests/kube-metrics-adapter/vpa.yaml
+++ b/cluster/manifests/kube-metrics-adapter/vpa.yaml
@@ -12,7 +12,7 @@ spec:
     kind: Deployment
     name: kube-metrics-adapter
   updatePolicy:
-    updateMode: Auto
+    updateMode: Recreate
   resourcePolicy:
     containerPolicies:
     - containerName: kube-metrics-adapter

--- a/cluster/manifests/kubenurse/prometheus.yaml
+++ b/cluster/manifests/kubenurse/prometheus.yaml
@@ -90,7 +90,7 @@ spec:
     kind: StatefulSet
     name: prometheus
   updatePolicy:
-    updateMode: Auto
+    updateMode: Recreate
   resourcePolicy:
     containerPolicies:
       - containerName: prometheus

--- a/cluster/manifests/kubernetes-lifecycle-metrics/vpa.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/vpa.yaml
@@ -12,7 +12,7 @@ spec:
     kind: Deployment
     name: kubernetes-lifecycle-metrics
   updatePolicy:
-    updateMode: Auto
+    updateMode: Recreate
   resourcePolicy:
     containerPolicies:
     - containerName: kubernetes-lifecycle-metrics

--- a/cluster/manifests/pdb-controller/vpa.yaml
+++ b/cluster/manifests/pdb-controller/vpa.yaml
@@ -12,7 +12,7 @@ spec:
     kind: Deployment
     name: pdb-controller
   updatePolicy:
-    updateMode: Auto
+    updateMode: Recreate
   resourcePolicy:
     containerPolicies:
     - containerName: pdb-controller

--- a/cluster/manifests/prometheus/prometheus-vpa.yaml
+++ b/cluster/manifests/prometheus/prometheus-vpa.yaml
@@ -16,7 +16,7 @@ spec:
     kind: StatefulSet
     name: prometheus
   updatePolicy:
-    updateMode: Auto
+    updateMode: Recreate
   resourcePolicy:
     containerPolicies:
     - containerName: prometheus

--- a/cluster/manifests/skipper/pod-deletion-cost-controller-vpa.yaml
+++ b/cluster/manifests/skipper/pod-deletion-cost-controller-vpa.yaml
@@ -12,7 +12,7 @@ spec:
     kind: Deployment
     name: pod-deletion-cost-controller
   updatePolicy:
-    updateMode: Auto
+    updateMode: Recreate
   resourcePolicy:
     containerPolicies:
     - containerName: pod-deletion-cost-controller

--- a/cluster/manifests/stackset-controller/vpa.yaml
+++ b/cluster/manifests/stackset-controller/vpa.yaml
@@ -12,7 +12,7 @@ spec:
     kind: Deployment
     name: stackset-controller
   updatePolicy:
-    updateMode: Auto
+    updateMode: Recreate
   resourcePolicy:
     containerPolicies:
     - containerName: stackset-controller


### PR DESCRIPTION
`updateMode: Auto` is deprecated in the latest VPA version (#10269, see: https://github.com/kubernetes/autoscaler/issues/8424)

Therefore change to `Recreate` which is the same behavior.

The alternative is: `InPlaceOrRecreate` which is available with the InPlace pod resource changes feature. Since we haven't validate that our setup works with this yet, let's use `Recreate` for now. 