### PR TITLE
Disable amd instance types in production by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -69,6 +69,18 @@ karpenter_amd_cpu_types_enabled: "false"
 karpenter_amd_cpu_types_enabled: "true"
 {{end}}
 
+# configure whether we allow flex instance types for Karpenter nodes
+# flex instance types have a baseline CPU performance with burst capability.
+# This provides an unpredictable performance, hence we want to avoid running
+# those by default in production.
+{{if eq .Cluster.Environment "production"}}
+karpenter_flex_types_enabled: "false"
+{{else}}
+karpenter_flex_types_enabled: "true"
+{{end}}
+
+
+
 # configure whether spot instances should be enabled in Karpenter's capacity-types
 karpenter_enable_spot: "true"
 

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -52,10 +52,22 @@ karpenter_in_transit_support_required: "false"
 # t type instances have burstable CPU, which can be undesirable in production
 karpenter_instance_family_t_enabled: "false"
 
+
+
 # configure whether we allow g6f instance family for Karpenter nodes
 # g6f has fractional GPU count which is also mislabeled by Karpenter and causes
 # scheduling issues, we need to properly test and support it later if needed
 karpenter_instance_family_g6f_enabled: "false"
+
+# configure whether we allow AMD CPU types for Karpenter nodes
+# AMD CPU instance types (denoted by a types) are generally performing worse
+# from a cost/performance perspective than intel counterparts. Therefore we
+# exclude them by default in production
+{{if eq .Cluster.Environment "production"}}
+karpenter_amd_cpu_types_enabled: "false"
+{{else}}
+karpenter_amd_cpu_types_enabled: "true"
+{{end}}
 
 # configure whether spot instances should be enabled in Karpenter's capacity-types
 karpenter_enable_spot: "true"

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -248,6 +248,12 @@ spec:
           values:
             - "amd"
         # {{ end }}
+        # {{ if ne .NodePool.ConfigItems.karpenter_flex_types_enabled "true" }}
+        - key: "karpenter.k8s.aws/instance-capability-flex"
+          operator: "NotIn"
+          values:
+            - "true"
+        # {{ end }}
 #{{end}}
 
 #{{ if (index .NodePool.ConfigItems "requirements") }}

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -242,6 +242,12 @@ spec:
             - "c5d.large"
             - "m5d.large"
             - "r5d.large"
+        # {{ if ne .NodePool.ConfigItems.karpenter_amd_cpu_types_enabled "true" }}
+        - key: "karpenter.k8s.aws/instance-cpu-manufacturer"
+          operator: "NotIn"
+          values:
+            - "amd"
+        # {{ end }}
 #{{end}}
 
 #{{ if (index .NodePool.ConfigItems "requirements") }}


### PR DESCRIPTION
### Description

<!-- Describe the purpose and goal of this pull request, as well as the set of changes
     (supported by examples and images) in a few sentences or bullet points to guide the
     reviewer. If this section becomes to long consider splitting the pull request. -->

We want to remove the use of `default-karpenter` pool to fix scheduling annotation: `zalando.org/compute-instance-architecture` with the values `prioritize-arm64` and `any` as they currently don't work when the `default-karpenter` pool with only x86 instances have higher priority (see internal ticket for more context).

Doing this has the side-effect of using the `catch-all` pools which allow any instance types including amd based instances (e.g. c5a). We generally don't use AMD instance types as they historically have a worse cost/performance ratio compared to intel, based on user feedback, therefore we didn't include them in the `default-karpenter` pool, but they are currently optional in the catch-all pools.

While we could/should re-evaluate cost/performance of amd instance types for newer generation, for now simply disable them to avoid a potential performance degradation across the fleet while we work on the initial goal to remove `default-karpenter` pool and fix `prioritize-arm64` and `any` scheduling annotations.

Currently only a subset of clusters use amd instances because they use scheduling annotations for a subset of pods.

This adds a requirement to node pools to exlcude amd instance types.

The change _only_ applies to _production_ clusters as for test we don't care as much about performance but just want the cheapest setup as there is generally very little load in test for it to matter.

Additionally do the same for `flex` instance types with the same reason as for AMD. Flex types provide baseline CPU performance with burst capability so it's unpredictable how they perform. We want to avoid those by default in production.