### PR TITLE
skipper: update tokeninfo

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,6 +1,6 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.24.5-1333" }}
+{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.24.27-1357" }}
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.24.27-1357" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}


### PR DESCRIPTION
skipper: update tokeninfo

valkey for cluster ratelimit is possible

ref https://github.com/zalando/skipper/compare/v0.24.5...v0.24.27

