### PR TITLE
validation-webhook: override discovery bundle's decision_logs and status config

### DIFF
--- a/cluster/manifests/02-skipper-validation-webhook/02-configmap-open-policy-agent.yaml
+++ b/cluster/manifests/02-skipper-validation-webhook/02-configmap-open-policy-agent.yaml
@@ -25,12 +25,15 @@ data:
             session_name: open-policy-agent-instance
       name: styra-bundles
       url: "{{ .Cluster.ConfigItems.skipper_open_policy_agent_bundles_url }}"
-    {{ if eq .Cluster.ConfigItems.skipper_open_policy_agent_decision_logs_buffer_type_event_enable "true" }}
     decision_logs:
-      reporting:
-        buffer_type: "event"
-        buffer_size_limit_events: {{ .Cluster.ConfigItems.skipper_open_policy_agent_decision_logs_buffer_type_event_limit }}
-    {{ end }}
+      console: true
+      # Disable decision logging for the validation webhook
+      service: ""
+    status:
+      # This ensures we disable status reporting for the validation webhook
+      console: false
+      prometheus: true
+      service: ""
     {{ if eq .Cluster.ConfigItems.skipper_open_policy_agent_jwt_cache_enable "true" }}
     caching: 
       inter_query_builtin_value_cache:


### PR DESCRIPTION
### Context

When advanced validation was enabled in Skipper's dynamic admission control (i.e. the skipper-validation webhook), we started seeing the following errors in the skipper-validation-webhook logs (_Note that the service name is for illustration purposes only_)
```
Discovery reconfiguration error occurred: invalid service name "example-service" in decision_logs
Discovery reconfiguration error occurred: invalid service name "example-service" in status
```

This happens if the discovery bundle the OPA pulls includes `decision_logs` and `status` configurations that reference a service which isn't defined in the `services` section of the OPA config.

This PR addresses the issue by overriding the `decision_logs` and `status` plugin configurations in the OPA boot config injected into Skipper, ensuring that the invalid service references from the discovery bundle are not used for these plugins in the validation webhook.

### Disabling decision_log and status plugins in the validation webhook

Given that with the [eopa_dl plugin](https://github.com/zalando/skipper/pull/3846) [change](https://github.com/zalando/skipper/pull/3846/changes#diff-c149d1342ef3074c13f6b2397eb74e17bdbea1e557e4c93ad7fd083efe1ee1abR733), we ensure that the bootstrap configuration as [documented](https://www.openpolicyagent.org/docs/management-discovery) is leveraged, we could override these configs in the OPA boot config (`opaconfig.yaml`) is injected into Skipper to prevent the discovery bundle's invalid service references from being used for both the `status` and `decision_logs` plugins as shown below:

```yaml
decision_logs:
  console: true
  service: ""
status:
  console: false
  prometheus: true
  service: ""
```

### Additional context on the override

OPA's discovery plugin [merges boot config with discovery config](https://github.com/open-policy-agent/opa/blob/main/v1/plugins/discovery/discovery.go#L771-L810), with **boot config taking precedence**. By explicitly setting `service: ""` in boot config, we override the discovery bundle's `service: "example-service"`.

See the [OPA docs](https://www.openpolicyagent.org/docs/management-discovery) for more details on the discovery plugin.
- **decision_logs**: Either `console: true` OR a valid service ([logs/plugin.go#L318-L328](https://github.com/open-policy-agent/opa/blob/main/v1/plugins/logs/plugin.go#L318-L328))
- **status**: Either `console: true` OR `prometheus: true` OR a valid service ([status/plugin.go#L103-L109](https://github.com/open-policy-agent/opa/blob/main/v1/plugins/status/plugin.go#L103-L109))