### PR TITLE
Move from /opt/podruntime/kubelet to /var/lib/kubelet

### DIFF
--- a/cluster/manifests/04-ebs-csi/node.yaml
+++ b/cluster/manifests/04-ebs-csi/node.yaml
@@ -47,9 +47,6 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           volumeMounts:
-            - name: kubelet-dir-legacy
-              mountPath: /opt/podruntime/kubelet
-              mountPropagation: Bidirectional
             - name: kubelet-dir
               mountPath: /var/lib/kubelet
               mountPropagation: Bidirectional
@@ -89,7 +86,7 @@ spec:
             - name: ADDRESS
               value: /csi/csi.sock
             - name: DRIVER_REG_SOCK_PATH
-              value: /opt/podruntime/kubelet/plugins/ebs.csi.aws.com/csi.sock
+              value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
           livenessProbe:
             exec:
               command:
@@ -105,7 +102,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
             - name: probe-dir
-              mountPath: /opt/podruntime/kubelet/plugins/ebs.csi.aws.com/
+              mountPath: /var/lib/kubelet/plugins/ebs.csi.aws.com/
           resources:
             requests:
               cpu: 10m
@@ -134,21 +131,17 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
       volumes:
-        - name: kubelet-dir-legacy
-          hostPath:
-            path: /opt/podruntime/kubelet
-            type: Directory
         - name: kubelet-dir
           hostPath:
             path: /var/lib/kubelet
             type: Directory
         - name: plugin-dir
           hostPath:
-            path: /opt/podruntime/kubelet/plugins/ebs.csi.aws.com/
+            path: /var/lib/kubelet/plugins/ebs.csi.aws.com/
             type: DirectoryOrCreate
         - name: registration-dir
           hostPath:
-            path: /opt/podruntime/kubelet/plugins_registry/
+            path: /var/lib/kubelet/plugins_registry/
             type: Directory
         - name: device-dir
           hostPath:

--- a/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
+++ b/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
@@ -56,7 +56,7 @@ spec:
 {{- if eq .Cluster.ConfigItems.nvidia_dcgm_exporter_enabled "true" }}
       - name: pod-gpu-resources
         hostPath:
-          path: /opt/podruntime/kubelet/pod-resources
+          path: /var/lib/kubelet/pod-resources
 {{- end}}
       containers:
       - name: nvidia-gpu-device-plugin


### PR DESCRIPTION
Rename paths from `/opt/podruntime/kubelet` to `/var/lib/kubelet`

Depends on #10383 

* [x] dev
* [x] alpha
* [x] beta
* [x] stable
* [x] All clusters run latest AMI