### PR TITLE
Add efs-provisoner to deletions.yaml so it can be turned off

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -384,3 +384,27 @@ post_apply:
 - name: verticalpodautoscalers.zalando.org
   kind: CustomResourceDefinition
 {{- end}}
+{{ if not (index .Cluster.ConfigItems "efs_id") }}
+- name: efs-provisioner
+  kind: Deployment
+  namespace: kube-system
+- name: efs-provisioner
+  kind: ConfigMap
+  namespace: kube-system
+- name: efs-provisioner
+  kind: ServiceAccount
+  namespace: kube-system
+- name: efs-provisioner-runner
+  kind: ClusterRole
+- name: leader-locking-efs-provisioner
+  kind: Role
+  namespace: kube-system
+- name: leader-locking-efs-provisioner
+  kind: RoleBinding
+  namespace: kube-system
+- name: efs-provisioner-privileged-psp
+  kind: RoleBinding
+  namespace: kube-system
+- name: aws-efs
+  kind: StorageClass
+{{ end }}


### PR DESCRIPTION
Provide a way to turn off the legacy EFS provisioner when the old config item is flipped off.

This will remove all legacy EFS provisioner resources in the cluster (not the EFS itself) and it will also keep the PVC and PV resources. So, turning it off accidentally won't delete any data and it can be brought back by setting the previous value.