### PR TITLE
skipper: migrate redis to valkey

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -258,7 +258,7 @@ skipper_ingress_redis_swim_enabled: "false"
 # to switch redis/valkey force and back
 # switch to redis: "redis"
 # switch to valkey: "valkey"
-skipper_ingress_swarm_type: "valkey"
+skipper_ingress_swarm_type: "redis"
 
 # skipper valkey settings
 skipper_valkey_cpu: "100m"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -246,13 +246,17 @@ skipper_redis_write_timeout: "25ms"
 skipper_redis_min_conns: 25
 skipper_redis_max_conns: 100
 skipper_ingress_redis_swarm_enabled: "true"
-skipper_ingress_redis_swim_enabled: "false"
 skipper_ingress_redis_target_average_utilization_cpu: "30"
 skipper_ingress_redis_target_average_utilization_memory: "60"
 skipper_ingress_redis_min_replicas: "1"
 skipper_ingress_redis_max_replicas: "100"
 skipper_ingress_redis_cluster_scaling_schedules: ""
 skipper_ingress_redis_hpa_scale_down_wait: "600"
+# requires cleanup in cluster.yaml
+skipper_ingress_redis_swim_enabled: "false"
+
+# to switch redis/valkey force and back
+skipper_ingress_swarm_type: "valkey"
 
 # skipper valkey settings
 skipper_valkey_cpu: "100m"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -236,7 +236,7 @@ skipper_idle_timeout_server: "352s"
 skipper_termination_grace_period: "392"
 
 # skipper redis settings
-enable_dedicate_nodepool_skipper_redis: "false"
+skipper_redis_cleanup_enabled: "false" # if set to true we should be able to cleanup all of the cfg items below
 skipper_redis_cpu: "100m"
 skipper_redis_memory: "512Mi"
 skipper_redis_dial_timeout: "25ms"
@@ -245,7 +245,6 @@ skipper_redis_read_timeout: "25ms"
 skipper_redis_write_timeout: "25ms"
 skipper_redis_min_conns: 25
 skipper_redis_max_conns: 100
-
 skipper_ingress_redis_swarm_enabled: "true"
 skipper_ingress_redis_swim_enabled: "false"
 skipper_ingress_redis_target_average_utilization_cpu: "30"
@@ -255,6 +254,17 @@ skipper_ingress_redis_max_replicas: "100"
 skipper_ingress_redis_cluster_scaling_schedules: ""
 skipper_ingress_redis_hpa_scale_down_wait: "600"
 
+# skipper valkey settings
+skipper_valkey_cpu: "100m"
+skipper_valkey_memory: "512Mi"
+skipper_valkey_conn_timeout: "25ms"
+skipper_ingress_valkey_min_replicas: "1"
+skipper_ingress_valkey_max_replicas: "100"
+skipper_ingress_valkey_target_average_utilization_cpu: "30"
+skipper_ingress_valkey_target_average_utilization_memory: "60"
+skipper_ingress_valkey_hpa_scale_down_wait: "600"
+skipper_ingress_valkey_cluster_scaling_schedules: ""
+enable_dedicate_nodepool_skipper_redis: "false"
 skipper_cluster_ratelimit_max_group_shards: 1
 
 # webhook protection poc

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -258,7 +258,11 @@ skipper_ingress_redis_swim_enabled: "false"
 # to switch redis/valkey force and back
 # switch to redis: "redis"
 # switch to valkey: "valkey"
+{{if eq .Cluster.Environment "production"}}
 skipper_ingress_swarm_type: "redis"
+{{else}}
+skipper_ingress_swarm_type: "valkey"
+{{end}}
 
 # skipper valkey settings
 skipper_valkey_cpu: "100m"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -256,6 +256,8 @@ skipper_ingress_redis_hpa_scale_down_wait: "600"
 skipper_ingress_redis_swim_enabled: "false"
 
 # to switch redis/valkey force and back
+# switch to redis: "redis"
+# switch to valkey: "valkey"
 skipper_ingress_swarm_type: "valkey"
 
 # skipper valkey settings

--- a/cluster/manifests/02-skipper-validation-webhook/deployment.yaml
+++ b/cluster/manifests/02-skipper-validation-webhook/deployment.yaml
@@ -54,10 +54,10 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: skipper-validation-webhook
       containers:
-      - name: redis-sidecar
-        image: container-registry.zalando.net/library/redis-7-alpine:7.2-alpine-20250805
+      - name: valkey-sidecar
+        image: container-registry.zalando.net/library/valkey-9-alpine:9-alpine3.22-20260302
         args:
-        - /usr/local/bin/docker-entrypoint.sh
+        - valkey-server
         - --save
         - ""  # Disable persistence for sidecar use
         - --maxmemory
@@ -67,11 +67,11 @@ spec:
         ports:
         - containerPort: 6379
           protocol: TCP
-          name: redis
+          name: valkey
         readinessProbe:
           exec:
             command:
-            - redis-cli
+            - valkey-cli
             - ping
           failureThreshold: 3
           initialDelaySeconds: 5
@@ -150,18 +150,11 @@ spec:
           - "-disabled-filters={{ .Cluster.ConfigItems.skipper_disabled_filters }}"
           - "-compress-encodings={{ .Cluster.ConfigItems.skipper_compress_encodings }}"
           - "-enable-ratelimits"
-{{ if eq .Cluster.ConfigItems.skipper_ingress_redis_swarm_enabled "true" }}
           - "-enable-swarm"
-          - "-swarm-redis-dial-timeout=5s"
-          - "-swarm-redis-pool-timeout=5s"
-          - "-swarm-redis-read-timeout=5s"
-          - "-swarm-redis-write-timeout=5s"
-          - "-swarm-redis-heartbeat-frequency=720h"
+          - "-swarm-valkey-conn-timeout=5s"
+          - "-swarm-valkey-update-interval=720h"
           - "-cluster-ratelimit-max-group-shards={{ .Cluster.ConfigItems.skipper_cluster_ratelimit_max_group_shards }}"
-          - "-swarm-redis-min-conns=1"
-          - "-swarm-redis-max-conns=1"
-          - "-swarm-redis-urls=127.0.0.1:6379"
-{{ end }}
+          - "-swarm-valkey-urls=127.0.0.1:6379"
           - "-lua-sources={{ .Cluster.ConfigItems.skipper_lua_sources }}"
           - "-default-filters-dir=/etc/config/default-filters"
           - '-default-filters-prepend={{ .Cluster.ConfigItems.skipper_default_filters }}'

--- a/cluster/manifests/02-skipper-validation-webhook/deployment.yaml
+++ b/cluster/manifests/02-skipper-validation-webhook/deployment.yaml
@@ -54,6 +54,43 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: skipper-validation-webhook
       containers:
+{{- if eq .Cluster.ConfigItems.skipper_ingress_swarm_type "redis" }}
+      - name: redis-sidecar
+        image: container-registry.zalando.net/library/redis-7-alpine:7.2-alpine-20250805
+        args:
+        - /usr/local/bin/docker-entrypoint.sh
+        - --save
+        - ""  # Disable persistence for sidecar use
+        - --maxmemory
+        - "256mb"
+        - --maxmemory-policy
+        - "allkeys-lru"
+        ports:
+        - containerPort: 6379
+          protocol: TCP
+          name: redis
+        readinessProbe:
+          exec:
+            command:
+            - redis-cli
+            - ping
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "100m"
+            memory: "128Mi"
+        lifecycle:
+          preStop:
+            sleep:
+              seconds: 10
+{{- else if eq .Cluster.ConfigItems.skipper_ingress_swarm_type "valkey" }}
       - name: valkey-sidecar
         image: container-registry.zalando.net/library/valkey-9-alpine:9-alpine3.22-20260302
         args:
@@ -89,6 +126,7 @@ spec:
           preStop:
             sleep:
               seconds: 10
+{{ end }}
       - name: skipper-admission-webhook
         image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/skipper:v0.24.23
         env:
@@ -151,10 +189,21 @@ spec:
           - "-compress-encodings={{ .Cluster.ConfigItems.skipper_compress_encodings }}"
           - "-enable-ratelimits"
           - "-enable-swarm"
+          - "-cluster-ratelimit-max-group-shards={{ .Cluster.ConfigItems.skipper_cluster_ratelimit_max_group_shards }}"
+{{- if eq .Cluster.ConfigItems.skipper_ingress_swarm_type "valkey" }}
           - "-swarm-valkey-conn-timeout=5s"
           - "-swarm-valkey-update-interval=720h"
-          - "-cluster-ratelimit-max-group-shards={{ .Cluster.ConfigItems.skipper_cluster_ratelimit_max_group_shards }}"
           - "-swarm-valkey-urls=127.0.0.1:6379"
+{{- else if eq .Cluster.ConfigItems.skipper_ingress_swarm_type "redis" }}
+          - "-swarm-redis-dial-timeout=5s"
+          - "-swarm-redis-pool-timeout=5s"
+          - "-swarm-redis-read-timeout=5s"
+          - "-swarm-redis-write-timeout=5s"
+          - "-swarm-redis-heartbeat-frequency=720h"
+          - "-swarm-redis-min-conns=1"
+          - "-swarm-redis-max-conns=1"
+          - "-swarm-redis-urls=127.0.0.1:6379"
+{{ end }}
           - "-lua-sources={{ .Cluster.ConfigItems.skipper_lua_sources }}"
           - "-default-filters-dir=/etc/config/default-filters"
           - '-default-filters-prepend={{ .Cluster.ConfigItems.skipper_default_filters }}'

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -4,6 +4,14 @@ pre_apply:
 - name: deployment-service-controller
   kind: StatefulSet
   namespace: kube-system
+{{- if eq .Cluster.ConfigItems.skipper_redis_cleanup_enabled "true" }}
+- kind: StatefulSet
+  name: skipper-ingress-redis
+- kind: HorizontalPodAutoscaler
+  name: skipper-ingress-redis
+- kind: Service
+  name: skipper-ingress-redis
+{{- end }}
 
 # everything defined under here will be deleted after applying the manifests
 post_apply:

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -263,7 +263,7 @@ spec:
           - "-max-audit-body=0"
           - "-enable-swarm"
           - "-cluster-ratelimit-max-group-shards={{ .Cluster.ConfigItems.skipper_cluster_ratelimit_max_group_shards }}"
-{{ if .Cluster.ConfigItems.skipper_ingress_swarm_type "redis" }}
+{{ if eq .Cluster.ConfigItems.skipper_ingress_swarm_type "redis" }}
           - "-swarm-redis-dial-timeout={{ .Cluster.ConfigItems.skipper_redis_dial_timeout }}"
           - "-swarm-redis-pool-timeout={{ .Cluster.ConfigItems.skipper_redis_pool_timeout }}"
           - "-swarm-redis-read-timeout={{ .Cluster.ConfigItems.skipper_redis_read_timeout }}"
@@ -271,7 +271,7 @@ spec:
           - "-swarm-redis-min-conns={{ .Cluster.ConfigItems.skipper_redis_min_conns }}"
           - "-swarm-redis-max-conns={{ .Cluster.ConfigItems.skipper_redis_max_conns }}"
           - "-swarm-redis-remote=http://skipper-ingress-routesrv.kube-system.svc.cluster.local/swarm/redis/shards"
-{{ else if .Cluster.ConfigItems.skipper_ingress_swarm_type "valkey" }}
+{{ else if eq .Cluster.ConfigItems.skipper_ingress_swarm_type "valkey" }}
           - "-swarm-valkey-conn-timeout={{ .Cluster.ConfigItems.skipper_valkey_conn_timeout }}"
           - "-swarm-valkey-remote=http://skipper-ingress-routesrv.kube-system.svc.cluster.local/swarm/valkey/shards"
 {{ end }}
@@ -643,11 +643,11 @@ spec:
           - '-default-filters-append={{ .Cluster.ConfigItems.skipper_default_filters_authentication }}'
           - '-default-filters-append={{ .Cluster.ConfigItems.skipper_default_filters_append }}'
           - "-enable-swarm"
-{{ if .Cluster.ConfigItems.skipper_ingress_swarm_type "redis" }}
+{{ if eq .Cluster.ConfigItems.skipper_ingress_swarm_type "redis" }}
           - "-kubernetes-redis-service-namespace=kube-system"
           - "-kubernetes-redis-service-name=skipper-ingress-redis"
           - "-kubernetes-redis-service-port=6379"
-{{ else if .Cluster.ConfigItems.skipper_ingress_swarm_type "valkey" }}
+{{ else if eq .Cluster.ConfigItems.skipper_ingress_swarm_type "valkey" }}
           - "-kubernetes-valkey-service-namespace=kube-system"
           - "-kubernetes-valkey-service-name=skipper-ingress-valkey"
           - "-kubernetes-valkey-service-port=6379"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -261,23 +261,10 @@ spec:
           - "-default-filters-dir=/etc/config/default-filters"
 {{ end }}
           - "-max-audit-body=0"
-{{ if eq .Cluster.ConfigItems.skipper_ingress_redis_swarm_enabled "true" }}
           - "-enable-swarm"
-          - "-swarm-redis-dial-timeout={{ .Cluster.ConfigItems.skipper_redis_dial_timeout }}"
-          - "-swarm-redis-pool-timeout={{ .Cluster.ConfigItems.skipper_redis_pool_timeout }}"
-          - "-swarm-redis-read-timeout={{ .Cluster.ConfigItems.skipper_redis_read_timeout }}"
-          - "-swarm-redis-write-timeout={{ .Cluster.ConfigItems.skipper_redis_write_timeout }}"
+          - "-swarm-valkey-conn-timeout={{ .Cluster.ConfigItems.skipper_valkey_conn_timeout }}"
           - "-cluster-ratelimit-max-group-shards={{ .Cluster.ConfigItems.skipper_cluster_ratelimit_max_group_shards }}"
-          - "-swarm-redis-min-conns={{ .Cluster.ConfigItems.skipper_redis_min_conns }}"
-          - "-swarm-redis-max-conns={{ .Cluster.ConfigItems.skipper_redis_max_conns }}"
-{{ if eq .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
-          - "-swarm-redis-remote=http://skipper-ingress-routesrv.kube-system.svc.cluster.local/swarm/redis/shards"
-{{ else }}
-          - "-kubernetes-redis-service-namespace=kube-system"
-          - "-kubernetes-redis-service-name=skipper-ingress-redis"
-          - "-kubernetes-redis-service-port=6379"
-{{ end }}
-{{ end }}
+          - "-swarm-valkey-remote=http://skipper-ingress-routesrv.kube-system.svc.cluster.local/swarm/valkey/shards"
           - "-histogram-metric-buckets=.0001,.00025,.0005,.00075,.001,.0025,.005,.0075,.01,.025,.05,.075,.1,.2,.3,.4,.5,.75,1,2,3,4,5,7,10,15,20,30,60,120,300,600"
 {{if ne .Cluster.ConfigItems.skipper_ingress_response_size_buckets ""}}
           - "-response-size-buckets={{ .Cluster.ConfigItems.skipper_ingress_response_size_buckets }}"
@@ -645,12 +632,10 @@ spec:
           - '-default-filters-prepend={{ .Cluster.ConfigItems.skipper_default_filters }}'
           - '-default-filters-append={{ .Cluster.ConfigItems.skipper_default_filters_authentication }}'
           - '-default-filters-append={{ .Cluster.ConfigItems.skipper_default_filters_append }}'
-{{ if eq .Cluster.ConfigItems.skipper_ingress_redis_swarm_enabled "true" }}
           - "-enable-swarm"
-          - "-kubernetes-redis-service-namespace=kube-system"
-          - "-kubernetes-redis-service-name=skipper-ingress-redis"
-          - "-kubernetes-redis-service-port=6379"
-{{ end }}
+          - "-kubernetes-valkey-service-namespace=kube-system"
+          - "-kubernetes-valkey-service-name=skipper-ingress-valkey"
+          - "-kubernetes-valkey-service-port=6379"
 {{ if eq .Cluster.ConfigItems.skipper_oauth2_ui_login "true" }}
           - "-enable-oauth2-grant-flow"
           - "-oauth2-callback-path={{ .Cluster.ConfigItems.skipper_oauth2_redirect_uri_path }}"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -262,9 +262,19 @@ spec:
 {{ end }}
           - "-max-audit-body=0"
           - "-enable-swarm"
-          - "-swarm-valkey-conn-timeout={{ .Cluster.ConfigItems.skipper_valkey_conn_timeout }}"
           - "-cluster-ratelimit-max-group-shards={{ .Cluster.ConfigItems.skipper_cluster_ratelimit_max_group_shards }}"
+{{ if .Cluster.ConfigItems.skipper_ingress_swarm_type "redis" }}
+          - "-swarm-redis-dial-timeout={{ .Cluster.ConfigItems.skipper_redis_dial_timeout }}"
+          - "-swarm-redis-pool-timeout={{ .Cluster.ConfigItems.skipper_redis_pool_timeout }}"
+          - "-swarm-redis-read-timeout={{ .Cluster.ConfigItems.skipper_redis_read_timeout }}"
+          - "-swarm-redis-write-timeout={{ .Cluster.ConfigItems.skipper_redis_write_timeout }}"
+          - "-swarm-redis-min-conns={{ .Cluster.ConfigItems.skipper_redis_min_conns }}"
+          - "-swarm-redis-max-conns={{ .Cluster.ConfigItems.skipper_redis_max_conns }}"
+          - "-swarm-redis-remote=http://skipper-ingress-routesrv.kube-system.svc.cluster.local/swarm/redis/shards"
+{{ else if .Cluster.ConfigItems.skipper_ingress_swarm_type "valkey" }}
+          - "-swarm-valkey-conn-timeout={{ .Cluster.ConfigItems.skipper_valkey_conn_timeout }}"
           - "-swarm-valkey-remote=http://skipper-ingress-routesrv.kube-system.svc.cluster.local/swarm/valkey/shards"
+{{ end }}
           - "-histogram-metric-buckets=.0001,.00025,.0005,.00075,.001,.0025,.005,.0075,.01,.025,.05,.075,.1,.2,.3,.4,.5,.75,1,2,3,4,5,7,10,15,20,30,60,120,300,600"
 {{if ne .Cluster.ConfigItems.skipper_ingress_response_size_buckets ""}}
           - "-response-size-buckets={{ .Cluster.ConfigItems.skipper_ingress_response_size_buckets }}"
@@ -633,9 +643,15 @@ spec:
           - '-default-filters-append={{ .Cluster.ConfigItems.skipper_default_filters_authentication }}'
           - '-default-filters-append={{ .Cluster.ConfigItems.skipper_default_filters_append }}'
           - "-enable-swarm"
+{{ if .Cluster.ConfigItems.skipper_ingress_swarm_type "redis" }}
+          - "-kubernetes-redis-service-namespace=kube-system"
+          - "-kubernetes-redis-service-name=skipper-ingress-redis"
+          - "-kubernetes-redis-service-port=6379"
+{{ else if .Cluster.ConfigItems.skipper_ingress_swarm_type "valkey" }}
           - "-kubernetes-valkey-service-namespace=kube-system"
           - "-kubernetes-valkey-service-name=skipper-ingress-valkey"
           - "-kubernetes-valkey-service-port=6379"
+{{ end }}
 {{ if eq .Cluster.ConfigItems.skipper_oauth2_ui_login "true" }}
           - "-enable-oauth2-grant-flow"
           - "-oauth2-callback-path={{ .Cluster.ConfigItems.skipper_oauth2_redirect_uri_path }}"

--- a/cluster/manifests/skipper/hpa-redis.yaml
+++ b/cluster/manifests/skipper/hpa-redis.yaml
@@ -1,32 +1,33 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: skipper-ingress-redis
+  name: skipper-ingress-valkey
   namespace: kube-system
   labels:
-    application: skipper-ingress-redis
+    application: skipper-ingress
+    component: valkey
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: StatefulSet
-    name: skipper-ingress-redis
-  minReplicas: {{ .Cluster.ConfigItems.skipper_ingress_redis_min_replicas }}
-  maxReplicas: {{ .Cluster.ConfigItems.skipper_ingress_redis_max_replicas }}
+    name: skipper-ingress-valkey
+  minReplicas: {{ .Cluster.ConfigItems.skipper_ingress_valkey_min_replicas }}
+  maxReplicas: {{ .Cluster.ConfigItems.skipper_ingress_valkey_max_replicas }}
   metrics:
   - type: Resource
     resource:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: {{ .Cluster.ConfigItems.skipper_ingress_redis_target_average_utilization_cpu }}
+        averageUtilization: {{ .Cluster.ConfigItems.skipper_ingress_valkey_target_average_utilization_cpu }}
   - type: Resource
     resource:
       name: memory
       target:
         type: Utilization
-        averageUtilization: {{ .Cluster.ConfigItems.skipper_ingress_redis_target_average_utilization_memory }}
-{{ if .Cluster.ConfigItems.skipper_ingress_redis_cluster_scaling_schedules }}
-  {{ range split .Cluster.ConfigItems.skipper_ingress_redis_cluster_scaling_schedules "," }}
+        averageUtilization: {{ .Cluster.ConfigItems.skipper_ingress_valkey_target_average_utilization_memory }}
+{{ if .Cluster.ConfigItems.skipper_ingress_valkey_cluster_scaling_schedules }}
+  {{ range split .Cluster.ConfigItems.skipper_ingress_valkey_cluster_scaling_schedules "," }}
   {{ $name_target := split . "=" }}
   - type: Object
     object:
@@ -43,7 +44,7 @@ spec:
 {{ end }}
   behavior:
     scaleDown:
-      stabilizationWindowSeconds: {{ .Cluster.ConfigItems.skipper_ingress_redis_hpa_scale_down_wait }}
+      stabilizationWindowSeconds: {{ .Cluster.ConfigItems.skipper_ingress_valkey_hpa_scale_down_wait }}
       policies:
       - type: Pods
         value: 10

--- a/cluster/manifests/skipper/hpa-redis.yaml
+++ b/cluster/manifests/skipper/hpa-redis.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Cluster.ConfigItems.skipper_ingress_swarm_type "redis" }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -52,3 +53,4 @@ spec:
         value: 100
         periodSeconds: 60
       selectPolicy: Min
+{{ end }}

--- a/cluster/manifests/skipper/hpa-valkey.yaml
+++ b/cluster/manifests/skipper/hpa-valkey.yaml
@@ -1,32 +1,33 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: skipper-ingress-redis
+  name: skipper-ingress-valkey
   namespace: kube-system
   labels:
-    application: skipper-ingress-redis
+    application: skipper-ingress
+    component: valkey
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: StatefulSet
-    name: skipper-ingress-redis
-  minReplicas: {{ .Cluster.ConfigItems.skipper_ingress_redis_min_replicas }}
-  maxReplicas: {{ .Cluster.ConfigItems.skipper_ingress_redis_max_replicas }}
+    name: skipper-ingress-valkey
+  minReplicas: {{ .Cluster.ConfigItems.skipper_ingress_valkey_min_replicas }}
+  maxReplicas: {{ .Cluster.ConfigItems.skipper_ingress_valkey_max_replicas }}
   metrics:
   - type: Resource
     resource:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: {{ .Cluster.ConfigItems.skipper_ingress_redis_target_average_utilization_cpu }}
+        averageUtilization: {{ .Cluster.ConfigItems.skipper_ingress_valkey_target_average_utilization_cpu }}
   - type: Resource
     resource:
       name: memory
       target:
         type: Utilization
-        averageUtilization: {{ .Cluster.ConfigItems.skipper_ingress_redis_target_average_utilization_memory }}
-{{ if .Cluster.ConfigItems.skipper_ingress_redis_cluster_scaling_schedules }}
-  {{ range split .Cluster.ConfigItems.skipper_ingress_redis_cluster_scaling_schedules "," }}
+        averageUtilization: {{ .Cluster.ConfigItems.skipper_ingress_valkey_target_average_utilization_memory }}
+{{ if .Cluster.ConfigItems.skipper_ingress_valkey_cluster_scaling_schedules }}
+  {{ range split .Cluster.ConfigItems.skipper_ingress_valkey_cluster_scaling_schedules "," }}
   {{ $name_target := split . "=" }}
   - type: Object
     object:
@@ -43,7 +44,7 @@ spec:
 {{ end }}
   behavior:
     scaleDown:
-      stabilizationWindowSeconds: {{ .Cluster.ConfigItems.skipper_ingress_redis_hpa_scale_down_wait }}
+      stabilizationWindowSeconds: {{ .Cluster.ConfigItems.skipper_ingress_valkey_hpa_scale_down_wait }}
       policies:
       - type: Pods
         value: 10

--- a/cluster/manifests/skipper/hpa-valkey.yaml
+++ b/cluster/manifests/skipper/hpa-valkey.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Cluster.ConfigItems.skipper_ingress_swarm_type "valkey" }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -53,3 +54,4 @@ spec:
         value: 100
         periodSeconds: 60
       selectPolicy: Min
+{{ end }}

--- a/cluster/manifests/skipper/skipper-redis-service.yaml
+++ b/cluster/manifests/skipper/skipper-redis-service.yaml
@@ -2,8 +2,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    application: skipper-ingress-redis
-  name: skipper-ingress-redis
+    application: skipper-ingress
+    component: valkey
+  name: skipper-ingress-valkey
   namespace: kube-system
 spec:
   clusterIP: None
@@ -12,5 +13,6 @@ spec:
     protocol: TCP
     targetPort: 6379
   selector:
-    application: skipper-ingress-redis
+    application: skipper-ingress
+    component: valkey
   type: ClusterIP

--- a/cluster/manifests/skipper/skipper-redis-service.yaml
+++ b/cluster/manifests/skipper/skipper-redis-service.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Cluster.ConfigItems.skipper_ingress_swarm_type "redis" }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -14,3 +15,4 @@ spec:
   selector:
     application: skipper-ingress-redis
   type: ClusterIP
+{{ end }}

--- a/cluster/manifests/skipper/skipper-redis.yaml
+++ b/cluster/manifests/skipper/skipper-redis.yaml
@@ -1,5 +1,6 @@
 # {{ $image := "container-registry.zalando.net/library/redis-7-alpine:7.2-alpine-20250805" }}
 # {{ $version := index (split $image ":") 1 }}
+{{- if eq .Cluster.ConfigItems.skipper_ingress_swarm_type "redis" }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -109,3 +110,4 @@ spec:
         operator: Exists
         effect: NoSchedule
 {{ end }}
+{{- end }}

--- a/cluster/manifests/skipper/skipper-redis.yaml
+++ b/cluster/manifests/skipper/skipper-redis.yaml
@@ -1,26 +1,28 @@
-# {{ $image := "container-registry.zalando.net/library/redis-7-alpine:7.2-alpine-20250805" }}
+# {{ $image := "container-registry.zalando.net/library/valkey-9-alpine:9-alpine3.22-20260302" }}
 # {{ $version := index (split $image ":") 1 }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:
-    application: skipper-ingress-redis
+    application: skipper-ingress
+    component: valkey
     version: "{{ $version }}"
   annotations:
-    zalando.org/update-using-hpa-replicas: skipper-ingress-redis
-  name: skipper-ingress-redis
+    zalando.org/update-using-hpa-replicas: skipper-ingress-valkey
+  name: skipper-ingress-valkey
   namespace: kube-system
 spec:
   podManagementPolicy: Parallel
   selector:
     matchLabels:
-      statefulset: skipper-ingress-redis
-  serviceName: skipper-ingress-redis
+      statefulset: skipper-ingress-valkey
+  serviceName: skipper-ingress-valkey
   template:
     metadata:
       labels:
-        statefulset: skipper-ingress-redis
-        application: skipper-ingress-redis
+        statefulset: skipper-ingress-valkey
+        application: skipper-ingress
+        component: valkey
         version: "{{ $version }}"
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
@@ -38,7 +40,7 @@ spec:
           whenUnsatisfiable: DoNotSchedule
           labelSelector:
             matchLabels:
-              statefulset: skipper-ingress-redis
+              statefulset: skipper-ingress-valkey
 {{- end }}
       affinity:
         podAntiAffinity:
@@ -49,7 +51,11 @@ spec:
               - key: application
                 operator: In
                 values:
-                - skipper-ingress-redis
+                - skipper-ingress
+              - key: component
+                operator: In
+                values:
+                - valkey
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100
@@ -72,9 +78,9 @@ spec:
       terminationGracePeriodSeconds: 45
       containers:
       - image: "{{ $image }}"
-        name: skipper-ingress-redis
+        name: skipper-ingress-valkey
         args:
-        - /usr/local/bin/docker-entrypoint.sh
+        - valkey-server
         - --save
         - ""
         ports:
@@ -83,7 +89,7 @@ spec:
         readinessProbe:
           exec:
             command:
-            - redis-cli
+            - valkey-cli
             - ping
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -92,8 +98,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: {{ .Cluster.ConfigItems.skipper_redis_cpu }}
-            memory: {{ .Cluster.ConfigItems.skipper_redis_memory }}
+            cpu: {{ .Cluster.ConfigItems.skipper_valkey_cpu }}
+            memory: {{ .Cluster.ConfigItems.skipper_valkey_memory }}
         lifecycle:
           preStop:
             sleep:

--- a/cluster/manifests/skipper/skipper-valkey-service.yaml
+++ b/cluster/manifests/skipper/skipper-valkey-service.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Cluster.ConfigItems.skipper_ingress_swarm_type "valkey" }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -16,3 +17,4 @@ spec:
     application: skipper-ingress
     component: valkey
   type: ClusterIP
+{{ end }}

--- a/cluster/manifests/skipper/skipper-valkey-service.yaml
+++ b/cluster/manifests/skipper/skipper-valkey-service.yaml
@@ -2,8 +2,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    application: skipper-ingress-redis
-  name: skipper-ingress-redis
+    application: skipper-ingress
+    component: valkey
+  name: skipper-ingress-valkey
   namespace: kube-system
 spec:
   clusterIP: None
@@ -12,5 +13,6 @@ spec:
     protocol: TCP
     targetPort: 6379
   selector:
-    application: skipper-ingress-redis
+    application: skipper-ingress
+    component: valkey
   type: ClusterIP

--- a/cluster/manifests/skipper/skipper-valkey.yaml
+++ b/cluster/manifests/skipper/skipper-valkey.yaml
@@ -1,5 +1,6 @@
 # {{ $image := "container-registry.zalando.net/library/valkey-9-alpine:9-alpine3.22-20260302" }}
 # {{ $version := index (split $image ":") 1 }}
+{{- if eq .Cluster.ConfigItems.skipper_ingress_swarm_type "valkey" }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -115,3 +116,4 @@ spec:
         operator: Exists
         effect: NoSchedule
 {{ end }}
+{{- end }}

--- a/cluster/manifests/skipper/skipper-valkey.yaml
+++ b/cluster/manifests/skipper/skipper-valkey.yaml
@@ -1,26 +1,28 @@
-# {{ $image := "container-registry.zalando.net/library/redis-7-alpine:7.2-alpine-20250805" }}
+# {{ $image := "container-registry.zalando.net/library/valkey-9-alpine:9-alpine3.22-20260302" }}
 # {{ $version := index (split $image ":") 1 }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:
-    application: skipper-ingress-redis
+    application: skipper-ingress
+    component: valkey
     version: "{{ $version }}"
   annotations:
-    zalando.org/update-using-hpa-replicas: skipper-ingress-redis
-  name: skipper-ingress-redis
+    zalando.org/update-using-hpa-replicas: skipper-ingress-valkey
+  name: skipper-ingress-valkey
   namespace: kube-system
 spec:
   podManagementPolicy: Parallel
   selector:
     matchLabels:
-      statefulset: skipper-ingress-redis
-  serviceName: skipper-ingress-redis
+      statefulset: skipper-ingress-valkey
+  serviceName: skipper-ingress-valkey
   template:
     metadata:
       labels:
-        statefulset: skipper-ingress-redis
-        application: skipper-ingress-redis
+        statefulset: skipper-ingress-valkey
+        application: skipper-ingress
+        component: valkey
         version: "{{ $version }}"
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
@@ -38,7 +40,7 @@ spec:
           whenUnsatisfiable: DoNotSchedule
           labelSelector:
             matchLabels:
-              statefulset: skipper-ingress-redis
+              statefulset: skipper-ingress-valkey
 {{- end }}
       affinity:
         podAntiAffinity:
@@ -49,7 +51,11 @@ spec:
               - key: application
                 operator: In
                 values:
-                - skipper-ingress-redis
+                - skipper-ingress
+              - key: component
+                operator: In
+                values:
+                - valkey
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100
@@ -72,9 +78,9 @@ spec:
       terminationGracePeriodSeconds: 45
       containers:
       - image: "{{ $image }}"
-        name: skipper-ingress-redis
+        name: skipper-ingress-valkey
         args:
-        - /usr/local/bin/docker-entrypoint.sh
+        - valkey-server
         - --save
         - ""
         ports:
@@ -83,7 +89,7 @@ spec:
         readinessProbe:
           exec:
             command:
-            - redis-cli
+            - valkey-cli
             - ping
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -92,8 +98,8 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: {{ .Cluster.ConfigItems.skipper_redis_cpu }}
-            memory: {{ .Cluster.ConfigItems.skipper_redis_memory }}
+            cpu: {{ .Cluster.ConfigItems.skipper_valkey_cpu }}
+            memory: {{ .Cluster.ConfigItems.skipper_valkey_memory }}
         lifecycle:
           preStop:
             sleep:


### PR DESCRIPTION
skipper: migrate redis to valkey

Changing the name from redis to valkey is done on purpose such that valkey can start running and skipper-ingress rolling before skipper redis objects will be deleted. 

Right now only for load testing and change channel in our test cluster.
Test was successful