### PR TITLE
scale down albc to one replica

### DIFF
--- a/cluster/manifests/aws-load-balancer-controller/deployment.yaml
+++ b/cluster/manifests/aws-load-balancer-controller/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     application: kubernetes
     component: aws-load-balancer-controller
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       deployment: aws-load-balancer-controller


### PR DESCRIPTION
This component is now less critical, so let's use only 1 replica.