### PR TITLE
Wrap WIZ Namespace behind config items

### DIFF
--- a/cluster/manifests/wiz/001-namespace.yaml
+++ b/cluster/manifests/wiz/001-namespace.yaml
@@ -1,4 +1,11 @@
+{{ if or 
+(eq .Cluster.ConfigItems.wiz_enable_runtime_connector "true")
+(eq .Cluster.ConfigItems.wiz_enable_runtime_connector_broker "true")
+(eq .Cluster.ConfigItems.wiz_enable_runtime_sensor "true")
+}}
+---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: wiz
+{{ end }}


### PR DESCRIPTION
Only create the WIZ Namespace when WIZ components are enabled. Currently if WIZ is disabled, the Namespace will be created and then subsequently cleaned up due to the deletions.