### PR TITLE
Remove feature gate SizeMemoryBackedVolumes

### DIFF
--- a/cluster/manifests/kube-proxy/configmap.yaml
+++ b/cluster/manifests/kube-proxy/configmap.yaml
@@ -23,7 +23,6 @@ data:
       tcpEstablishedTimeout: 24h0m0s
     enableProfiling: false
     featureGates:
-      SizeMemoryBackedVolumes: {{ .Cluster.ConfigItems.enable_size_memory_backed_volumes }}
 {{- if eq .Cluster.ConfigItems.enable_image_volumes "true" }}
       ImageVolume: true
 {{- end }}

--- a/cluster/manifests/kube-proxy/configmap.yaml
+++ b/cluster/manifests/kube-proxy/configmap.yaml
@@ -22,8 +22,8 @@ data:
       tcpCloseWaitTimeout: 1h0m0s
       tcpEstablishedTimeout: 24h0m0s
     enableProfiling: false
-    featureGates:
 {{- if eq .Cluster.ConfigItems.enable_image_volumes "true" }}
+    featureGates:
       ImageVolume: true
 {{- end }}
     healthzBindAddress: 127.0.0.1:10256


### PR DESCRIPTION
this is GA since 1.32 and default to true

https://github.com/kubernetes/kubernetes/pull/133720

general pr for v1.35 will remove any other occurrence

removing this here to fix 1.35 pipeline since upgrading the aws master nodes will fail with this still active since the kube-proxy cannot start on the master nodes when upgrading to 1.35

related logs from a current 1.34 cluster

```
W0224 16:11:21.469327       1 feature_gate.go:352] Setting GA feature gate SizeMemoryBackedVolumes=true. It will be removed in a future release.
I0224 16:11:21.469338       1 feature_gate.go:385] feature gates: {map[SizeMemoryBackedVolumes:true]}
```  