### PR TITLE
feat: add additional capability to WIZ sensor

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1333,6 +1333,8 @@ wiz_priority: "true"
 # to deploy the sensor and connector on specific nodes, by manually setting the node selector label on the nodes.
 # This is useful when you want to deploy the sensor and connector on specific nodes.
 wiz_node_feature_rollout : "false"
+# Enable runtime sensor response capabilities such as KILL
+wiz_enable_runtime_sensor_response_capabilities: "false"
 
 # EKS specific configuration
 eks_control_plane_logging: "true"

--- a/cluster/manifests/wiz/sensor-daemonset.yaml
+++ b/cluster/manifests/wiz/sensor-daemonset.yaml
@@ -67,7 +67,6 @@ spec:
             - FOWNER # file hashing
             - SYS_PTRACE # eBPF
             - SYSLOG # kernel symbol resolve
-            drop:
             - KILL # response
           privileged: false
           runAsNonRoot: true

--- a/cluster/manifests/wiz/sensor-daemonset.yaml
+++ b/cluster/manifests/wiz/sensor-daemonset.yaml
@@ -67,7 +67,9 @@ spec:
             - FOWNER # file hashing
             - SYS_PTRACE # eBPF
             - SYSLOG # kernel symbol resolve
+            {{- if eq .Cluster.ConfigItems.wiz_enable_runtime_sensor_response_capabilities "true" }}
             - KILL # response
+            {{- end }}
           privileged: false
           runAsNonRoot: true
           runAsUser: 2202
@@ -150,7 +152,11 @@ spec:
               resource: limits.cpu
               divisor: "1m"
         - name: DISALLOW_RUNTIME_RESPONSE
+          {{- if eq .Cluster.ConfigItems.wiz_enable_runtime_sensor_response_capabilities "true" }}
+          value: "false"
+          {{- else }}
           value: "true"
+          {{- end }}
         - name: HELM_CHART_VERSION
           value: 1.0.8831
         - name: ALLOW_KUBELET_COMMUNICATION

--- a/cluster/manifests/wiz/sensor-daemonset.yaml
+++ b/cluster/manifests/wiz/sensor-daemonset.yaml
@@ -69,6 +69,9 @@ spec:
             - SYSLOG # kernel symbol resolve
             {{- if eq .Cluster.ConfigItems.wiz_enable_runtime_sensor_response_capabilities "true" }}
             - KILL # response
+            {{- else }}
+            drop:
+            - KILL
             {{- end }}
           privileged: false
           runAsNonRoot: true


### PR DESCRIPTION
To use WIZ run time response policies we have to enable the KILL capabilities to the WIZ sensor. 

- WIZ Sensor Capabilities : https://docs.wiz.io/docs/sensor-required-permissions?lng=en#linux-capabilities 
- WIZ Runtime Response Policies : https://docs.wiz.io/docs/runtime-response-policies 
- added wiz_enable_untime_sensor_response_capabilities to enable per cluster 

This feature is necessary to enable the Traffic restrictions based on Geo based threat detection rules. 