### PR TITLE
Expose account clusters as deployment variable

### DIFF
--- a/cluster/manifests/deployment-service/01-config.yaml
+++ b/cluster/manifests/deployment-service/01-config.yaml
@@ -16,6 +16,7 @@ data:
   oidc-provider-arn: "{{.Cluster.OIDCProviderARN}}"
   oidc-subject-key: "{{.Cluster.OIDCSubjectKey}}"
   iam-role-trust-relationship-template: '{{.Cluster.IAMRoleTrustRelationshipTemplate}}'
+  account-clusters: '{{$sep := ""}}{{- range .Cluster.AccountClusters}}{{ if eq .LifecycleStatus "ready" }}{{$sep}}{{.Alias}}{{$sep = ","}}{{- end}}{{- end}}'
   s3-bucket-name: "{{ .Cluster.ConfigItems.deployment_service_bucket_name }}"
   status-service-url: "https://depl-status-{{.Cluster.Alias}}.{{.Values.hosted_zone}}"
   status-service-url-local: "http://deployment-status-service.ingress.cluster.local."


### PR DESCRIPTION
Simple list of cluster aliases of the account and region. Returns the following in `stups-test` and `stups-euc1-test`.

```console
$ kubectl -n kube-system get cm deployment-config -o yaml | grep clusters
account-clusters: stups-test,stups-euc1-test
```

This is just a test to support [this use case](https://chat.google.com/room/AAAA1dSbk8M/X_i1a0RMEMk/X_i1a0RMEMk?cls=10) in a quick way.