### PR TITLE
validation: allow access to OPA bucket

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -2152,6 +2152,51 @@ Resources:
           PolicyName: read-opa-bundles
       RoleName: "{{.Cluster.LocalID}}-app-skipper-ingress"
     Type: 'AWS::IAM::Role'
+  # Note: this is not strictly specific to Open Policy Agent and can be extend
+  # if Skipper Validation Webhook needs to access other AWS resources
+  SkipperWebhookIAMRole:
+    Properties:
+      AssumeRolePolicyDocument: !Sub
+        - |
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Principal": {
+                  "Federated": [
+                    "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
+                  ]
+                },
+                "Action": [
+                  "sts:AssumeRoleWithWebIdentity"
+                ],
+                "Condition": {
+                  "StringEquals": {
+                    "${OIDC}:sub": "system:serviceaccount:kube-system:skipper-validation-webhook"
+                  }
+                }
+              }
+            ]
+          }
+{{- if eq .Cluster.Provider "zalando-eks" }}
+        - OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
+{{- else }}
+        - OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+{{- end }}
+      Path: /
+      Policies:
+        - PolicyDocument:
+            Statement:
+              - Effect: "Allow"
+                Action:
+                  - "s3:GetObject"
+                Resource:
+                  - "{{ .Cluster.ConfigItems.skipper_open_policy_agent_bucket_arn }}/*"
+            Version: 2012-10-17
+          PolicyName: read-opa-bundles
+      RoleName: "{{.Cluster.LocalID}}-app-skipper-validation-webhook"
+    Type: 'AWS::IAM::Role'
   ClusterLifecycleControllerIAMRole:
     Properties:
       AssumeRolePolicyDocument: !Sub

--- a/cluster/manifests/02-skipper-validation-webhook/01-rbac.yaml
+++ b/cluster/manifests/02-skipper-validation-webhook/01-rbac.yaml
@@ -6,6 +6,15 @@ metadata:
   labels:
     application: skipper-ingress
     component: webhook
+# {{ if eq .Cluster.ConfigItems.skipper_open_policy_agent_enabled "true" }}
+  # Note: if the role extends beyond OPA use, this condition can be removed
+  annotations:
+    # {{- if eq .Cluster.Provider "zalando-eks" }}
+    eks.amazonaws.com/role-arn: "arn:aws:iam::{{.Cluster.InfrastructureAccountID}}:role/{{ .Cluster.LocalID }}-app-skipper-validation-webhook"
+    # {{- else}}
+    iam.amazonaws.com/role: "{{ .Cluster.LocalID }}-app-skipper-validation-webhook"
+    # {{- end}}
+# {{ end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
Create an IAM role for skipper validation webhook and give access to OPA bucket to run discovery bundles.