### PR TITLE
don't force skipper on spot for test clusters

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -533,8 +533,6 @@ spec:
         dedicated: skipper-ingress
 {{ if eq .Cluster.Environment "production" }}
         karpenter.sh/capacity-type: on-demand
-{{ else }}
-        karpenter.sh/capacity-type: spot
 {{ end }}
       tolerations:
       - effect: NoSchedule


### PR DESCRIPTION
This PR remove the nodeSelector that forces skipper to use `spot`.
The issue is we are forcing Karpenter to use `spot` instances even when it's not the best option.
This sometimes results in higher costs when choosing bigger instances that stay for longer times.

More details in https://github.com/zalando-build/cloud-platform/issues/7799