### PR TITLE
Add node affinity for skipper-ingress scheduling 

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -128,6 +128,7 @@ worker_sg_legacy_cluster: ""
 # skipper node-pool
 enable_dedicate_nodepool_skipper: "true"
 skipper_attach_only_to_skipper_node_pool: "true"
+skipper_karpenter_node_pools_enabled: "true"
 
 skipper_suppress_route_update_logs: "true"
 skipper_validate_query: "true"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -92,6 +92,56 @@ spec:
               component: ingress
               application: skipper-ingress
 {{- end }}
+{{ if eq .Cluster.ConfigItems.skipper_karpenter_node_pools_enabled "true" }}
+      affinity:
+       podAntiAffinity:
+         requiredDuringSchedulingIgnoredDuringExecution:
+         - labelSelector:
+             matchExpressions:
+             - key: application
+               operator: In
+               values:
+               - skipper-ingress
+             - key: component
+               operator: In
+               values:
+               - ingress
+           topologyKey: kubernetes.io/hostname
+       nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: node.kubernetes.io/instance-type
+                operator: In
+                values:
+                - c7g.large
+                - c7g.xlarge
+                - c7g.2xlarge
+                - c7g.4xlarge
+                - c7g.8xlarge
+                - m7g.large
+          - weight: 50
+            preference:
+              matchExpressions:
+              - key: node.kubernetes.io/instance-type
+                operator: In
+                values:
+                - c6g.large
+                - c6g.xlarge
+                - c6g.2xlarge
+                - c6g.4xlarge
+                - c6g.8xlarge
+                - m6g.large
+{{ else }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: zalando.org/ingress-karpenter-managed
+                operator: DoesNotExist
+{{ end }}
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       serviceAccountName: skipper-ingress
       terminationGracePeriodSeconds: {{ .Cluster.ConfigItems.skipper_termination_grace_period }}
@@ -480,6 +530,9 @@ spec:
 {{ if eq .Cluster.ConfigItems.enable_dedicate_nodepool_skipper "true"}}
       nodeSelector:
         dedicated: skipper-ingress
+{{ if eq .Cluster.ConfigItems.skipper_karpenter_node_pools_enabled "true" }}
+        zalando.org/ingress-karpenter-managed: "true"
+{{ end }}
       tolerations:
       - effect: NoSchedule
         key: dedicated

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -192,6 +192,12 @@ spec:
 #    {{ end}}
 #  {{ end}}
 #{{ end}}
+#{{ if eq (index .NodePool.ConfigItems "taints") "dedicated=skipper-ingress:NoSchedule" }}
+        - key: zalando.org/ingress-karpenter-managed
+          operator: In
+          values:
+            - "true"
+#{{ end }}
 
 #{{ if (eq .NodePool.KarpenterInstanceTypeStrategy "default-for-karpenter" )  }}
         - key: "karpenter.k8s.aws/instance-family"

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -132,6 +132,16 @@ EOFF
       taints: dedicated=skipper-ingress:NoSchedule
   - discount_strategy: spot
     instance_types:
+    - "not-specified"
+    min_size: 0
+    max_size: 0
+    profile: worker-karpenter
+    name: skipper-ingress-karpenter-catch-all
+    config_items:
+      labels: dedicated=skipper-ingress
+      taints: dedicated=skipper-ingress:NoSchedule
+  - discount_strategy: spot
+    instance_types:
     - "default-for-karpenter"
     min_size: 0
     max_size: 0


### PR DESCRIPTION
## Summary
Add Karpenter node pool support for skipper ingress scheduling with node affinity preferences.

## Changes
- Add `skipper_karpenter_node_pools_enabled` configuration flag (default: true)
- Add pod anti-affinity to spread skipper pods across different nodes
- Add node affinity rules to prefer c7g and m7g instances when Karpenter pools are enabled
- Maintain fallback scheduling for non-Karpenter environments (prevent scheduling on karpenter-managed nodes)
- Add Karpenter node pool with skipper-ingress taint for dedicated scheduling
- Add Karpenter provisioner requirements to label skipper-ingress nodes with `zalando.org/ingress-karpenter-managed`

## Testing
- Updated e2e cluster configuration with new Karpenter skipper ingress node pool