### PR TITLE
Beta to stable custom

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1,5 +1,5 @@
 # Autoscaling settings
-cluster_autoscaler_enabled: "true"
+cluster_autoscaler_enabled: "false"
 autoscaling_scale_down_enabled: "true"
 autoscaling_buffer_cpu: "1m"
 autoscaling_buffer_memory: "10Mi"

--- a/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/buffer-pods-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Cluster.ConfigItems.cluster_autoscaler_enabled "true" }}
 {{ with $data := . }}
 {{ range $zone := $data.Values.availability_zones }}
 apiVersion: apps/v1
@@ -46,3 +47,4 @@ spec:
 ---
 {{ end }}
 {{ end }}
+{{- end }}


### PR DESCRIPTION
Cherry-pick #10614 to stable.

It doesn't work with e2e because of a race when deleting the deployments:

```
time="2026-02-23T14:04:14Z" level=fatal msg="Fail to provision: unable to delete: admission webhook \"serviceaccount-admitter.teapot.zalan.do\" denied the request: serviceaccount is still used by the following pods: kube-cluster-autoscaler-d499d586-csc9v"
```

CLM running on real clusters handle this by just rerunning the loop for the cluster, but in e2e it fails once and doesn't retry. Accept this as we only need to merge this through channels once and it's fixed.