### PR TITLE
Enable OPA Status Plugin

### DIFF
--- a/cluster/manifests/02-skipper-validation-webhook/02-configmap-open-policy-agent.yaml
+++ b/cluster/manifests/02-skipper-validation-webhook/02-configmap-open-policy-agent.yaml
@@ -44,6 +44,8 @@ data:
           io_jwt:
             max_num_entries: {{ .Cluster.ConfigItems.skipper_open_policy_agent_jwt_cache_max_num_entries }}
     {{ end }}
+    status:
+      console: false
   envoymetadata.json: |-
     {
       "filter_metadata": {


### PR DESCRIPTION
## What & Why?

Part of [Expose OPA Status Metrics](https://github.com/zalando-infosec/corporate-iam-issues/issues/1331)

This change to the OPA configmap ensures that the PrometheusOverride hook added via https://github.com/zalando/skipper/pull/3631 enables the Status metrics that we plan to consume.