### PR TITLE
e2e: Change limit-az test pool to karpenter

### DIFF
--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -84,24 +84,13 @@ EOFF
   fi)
   - discount_strategy: spot
     instance_types:
-    - "c6i.xlarge"
-    - "m6i.xlarge"
-    - "r6i.xlarge"
-    - "c7i.xlarge"
-    - "m7i.xlarge"
-    - "r7i.xlarge"
-    - "c6i.2xlarge"
-    - "m6i.2xlarge"
-    - "r6i.2xlarge"
-    - "c7i.2xlarge"
-    - "m7i.2xlarge"
-    - "r7i.2xlarge"
+    - default-for-karpenter
     config_items:
       availability_zones: "eu-central-1c"
       labels: dedicated=worker-limit-az
       taints: dedicated=worker-limit-az:NoSchedule
     name: worker-limit-az
-    profile: worker-splitaz
+    profile: worker-karpenter
     min_size: 0
     max_size: 21
   - name: karpenter-arm


### PR DESCRIPTION
Change the limit-az test node pool to be karpenter based as we're phasing out CA pools.