### PR TITLE
use cluster LocalID to be within maximum IAM role name length

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -3371,6 +3371,7 @@ Resources:
       RoleName: "{{.Cluster.LocalID}}-audittrail-adapter"
     Type: 'AWS::IAM::Role'
 # {{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6") }}
+# {{- if ne .Cluster.Name "business-partners-solutions-euc1-test" }}
   AWSLoadBalancerControllerIAMRole:
     Properties:
       AssumeRolePolicyDocument: !Sub
@@ -3580,6 +3581,7 @@ Resources:
           PolicyName: root
       RoleName: "aws-load-balancer-controller-{{.Cluster.Name}}"
     Type: 'AWS::IAM::Role'
+# {{- end }}
   AWSLBControllerIAMRole:
     Properties:
       AssumeRolePolicyDocument: !Sub

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -3578,7 +3578,7 @@ Resources:
               - elasticloadbalancing:SetRulePriorities
               Resource: "*"
           PolicyName: root
-      RoleName: "aws-load-balancer-controller-{{.Cluster.Alias}}"
+      RoleName: "aws-load-balancer-controller-{{.Cluster.Name}}"
     Type: 'AWS::IAM::Role'
   AWSLBControllerIAMRole:
     Properties:

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -3578,7 +3578,7 @@ Resources:
               - elasticloadbalancing:SetRulePriorities
               Resource: "*"
           PolicyName: root
-      RoleName: "aws-load-balancer-controller-{{.Cluster.Name}}"
+      RoleName: "aws-load-balancer-controller-{{.Cluster.LocalID}}"
     Type: 'AWS::IAM::Role'
 # {{- end }}
   RemoteFilesEncryptionKey:

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -3578,7 +3578,216 @@ Resources:
               - elasticloadbalancing:SetRulePriorities
               Resource: "*"
           PolicyName: root
-      RoleName: "aws-load-balancer-controller-{{.Cluster.LocalID}}"
+      RoleName: "aws-load-balancer-controller-{{.Cluster.Alias}}"
+    Type: 'AWS::IAM::Role'
+  AWSLBControllerIAMRole:
+    Properties:
+      AssumeRolePolicyDocument: !Sub
+        - |
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Principal": {
+                  "Federated": [
+                    "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
+                  ]
+                },
+                "Action": [
+                  "sts:AssumeRoleWithWebIdentity"
+                ],
+                "Condition": {
+                  "StringEquals": {
+                    "${OIDC}:sub": "system:serviceaccount:kube-system:aws-load-balancer-controller"
+                  }
+                }
+              }
+            ]
+          }
+        - OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
+      Path: /
+      Policies:
+        - PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+            - Effect: Allow
+              Action:
+              - iam:CreateServiceLinkedRole
+              Resource: "*"
+              Condition:
+                StringEquals:
+                  iam:AWSServiceName: elasticloadbalancing.amazonaws.com
+            - Effect: Allow
+              Action:
+              - ec2:DescribeAccountAttributes
+              - ec2:DescribeAddresses
+              - ec2:DescribeAvailabilityZones
+              - ec2:DescribeInternetGateways
+              - ec2:DescribeVpcs
+              - ec2:DescribeVpcPeeringConnections
+              - ec2:DescribeSubnets
+              - ec2:DescribeSecurityGroups
+              - ec2:DescribeInstances
+              - ec2:DescribeNetworkInterfaces
+              - ec2:DescribeTags
+              - ec2:GetCoipPoolUsage
+              - ec2:DescribeCoipPools
+              - ec2:GetSecurityGroupsForVpc
+              - ec2:DescribeIpamPools
+              - elasticloadbalancing:DescribeLoadBalancers
+              - elasticloadbalancing:DescribeLoadBalancerAttributes
+              - elasticloadbalancing:DescribeListeners
+              - elasticloadbalancing:DescribeListenerCertificates
+              - elasticloadbalancing:DescribeSSLPolicies
+              - elasticloadbalancing:DescribeRules
+              - elasticloadbalancing:DescribeTargetGroups
+              - elasticloadbalancing:DescribeTargetGroupAttributes
+              - elasticloadbalancing:DescribeTargetHealth
+              - elasticloadbalancing:DescribeTags
+              - elasticloadbalancing:DescribeTrustStores
+              - elasticloadbalancing:DescribeListenerAttributes
+              - elasticloadbalancing:DescribeCapacityReservation
+              Resource: "*"
+            - Effect: Allow
+              Action:
+              - cognito-idp:DescribeUserPoolClient
+              - acm:ListCertificates
+              - acm:DescribeCertificate
+              - iam:ListServerCertificates
+              - iam:GetServerCertificate
+              - waf-regional:GetWebACL
+              - waf-regional:GetWebACLForResource
+              - waf-regional:AssociateWebACL
+              - waf-regional:DisassociateWebACL
+              - wafv2:GetWebACL
+              - wafv2:GetWebACLForResource
+              - wafv2:AssociateWebACL
+              - wafv2:DisassociateWebACL
+              - shield:GetSubscriptionState
+              - shield:DescribeProtection
+              - shield:CreateProtection
+              - shield:DeleteProtection
+              Resource: "*"
+            - Effect: Allow
+              Action:
+              - ec2:AuthorizeSecurityGroupIngress
+              - ec2:RevokeSecurityGroupIngress
+              Resource: "*"
+            - Effect: Allow
+              Action:
+              - ec2:CreateSecurityGroup
+              Resource: "*"
+            - Effect: Allow
+              Action:
+              - ec2:CreateTags
+              Resource: arn:aws:ec2:*:*:security-group/*
+              Condition:
+                StringEquals:
+                  ec2:CreateAction: CreateSecurityGroup
+                'Null':
+                  aws:RequestTag/elbv2.k8s.aws/cluster: 'false'
+            - Effect: Allow
+              Action:
+              - ec2:CreateTags
+              - ec2:DeleteTags
+              Resource: arn:aws:ec2:*:*:security-group/*
+              Condition:
+                'Null':
+                  aws:RequestTag/elbv2.k8s.aws/cluster: 'true'
+                  aws:ResourceTag/elbv2.k8s.aws/cluster: 'false'
+            - Effect: Allow
+              Action:
+              - ec2:AuthorizeSecurityGroupIngress
+              - ec2:RevokeSecurityGroupIngress
+              - ec2:DeleteSecurityGroup
+              Resource: "*"
+              Condition:
+                'Null':
+                  aws:ResourceTag/elbv2.k8s.aws/cluster: 'false'
+            - Effect: Allow
+              Action:
+              - elasticloadbalancing:CreateLoadBalancer
+              - elasticloadbalancing:CreateTargetGroup
+              Resource: "*"
+              Condition:
+                'Null':
+                  aws:RequestTag/elbv2.k8s.aws/cluster: 'false'
+            - Effect: Allow
+              Action:
+              - elasticloadbalancing:CreateListener
+              - elasticloadbalancing:DeleteListener
+              - elasticloadbalancing:CreateRule
+              - elasticloadbalancing:DeleteRule
+              Resource: "*"
+            - Effect: Allow
+              Action:
+              - elasticloadbalancing:AddTags
+              - elasticloadbalancing:RemoveTags
+              Resource:
+              - arn:aws:elasticloadbalancing:*:*:targetgroup/*/*
+              - arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*
+              - arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*
+              Condition:
+                'Null':
+                  aws:RequestTag/elbv2.k8s.aws/cluster: 'true'
+                  aws:ResourceTag/elbv2.k8s.aws/cluster: 'false'
+            - Effect: Allow
+              Action:
+              - elasticloadbalancing:AddTags
+              - elasticloadbalancing:RemoveTags
+              Resource:
+              - arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*
+              - arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*
+              - arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*
+              - arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*
+            - Effect: Allow
+              Action:
+              - elasticloadbalancing:ModifyLoadBalancerAttributes
+              - elasticloadbalancing:SetIpAddressType
+              - elasticloadbalancing:SetSecurityGroups
+              - elasticloadbalancing:SetSubnets
+              - elasticloadbalancing:DeleteLoadBalancer
+              - elasticloadbalancing:ModifyTargetGroup
+              - elasticloadbalancing:ModifyTargetGroupAttributes
+              - elasticloadbalancing:DeleteTargetGroup
+              - elasticloadbalancing:ModifyListenerAttributes
+              - elasticloadbalancing:ModifyCapacityReservation
+              - elasticloadbalancing:ModifyIpPools
+              Resource: "*"
+              Condition:
+                'Null':
+                  aws:ResourceTag/elbv2.k8s.aws/cluster: 'false'
+            - Effect: Allow
+              Action:
+              - elasticloadbalancing:AddTags
+              Resource:
+              - arn:aws:elasticloadbalancing:*:*:targetgroup/*/*
+              - arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*
+              - arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*
+              Condition:
+                StringEquals:
+                  elasticloadbalancing:CreateAction:
+                  - CreateTargetGroup
+                  - CreateLoadBalancer
+                'Null':
+                  aws:RequestTag/elbv2.k8s.aws/cluster: 'false'
+            - Effect: Allow
+              Action:
+              - elasticloadbalancing:RegisterTargets
+              - elasticloadbalancing:DeregisterTargets
+              Resource: arn:aws:elasticloadbalancing:*:*:targetgroup/*/*
+            - Effect: Allow
+              Action:
+              - elasticloadbalancing:SetWebAcl
+              - elasticloadbalancing:ModifyListener
+              - elasticloadbalancing:AddListenerCertificates
+              - elasticloadbalancing:RemoveListenerCertificates
+              - elasticloadbalancing:ModifyRule
+              - elasticloadbalancing:SetRulePriorities
+              Resource: "*"
+          PolicyName: root
+      RoleName: "aws-lb-controller-{{.Cluster.LocalID}}"
     Type: 'AWS::IAM::Role'
 # {{- end }}
   RemoteFilesEncryptionKey:

--- a/cluster/manifests/aws-load-balancer-controller/deployment.yaml
+++ b/cluster/manifests/aws-load-balancer-controller/deployment.yaml
@@ -18,8 +18,8 @@ spec:
         application: kubernetes
         component: aws-load-balancer-controller
         deployment: aws-load-balancer-controller
-    annotations:
-      force-redeploy: "iamrole"
+      annotations:
+        force-redeploy: "iamrole"
     spec:
       containers:
       - args:

--- a/cluster/manifests/aws-load-balancer-controller/deployment.yaml
+++ b/cluster/manifests/aws-load-balancer-controller/deployment.yaml
@@ -18,6 +18,8 @@ spec:
         application: kubernetes
         component: aws-load-balancer-controller
         deployment: aws-load-balancer-controller
+    annotations:
+      force-redeploy: "iamrole"
     spec:
       containers:
       - args:

--- a/cluster/manifests/aws-load-balancer-controller/serviceaccount.yaml
+++ b/cluster/manifests/aws-load-balancer-controller/serviceaccount.yaml
@@ -8,5 +8,5 @@ metadata:
     application: kubernetes
     component: aws-load-balancer-controller
   annotations:
-    eks.amazonaws.com/role-arn: "arn:aws:iam::{{.Cluster.InfrastructureAccountID}}:role/aws-load-balancer-controller-{{.Cluster.Name}}"
+    eks.amazonaws.com/role-arn: "arn:aws:iam::{{.Cluster.InfrastructureAccountID}}:role/aws-load-balancer-controller-{{.Cluster.LocalID}}"
 # {{- end }}

--- a/cluster/manifests/aws-load-balancer-controller/serviceaccount.yaml
+++ b/cluster/manifests/aws-load-balancer-controller/serviceaccount.yaml
@@ -8,5 +8,5 @@ metadata:
     application: kubernetes
     component: aws-load-balancer-controller
   annotations:
-    eks.amazonaws.com/role-arn: "arn:aws:iam::{{.Cluster.InfrastructureAccountID}}:role/aws-load-balancer-controller-{{.Cluster.LocalID}}"
+    eks.amazonaws.com/role-arn: "arn:aws:iam::{{.Cluster.InfrastructureAccountID}}:role/aws-lb-controller-{{.Cluster.LocalID}}"
 # {{- end }}


### PR DESCRIPTION
Use cluster LocalID to be within the maximum IAM role name length allowed by AWS.
A new cluster was created within the maximum allowed name length, and this is failing since we are over the maximum size for the IAM role.
This will also affect the cluster with longer names that will be migrated to EKS.