### PR TITLE
Revert "Skipper ingress Karpenter scheduling annotations"

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -128,7 +128,6 @@ worker_sg_legacy_cluster: ""
 # skipper node-pool
 enable_dedicate_nodepool_skipper: "true"
 skipper_attach_only_to_skipper_node_pool: "true"
-skipper_karpenter_node_pools_enabled: "false"
 
 skipper_suppress_route_update_logs: "true"
 skipper_validate_query: "true"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -92,48 +92,6 @@ spec:
               component: ingress
               application: skipper-ingress
 {{- end }}
-{{- if eq .Cluster.ConfigItems.skipper_karpenter_node_pools_enabled "true" }}
-      affinity:
-       podAntiAffinity:
-         requiredDuringSchedulingIgnoredDuringExecution:
-         - labelSelector:
-             matchExpressions:
-             - key: application
-               operator: In
-               values:
-               - skipper-ingress
-             - key: component
-               operator: In
-               values:
-               - ingress
-           topologyKey: kubernetes.io/hostname
-       nodeAffinity:
-         preferredDuringSchedulingIgnoredDuringExecution:
-         - weight: 100
-           preference:
-             matchExpressions:
-             - key: node.kubernetes.io/instance-type
-               operator: In
-               values:
-               - c7g.large
-               - c7g.xlarge
-               - c7g.2xlarge
-               - c7g.4xlarge
-               - c7g.8xlarge
-               - m7g.large
-         - weight: 50
-           preference:
-             matchExpressions:
-             - key: node.kubernetes.io/instance-type
-               operator: In
-               values:
-               - c6g.large
-               - c6g.xlarge
-               - c6g.2xlarge
-               - c6g.4xlarge
-               - c6g.8xlarge
-               - m6g.large
-{{- end }}
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       serviceAccountName: skipper-ingress
       terminationGracePeriodSeconds: {{ .Cluster.ConfigItems.skipper_termination_grace_period }}
@@ -514,21 +472,12 @@ spec:
             name: open-policy-agent-config
 {{ end }}
 {{ if eq .Cluster.ConfigItems.enable_dedicate_nodepool_skipper "true"}}
-{{- if eq .Cluster.ConfigItems.skipper_karpenter_node_pools_enabled "true" }}
-      nodeSelector:
-        zalando.org/dedicated: skipper-ingress
-      tolerations:
-      - key: "zalando.org/dedicated"
-        operator: Exists
-        effect: NoSchedule
-{{ else }}
       nodeSelector:
         dedicated: skipper-ingress
       tolerations:
       - effect: NoSchedule
         key: dedicated
         value: skipper-ingress
-{{ end}}
 {{ end }}
 {{ end }}
 


### PR DESCRIPTION
Reverts zalando-incubator/kubernetes-on-aws#10292

We have decided to not use scheduled annotations, but rather use the standard dedicated node pools. With the dedicated node pools we can automatically propagate the label `ingress-enabled: true` to the EC2 nodes. But. with scheduled annotations this is right now not possible and we need to implement dynamic tagging. This will take longer and hence we proceed with dedicated node pool.

See label propagation https://github.com/zalando-incubator/kubernetes-on-aws/blob/dev/cluster/node-pools/worker-karpenter/provisioners.yaml#L80-L85 for dedicated node pools.