### PR TITLE
Expose cluster's channel in deployment-config

### DIFF
--- a/cluster/manifests/deployment-service/01-config.yaml
+++ b/cluster/manifests/deployment-service/01-config.yaml
@@ -8,6 +8,7 @@ data:
   aws-account-name: "{{.Cluster.AccountName}}"
   cluster-alias: "{{.Cluster.Alias}}"
   cluster-provider: "{{.Cluster.Provider}}"
+  cluster-channel: "{{.Cluster.Channel}}"
   cluster-vpc-id: "{{.Cluster.ConfigItems.vpc_id}}"
   scalyr-team-token: "{{.Cluster.ConfigItems.scalyr_team_token}}"
   create-namespaces: "true"


### PR DESCRIPTION
Expose cluster's channel as field in deployment-config so it can be queried via kubectl et al.