### PR TITLE
Allow cluster-cleaner to delete deployment-service bucket in playground

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1662,6 +1662,9 @@ Resources:
                   - !Sub "arn:aws:iam::${AWS::AccountId}:role/cluster-lifecycle-manager-entrypoint"
                   - !Sub "arn:aws:iam::${AWS::AccountId}:role/Shibboleth-Administrator"
                   - !Sub "arn:aws:iam::${AWS::AccountId}:role/Administrator"
+                  {{- if eq .Cluster.Name "playground" }}
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/cluster-cleaner-nuke-entrypoint"
+                  {{- end }}
   DeploymentControllerRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
cluster-cleaner was denied to clean up the deployment-service bucket

```
api error AccessDenied: User: arn:aws:sts::407797183256:assumed-role/cluster-cleaner-nuke-entrypoint/aws-go-sdk-1767988816457069807 is not authorized to perform: s3:GetBucketLocation on resource: \"arn:aws:s3:::zalando-deployment-service-407797183256-playground\" with an explicit deny in a resource-based policy" '
```

We recently switched cluster-cleaner to its own role. I assume it used the lifecycle-manager's role before, hence adding the new role in the same place (but only for playground).