### PR TITLE
Update to Karpenter aws provider v1.8.6

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1472,7 +1472,6 @@ Resources:
                   "Effect": "Allow",
                   "Resource": "*",
                   "Action": [
-                    "ec2:DescribeAvailabilityZones",
                     "ec2:DescribeCapacityReservations",
                     "ec2:DescribeImages",
                     "ec2:DescribeInstances",
@@ -1585,6 +1584,12 @@ Resources:
                   "Effect": "Allow",
                   "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
                   "Action": "iam:GetInstanceProfile"
+                },
+                {
+                  "Sid": "AllowUnscopedInstanceProfileListAction",
+                  "Effect": "Allow",
+                  "Resource": "*",
+                  "Action": "iam:ListInstanceProfiles"
                 },
                 {
                   "Sid": "AllowAPIServerEndpointDiscovery",

--- a/cluster/manifests/z-karpenter/deployment.yaml
+++ b/cluster/manifests/z-karpenter/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             capabilities:
               drop:
                 - ALL
-          image: "container-registry.zalando.net/teapot/karpenter:1.8.2-main-47.patched"
+          image: "container-registry.zalando.net/teapot/karpenter:1.8.2-main-48.patched"
           imagePullPolicy: IfNotPresent
           env:
             - name: KUBERNETES_MIN_VERSION


### PR DESCRIPTION
This updates to the latest Karpenter version (aws-provider v1.8.6)

Additionally it updates to the latest IAM permissions according to https://karpenter.sh/docs/reference/cloudformation/

This will fix an issue currently seen in logs:

```
controller {"level":"ERROR","time":"2026-02-03T13:20:05.695Z","logger":"controller","caller":"controller/controller.go:474","message":"Reconciler error","commit":"51932b4-dirty","controller":"nodeclass","controllerGroup":"karpenter.k8s.aws","controllerKind":"EC2NodeClass","EC2NodeClass":{"name":"worker-ephemeral-agents-karpenter"},"namespace":"","name":"worker-ephemeral-agents-karpenter","reconcileID":"0000","aws-error-code":"AccessDenied","aws-operation-name":"ListInstanceProfiles","aws-request-id":"0000","aws-service-name":"IAM","aws-status-code":403,"error":"listing instance profiles, listing instance profiles, operation error IAM: ListInstanceProfiles, https response error StatusCode: 403, RequestID: 0000, api error AccessDenied: User: arn:aws:sts::0000:assumed-role/kube-1-app-karpenter/000 is not authorized to perform: iam:ListInstanceProfiles on resource: arn:aws:iam::0000:instance-profile/karpenter/eu-central-1/aws:0000:eu-central-1:kube-1/1d64bcbd-7cb1-431e-b763-f5e0f83f2545/ because no identity-based policy allows the iam:ListInstanceProfiles action (aws-error-code=AccessDenied, aws-operation-name=ListInstanceProfiles, aws-request-id=000, aws-service-name=IAM, aws-status-code=403)"}
```

I believe this error is causing deleted ec2nodeclasses to be stuck in deletion with a finalizer.