### PR TITLE
Prepare for Amazon VPC CNI addon

### DIFF
--- a/cluster/manifests/01-aws-node/daemonset.yaml
+++ b/cluster/manifests/01-aws-node/daemonset.yaml
@@ -113,7 +113,7 @@ spec:
               apiVersion: v1
               fieldPath: metadata.name
         image: 602401143452.dkr.ecr.{{.Cluster.Region}}.amazonaws.com/amazon-k8s-cni:v1.19.5-eksbuild.1
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         livenessProbe:
           exec:
             command:
@@ -181,7 +181,7 @@ spec:
               apiVersion: v1
               fieldPath: spec.nodeName
         image: 602401143452.dkr.ecr.{{.Cluster.Region}}.amazonaws.com/amazon/aws-network-policy-agent:v1.2.1-eksbuild.1
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: aws-eks-nodeagent
         ports:
         - containerPort: 8162
@@ -215,7 +215,7 @@ spec:
         - name: ENABLE_IPv6
           value: "{{ if eq .Cluster.ConfigItems.eks_ip_family "ipv4" }}false{{else}}true{{end}}"
         image: 602401143452.dkr.ecr.{{.Cluster.Region}}.amazonaws.com/amazon-k8s-cni-init:v1.19.5-eksbuild.1
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: aws-vpc-cni-init
         resources:
           requests:


### PR DESCRIPTION
This prepares the aws-node daemonset config such that it's compatible with moving to manage this via the EKS addon.

Without this prerequisite we get errors like this when trying to switch to the addon:

```
Resource handler returned message: "Addon moved to failed status during Create operation. Code: ConfigurationConflict, Message: Conflicts found when trying to apply. Will not continue due to resolve conflicts mode. Conflicts:

DaemonSet.apps aws-node - .spec.template.spec.containers[name="aws-eks-nodeagent"].imagePullPolicy
DaemonSet.apps aws-node - .spec.template.spec.initContainers[name="aws-vpc-cni-init"].imagePullPolic
```