### PR TITLE
don't force cluster-lifecycle-controller to run on seed

### DIFF
--- a/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
@@ -51,6 +51,9 @@ spec:
           value: "{{ .Cluster.Region }}"
 {{- if eq .Cluster.Provider "zalando-eks"}}
       tolerations:
+      - key: dedicated
+        value: cluster-seed
+        effect: NoSchedule
       - key: node.kubernetes.io/not-ready
         operator: Exists
 {{- else}}

--- a/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/deployment.yaml
@@ -50,12 +50,7 @@ spec:
         - name: AWS_REGION
           value: "{{ .Cluster.Region }}"
 {{- if eq .Cluster.Provider "zalando-eks"}}
-      nodeSelector:
-        dedicated: cluster-seed
       tolerations:
-      - key: dedicated
-        value: cluster-seed
-        effect: NoSchedule
       - key: node.kubernetes.io/not-ready
         operator: Exists
 {{- else}}


### PR DESCRIPTION
don't force cluster-lifecycle-controller to run on seed, so it can also run in any worker node

This is a follow up on https://github.com/zalando-incubator/kubernetes-on-aws/pull/10117, where this specific component was not adjusted