### PR TITLE
Update deletions order for cluster_autoscaler_enabled config item

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -428,9 +428,17 @@ post_apply:
   kind: StorageClass
 {{ end }}
 {{- if ne .Cluster.ConfigItems.cluster_autoscaler_enabled "true" }}
-- name: cluster-autoscaler
+- name: kube-cluster-autoscaler
   namespace: kube-system
-  kind: ServiceAccount
+  kind: DaemonSet
+- name: kube-cluster-autoscaler
+  namespace: kube-system
+  kind: Deployment
+- kind: Deployment
+  namespace: kube-system
+  labels:
+    application: kubernetes
+    component: autoscaling-buffer
 - name: cluster-autoscaler
   kind: ClusterRole
 - name: cluster-autoscaler
@@ -443,18 +451,10 @@ post_apply:
   kind: RoleBinding
 - name: autoscaling-buffer-nonpreempting
   kind: PriorityClass
-- name: kube-cluster-autoscaler
-  namespace: kube-system
-  kind: DaemonSet
-- name: kube-cluster-autoscaler
-  namespace: kube-system
-  kind: Deployment
 - name: autoscaling-buffer
   namespace: kube-system
   kind: PodDisruptionBudget
-- kind: Deployment
+- name: cluster-autoscaler
   namespace: kube-system
-  labels:
-    application: kubernetes
-    component: autoscaling-buffer
+  kind: ServiceAccount
 {{- end }}


### PR DESCRIPTION
The current deletions order attempts to delete the `ServiceAccount` first, which fails as the `Daemonset` Pods are still running (and it's deletion is never reached as CLM discontinues on failure). This PR changes the order so the `Daemonset` and `Deployment`s are removed first.