### PR TITLE
Enable S3 CSI Driver EKS Addon

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -330,6 +330,17 @@ Resources:
         - RoleArn: !GetAtt EKSEFSCSIDriverIAMRole.Arn
           ServiceAccount: efs-csi-controller-sa
 {{- end }}
+{{- if eq .Cluster.ConfigItems.eks_s3_csi_support_enabled "true" }}
+  EKSAddonS3CSIDriver:
+    Type: AWS::EKS::Addon
+    Properties:
+      AddonName: aws-mountpoint-s3-csi-driver
+      AddonVersion: "v2.3.0-eksbuild.1"
+      ClusterName: !Ref EKSCluster
+      PodIdentityAssociations:
+        - RoleArn: !GetAtt EKSS3CSIDriverIAMRole.Arn
+          ServiceAccount: s3-csi-driver-sa
+{{- end }}
   EKSAddonAmazonVPCCNI:
     Type: AWS::EKS::Addon
     Properties:
@@ -664,6 +675,30 @@ Resources:
       - !Ref EKSWorkerSecurityGroup
   {{ end }}
   {{ end }}
+{{- end }}
+{{- if eq .Cluster.ConfigItems.eks_s3_csi_support_enabled "true" }}
+  EKSS3CSIDriverIAMRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: "{{.Cluster.LocalID}}-aws-mountpoint-s3-csi-driver"
+      AssumeRolePolicyDocument: {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {
+                    "Service": "pods.eks.amazonaws.com"
+                },
+                "Action": [
+                    "sts:AssumeRole",
+                    "sts:TagSession"
+                ]
+            }
+        ]
+      }
+      Path: /
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/AmazonS3FullAccess
 {{- end }}
   EKSZalandoIAMProxyIAMRole:
     Type: AWS::IAM::Role

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1368,10 +1368,13 @@ eks_fis_support_enabled: "false"
 {{ if eq .Cluster.Environment "e2e" }}
 # Enables the Amazon EFS CSI driver addon and sets up the default EFS
 eks_efs_csi_support_enabled: "true"
+# Enables the Amazon S3 CSI driver addon
+eks_s3_csi_support_enabled: "true"
 # Enables the EKS Node Monitoring Agent
 eks_node_monitoring_enabled: "true"
 {{ else }}
 eks_efs_csi_support_enabled: "false"
+eks_s3_csi_support_enabled: "false"
 eks_node_monitoring_enabled: "false"
 {{ end }}
 

--- a/cluster/manifests/02-admission-control/teapot.yaml
+++ b/cluster/manifests/02-admission-control/teapot.yaml
@@ -265,7 +265,7 @@ webhooks:
     # avoid admission-control applying to eks managed addon resources
     matchConditions:
     - name: "exclude-by-name"
-      expression: "oldObject == null || !(oldObject.metadata.name in ['eniconfigs.crd.k8s.amazonaws.com', 'nodediagnostics.eks.amazonaws.com'])"
+      expression: "oldObject == null || !(oldObject.metadata.name in ['eniconfigs.crd.k8s.amazonaws.com', 'nodediagnostics.eks.amazonaws.com', 'mountpoints3podattachments.s3.csi.aws.com'])"
 {{- end }}
     clientConfig:
       {{- if eq .Cluster.Provider "zalando-eks"}}

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -240,7 +240,7 @@ post_apply:
 - name: skipper-canary-conrtroller
   kind: CronJob
   namespace: kube-system
-{{- if ne .Cluster.ConfigItems.s3_csi_driver "true" }}
+{{- if and (ne .Cluster.ConfigItems.s3_csi_driver "true") (ne .Cluster.ConfigItems.eks_s3_csi_support_enabled "true") }}
 - name: s3.csi.aws.com
   kind: CSIDriver
 - name: s3-csi-driver


### PR DESCRIPTION
Allow to enable the S3 CSI Driver EKS addon.

Some resources overlap with the self-managed driver setup which can also be enabled (not at the same time though). So deletion will only happen when both config items are turned off.