### PR TITLE
Enable scheduled scaling VPA by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -563,7 +563,7 @@ prometheus_ui_users: ""
 prometheus_scheduled_scaling_events: ""
 
 # Enable scheduled scaling for VPA
-scheduled_scaling_vpa_enabled: "false"
+scheduled_scaling_vpa_enabled: "true"
 
 metrics_service_cpu: "100m"
 metrics_service_mem_max: "4Gi"


### PR DESCRIPTION
This was successfully enabled in all current clusters so we can enable it by default.