### PR TITLE
Exclude node monitoring agent from admission controller

### DIFF
--- a/cluster/manifests/02-admission-control/teapot.yaml
+++ b/cluster/manifests/02-admission-control/teapot.yaml
@@ -356,7 +356,9 @@ webhooks:
           values: ["kube-proxy", "aws-node"]
         - key: app.kubernetes.io/name
           operator: NotIn
-          values: ["aws-efs-csi-driver"]
+          values:
+            - "aws-efs-csi-driver"
+            - "eks-node-monitoring-agent"
 {{- end }}
     clientConfig:
       {{- if eq .Cluster.Provider "zalando-eks"}}

--- a/cluster/manifests/02-admission-control/teapot.yaml
+++ b/cluster/manifests/02-admission-control/teapot.yaml
@@ -393,7 +393,10 @@ webhooks:
           values: ["kube-proxy"]
         - key: app.kubernetes.io/name
           operator: NotIn
-          values: ["eks-pod-identity-agent", "aws-efs-csi-driver"]
+          values:
+            - "eks-pod-identity-agent"
+            - "aws-efs-csi-driver"
+            - "eks-node-monitoring-agent"
 {{- end }}
     clientConfig:
       {{- if eq .Cluster.Provider "zalando-eks"}}


### PR DESCRIPTION
delete fails in playground with node monitoring agent enabled

this excludes node monitoring agent from admission controller