### PR TITLE
allow EKS worker to connect to legacy EFS

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1099,6 +1099,16 @@ Resources:
       SourceSecurityGroupId: !Ref WorkerSecurityGroup
       ToPort: 2049
     Type: 'AWS::EC2::SecurityGroupIngress'
+{{- if eq .Cluster.ConfigItems.efs_allow_vpc_connection "true" }}
+  EFSSecurityGroupIngressFromVPCCIDR:
+    Properties:
+      FromPort: 2049
+      GroupId: !Ref EFSWorkerSecurityGroup
+      IpProtocol: tcp
+      CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+      ToPort: 2049
+    Type: 'AWS::EC2::SecurityGroupIngress'
+{{- end }}
   EFSWorkerSecurityGroup:
     Properties:
       GroupDescription: worker to EFS sg

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1339,6 +1339,9 @@ wiz_node_feature_rollout : "false"
 # Enable runtime sensor response capabilities such as KILL
 wiz_enable_runtime_sensor_response_capabilities: "false"
 
+# Configure legacy EFS connectivity from the entire VPC. This allows EKS clusters to connect to the legacy EFS file system.
+efs_allow_vpc_connection: "false"
+
 # EKS specific configuration
 eks_control_plane_logging: "true"
 eks_ip_family: "ipv4"


### PR DESCRIPTION
This expands the legacy EFS security group to allow access from the entire VPC.

This allows to mount the legacy EFS from the EKS cluster using NFS. It's already possible without any provisioner needed. The only thing missing is network connectivity.

FYI: Merging the two SGs would make this PR obsolete.