### PR TITLE
Test CLM with aws-sdk-go-v2

### DIFF
--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -25,7 +25,7 @@ RUN curl -L -s --fail "https://dl.k8s.io/${KUBE_VERSION}/kubernetes-client-linux
 COPY --from=builder /go/bin/ginkgo /usr/local/bin/ginkgo
 
 # copy CLM
-COPY --from=container-registry.zalando.net/teapot/cluster-lifecycle-manager:latest /clm /usr/bin/clm
+COPY --from=container-registry-test.zalando.net/teapot/cluster-lifecycle-manager:pr-897-5 /clm /usr/bin/clm
 COPY --from=container-registry.zalando.net/teapot/aws-account-creator:latest /aws-account-creator /usr/bin/aws-account-creator
 
 ADD . /workdir


### PR DESCRIPTION
Test updating CLM to use aws-sdk-go-v2: https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/897