### PR TITLE
Skipper ingress port open only cleanup [2/2]

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -132,6 +132,33 @@ Resources:
         - Key: 'karpenter.sh/discovery'
           Value: '{{ .Cluster.ID }}/WorkerNodeSecurityGroup'
       VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
+  EKSIngressWorkerSecurityGroup:
+    Type: "AWS::EC2::SecurityGroup"
+    Properties:
+      GroupDescription: "{{ .Cluster.ID }}-ingress-worker-sg"
+      SecurityGroupIngress:
+        - CidrIp: "0.0.0.0/0"
+          FromPort: 9998
+          IpProtocol: tcp
+          ToPort: 9999
+        - CidrIpv6: "::/0"
+          FromPort: 9998
+          IpProtocol: tcp
+          ToPort: 9999
+{{- if eq .Cluster.ConfigItems.skipper_ingress_redis_swim_enabled "true" }}
+        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+          FromPort: 9990
+          IpProtocol: tcp
+          ToPort: 9990
+        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+          FromPort: 9990
+          IpProtocol: udp
+          ToPort: 9990
+{{- end }}
+      Tags:
+        - Key: 'karpenter.sh/discovery'
+          Value: '{{ .Cluster.ID }}/SkipperIngressNodeSecurityGroup'
+      VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
   EKSSelfWorkerSecurityIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
@@ -1069,6 +1096,33 @@ Resources:
           Value: '{{ .Cluster.ID }}/WorkerNodeSecurityGroup'
       VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
     Type: 'AWS::EC2::SecurityGroup'
+  IngressWorkerSecurityGroup:
+    Type: "AWS::EC2::SecurityGroup"
+    Properties:
+      GroupDescription: "{{ .Cluster.ID }}-ingress-worker-sg"
+      SecurityGroupIngress:
+        - CidrIp: "0.0.0.0/0"
+          FromPort: 9998
+          IpProtocol: tcp
+          ToPort: 9999
+        - CidrIpv6: "::/0"
+          FromPort: 9998
+          IpProtocol: tcp
+          ToPort: 9999
+{{- if eq .Cluster.ConfigItems.skipper_ingress_redis_swim_enabled "true" }}
+        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+          FromPort: 9990
+          IpProtocol: tcp
+          ToPort: 9990
+        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+          FromPort: 9990
+          IpProtocol: udp
+          ToPort: 9990
+{{- end }}
+      Tags:
+        - Key: 'karpenter.sh/discovery'
+          Value: '{{ .Cluster.ID }}/SkipperIngressNodeSecurityGroup'
+      VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
   WorkerSecurityGroupIngressFromMasterToFlannel:
     Properties:
       FromPort: 8472

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -83,24 +83,6 @@ Resources:
           ToPort: {{ $element.ToPort }}
 {{- end }}
 {{- end }}
-        - CidrIp: "0.0.0.0/0"
-          FromPort: 9998
-          IpProtocol: tcp
-          ToPort: 9999
-        - CidrIpv6: "::/0"
-          FromPort: 9998
-          IpProtocol: tcp
-          ToPort: 9999
-{{- if eq .Cluster.ConfigItems.skipper_ingress_redis_swim_enabled "true" }}
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 9990
-          IpProtocol: tcp
-          ToPort: 9990
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 9990
-          IpProtocol: udp
-          ToPort: 9990
-{{- end }}
         - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
           FromPort: 10248
           IpProtocol: tcp
@@ -1048,20 +1030,6 @@ Resources:
           IpProtocol: {{ $element.Protocol }}
           ToPort: {{ $element.ToPort }}
 {{- end }}
-{{- end }}
-        - CidrIp: "0.0.0.0/0"
-          FromPort: 9998
-          IpProtocol: tcp
-          ToPort: 9999
-{{- if eq .Cluster.ConfigItems.skipper_ingress_redis_swim_enabled "true" }}
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 9990
-          IpProtocol: tcp
-          ToPort: 9990
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 9990
-          IpProtocol: udp
-          ToPort: 9990
 {{- end }}
         - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
           FromPort: 10248

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -28,6 +28,10 @@ spec:
   securityGroupSelectorTerms:
     - tags:
         karpenter.sh/discovery: "{{ .Cluster.ID }}/WorkerNodeSecurityGroup"
+    #{{ if eq (index .NodePool.ConfigItems "taints") "dedicated=skipper-ingress:NoSchedule" }}
+    - tags:
+        karpenter.sh/discovery: "{{ .Cluster.ID }}/SkipperIngressNodeSecurityGroup"
+    #{{ end }}
   # {{ if and (eq .NodePool.ConfigItems.associate_public_ip_on_launch "true") (ne .NodePool.ConfigItems.internal_node_subnets_enabled "true") }}
   associatePublicIPAddress: true
   # {{ end }}


### PR DESCRIPTION
Depends on full roll out of #10596

This removes the skipper-ingress ports from the Worker Security Group attached to _all_ Kubernetes nodes. These ports will be opened via the SkipperIngress worker security group, only attached to skipper-ingress nodes.

* [ ] dev (#10596)
* [ ] alpha
* [ ] beta
* [ ] stable