### PR TITLE
skipper ingress version update

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,6 +1,6 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.24.39-1369" }}
+{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.24.43-1373" }}
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.24.43-1373" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -4,7 +4,7 @@
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.24.43-1373" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}
-{{ $canary_args := "-disable-metrics-compression" }}
+{{ $canary_args := "" }}
 
 {{ $cluster_internal_cidrs := list "10.2.0.0/15" .Values.vpc_ipv4_cidr }}
 {{ if eq .Cluster.Provider "zalando-eks" }}
@@ -240,6 +240,7 @@ spec:
           - "-combined-response-metrics={{ .Cluster.ConfigItems.skipper_combined_response_metrics }}"
           - "-backend-host-metrics={{ .Cluster.ConfigItems.skipper_backend_host_metrics }}"
           - "-disable-metrics-compat"
+          - "-disable-metrics-compression"
           - "-enable-profile"
           - "-memory-profile-rate={{ .Cluster.ConfigItems.skipper_memory_profile_rate }}"
           - "-block-profile-rate={{ .Cluster.ConfigItems.skipper_block_profile_rate }}"


### PR DESCRIPTION
Skipper ingress version upgrade to fix opa version used in ingress skippers.

More information in https://github.com/zalando/skipper/pull/3911