### PR TITLE
Allow to configure static prescale for Prometheus

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -558,9 +558,18 @@ prometheus_remote_max_backoff: "10s"
 # Comma-separated list of user ids allowed to access Prometheus UI
 prometheus_ui_users: ""
 
-# Scheduled scaling events for Prometheus VPA (in the format
-# <name>:<pre-start-min>:<cpu>:<memory>, multiple events separated by commas)
+# Dynamic Scheduled scaling events for Prometheus VPA (in the format
+# <event-name>:<pre-start-min>:<cpu>:<memory>, multiple events separated by commas)
+# <cpu> and <memory> must be a scaling function which takes scalingValue as a
+# parameter. Example for linear regression function:
+# ("<coef> * scalingValue + <constant>")
 prometheus_scheduled_scaling_events: ""
+
+# Static scheduled scaling events for Prometheus VPA (in the format 
+# <event-name>:<pre-start-min>:<cpu>:<memory>, multiple events separated by commas)
+# <cpu> and <memory> must be fixed values like "10" or "20Gi" this is for static
+# pre-scaling during scheduled scaling event.
+prometheus_static_scheduled_scaling_events: ""
 
 # Enable scheduled scaling for VPA
 scheduled_scaling_vpa_enabled: "false"

--- a/cluster/manifests/prometheus/prometheus-vpa.yaml
+++ b/cluster/manifests/prometheus/prometheus-vpa.yaml
@@ -23,16 +23,27 @@ spec:
       minAllowed:
         memory: {{.Cluster.ConfigItems.prometheus_mem_min}}
         cpu: {{.Cluster.ConfigItems.prometheus_cpu_min}}
-{{- if and (eq .Cluster.ConfigItems.scheduled_scaling_vpa_enabled "true") (ne .Cluster.ConfigItems.prometheus_scheduled_scaling_events "") }}
+{{- if and (eq .Cluster.ConfigItems.scheduled_scaling_vpa_enabled "true") (or (ne .Cluster.ConfigItems.prometheus_scheduled_scaling_events "") (ne .Cluster.ConfigItems.prometheus_static_scheduled_scaling_events "")) }}
   schedules:
   {{- range split .Cluster.ConfigItems.prometheus_scheduled_scaling_events "," }}
-  {{- $tuple := split . ":" }} # <name>:<pre-start-minutes>:<cpu>:<memory>
+  {{- $tuple := split . ":" }} # <event-name>:<pre-start-minutes>:<cpu>:<memory>
   - name: "{{ index $tuple 0 }}"
     preStartMinutes: {{ index $tuple 1 }}
     resourcePolicy:
       containerPolicies:
       - containerName: prometheus
         unitResource:
+          cpu: {{ index $tuple 2 }}
+          memory: {{ index $tuple 3 }}
+  {{- end }}
+  {{- range split .Cluster.ConfigItems.prometheus_static_scheduled_scaling_events "," }}
+  {{- $tuple := split . ":" }} # <event-name>:<pre-start-minutes>:<cpu>:<memory>
+  - name: "{{ index $tuple 0 }}"
+    preStartMinutes: {{ index $tuple 1 }}
+    resourcePolicy:
+      containerPolicies:
+      - containerName: prometheus
+        minAllowed:
           cpu: {{ index $tuple 2 }}
           memory: {{ index $tuple 3 }}
   {{- end }}


### PR DESCRIPTION
This adds a new config-item: `prometheus_static_scheduled_scaling_events` which allows defining a list of static scheduled scaling configurations for Prometheus. This is an alternative to `prometheus_scheduled_scaling_events` which assumes a dynamic scaling function.

The purpose of this is to handle cases where scheduled scaling is used with a static value and a scaling function is hard to create. Concrete examples in Zalando are ZPS and ZL-UJLT loadtests where a static value is used for the scheduled scaling event. In this case it makes sense to configure Prometheus to scale to the last known needed resources based on previous loadtests.