### PR TITLE
Allow disabling kube-cluster-autoscaler

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1,4 +1,5 @@
 # Autoscaling settings
+cluster_autoscaler_enabled: "true"
 autoscaling_scale_down_enabled: "true"
 autoscaling_buffer_cpu: "1m"
 autoscaling_buffer_memory: "10Mi"

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -408,3 +408,34 @@ post_apply:
 - name: aws-efs
   kind: StorageClass
 {{ end }}
+{{- if ne .Cluster.ConfigItems.cluster_autoscaler_enabled "true" }}
+- name: cluster-autoscaler
+  namespace: kube-system
+  kind: ServiceAccount
+- name: cluster-autoscaler
+  kind: ClusterRole
+- name: cluster-autoscaler
+  namespace: kube-system
+  kind: Role
+- name: cluster-autoscaler
+  kind: ClusterRoleBinding
+- name: cluster-autoscaler
+  namespace: kube-system
+  kind: RoleBinding
+- name: autoscaling-buffer-nonpreempting
+  kind: PriorityClass
+- name: kube-cluster-autoscaler
+  namespace: kube-system
+  kind: DaemonSet
+- name: kube-cluster-autoscaler
+  namespace: kube-system
+  kind: Deployment
+- name: autoscaling-buffer
+  namespace: kube-system
+  kind: PodDisruptionBudget
+- kind: Deployment
+  namespace: kube-system
+  labels:
+    application: kubernetes
+    component: autoscaling-buffer
+{{- end }}

--- a/cluster/manifests/kube-cluster-autoscaler/01-rbac.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/01-rbac.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Cluster.ConfigItems.cluster_autoscaler_enabled "true" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -118,3 +119,4 @@ subjects:
 - kind: ServiceAccount
   name: cluster-autoscaler
   namespace: kube-system
+{{- end }}

--- a/cluster/manifests/kube-cluster-autoscaler/autoscaling-priority-class.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/autoscaling-priority-class.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Cluster.ConfigItems.cluster_autoscaler_enabled "true" }}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
@@ -6,3 +7,4 @@ value: -1000000
 globalDefault: false
 description: "This priority class is used by the autoscalling buffer pods."
 preemptionPolicy: Never
+{{- end }}

--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Cluster.ConfigItems.cluster_autoscaler_enabled "true" }}
 apiVersion: apps/v1
 {{- if eq .Cluster.Provider "zalando-eks"}}
 kind: Deployment
@@ -81,4 +82,5 @@ spec:
       - key: node.kubernetes.io/role
         value: master
         effect: NoSchedule
+{{- end}}
 {{- end}}

--- a/cluster/manifests/kube-cluster-autoscaler/pdb.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/pdb.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Cluster.ConfigItems.cluster_autoscaler_enabled "true" }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -12,3 +13,4 @@ spec:
     matchLabels:
       application: kubernetes
       component: autoscaling-buffer
+{{- end}}


### PR DESCRIPTION
With skipper-ingress moving to karpenter based pools, we soon won't need to run CA anymore.

Add config-item to allow disabling kube-cluster-autoscaler per cluster (enabled by default).