### PR TITLE
Increase the remaining sandbox e2e test timeouts to 5 minutes

### DIFF
--- a/test/e2e/sandbox.go
+++ b/test/e2e/sandbox.go
@@ -168,7 +168,7 @@ var _ = describe("Sandbox Controller", func() {
 					return nil, err
 				}
 				return r.Items, nil
-			}).WithTimeout(1 * time.Minute).WithPolling(1 * time.Second).Should(HaveLen(0))
+			}).WithTimeout(5 * time.Minute).WithPolling(1 * time.Second).Should(HaveLen(0))
 		})
 
 		It("Should proocess a Sandbox resource and create an ingress [Sandbox] [Zalando]", func() {
@@ -211,7 +211,7 @@ var _ = describe("Sandbox Controller", func() {
 					return nil, err
 				}
 				return i.Items, nil
-			}).WithTimeout(1 * time.Minute).WithPolling(1 * time.Second).Should(HaveLen(0))
+			}).WithTimeout(5 * time.Minute).WithPolling(1 * time.Second).Should(HaveLen(0))
 		})
 
 	})


### PR DESCRIPTION
To reduce test flakiness 