### PR TITLE
s3-csi-driver: Update kubelet dir

### DIFF
--- a/cluster/manifests/s3-csi-driver/daemonset.yaml
+++ b/cluster/manifests/s3-csi-driver/daemonset.yaml
@@ -47,7 +47,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: HOST_PLUGIN_DIR
-          value: /opt/podruntime/kubelet/plugins/s3.csi.aws.com/
+          value: /var/lib/kubelet/plugins/s3.csi.aws.com/
         image: container-registry.zalando.net/teapot/aws-mountpoint-s3-csi-driver:v1.14.1-master-30
         resources:
           requests:
@@ -73,7 +73,7 @@ spec:
         securityContext:
           privileged: false
         volumeMounts:
-        - mountPath: /opt/podruntime/kubelet
+        - mountPath: /var/lib/kubelet
           name: kubelet-dir
         - mountPath: /csi
           name: plugin-dir
@@ -90,7 +90,7 @@ spec:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
-          value: /opt/podruntime/kubelet/plugins/s3.csi.aws.com/csi.sock
+          value: /var/lib/kubelet/plugins/s3.csi.aws.com/csi.sock
         - name: KUBE_NODE_NAME
           valueFrom:
             fieldRef:
@@ -166,15 +166,15 @@ spec:
           type: Socket
         name: systemd-bus
       - hostPath:
-          path: /opt/podruntime/kubelet
+          path: /var/lib/kubelet
           type: Directory
         name: kubelet-dir
       - hostPath:
-          path: /opt/podruntime/kubelet/plugins_registry/
+          path: /var/lib/kubelet/plugins_registry/
           type: Directory
         name: registration-dir
       - hostPath:
-          path: /opt/podruntime/kubelet/plugins/s3.csi.aws.com/
+          path: /var/lib/kubelet/plugins/s3.csi.aws.com/
           type: DirectoryOrCreate
         name: plugin-dir
 {{- end }}


### PR DESCRIPTION
This updates the kubelet dir path to `/var/lib/kubelet` after it was changed as part of Kubernetes v1.34 roll out.

This is just for the s3-csi driver which is used only by 1 clusters so far.

The rest is done in https://github.com/zalando-incubator/kubernetes-on-aws/pull/10384