### PR TITLE
fix: enable console decision logging for validation webhook

### DIFF
--- a/cluster/manifests/02-skipper-validation-webhook/02-configmap-open-policy-agent.yaml
+++ b/cluster/manifests/02-skipper-validation-webhook/02-configmap-open-policy-agent.yaml
@@ -31,8 +31,9 @@ data:
             session_name: open-policy-agent-instance
       name: styra-bundles
       url: "{{ .Cluster.ConfigItems.skipper_open_policy_agent_bundles_url }}"
-    {{ if eq .Cluster.ConfigItems.skipper_open_policy_agent_decision_logs_buffer_type_event_enable "true" }}
     decision_logs:
+      console: true
+    {{ if eq .Cluster.ConfigItems.skipper_open_policy_agent_decision_logs_buffer_type_event_enable "true" }}
       reporting:
         buffer_type: "event"
         buffer_size_limit_events: {{ .Cluster.ConfigItems.skipper_open_policy_agent_decision_logs_buffer_type_event_limit }}


### PR DESCRIPTION
## What & Why?

Override the discovery bundle's decision logging configuration to prevent OPA from attempting to upload logs to a remote service.

See [decision-logs](https://www.openpolicyagent.org/docs/configuration#decision-logs)'s `decision_logs.console` property