### PR TITLE
Fix e2e build

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -11,7 +11,7 @@ pipeline:
   - event: pull_request
   vm_config:
     type: linux
-    image: "cdp-runtime/go-1.24"
+    image: "cdp-runtime/go-1.25"
     size: large  # speed up building kubernetes/kubernetes
   cache:
     paths:
@@ -25,7 +25,7 @@ pipeline:
   - desc: build and push
     cmd: |
       cd ./test/e2e/
-      make
+      make build.linux.amd64
       go mod tidy
       if ! git diff --quiet go.mod go.sum; then
         echo "Running go mod tidy modified go.mod and/or go.sum"

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -1,5 +1,5 @@
 # builder image
-FROM golang:1.24 AS builder
+FROM golang:1.25 AS builder
 
 RUN CGO_ENABLED=0 go install github.com/onsi/ginkgo/v2/ginkgo@v2.21.0
 
@@ -28,7 +28,14 @@ COPY --from=builder /go/bin/ginkgo /usr/local/bin/ginkgo
 COPY --from=container-registry.zalando.net/teapot/cluster-lifecycle-manager:latest /clm /usr/bin/clm
 COPY --from=container-registry.zalando.net/teapot/aws-account-creator:latest /aws-account-creator /usr/bin/aws-account-creator
 
-ADD . /workdir
+ADD test/e2e/build/linux/${TARGETARCH}/e2e.test /workdir/test/e2e/e2e.test
+ADD test/e2e/build/linux/${TARGETARCH}/stackset-e2e /workdir/test/e2e/stackset-e2e
+ADD test/e2e/build/linux/${TARGETARCH}/check-daemonset-updated /workdir/test/e2e/check-daemonset-updated
+COPY test/e2e/*.sh /workdir/test/e2e/
+COPY test/e2e/*.py /workdir/test/e2e/
+ADD test/e2e/apply /workdir/test/e2e/apply
+ADD test/e2e/loadtest /workdir/test/e2e/loadtest
+ADD cluster /workdir/cluster
 
 ENV KUBECTL_PATH=/usr/bin/kubectl
 ENV KUBERNETES_PROVIDER=skeleton

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -14,7 +14,7 @@ deps:
 	CGO_ENABLED=0 go install github.com/onsi/ginkgo/v2/ginkgo@v2.21.0
 
 e2e.test: go.mod $(SOURCES)
-	go test -v -c -o e2e.test
+	CGO_ENABLED=0 go test -v -c -o e2e.test
 
 stackset-e2e:
 	CGO_ENABLED=0 go test -modfile stackset/go.mod -c -o stackset-e2e github.com/zalando-incubator/stackset-controller/cmd/e2e
@@ -30,14 +30,20 @@ build/linux/amd64/e2e.test: go.mod $(SOURCES)
 build/linux/amd64/stackset-e2e:
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -modfile stackset/go.mod -c -o $@ github.com/zalando-incubator/stackset-controller/cmd/e2e
 
+build/linux/amd64/check-daemonset-updated: go.mod daemonset-updated/main.go
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -trimpath -v -o $@ ./daemonset-updated
+
 build/linux/arm64/e2e.test: go.mod $(SOURCES)
 	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go test -v -c -o $@
 
 build/linux/arm64/stackset-e2e:
 	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go test -modfile stackset/go.mod -c -o $@ github.com/zalando-incubator/stackset-controller/cmd/e2e
 
-build.linux.amd64: build/linux/amd64/e2e.test build/linux/amd64/stackset-e2e
-build.linux.arm64: build/linux/arm64/e2e.test build/linux/arm64/stackset-e2e
+build/linux/arm64/check-daemonset-updated: go.mod daemonset-updated/main.go
+	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -trimpath -v -o $@ ./daemonset-updated
+
+build.linux.amd64: build/linux/amd64/e2e.test build/linux/amd64/stackset-e2e build/linux/amd64/check-daemonset-updated
+build.linux.arm64: build/linux/arm64/e2e.test build/linux/arm64/stackset-e2e build/linux/armd4/check-daemonset-updated
 
 build.docker: build
 	docker build --rm --build-arg KUBE_VERSION=$(KUBE_VERSION) -t "$(IMAGE):$(TAG)" -f $(DOCKERFILE) ../..
@@ -47,7 +53,7 @@ build.push: build.docker
 
 build.push.multiarch: build.linux.amd64 #build.linux.arm64
 	docker buildx create --config /etc/cdp-buildkitd.toml --driver-opt network=host --bootstrap --use
-	# docker buildx build --rm --build-arg KUBE_VERSION=$(KUBE_VERSION) -t "$(IMAGE):$(TAG)" --platform linux/amd64,linux/arm64 --push -f $(DOCKERFILE) ../..
+	# docker buildx build --quiet --rm --build-arg KUBE_VERSION=$(KUBE_VERSION) -t "$(IMAGE):$(TAG)" --platform linux/amd64,linux/arm64 --push -f $(DOCKERFILE) ../..
 	docker buildx build --quiet --rm --build-arg KUBE_VERSION=$(KUBE_VERSION) -t "$(IMAGE):$(TAG)" --platform linux/amd64 --push -f $(DOCKERFILE) ../..
 
 clean:


### PR DESCRIPTION
After the CDP golang runtime was updated from Ubuntu 20.04 to 24.04 the e2e tests started failing because the `e2e.test` was dynamically linked.

```
/workdir/test/e2e/e2e.test: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /workdir/test/e2e/e2e.test)
```

The problem was that is used the binary `e2e.test` build from the make target `make build` as opposed to the one from `make build.linux.amd64` which is correctly statically build.

This PR fixes various things around the e2e build related to this:

1. Only add the files needed for e2e to the docker image
2. Explicitly add the binaries under `build/linux/${TARGETARCH}` to the image such that we have the right architecture.
3. Update build to use Go 1.25 (from 1.24).