### PR TITLE
Add missing deletions for legacy S3 CSI Driver setup

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -246,6 +246,10 @@ post_apply:
 - name: s3-csi-driver
   kind: ServiceAccount
   namespace: kube-system
+- name: s3-csi-driver-cluster-role
+  kind: ClusterRole
+- name: mountpoint-s3-csi-node-binding
+  kind: ClusterRoleBinding
 - name: s3-csi-node
   kind: DaemonSet
   namespace: kube-system


### PR DESCRIPTION
These resources are deployed but not added to deletions.yaml.

If they aren't cleaned up, the addon-based v2 implementation cannot be turned on.