### PR TITLE
Disable flex instance types in production

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -57,6 +57,16 @@ karpenter_instance_family_t_enabled: "false"
 # scheduling issues, we need to properly test and support it later if needed
 karpenter_instance_family_g6f_enabled: "false"
 
+# configure whether we allow flex instance types for Karpenter nodes
+# flex instance types have a baseline CPU performance with burst capability.
+# This provides an unpredictable performance, hence we want to avoid running
+# those by default in production.
+{{if eq .Cluster.Environment "production"}}
+karpenter_flex_types_enabled: "false"
+{{else}}
+karpenter_flex_types_enabled: "true"
+{{end}}
+
 # configure whether spot instances should be enabled in Karpenter's capacity-types
 karpenter_enable_spot: "true"
 

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -242,6 +242,12 @@ spec:
             - "c5d.large"
             - "m5d.large"
             - "r5d.large"
+        # {{ if ne .NodePool.ConfigItems.karpenter_flex_types_enabled "true" }}
+        - key: "karpenter.k8s.aws/instance-capability-flex"
+          operator: "NotIn"
+          values:
+            - "true"
+        # {{ end }}
 #{{end}}
 
 #{{ if (index .NodePool.ConfigItems "requirements") }}


### PR DESCRIPTION
Flex instances provide burstable CPU performance leading to unpredictable performance.

To make the roll out of catch-all node pools more safe we disable flex instance types from production by default to avoid getting those instance types as they are cheaper than non-flex counterpart.