### PR TITLE
Simplify enabling Prometheus scheduled scaling vpa

### DIFF
--- a/cluster/manifests/prometheus/prometheus-vpa.yaml
+++ b/cluster/manifests/prometheus/prometheus-vpa.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Cluster.ConfigItems.scheduled_scaling_vpa_enabled "true") (ne .Cluster.ConfigItems.prometheus_scheduled_scaling_events "") }}
+{{- if eq .Cluster.ConfigItems.scheduled_scaling_vpa_enabled "true" }}
 apiVersion: zalando.org/v1
 {{- else }}
 apiVersion: autoscaling.k8s.io/v1


### PR DESCRIPTION
Make Prometheus use the Scheduled Scaling VPA resource type if the scheduled-scaling-vpa controller is enabled, even if no schedules are defined for Prometheus for the cluster.

The motivation for this is:

1. When switching to the Scheduled Scaling VPA type we need to delete/change ownership of the existing VPA resource such that it can be owned by the Scheduled Scaling VPA resource, this is a manual, one of, migration step. To avoid having this step again if schedules are disabled for Prometheus we simply use the Scheduled Scaling VPA type for all Prometheus in all clusters where the Scheduled Scaling VPA is enabled.
2. While this makes scheduled scaling VPA more critical to the operation of Prometheus, also in clusters where there are not scaling scheduled defined, it has the benefit of validating the Scheduled Scaling VPA controller e.g. in test clusters without schedules and it means all Prometheus runs with the same VPA type.

This change, byt itself, does not effect current clusters. We will still enable (`scheduled_scaling_vpa_enabled: true`) per cluster for a safe roll out.