### PR TITLE
Update Scheduled Scaling VPA CRD

### DIFF
--- a/cluster/manifests/02-scheduled-scaling-vpa/zalando.org_verticalpodautoscalers.yaml
+++ b/cluster/manifests/02-scheduled-scaling-vpa/zalando.org_verticalpodautoscalers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: verticalpodautoscalers.zalando.org
 spec:
   group: zalando.org
@@ -218,6 +218,11 @@ spec:
                                 - Auto
                                 - "Off"
                                 type: string
+                              unitResource:
+                                additionalProperties:
+                                  type: string
+                                description: Specifies the unit resource for the container.
+                                type: object
                             type: object
                           type: array
                       type: object
@@ -308,6 +313,7 @@ spec:
                     - "Off"
                     - Initial
                     - Recreate
+                    - InPlaceOrRecreate
                     - Auto
                     type: string
                 type: object
@@ -427,6 +433,7 @@ spec:
                 type: object
             type: object
         required:
+        - metadata
         - spec
         type: object
     served: true


### PR DESCRIPTION
Follow up to #10097 updating the VPA CRD to the latest version which includes the unitResource field used by the prometheus vpa when schedules are enabled.