### PR TITLE
Switch default target type of ALBC to instance

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1353,6 +1353,7 @@ aws_vpc_cni_network_policy_enforcing_mode: "standard"
 # aws-load-balancer-controller resource settings
 aws_load_balancer_controller_cpu: "100m"
 aws_load_balancer_controller_mem_max: "4Gi"
+aws_load_balancer_controller_default_target_type: "instance"
 
 # configure if sandbox-controller should be deployed
 sandbox_controller_enabled: "false"

--- a/cluster/manifests/aws-load-balancer-controller/deployment.yaml
+++ b/cluster/manifests/aws-load-balancer-controller/deployment.yaml
@@ -29,7 +29,7 @@ spec:
         - --webhook-key-file=admission-controller-key.pem
         - --default-ssl-policy=ELBSecurityPolicy-TLS13-1-2-2021-06
         - --default-load-balancer-scheme=internet-facing
-        - --default-target-type=ip
+        - --default-target-type={{ .Cluster.ConfigItems.aws_load_balancer_controller_default_target_type }}
         image: container-registry.zalando.net/teapot/aws-load-balancer-controller:v2.12.0-main-2.patched
         livenessProbe:
           failureThreshold: 2


### PR DESCRIPTION
Switch the default target type from `ip` to `instance`.

`instance` matches the old behaviour more closely and avoids `albc` to manage Pod IPs in target groups. This makes this component less critical as rotating pod IPs don't need to updated in the target group by `albc`. Instead, instances stay in the target group for their entire lifetime and pod IPs are mapped by `kube-proxy`.

There are five clusters that already have active load balancers using `ip` mode. The ~default~Config Item has been set to `ip` in these clusters to keep them unchanged. After this rollout, the existing Services can be migrated separately. This seems doable because the list of services suggests there can be a short downtime for each of them.