### PR TITLE
Update to vpa v1.6.0

### DIFF
--- a/cluster/manifests/02-vertical-pod-autoscaler/01-crd.yaml
+++ b/cluster/manifests/02-vertical-pod-autoscaler/01-crd.yaml
@@ -76,7 +76,7 @@ spec:
                     type: number
                 type: object
               firstSampleStart:
-                description: Timestamp of the fist sample from the histograms.
+                description: Timestamp of the first sample from the histograms.
                 format: date-time
                 nullable: true
                 type: string
@@ -177,7 +177,7 @@ spec:
                     type: number
                 type: object
               firstSampleStart:
-                description: Timestamp of the fist sample from the histograms.
+                description: Timestamp of the first sample from the histograms.
                 format: date-time
                 nullable: true
                 type: string
@@ -372,6 +372,22 @@ spec:
                           - Auto
                           - "Off"
                           type: string
+                        oomBumpUpRatio:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: oomBumpUpRatio is the ratio to increase memory
+                            when OOM is detected.
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        oomMinBumpUp:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: oomMinBumpUp is the minimum increase in memory
+                            when OOM is detected.
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
                       type: object
                     type: array
                 type: object
@@ -453,7 +469,7 @@ spec:
                   updateMode:
                     description: |-
                       Controls when autoscaler applies changes to the pod resources.
-                      The default is 'Auto'.
+                      The default is 'Recreate'.
                     enum:
                     - "Off"
                     - Initial

--- a/cluster/manifests/02-vertical-pod-autoscaler/admission-controller-deployment.yaml
+++ b/cluster/manifests/02-vertical-pod-autoscaler/admission-controller-deployment.yaml
@@ -26,9 +26,9 @@ spec:
       containers:
       - name: admission-controller
         {{if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "current"}}
-        image: container-registry.zalando.net/teapot/vpa-admission-controller:v1.5.1-main-11-custom
+        image: container-registry.zalando.net/teapot/vpa-admission-controller:v1.6.0-main-12-custom
         {{else if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "legacy"}}
-        image: container-registry.zalando.net/teapot/vpa-admission-controller:v1.3.1-main-10-custom
+        image: container-registry.zalando.net/teapot/vpa-admission-controller:v1.5.1-main-11-custom
         {{end}}
         command:
           - /admission-controller

--- a/cluster/manifests/02-vertical-pod-autoscaler/recommender-deployment.yaml
+++ b/cluster/manifests/02-vertical-pod-autoscaler/recommender-deployment.yaml
@@ -24,9 +24,9 @@ spec:
       containers:
       - name: recommender
         {{if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "current"}}
-        image: container-registry.zalando.net/teapot/vpa-recommender:v1.5.1-main-11-custom
+        image: container-registry.zalando.net/teapot/vpa-recommender:v1.6.0-main-12-custom
         {{else if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "legacy"}}
-        image: container-registry.zalando.net/teapot/vpa-recommender:v1.3.1-main-10-custom
+        image: container-registry.zalando.net/teapot/vpa-recommender:v1.5.1-main-11-custom
         {{end}}
         args:
         - --logtostderr

--- a/cluster/manifests/02-vertical-pod-autoscaler/updater-deployment.yaml
+++ b/cluster/manifests/02-vertical-pod-autoscaler/updater-deployment.yaml
@@ -24,9 +24,9 @@ spec:
       containers:
       - name: updater
         {{if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "current"}}
-        image: container-registry.zalando.net/teapot/vpa-updater:v1.5.1-main-11-custom
+        image: container-registry.zalando.net/teapot/vpa-updater:v1.6.0-main-12-custom
         {{else if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "legacy"}}
-        image: container-registry.zalando.net/teapot/vpa-updater:v1.3.1-main-10-custom
+        image: container-registry.zalando.net/teapot/vpa-updater:v1.5.1-main-11-custom
         {{end}}
         command:
           - ./updater

--- a/cluster/manifests/03-kube-aws-iam-controller/vpa.yaml
+++ b/cluster/manifests/03-kube-aws-iam-controller/vpa.yaml
@@ -12,7 +12,7 @@ spec:
     kind: Deployment
     name: kube-aws-iam-controller
   updatePolicy:
-    updateMode: "Auto"
+    updateMode: Recreate
   resourcePolicy:
     containerPolicies:
     - containerName: kube-aws-iam-controller

--- a/cluster/manifests/kube-state-metrics/vpa.yaml
+++ b/cluster/manifests/kube-state-metrics/vpa.yaml
@@ -12,7 +12,7 @@ spec:
     kind: Deployment
     name: kube-state-metrics
   updatePolicy:
-    updateMode: "Auto"
+    updateMode: Recreate
   resourcePolicy:
     containerPolicies:
     - containerName: kube-state-metrics

--- a/cluster/manifests/metrics-server/metrics-server-vpa.yaml
+++ b/cluster/manifests/metrics-server/metrics-server-vpa.yaml
@@ -12,7 +12,7 @@ spec:
     kind: Deployment
     name: metrics-server
   updatePolicy:
-    updateMode: "Auto"
+    updateMode: Recreate
   resourcePolicy:
     containerPolicies:
     - containerName: metrics-server

--- a/cluster/manifests/z-karpenter/vpa.yaml
+++ b/cluster/manifests/z-karpenter/vpa.yaml
@@ -13,7 +13,7 @@ spec:
     kind: Deployment
     name: karpenter
   updatePolicy:
-    updateMode: "Auto"
+    updateMode: Recreate
   resourcePolicy:
     containerPolicies:
       - containerName: controller


### PR DESCRIPTION
Updates VPA to v1.6.0

https://github.com/kubernetes/autoscaler/releases/tag/vertical-pod-autoscaler-1.6.0