### PR TITLE
Exclude crd of node monitoring agent from admission controller

### DIFF
--- a/cluster/manifests/02-admission-control/teapot.yaml
+++ b/cluster/manifests/02-admission-control/teapot.yaml
@@ -264,7 +264,7 @@ webhooks:
     # avoid admission-control applying to eks managed addon resources
     matchConditions:
     - name: "exclude-by-name"
-      expression: "oldObject == null || oldObject.metadata.name != 'eniconfigs.crd.k8s.amazonaws.com'"
+      expression: "oldObject == null || oldObject.metadata.name != 'eniconfigs.crd.k8s.amazonaws.com' || oldObject.metadata.name != 'nodediagnostics.eks.amazonaws.com'"
 {{- end }}
     clientConfig:
       {{- if eq .Cluster.Provider "zalando-eks"}}

--- a/cluster/manifests/02-admission-control/teapot.yaml
+++ b/cluster/manifests/02-admission-control/teapot.yaml
@@ -264,7 +264,7 @@ webhooks:
     # avoid admission-control applying to eks managed addon resources
     matchConditions:
     - name: "exclude-by-name"
-      expression: "oldObject == null || oldObject.metadata.name != 'eniconfigs.crd.k8s.amazonaws.com' || oldObject.metadata.name != 'nodediagnostics.eks.amazonaws.com'"
+      expression: "oldObject == null || !(oldObject.metadata.name in ['eniconfigs.crd.k8s.amazonaws.com', 'nodediagnostics.eks.amazonaws.com'])"
 {{- end }}
     clientConfig:
       {{- if eq .Cluster.Provider "zalando-eks"}}


### PR DESCRIPTION
related to https://github.com/zalando-incubator/kubernetes-on-aws/pull/10525

also exclude the node monitoring agent specific crd so delete of cluster do not get stuck