### PR TITLE
Add spot capacity type for skipper in non-production environments

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -534,6 +534,8 @@ spec:
         zalando.org/ingress-karpenter-managed: "true"
 {{ if eq .Cluster.Environment "production" }}
         karpenter.sh/capacity-type: on-demand
+{{ else }}
+        karpenter.sh/capacity-type: spot
 {{ end }}
 {{ end }}
       tolerations:


### PR DESCRIPTION
## Summary

- Add spot capacity type for skipper karpenter nodes in non-production environments
- Only applies to non-production clusters (maintains on-demand for production)
- Reduces infrastructure costs for non-production workloads