### PR TITLE
Use on-demand Karpenter nodes for skipper ingress in production

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -532,6 +532,9 @@ spec:
         dedicated: skipper-ingress
 {{ if eq .Cluster.ConfigItems.skipper_karpenter_node_pools_enabled "true" }}
         zalando.org/ingress-karpenter-managed: "true"
+{{ if eq .Cluster.Environment "production" }}
+        karpenter.sh/capacity-type: on-demand
+{{ end }}
 {{ end }}
       tolerations:
       - effect: NoSchedule


### PR DESCRIPTION
## Summary
- Add conditional nodeSelector to use on-demand Karpenter capacity-type for skipper ingress in production environments
- Non-production environments continue to use spot instances

## Context
When `skipper_karpenter_node_pools_enabled` is true and the cluster environment is production, the deployment now specifies `karpenter.sh/capacity-type: on-demand` to ensure production traffic uses reliable on-demand instances rather than spot instances.

## Test plan
- [ ] Verify the change is applied only in production environments
- [ ] Confirm skipper ingress pods are scheduled on on-demand nodes in production
- [ ] Ensure non-production clusters continue to use spot instances