### PR TITLE
Update to AMI with increased nofile limit

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -858,8 +858,8 @@ tracing_coredns_local_zone_traces_endpoint: ""
 # AMI id given the image name and the Image AWS account owner.
 #
 # [0]: https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/8a9bd1cb2d094038a9e23e646421f8146b48886a/provisioner/template.go#L116
-kuberuntu_image_v1_35_new_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.35.2-amd64-master-390" "861068367966" }}
-kuberuntu_image_v1_35_new_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.35.2-arm64-master-390" "861068367966" }}
+kuberuntu_image_v1_35_new_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.35.2-amd64-master-391" "861068367966" }}
+kuberuntu_image_v1_35_new_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.35.2-arm64-master-391" "861068367966" }}
 
 # This is used to determine which AMI to use for the cluster or individual node
 # pools. Possible values are 'new' or 'old'


### PR DESCRIPTION
This updates the AMI to a version with an increased nofile limit:

```
cat /etc/systemd/system.conf.d/02-nofile-limit.conf‎
[Manager]
DefaultLimitNOFILE=1048576
```

This limit increase is done to ensure both amd64 and arm64 instances have the same limit set. Before, the arm64 instances had a much lower limit leading to issues for applications that don't automatically increase the soft limit on startup and need many file descriptors because of high load e.g. envoy.

This is targeting the Kubernetes v1.35 branch to piggy-back on the AMI roll out for that.