### PR TITLE
Add both kubelet-dir basedirs ahead of migration

### DIFF
--- a/cluster/manifests/04-ebs-csi/node.yaml
+++ b/cluster/manifests/04-ebs-csi/node.yaml
@@ -47,8 +47,11 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           volumeMounts:
-            - name: kubelet-dir
+            - name: kubelet-dir-legacy
               mountPath: /opt/podruntime/kubelet
+              mountPropagation: Bidirectional
+            - name: kubelet-dir
+              mountPath: /var/lib/kubelet
               mountPropagation: Bidirectional
             - name: plugin-dir
               mountPath: /csi
@@ -131,9 +134,13 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
       volumes:
-        - name: kubelet-dir
+        - name: kubelet-dir-legacy
           hostPath:
             path: /opt/podruntime/kubelet
+            type: Directory
+        - name: kubelet-dir
+          hostPath:
+            path: /var/lib/kubelet
             type: Directory
         - name: plugin-dir
           hostPath:


### PR DESCRIPTION
This configures old (`/opt/podruntime/kubelet`) and new (`/var/lib/kubelet`) paths on the ebs-csi to make it compatible with the AMI upgrade that switches kubelet to use `/var/lib/kubelet`.