### PR TITLE
deployment-service-controller: migrate to deployment with VPA

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1114,8 +1114,6 @@ experimental_nlb_alpn_h2_enabled: "true"
 exec_probe_timeout_enabled: "true"
 
 # Settings for the deployment service
-deployment_service_controller_cpu: "100m"
-deployment_service_controller_memory: "1Gi"
 deployment_service_api_role_arn: ""
 deployment_service_tokeninfo_url: ""
 deployment_service_lightstep_token: ""

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1114,6 +1114,7 @@ experimental_nlb_alpn_h2_enabled: "true"
 exec_probe_timeout_enabled: "true"
 
 # Settings for the deployment service
+deployment_service_controller_memory_min: "50Mi"
 deployment_service_api_role_arn: ""
 deployment_service_tokeninfo_url: ""
 deployment_service_lightstep_token: ""

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -1,5 +1,9 @@
 # everything defined under here will be deleted before applying the manifests
-pre_apply: []
+# adding the StatefulSet temporary to migrate to Deployment with VPA
+pre_apply:
+- name: deployment-service-controller
+  kind: StatefulSet
+  namespace: kube-system
 
 # everything defined under here will be deleted after applying the manifests
 post_apply:

--- a/cluster/manifests/deployment-service/controller-deployment.yaml
+++ b/cluster/manifests/deployment-service/controller-deployment.yaml
@@ -14,7 +14,6 @@ spec:
     matchLabels:
       application: "deployment-service"
       component: "controller"
-  serviceName: "deployment-service-controller"
   template:
     metadata:
       labels:

--- a/cluster/manifests/deployment-service/controller-deployment.yaml
+++ b/cluster/manifests/deployment-service/controller-deployment.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: "deployment-service-controller"
   namespace: "kube-system"
@@ -8,6 +8,8 @@ metadata:
     component: "controller"
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       application: "deployment-service"

--- a/cluster/manifests/deployment-service/controller-deployment.yaml
+++ b/cluster/manifests/deployment-service/controller-deployment.yaml
@@ -48,11 +48,11 @@ spec:
               name: deployment-credentials
           resources:
             requests:
-              cpu: "{{.Cluster.ConfigItems.deployment_service_controller_cpu}}"
-              memory: "{{.Cluster.ConfigItems.deployment_service_controller_memory}}"
+              cpu: "100m"
+              memory: "1Gi"
             limits:
-              cpu: "{{.Cluster.ConfigItems.deployment_service_controller_cpu}}"
-              memory: "{{.Cluster.ConfigItems.deployment_service_controller_memory}}"
+              cpu: "100m"
+              memory: "1Gi"
           ports:
             - containerPort: 8080
               name: http

--- a/cluster/manifests/deployment-service/controller-vpa.yaml
+++ b/cluster/manifests/deployment-service/controller-vpa.yaml
@@ -16,7 +16,5 @@ spec:
   resourcePolicy:
     containerPolicies:
     - containerName: "deployment-service-controller"
-      maxAllowed:
-        memory: 2Gi
       minAllowed:
         memory: "{{.Cluster.ConfigItems.deployment_service_controller_memory_min}}"

--- a/cluster/manifests/deployment-service/controller-vpa.yaml
+++ b/cluster/manifests/deployment-service/controller-vpa.yaml
@@ -1,0 +1,20 @@
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: "deployment-service-controller"
+  namespace: "kube-system"
+  labels:
+    application: "deployment-service"
+    component: "controller"
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: "deployment-service-controller"
+  updatePolicy:
+    updateMode: Recreate
+  resourcePolicy:
+    containerPolicies:
+    - containerName: "deployment-service-controller"
+      maxAllowed:
+        memory: 2Gi

--- a/cluster/manifests/deployment-service/controller-vpa.yaml
+++ b/cluster/manifests/deployment-service/controller-vpa.yaml
@@ -18,3 +18,5 @@ spec:
     - containerName: "deployment-service-controller"
       maxAllowed:
         memory: 2Gi
+      minAllowed:
+        memory: "{{.Cluster.ConfigItems.deployment_service_controller_memory_min}}"


### PR DESCRIPTION
Migrate the `deployment-service-controller` to deployment with a single replica with a VPA.

- This will help to reduce costs since most clusters don't really need a static 1Gi for memory.
- The change to `deployment` instead of `statefulset` is more aligned with the purpose of the resources in kubernetes, and there were a few issue in using statefulsets with VPA in the past we want to avoid.
- Remove the config items that does not have any effect anymore with VPA.

The statefulset will be deleted before applying (pre-apply) the new resource to ensure we don't have concurrency and be on the safe side, this might create a small downtime but the deployment should pick the create task after created