### PR TITLE
enable c7g instance family for default karpenter node-pool

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -57,6 +57,9 @@ karpenter_instance_family_t_enabled: "false"
 # scheduling issues, we need to properly test and support it later if needed
 karpenter_instance_family_g6f_enabled: "false"
 
+# configure whether we allow c7g instance family for Karpenter nodes
+karpenter_instance_family_c7g_enabled: "false"
+
 # configure whether spot instances should be enabled in Karpenter's capacity-types
 karpenter_enable_spot: "true"
 

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -218,6 +218,9 @@ spec:
             - "c6in"
             - "m6in"
             - "r6in"
+#{{ if eq .Cluster.ConfigItems.karpenter_instance_family_c7g_enabled "true" }}
+            - "c7g"
+#{{ end }}
             - "c7i"
             - "m7i"
             - "r7i"


### PR DESCRIPTION
It's been request by some users that they wish to test the `c7g` instance family for their workloads. Enabling it behind a config-item to be able to turn it off easily. 

Once we determine it's fine to enable it by default in all clusters, we can drop the feature flag.