### PR TITLE
Add label stackset to pod labels allow list in kube-state-metrics

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1131,7 +1131,7 @@ observability_metrics_endpoint: "ingest.lightstep.com"
 observability_metrics_port: "443"
 
 # labels whitelisted to kube-state-metrics
-observability_metrics_pods_labels: "application,component,version,environment,stack_name,stack_version,application_id,application_version,team,job-name"
+observability_metrics_pods_labels: "application,component,version,environment,stack_name,stack_version,application_id,application_version,team,job-name,stackset"
 
 observability_metrics_ingresses_labels: ""
 


### PR DESCRIPTION
to better understand resource dependencies (to which stackset a pod belongs to) we add the label `stackset` to the allow list of pod labels in kube-state-metrics

https://github.com/zalando-build/cloud-platform/issues/7754#event-22592239825