### PR TITLE
Allow more nodes to compensate spot shortage in a single zone

### DIFF
--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -124,7 +124,7 @@ EOFF
     - "m6g.large"
     - "m7g.large"
     min_size: 0
-    max_size: 9
+    max_size: 18
     profile: worker-splitaz
     name: skipper-ingress-node
     config_items:


### PR DESCRIPTION
When one zone has no instances due to spot shortage, the maximum we get is 6 instances in both other zones combined. This isn't enough for all skippers sometimes: https://sunrise.zalando.net/cdp/gh/zalando-incubator/kubernetes-on-aws/l-wja18mnrxxdeqsz54zppws6zz/steps/1/logs