### PR TITLE
skipper-internal: main-fleet-v0.24.39, features haproxy v2 protocol, proxy span logs to attributes

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -104,6 +104,12 @@ skipper_topology_spread_timeout: "7m"
 
 skipper_copy_stream_pool_enabled: "true"
 
+# haproxy protocol: cidrs are a comma seperated list of CIDRs, for example "::0/0,0.0.0.0/0" for all IPs
+skipper_enable_proxy_protocol: "false"
+skipper_proxy_allow_cidrs: ""
+skipper_proxy_deny_cidrs: ""
+skipper_proxy_skip_cidrs: ""
+
 # PHC
 skipper_ingress_health_check_options: "period=10s,min-requests=10,min-drop-probability=0.05,max-drop-probability=0.9,max-unhealthy-endpoints-ratio=0.9"
 
@@ -310,6 +316,7 @@ skipper_max_tcp_listener_concurrency: "-1"
 skipper_max_tcp_listener_queue: "-1"
 
 # opentracing
+skipper_ingress_opentracing_client_trace_by_tag: "true"
 skipper_ingress_opentracing_excluded_proxy_tags: ""
 skipper_ingress_opentracing_backend_name_tag: "true"
 skipper_opentracing_disable_filter_spans: "true"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,6 +1,6 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.24.27-1357" }}
+{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.24.39-1369" }}
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.24.39-1369" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}
@@ -304,6 +304,9 @@ spec:
             propagators={{ .Cluster.ConfigItems.skipper_ingress_lightstep_propagators }}
             {{ .Cluster.ConfigItems.skipper_ingress_lightstep_log_events }}
           - "-opentracing-excluded-proxy-tags={{ .Cluster.ConfigItems.skipper_ingress_opentracing_excluded_proxy_tags }}"
+{{ if eq .Cluster.ConfigItems.skipper_ingress_opentracing_client_trace_by_tag "true" }}
+          - "-opentracing-client-trace-by-tag"
+{{ end }}
 {{ if eq .Cluster.ConfigItems.skipper_ingress_opentracing_backend_name_tag "true" }}
           - "-opentracing-backend-name-tag"
 {{ end }}
@@ -339,6 +342,12 @@ spec:
           - "-expected-bytes-per-request={{ .Cluster.ConfigItems.skipper_expected_bytes_per_request }}"
           - "-max-tcp-listener-concurrency={{ .Cluster.ConfigItems.skipper_max_tcp_listener_concurrency }}"
           - "-max-tcp-listener-queue={{ .Cluster.ConfigItems.skipper_max_tcp_listener_queue }}"
+{{ end }}
+{{ if eq .Cluster.ConfigItems.skipper_enable_proxy_protocol "true" }}
+          - "-enable-proxy-protocol"
+          - "-proxy-allow-cidrs={{ .Cluster.ConfigItems.skipper_proxy_allow_cidrs }}"
+          - "-proxy-deny-cidrs={{ .Cluster.ConfigItems.skipper_proxy_deny_cidrs }}"
+          - "-proxy-skip-cidrs={{ .Cluster.ConfigItems.skipper_proxy_skip_cidrs }}"
 {{ end }}
 {{ if eq .Cluster.ConfigItems.skipper_local_tokeninfo "bridge" }}
           - "-oauth2-tokeninfo-url=http://127.0.0.1:9000/oauth2/tokeninfo"


### PR DESCRIPTION
feature: skipper-ingress option to allow haproxy v2 proxy protocol for ip preservation
cost saving: dash0 tracing provider pricing adoption: client "proxy" span does not have logs to measure but span Tags

The visibility change I would classify as "major", rest is opt-in

https://github.com/zalando/skipper/compare/v0.24.27...v0.24.39