### PR TITLE
Add the EKS Node Monitoring Agent

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -391,6 +391,15 @@ Resources:
             "component": "kube-proxy"
           }
         }
+  {{ if eq .Cluster.ConfigItems.eks_node_monitoring_enabled "true" }}
+  EKSAddonNodeMonitoringAgent:
+    Type: AWS::EKS::Addon
+    Properties:
+      AddonName: eks-node-monitoring-agent
+      AddonVersion: "v1.4.3-eksbuild.2"
+      ClusterName: !Ref EKSCluster
+  {{ end }}
+
   {{ if eq .Cluster.Environment "e2e" }}
   E2EEKSIAMTestRoleReadOnly:
     Properties:

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1351,8 +1351,11 @@ eks_fis_support_enabled: "false"
 {{ if eq .Cluster.Environment "e2e" }}
 # Enables the Amazon EFS CSI driver addon and sets up the default EFS
 eks_efs_csi_support_enabled: "true"
+# Enables the EKS Node Monitoring Agent
+eks_node_monitoring_enabled: "true"
 {{ else }}
 eks_efs_csi_support_enabled: "false"
+eks_node_monitoring_enabled: "false"
 {{ end }}
 
 # prefix delegation can only be configured for ipv4. For ipv6 it can only be true.

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -358,6 +358,22 @@ post_apply:
   kind: ServiceAccount
   namespace: kube-system
 {{- end}}
+{{- if ne .Cluster.ConfigItems.eks_node_monitoring_enabled "true"}}
+- name: eks-node-monitoring-agent
+  kind: DaemonSet
+  namespace: kube-system
+- name: eks-node-monitoring-agent
+  kind: ServiceAccount
+  namespace: kube-system
+- name: eks-node-monitoring-agent
+  kind: ClusterRole
+- name: eks-node-monitoring-agent
+  kind: ClusterRoleBinding
+- name: eks-node-monitoring-agent-extended
+  kind: ClusterRole
+- name: eks-node-monitoring-agent-extended
+  kind: ClusterRoleBinding
+{{- end}}
 {{- if ne .Cluster.ConfigItems.kube_node_decommissioner_enabled "true"}}
 - name: kube-node-decommissioner
   kind: CronJob

--- a/cluster/manifests/roles/node-monitoring-agent-rbac.yaml
+++ b/cluster/manifests/roles/node-monitoring-agent-rbac.yaml
@@ -1,0 +1,35 @@
+{{- if eq .Cluster.ConfigItems.eks_node_monitoring_enabled "true" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: eks-node-monitoring-agent-extended
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: eks-node-monitoring-agent-extended
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: eks-node-monitoring-agent-extended
+subjects:
+- kind: ServiceAccount
+  name: eks-node-monitoring-agent
+  namespace: kube-system
+
+{{- end }}

--- a/cluster/manifests/roles/node-monitoring-agent-rbac.yaml
+++ b/cluster/manifests/roles/node-monitoring-agent-rbac.yaml
@@ -31,5 +31,4 @@ subjects:
 - kind: ServiceAccount
   name: eks-node-monitoring-agent
   namespace: kube-system
-
 {{- end }}


### PR DESCRIPTION
Introduce the [EKS Node Monitoring Agent](https://github.com/aws/eks-node-monitoring-agent) as an EKS Addon. This agent provides additional insights into node health issues (see [docs](https://docs.aws.amazon.com/eks/latest/userguide/node-health.html)).

The config is wrapped behind a config item: `eks_node_monitoring_enabled`.