### PR TITLE
Configuration for eopa_dl

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -421,6 +421,8 @@ skipper_open_policy_agent_data_preprocessing_optimization_enabled: "true"
 skipper_open_policy_agent_preloading_enabled: "false"
 skipper_open_policy_agent_decision_log_export_enabled: "false"
 skipper_open_policy_agent_console_logs_enabled: "false"
+skipper_open_policy_agent_decision_log_s3_endpoint: ""
+skipper_open_policy_agent_decision_log_s3_region: ""
 
 # Default timeout value in seconds for outgoing http calls from Open Policy Agent in a skipper filter
 skipper_open_policy_agent_styra_response_header_timeout: "2"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -419,8 +419,8 @@ skipper_open_policy_agent_enabled: "false"
 skipper_open_policy_agent_styra_token: ""
 skipper_open_policy_agent_data_preprocessing_optimization_enabled: "true"
 skipper_open_policy_agent_preloading_enabled: "false"
-skipper_open_policy_agent_eopa_dl_enabled: "false"
-skipper_open_policy_agent_eopa_dl_console_log_enabled: "false"
+skipper_open_policy_agent_decision_log_export_enabled: "false"
+skipper_open_policy_agent_console_logs_enabled: "false"
 
 # Default timeout value in seconds for outgoing http calls from Open Policy Agent in a skipper filter
 skipper_open_policy_agent_styra_response_header_timeout: "2"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -420,6 +420,8 @@ skipper_open_policy_agent_enabled: "false"
 skipper_open_policy_agent_styra_token: ""
 skipper_open_policy_agent_data_preprocessing_optimization_enabled: "true"
 skipper_open_policy_agent_preloading_enabled: "false"
+skipper_open_policy_agent_eopa_dl_enabled: "false"
+skipper_open_policy_agent_eopa_dl_console_log_enabled: "false"
 
 # Default timeout value in seconds for outgoing http calls from Open Policy Agent in a skipper filter
 skipper_open_policy_agent_styra_response_header_timeout: "2"

--- a/cluster/manifests/skipper/02-configmap-open-policy-agent.yaml
+++ b/cluster/manifests/skipper/02-configmap-open-policy-agent.yaml
@@ -62,6 +62,8 @@ data:
             at_period: 10s
     {{ end }}
     {{ if eq .Cluster.ConfigItems.skipper_open_policy_agent_jwt_cache_enable "true" }}
+    status:
+      prometheus: true
     caching: 
       inter_query_builtin_value_cache:
         named:

--- a/cluster/manifests/skipper/02-configmap-open-policy-agent.yaml
+++ b/cluster/manifests/skipper/02-configmap-open-policy-agent.yaml
@@ -37,6 +37,8 @@ data:
         buffer_type: "event"
         buffer_size_limit_events: {{ .Cluster.ConfigItems.skipper_open_policy_agent_decision_logs_buffer_type_event_limit }}
     {{ else if eq .Cluster.ConfigItems.skipper_open_policy_agent_decision_log_export_enabled "true" }}
+    status:
+      prometheus: true
     decision_logs:
       plugin: eopa_dl
     plugins:
@@ -62,8 +64,6 @@ data:
             at_period: 10s
     {{ end }}
     {{ if eq .Cluster.ConfigItems.skipper_open_policy_agent_jwt_cache_enable "true" }}
-    status:
-      prometheus: true
     caching: 
       inter_query_builtin_value_cache:
         named:

--- a/cluster/manifests/skipper/02-configmap-open-policy-agent.yaml
+++ b/cluster/manifests/skipper/02-configmap-open-policy-agent.yaml
@@ -36,7 +36,7 @@ data:
       reporting:
         buffer_type: "event"
         buffer_size_limit_events: {{ .Cluster.ConfigItems.skipper_open_policy_agent_decision_logs_buffer_type_event_limit }}
-    {{ else if eq .Cluster.ConfigItems.skipper_open_policy_agent_eopa_dl_enabled "true" }}
+    {{ else if eq .Cluster.ConfigItems.skipper_open_policy_agent_decision_log_export_enabled "true" }}
     decision_logs:
       plugin: eopa_dl
     plugins:
@@ -47,15 +47,15 @@ data:
           flush_at_bytes: 10485760
           flush_at_period: 15s
         output:
-        {{ if eq .Cluster.ConfigItems.skipper_open_policy_agent_eopa_dl_console_log_enabled "true" }}
+        {{ if eq .Cluster.ConfigItems.skipper_open_policy_agent_console_logs_enabled "true" }}
         - type: console
         {{ end }}
         - type: s3
           bucket: {{ `{{ .bundlename }}` }}
           timeout: "2s"
-          endpoint: "{{ .Cluster.ConfigItems.skipper_open_policy_agent_eopa_dl_s3_endpoint }}/{{ .Cluster.Alias }}/"
+          endpoint: "{{ .Cluster.ConfigItems.skipper_open_policy_agent_decision_log_s3_endpoint }}/{{ .Cluster.Alias }}/"
           force_path: true
-          region: "{{ .Cluster.ConfigItems.skipper_open_policy_agent_eopa_dl_region }}"
+          region: "{{ .Cluster.ConfigItems.skipper_open_policy_agent_decision_log_s3_region }}"
           batching:
             compress: true
             at_bytes: 1048576

--- a/cluster/manifests/skipper/02-configmap-open-policy-agent.yaml
+++ b/cluster/manifests/skipper/02-configmap-open-policy-agent.yaml
@@ -36,6 +36,30 @@ data:
       reporting:
         buffer_type: "event"
         buffer_size_limit_events: {{ .Cluster.ConfigItems.skipper_open_policy_agent_decision_logs_buffer_type_event_limit }}
+    {{ else if eq .Cluster.ConfigItems.skipper_open_policy_agent_eopa_dl_enabled "true" }}
+    decision_logs:
+      plugin: eopa_dl
+    plugins:
+      eopa_dl:
+        buffer:
+          type: memory
+          max_bytes: 15728640
+          flush_at_bytes: 10485760
+          flush_at_period: 15s
+        output:
+        {{ if eq .Cluster.ConfigItems.skipper_open_policy_agent_eopa_dl_console_log_enabled "true" }}
+        - type: console
+        {{ end }}
+        - type: s3
+          bucket: {{ `{{ .bundlename }}` }}
+          timeout: "2s"
+          endpoint: "{{ .Cluster.ConfigItems.skipper_open_policy_agent_eopa_dl_s3_endpoint }}/{{ .Cluster.Alias }}/"
+          force_path: true
+          region: "{{ .Cluster.ConfigItems.skipper_open_policy_agent_eopa_dl_region }}"
+          batching:
+            compress: true
+            at_bytes: 1048576
+            at_period: 10s
     {{ end }}
     {{ if eq .Cluster.ConfigItems.skipper_open_policy_agent_jwt_cache_enable "true" }}
     caching: 

--- a/cluster/manifests/skipper/02-configmap-open-policy-agent.yaml
+++ b/cluster/manifests/skipper/02-configmap-open-policy-agent.yaml
@@ -55,7 +55,7 @@ data:
         - type: s3
           bucket: {{ `{{ .bundlename }}` }}
           timeout: "2s"
-          endpoint: "{{ .Cluster.ConfigItems.skipper_open_policy_agent_decision_log_s3_endpoint }}/{{ .Cluster.Alias }}/"
+          endpoint: "{{ .Cluster.ConfigItems.skipper_open_policy_agent_decision_log_s3_endpoint }}/{{ .Cluster.InfrastructureAccountID }}/{{ .Cluster.Alias }}/"
           force_path: true
           region: "{{ .Cluster.ConfigItems.skipper_open_policy_agent_decision_log_s3_region }}"
           batching:

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,6 +1,6 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.24.5-1333" }}
+{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.24.23-1351" }}
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.24.23-1351" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,7 +1,7 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.24.5-1333" }}
-{{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.24.5-1333" }}
+{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.24.18-1346" }}
+{{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.24.18-1346" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}
 {{ $canary_args := "" }}


### PR DESCRIPTION
Config is controlled with flags which will be provided in each cluster configurations.

When pushing to S3, opa constructs the log path `<output.endpoint>/<output.bucket>`

Buffer and batching configurations are common across clusters. These values are set to match our current decision log configurations which has `{"buffer_size_limit_bytes":16000000,"max_delay_seconds":15,"min_delay_seconds":10,"upload_size_limit_bytes":1048576}`
- Buffer max size is 15MB and flushed at 10MB or every 15 seconds
- Compressed batching is used and batched either 1MB or every 10 seconds