### PR TITLE
Update memory limit from 0.3Gi to 300Mi for sandbox-controller

### DIFF
--- a/cluster/manifests/sandbox-controller/30-deployment.yaml
+++ b/cluster/manifests/sandbox-controller/30-deployment.yaml
@@ -36,8 +36,8 @@ spec:
           resources:
             limits:
               cpu: 50m
-              memory: 0.3Gi
+              memory: 300Mi
             requests:
               cpu: 50m
-              memory: 0.3Gi
+              memory: 300Mi
 {{ end }}


### PR DESCRIPTION
Using this format leads to warnings in the logs. Let's use the format that we use in other files as well.

<img width="1534" height="73" alt="image" src="https://github.com/user-attachments/assets/691b7df7-7b5c-4989-b87a-85e0412593df" />
