### PR TITLE
Create default EFS and storage class

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -637,7 +637,6 @@ Resources:
       Path: /
       ManagedPolicyArns:
       - arn:aws:iam::aws:policy/service-role/AmazonEFSCSIDriverPolicy
-{{- if eq .Cluster.ConfigItems.eks_efs_filesystem_deployed "true" }}
   EFSFileSystem:
     Type: AWS::EFS::FileSystem
     Properties:
@@ -656,7 +655,6 @@ Resources:
       - !Ref EKSWorkerSecurityGroup
   {{ end }}
   {{ end }}
-{{- end }}
 {{- end }}
   EKSZalandoIAMProxyIAMRole:
     Type: AWS::IAM::Role
@@ -4007,7 +4005,7 @@ Outputs:
   #   Export:
   #     Name: "{{.Cluster.ID}}:eks-certificate-authority-data"
   #   Value: !GetAtt EKSCluster.CertificateAuthorityData
-  {{- if eq .Cluster.ConfigItems.eks_efs_filesystem_deployed "true" }}
+  {{- if eq .Cluster.ConfigItems.eks_efs_csi_support_enabled "true" }}
   EFSFileSystemID:
     Export:
       Name: '{{ .Cluster.ID}}:efs-filesystem-id'

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -637,6 +637,26 @@ Resources:
       Path: /
       ManagedPolicyArns:
       - arn:aws:iam::aws:policy/service-role/AmazonEFSCSIDriverPolicy
+{{- if eq .Cluster.ConfigItems.eks_efs_filesystem_deployed "true" }}
+  EFSFileSystem:
+    Type: AWS::EFS::FileSystem
+    Properties:
+      Encrypted: true
+      FileSystemTags:
+      - Key: Name
+        Value: "Default EFS for {{.Cluster.Alias}}"
+  {{ with $values := .Values }}
+  {{ range $index, $az := $values.availability_zones }}
+  EFSMountTargetZone{{$index}}:
+    Type: AWS::EFS::MountTarget
+    Properties:
+      FileSystemId: !Ref EFSFileSystem
+      SubnetId: "{{ index $values.subnets $az }}"
+      SecurityGroups:
+      - !Ref EKSWorkerSecurityGroup
+  {{ end }}
+  {{ end }}
+{{- end }}
 {{- end }}
   EKSZalandoIAMProxyIAMRole:
     Type: AWS::IAM::Role
@@ -1149,6 +1169,10 @@ Resources:
                 Effect: Allow
                 Resource: '*'
               - Action: 'ec2:DetachVolume'
+                Effect: Allow
+                Resource: '*'
+              # Required by AWS EFS CSI Driver
+              - Action: 'elasticfilesystem:DescribeMountTargets'
                 Effect: Allow
                 Resource: '*'
               - Action: 'kms:Decrypt'
@@ -3983,6 +4007,12 @@ Outputs:
   #   Export:
   #     Name: "{{.Cluster.ID}}:eks-certificate-authority-data"
   #   Value: !GetAtt EKSCluster.CertificateAuthorityData
+  {{- if eq .Cluster.ConfigItems.eks_efs_filesystem_deployed "true" }}
+  EFSFileSystemID:
+    Export:
+      Name: '{{ .Cluster.ID}}:efs-filesystem-id'
+    Value: !Ref EFSFileSystem
+  {{- end}}
 {{- else }}
   MasterIAMRole:
     Export:

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1344,7 +1344,15 @@ eks_zalando_iam_aws_proxy_hpa_cpu_target: "80"
 eks_zalando_iam_aws_proxy_hpa_memory_target: "80"
 eks_okta_identity_provider: "true"
 eks_fis_support_enabled: "false"
+# {{if eq .Cluster.Environment "e2e"}}
+# Enables the Amazon EFS CSI driver addon
+eks_efs_csi_support_enabled: "true"
+# Sets up the default EFS for the cluster
+eks_efs_filesystem_deployed: "true"
+# {{else}}
 eks_efs_csi_support_enabled: "false"
+eks_efs_filesystem_deployed: "false"
+# {{end}}
 
 # prefix delegation can only be configured for ipv4. For ipv6 it can only be true.
 aws_vpc_cni_prefix_delegation: "false"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1344,12 +1344,12 @@ eks_zalando_iam_aws_proxy_hpa_cpu_target: "80"
 eks_zalando_iam_aws_proxy_hpa_memory_target: "80"
 eks_okta_identity_provider: "true"
 eks_fis_support_enabled: "false"
-# {{if eq .Cluster.Environment "e2e"}}
+{{ if eq .Cluster.Environment "e2e" }}
 # Enables the Amazon EFS CSI driver addon and sets up the default EFS
 eks_efs_csi_support_enabled: "true"
-# {{else}}
+{{ else }}
 eks_efs_csi_support_enabled: "false"
-# {{end}}
+{{ end }}
 
 # prefix delegation can only be configured for ipv4. For ipv6 it can only be true.
 aws_vpc_cni_prefix_delegation: "false"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1345,13 +1345,10 @@ eks_zalando_iam_aws_proxy_hpa_memory_target: "80"
 eks_okta_identity_provider: "true"
 eks_fis_support_enabled: "false"
 # {{if eq .Cluster.Environment "e2e"}}
-# Enables the Amazon EFS CSI driver addon
+# Enables the Amazon EFS CSI driver addon and sets up the default EFS
 eks_efs_csi_support_enabled: "true"
-# Sets up the default EFS for the cluster
-eks_efs_filesystem_deployed: "true"
 # {{else}}
 eks_efs_csi_support_enabled: "false"
-eks_efs_filesystem_deployed: "false"
 # {{end}}
 
 # prefix delegation can only be configured for ipv4. For ipv6 it can only be true.

--- a/cluster/manifests/02-admission-control/teapot.yaml
+++ b/cluster/manifests/02-admission-control/teapot.yaml
@@ -357,6 +357,9 @@ webhooks:
         - key: k8s-app
           operator: NotIn
           values: ["kube-proxy", "aws-node"]
+        - key: app.kubernetes.io/name
+          operator: NotIn
+          values: ["aws-efs-csi-driver"]
 {{- end }}
     clientConfig:
       {{- if eq .Cluster.Provider "zalando-eks"}}

--- a/cluster/manifests/04-efs-csi/storageclass.yaml
+++ b/cluster/manifests/04-efs-csi/storageclass.yaml
@@ -1,4 +1,4 @@
-# {{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_efs_filesystem_deployed "true") }}
+# {{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_efs_csi_support_enabled "true") }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:

--- a/cluster/manifests/04-efs-csi/storageclass.yaml
+++ b/cluster/manifests/04-efs-csi/storageclass.yaml
@@ -1,0 +1,11 @@
+# {{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_efs_filesystem_deployed "true") }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: efs-sc
+provisioner: efs.csi.aws.com
+parameters:
+  provisioningMode: efs-ap
+  fileSystemId: "{{ .Values.ClusterStackOutputs.EFSFileSystemID }}"
+  directoryPerms: "700"
+# {{- end }}

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -16,6 +16,10 @@ post_apply:
 - name: fis-experiment
   kind: ClusterRole
 {{- end }}
+{{- if ne .Cluster.ConfigItems.eks_efs_filesystem_deployed "true" }}
+- name: efs-sc
+  kind: StorageClass
+{{- end }}
 {{- end }}
 {{ if eq .Cluster.ConfigItems.teapot_admission_controller_process_resources "true" }}
 - name: limits

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -16,7 +16,7 @@ post_apply:
 - name: fis-experiment
   kind: ClusterRole
 {{- end }}
-{{- if ne .Cluster.ConfigItems.eks_efs_filesystem_deployed "true" }}
+{{- if ne .Cluster.ConfigItems.eks_efs_csi_support_enabled "true" }}
 - name: efs-sc
   kind: StorageClass
 {{- end }}


### PR DESCRIPTION
This creates a default EFS and its storage class. This matches the old behaviour with the additional benefit that the EFS doesn't need to be [created manually](https://cloud-platform.docs.zalando.net/howtos/enable-efs-storage-class/).

Users don't need to know the EFS ID. They only need to specify storage claims and mount them to their pods, e.g.:

```yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: efs-claim
spec:
  accessModes:
    - ReadWriteMany
  storageClassName: efs-sc
  resources:
    requests:
      storage: 5Gi

---

apiVersion: v1
kind: Pod
metadata:
  name: efs-app
spec:
  containers:
    - name: app
      image: rockylinux:8
      command: ["/bin/sh"]
      args: ["-c", "while true; do echo $(date -u) >> /data/out; sleep 5; done"]
      volumeMounts:
        - name: persistent-storage
          mountPath: /data
  volumes:
    - name: persistent-storage
      persistentVolumeClaim:
        claimName: efs-claim
```

The storage class points to the EFS created via the CF stack by reading the Stacks output variable. A mount point needs to be created for each region that the EFS is accessed from. It's protected by the worker nodes' security group. This was basically [done manually](https://cloud-platform.docs.zalando.net/howtos/enable-efs-storage-class/) before.

Each User volume is implemented by an "Access Point" which is managed by the EFS addon and it's using a unique subfolder within the EFS. Different PVCs will be completely isolated on the AWS side.

<img width="1066" height="292" alt="image" src="https://github.com/user-attachments/assets/1fe60b04-07c1-418a-9aa1-13f3598da132" />
