### PR TITLE
sandbox-crd: adds paths support to sandbox spec

### DIFF
--- a/cluster/manifests/sandbox-controller/10-sandbox_crd.yaml
+++ b/cluster/manifests/sandbox-controller/10-sandbox_crd.yaml
@@ -41,6 +41,16 @@ spec:
             type: object
           spec:
             properties:
+              paths:
+                description: Optional paths to further filter the rerouted traffic
+                  along with the sourceHosts.
+                items:
+                  type: string
+                  x-kubernetes-validations:
+                  - message: paths must start with '/'
+                    rule: self.startsWith("/")
+                type: array
+                x-kubernetes-list-type: set
               sourceHosts:
                 description: Traffic to these hosts will be rerouted to the targetHost
                   if testProject matches.


### PR DESCRIPTION
Adds paths support to Sandbox. Paths should not be duplicated, and startsWith a '/'

### Related Issue(s)

https://github.com/zalando-build/pg9-issues/issues/871