### PR TITLE
kube-ingress-aws-controller: Add configurable CNI mode support for EKS clusters

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -2082,6 +2082,11 @@ Resources:
               - Action: 'ec2:DescribeVpcs'
                 Effect: Allow
                 Resource: '*'
+{{- if eq .Cluster.Provider "zalando-eks" }}
+              - Action: 'ec2:DescribeVpcPeeringConnections'
+                Effect: Allow
+                Resource: '*'
+{{- end }}
               - Action: 'iam:CreateServiceLinkedRole'
                 Effect: Allow
                 Resource: '*'

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -72,7 +72,13 @@ kube_aws_ingress_controller_cert_polling_interval: "2m"
 kube_aws_ingress_default_lb_type: "application"
 # cert filter
 kube_aws_ingress_controller_cert_filter_tag: "kubernetes=enabled"
-
+# ip address type for LB, can be "ipv4", "dualstack"
+kube_aws_ingress_controller_lb_ip_addr_type: "ipv4"
+# ip address type for target group, can be "ipv4" or "ipv6"
+# Note: if LB ip address type is "ipv4", target group ip address type must be "ipv4".
+kube_aws_ingress_controller_target_group_ip_addr_type: "ipv4"
+# when enabled, the ingress controller will use AWS CNI to attach ENIs to the ingress controller pods and use pod IPs as targets in the target group.
+kube_aws_ingress_controller_enable_cni_mode: "false"
 # ALB to NLB switch
 # "pre":
 # - kube-ingress-aws-controller will configure NLB to forward HTTPS requests

--- a/cluster/manifests/ingress-controller/01-rbac.yaml
+++ b/cluster/manifests/ingress-controller/01-rbac.yaml
@@ -45,6 +45,17 @@ rules:
   verbs:
   - patch
   - update
+{{- if eq .Cluster.Provider "zalando-eks" }}
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/status
+  verbs:
+  - get
+  - list
+  - watch
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -38,6 +38,15 @@ spec:
           image: "{{ $image }}"
           args:
             - --target-access-mode=HostPort
+{{- if eq .Cluster.Provider "zalando-eks" }}
+            - --ip-addr-type={{ .Cluster.ConfigItems.kube_aws_ingress_controller_lb_ip_addr_type }}
+            - --target-group-ip-addr-type={{ .Cluster.ConfigItems.kube_aws_ingress_controller_target_group_ip_addr_type }}
+{{- if eq .Cluster.ConfigItems.kube_aws_ingress_controller_enable_cni_mode "true" }}
+            - --target-access-mode=AWSCNI
+            - --target-cni-namespace=kube-system
+            - --target-cni-pod-labelselector=application=skipper-ingress,component=ingress
+{{- end }}
+{{- end }}
             - --stack-termination-protection
             - --ssl-policy={{ .Cluster.ConfigItems.kube_aws_ingress_controller_ssl_policy }}
             - --idle-connection-timeout={{ .Cluster.ConfigItems.kube_aws_ingress_controller_idle_timeout }}


### PR DESCRIPTION
## Summary

Add configuration flags to support CNI mode targeting in kube-ingress-aws-controller for zalando-eks clusters. This enables flexible IP address type configuration (dualstack, IPv6) and CNI mode targeting through config items, allowing gradual rollout and easy rollback via cluster configuration management.

## Changes

- Add `kube_aws_ingress_controller_lb_ip_addr_type` config for load balancer IP address type
- Add `kube_aws_ingress_controller_target_group_ip_addr_type` config for target group IP address type  
- Add `kube_aws_ingress_controller_enable_cni_mode` config to enable pod-level targeting with AWS CNI
- Add necessary IAM permissions (VPC peering, pod discovery) for EKS clusters
- Add RBAC permissions for pod watching when CNI mode is enabled

## Test plan

- [ ] Verify config items are properly templated
- [ ] Review RBAC and IAM permission additions
- [ ] Test with dualstack LB configuration on zalando-eks cluster
- [ ] Verify graceful rollback via config changes