### PR TITLE
Update to AMZN VPC CNI Addon v1.21.1

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -323,7 +323,7 @@ Resources:
     Type: AWS::EKS::Addon
     Properties:
       AddonName: vpc-cni
-      AddonVersion: "v1.19.5-eksbuild.1"
+      AddonVersion: "v1.21.1-eksbuild.1"
       ClusterName: !Ref EKSCluster
       ConfigurationValues: !Sub |
 {{- if eq .Cluster.ConfigItems.aws_vpc_cni_custom_networking "true" }}


### PR DESCRIPTION
Updates the Amzon VPC CNI Addon to v1.21.1 (current latest)

Depends on #10368 

* [x] dev
  * [x] kube-1.34
* [x] alpha
* [x] beta
* [x] stable