### PR TITLE
fix: routesrv can cause fatal of new ingress pods in test 

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -234,12 +234,11 @@ kasada_api_key: ""
 # - "exec" - routesrv is deployed, skipper uses routesrv
 skipper_routesrv_enabled: "exec"
 skipper_routesrv_memory: "1Gi"
+skipper_routesrv_min_replicas: 2
 {{if eq .Cluster.Environment "production"}}
 skipper_routesrv_cpu: "1000m"
-skipper_routesrv_min_replicas: 2
 {{else}}
 skipper_routesrv_cpu: "100m"
-skipper_routesrv_min_replicas: 1
 {{end}}
 
 skipper_routesrv_node_affinity_enabled: "false"


### PR DESCRIPTION
fix: routesrv can cause fatal of new ingress pods in test 
Alerting happens if component ingress and routesrv are updated in test clusters at the same time