### PR TITLE
Wiz version upgrade

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1318,7 +1318,7 @@ wiz_enable_runtime_connector: "true"
 wiz_enable_runtime_connector_broker: "true"
 {{ end }}
 {{if eq .Cluster.Environment "e2e"}}
-wiz_enable_runtime_sensor: "false"
+wiz_enable_runtime_sensor: "true"
 wiz_sensor_cpu: "200m"
 wiz_sensor_memory: "300Mi"
 {{ else }}

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1317,9 +1317,15 @@ wiz_enable_runtime_connector_broker: "false"
 wiz_enable_runtime_connector: "true"
 wiz_enable_runtime_connector_broker: "true"
 {{ end }}
+{{if eq .Cluster.Environment "e2e"}}
 wiz_enable_runtime_sensor: "false"
 wiz_sensor_cpu: "200m"
 wiz_sensor_memory: "300Mi"
+{{ else }}
+wiz_enable_runtime_sensor: "false"
+wiz_sensor_cpu: "200m"
+wiz_sensor_memory: "300Mi"
+{{ end }}
 wiz_connector_cpu: "50m"
 wiz_connector_memory: "150Mi"
 wiz_priority: "true"

--- a/cluster/manifests/02-admission-control/config.yaml
+++ b/cluster/manifests/02-admission-control/config.yaml
@@ -123,7 +123,7 @@ data:
   pod.pod-security-policy.privileged-service-accounts.{{ $sa }}: ""
 {{- end}}
 {{- if eq .Cluster.ConfigItems.wiz_enable_runtime_sensor "true" }}
-  pod.pod-security-policy.privileged-service-accounts.wiz_wiz-connector-wiz-sensor: ""
+  pod.pod-security-policy.privileged-service-accounts.wiz_wiz-sensor: ""
 {{- end }}
 {{- if eq .Cluster.ConfigItems.polarsignals_enabled "true" }}
   pod.pod-security-policy.privileged-service-accounts.polarsignals_polarsignals-agent: ""

--- a/cluster/manifests/02-admission-control/config.yaml
+++ b/cluster/manifests/02-admission-control/config.yaml
@@ -123,7 +123,7 @@ data:
   pod.pod-security-policy.privileged-service-accounts.{{ $sa }}: ""
 {{- end}}
 {{- if eq .Cluster.ConfigItems.wiz_enable_runtime_sensor "true" }}
-  pod.pod-security-policy.privileged-service-accounts.wiz_wiz-sensor: ""
+  pod.pod-security-policy.privileged-service-accounts.wiz_wiz-connector-wiz-sensor: ""
 {{- end }}
 {{- if eq .Cluster.ConfigItems.polarsignals_enabled "true" }}
   pod.pod-security-policy.privileged-service-accounts.polarsignals_polarsignals-agent: ""

--- a/cluster/manifests/wiz/002-connector-broker-serviceaccount.yaml
+++ b/cluster/manifests/wiz/002-connector-broker-serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
   name: wiz-broker
   namespace: "wiz"
   labels:
-    helm.sh/chart: wiz-broker-2.3.8
+    helm.sh/chart: wiz-broker-3.0.3
     application: "wiz"
     component: "connector"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: wiz-cluster-reader
   namespace: "wiz"
   labels:
-    helm.sh/chart: wiz-kubernetes-connector-3.3.11
+    helm.sh/chart: wiz-kubernetes-connector-4.0.3
     application: "wiz"
     component: "connector"
 {{end}}

--- a/cluster/manifests/wiz/002-connector-job-serviceaccount.yaml
+++ b/cluster/manifests/wiz/002-connector-job-serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: wiz-auto-modify-connector
   namespace: "wiz"
   labels:
-    helm.sh/chart: wiz-kubernetes-connector-3.3.11
+    helm.sh/chart: wiz-kubernetes-connector-4.0.3
     application: "wiz"
     component: "connector"
 {{ end }}

--- a/cluster/manifests/wiz/002-sensor-serviceaccount.yaml
+++ b/cluster/manifests/wiz/002-sensor-serviceaccount.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: wiz-connector-wiz-sensor
+  name: wiz-sensor
   namespace: wiz
   labels:
     helm.sh/chart: wiz-sensor-1.0.8831

--- a/cluster/manifests/wiz/002-sensor-serviceaccount.yaml
+++ b/cluster/manifests/wiz/002-sensor-serviceaccount.yaml
@@ -4,10 +4,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: wiz-sensor
+  name: wiz-connector-wiz-sensor
   namespace: wiz
   labels:
-    helm.sh/chart: wiz-sensor-1.0.6440
+    helm.sh/chart: wiz-sensor-1.0.8831
     application: "wiz"
-    component: "connector"
+    component: "sensor"
 {{end}}

--- a/cluster/manifests/wiz/003-connector-broker-clusterrole.yaml
+++ b/cluster/manifests/wiz/003-connector-broker-clusterrole.yaml
@@ -8,7 +8,7 @@ kind: ClusterRoleBinding
 metadata:
   name: wiz-cluster-reader
   labels:
-    helm.sh/chart: wiz-kubernetes-connector-3.3.11
+    helm.sh/chart: wiz-kubernetes-connector-4.0.3
     application: "wiz"
     component: "connector"
 roleRef:

--- a/cluster/manifests/wiz/003-connector-job-role.yaml
+++ b/cluster/manifests/wiz/003-connector-job-role.yaml
@@ -7,7 +7,7 @@ metadata:
   name: wiz-auto-modify-connector
   namespace: "wiz"
   labels:
-    helm.sh/chart: wiz-kubernetes-connector-3.3.11
+    helm.sh/chart: wiz-kubernetes-connector-4.0.3
     application: "wiz"
     component: "connector"
 rules:
@@ -29,7 +29,7 @@ metadata:
   name: wiz-auto-modify-connector
   namespace: "wiz"
   labels:
-    helm.sh/chart: wiz-kubernetes-connector-3.3.11
+    helm.sh/chart: wiz-kubernetes-connector-4.0.3
     application: "wiz"
     component: "connector"
 roleRef:

--- a/cluster/manifests/wiz/003-sensor-clusterrole.yaml
+++ b/cluster/manifests/wiz/003-sensor-clusterrole.yaml
@@ -4,7 +4,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: wiz-connector-wiz-sensor
+  name: wiz-sensor
   labels:
     helm.sh/chart: wiz-sensor-1.0.8831
     application: "wiz"
@@ -26,17 +26,17 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: wiz-connector-wiz-sensor
+  name: wiz-sensor
   labels:
     helm.sh/chart: wiz-sensor-1.0.8831
     application: "wiz"
     component: "sensor"
 subjects:
 - kind: ServiceAccount
-  name: wiz-connector-wiz-sensor
+  name: wiz-sensor
   namespace: wiz
 roleRef:
   kind: ClusterRole
-  name: wiz-connector-wiz-sensor
+  name: wiz-sensor
   apiGroup: rbac.authorization.k8s.io
 {{end}}

--- a/cluster/manifests/wiz/003-sensor-clusterrole.yaml
+++ b/cluster/manifests/wiz/003-sensor-clusterrole.yaml
@@ -4,39 +4,39 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: wiz-sensor
+  name: wiz-connector-wiz-sensor
   labels:
-    helm.sh/chart: wiz-sensor-1.0.6440
+    helm.sh/chart: wiz-sensor-1.0.8831
     application: "wiz"
     component: "sensor"
 rules:
   - apiGroups: [""]
-    resources: ["pods", "namespaces", "nodes", "replicationcontrollers", "serviceaccounts"]
+    resources: ["pods"]
     verbs: ["get", "list", "watch"]
 
-  - apiGroups: ["apps"]
-    resources: ["daemonsets", "replicasets", "deployments", "statefulsets"]
-    verbs: ["get", "list", "watch"]
-
-  - apiGroups: ["batch"]
-    resources: ["cronjobs"]
+  - apiGroups: ["", "apps", "batch"]
+    resources: [
+      "namespaces", "nodes", "daemonsets", "replicasets", "deployments",
+      "jobs", "cronjobs", "statefulsets", "replicationcontrollers", "serviceaccounts",
+      "nodes/proxy"
+    ]
     verbs: ["get", "list", "watch"]
 ---
 # Source: wiz-sensor/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: wiz-sensor
+  name: wiz-connector-wiz-sensor
   labels:
-    helm.sh/chart: wiz-sensor-1.0.6440
+    helm.sh/chart: wiz-sensor-1.0.8831
     application: "wiz"
     component: "sensor"
 subjects:
 - kind: ServiceAccount
-  name: wiz-sensor
+  name: wiz-connector-wiz-sensor
   namespace: wiz
 roleRef:
   kind: ClusterRole
-  name: wiz-sensor
+  name: wiz-connector-wiz-sensor
   apiGroup: rbac.authorization.k8s.io
 {{end}}

--- a/cluster/manifests/wiz/004-connector-broker-secrets.yaml
+++ b/cluster/manifests/wiz/004-connector-broker-secrets.yaml
@@ -9,7 +9,7 @@ metadata:
   name: wiz-connector-connector
   namespace: "wiz"
   labels:
-    helm.sh/chart: wiz-kubernetes-connector-3.3.11
+    helm.sh/chart: wiz-kubernetes-connector-4.0.3
     application: "wiz"
     component: "connector"
 type: Opaque
@@ -25,7 +25,7 @@ metadata:
   name: wiz-cluster-reader-token
   namespace: "wiz"
   labels:
-    helm.sh/chart: wiz-kubernetes-connector-3.3.11
+    helm.sh/chart: wiz-kubernetes-connector-4.0.3
     application: "wiz"
     component: "connector"
   annotations:
@@ -39,7 +39,7 @@ metadata:
   name: wiz-api-token
   namespace: wiz
   labels:
-    helm.sh/chart: wiz-kubernetes-integration-0.2.91
+    helm.sh/chart: wiz-kubernetes-integration-0.3.6
     application: "wiz"
     component: "connector"
 type: Opaque

--- a/cluster/manifests/wiz/004-sensor-secrets.yaml
+++ b/cluster/manifests/wiz/004-sensor-secrets.yaml
@@ -14,18 +14,4 @@ type: Opaque
 stringData:
   clientId: "{{ .Cluster.ConfigItems.wiz_api_client_id }}"
   clientToken: "{{ .Cluster.ConfigItems.wiz_api_client_token }}"
-# ---
-# # Source: wiz-sensor/templates/imagepullsecret.yaml
-# apiVersion: v1
-# kind: Secret
-# type: kubernetes.io/dockerconfigjson
-# metadata:
-#   name: wiz-sensor-imagepullkey
-#   labels:
-#     helm.sh/chart: wiz-sensor-1.0.4760
-#     application: "wiz"
-#     component: "sensor"
-#   namespace: wiz
-# data:
-#   .dockerconfigjson: "{{ .Cluster.ConfigItems.wiz_sensor_dockerconfigjson }}"
 {{end}}

--- a/cluster/manifests/wiz/004-sensor-secrets.yaml
+++ b/cluster/manifests/wiz/004-sensor-secrets.yaml
@@ -4,10 +4,10 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: wiz-sensor-apikey
+  name: custom-wiz-sensor-api-token
   namespace: wiz
   labels:
-    helm.sh/chart: wiz-kubernetes-integration-0.2.91
+    helm.sh/chart: wiz-kubernetes-integration-0.3.6
     application: "wiz"
     component: "sensor"
 type: Opaque

--- a/cluster/manifests/wiz/005-connector-job.yaml
+++ b/cluster/manifests/wiz/005-connector-job.yaml
@@ -7,7 +7,7 @@ metadata:
   name: wiz-kubernetes-connector-create-connector
   namespace: "wiz"
   labels:
-    helm.sh/chart: wiz-kubernetes-connector-3.3.11
+    helm.sh/chart: wiz-kubernetes-connector-4.0.3
     application: "wiz"
     component: "connector"
     job: "wiz-connector-agent"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       labels: 
-        helm.sh/chart: wiz-kubernetes-connector-3.3.11
+        helm.sh/chart: wiz-kubernetes-connector-4.0.3
         application: "wiz"
         component: "connector"
         job: "wiz-connector-agent"
@@ -39,9 +39,14 @@ spec:
         - name: wiz-connector-creator
           securityContext:
             allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 10000
             runAsNonRoot: true
-            runAsUser: 1000
-          image: "container-registry.zalando.net/secops-systems/wiz-broker:2.7-main-4"
+            runAsUser: 10000
+          image: "container-registry.zalando.net/secops-systems/wiz-broker:3.0.3-main-8"
           imagePullPolicy: IfNotPresent
           command:
             - "wiz-broker"
@@ -68,6 +73,10 @@ spec:
             value: info
           - name: WIZ_ENV
             value: 
+          - name: WIZ_USE_HATUNNEL
+            value: "1"
+          - name: WIZ_BROKER_HEARTBEAT_DISABLE_CLUSTER_ID
+            value: "1"
           resources:
             limits:
               cpu: {{ .Cluster.ConfigItems.wiz_connector_cpu }} 

--- a/cluster/manifests/wiz/connector-deployment.yaml
+++ b/cluster/manifests/wiz/connector-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   name: wiz-connector-agent
   namespace: "wiz"
   labels:
-    helm.sh/chart: wiz-broker-2.3.8
+    helm.sh/chart: wiz-broker-3.0.3
     application: "wiz"
     component: "connector"
     deployment: "wiz-connector-agent"
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: wiz-broker-2.3.8
+        helm.sh/chart: wiz-broker-3.0.3
         application: "wiz"
         component: "connector"
         deployment: "wiz-connector-agent"
@@ -42,9 +42,14 @@ spec:
         - name: wiz-broker
           securityContext:
             allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 10000
             runAsNonRoot: true
-            runAsUser: 1000
-          image: "container-registry.zalando.net/secops-systems/wiz-broker:2.7-main-4"
+            runAsUser: 10000
+          image: "container-registry.zalando.net/secops-systems/wiz-broker:3.0.3-main-8"
           imagePullPolicy: IfNotPresent
           volumeMounts:
           - name: api-client
@@ -54,7 +59,8 @@ spec:
             mountPath: /etc/connectorData
             readOnly: true
           args:
-            - /etc/connectorData/data
+            - --connector-data-file-path
+            - "/etc/connectorData/data"
           env:
           - name: LOG_LEVEL
             value: info
@@ -66,6 +72,49 @@ spec:
             value: kubernetes.default.svc.cluster.local
           - name: TARGET_PORT
             value: "443"
+          - name: K8S_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: K8S_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: K8S_DEPLOYMENT_NAME
+            value: wiz-connector-agent
+          - name: WIZ_CHART_VERSION
+            value: "3.0.3"
+          - name: WIZ_IMAGE_REF
+            value: "container-registry.zalando.net/secops-systems/wiz-broker:3.0.3-main-8"
+          - name: WIZ_USE_HATUNNEL # toggle WebSocket usage on
+            value: "1"
+          - name: WIZ_BROKER_HEARTBEAT_DISABLE_CLUSTER_ID
+            value: "1"
+          - name: WIZ_AUTO_ROLLOUT_ROLE
+            value: "false"
+          - name: WIZ_HEALTH_PORT
+            value: "30000"
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+            httpGet:
+              port: 30000
+              path: /ready
+          livenessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 90 # 15 minutes
+            httpGet:
+              port: 30000
+              path: /live
+          ports:
+            - containerPort: 30000
+              name: health
           resources:
             limits:
               cpu: {{ .Cluster.ConfigItems.wiz_connector_cpu }} 

--- a/cluster/manifests/wiz/sensor-daemonset.yaml
+++ b/cluster/manifests/wiz/sensor-daemonset.yaml
@@ -4,7 +4,7 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: wiz-connector-wiz-sensor
+  name: wiz-sensor
   labels:
     helm.sh/chart: wiz-sensor-1.0.8831
     image/tag: v1
@@ -31,7 +31,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/enable-ds-eviction: "true"
     spec:
-      serviceAccountName: wiz-connector-wiz-sensor
+      serviceAccountName: wiz-sensor
       {{- if eq .Cluster.ConfigItems.wiz_priority "true" }}
       priorityClassName: system-node-critical
       {{- end }}

--- a/cluster/manifests/wiz/sensor-daemonset.yaml
+++ b/cluster/manifests/wiz/sensor-daemonset.yaml
@@ -29,7 +29,6 @@ spec:
         component: "sensor"
         daemonset: "wiz-sensor"
       annotations:
-        container.apparmor.security.beta.kubernetes.io/wiz-sensor: unconfined
         cluster-autoscaler.kubernetes.io/enable-ds-eviction: "true"
     spec:
       serviceAccountName: wiz-connector-wiz-sensor
@@ -75,6 +74,8 @@ spec:
           runAsUser: 2202
           runAsGroup: 2202
           readOnlyRootFilesystem: true
+          appArmorProfile:
+            type: Unconfined
           seccompProfile:
             type: Unconfined
           seLinuxOptions:

--- a/cluster/manifests/wiz/sensor-daemonset.yaml
+++ b/cluster/manifests/wiz/sensor-daemonset.yaml
@@ -4,10 +4,10 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: wiz-sensor
+  name: wiz-connector-wiz-sensor
   labels:
-    helm.sh/chart: wiz-sensor-1.0.6440
-    image/tag: 1.0.6572
+    helm.sh/chart: wiz-sensor-1.0.8831
+    image/tag: v1
     application: "wiz"
     component: "sensor"
     daemonset: "wiz-sensor"
@@ -23,8 +23,8 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: wiz-sensor-1.0.6440
-        image/tag: 1.0.6572
+        helm.sh/chart: wiz-sensor-1.0.8831
+        image/tag: v1
         application: "wiz"
         component: "sensor"
         daemonset: "wiz-sensor"
@@ -32,7 +32,7 @@ spec:
         container.apparmor.security.beta.kubernetes.io/wiz-sensor: unconfined
         cluster-autoscaler.kubernetes.io/enable-ds-eviction: "true"
     spec:
-      serviceAccountName: wiz-sensor
+      serviceAccountName: wiz-connector-wiz-sensor
       {{- if eq .Cluster.ConfigItems.wiz_priority "true" }}
       priorityClassName: system-node-critical
       {{- end }}
@@ -51,17 +51,8 @@ spec:
       restartPolicy: Always
       containers:
       - name: wiz-sensor
-        image: container-registry.zalando.net/secops-systems/wiz-sensor:1.0.6572-main-4
+        image: container-registry.zalando.net/secops-systems/wiz-sensor:1.0.8831-main-8
         imagePullPolicy: IfNotPresent
-        startupProbe:
-            exec:
-              command:
-              - "/usr/src/app/wiz-sensor"
-              - "version"
-            initialDelaySeconds: 15
-            periodSeconds: 60
-            timeoutSeconds: 30
-            failureThreshold: 5
         securityContext:
           capabilities:
             add:
@@ -122,7 +113,7 @@ spec:
               fieldPath: metadata.namespace
         - name: MY_APIKEY_SECRET_NAME
           value: wiz-sensor-apikey
-        - name: AWS_EC2_METADATA_DISABLED
+        - name: AWS_EC2_METADATA_DISABLED # don't use AWS ISDS for IAM
           value: "true"
         - name: CRI_SOCKET_CUSTOM_PATH
           value: 
@@ -160,6 +151,12 @@ spec:
               divisor: "1m"
         - name: DISALLOW_RUNTIME_RESPONSE
           value: "true"
+        - name: HELM_CHART_VERSION
+          value: 1.0.8831
+        - name: ALLOW_KUBELET_COMMUNICATION
+          value: "false"
+        - name: FORCE_KUBELET_COMMUNICATION
+          value: "false"
         volumeMounts:
         - name: sensor-host-cache
           mountPath: /wiz-host-cache/
@@ -178,9 +175,7 @@ spec:
           requests:
             cpu: {{ .Cluster.ConfigItems.wiz_sensor_cpu }}
             memory: {{ .Cluster.ConfigItems.wiz_sensor_memory }} 
-      terminationGracePeriodSeconds: 90
-      # imagePullSecrets:
-      #   - name: wiz-sensor-imagepullkey
+      terminationGracePeriodSeconds: 25
       volumes:
       - name: sensor-host-cache
         hostPath:
@@ -188,7 +183,7 @@ spec:
           type: DirectoryOrCreate
       - name: api-client-secret
         secret:
-          secretName: wiz-sensor-apikey
+          secretName: custom-wiz-sensor-api-token
           items:
             - key: clientId
               path: clientId
@@ -196,7 +191,7 @@ spec:
               path: clientToken
       - name: api-endpoint-name-secret
         secret:
-          secretName: wiz-sensor-apikey
+          secretName: custom-wiz-sensor-api-token
           optional: true
           items:
             - key: clientEndpoint

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -38,7 +38,7 @@ clusters:
     routegroups_validation: "enabled"
     stackset_routegroup_support_enabled: "true"
     stackset_ingress_source_switch_ttl: "1m"
-    teapot_admission_controller_daemonset_reserved_cpu: "518m"
+    teapot_admission_controller_daemonset_reserved_cpu: "718m"
     okta_auth_client_id: "kubernetes.cluster.teapot-e2e"
     teapot_admission_controller_validate_pod_images_soft_fail_namespaces: "^kube-system$"
     eks_okta_identity_provider: "false" # disabled to speed up EKS cluster creation for e2e.


### PR DESCRIPTION
Upgrades the Wiz component to the latest version using manifests from `wiz-kubernetes-integration` with version 0.3.6.
This is a patch for the sensor and a major version upgrade for the connector.

Changes in this PR:
- runs the wiz-sensor in the e2e clusters
- deletes unused secret: `wiz-sensor-apikey`
- adds jobs and nodes/proxy api groups to sensor cluster role
- removes the startup probe from the sensor
- adds readiness and liveness probes to connector
- major broker version is switching to using the same tunnel as the sensor, toggle with `WIZ_USE_HATUNNEL`
- `WIZ_BROKER_HEARTBEAT_DISABLE_CLUSTER_ID` is a temporary bug fix by Wiz