### PR TITLE
Disable Cluster Autoscaler by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1,5 +1,5 @@
 # Autoscaling settings
-cluster_autoscaler_enabled: "true"
+cluster_autoscaler_enabled: "false"
 autoscaling_scale_down_enabled: "true"
 autoscaling_buffer_cpu: "1m"
 autoscaling_buffer_memory: "10Mi"

--- a/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Cluster.ConfigItems.cluster_autoscaler_enabled "true" }}
 {{ with $data := . }}
 {{ range $zone := $data.Values.availability_zones }}
 apiVersion: apps/v1
@@ -46,3 +47,4 @@ spec:
 ---
 {{ end }}
 {{ end }}
+{{- end }}


### PR DESCRIPTION
Disable the Cluster Autoscaler by default as there are no clusters using CA based pools anymore.