### PR TITLE
Make Karpenter the default by removing migration flags

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -129,7 +129,6 @@ worker_sg_legacy_cluster: ""
 # skipper node-pool
 enable_dedicate_nodepool_skipper: "true"
 skipper_attach_only_to_skipper_node_pool: "true"
-skipper_karpenter_node_pools_enabled: "true"
 
 skipper_suppress_route_update_logs: "true"
 skipper_validate_query: "true"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -92,7 +92,6 @@ spec:
               component: ingress
               application: skipper-ingress
 {{- end }}
-{{ if eq .Cluster.ConfigItems.skipper_karpenter_node_pools_enabled "true" }}
       affinity:
        podAntiAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
@@ -133,15 +132,6 @@ spec:
                 - c6g.4xlarge
                 - c6g.8xlarge
                 - m6g.large
-{{ else }}
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: zalando.org/ingress-karpenter-managed
-                operator: DoesNotExist
-{{ end }}
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       serviceAccountName: skipper-ingress
       terminationGracePeriodSeconds: {{ .Cluster.ConfigItems.skipper_termination_grace_period }}
@@ -532,13 +522,10 @@ spec:
 {{ if eq .Cluster.ConfigItems.enable_dedicate_nodepool_skipper "true"}}
       nodeSelector:
         dedicated: skipper-ingress
-{{ if eq .Cluster.ConfigItems.skipper_karpenter_node_pools_enabled "true" }}
-        zalando.org/ingress-karpenter-managed: "true"
 {{ if eq .Cluster.Environment "production" }}
         karpenter.sh/capacity-type: on-demand
 {{ else }}
         karpenter.sh/capacity-type: spot
-{{ end }}
 {{ end }}
       tolerations:
       - effect: NoSchedule

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -192,12 +192,6 @@ spec:
 #    {{ end}}
 #  {{ end}}
 #{{ end}}
-#{{ if eq (index .NodePool.ConfigItems "taints") "dedicated=skipper-ingress:NoSchedule" }}
-        - key: zalando.org/ingress-karpenter-managed
-          operator: In
-          values:
-            - "true"
-#{{ end }}
 
 #{{ if (eq .NodePool.KarpenterInstanceTypeStrategy "default-for-karpenter" )  }}
         - key: "karpenter.k8s.aws/instance-family"

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -116,22 +116,6 @@ EOFF
       taints: kubernetes.io/arch=arm64:NoSchedule
   - discount_strategy: spot
     instance_types:
-    - "c7g.large"
-    - "c6i.large"
-    - "c6a.large"
-    - "m6i.large"
-    - "m6a.large"
-    - "m6g.large"
-    - "m7g.large"
-    min_size: 0
-    max_size: 18
-    profile: worker-splitaz
-    name: skipper-ingress-node
-    config_items:
-      labels: dedicated=skipper-ingress
-      taints: dedicated=skipper-ingress:NoSchedule
-  - discount_strategy: spot
-    instance_types:
     - "not-specified"
     min_size: 0
     max_size: 0


### PR DESCRIPTION
## Summary
- Removes the `skipper_karpenter_node_pools_enabled` feature flag from config defaults
- Removes conditional logic in skipper deployment that was checking for the migration flag
- Removes fallback conditions that targeted non-Karpenter managed nodes
- Removes corresponding test configuration for the ASG node pools

This change makes Karpenter the default scheduler for skipper ingress pods

## Test plan
- [ ] Verify skipper deploys successfully on existing clusters
- [ ] Verify that skipper pods are scheduled on dedicated Karpenter node pool
- [ ] Verify capacity-type labels (spot/on-demand) are respected for skipper deployments