### PR TITLE
skipper: update to v0.24

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,10 +1,10 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.22.223-1325" }}
+{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.24.5-1333" }}
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.24.5-1333" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}
-{{ $canary_args := print "-enable-kubernetes-external-names=" .Cluster.ConfigItems.skipper_externalname_service_enabled "[cf724afc]-enable-lua=" .Cluster.ConfigItems.skipper_lua_scripts_enabled  }}
+{{ $canary_args := "" }}
 
 {{ $cluster_internal_cidrs := list "10.2.0.0/15" .Values.vpc_ipv4_cidr }}
 {{ if eq .Cluster.Provider "zalando-eks" }}
@@ -240,6 +240,7 @@ spec:
           - '-kubernetes-east-west-range-annotation-predicates={{ .Cluster.ConfigItems.skipper_kubernetes_east_west_range_annotation_predicates }}'
           - '-kubernetes-east-west-range-annotation-filters-append={{ .Cluster.ConfigItems.skipper_kubernetes_east_west_range_annotation_filters_append }}'
 {{ end }}
+          - "-enable-kubernetes-external-names={{ .Cluster.ConfigItems.skipper_externalname_service_enabled }}"
           - "-proxy-preserve-host"
           - "-compress-encodings={{ .Cluster.ConfigItems.skipper_compress_encodings }}"
           - "-serve-host-metrics"
@@ -329,6 +330,7 @@ spec:
           - "-write-timeout-server={{ .Cluster.ConfigItems.skipper_write_timeout_server }}"
           - "-keepalive-server={{ .Cluster.ConfigItems.skipper_keepalive_server }}"
           - "-keepalive-requests-server={{ .Cluster.ConfigItems.skipper_keepalive_requests_server }}"
+          - "-enable-lua={{ .Cluster.ConfigItems.skipper_lua_scripts_enabled }}"
           - "-lua-sources={{ .Cluster.ConfigItems.skipper_lua_sources }}"
           - "-disabled-filters={{ .Cluster.ConfigItems.skipper_disabled_filters }}"
 {{ if ne .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}


### PR DESCRIPTION
2 minor version jump because these were 2 security related default config breaking changes.
    1. We know that we have disabled lua, so we change the default to "false" as all checks test for "true" it does not change anything, but we can pass the result to -enable-lua arg.
    2. we set externalname service to enabled but use config item to remove it in clusters that do not use this feature. In our current case it does not matter much, but changing towards multi tenant config is always a good thing