### PR TITLE
Add /var/lib/kubelet symlink to AMI

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -835,8 +835,8 @@ tracing_coredns_local_zone_traces_endpoint: ""
 # AMI id given the image name and the Image AWS account owner.
 #
 # [0]: https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/8a9bd1cb2d094038a9e23e646421f8146b48886a/provisioner/template.go#L116
-kuberuntu_image_v1_34_new_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.34.3-amd64-master-385" "861068367966" }}
-kuberuntu_image_v1_34_new_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.34.3-arm64-master-385" "861068367966" }}
+kuberuntu_image_v1_34_new_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.34.3-amd64-master-386" "861068367966" }}
+kuberuntu_image_v1_34_new_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.34.3-arm64-master-386" "861068367966" }}
 
 # This is used to determine which AMI to use for the cluster or individual node
 # pools. Possible values are 'new' or 'old'

--- a/cluster/manifests/node-monitor/daemonset.yaml
+++ b/cluster/manifests/node-monitor/daemonset.yaml
@@ -42,7 +42,7 @@ spec:
             - --no-collector.wifi
             - --no-collector.hwmon
             - --no-collector.btrfs
-            - --collector.filesystem.mount-points-exclude=^/(dev|proc|run|sys|host|var/lib/lxcfs|opt/podruntime/containerd/.+|opt/podruntime/kubelet/.+)($|/)
+            - --collector.filesystem.mount-points-exclude=^/(dev|proc|run|sys|host|var/lib/lxcfs|opt/podruntime/containerd/.+|opt/podruntime/kubelet/.+|var/lib/kubelet/.+)($|/)
             - --collector.netdev.device-exclude=^veth.*$
             - --collector.netclass.ignored-devices=^veth.*$
           name: prometheus-node-exporter


### PR DESCRIPTION
This updates the AMI to a version that adds `/var/lib/kubelet` as symlink to `/opt/podruntime/kubelet`

This is done to ensure tools assuming kubelet data dir is at `/var/lib/kubelet` will work out of the box without work-arounds.

Specifically it supports #10330 

Depends on #10389 being fully rolled out

* [x] dev
* [x] alpha
* [x] beta
* [x] stable