### PR TITLE
skipper: update canary to v0.24

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -143,6 +143,7 @@ skipper_edit_route_placeholders: ""
 skipper_ingress_inline_routes: ""
 skipper_ingress_refuse_payload: ""
 skipper_endpointslices_enabled: "true"
+skipper_externalname_service_enabled: "true"
 
 skipper_kubernetes_annotation_predicates: ''
 skipper_kubernetes_annotation_filters_append: ''
@@ -218,7 +219,7 @@ skipper_ingress_redis_hpa_scale_down_wait: "600"
 skipper_cluster_ratelimit_max_group_shards: 1
 
 # webhook protection poc
-skipper_lua_scripts_enabled: ""
+skipper_lua_scripts_enabled: "false"
 ## datadome poc
 datadome_api_key: ""
 ## kasada poc

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,10 +1,10 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
 {{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.22.223-1325" }}
-{{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.22.223-1325" }}
+{{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.24.5-1333" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}
-{{ $canary_args := "" }}
+{{ $canary_args := "-enable-kubernetes-external-names={{ .Cluster.ConfigItems.skipper_externalname_service_enabled }}[cf724afc]-enable-lua={{ .Cluster.ConfigItems.skipper_lua_scripts_enabled }}" }}
 
 {{ $cluster_internal_cidrs := list "10.2.0.0/15" .Values.vpc_ipv4_cidr }}
 {{ if eq .Cluster.Provider "zalando-eks" }}


### PR DESCRIPTION
skipper: update canary to v0.24

2 minor version jump because these were 2 security related default config breaking changes.
1. We know that we have disabled lua, so we change the default to "false" as all checks test for "true" it does not change anything, but we can pass the result to -enable-lua arg.
2. we set externalname service to enabled but use config item to remove it in clusters that do not use this feature. In our current case it does not matter much, but changing towards multi tenant config is always a good thing

replaces https://github.com/zalando-incubator/kubernetes-on-aws/pull/10416