### PR TITLE
Replace sleep with poll when verifying mocked response

### DIFF
--- a/test/e2e/sandbox.go
+++ b/test/e2e/sandbox.go
@@ -429,7 +429,7 @@ var _ = describe("Sandbox Controller", func() {
 			})
 
 			By("Executing HTTP request to verify mocked response is returned")
-			err = wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, 30*time.Second, false, func(ctx context.Context) (bool, error) {
+			err = wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, 60*time.Second, false, func(ctx context.Context) (bool, error) {
 				output, err = e2ekubectl.RunKubectl(ns, "exec", createdPod.Name, "-c", "app", "--", "sh", "-c", cmd)
 				if err != nil {
 					return false, err

--- a/test/e2e/sandbox.go
+++ b/test/e2e/sandbox.go
@@ -41,7 +41,7 @@ import (
 
 func waitForSandboxedRoutegrouop(ctx context.Context, c clientset.Interface, ns, originalRGName string) (*rgv1.RouteGroup, error) {
 	var sandboxedRG *rgv1.RouteGroup
-	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		rgs, err := c.ZalandoV1().RouteGroups(ns).List(
 			context.TODO(),
 			metav1.ListOptions{
@@ -62,7 +62,7 @@ func waitForSandboxedRoutegrouop(ctx context.Context, c clientset.Interface, ns,
 
 func waitForSandboxedIngress(ctx context.Context, c clientset.Interface, ns, originalIngName string) (*netv1.Ingress, error) {
 	var sandboxedIng *netv1.Ingress
-	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		ings, err := c.NetworkingV1().Ingresses(ns).List(
 			context.TODO(),
 			metav1.ListOptions{
@@ -351,7 +351,7 @@ var _ = describe("Sandbox Controller", func() {
 			framework.ExpectNoError(err)
 
 			By("Waiting for egress-ready pod to be running")
-			err = wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+			err = wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
 				pod, err := c.CoreV1().Pods(ns).Get(context.TODO(), createdPod.Name, metav1.GetOptions{})
 				if err != nil {
 					return false, nil
@@ -414,7 +414,7 @@ var _ = describe("Sandbox Controller", func() {
 			framework.ExpectNoError(err)
 
 			By("Waiting for SandboxEgress to be processed and routes to be updated in ConfigMap")
-			err = wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+			err = wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
 				cm, err := c.CoreV1().ConfigMaps(ns).Get(context.TODO(), configMapName, metav1.GetOptions{})
 				if err != nil {
 					return false, nil
@@ -427,7 +427,7 @@ var _ = describe("Sandbox Controller", func() {
 			})
 
 			By("Executing HTTP request to verify mocked response is returned")
-			err = wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, 120*time.Second, false, func(ctx context.Context) (bool, error) {
+			err = wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
 				output, err = e2ekubectl.RunKubectl(ns, "exec", createdPod.Name, "-c", "app", "--", "sh", "-c", cmd)
 				if err != nil {
 					return false, err

--- a/test/e2e/sandbox.go
+++ b/test/e2e/sandbox.go
@@ -16,6 +16,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -422,14 +423,11 @@ var _ = describe("Sandbox Controller", func() {
 				if !exists {
 					return false, nil
 				}
-				if routes != initialRoutes {
-					return true, nil
-				}
-				return false, nil
+				return strings.Contains(routes, "production-backend"), nil
 			})
 
 			By("Executing HTTP request to verify mocked response is returned")
-			err = wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, 60*time.Second, false, func(ctx context.Context) (bool, error) {
+			err = wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, 120*time.Second, false, func(ctx context.Context) (bool, error) {
 				output, err = e2ekubectl.RunKubectl(ns, "exec", createdPod.Name, "-c", "app", "--", "sh", "-c", cmd)
 				if err != nil {
 					return false, err

--- a/test/e2e/sandbox.go
+++ b/test/e2e/sandbox.go
@@ -428,13 +428,15 @@ var _ = describe("Sandbox Controller", func() {
 				return false, nil
 			})
 
-			time.Sleep(2 * time.Second) // small delay to ensure Skipper picks up the new routes
-
 			By("Executing HTTP request to verify mocked response is returned")
-			output, err = e2ekubectl.RunKubectl(ns, "exec", createdPod.Name, "-c", "app", "--", "sh", "-c", cmd)
+			err = wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, 30*time.Second, false, func(ctx context.Context) (bool, error) {
+				output, err = e2ekubectl.RunKubectl(ns, "exec", createdPod.Name, "-c", "app", "--", "sh", "-c", cmd)
+				if err != nil {
+					return false, err
+				}
+				return string(output) == "intercepted response", nil
+			})
 			framework.ExpectNoError(err)
-			framework.Logf("Mocked response: %s", output)
-			Expect(output).To(Equal("intercepted response"))
 		})
 	})
 


### PR DESCRIPTION
Use wait.PollUntilContextTimeout instead of a fixed 2-second sleep to wait for Skipper to pick up new routes, with a 30-second timeout and 2-second polling interval.