### PR TITLE
Update admission controller config for  eks-node-monitoring-agent

### DIFF
--- a/cluster/manifests/02-admission-control/teapot.yaml
+++ b/cluster/manifests/02-admission-control/teapot.yaml
@@ -24,13 +24,13 @@ webhooks:
           values: ["kube-proxy"]
         - key: app.kubernetes.io/name
           operator: NotIn
-          values: ["eks-pod-identity-agent"]
+          values:
+            - "eks-pod-identity-agent"
+            - "aws-efs-csi-driver"
+            - "eks-node-monitoring-agent"
         - key: application
           operator: NotIn
           values: ["kube-ingress-aws-controller"]
-        - key: app.kubernetes.io/name
-          operator: NotIn
-          values: ["aws-efs-csi-driver"]
 {{- end }}
     clientConfig:
       {{- if eq .Cluster.Provider "zalando-eks"}}
@@ -70,13 +70,10 @@ webhooks:
           values: ["kube-proxy"]
         - key: app.kubernetes.io/name
           operator: NotIn
-          values: ["eks-pod-identity-agent"]
+          values: ["eks-pod-identity-agent", "aws-efs-csi-driver"]
         - key: application
           operator: NotIn
           values: ["kube-ingress-aws-controller"]
-        - key: app.kubernetes.io/name
-          operator: NotIn
-          values: ["aws-efs-csi-driver"]
 {{- end }}
     clientConfig:
       {{- if eq .Cluster.Provider "zalando-eks"}}
@@ -394,10 +391,7 @@ webhooks:
           values: ["kube-proxy"]
         - key: app.kubernetes.io/name
           operator: NotIn
-          values: ["eks-pod-identity-agent"]
-        - key: app.kubernetes.io/name
-          operator: NotIn
-          values: ["aws-efs-csi-driver"]
+          values: ["eks-pod-identity-agent", "aws-efs-csi-driver"]
 {{- end }}
     clientConfig:
       {{- if eq .Cluster.Provider "zalando-eks"}}


### PR DESCRIPTION
Add admission controller exclusion for the eks-node-monitoring-agent. In EKS Clusters the agent runs as an EKS Addon and excluding it from the Pod admitter works around checks such as a non-compliant image (the image is not being republished for EKS Clusters).