### PR TITLE
Adjust skipper resources to reduce costs

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -227,11 +227,7 @@ skipper_redis_max_conns: 100
 
 skipper_ingress_redis_swarm_enabled: "true"
 skipper_ingress_redis_swim_enabled: "false"
-{{if eq .Cluster.Environment "production"}}
 skipper_ingress_redis_target_average_utilization_cpu: "30"
-{{else}}
-skipper_ingress_redis_target_average_utilization_cpu: "60"
-{{end}}
 skipper_ingress_redis_target_average_utilization_memory: "60"
 skipper_ingress_redis_min_replicas: "1"
 skipper_ingress_redis_max_replicas: "100"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -104,11 +104,10 @@ skipper_ingress_max_replicas: "50"
 {{end}}
 {{if eq .Cluster.Environment "production"}}
 skipper_ingress_cpu: "1000m"
-skipper_ingress_memory: "1500Mi"
 {{else}}
 skipper_ingress_cpu: "500m"
-skipper_ingress_memory: "750Mi"
 {{end}}
+skipper_ingress_memory: "1500Mi"
 
 skipper_topology_spread_enabled: "true"
 skipper_topology_spread_timeout: "7m"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -222,7 +222,11 @@ skipper_redis_max_conns: 100
 
 skipper_ingress_redis_swarm_enabled: "true"
 skipper_ingress_redis_swim_enabled: "false"
+{{if eq .Cluster.Environment "production"}}
 skipper_ingress_redis_target_average_utilization_cpu: "30"
+{{else}}
+skipper_ingress_redis_target_average_utilization_cpu: "60"
+{{end}}
 skipper_ingress_redis_target_average_utilization_memory: "60"
 skipper_ingress_redis_min_replicas: "1"
 skipper_ingress_redis_max_replicas: "100"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -102,8 +102,13 @@ skipper_ingress_max_replicas: "300"
 skipper_ingress_min_replicas: "2"
 skipper_ingress_max_replicas: "50"
 {{end}}
+{{if eq .Cluster.Environment "production"}}
 skipper_ingress_cpu: "1000m"
 skipper_ingress_memory: "1500Mi"
+{{else}}
+skipper_ingress_cpu: "500m"
+skipper_ingress_memory: "750Mi"
+{{end}}
 
 skipper_topology_spread_enabled: "true"
 skipper_topology_spread_timeout: "7m"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -114,34 +114,27 @@ spec:
               - key: node.kubernetes.io/instance-type
                 operator: In
                 values:
-                {{- if eq .Cluster.Environment "test" }}
                 - c7g.medium
-                {{- end }}
                 - c7g.large
                 - c7g.xlarge
                 - c7g.2xlarge
                 - c7g.4xlarge
                 - c7g.8xlarge
                 - m7g.large
-                {{- if eq .Cluster.Environment "test" }}
                 - m7g.medium
-                {{- end }}
           - weight: 50
             preference:
               matchExpressions:
               - key: node.kubernetes.io/instance-type
                 operator: In
                 values:
-                {{- if eq .Cluster.Environment "test" }}
                 - c6g.medium
-                {{- end }}
                 - c6g.large
                 - c6g.xlarge
                 - c6g.2xlarge
                 - c6g.4xlarge
                 - c6g.8xlarge
                 - m6g.large
-                {{- if eq .Cluster.Environment "test" }}
                 - m6g.medium
                 {{- end }}
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -116,7 +116,7 @@ spec:
                 values:
                 {{- if eq .Cluster.Environment "test" }}
                 - c7g.medium
-                {{- end}
+                {{- end }}
                 - c7g.large
                 - c7g.xlarge
                 - c7g.2xlarge
@@ -125,7 +125,7 @@ spec:
                 - m7g.large
                 {{- if eq .Cluster.Environment "test" }}
                 - m7g.medium
-                {{- end}
+                {{- end }}
           - weight: 50
             preference:
               matchExpressions:
@@ -134,7 +134,7 @@ spec:
                 values:
                 {{- if eq .Cluster.Environment "test" }}
                 - c6g.medium
-                {{- end}
+                {{- end }}
                 - c6g.large
                 - c6g.xlarge
                 - c6g.2xlarge
@@ -143,7 +143,7 @@ spec:
                 - m6g.large
                 {{- if eq .Cluster.Environment "test" }}
                 - m6g.medium
-                {{- end}
+                {{- end }}
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       serviceAccountName: skipper-ingress
       terminationGracePeriodSeconds: {{ .Cluster.ConfigItems.skipper_termination_grace_period }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -114,24 +114,36 @@ spec:
               - key: node.kubernetes.io/instance-type
                 operator: In
                 values:
+                {{- if eq .Cluster.Environment "test" }}
+                - c7g.medium
+                {{- end}
                 - c7g.large
                 - c7g.xlarge
                 - c7g.2xlarge
                 - c7g.4xlarge
                 - c7g.8xlarge
                 - m7g.large
+                {{- if eq .Cluster.Environment "test" }}
+                - m7g.medium
+                {{- end}
           - weight: 50
             preference:
               matchExpressions:
               - key: node.kubernetes.io/instance-type
                 operator: In
                 values:
+                {{- if eq .Cluster.Environment "test" }}
+                - c6g.medium
+                {{- end}
                 - c6g.large
                 - c6g.xlarge
                 - c6g.2xlarge
                 - c6g.4xlarge
                 - c6g.8xlarge
                 - m6g.large
+                {{- if eq .Cluster.Environment "test" }}
+                - m6g.medium
+                {{- end}
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       serviceAccountName: skipper-ingress
       terminationGracePeriodSeconds: {{ .Cluster.ConfigItems.skipper_termination_grace_period }}


### PR DESCRIPTION
Reduce skipper costs with the changes on test clusters that have small load.
- add smaller instances since load is small in test clusters
- reduce resources (memory and cpu) to half in test clusters since most of the time they are doing nothing.