### PR TITLE
Write access to the logs bucket

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -2214,6 +2214,15 @@ Resources:
                   - "{{ .Cluster.ConfigItems.skipper_open_policy_agent_bucket_arn }}/*"
             Version: 2012-10-17
           PolicyName: read-opa-bundles
+        - PolicyDocument:
+            Statement:
+              - Effect: "Allow"
+                Action:
+                  - "s3:PutObject"
+                Resource:
+                  - "{{ .Cluster.ConfigItems.skipper_open_policy_agent_decision_log_bucket_arn }}/*"
+            Version: 2012-10-17
+          PolicyName: write-opa-decision-logs
       RoleName: "{{.Cluster.LocalID}}-app-skipper-ingress"
     Type: 'AWS::IAM::Role'
   # Note: this is not strictly specific to Open Policy Agent and can be extend
@@ -2259,6 +2268,15 @@ Resources:
                   - "{{ .Cluster.ConfigItems.skipper_open_policy_agent_bucket_arn }}/*"
             Version: 2012-10-17
           PolicyName: read-opa-bundles
+        - PolicyDocument:
+            Statement:
+              - Effect: "Allow"
+                Action:
+                  - "s3:PutObject"
+                Resource:
+                  - "{{ .Cluster.ConfigItems.skipper_open_policy_agent_decision_log_bucket_arn }}/*"
+            Version: 2012-10-17
+          PolicyName: write-opa-decision-logs
       RoleName: "{{.Cluster.LocalID}}-app-skipper-validation-webhook"
     Type: 'AWS::IAM::Role'
   ClusterLifecycleControllerIAMRole:

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -2205,7 +2205,9 @@ Resources:
 {{- end }}
       Path: /
       Policies:
-        - PolicyDocument:
+        - PolicyName: s3-access-for-opa
+          PolicyDocument:
+            Version: 2012-10-17
             Statement:
               - Effect: "Allow"
                 Action:
@@ -2217,8 +2219,6 @@ Resources:
                   - "s3:PutObject"
                 Resource:
                   - "{{ .Cluster.ConfigItems.skipper_open_policy_agent_decision_log_bucket_arn }}/*"
-            Version: 2012-10-17
-          PolicyName: s3-access-for-opa
       RoleName: "{{.Cluster.LocalID}}-app-skipper-ingress"
     Type: 'AWS::IAM::Role'
   # Note: this is not strictly specific to Open Policy Agent and can be extend
@@ -2255,7 +2255,9 @@ Resources:
 {{- end }}
       Path: /
       Policies:
-        - PolicyDocument:
+        - PolicyName: s3-access-for-opa
+          PolicyDocument:
+            Version: 2012-10-17
             Statement:
               - Effect: "Allow"
                 Action:
@@ -2267,8 +2269,6 @@ Resources:
                   - "s3:PutObject"
                 Resource:
                   - "{{ .Cluster.ConfigItems.skipper_open_policy_agent_decision_log_bucket_arn }}/*"
-            Version: 2012-10-17
-          PolicyName: s3-access-for-opa
       RoleName: "{{.Cluster.LocalID}}-app-skipper-validation-webhook"
     Type: 'AWS::IAM::Role'
   ClusterLifecycleControllerIAMRole:

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -2212,17 +2212,13 @@ Resources:
                   - "s3:GetObject"
                 Resource:
                   - "{{ .Cluster.ConfigItems.skipper_open_policy_agent_bucket_arn }}/*"
-            Version: 2012-10-17
-          PolicyName: read-opa-bundles
-        - PolicyDocument:
-            Statement:
               - Effect: "Allow"
                 Action:
                   - "s3:PutObject"
                 Resource:
                   - "{{ .Cluster.ConfigItems.skipper_open_policy_agent_decision_log_bucket_arn }}/*"
             Version: 2012-10-17
-          PolicyName: write-opa-decision-logs
+          PolicyName: s3-access-for-opa
       RoleName: "{{.Cluster.LocalID}}-app-skipper-ingress"
     Type: 'AWS::IAM::Role'
   # Note: this is not strictly specific to Open Policy Agent and can be extend
@@ -2266,17 +2262,13 @@ Resources:
                   - "s3:GetObject"
                 Resource:
                   - "{{ .Cluster.ConfigItems.skipper_open_policy_agent_bucket_arn }}/*"
-            Version: 2012-10-17
-          PolicyName: read-opa-bundles
-        - PolicyDocument:
-            Statement:
               - Effect: "Allow"
                 Action:
                   - "s3:PutObject"
                 Resource:
                   - "{{ .Cluster.ConfigItems.skipper_open_policy_agent_decision_log_bucket_arn }}/*"
             Version: 2012-10-17
-          PolicyName: write-opa-decision-logs
+          PolicyName: s3-access-for-opa
       RoleName: "{{.Cluster.LocalID}}-app-skipper-validation-webhook"
     Type: 'AWS::IAM::Role'
   ClusterLifecycleControllerIAMRole:

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -8,712 +8,712 @@ Metadata:
     "kubernetes.io/cluster/{{.Cluster.Name}}": "owned"
 
 Resources:
-{{ if eq .Cluster.Provider "zalando-eks" }}
-  # https://aws.amazon.com/blogs/containers/aws-fault-injection-simulator-supports-chaos-engineering-experiments-on-amazon-eks-pods/
+  {{ if eq .Cluster.Provider "zalando-eks" }}
+# https://aws.amazon.com/blogs/containers/aws-fault-injection-simulator-supports-chaos-engineering-experiments-on-amazon-eks-pods/
   {{- if eq .Cluster.ConfigItems.eks_fis_support_enabled "true" }}
-  FISEKSClusterRole:
-    Type: AWS::IAM::Role
-    Properties:
-      RoleName: "{{.Cluster.LocalID}}-eks-fis-experiment-executor"
-      AssumeRolePolicyDocument:
-        Version: '2012-10-17'
-        Statement:
+FISEKSClusterRole:
+  Type: AWS::IAM::Role
+  Properties:
+    RoleName: "{{.Cluster.LocalID}}-eks-fis-experiment-executor"
+    AssumeRolePolicyDocument:
+      Version: '2012-10-17'
+      Statement:
         - Effect: Allow
           Principal:
             Service:
-            - fis.amazonaws.com
+              - fis.amazonaws.com
           Action:
-          - sts:AssumeRole
-      ManagedPolicyArns:
+            - sts:AssumeRole
+    ManagedPolicyArns:
       - arn:aws:iam::aws:policy/service-role/AWSFaultInjectionSimulatorEKSAccess
-      Policies:
+    Policies:
       - PolicyDocument:
           Statement:
             - Action:
-              - "logs:CreateLogDelivery"
-              - "logs:PutResourcePolicy"
-              - "logs:DescribeResourcePolicies"
-              - "logs:DescribeLogGroups"
+                - "logs:CreateLogDelivery"
+                - "logs:PutResourcePolicy"
+                - "logs:DescribeResourcePolicies"
+                - "logs:DescribeLogGroups"
               Effect: Allow
               Resource: "*"
           Version: 2012-10-17
         PolicyName: root
   {{- end }}
 
-  EKSClusterRole:
-    Type: AWS::IAM::Role
-    Properties:
-      RoleName: "{{.Cluster.LocalID}}-eks-cluster-role"
-      AssumeRolePolicyDocument:
-        Version: '2012-10-17'
-        Statement:
+EKSClusterRole:
+  Type: AWS::IAM::Role
+  Properties:
+    RoleName: "{{.Cluster.LocalID}}-eks-cluster-role"
+    AssumeRolePolicyDocument:
+      Version: '2012-10-17'
+      Statement:
         - Effect: Allow
           Principal:
             Service:
-            - eks.amazonaws.com
+              - eks.amazonaws.com
           Action:
-          - sts:AssumeRole
-      ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
-        - arn:aws:iam::aws:policy/AmazonEKSVPCResourceController
+            - sts:AssumeRole
+    ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
+      - arn:aws:iam::aws:policy/AmazonEKSVPCResourceController
 
-  EKSControlPlaneSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupDescription: "{{ .Cluster.Alias }}-control-plane"
-      VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
-  EKSWorkerSecurityGroup:
-    Type: "AWS::EC2::SecurityGroup"
-    Properties:
-      GroupDescription: "{{ .Cluster.ID }}-worker-sg"
-      SecurityGroupIngress:
-        - CidrIp: 0.0.0.0/0
-          FromPort: -1
-          IpProtocol: icmp
-          ToPort: -1
-        - CidrIp: {{ if eq .Cluster.ConfigItems.ssh_vpc_only "true" }}"{{.Values.vpc_ipv4_cidr}}"{{ else }}"0.0.0.0/0"{{ end }}
-          FromPort: 22
-          IpProtocol: tcp
-          ToPort: 22
-{{- if index .Cluster.ConfigItems "open_sg_ingress_ranges" }}
-{{- range $index, $element := sgIngressRanges .Cluster.ConfigItems.open_sg_ingress_ranges }}
-        - CidrIp: {{ $element.CIDR }}
-          FromPort: {{ $element.FromPort }}
-          IpProtocol: {{ $element.Protocol }}
-          ToPort: {{ $element.ToPort }}
-{{- end }}
-{{- end }}
-        - CidrIp: "0.0.0.0/0"
-          FromPort: 9998
-          IpProtocol: tcp
-          ToPort: 9999
-        - CidrIpv6: "::/0"
-          FromPort: 9998
-          IpProtocol: tcp
-          ToPort: 9999
-{{- if eq .Cluster.ConfigItems.skipper_ingress_redis_swim_enabled "true" }}
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 9990
-          IpProtocol: tcp
-          ToPort: 9990
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 9990
-          IpProtocol: udp
-          ToPort: 9990
-{{- end }}
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 10248
-          IpProtocol: tcp
-          ToPort: 10248
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 9054
-          IpProtocol: tcp
-          ToPort: 9054
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 9153
-          IpProtocol: tcp
-          ToPort: 9153
-        # Allow all traffic from Cluster Security Group
-        - SourceSecurityGroupId: !GetAtt EKSCluster.ClusterSecurityGroupId
-          IpProtocol : "-1"
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 30000
-          IpProtocol: tcp
-          ToPort: 32767
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 53
-          IpProtocol: tcp
-          ToPort: 53
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 53
-          IpProtocol: udp
-          ToPort: 53
-      Tags:
-        - Key: 'karpenter.sh/discovery'
-          Value: '{{ .Cluster.ID }}/WorkerNodeSecurityGroup'
-      VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
-  EKSSelfWorkerSecurityIngress:
-    Type: AWS::EC2::SecurityGroupIngress
-    Properties:
-      IpProtocol: "-1"
-      GroupId: !Ref EKSWorkerSecurityGroup
-      SourceSecurityGroupId: !Ref EKSWorkerSecurityGroup
-  # allow access from Worker Security Group to the Control Plane SG
-  EKSGroupControlPlaneWorkerSecurityIngress:
-    Type: AWS::EC2::SecurityGroupIngress
-    Properties:
-      FromPort: 443
-      GroupId: !GetAtt EKSCluster.ClusterSecurityGroupId
-      IpProtocol: tcp
-      SourceSecurityGroupId: !Ref EKSWorkerSecurityGroup
-      ToPort: 443
-  EKSEFSSecurityGroupIngressFromEKSWorkerSecurityGroup:
-    Properties:
-      FromPort: 2049
-      GroupId: !Ref EKSEFSWorkerSecurityGroup
-      IpProtocol: tcp
-      SourceSecurityGroupId: !Ref EKSWorkerSecurityGroup
-      ToPort: 2049
-    Type: 'AWS::EC2::SecurityGroupIngress'
-  EKSEFSWorkerSecurityGroup:
-    Properties:
-      GroupDescription: EKS worker to EFS sg
-      VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
-    Type: 'AWS::EC2::SecurityGroup'
-{{- if eq .Cluster.ConfigItems.eks_control_plane_logging "true" }}
-  ControlPlaneLogGroup:
-    Type: AWS::Logs::LogGroup
-    Properties:
-      LogGroupName: "/aws/eks/{{.Cluster.Name}}/cluster"
-      RetentionInDays: 545
-{{- end }}
-  EKSCluster:
-    Type: AWS::EKS::Cluster
-{{- if eq .Cluster.ConfigItems.eks_control_plane_logging "true" }}
-    DependsOn: ControlPlaneLogGroup
-{{- end }}
-    Properties:
-      Name: "{{.Cluster.Name}}"
-      Version: "1.34"
-      RoleArn: !GetAtt EKSClusterRole.Arn
-      KubernetesNetworkConfig:
-        IpFamily: "{{.Cluster.ConfigItems.eks_ip_family}}"
-      AccessConfig:
-        AuthenticationMode: API
-        BootstrapClusterCreatorAdminPermissions: false
-      EncryptionConfig:
-        - Provider:
-            KeyArn: !GetAtt EtcdEncryptionKey.Arn # TODO: maybe use another key for EKS?
-          Resources:
-          - secrets
-      ResourcesVpcConfig:
-        SecurityGroupIds:
-          - !Ref EKSControlPlaneSecurityGroup
-        SubnetIds:
-        {{ with $values := .Values }}
-        {{ range $az := $values.availability_zones }}
-          - "{{ index $values.subnets $az }}"
-        {{ end }}
-        {{ end }}
-        EndpointPublicAccess: true
-        EndpointPrivateAccess: true
-        # PublicAccessCidrs: [ "1.1.1.2/32" ]
-      Logging:
-        ClusterLogging:
-{{- if eq .Cluster.ConfigItems.eks_control_plane_logging "true" }}
-          EnabledTypes:
-            - Type: api
-            - Type: audit
-            - Type: authenticator
-            - Type: controllerManager
-            - Type: scheduler
-{{- else }}
-          EnabledTypes: []
-{{- end }}
-      # Tags:
-      # - Key: "application"
-      #   Value: "kubernetes"
-      # TODO: vanity domain name? (certificate issue)
-      #
-      #
-{{- if eq .Cluster.ConfigItems.eks_okta_identity_provider "true" }}
-  EKSIdentityProvider:
-    Type: AWS::EKS::IdentityProviderConfig
-    Properties:
-      ClusterName: !Ref EKSCluster
-      IdentityProviderConfigName: "okta"
-      Oidc:
-        IssuerUrl: "{{.Cluster.ConfigItems.okta_auth_issuer_url}}"
-        ClientId: "{{.Cluster.ConfigItems.okta_auth_client_id}}"
-        UsernameClaim: "email"
-        UsernamePrefix: "okta:"
-        GroupsClaim: "groups"
-        GroupsPrefix: "okta:"
-      Type: "oidc"
-{{- end }}
-  EKSAccessEntryNodeAuth:
-    Type: "AWS::EKS::AccessEntry"
-    Properties:
-      ClusterName: !Ref EKSCluster
-      PrincipalArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/{{.Cluster.LocalID}}-worker"
-      Type: "EC2_LINUX"
-  EKSAccessEntryClusterLifecycleManagerAuth:
-    Type: "AWS::EKS::AccessEntry"
-    Properties:
-      AccessPolicies:
-      - AccessScope:
-          Type: "cluster"
-        PolicyArn: "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
-      ClusterName: !Ref EKSCluster
-      PrincipalArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/cluster-lifecycle-manager-entrypoint"
-      Username: !Sub "arn:aws:sts::${AWS::AccountId}:assumed-role/cluster-lifecycle-manager-entrypoint/{{`{{SessionName}}`}}"
-      KubernetesGroups:
-      - zalando:administrator
-      Type: "STANDARD"
-  {{- if eq .Cluster.ConfigItems.eks_fis_support_enabled "true" }}
-  EKSAccessEntryFISEKSRole:
-    Type: "AWS::EKS::AccessEntry"
-    Properties:
-      ClusterName: !Ref EKSCluster
-      PrincipalArn: !GetAtt FISEKSClusterRole.Arn
-      Username: "fis-experiment-executor"
-      Type: "STANDARD"
+EKSControlPlaneSecurityGroup:
+  Type: AWS::EC2::SecurityGroup
+  Properties:
+    GroupDescription: "{{ .Cluster.Alias }}-control-plane"
+    VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
+EKSWorkerSecurityGroup:
+  Type: "AWS::EC2::SecurityGroup"
+  Properties:
+    GroupDescription: "{{ .Cluster.ID }}-worker-sg"
+    SecurityGroupIngress:
+      - CidrIp: 0.0.0.0/0
+        FromPort: -1
+        IpProtocol: icmp
+        ToPort: -1
+      - CidrIp: {{ if eq .Cluster.ConfigItems.ssh_vpc_only "true" }}"{{.Values.vpc_ipv4_cidr}}"{{ else }}"0.0.0.0/0"{{ end }}
+        FromPort: 22
+        IpProtocol: tcp
+        ToPort: 22
+  {{- if index .Cluster.ConfigItems "open_sg_ingress_ranges" }}
+  {{- range $index, $element := sgIngressRanges .Cluster.ConfigItems.open_sg_ingress_ranges }}
+- CidrIp: {{ $element.CIDR }}
+  FromPort: {{ $element.FromPort }}
+  IpProtocol: {{ $element.Protocol }}
+  ToPort: {{ $element.ToPort }}
   {{- end }}
-  EKSAccessEntryZalandoIAMAuth:
-    Type: "AWS::EKS::AccessEntry"
-    Properties:
-      ClusterName: !Ref EKSCluster
-      PrincipalArn: !GetAtt EKSZalandoIAMIAMRole.Arn
-      Username: "zalando-iam:zalando:service:{{`{{SessionName}}`}}"
-      Type: "STANDARD"
-  EKSAccessEntryAdministratorAuth:
-    Type: "AWS::EKS::AccessEntry"
-    Properties:
-      AccessPolicies:
+  {{- end }}
+- CidrIp: "0.0.0.0/0"
+  FromPort: 9998
+  IpProtocol: tcp
+  ToPort: 9999
+- CidrIpv6: "::/0"
+  FromPort: 9998
+  IpProtocol: tcp
+  ToPort: 9999
+  {{- if eq .Cluster.ConfigItems.skipper_ingress_redis_swim_enabled "true" }}
+- CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+  FromPort: 9990
+  IpProtocol: tcp
+  ToPort: 9990
+- CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+  FromPort: 9990
+  IpProtocol: udp
+  ToPort: 9990
+  {{- end }}
+- CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+  FromPort: 10248
+  IpProtocol: tcp
+  ToPort: 10248
+- CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+  FromPort: 9054
+  IpProtocol: tcp
+  ToPort: 9054
+- CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+  FromPort: 9153
+  IpProtocol: tcp
+  ToPort: 9153
+# Allow all traffic from Cluster Security Group
+- SourceSecurityGroupId: !GetAtt EKSCluster.ClusterSecurityGroupId
+  IpProtocol : "-1"
+- CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+  FromPort: 30000
+  IpProtocol: tcp
+  ToPort: 32767
+- CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+  FromPort: 53
+  IpProtocol: tcp
+  ToPort: 53
+- CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+  FromPort: 53
+  IpProtocol: udp
+  ToPort: 53
+Tags:
+  - Key: 'karpenter.sh/discovery'
+    Value: '{{ .Cluster.ID }}/WorkerNodeSecurityGroup'
+VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
+EKSSelfWorkerSecurityIngress:
+  Type: AWS::EC2::SecurityGroupIngress
+  Properties:
+    IpProtocol: "-1"
+    GroupId: !Ref EKSWorkerSecurityGroup
+    SourceSecurityGroupId: !Ref EKSWorkerSecurityGroup
+# allow access from Worker Security Group to the Control Plane SG
+EKSGroupControlPlaneWorkerSecurityIngress:
+  Type: AWS::EC2::SecurityGroupIngress
+  Properties:
+    FromPort: 443
+    GroupId: !GetAtt EKSCluster.ClusterSecurityGroupId
+    IpProtocol: tcp
+    SourceSecurityGroupId: !Ref EKSWorkerSecurityGroup
+    ToPort: 443
+EKSEFSSecurityGroupIngressFromEKSWorkerSecurityGroup:
+  Properties:
+    FromPort: 2049
+    GroupId: !Ref EKSEFSWorkerSecurityGroup
+    IpProtocol: tcp
+    SourceSecurityGroupId: !Ref EKSWorkerSecurityGroup
+    ToPort: 2049
+  Type: 'AWS::EC2::SecurityGroupIngress'
+EKSEFSWorkerSecurityGroup:
+  Properties:
+    GroupDescription: EKS worker to EFS sg
+    VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
+  Type: 'AWS::EC2::SecurityGroup'
+  {{- if eq .Cluster.ConfigItems.eks_control_plane_logging "true" }}
+ControlPlaneLogGroup:
+  Type: AWS::Logs::LogGroup
+  Properties:
+    LogGroupName: "/aws/eks/{{.Cluster.Name}}/cluster"
+    RetentionInDays: 545
+  {{- end }}
+EKSCluster:
+  Type: AWS::EKS::Cluster
+  {{- if eq .Cluster.ConfigItems.eks_control_plane_logging "true" }}
+DependsOn: ControlPlaneLogGroup
+  {{- end }}
+Properties:
+  Name: "{{.Cluster.Name}}"
+  Version: "1.34"
+  RoleArn: !GetAtt EKSClusterRole.Arn
+  KubernetesNetworkConfig:
+    IpFamily: "{{.Cluster.ConfigItems.eks_ip_family}}"
+  AccessConfig:
+    AuthenticationMode: API
+    BootstrapClusterCreatorAdminPermissions: false
+  EncryptionConfig:
+    - Provider:
+        KeyArn: !GetAtt EtcdEncryptionKey.Arn # TODO: maybe use another key for EKS?
+      Resources:
+        - secrets
+  ResourcesVpcConfig:
+    SecurityGroupIds:
+      - !Ref EKSControlPlaneSecurityGroup
+    SubnetIds:
+    {{ with $values := .Values }}
+    {{ range $az := $values.availability_zones }}
+    - "{{ index $values.subnets $az }}"
+    {{ end }}
+    {{ end }}
+    EndpointPublicAccess: true
+    EndpointPrivateAccess: true
+    # PublicAccessCidrs: [ "1.1.1.2/32" ]
+  Logging:
+    ClusterLogging:
+  {{- if eq .Cluster.ConfigItems.eks_control_plane_logging "true" }}
+EnabledTypes:
+  - Type: api
+  - Type: audit
+  - Type: authenticator
+  - Type: controllerManager
+  - Type: scheduler
+  {{- else }}
+EnabledTypes: []
+  {{- end }}
+# Tags:
+# - Key: "application"
+#   Value: "kubernetes"
+# TODO: vanity domain name? (certificate issue)
+#
+#
+  {{- if eq .Cluster.ConfigItems.eks_okta_identity_provider "true" }}
+EKSIdentityProvider:
+  Type: AWS::EKS::IdentityProviderConfig
+  Properties:
+    ClusterName: !Ref EKSCluster
+    IdentityProviderConfigName: "okta"
+    Oidc:
+      IssuerUrl: "{{.Cluster.ConfigItems.okta_auth_issuer_url}}"
+      ClientId: "{{.Cluster.ConfigItems.okta_auth_client_id}}"
+      UsernameClaim: "email"
+      UsernamePrefix: "okta:"
+      GroupsClaim: "groups"
+      GroupsPrefix: "okta:"
+    Type: "oidc"
+  {{- end }}
+EKSAccessEntryNodeAuth:
+  Type: "AWS::EKS::AccessEntry"
+  Properties:
+    ClusterName: !Ref EKSCluster
+    PrincipalArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/{{.Cluster.LocalID}}-worker"
+    Type: "EC2_LINUX"
+EKSAccessEntryClusterLifecycleManagerAuth:
+  Type: "AWS::EKS::AccessEntry"
+  Properties:
+    AccessPolicies:
       - AccessScope:
           Type: "cluster"
         PolicyArn: "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
-      ClusterName: !Ref EKSCluster
-      PrincipalArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/Administrator"
-      Username: !Sub "arn:aws:sts::${AWS::AccountId}:assumed-role/Administrator/{{`{{SessionName}}`}}"
-      KubernetesGroups:
+    ClusterName: !Ref EKSCluster
+    PrincipalArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/cluster-lifecycle-manager-entrypoint"
+    Username: !Sub "arn:aws:sts::${AWS::AccountId}:assumed-role/cluster-lifecycle-manager-entrypoint/{{`{{SessionName}}`}}"
+    KubernetesGroups:
       - zalando:administrator
-      Type: "STANDARD"
-{{- if eq .Cluster.Environment "e2e" }}
-  EKSAccessEntryManualAdministratorAuth:
-    Type: "AWS::EKS::AccessEntry"
-    Properties:
-      AccessPolicies:
+    Type: "STANDARD"
+  {{- if eq .Cluster.ConfigItems.eks_fis_support_enabled "true" }}
+EKSAccessEntryFISEKSRole:
+  Type: "AWS::EKS::AccessEntry"
+  Properties:
+    ClusterName: !Ref EKSCluster
+    PrincipalArn: !GetAtt FISEKSClusterRole.Arn
+    Username: "fis-experiment-executor"
+    Type: "STANDARD"
+  {{- end }}
+EKSAccessEntryZalandoIAMAuth:
+  Type: "AWS::EKS::AccessEntry"
+  Properties:
+    ClusterName: !Ref EKSCluster
+    PrincipalArn: !GetAtt EKSZalandoIAMIAMRole.Arn
+    Username: "zalando-iam:zalando:service:{{`{{SessionName}}`}}"
+    Type: "STANDARD"
+EKSAccessEntryAdministratorAuth:
+  Type: "AWS::EKS::AccessEntry"
+  Properties:
+    AccessPolicies:
       - AccessScope:
           Type: "cluster"
         PolicyArn: "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
-      ClusterName: !Ref EKSCluster
-      PrincipalArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/Manual"
-      Username: !Sub "arn:aws:sts::${AWS::AccountId}:assumed-role/Manual/{{`{{SessionName}}`}}"
-      KubernetesGroups:
+    ClusterName: !Ref EKSCluster
+    PrincipalArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/Administrator"
+    Username: !Sub "arn:aws:sts::${AWS::AccountId}:assumed-role/Administrator/{{`{{SessionName}}`}}"
+    KubernetesGroups:
       - zalando:administrator
-      Type: "STANDARD"
-{{- else }}
-  EKSAccessEntryManualAuth:
-    Type: "AWS::EKS::AccessEntry"
-    Properties:
-      ClusterName: !Ref EKSCluster
-      PrincipalArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/Manual"
-      Type: "STANDARD"
-      KubernetesGroups:
-        - zalando:engineer
-{{- end }}
-  EKSAccessEntrySecurityAuth:
-    Type: "AWS::EKS::AccessEntry"
-    Properties:
-      ClusterName: !Ref EKSCluster
-      PrincipalArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/SecAudit"
-      Type: "STANDARD"
-      KubernetesGroups:
-        - zalando:readonly
-  EKSAccessEntryReadOnlyAuth:
-    Type: "AWS::EKS::AccessEntry"
-    Properties:
-      ClusterName: !Ref EKSCluster
-      PrincipalArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/ReadOnly"
-      Type: "STANDARD"
-      KubernetesGroups:
-        - zalando:readonly
-{{- if eq .Cluster.ConfigItems.eks_efs_csi_support_enabled "true" }}
-  EKSAddonEFSCSIDriver:
-    Type: AWS::EKS::Addon
-    Properties:
-      AddonName: aws-efs-csi-driver
-      AddonVersion: "v2.1.15-eksbuild.1"
-      ClusterName: !Ref EKSCluster
-      PodIdentityAssociations:
-        - RoleArn: !GetAtt EKSEFSCSIDriverIAMRole.Arn
-          ServiceAccount: efs-csi-controller-sa
-{{- end }}
-{{- if eq .Cluster.ConfigItems.eks_s3_csi_support_enabled "true" }}
-  EKSAddonS3CSIDriver:
-    Type: AWS::EKS::Addon
-    Properties:
-      AddonName: aws-mountpoint-s3-csi-driver
-      AddonVersion: "v2.3.0-eksbuild.1"
-      ClusterName: !Ref EKSCluster
-{{- end }}
-  EKSAddonAmazonVPCCNI:
-    Type: AWS::EKS::Addon
-    Properties:
-      AddonName: vpc-cni
-      AddonVersion: "v1.21.1-eksbuild.3"
-      ClusterName: !Ref EKSCluster
-      ConfigurationValues: !Sub |
-{{- if eq .Cluster.ConfigItems.aws_vpc_cni_custom_networking "true" }}
-        eniConfig:
-          create: true
-          region: "{{.Cluster.Region}}"
-          subnets:
-{{- range $az := .Values.availability_zones }}
-            "{{$az}}":
-              id: "{{ index $.Values.pod_subnets $az }}"
-              securityGroups:
-                - ${EKSWorkerSecurityGroup}
-{{- end}}
-{{- end}}
-        podLabels:
-          application: "kubernetes"
-          component: "aws-node"
-        enableNetworkPolicy: "{{.Cluster.ConfigItems.aws_vpc_cni_enable_network_policy}}"
-        env:
-          NETWORK_POLICY_ENFORCING_MODE: "{{.Cluster.ConfigItems.aws_vpc_cni_network_policy_enforcing_mode}}"
-{{- if eq .Cluster.ConfigItems.eks_ip_family "ipv4" }}
-          ENABLE_PREFIX_DELEGATION: "{{.Cluster.ConfigItems.aws_vpc_cni_prefix_delegation}}"
-{{- end }}
-          AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG: "{{.Cluster.ConfigItems.aws_vpc_cni_custom_networking}}"
-{{- if eq .Cluster.ConfigItems.aws_vpc_cni_custom_networking "true" }}
-          ENI_CONFIG_LABEL_DEF: "topology.kubernetes.io/zone"
-{{- end }}
-      # PodIdentityAssociations:
-      #   - RoleArn: !GetAtt EKSAWSNodeIAMRole.Arn
-      #     ServiceAccount: aws-node
-  EKSAddonPodIdentityAgent:
-    Type: AWS::EKS::Addon
-    Properties:
-      AddonName: eks-pod-identity-agent
-      AddonVersion: "v1.3.10-eksbuild.2"
-      ClusterName: !Ref EKSCluster
-      ConfigurationValues: |
-        {
-          "podLabels": {
-            "application": "kubernetes",
-            "component": "eks-pod-identity-agent"
-          }
+    Type: "STANDARD"
+  {{- if eq .Cluster.Environment "e2e" }}
+EKSAccessEntryManualAdministratorAuth:
+  Type: "AWS::EKS::AccessEntry"
+  Properties:
+    AccessPolicies:
+      - AccessScope:
+          Type: "cluster"
+        PolicyArn: "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+    ClusterName: !Ref EKSCluster
+    PrincipalArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/Manual"
+    Username: !Sub "arn:aws:sts::${AWS::AccountId}:assumed-role/Manual/{{`{{SessionName}}`}}"
+    KubernetesGroups:
+      - zalando:administrator
+    Type: "STANDARD"
+  {{- else }}
+EKSAccessEntryManualAuth:
+  Type: "AWS::EKS::AccessEntry"
+  Properties:
+    ClusterName: !Ref EKSCluster
+    PrincipalArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/Manual"
+    Type: "STANDARD"
+    KubernetesGroups:
+      - zalando:engineer
+  {{- end }}
+EKSAccessEntrySecurityAuth:
+  Type: "AWS::EKS::AccessEntry"
+  Properties:
+    ClusterName: !Ref EKSCluster
+    PrincipalArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/SecAudit"
+    Type: "STANDARD"
+    KubernetesGroups:
+      - zalando:readonly
+EKSAccessEntryReadOnlyAuth:
+  Type: "AWS::EKS::AccessEntry"
+  Properties:
+    ClusterName: !Ref EKSCluster
+    PrincipalArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/ReadOnly"
+    Type: "STANDARD"
+    KubernetesGroups:
+      - zalando:readonly
+  {{- if eq .Cluster.ConfigItems.eks_efs_csi_support_enabled "true" }}
+EKSAddonEFSCSIDriver:
+  Type: AWS::EKS::Addon
+  Properties:
+    AddonName: aws-efs-csi-driver
+    AddonVersion: "v2.1.15-eksbuild.1"
+    ClusterName: !Ref EKSCluster
+    PodIdentityAssociations:
+      - RoleArn: !GetAtt EKSEFSCSIDriverIAMRole.Arn
+        ServiceAccount: efs-csi-controller-sa
+  {{- end }}
+  {{- if eq .Cluster.ConfigItems.eks_s3_csi_support_enabled "true" }}
+EKSAddonS3CSIDriver:
+  Type: AWS::EKS::Addon
+  Properties:
+    AddonName: aws-mountpoint-s3-csi-driver
+    AddonVersion: "v2.3.0-eksbuild.1"
+    ClusterName: !Ref EKSCluster
+  {{- end }}
+EKSAddonAmazonVPCCNI:
+  Type: AWS::EKS::Addon
+  Properties:
+    AddonName: vpc-cni
+    AddonVersion: "v1.21.1-eksbuild.3"
+    ClusterName: !Ref EKSCluster
+    ConfigurationValues: !Sub |
+  {{- if eq .Cluster.ConfigItems.aws_vpc_cni_custom_networking "true" }}
+eniConfig:
+  create: true
+  region: "{{.Cluster.Region}}"
+  subnets:
+  {{- range $az := .Values.availability_zones }}
+"{{$az}}":
+  id: "{{ index $.Values.pod_subnets $az }}"
+  securityGroups:
+    - ${EKSWorkerSecurityGroup}
+  {{- end}}
+  {{- end}}
+podLabels:
+  application: "kubernetes"
+  component: "aws-node"
+enableNetworkPolicy: "{{.Cluster.ConfigItems.aws_vpc_cni_enable_network_policy}}"
+env:
+  NETWORK_POLICY_ENFORCING_MODE: "{{.Cluster.ConfigItems.aws_vpc_cni_network_policy_enforcing_mode}}"
+  {{- if eq .Cluster.ConfigItems.eks_ip_family "ipv4" }}
+ENABLE_PREFIX_DELEGATION: "{{.Cluster.ConfigItems.aws_vpc_cni_prefix_delegation}}"
+  {{- end }}
+AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG: "{{.Cluster.ConfigItems.aws_vpc_cni_custom_networking}}"
+  {{- if eq .Cluster.ConfigItems.aws_vpc_cni_custom_networking "true" }}
+ENI_CONFIG_LABEL_DEF: "topology.kubernetes.io/zone"
+  {{- end }}
+# PodIdentityAssociations:
+#   - RoleArn: !GetAtt EKSAWSNodeIAMRole.Arn
+#     ServiceAccount: aws-node
+EKSAddonPodIdentityAgent:
+  Type: AWS::EKS::Addon
+  Properties:
+    AddonName: eks-pod-identity-agent
+    AddonVersion: "v1.3.10-eksbuild.2"
+    ClusterName: !Ref EKSCluster
+    ConfigurationValues: |
+      {
+        "podLabels": {
+          "application": "kubernetes",
+          "component": "eks-pod-identity-agent"
         }
-  EKSAddonKubeProxy:
-    Type: AWS::EKS::Addon
-    Properties:
-      AddonName: kube-proxy
-      AddonVersion: "v1.34.3-eksbuild.2"
-      ClusterName: !Ref EKSCluster
-      ConfigurationValues: |
-        {
-          "podLabels": {
-            "application": "kubernetes",
-            "component": "kube-proxy"
-          }
+      }
+EKSAddonKubeProxy:
+  Type: AWS::EKS::Addon
+  Properties:
+    AddonName: kube-proxy
+    AddonVersion: "v1.34.3-eksbuild.2"
+    ClusterName: !Ref EKSCluster
+    ConfigurationValues: |
+      {
+        "podLabels": {
+          "application": "kubernetes",
+          "component": "kube-proxy"
         }
+      }
   {{ if eq .Cluster.ConfigItems.eks_node_monitoring_enabled "true" }}
-  EKSAddonNodeMonitoringAgent:
-    Type: AWS::EKS::Addon
-    Properties:
-      AddonName: eks-node-monitoring-agent
-      AddonVersion: "v1.4.3-eksbuild.2"
-      ClusterName: !Ref EKSCluster
+EKSAddonNodeMonitoringAgent:
+  Type: AWS::EKS::Addon
+  Properties:
+    AddonName: eks-node-monitoring-agent
+    AddonVersion: "v1.4.3-eksbuild.2"
+    ClusterName: !Ref EKSCluster
   {{ end }}
 
   {{ if eq .Cluster.Environment "e2e" }}
-  E2EEKSIAMTestRoleReadOnly:
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
+E2EEKSIAMTestRoleReadOnly:
+  Properties:
+    AssumeRolePolicyDocument:
+      Statement:
         - Action:
-          - 'sts:AssumeRole'
-          - 'sts:SetSourceIdentity'
+            - 'sts:AssumeRole'
+            - 'sts:SetSourceIdentity'
           Effect: Allow
           Principal:
             AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
-        Version: 2012-10-17
-      Path: /
-      RoleName: "{{.Cluster.LocalID}}-e2e-eks-iam-test-read-only-role"
-    Type: 'AWS::IAM::Role'
-  E2EEKSIAMTestAccessEntryReadOnly:
-    Type: "AWS::EKS::AccessEntry"
-    Properties:
-      AccessPolicies:
+      Version: 2012-10-17
+    Path: /
+    RoleName: "{{.Cluster.LocalID}}-e2e-eks-iam-test-read-only-role"
+  Type: 'AWS::IAM::Role'
+E2EEKSIAMTestAccessEntryReadOnly:
+  Type: "AWS::EKS::AccessEntry"
+  Properties:
+    AccessPolicies:
       - AccessScope:
           Type: "cluster"
         PolicyArn: "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
-      ClusterName: !Ref EKSCluster
-      PrincipalArn: !GetAtt E2EEKSIAMTestRoleReadOnly.Arn
-      Username: !Join
-          - ''
-          - - !Sub 'arn:aws:sts::${AWS::AccountId}:assumed-role/'
-            - !Ref E2EEKSIAMTestRoleReadOnly
-            - '/{{`{{SessionName}}`}}'
-      KubernetesGroups:
+    ClusterName: !Ref EKSCluster
+    PrincipalArn: !GetAtt E2EEKSIAMTestRoleReadOnly.Arn
+    Username: !Join
+      - ''
+      - - !Sub 'arn:aws:sts::${AWS::AccountId}:assumed-role/'
+        - !Ref E2EEKSIAMTestRoleReadOnly
+        - '/{{`{{SessionName}}`}}'
+    KubernetesGroups:
       - zalando:readonly
-      Type: "STANDARD"
-  E2EEKSIAMTestRoleAdministrator:
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
+    Type: "STANDARD"
+E2EEKSIAMTestRoleAdministrator:
+  Properties:
+    AssumeRolePolicyDocument:
+      Statement:
         - Action:
-          - 'sts:AssumeRole'
-          - 'sts:SetSourceIdentity'
+            - 'sts:AssumeRole'
+            - 'sts:SetSourceIdentity'
           Effect: Allow
           Principal:
             AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
-        Version: 2012-10-17
-      Path: /
-      RoleName: "{{.Cluster.LocalID}}-e2e-eks-iam-test-administrator-role"
-    Type: 'AWS::IAM::Role'
-  E2EEKSIAMTestAccessEntryAdministrator:
-    Type: "AWS::EKS::AccessEntry"
-    Properties:
-      AccessPolicies:
+      Version: 2012-10-17
+    Path: /
+    RoleName: "{{.Cluster.LocalID}}-e2e-eks-iam-test-administrator-role"
+  Type: 'AWS::IAM::Role'
+E2EEKSIAMTestAccessEntryAdministrator:
+  Type: "AWS::EKS::AccessEntry"
+  Properties:
+    AccessPolicies:
       - AccessScope:
           Type: "cluster"
         PolicyArn: "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
-      ClusterName: !Ref EKSCluster
-      PrincipalArn: !GetAtt E2EEKSIAMTestRoleAdministrator.Arn
-      Username: !Join
-          - ''
-          - - !Sub 'arn:aws:sts::${AWS::AccountId}:assumed-role/'
-            - !Ref E2EEKSIAMTestRoleAdministrator
-            - '/{{`{{SessionName}}`}}'
-      KubernetesGroups:
+    ClusterName: !Ref EKSCluster
+    PrincipalArn: !GetAtt E2EEKSIAMTestRoleAdministrator.Arn
+    Username: !Join
+      - ''
+      - - !Sub 'arn:aws:sts::${AWS::AccountId}:assumed-role/'
+        - !Ref E2EEKSIAMTestRoleAdministrator
+        - '/{{`{{SessionName}}`}}'
+    KubernetesGroups:
       - zalando:administrator
-      Type: "STANDARD"
-  E2EEKSIAMTestRoleCollaborator:
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
+    Type: "STANDARD"
+E2EEKSIAMTestRoleCollaborator:
+  Properties:
+    AssumeRolePolicyDocument:
+      Statement:
         - Action:
-          - 'sts:AssumeRole'
-          - 'sts:SetSourceIdentity'
+            - 'sts:AssumeRole'
+            - 'sts:SetSourceIdentity'
           Effect: Allow
           Principal:
             AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
-        Version: 2012-10-17
-      Path: /
-      RoleName: "{{.Cluster.LocalID}}-e2e-eks-iam-test-collaborator-role"
-    Type: 'AWS::IAM::Role'
-  E2EEKSIAMTestAccessEntryCollaborator:
-    Type: "AWS::EKS::AccessEntry"
-    Properties:
-      AccessPolicies:
+      Version: 2012-10-17
+    Path: /
+    RoleName: "{{.Cluster.LocalID}}-e2e-eks-iam-test-collaborator-role"
+  Type: 'AWS::IAM::Role'
+E2EEKSIAMTestAccessEntryCollaborator:
+  Type: "AWS::EKS::AccessEntry"
+  Properties:
+    AccessPolicies:
       - AccessScope:
           Type: "cluster"
         PolicyArn: "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
-      ClusterName: !Ref EKSCluster
-      PrincipalArn: !GetAtt E2EEKSIAMTestRoleCollaborator.Arn
-      Username: !Join
-          - ''
-          - - !Sub 'arn:aws:sts::${AWS::AccountId}:assumed-role/'
-            - !Ref E2EEKSIAMTestRoleCollaborator
-            - '/{{`{{SessionName}}`}}'
-      KubernetesGroups:
+    ClusterName: !Ref EKSCluster
+    PrincipalArn: !GetAtt E2EEKSIAMTestRoleCollaborator.Arn
+    Username: !Join
+      - ''
+      - - !Sub 'arn:aws:sts::${AWS::AccountId}:assumed-role/'
+        - !Ref E2EEKSIAMTestRoleCollaborator
+        - '/{{`{{SessionName}}`}}'
+    KubernetesGroups:
       - zalando:collaborator
-      Type: "STANDARD"
-  E2EEKSIAMTestRoleEngineer:
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
+    Type: "STANDARD"
+E2EEKSIAMTestRoleEngineer:
+  Properties:
+    AssumeRolePolicyDocument:
+      Statement:
         - Action:
-          - 'sts:AssumeRole'
-          - 'sts:SetSourceIdentity'
+            - 'sts:AssumeRole'
+            - 'sts:SetSourceIdentity'
           Effect: Allow
           Principal:
             AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
-        Version: 2012-10-17
-      Path: /
-      RoleName: "{{.Cluster.LocalID}}-e2e-eks-iam-test-engineer-role"
-    Type: 'AWS::IAM::Role'
-  E2EEKSIAMTestAccessEntryEngineer:
-    Type: "AWS::EKS::AccessEntry"
-    Properties:
-      AccessPolicies:
+      Version: 2012-10-17
+    Path: /
+    RoleName: "{{.Cluster.LocalID}}-e2e-eks-iam-test-engineer-role"
+  Type: 'AWS::IAM::Role'
+E2EEKSIAMTestAccessEntryEngineer:
+  Type: "AWS::EKS::AccessEntry"
+  Properties:
+    AccessPolicies:
       - AccessScope:
           Type: "cluster"
         PolicyArn: "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
-      ClusterName: !Ref EKSCluster
-      PrincipalArn: !GetAtt E2EEKSIAMTestRoleEngineer.Arn
-      Username: !Join
-          - ''
-          - - !Sub 'arn:aws:sts::${AWS::AccountId}:assumed-role/'
-            - !Ref E2EEKSIAMTestRoleEngineer
-            - '/{{`{{SessionName}}`}}'
-      KubernetesGroups:
+    ClusterName: !Ref EKSCluster
+    PrincipalArn: !GetAtt E2EEKSIAMTestRoleEngineer.Arn
+    Username: !Join
+      - ''
+      - - !Sub 'arn:aws:sts::${AWS::AccountId}:assumed-role/'
+        - !Ref E2EEKSIAMTestRoleEngineer
+        - '/{{`{{SessionName}}`}}'
+    KubernetesGroups:
       - zalando:engineer
-      Type: "STANDARD"
-  E2EEKSIAMTestRolePostgresAdministrator:
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
+    Type: "STANDARD"
+E2EEKSIAMTestRolePostgresAdministrator:
+  Properties:
+    AssumeRolePolicyDocument:
+      Statement:
         - Action:
-          - 'sts:AssumeRole'
-          - 'sts:SetSourceIdentity'
+            - 'sts:AssumeRole'
+            - 'sts:SetSourceIdentity'
           Effect: Allow
           Principal:
             AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
-        Version: 2012-10-17
-      Path: /
-      RoleName: "{{.Cluster.LocalID}}-e2e-eks-iam-test-postgres-admin-role"
-    Type: 'AWS::IAM::Role'
-  E2EEKSIAMTestAccessEntryPostgresAdministrator:
-    Type: "AWS::EKS::AccessEntry"
-    Properties:
-      AccessPolicies:
+      Version: 2012-10-17
+    Path: /
+    RoleName: "{{.Cluster.LocalID}}-e2e-eks-iam-test-postgres-admin-role"
+  Type: 'AWS::IAM::Role'
+E2EEKSIAMTestAccessEntryPostgresAdministrator:
+  Type: "AWS::EKS::AccessEntry"
+  Properties:
+    AccessPolicies:
       - AccessScope:
           Type: "cluster"
         PolicyArn: "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
-      ClusterName: !Ref EKSCluster
-      PrincipalArn: !GetAtt E2EEKSIAMTestRolePostgresAdministrator.Arn
-      Username: !Join
-          - ''
-          - - !Sub 'arn:aws:sts::${AWS::AccountId}:assumed-role/'
-            - !Ref E2EEKSIAMTestRolePostgresAdministrator
-            - '/{{`{{SessionName}}`}}'
-      KubernetesGroups:
+    ClusterName: !Ref EKSCluster
+    PrincipalArn: !GetAtt E2EEKSIAMTestRolePostgresAdministrator.Arn
+    Username: !Join
+      - ''
+      - - !Sub 'arn:aws:sts::${AWS::AccountId}:assumed-role/'
+        - !Ref E2EEKSIAMTestRolePostgresAdministrator
+        - '/{{`{{SessionName}}`}}'
+    KubernetesGroups:
       - zalando:postgres-admin
-      Type: "STANDARD"
+    Type: "STANDARD"
   {{ end }}
-  # TODO: IAM POLICY
-  EKSCNIIPv6Policy:
-    Type: AWS::IAM::ManagedPolicy
-    Properties:
-      # PolicyName: "{{.Cluster.LocalID}}-eks-cni-ipv6"
-      PolicyDocument:
-        Version: "2012-10-17"
-        Statement:
+# TODO: IAM POLICY
+EKSCNIIPv6Policy:
+  Type: AWS::IAM::ManagedPolicy
+  Properties:
+    # PolicyName: "{{.Cluster.LocalID}}-eks-cni-ipv6"
+    PolicyDocument:
+      Version: "2012-10-17"
+      Statement:
         - Effect: Allow
           Action:
-          - "ec2:AssignIpv6Addresses"
-          - "ec2:DescribeInstances"
-          - "ec2:DescribeTags"
-          - "ec2:DescribeNetworkInterfaces"
-          - "ec2:DescribeInstanceTypes"
+            - "ec2:AssignIpv6Addresses"
+            - "ec2:DescribeInstances"
+            - "ec2:DescribeTags"
+            - "ec2:DescribeNetworkInterfaces"
+            - "ec2:DescribeInstanceTypes"
           Resource: "*"
         - Effect: Allow
           Action:
-          - "ec2:CreateTags"
+            - "ec2:CreateTags"
           Resource:
-          - "arn:aws:ec2:*:*:network-interface/*"
-  EKSAWSNodeIAMRole:
-    Type: AWS::IAM::Role
-    Properties:
-      RoleName: "{{.Cluster.LocalID}}-aws-node"
-      AssumeRolePolicyDocument: {
-            "Version": "2012-10-17",
-            "Statement": [
-              {
-                "Effect": "Allow",
-                "Principal": {
-                  "Service": [
-                    "ec2.amazonaws.com"
-                  ]
-                },
-                "Action": [
-                  "sts:AssumeRole"
-                ]
-              },
-              {
-                "Sid": "AllowEksAuthToAssumeRoleForPodIdentity",
-                "Effect": "Allow",
-                "Principal": {
-                    "Service": "pods.eks.amazonaws.com"
-                },
-                "Action": [
-                    "sts:AssumeRole",
-                    "sts:TagSession"
-                ]
-              }
+            - "arn:aws:ec2:*:*:network-interface/*"
+EKSAWSNodeIAMRole:
+  Type: AWS::IAM::Role
+  Properties:
+    RoleName: "{{.Cluster.LocalID}}-aws-node"
+    AssumeRolePolicyDocument: {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "Service": [
+              "ec2.amazonaws.com"
             ]
-          }
-      Path: /
-      ManagedPolicyArns:
-{{- if eq .Cluster.ConfigItems.eks_ip_family "ipv4" }}
-      - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
-{{- else }}
-      - !Ref EKSCNIIPv6Policy
-{{- end }}
-  EKSAWSNodePodIdentity:
-    Type: "AWS::EKS::PodIdentityAssociation"
-    Properties:
-      ClusterName: !Ref EKSCluster
-      Namespace: kube-system
-      RoleArn: !GetAtt EKSAWSNodeIAMRole.Arn
-      ServiceAccount: aws-node
-{{- if eq .Cluster.ConfigItems.eks_efs_csi_support_enabled "true" }}
-  EKSEFSCSIDriverIAMRole:
-    Type: AWS::IAM::Role
-    Properties:
-      RoleName: "{{.Cluster.LocalID}}-aws-efs-csi-driver"
-      AssumeRolePolicyDocument: {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-                "Effect": "Allow",
-                "Principal": {
-                    "Service": "pods.eks.amazonaws.com"
-                },
-                "Action": [
-                    "sts:AssumeRole",
-                    "sts:TagSession"
-                ]
-            }
-        ]
-      }
-      Path: /
-      ManagedPolicyArns:
+          },
+          "Action": [
+            "sts:AssumeRole"
+          ]
+        },
+        {
+          "Sid": "AllowEksAuthToAssumeRoleForPodIdentity",
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "pods.eks.amazonaws.com"
+          },
+          "Action": [
+            "sts:AssumeRole",
+            "sts:TagSession"
+          ]
+        }
+      ]
+    }
+    Path: /
+    ManagedPolicyArns:
+  {{- if eq .Cluster.ConfigItems.eks_ip_family "ipv4" }}
+- arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+  {{- else }}
+- !Ref EKSCNIIPv6Policy
+  {{- end }}
+EKSAWSNodePodIdentity:
+  Type: "AWS::EKS::PodIdentityAssociation"
+  Properties:
+    ClusterName: !Ref EKSCluster
+    Namespace: kube-system
+    RoleArn: !GetAtt EKSAWSNodeIAMRole.Arn
+    ServiceAccount: aws-node
+  {{- if eq .Cluster.ConfigItems.eks_efs_csi_support_enabled "true" }}
+EKSEFSCSIDriverIAMRole:
+  Type: AWS::IAM::Role
+  Properties:
+    RoleName: "{{.Cluster.LocalID}}-aws-efs-csi-driver"
+    AssumeRolePolicyDocument: {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "pods.eks.amazonaws.com"
+          },
+          "Action": [
+            "sts:AssumeRole",
+            "sts:TagSession"
+          ]
+        }
+      ]
+    }
+    Path: /
+    ManagedPolicyArns:
       - arn:aws:iam::aws:policy/service-role/AmazonEFSCSIDriverPolicy
-  EFSFileSystem:
-    Type: AWS::EFS::FileSystem
-    Properties:
-      Encrypted: true
-      FileSystemTags:
+EFSFileSystem:
+  Type: AWS::EFS::FileSystem
+  Properties:
+    Encrypted: true
+    FileSystemTags:
       - Key: Name
         Value: "Default EFS for {{.Cluster.Alias}}"
   {{ with $values := .Values }}
   {{ range $index, $az := $values.availability_zones }}
-  EFSMountTargetZone{{$index}}:
-    Type: AWS::EFS::MountTarget
-    Properties:
-      FileSystemId: !Ref EFSFileSystem
-      SubnetId: "{{ index $values.subnets $az }}"
-      SecurityGroups:
+EFSMountTargetZone{{$index}}:
+  Type: AWS::EFS::MountTarget
+  Properties:
+    FileSystemId: !Ref EFSFileSystem
+    SubnetId: "{{ index $values.subnets $az }}"
+    SecurityGroups:
       - !Ref EKSWorkerSecurityGroup
   {{ end }}
   {{ end }}
-{{- end }}
-  EKSZalandoIAMProxyIAMRole:
-    Type: AWS::IAM::Role
-    Properties:
-      RoleName: "{{.Cluster.LocalID}}-zalando-iam-aws-proxy"
-      AssumeRolePolicyDocument: !Sub
-        - |
-          {
-            "Version": "2012-10-17",
-            "Statement": [
-              {
-                "Effect": "Allow",
-                "Principal": {
-                  "Service": [
-                    "ec2.amazonaws.com"
-                  ]
-                },
-                "Action": [
-                  "sts:AssumeRole"
+  {{- end }}
+EKSZalandoIAMProxyIAMRole:
+  Type: AWS::IAM::Role
+  Properties:
+    RoleName: "{{.Cluster.LocalID}}-zalando-iam-aws-proxy"
+    AssumeRolePolicyDocument: !Sub
+      - |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "ec2.amazonaws.com"
                 ]
               },
-              {
-                "Effect": "Allow",
-                "Principal": {
-                  "Federated": [
-                    "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
-                  ]
-                },
-                "Action": [
-                  "sts:AssumeRoleWithWebIdentity"
-                ],
-                "Condition": {
-                  "StringEquals": {
-                    "${OIDC}:sub": "system:serviceaccount:kube-system:zalando-iam-aws-proxy"
-                  }
+              "Action": [
+                "sts:AssumeRole"
+              ]
+            },
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Federated": [
+                  "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
+                ]
+              },
+              "Action": [
+                "sts:AssumeRoleWithWebIdentity"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "${OIDC}:sub": "system:serviceaccount:kube-system:zalando-iam-aws-proxy"
                 }
               }
-            ]
-          }
-        - OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
-      Path: /
-      Policies:
+            }
+          ]
+        }
+      - OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
+    Path: /
+    Policies:
       - PolicyDocument:
           Statement:
             - Action: "sts:AssumeRole"
@@ -724,2868 +724,2858 @@ Resources:
               Resource: "*"
           Version: 2012-10-17
         PolicyName: root
-  EKSZalandoIAMIAMRole:
-    Type: AWS::IAM::Role
-    Properties:
-      RoleName: "{{.Cluster.LocalID}}-zalando-iam"
-      Path: /
-      AssumeRolePolicyDocument:
-        Statement:
-          - Effect: Allow
-            Principal:
-              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
-            Action:
-              - 'sts:AssumeRole'
-              - 'sts:SetSourceIdentity'
-        Version: '2012-10-17'
-  EKSOIDCProvider:
-    Type: AWS::IAM::OIDCProvider
-    Properties:
-      ClientIdList:
+EKSZalandoIAMIAMRole:
+  Type: AWS::IAM::Role
+  Properties:
+    RoleName: "{{.Cluster.LocalID}}-zalando-iam"
+    Path: /
+    AssumeRolePolicyDocument:
+      Statement:
+        - Effect: Allow
+          Principal:
+            AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+          Action:
+            - 'sts:AssumeRole'
+            - 'sts:SetSourceIdentity'
+      Version: '2012-10-17'
+EKSOIDCProvider:
+  Type: AWS::IAM::OIDCProvider
+  Properties:
+    ClientIdList:
       - "sts.amazonaws.com"
-      Url: !GetAtt EKSCluster.OpenIdConnectIssuerUrl
-      ThumbprintList:
+    Url: !GetAtt EKSCluster.OpenIdConnectIssuerUrl
+    ThumbprintList:
       # SHA-1 sum of the root certificate in the trust chain for the certificate
       # use to serve the open id discovery document.
       - "9e99a48a9960b14926bb7f3b02e22da2b0ab7280"
-{{ else }}
-{{ if ne .Cluster.ConfigItems.delete_vpc_resources "true" }}
-  EtcdClusterSecurityGroupIngressFromMaster:
-    Type: 'AWS::EC2::SecurityGroupIngress'
-    Properties:
-      FromPort: 2379
-      ToPort: 2379
-      GroupId: !ImportValue '{{.Cluster.ConfigItems.etcd_stack_name}}:etcd-security-group-id'
-      IpProtocol: tcp
-      SourceSecurityGroupId: !Ref MasterSecurityGroup
-  EtcdClusterSecurityGroupTLSIngressFromMaster:
-    Type: 'AWS::EC2::SecurityGroupIngress'
-    Properties:
-      FromPort: 2479
-      ToPort: 2479
-      GroupId: !ImportValue '{{.Cluster.ConfigItems.etcd_stack_name}}:etcd-security-group-id'
-      IpProtocol: tcp
-      SourceSecurityGroupId: !Ref MasterSecurityGroup
-  MasterKubeletToMasterKubeletSecurityGroup:
-    Properties:
-      FromPort: 10250
-      GroupId: !Ref MasterSecurityGroup
-      IpProtocol: tcp
-      SourceSecurityGroupId: !Ref MasterSecurityGroup
-      ToPort: 10250
-    Type: 'AWS::EC2::SecurityGroupIngress'
-{{- if or (eq .Cluster.ConfigItems.control_plane_load_balancer_internal "pre") (eq .Cluster.ConfigItems.control_plane_load_balancer_internal "serving") (eq .Cluster.ConfigItems.control_plane_load_balancer_internal "active") }}
-  ControlPlaneInternalLB:
-    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
-    Properties:
-      Name: "{{.Cluster.LocalID}}-nlb-internal"
-      LoadBalancerAttributes:
-        - Key: load_balancing.cross_zone.enabled
-          Value: true
-      Scheme: internal
-      Subnets:
+  {{ else }}
+  {{ if ne .Cluster.ConfigItems.delete_vpc_resources "true" }}
+EtcdClusterSecurityGroupIngressFromMaster:
+  Type: 'AWS::EC2::SecurityGroupIngress'
+  Properties:
+    FromPort: 2379
+    ToPort: 2379
+    GroupId: !ImportValue '{{.Cluster.ConfigItems.etcd_stack_name}}:etcd-security-group-id'
+    IpProtocol: tcp
+    SourceSecurityGroupId: !Ref MasterSecurityGroup
+EtcdClusterSecurityGroupTLSIngressFromMaster:
+  Type: 'AWS::EC2::SecurityGroupIngress'
+  Properties:
+    FromPort: 2479
+    ToPort: 2479
+    GroupId: !ImportValue '{{.Cluster.ConfigItems.etcd_stack_name}}:etcd-security-group-id'
+    IpProtocol: tcp
+    SourceSecurityGroupId: !Ref MasterSecurityGroup
+MasterKubeletToMasterKubeletSecurityGroup:
+  Properties:
+    FromPort: 10250
+    GroupId: !Ref MasterSecurityGroup
+    IpProtocol: tcp
+    SourceSecurityGroupId: !Ref MasterSecurityGroup
+    ToPort: 10250
+  Type: 'AWS::EC2::SecurityGroupIngress'
+  {{- if or (eq .Cluster.ConfigItems.control_plane_load_balancer_internal "pre") (eq .Cluster.ConfigItems.control_plane_load_balancer_internal "serving") (eq .Cluster.ConfigItems.control_plane_load_balancer_internal "active") }}
+ControlPlaneInternalLB:
+  Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+  Properties:
+    Name: "{{.Cluster.LocalID}}-nlb-internal"
+    LoadBalancerAttributes:
+      - Key: load_balancing.cross_zone.enabled
+        Value: true
+    Scheme: internal
+    Subnets:
   {{ with $values := .Values }}
   {{ range $az := $values.availability_zones }}
-        - "{{ index $values.lb_subnets $az }}"
+- "{{ index $values.lb_subnets $az }}"
   {{ end }}
   {{ end }}
-      Tags:
-        - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
-          Value: owned
-        - Key: "component"
-          Value: "kube-apiserver"
-      Type: network
-  ControlPlaneInternalLBTargetGroup:
-    Type: AWS::ElasticLoadBalancingV2::TargetGroup
-    Properties:
-      HealthCheckIntervalSeconds: 10
-      HealthCheckPort: 8443
-      HealthCheckProtocol: HTTPS
-      HealthCheckPath: "/readyz"
-      HealthyThresholdCount: 2
-      UnhealthyThresholdCount: 2
-      Name: "{{.Cluster.LocalID}}-nlb-internal"
-      Port: 8443
-      Protocol: TLS
-      Tags:
-        - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
-          Value: owned
-        - Key: "component"
-          Value: "kube-apiserver"
-      VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
-      TargetGroupAttributes:
-        - Key: deregistration_delay.timeout_seconds
-          Value: 60
-        - Key: preserve_client_ip.enabled
-          Value: "false"
-  ControlPlaneInternalLBListener:
-    Type: AWS::ElasticLoadBalancingV2::Listener
-    Properties:
-      AlpnPolicy:
-        - {{ if eq .Cluster.ConfigItems.experimental_nlb_alpn_h2_enabled "true" }}HTTP2Preferred{{else}}None{{end}}
-      SslPolicy: "ELBSecurityPolicy-TLS13-1-2-2021-06"
-      Certificates:
-        - CertificateArn: "{{.Values.load_balancer_certificate}}"
-      DefaultActions:
+Tags:
+  - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
+    Value: owned
+  - Key: "component"
+    Value: "kube-apiserver"
+Type: network
+ControlPlaneInternalLBTargetGroup:
+  Type: AWS::ElasticLoadBalancingV2::TargetGroup
+  Properties:
+    HealthCheckIntervalSeconds: 10
+    HealthCheckPort: 8443
+    HealthCheckProtocol: HTTPS
+    HealthCheckPath: "/readyz"
+    HealthyThresholdCount: 2
+    UnhealthyThresholdCount: 2
+    Name: "{{.Cluster.LocalID}}-nlb-internal"
+    Port: 8443
+    Protocol: TLS
+    Tags:
+      - Key: 'kubernetes.io/cluster/{{.Cluster.ID}}'
+        Value: owned
+      - Key: "component"
+        Value: "kube-apiserver"
+    VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
+    TargetGroupAttributes:
+      - Key: deregistration_delay.timeout_seconds
+        Value: 60
+      - Key: preserve_client_ip.enabled
+        Value: "false"
+ControlPlaneInternalLBListener:
+  Type: AWS::ElasticLoadBalancingV2::Listener
+  Properties:
+    AlpnPolicy:
+      - {{ if eq .Cluster.ConfigItems.experimental_nlb_alpn_h2_enabled "true" }}HTTP2Preferred{{else}}None{{end}}
+    SslPolicy: "ELBSecurityPolicy-TLS13-1-2-2021-06"
+    Certificates:
+      - CertificateArn: "{{.Values.load_balancer_certificate}}"
+    DefaultActions:
       - Type: forward
         TargetGroupArn: !Ref ControlPlaneInternalLBTargetGroup
-      LoadBalancerArn: !Ref ControlPlaneInternalLB
-      Port: 443
-      Protocol: TLS
-  ControlPlaneInternalLBVersionDomain:
-    Properties:
-      AliasTarget:
-        DNSName: !GetAtt
-          - ControlPlaneInternalLB
-          - DNSName
-        HostedZoneId: !GetAtt
-          - ControlPlaneInternalLB
-          - CanonicalHostedZoneID
-      HostedZoneName: "{{.Values.hosted_zone}}."
-      Name: "{{.Cluster.LocalID}}-internal.{{.Values.hosted_zone}}."
-      Type: A
-    Type: 'AWS::Route53::RecordSet'
-{{- end  }}
-  MasterLoadBalancerNLB:
-    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
-    Properties:
-      Name: "{{.Cluster.LocalID}}-nlb"
-      LoadBalancerAttributes:
-        - Key: load_balancing.cross_zone.enabled
-          Value: true
-      Scheme: internet-facing
-      Subnets:
+    LoadBalancerArn: !Ref ControlPlaneInternalLB
+    Port: 443
+    Protocol: TLS
+ControlPlaneInternalLBVersionDomain:
+  Properties:
+    AliasTarget:
+      DNSName: !GetAtt
+        - ControlPlaneInternalLB
+        - DNSName
+      HostedZoneId: !GetAtt
+        - ControlPlaneInternalLB
+        - CanonicalHostedZoneID
+    HostedZoneName: "{{.Values.hosted_zone}}."
+    Name: "{{.Cluster.LocalID}}-internal.{{.Values.hosted_zone}}."
+    Type: A
+  Type: 'AWS::Route53::RecordSet'
+  {{- end  }}
+MasterLoadBalancerNLB:
+  Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+  Properties:
+    Name: "{{.Cluster.LocalID}}-nlb"
+    LoadBalancerAttributes:
+      - Key: load_balancing.cross_zone.enabled
+        Value: true
+    Scheme: internet-facing
+    Subnets:
   {{ with $values := .Values }}
   {{ range $az := $values.availability_zones }}
-        - "{{ index $values.lb_subnets $az }}"
+- "{{ index $values.lb_subnets $az }}"
   {{ end }}
   {{ end }}
-      Tags:
-        - Key: "component"
-          Value: "kube-apiserver"
-      Type: network
-  MasterLoadBalancerNLBTargetGroup:
-    Type: AWS::ElasticLoadBalancingV2::TargetGroup
-    Properties:
-      HealthCheckIntervalSeconds: 10
-      HealthCheckPort: 8443
-      HealthCheckProtocol: HTTPS
-      HealthCheckPath: "/readyz"
-      HealthyThresholdCount: 2
-      UnhealthyThresholdCount: 2
-      Name: "{{.Cluster.LocalID}}-nlb"
-      Port: 8443
-      Protocol: TLS
-      Tags:
-        - Key: "component"
-          Value: "kube-apiserver"
-      VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
-      TargetGroupAttributes:
-        - Key: deregistration_delay.timeout_seconds
-          Value: 60
-        - Key: preserve_client_ip.enabled
-          Value: "false"
-  MasterLoadBalancerNLBListener:
-    Type: AWS::ElasticLoadBalancingV2::Listener
-    Properties:
-      AlpnPolicy:
-        - {{ if eq .Cluster.ConfigItems.experimental_nlb_alpn_h2_enabled "true" }}HTTP2Preferred{{else}}None{{end}}
-      SslPolicy: "ELBSecurityPolicy-TLS13-1-2-2021-06"
-      Certificates:
-        - CertificateArn: "{{.Values.load_balancer_certificate}}"
-      DefaultActions:
+Tags:
+  - Key: "component"
+    Value: "kube-apiserver"
+Type: network
+MasterLoadBalancerNLBTargetGroup:
+  Type: AWS::ElasticLoadBalancingV2::TargetGroup
+  Properties:
+    HealthCheckIntervalSeconds: 10
+    HealthCheckPort: 8443
+    HealthCheckProtocol: HTTPS
+    HealthCheckPath: "/readyz"
+    HealthyThresholdCount: 2
+    UnhealthyThresholdCount: 2
+    Name: "{{.Cluster.LocalID}}-nlb"
+    Port: 8443
+    Protocol: TLS
+    Tags:
+      - Key: "component"
+        Value: "kube-apiserver"
+    VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
+    TargetGroupAttributes:
+      - Key: deregistration_delay.timeout_seconds
+        Value: 60
+      - Key: preserve_client_ip.enabled
+        Value: "false"
+MasterLoadBalancerNLBListener:
+  Type: AWS::ElasticLoadBalancingV2::Listener
+  Properties:
+    AlpnPolicy:
+      - {{ if eq .Cluster.ConfigItems.experimental_nlb_alpn_h2_enabled "true" }}HTTP2Preferred{{else}}None{{end}}
+    SslPolicy: "ELBSecurityPolicy-TLS13-1-2-2021-06"
+    Certificates:
+      - CertificateArn: "{{.Values.load_balancer_certificate}}"
+    DefaultActions:
       - Type: forward
         TargetGroupArn: !Ref MasterLoadBalancerNLBTargetGroup
-      LoadBalancerArn: !Ref MasterLoadBalancerNLB
-      Port: 443
-      Protocol: TLS
-  MasterLoadBalancerVersionDomain:
-    Properties:
-      AliasTarget:
-        DNSName: !GetAtt
-          - MasterLoadBalancerNLB
-          - DNSName
-        HostedZoneId: !GetAtt
-          - MasterLoadBalancerNLB
-          - CanonicalHostedZoneID
-      HostedZoneName: "{{.Values.hosted_zone}}."
-      Name: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}."
-      Type: A
-    Type: 'AWS::Route53::RecordSet'
-  MasterSecurityGroup:
-    Properties:
-      GroupDescription: !Ref 'AWS::StackName'
-      SecurityGroupIngress:
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 8443
-          IpProtocol: tcp
-          ToPort: 8443
-        - CidrIp: 0.0.0.0/0
-          FromPort: -1
-          IpProtocol: icmp
-          ToPort: -1
-        - CidrIp: {{ if eq .Cluster.ConfigItems.ssh_vpc_only "true" }}"{{.Values.vpc_ipv4_cidr}}"{{ else }}"0.0.0.0/0"{{ end }}
-          FromPort: 22
-          IpProtocol: tcp
-          ToPort: 22
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 7980
-          IpProtocol: tcp
-          ToPort: 7980
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 30080
-          IpProtocol: tcp
-          ToPort: 30080
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 9054
-          IpProtocol: tcp
-          ToPort: 9054
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 9153
-          IpProtocol: tcp
-          ToPort: 9153
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 53
-          IpProtocol: tcp
-          ToPort: 53
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 53
-          IpProtocol: udp
-          ToPort: 53
-      VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
-    Type: 'AWS::EC2::SecurityGroup'
-  MasterSecurityGroupIngressFromFlannelToMaster:
-    Properties:
-      FromPort: 8472
-      GroupId: !Ref MasterSecurityGroup
-      IpProtocol: udp
-      SourceSecurityGroupId: !Ref WorkerSecurityGroup
-      ToPort: 8472
-    Type: 'AWS::EC2::SecurityGroupIngress'
-  MasterSecurityGroupIngressFromMasterFlannelToMaster:
-    Properties:
-      FromPort: 8472
-      GroupId: !Ref MasterSecurityGroup
-      IpProtocol: udp
-      SourceSecurityGroupId: !Ref MasterSecurityGroup
-      ToPort: 8472
-    Type: 'AWS::EC2::SecurityGroupIngress'
-  MasterSecurityGroupIngressFromMaster:
-    Properties:
-      FromPort: 443
-      GroupId: !Ref MasterSecurityGroup
-      IpProtocol: tcp
-      SourceSecurityGroupId: !Ref MasterSecurityGroup
-      ToPort: 443
-    Type: 'AWS::EC2::SecurityGroupIngress'
-  MasterSecurityGroupIngressFromWorker:
-    Properties:
-      FromPort: 443
-      GroupId: !Ref MasterSecurityGroup
-      IpProtocol: tcp
-      SourceSecurityGroupId: !Ref WorkerSecurityGroup
-      ToPort: 443
-    Type: 'AWS::EC2::SecurityGroupIngress'
-  MasterSecurityGroupIngressFromWorkerToMasterKubeletAndKubeProxy:
-    Properties:
-      FromPort: 10249 # KubeProxy
-      GroupId: !Ref MasterSecurityGroup
-      IpProtocol: tcp
-      SourceSecurityGroupId: !Ref WorkerSecurityGroup
-      ToPort: 10250 # Kubelet
-    Type: 'AWS::EC2::SecurityGroupIngress'
-  MasterSecurityGroupIngressFromWorkerToNodeMonitor:
-    Properties:
-      FromPort: 9100
-      ToPort: 9101
-      GroupId: !Ref MasterSecurityGroup
-      IpProtocol: tcp
-      SourceSecurityGroupId: !Ref WorkerSecurityGroup
-    Type: 'AWS::EC2::SecurityGroupIngress'
-  MasterSecurityGroupIngressFromWorkerToSkipperMetrics:
-    Properties:
-      FromPort: 9005
-      ToPort: 9005
-      GroupId: !Ref MasterSecurityGroup
-      IpProtocol: tcp
-      SourceSecurityGroupId: !Ref WorkerSecurityGroup
-    Type: 'AWS::EC2::SecurityGroupIngress'
-  WorkerSecurityGroup:
-    Properties:
-      GroupDescription: !Ref 'AWS::StackName'
-      SecurityGroupIngress:
-        - CidrIp: 0.0.0.0/0
-          FromPort: -1
-          IpProtocol: icmp
-          ToPort: -1
-        - CidrIp: {{ if eq .Cluster.ConfigItems.ssh_vpc_only "true" }}"{{.Values.vpc_ipv4_cidr}}"{{ else }}"0.0.0.0/0"{{ end }}
-          FromPort: 22
-          IpProtocol: tcp
-          ToPort: 22
-{{- if index .Cluster.ConfigItems "open_sg_ingress_ranges" }}
-{{- range $index, $element := sgIngressRanges .Cluster.ConfigItems.open_sg_ingress_ranges }}
-        - CidrIp: {{ $element.CIDR }}
-          FromPort: {{ $element.FromPort }}
-          IpProtocol: {{ $element.Protocol }}
-          ToPort: {{ $element.ToPort }}
-{{- end }}
-{{- end }}
-        - CidrIp: "0.0.0.0/0"
-          FromPort: 9998
-          IpProtocol: tcp
-          ToPort: 9999
-{{- if eq .Cluster.ConfigItems.skipper_ingress_redis_swim_enabled "true" }}
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 9990
-          IpProtocol: tcp
-          ToPort: 9990
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 9990
-          IpProtocol: udp
-          ToPort: 9990
-{{- end }}
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 10248
-          IpProtocol: tcp
-          ToPort: 10248
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 9054
-          IpProtocol: tcp
-          ToPort: 9054
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 9153
-          IpProtocol: tcp
-          ToPort: 9153
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 10250
-          IpProtocol: tcp
-          ToPort: 10250
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 30000
-          IpProtocol: tcp
-          ToPort: 32767
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 53
-          IpProtocol: tcp
-          ToPort: 53
-        - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-          FromPort: 53
-          IpProtocol: udp
-          ToPort: 53
-      Tags:
-        - Key: 'karpenter.sh/discovery'
-          Value: '{{ .Cluster.ID }}/WorkerNodeSecurityGroup'
-      VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
-    Type: 'AWS::EC2::SecurityGroup'
-  WorkerSecurityGroupIngressFromMasterToFlannel:
-    Properties:
-      FromPort: 8472
-      GroupId: !Ref WorkerSecurityGroup
-      IpProtocol: udp
-      SourceSecurityGroupId: !Ref MasterSecurityGroup
-      ToPort: 8472
-    Type: 'AWS::EC2::SecurityGroupIngress'
-  WorkerSecurityGroupIngressFromMasterToKubelet:
-    Properties:
-      FromPort: 10250
-      GroupId: !Ref WorkerSecurityGroup
-      IpProtocol: tcp
-      SourceSecurityGroupId: !Ref MasterSecurityGroup
-      ToPort: 10250
-    Type: 'AWS::EC2::SecurityGroupIngress'
-  WorkerSecurityGroupWorkerToWorker:
-    Type: AWS::EC2::SecurityGroupIngress
-    Properties:
-      IpProtocol: "-1"
-      GroupId: !Ref WorkerSecurityGroup
-      SourceSecurityGroupId: !Ref WorkerSecurityGroup
-  EFSSecurityGroupIngressFromWorkerSecurityGroup:
-    Properties:
-      FromPort: 2049
-      GroupId: !Ref EFSWorkerSecurityGroup
-      IpProtocol: tcp
-      SourceSecurityGroupId: !Ref WorkerSecurityGroup
-      ToPort: 2049
-    Type: 'AWS::EC2::SecurityGroupIngress'
-{{- if eq .Cluster.ConfigItems.efs_allow_vpc_connection "true" }}
-  EFSSecurityGroupIngressFromVPCCIDR:
-    Properties:
-      FromPort: 2049
-      GroupId: !Ref EFSWorkerSecurityGroup
-      IpProtocol: tcp
-      CidrIp: "{{.Values.vpc_ipv4_cidr}}"
-      ToPort: 2049
-    Type: 'AWS::EC2::SecurityGroupIngress'
-{{- end }}
-  EFSWorkerSecurityGroup:
-    Properties:
-      GroupDescription: worker to EFS sg
-      VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
-    Type: 'AWS::EC2::SecurityGroup'
+    LoadBalancerArn: !Ref MasterLoadBalancerNLB
+    Port: 443
+    Protocol: TLS
+MasterLoadBalancerVersionDomain:
+  Properties:
+    AliasTarget:
+      DNSName: !GetAtt
+        - MasterLoadBalancerNLB
+        - DNSName
+      HostedZoneId: !GetAtt
+        - MasterLoadBalancerNLB
+        - CanonicalHostedZoneID
+    HostedZoneName: "{{.Values.hosted_zone}}."
+    Name: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}."
+    Type: A
+  Type: 'AWS::Route53::RecordSet'
+MasterSecurityGroup:
+  Properties:
+    GroupDescription: !Ref 'AWS::StackName'
+    SecurityGroupIngress:
+      - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+        FromPort: 8443
+        IpProtocol: tcp
+        ToPort: 8443
+      - CidrIp: 0.0.0.0/0
+        FromPort: -1
+        IpProtocol: icmp
+        ToPort: -1
+      - CidrIp: {{ if eq .Cluster.ConfigItems.ssh_vpc_only "true" }}"{{.Values.vpc_ipv4_cidr}}"{{ else }}"0.0.0.0/0"{{ end }}
+        FromPort: 22
+        IpProtocol: tcp
+        ToPort: 22
+      - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+        FromPort: 7980
+        IpProtocol: tcp
+        ToPort: 7980
+      - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+        FromPort: 30080
+        IpProtocol: tcp
+        ToPort: 30080
+      - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+        FromPort: 9054
+        IpProtocol: tcp
+        ToPort: 9054
+      - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+        FromPort: 9153
+        IpProtocol: tcp
+        ToPort: 9153
+      - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+        FromPort: 53
+        IpProtocol: tcp
+        ToPort: 53
+      - CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+        FromPort: 53
+        IpProtocol: udp
+        ToPort: 53
+    VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
+  Type: 'AWS::EC2::SecurityGroup'
+MasterSecurityGroupIngressFromFlannelToMaster:
+  Properties:
+    FromPort: 8472
+    GroupId: !Ref MasterSecurityGroup
+    IpProtocol: udp
+    SourceSecurityGroupId: !Ref WorkerSecurityGroup
+    ToPort: 8472
+  Type: 'AWS::EC2::SecurityGroupIngress'
+MasterSecurityGroupIngressFromMasterFlannelToMaster:
+  Properties:
+    FromPort: 8472
+    GroupId: !Ref MasterSecurityGroup
+    IpProtocol: udp
+    SourceSecurityGroupId: !Ref MasterSecurityGroup
+    ToPort: 8472
+  Type: 'AWS::EC2::SecurityGroupIngress'
+MasterSecurityGroupIngressFromMaster:
+  Properties:
+    FromPort: 443
+    GroupId: !Ref MasterSecurityGroup
+    IpProtocol: tcp
+    SourceSecurityGroupId: !Ref MasterSecurityGroup
+    ToPort: 443
+  Type: 'AWS::EC2::SecurityGroupIngress'
+MasterSecurityGroupIngressFromWorker:
+  Properties:
+    FromPort: 443
+    GroupId: !Ref MasterSecurityGroup
+    IpProtocol: tcp
+    SourceSecurityGroupId: !Ref WorkerSecurityGroup
+    ToPort: 443
+  Type: 'AWS::EC2::SecurityGroupIngress'
+MasterSecurityGroupIngressFromWorkerToMasterKubeletAndKubeProxy:
+  Properties:
+    FromPort: 10249 # KubeProxy
+    GroupId: !Ref MasterSecurityGroup
+    IpProtocol: tcp
+    SourceSecurityGroupId: !Ref WorkerSecurityGroup
+    ToPort: 10250 # Kubelet
+  Type: 'AWS::EC2::SecurityGroupIngress'
+MasterSecurityGroupIngressFromWorkerToNodeMonitor:
+  Properties:
+    FromPort: 9100
+    ToPort: 9101
+    GroupId: !Ref MasterSecurityGroup
+    IpProtocol: tcp
+    SourceSecurityGroupId: !Ref WorkerSecurityGroup
+  Type: 'AWS::EC2::SecurityGroupIngress'
+MasterSecurityGroupIngressFromWorkerToSkipperMetrics:
+  Properties:
+    FromPort: 9005
+    ToPort: 9005
+    GroupId: !Ref MasterSecurityGroup
+    IpProtocol: tcp
+    SourceSecurityGroupId: !Ref WorkerSecurityGroup
+  Type: 'AWS::EC2::SecurityGroupIngress'
+WorkerSecurityGroup:
+  Properties:
+    GroupDescription: !Ref 'AWS::StackName'
+    SecurityGroupIngress:
+      - CidrIp: 0.0.0.0/0
+        FromPort: -1
+        IpProtocol: icmp
+        ToPort: -1
+      - CidrIp: {{ if eq .Cluster.ConfigItems.ssh_vpc_only "true" }}"{{.Values.vpc_ipv4_cidr}}"{{ else }}"0.0.0.0/0"{{ end }}
+        FromPort: 22
+        IpProtocol: tcp
+        ToPort: 22
+  {{- if index .Cluster.ConfigItems "open_sg_ingress_ranges" }}
+  {{- range $index, $element := sgIngressRanges .Cluster.ConfigItems.open_sg_ingress_ranges }}
+- CidrIp: {{ $element.CIDR }}
+  FromPort: {{ $element.FromPort }}
+  IpProtocol: {{ $element.Protocol }}
+  ToPort: {{ $element.ToPort }}
+  {{- end }}
+  {{- end }}
+- CidrIp: "0.0.0.0/0"
+  FromPort: 9998
+  IpProtocol: tcp
+  ToPort: 9999
+  {{- if eq .Cluster.ConfigItems.skipper_ingress_redis_swim_enabled "true" }}
+- CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+  FromPort: 9990
+  IpProtocol: tcp
+  ToPort: 9990
+- CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+  FromPort: 9990
+  IpProtocol: udp
+  ToPort: 9990
+  {{- end }}
+- CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+  FromPort: 10248
+  IpProtocol: tcp
+  ToPort: 10248
+- CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+  FromPort: 9054
+  IpProtocol: tcp
+  ToPort: 9054
+- CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+  FromPort: 9153
+  IpProtocol: tcp
+  ToPort: 9153
+- CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+  FromPort: 10250
+  IpProtocol: tcp
+  ToPort: 10250
+- CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+  FromPort: 30000
+  IpProtocol: tcp
+  ToPort: 32767
+- CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+  FromPort: 53
+  IpProtocol: tcp
+  ToPort: 53
+- CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+  FromPort: 53
+  IpProtocol: udp
+  ToPort: 53
+Tags:
+  - Key: 'karpenter.sh/discovery'
+    Value: '{{ .Cluster.ID }}/WorkerNodeSecurityGroup'
+VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
+Type: 'AWS::EC2::SecurityGroup'
+WorkerSecurityGroupIngressFromMasterToFlannel:
+  Properties:
+    FromPort: 8472
+    GroupId: !Ref WorkerSecurityGroup
+    IpProtocol: udp
+    SourceSecurityGroupId: !Ref MasterSecurityGroup
+    ToPort: 8472
+  Type: 'AWS::EC2::SecurityGroupIngress'
+WorkerSecurityGroupIngressFromMasterToKubelet:
+  Properties:
+    FromPort: 10250
+    GroupId: !Ref WorkerSecurityGroup
+    IpProtocol: tcp
+    SourceSecurityGroupId: !Ref MasterSecurityGroup
+    ToPort: 10250
+  Type: 'AWS::EC2::SecurityGroupIngress'
+WorkerSecurityGroupWorkerToWorker:
+  Type: AWS::EC2::SecurityGroupIngress
+  Properties:
+    IpProtocol: "-1"
+    GroupId: !Ref WorkerSecurityGroup
+    SourceSecurityGroupId: !Ref WorkerSecurityGroup
+EFSSecurityGroupIngressFromWorkerSecurityGroup:
+  Properties:
+    FromPort: 2049
+    GroupId: !Ref EFSWorkerSecurityGroup
+    IpProtocol: tcp
+    SourceSecurityGroupId: !Ref WorkerSecurityGroup
+    ToPort: 2049
+  Type: 'AWS::EC2::SecurityGroupIngress'
+  {{- if eq .Cluster.ConfigItems.efs_allow_vpc_connection "true" }}
+EFSSecurityGroupIngressFromVPCCIDR:
+  Properties:
+    FromPort: 2049
+    GroupId: !Ref EFSWorkerSecurityGroup
+    IpProtocol: tcp
+    CidrIp: "{{.Values.vpc_ipv4_cidr}}"
+    ToPort: 2049
+  Type: 'AWS::EC2::SecurityGroupIngress'
+  {{- end }}
+EFSWorkerSecurityGroup:
+  Properties:
+    GroupDescription: worker to EFS sg
+    VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
+  Type: 'AWS::EC2::SecurityGroup'
 
 # end of vpc dependent resources
-{{ end }}
-  OIDCProvider:
-    Type: AWS::IAM::OIDCProvider
-    Properties:
-      ClientIdList:
+  {{ end }}
+OIDCProvider:
+  Type: AWS::IAM::OIDCProvider
+  Properties:
+    ClientIdList:
       - "sts.amazonaws.com"
-      Url: "https://{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
-      ThumbprintList:
+    Url: "https://{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+    ThumbprintList:
       # SHA-1 sum of the root certificate in the trust chain for the certificate
       # use to serve the open id discovery document.
       - "9e99a48a9960b14926bb7f3b02e22da2b0ab7280"
 # end of non eks resources
-{{ end }}
-{{- if ne .Cluster.ConfigItems.delete_vpc_resources "true" }}
-  IngressLoadBalancerSecurityGroup:
-    Properties:
-      GroupDescription: !Ref 'AWS::StackName'
-      SecurityGroupIngress:
-        - CidrIp: 0.0.0.0/0
-          FromPort: 80
-          IpProtocol: tcp
-          ToPort: 80
-        - CidrIp: 0.0.0.0/0
-          FromPort: 443
-          IpProtocol: tcp
-          ToPort: 443
-      Tags:
-        - Key: 'kubernetes:application'
-          Value: kube-ingress-aws-controller
-      VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
-    Type: 'AWS::EC2::SecurityGroup'
-{{- end }}
-  WorkerIAMRole: # role used by worker nodes, including karpenter ones
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-          - Action:
-              - 'sts:AssumeRole'
-            Effect: Allow
-            Principal:
-              Service:
-                - ec2.amazonaws.com
-          - Action:
-              - 'sts:AssumeRole'
-            Effect: Allow
-            Principal:
-              AWS: !Join
-                - ''
-                - - !Sub 'arn:aws:iam::${AWS::AccountId}:role/'
-                  - !Ref MasterIAMRole
-        Version: 2012-10-17
-      Path: /
-{{- if eq .Cluster.Provider "zalando-eks"}}
-      ManagedPolicyArns:
-        - "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
-        - "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
-{{- end }}
-      Policies:
-        - PolicyDocument:
-            Statement:
-              - Action: 'autoscaling:TerminateInstanceInAutoScalingGroup'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'ec2:Describe*'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'ec2:AttachVolume'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'ec2:DetachVolume'
-                Effect: Allow
-                Resource: '*'
-              # Required by AWS EFS CSI Driver
-              - Action: 'elasticfilesystem:DescribeMountTargets'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'kms:Decrypt'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'sts:AssumeRole'
-                Effect: Allow
-                Resource: '*'
-              - Action: 's3:GetObject'
-                Effect: Allow
-                Resource: 'arn:aws:s3:::*'
-              - Action:
-                  - 'ecr:BatchCheckLayerAvailability'
-                  - 'ecr:BatchGetImage'
-                  - 'ecr:GetDownloadUrlForLayer'
-                  - 'ecr:GetAuthorizationToken'
-                Effect: Allow
-                Resource: '*'
-              # allow connecting via Session Manager
-              - Action:
-                - "ssm:UpdateInstanceInformation"
-                - "ssmmessages:CreateControlChannel"
-                - "ssmmessages:CreateDataChannel"
-                - "ssmmessages:OpenControlChannel"
-                - "ssmmessages:OpenDataChannel"
-                Effect: Allow
-                Resource: "*"
-              - Action:
-                - "logs:CreateLogStream"
-                - "logs:PutLogEvents"
-                - "logs:DescribeLogGroups"
-                - "logs:DescribeLogStreams"
-                Effect: Allow
-                Resource: "*"
-{{ if eq .Cluster.Environment "e2e" }}
+  {{ end }}
+  {{- if ne .Cluster.ConfigItems.delete_vpc_resources "true" }}
+IngressLoadBalancerSecurityGroup:
+  Properties:
+    GroupDescription: !Ref 'AWS::StackName'
+    SecurityGroupIngress:
+      - CidrIp: 0.0.0.0/0
+        FromPort: 80
+        IpProtocol: tcp
+        ToPort: 80
+      - CidrIp: 0.0.0.0/0
+        FromPort: 443
+        IpProtocol: tcp
+        ToPort: 443
+    Tags:
+      - Key: 'kubernetes:application'
+        Value: kube-ingress-aws-controller
+    VpcId: "{{.Cluster.ConfigItems.vpc_id}}"
+  Type: 'AWS::EC2::SecurityGroup'
+  {{- end }}
+WorkerIAMRole: # role used by worker nodes, including karpenter ones
+  Properties:
+    AssumeRolePolicyDocument:
+      Statement:
+        - Action:
+            - 'sts:AssumeRole'
+          Effect: Allow
+          Principal:
+            Service:
+              - ec2.amazonaws.com
+        - Action:
+            - 'sts:AssumeRole'
+          Effect: Allow
+          Principal:
+            AWS: !Join
+              - ''
+              - - !Sub 'arn:aws:iam::${AWS::AccountId}:role/'
+                - !Ref MasterIAMRole
+      Version: 2012-10-17
+    Path: /
+  {{- if eq .Cluster.Provider "zalando-eks"}}
+ManagedPolicyArns:
+  - "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  - "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  {{- end }}
+Policies:
+  - PolicyDocument:
+      Statement:
+        - Action: 'autoscaling:TerminateInstanceInAutoScalingGroup'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'ec2:Describe*'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'ec2:AttachVolume'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'ec2:DetachVolume'
+          Effect: Allow
+          Resource: '*'
+        # Required by AWS EFS CSI Driver
+        - Action: 'elasticfilesystem:DescribeMountTargets'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'kms:Decrypt'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'sts:AssumeRole'
+          Effect: Allow
+          Resource: '*'
+        - Action: 's3:GetObject'
+          Effect: Allow
+          Resource: 'arn:aws:s3:::*'
+        - Action:
+            - 'ecr:BatchCheckLayerAvailability'
+            - 'ecr:BatchGetImage'
+            - 'ecr:GetDownloadUrlForLayer'
+            - 'ecr:GetAuthorizationToken'
+          Effect: Allow
+          Resource: '*'
+        # allow connecting via Session Manager
+        - Action:
+            - "ssm:UpdateInstanceInformation"
+            - "ssmmessages:CreateControlChannel"
+            - "ssmmessages:CreateDataChannel"
+            - "ssmmessages:OpenControlChannel"
+            - "ssmmessages:OpenDataChannel"
+          Effect: Allow
+          Resource: "*"
+        - Action:
+            - "logs:CreateLogStream"
+            - "logs:PutLogEvents"
+            - "logs:DescribeLogGroups"
+            - "logs:DescribeLogStreams"
+          Effect: Allow
+          Resource: "*"
+  {{ if eq .Cluster.Environment "e2e" }}
 # Add extra permissions to worker IAM role to test that if a pod manages to get
 # the WorkerIAMRole assigned it can list a specific s3 bucket.
 # see ../test/e2e/aws_iam.go for more information about the e2e test where this
 # is relevant.
-              - Action:
-                - 's3:ListBucket'
-                Effect: Allow
-                Resource:
-                - >-
-                  arn:aws:s3:::zalando-e2e-test-{{.Cluster.InfrastructureAccountID}}-{{.Cluster.LocalID}}
-              - Action:
-                - 's3:PutObject'
-                - 's3:GetObject'
-                - 's3:DeleteObject'
-                Effect: Allow
-                Resource:
-                - >-
-                  arn:aws:s3:::zalando-e2e-test-{{.Cluster.InfrastructureAccountID}}-{{.Cluster.LocalID}}/*
-{{ end }}
-            Version: 2012-10-17
-          PolicyName: root
-      RoleName: "{{.Cluster.LocalID}}-worker"
-    Type: 'AWS::IAM::Role'
-  AutoscalerIAMRole:
-    Properties:
-      AssumeRolePolicyDocument: !Sub
-        - |
-          {
-            "Version": "2012-10-17",
-            "Statement": [
-              {
-                "Effect": "Allow",
-                "Principal": {
-                  "Federated": [
-                    "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
-                  ]
-                },
-                "Action": [
-                  "sts:AssumeRoleWithWebIdentity"
-                ],
-                "Condition": {
-                  "StringEquals": {
-                    "${OIDC}:sub": "system:serviceaccount:kube-system:cluster-autoscaler"
-                  }
-                }
-              }
-            ]
-          }
-{{- if eq .Cluster.Provider "zalando-eks" }}
-        - OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
-{{- else }}
-        - OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
-{{- end }}
-      Path: /
-      Policies:
-        - PolicyDocument:
-            Statement:
-              - Action: 'ec2:Describe*'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'autoscaling:DescribeTags'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'autoscaling:DescribeAutoScalingGroups'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'autoscaling:DescribeAutoScalingInstances'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'autoscaling:DescribeLaunchConfigurations'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'autoscaling:DescribeScalingActivities'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'autoscaling:SetDesiredCapacity'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'autoscaling:TerminateInstanceInAutoScalingGroup'
-                Effect: Allow
-                Resource: '*'
-            Version: 2012-10-17
-          PolicyName: root
-      RoleName: "{{.Cluster.LocalID}}-app-autoscaler"
-    Type: 'AWS::IAM::Role'
-  KarpenterNodeInstanceProfile: # instance profile for worker nodes spawn by karpenter controller
-    Type: "AWS::IAM::InstanceProfile"
-    Properties:
-      InstanceProfileName: "{{ .Cluster.ID | awsValidID }}-WorkerKarpenter-InstanceProfile"
-      Path: "/"
-      Roles:
-        - !Ref WorkerIAMRole
-  KarpenterIAMRole: # role for the karpenter controller
-    Properties:
-      AssumeRolePolicyDocument: !Sub
-        - |
-          {
-            "Version": "2012-10-17",
-            "Statement": [
-              {
-                "Effect": "Allow",
-                "Principal": {
-                  "Federated": [
-                    "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
-                  ]
-                },
-                "Action": [
-                  "sts:AssumeRoleWithWebIdentity"
-                ],
-                "Condition": {
-                  "StringEquals": {
-                    "${OIDC}:aud": "sts.amazonaws.com",
-                    "${OIDC}:sub": "system:serviceaccount:kube-system:karpenter"
-                  }
-                }
-              }
-            ]
-          }
-{{- if eq .Cluster.Provider "zalando-eks" }}
-        - OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
-{{- else }}
-        - OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
-{{- end }}
-      Path: /
-      Policies:
-        - PolicyName: "KarpenterControllerPolicy-{{ .Cluster.ID | awsValidID }}"
-          # The PolicyDocument must be in JSON string format because we use a StringEquals condition that uses an interpolated
-          # value in one of its key parameters which isn't natively supported by CloudFormation
-          PolicyDocument: !Sub |
+- Action:
+    - 's3:ListBucket'
+  Effect: Allow
+  Resource:
+    - >-
+      arn:aws:s3:::zalando-e2e-test-{{.Cluster.InfrastructureAccountID}}-{{.Cluster.LocalID}}
+- Action:
+    - 's3:PutObject'
+    - 's3:GetObject'
+    - 's3:DeleteObject'
+  Effect: Allow
+  Resource:
+    - >-
+      arn:aws:s3:::zalando-e2e-test-{{.Cluster.InfrastructureAccountID}}-{{.Cluster.LocalID}}/*
+  {{ end }}
+Version: 2012-10-17
+PolicyName: root
+RoleName: "{{.Cluster.LocalID}}-worker"
+Type: 'AWS::IAM::Role'
+AutoscalerIAMRole:
+  Properties:
+    AssumeRolePolicyDocument: !Sub
+      - |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
             {
-              "Version": "2012-10-17",
-              "Statement": [
-                {
-                  "Sid": "AllowScopedEC2InstanceAccessActions",
-                  "Effect": "Allow",
-                  "Resource": [
-                    "arn:${AWS::Partition}:ec2:${AWS::Region}::image/*",
-                    "arn:${AWS::Partition}:ec2:${AWS::Region}::snapshot/*",
-                    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:security-group/*",
-                    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:subnet/*",
-                    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:capacity-reservation/*"
-                  ],
-                  "Action": [
-                    "ec2:RunInstances",
-                    "ec2:CreateFleet"
-                  ]
-                },
-                {
-                  "Sid": "AllowScopedEC2LaunchTemplateAccessActions",
-                  "Effect": "Allow",
-                  "Resource": "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*",
-                  "Action": [
-                    "ec2:RunInstances",
-                    "ec2:CreateFleet"
-                  ],
-                  "Condition": {
-                    "StringEquals": {
-                      "aws:ResourceTag/kubernetes.io/cluster/{{.Cluster.Name}}": "owned"
-                    },
-                    "StringLike": {
-                      "aws:ResourceTag/karpenter.sh/nodepool": "*"
-                    }
-                  }
-                },
-                {
-                  "Sid": "AllowScopedEC2InstanceActionsWithTags",
-                  "Effect": "Allow",
-                  "Resource": [
-                    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
-                    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
-                    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
-                    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*",
-                    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*",
-                    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*",
-                    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:capacity-reservation/*"
-                  ],
-                  "Action": [
-                    "ec2:RunInstances",
-                    "ec2:CreateFleet",
-                    "ec2:CreateLaunchTemplate"
-                  ],
-                  "Condition": {
-                    "StringEquals": {
-                      "aws:RequestTag/kubernetes.io/cluster/{{.Cluster.Name}}": "owned",
-                      "aws:RequestTag/eks:eks-cluster-name": "{{.Cluster.Name}}"
-                    },
-                    "StringLike": {
-                      "aws:RequestTag/karpenter.sh/nodepool": "*"
-                    }
-                  }
-                },
-                {
-                  "Sid": "AllowScopedResourceCreationTagging",
-                  "Effect": "Allow",
-                  "Resource": [
-                    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
-                    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
-                    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
-                    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*",
-                    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*",
-                    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*"
-                  ],
-                  "Action": "ec2:CreateTags",
-                  "Condition": {
-                    "StringEquals": {
-                      "aws:RequestTag/kubernetes.io/cluster/{{.Cluster.Name}}": "owned",
-                      "ec2:CreateAction": [
-                        "RunInstances",
-                        "CreateFleet",
-                        "CreateLaunchTemplate"
-                      ]
-                    },
-                    "StringLike": {
-                      "aws:RequestTag/karpenter.sh/nodepool": "*"
-                    }
-                  }
-                },
-                {
-                  "Sid": "AllowScopedResourceTagging",
-                  "Effect": "Allow",
-                  "Resource": "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
-                  "Action": "ec2:CreateTags",
-                  "Condition": {
-                    "StringEquals": {
-                      "aws:ResourceTag/kubernetes.io/cluster/{{.Cluster.Name}}": "owned"
-                    },
-                    "StringLike": {
-                      "aws:ResourceTag/karpenter.sh/nodepool": "*"
-                    },
-                    "StringEqualsIfExists": {
-                      "aws:RequestTag/eks:eks-cluster-name": "{{.Cluster.Name}}"
-                    },
-                    "ForAllValues:StringEquals": {
-                      "aws:TagKeys": [
-                        "eks:eks-cluster-name",
-                        "karpenter.sh/nodeclaim",
-                        "Name"
-                      ]
-                    }
-                  }
-                },
-                {
-                  "Sid": "AllowScopedDeletion",
-                  "Effect": "Allow",
-                  "Resource": [
-                    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
-                    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
-                  ],
-                  "Action": [
-                    "ec2:TerminateInstances",
-                    "ec2:DeleteLaunchTemplate"
-                  ],
-                  "Condition": {
-                    "StringEquals": {
-                      "aws:ResourceTag/kubernetes.io/cluster/{{.Cluster.Name}}": "owned"
-                    },
-                    "StringLike": {
-                      "aws:ResourceTag/karpenter.sh/nodepool": "*"
-                    }
-                  }
-                },
-                {
-                  "Sid": "AllowRegionalReadActions",
-                  "Effect": "Allow",
-                  "Resource": "*",
-                  "Action": [
-                    "ec2:DescribeCapacityReservations",
-                    "ec2:DescribeImages",
-                    "ec2:DescribeInstances",
-                    "ec2:DescribeInstanceTypeOfferings",
-                    "ec2:DescribeInstanceTypes",
-                    "ec2:DescribeLaunchTemplates",
-                    "ec2:DescribeSecurityGroups",
-                    "ec2:DescribeSpotPriceHistory",
-                    "ec2:DescribeSubnets"
-                  ],
-                  "Condition": {
-                    "StringEquals": {
-                      "aws:RequestedRegion": "${AWS::Region}"
-                    }
-                  }
-                },
-                {
-                  "Sid": "AllowSSMReadActions",
-                  "Effect": "Allow",
-                  "Resource": "arn:${AWS::Partition}:ssm:${AWS::Region}::parameter/aws/service/*",
-                  "Action": "ssm:GetParameter"
-                },
-                {
-                  "Sid": "AllowPricingReadActions",
-                  "Effect": "Allow",
-                  "Resource": "*",
-                  "Action": "pricing:GetProducts"
-                },
-                {
-                  "Sid": "AllowInterruptionQueueActions",
-                  "Effect": "Allow",
-                  "Resource": "${KarpenterInterruptionQueue.Arn}",
-                  "Action": [
-                    "sqs:DeleteMessage",
-                    "sqs:GetQueueUrl",
-                    "sqs:ReceiveMessage"
-                  ]
-                },
-                {
-                  "Sid": "AllowPassingInstanceRole",
-                  "Effect": "Allow",
-                  "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/{{.Cluster.LocalID}}-worker",
-                  "Action": "iam:PassRole",
-                  "Condition": {
-                    "StringEquals": {
-                      "iam:PassedToService": "ec2.amazonaws.com"
-                    }
-                  }
-                },
-                {
-                  "Sid": "AllowScopedInstanceProfileCreationActions",
-                  "Effect": "Allow",
-                  "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
-                  "Action": [
-                    "iam:CreateInstanceProfile"
-                  ],
-                  "Condition": {
-                    "StringEquals": {
-                      "aws:RequestTag/kubernetes.io/cluster/{{.Cluster.Name}}": "owned",
-                      "aws:RequestTag/eks:eks-cluster-name": "{{.Cluster.Name}}",
-                      "aws:RequestTag/topology.kubernetes.io/region": "${AWS::Region}"
-                    },
-                    "StringLike": {
-                      "aws:RequestTag/karpenter.k8s.aws/ec2nodeclass": "*"
-                    }
-                  }
-                },
-                {
-                  "Sid": "AllowScopedInstanceProfileTagActions",
-                  "Effect": "Allow",
-                  "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
-                  "Action": [
-                    "iam:TagInstanceProfile"
-                  ],
-                  "Condition": {
-                    "StringEquals": {
-                      "aws:ResourceTag/kubernetes.io/cluster/{{.Cluster.Name}}": "owned",
-                      "aws:ResourceTag/topology.kubernetes.io/region": "${AWS::Region}",
-                      "aws:RequestTag/kubernetes.io/cluster/{{.Cluster.Name}}": "owned",
-                      "aws:RequestTag/eks:eks-cluster-name": "{{.Cluster.Name}}",
-                      "aws:RequestTag/topology.kubernetes.io/region": "${AWS::Region}"
-                    },
-                    "StringLike": {
-                      "aws:ResourceTag/karpenter.k8s.aws/ec2nodeclass": "*",
-                      "aws:RequestTag/karpenter.k8s.aws/ec2nodeclass": "*"
-                    }
-                  }
-                },
-                {
-                  "Sid": "AllowScopedInstanceProfileActions",
-                  "Effect": "Allow",
-                  "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
-                  "Action": [
-                    "iam:AddRoleToInstanceProfile",
-                    "iam:RemoveRoleFromInstanceProfile",
-                    "iam:DeleteInstanceProfile"
-                  ],
-                  "Condition": {
-                    "StringEquals": {
-                      "aws:ResourceTag/kubernetes.io/cluster/{{.Cluster.Name}}": "owned",
-                      "aws:ResourceTag/topology.kubernetes.io/region": "${AWS::Region}"
-                    },
-                    "StringLike": {
-                      "aws:ResourceTag/karpenter.k8s.aws/ec2nodeclass": "*"
-                    }
-                  }
-                },
-                {
-                  "Sid": "AllowInstanceProfileReadActions",
-                  "Effect": "Allow",
-                  "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
-                  "Action": "iam:GetInstanceProfile"
-                },
-                {
-                  "Sid": "AllowUnscopedInstanceProfileListAction",
-                  "Effect": "Allow",
-                  "Resource": "*",
-                  "Action": "iam:ListInstanceProfiles"
-                },
-                {
-                  "Sid": "AllowAPIServerEndpointDiscovery",
-                  "Effect": "Allow",
-                  "Resource": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/{{.Cluster.Name}}",
-                  "Action": "eks:DescribeCluster"
+              "Effect": "Allow",
+              "Principal": {
+                "Federated": [
+                  "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
+                ]
+              },
+              "Action": [
+                "sts:AssumeRoleWithWebIdentity"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "${OIDC}:sub": "system:serviceaccount:kube-system:cluster-autoscaler"
                 }
-              ]
+              }
             }
-      RoleName: "{{.Cluster.LocalID}}-app-karpenter"
-    Type: 'AWS::IAM::Role'
-  KarpenterInterruptionQueue:
-    Type: AWS::SQS::Queue
-    Properties:
-      QueueName: !Sub "{{.Cluster.LocalID}}-karpenter-interruption-queue"
-      MessageRetentionPeriod: 300
-      SqsManagedSseEnabled: true
-  KarpenterInterruptionQueuePolicy:
-    Type: AWS::SQS::QueuePolicy
-    Properties:
-      Queues:
-        - !Ref KarpenterInterruptionQueue
-      PolicyDocument:
-        Id: EC2InterruptionPolicy
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service:
-                - events.amazonaws.com
-                - sqs.amazonaws.com
-            Action: sqs:SendMessage
-            Resource: !GetAtt KarpenterInterruptionQueue.Arn
-  ScheduledChangeRule:
-    Type: 'AWS::Events::Rule'
-    Properties:
-      EventPattern:
-        source:
-          - aws.health
-        detail-type:
-          - AWS Health Event
-      Targets:
-        - Id: KarpenterInterruptionQueueTarget
-          Arn: !GetAtt KarpenterInterruptionQueue.Arn
-  SpotInterruptionRule:
-    Type: 'AWS::Events::Rule'
-    Properties:
-      EventPattern:
-        source:
-          - aws.ec2
-        detail-type:
-          - EC2 Spot Instance Interruption Warning
-      Targets:
-        - Id: KarpenterInterruptionQueueTarget
-          Arn: !GetAtt KarpenterInterruptionQueue.Arn
-  RebalanceRule:
-    Type: 'AWS::Events::Rule'
-    Properties:
-      EventPattern:
-        source:
-          - aws.ec2
-        detail-type:
-          - EC2 Instance Rebalance Recommendation
-      Targets:
-        - Id: KarpenterInterruptionQueueTarget
-          Arn: !GetAtt KarpenterInterruptionQueue.Arn
-  InstanceStateChangeRule:
-    Type: 'AWS::Events::Rule'
-    Properties:
-      EventPattern:
-        source:
-          - aws.ec2
-        detail-type:
-          - EC2 Instance State-change Notification
-      Targets:
-        - Id: KarpenterInterruptionQueueTarget
-          Arn: !GetAtt KarpenterInterruptionQueue.Arn
-  DeploymentIAMRole:
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-          - Action:
-              - 'sts:AssumeRole'
-            Effect: Allow
-            Principal:
-              Service:
-                - ec2.amazonaws.com
-          - Action:
-              - 'sts:AssumeRole'
-            Effect: Allow
-            Principal:
-              AWS: !Join
-                - ''
-                - - !Sub 'arn:aws:iam::${AWS::AccountId}:role/'
-                  - !Ref WorkerIAMRole
-        Version: 2012-10-17
-      Path: /
-      ManagedPolicyArns:
-        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-DenyEc2UsApSa"
-        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-DenyModifyShibboleth"
-        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-DenyDefault"
-        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-AllowPowerUser"
-        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-AllowPowerUserCustom"
-        {{- if eq .Cluster.Name "playground" }}
-        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-AllowPowerUser-Playground"
-        {{- end }}
-      RoleName: "{{.Cluster.LocalID}}-deployment"
-    Type: 'AWS::IAM::Role'
-  DeploymentServiceBucket:
-    Type: AWS::S3::Bucket
-    DeletionPolicy: Delete
-    Properties:
-      BucketName: "{{ .Cluster.ConfigItems.deployment_service_bucket_name }}"
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: true
-        BlockPublicPolicy: true
-        IgnorePublicAcls: true
-        RestrictPublicBuckets: true
-      Tags:
-        - Key: component
-          Value: deployment-service
-      OwnershipControls:
-        Rules:
-          - ObjectOwnership: BucketOwnerPreferred
-  DeploymentServiceBucketPolicy:
-    Type: AWS::S3::BucketPolicy
-    Properties:
-      Bucket: !Ref DeploymentServiceBucket
-      PolicyDocument:
-        Statement:
-          - NotAction:
-              - s3:GetObject
-              - s3:DeleteObject
-              - s3:ListBucket
-              - s3:PutObject
-            Effect: Deny
-            Resource:
-              - !Sub "arn:aws:s3:::${DeploymentServiceBucket}/*"
-              - !Sub "arn:aws:s3:::${DeploymentServiceBucket}"
-            Principal:
-              AWS:
-                - !GetAtt DeploymentControllerRole.Arn
-                - !GetAtt DeploymentStatusServiceRole.Arn
-{{- if .Cluster.ConfigItems.deployment_service_api_role_arn }}
-          - Action:
-              - s3:PutObject
-              - s3:PutObjectAcl
-            Effect: Allow
-            Resource:
-              - !Sub "arn:aws:s3:::${DeploymentServiceBucket}/manifests/*"
-            Principal:
-              AWS: "{{.Cluster.ConfigItems.deployment_service_api_role_arn}}"
-{{- end }}
-          - Action: "s3:*"
-            Effect: Deny
-            Resource:
-              - !Sub "arn:aws:s3:::${DeploymentServiceBucket}/*"
-              - !Sub "arn:aws:s3:::${DeploymentServiceBucket}"
-            Principal: "*"
-            Condition:
-              ArnNotEquals:
-                aws:PrincipalArn:
-                  - !GetAtt DeploymentControllerRole.Arn
-                  - !GetAtt DeploymentStatusServiceRole.Arn
-{{- if .Cluster.ConfigItems.deployment_service_api_role_arn }}
-                  - "{{.Cluster.ConfigItems.deployment_service_api_role_arn}}"
-{{- end }}
-                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/cluster-lifecycle-manager-entrypoint"
-                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/Shibboleth-Administrator"
-                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/Administrator"
-                  {{- if eq .Cluster.Name "playground" }}
-                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/cluster-cleaner-nuke-entrypoint"
-                  {{- end }}
-  DeploymentControllerRole:
-    Type: AWS::IAM::Role
-    Properties:
-      RoleName: "{{.Cluster.ConfigItems.deployment_service_controller_role_name}}"
-      AssumeRolePolicyDocument: !Sub
-        - |
-          {
-            "Version": "2012-10-17",
-            "Statement": [
-              {
-                "Effect": "Allow",
-                "Principal": {
-                  "Federated": [
-                    "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
-                  ]
-                },
-                "Action": [
-                  "sts:AssumeRoleWithWebIdentity"
-                ],
-                "Condition": {
-                  "StringEquals": {
-                    "${OIDC}:sub": "system:serviceaccount:kube-system:deployment-service-controller"
-                  }
-                }
-              }
-            ]
-          }
-{{- if eq .Cluster.Provider "zalando-eks" }}
-        - OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
-{{- else }}
-        - OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
-{{- end }}
-      Policies:
-        - PolicyName: ControllerPolicy
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Action:
-                  - s3:DeleteObject
-                Resource:
-                  - !Sub "arn:aws:s3:::${DeploymentServiceBucket}/*"
-                Effect: Allow
-              - Action:
-                  - s3:GetObject
-                Resource:
-                  - !Sub "arn:aws:s3:::${DeploymentServiceBucket}/manifests/*"
-                Effect: Allow
-              - Action:
-                  - s3:PutObject
-                Resource:
-                  - !Sub "arn:aws:s3:::${DeploymentServiceBucket}/final-task-statuses/*"
-                Effect: Allow
-              - Action:
-                  - s3:ListBucket
-                Resource:
-                  - !Sub "arn:aws:s3:::${DeploymentServiceBucket}"
-                Effect: Allow
-              - Action:
-                  - kms:Decrypt
-                Effect: Allow
-                Resource: "*"
-                Condition:
-                  StringLike:
-                    "kms:RequestAlias": "alias/deployment-secret"
-              - Action:
-                  - 'sts:AssumeRole'
-                Effect: Allow
-                Resource:
-                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/{{.Cluster.ConfigItems.deployment_service_deployment_role_name}}"
-  DeploymentControllerDeploymentRole:
-    Type: AWS::IAM::Role
-    Properties:
-      RoleName: "{{.Cluster.ConfigItems.deployment_service_deployment_role_name}}"
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Principal:
-              AWS: !GetAtt DeploymentControllerRole.Arn
-            Action:
-              - sts:AssumeRole
-      ManagedPolicyArns:
-        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-DenyEc2UsApSa"
-        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-DenyModifyShibboleth"
-        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-DenyDefault"
-        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-AllowPowerUser"
-        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-AllowPowerUserCustom"
-        {{- if eq .Cluster.Name "playground" }}
-        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-AllowPowerUser-Playground"
-        {{- end }}
-{{- if eq .Cluster.ConfigItems.deployment_service_ml_experiments_enabled "true"}}
-  DeploymentControllerMLExperimentDeploymentRole:
-    Type: AWS::IAM::Role
-    Properties:
-      RoleName: "{{ .Cluster.ConfigItems.deployment_service_ml_experiments_role_name }}"
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Principal:
-              AWS: !GetAtt DeploymentControllerRole.Arn
-            Action:
-              - sts:AssumeRole
-      ManagedPolicyArns:
-        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-mlbuilder-permission-boundary"
-{{- end }}
-  DeploymentStatusServiceRole:
-    Type: AWS::IAM::Role
-    Properties:
-      RoleName: "{{.Cluster.ConfigItems.deployment_service_status_service_role_name}}"
-      AssumeRolePolicyDocument: !Sub
-        - |
-          {
-            "Version": "2012-10-17",
-            "Statement": [
-              {
-                "Effect": "Allow",
-                "Principal": {
-                  "Federated": [
-                    "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
-                  ]
-                },
-                "Action": [
-                  "sts:AssumeRoleWithWebIdentity"
-                ],
-                "Condition": {
-                  "StringEquals": {
-                    "${OIDC}:sub": "system:serviceaccount:kube-system:deployment-service-status-service"
-                  }
-                }
-              }
-            ]
-          }
-{{- if eq .Cluster.Provider "zalando-eks" }}
-        - OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
-{{- else }}
-        - OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
-{{- end }}
-      Policies:
-        - PolicyName: StatusServicePolicy
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Action:
-                  - s3:GetObject
-                Resource:
-                  - !Sub "arn:aws:s3:::${DeploymentServiceBucket}/final-task-statuses/*"
-                Effect: Allow
-              - Action:
-                  - s3:GetObject
-                  - s3:PutObject
-                Resource:
-                  - !Sub "arn:aws:s3:::${DeploymentServiceBucket}/cached-probe-results/*"
-                Effect: Allow
-              - Action:
-                  - s3:ListBucket
-                Resource:
-                  - !Sub "arn:aws:s3:::${DeploymentServiceBucket}"
-                Effect: Allow
-              - Action:
-                  - 'cloudformation:DescribeStackEvents'
-                  - 'cloudformation:DescribeStackResources'
-                  - 'cloudformation:DescribeStacks'
-                  - 'cloudformation:GetTemplate'
-                Effect: Allow
-                Resource: '*'
-  ExternalDNSIAMRole:
-    Properties:
-      AssumeRolePolicyDocument: !Sub
-        - |
-          {
-            "Version": "2012-10-17",
-            "Statement": [
-              {
-                "Effect": "Allow",
-                "Principal": {
-                  "Federated": [
-                    "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
-                  ]
-                },
-                "Action": [
-                  "sts:AssumeRoleWithWebIdentity"
-                ],
-                "Condition": {
-                  "StringEquals": {
-                    "${OIDC}:sub": "system:serviceaccount:kube-system:external-dns"
-                  }
-                }
-              }
-            ]
-          }
-{{- if eq .Cluster.Provider "zalando-eks" }}
-        - OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
-{{- else }}
-        - OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
-{{- end }}
-      Path: /
-      Policies:
-        - PolicyDocument:
-            Statement:
-              - Action: 'route53:*'
-                Effect: Allow
-                Resource: '*'
-            Version: 2012-10-17
-          PolicyName: root
-      RoleName: "{{.Cluster.LocalID}}-app-external-dns"
-    Type: 'AWS::IAM::Role'
-  IngressControllerIAMRole:
-    Properties:
-      AssumeRolePolicyDocument: !Sub
-        - |
-          {
-            "Version": "2012-10-17",
-            "Statement": [
-              {
-                "Effect": "Allow",
-                "Principal": {
-                  "Federated": [
-                    "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
-                  ]
-                },
-                "Action": [
-                  "sts:AssumeRoleWithWebIdentity"
-                ],
-                "Condition": {
-                  "StringEquals": {
-                    "${OIDC}:sub": "system:serviceaccount:kube-system:kube-ingress-aws-controller"
-                  }
-                }
-              }
-            ]
-          }
-{{- if eq .Cluster.Provider "zalando-eks" }}
-        - OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
-{{- else }}
-        - OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
-{{- end }}
-      Path: /
-      Policies:
-        - PolicyDocument:
-            Statement:
-              - Action: 'acm:ListCertificates'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'acm:GetCertificate'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'acm:DescribeCertificate'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'acm:ListTagsForCertificate'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'autoscaling:DescribeAutoScalingGroups'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'autoscaling:AttachLoadBalancers'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'autoscaling:DetachLoadBalancers'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'autoscaling:DetachLoadBalancerTargetGroups'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'autoscaling:AttachLoadBalancerTargetGroups'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'autoscaling:DescribeLoadBalancerTargetGroups'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'cloudformation:*'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'elasticloadbalancing:*'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'elasticloadbalancingv2:*'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'ec2:DescribeAccountAttributes'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'ec2:DescribeInstances'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'ec2:DescribeInternetGateways'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'ec2:DescribeSubnets'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'ec2:DescribeSecurityGroups'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'ec2:DescribeRouteTables'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'ec2:DescribeVpcs'
-                Effect: Allow
-                Resource: '*'
-{{- if eq .Cluster.Provider "zalando-eks" }}
-              - Action: 'ec2:DescribeVpcPeeringConnections'
-                Effect: Allow
-                Resource: '*'
-{{- end }}
-              - Action: 'iam:CreateServiceLinkedRole'
-                Effect: Allow
-                Resource: '*'
-                Condition:
-                  StringEquals:
-                    "iam:AWSServiceName": "elasticloadbalancing.amazonaws.com"
-              - Action: 'iam:GetServerCertificate'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'iam:ListServerCertificates'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'iam:ListServerCertificateTags'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'waf-regional:ListWebACLs'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'waf-regional:GetWebACL'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'waf-regional:GetWebACLForResource'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'waf-regional:AssociateWebACL'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'waf-regional:DisassociateWebACL'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'wafv2:ListWebACLs'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'wafv2:GetWebACL'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'wafv2:GetWebACLForResource'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'wafv2:AssociateWebACL'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'wafv2:DisassociateWebACL'
-                Effect: Allow
-                Resource: '*'
-            Version: 2012-10-17
-          PolicyName: root
-      RoleName: "{{.Cluster.LocalID}}-app-ingr-ctrl"
-    Type: 'AWS::IAM::Role'
-  # Note: this is not strictly specific to Open Policy Agent and can be extend
-  # if Skipper Ingress needs to access other AWS resources
-  SkipperIngressIAMRole:
-    Properties:
-      AssumeRolePolicyDocument: !Sub
-        - |
-          {
-            "Version": "2012-10-17",
-            "Statement": [
-              {
-                "Effect": "Allow",
-                "Principal": {
-                  "Federated": [
-                    "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
-                  ]
-                },
-                "Action": [
-                  "sts:AssumeRoleWithWebIdentity"
-                ],
-                "Condition": {
-                  "StringEquals": {
-                    "${OIDC}:sub": "system:serviceaccount:kube-system:skipper-ingress"
-                  }
-                }
-              }
-            ]
-          }
-{{- if eq .Cluster.Provider "zalando-eks" }}
-        - OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
-{{- else }}
-        - OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
-{{- end }}
-      Path: /
-      Policies:
-        - PolicyName: s3-access-for-opa
-          PolicyDocument:
-            Version: 2012-10-17
-            Statement:
-              - Effect: "Allow"
-                Action:
-                  - "s3:GetObject"
-                Resource:
-                  - "{{ .Cluster.ConfigItems.skipper_open_policy_agent_bucket_arn }}/*"
-              - Effect: "Allow"
-                Action:
-                  - "s3:PutObject"
-                Resource:
-                  - "{{ .Cluster.ConfigItems.skipper_open_policy_agent_decision_log_bucket_arn }}/*"
-      RoleName: "{{.Cluster.LocalID}}-app-skipper-ingress"
-    Type: 'AWS::IAM::Role'
-  # Note: this is not strictly specific to Open Policy Agent and can be extend
-  # if Skipper Validation Webhook needs to access other AWS resources
-  SkipperWebhookIAMRole:
-    Properties:
-      AssumeRolePolicyDocument: !Sub
-        - |
-          {
-            "Version": "2012-10-17",
-            "Statement": [
-              {
-                "Effect": "Allow",
-                "Principal": {
-                  "Federated": [
-                    "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
-                  ]
-                },
-                "Action": [
-                  "sts:AssumeRoleWithWebIdentity"
-                ],
-                "Condition": {
-                  "StringEquals": {
-                    "${OIDC}:sub": "system:serviceaccount:kube-system:skipper-validation-webhook"
-                  }
-                }
-              }
-            ]
-          }
-{{- if eq .Cluster.Provider "zalando-eks" }}
-        - OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
-{{- else }}
-        - OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
-{{- end }}
-      Path: /
-      Policies:
-        - PolicyName: s3-access-for-opa
-          PolicyDocument:
-            Version: 2012-10-17
-            Statement:
-              - Effect: "Allow"
-                Action:
-                  - "s3:GetObject"
-                Resource:
-                  - "{{ .Cluster.ConfigItems.skipper_open_policy_agent_bucket_arn }}/*"
-              - Effect: "Allow"
-                Action:
-                  - "s3:PutObject"
-                Resource:
-                  - "{{ .Cluster.ConfigItems.skipper_open_policy_agent_decision_log_bucket_arn }}/*"
-      RoleName: "{{.Cluster.LocalID}}-app-skipper-validation-webhook"
-    Type: 'AWS::IAM::Role'
-  ClusterLifecycleControllerIAMRole:
-    Properties:
-      AssumeRolePolicyDocument: !Sub
-        - |
-          {
-            "Version": "2012-10-17",
-            "Statement": [
-              {
-                "Effect": "Allow",
-                "Principal": {
-                  "Federated": [
-                    "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
-                  ]
-                },
-                "Action": [
-                  "sts:AssumeRoleWithWebIdentity"
-                ],
-                "Condition": {
-                  "StringEquals": {
-                    "${OIDC}:sub": "system:serviceaccount:kube-system:cluster-lifecycle-controller"
-                  }
-                }
-              }
-            ]
-          }
-{{- if eq .Cluster.Provider "zalando-eks" }}
-        - OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
-{{- else }}
-        - OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
-{{- end }}
-      Path: /
-      Policies:
-      - PolicyDocument:
-          Statement:
-          - Action: 'ec2:DescribeInstanceStatus'
-            Effect: Allow
-            Resource: '*'
-          - Action: 'ec2:TerminateInstances'
-            Effect: Allow
-            Resource: '*'
-          - Action: 'autoscaling:DescribeAutoScalingGroups'
-            Effect: Allow
-            Resource: '*'
-          - Action: 'autoscaling:DescribeAutoScalingInstances'
-            Effect: Allow
-            Resource: '*'
-          - Action: 'autoscaling:DescribeLoadBalancers'
-            Effect: Allow
-            Resource: '*'
-          - Action: 'autoscaling:DescribeLoadBalancerTargetGroups'
-            Effect: Allow
-            Resource: '*'
-          - Action: 'autoscaling:DescribeTags'
-            Effect: Allow
-            Resource: '*'
-          - Action: 'autoscaling:SetDesiredCapacity'
-            Effect: Allow
-            Resource: '*'
-          - Action: 'elasticloadbalancing:DescribeInstanceHealth'
-            Effect: Allow
-            Resource: '*'
-          - Action: 'elasticloadbalancing:DescribeTargetHealth'
-            Effect: Allow
-            Resource: '*'
-          - Action: 'autoscaling:TerminateInstanceInAutoScalingGroup'
-            Effect: Allow
-            Resource: '*'
-          Version: 2012-10-17
-        PolicyName: root
-      RoleName: "{{.Cluster.LocalID}}-cluster-lifecycle-controller"
-    Type: 'AWS::IAM::Role'
-  KubeReadyIAMRole:
-    Properties:
-      AssumeRolePolicyDocument: !Sub
-        - |
-          {
-            "Version": "2012-10-17",
-            "Statement": [
-{{- if ne .Cluster.Provider "zalando-eks" }}
-              {
-                "Action": [
-                  "sts:AssumeRole"
-                ],
-                "Effect": "Allow",
-                "Principal": {
-                  "AWS": "${MasterIAMRole}"
-                }
+          ]
+        }
+  {{- if eq .Cluster.Provider "zalando-eks" }}
+- OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
+  {{- else }}
+- OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+  {{- end }}
+Path: /
+Policies:
+  - PolicyDocument:
+      Statement:
+        - Action: 'ec2:Describe*'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'autoscaling:DescribeTags'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'autoscaling:DescribeAutoScalingGroups'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'autoscaling:DescribeAutoScalingInstances'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'autoscaling:DescribeLaunchConfigurations'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'autoscaling:DescribeScalingActivities'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'autoscaling:SetDesiredCapacity'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'autoscaling:TerminateInstanceInAutoScalingGroup'
+          Effect: Allow
+          Resource: '*'
+      Version: 2012-10-17
+    PolicyName: root
+RoleName: "{{.Cluster.LocalID}}-app-autoscaler"
+Type: 'AWS::IAM::Role'
+KarpenterNodeInstanceProfile: # instance profile for worker nodes spawn by karpenter controller
+  Type: "AWS::IAM::InstanceProfile"
+  Properties:
+    InstanceProfileName: "{{ .Cluster.ID | awsValidID }}-WorkerKarpenter-InstanceProfile"
+    Path: "/"
+    Roles:
+      - !Ref WorkerIAMRole
+KarpenterIAMRole: # role for the karpenter controller
+  Properties:
+    AssumeRolePolicyDocument: !Sub
+      - |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Federated": [
+                  "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
+                ]
               },
-{{- end }}
-              {
-                "Effect": "Allow",
-                "Principal": {
-                  "Federated": [
-                    "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
-                  ]
-                },
-                "Action": [
-                  "sts:AssumeRoleWithWebIdentity"
-                ],
-                "Condition": {
-                  "StringEquals": {
-                    "${OIDC}:sub": "system:serviceaccount:kube-system:kube-node-ready"
-                  }
+              "Action": [
+                "sts:AssumeRoleWithWebIdentity"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "${OIDC}:aud": "sts.amazonaws.com",
+                  "${OIDC}:sub": "system:serviceaccount:kube-system:karpenter"
                 }
               }
-            ]
-          }
-{{- if eq .Cluster.Provider "zalando-eks" }}
-        - OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
-{{- else }}
-        - OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
-          MasterIAMRole: !Join
-            - ''
-            - - !Sub 'arn:aws:iam::${AWS::AccountId}:role/'
-              - !Ref MasterIAMRole
-{{- end }}
-      Path: /
-      Policies:
-        - PolicyDocument:
-            Statement:
-              - Action: 'autoscaling:Describe*'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'autoscaling:CompleteLifecycleAction'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'sts:AssumeRole'
-                Effect: Allow
-                Resource: '*'
-            Version: 2012-10-17
-          PolicyName: root
-      RoleName: "{{.Cluster.LocalID}}-kube-node-ready"
-    Type: 'AWS::IAM::Role'
-  MasterIAMRole:
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-          - Action:
-              - 'sts:AssumeRole'
-            Effect: Allow
-            Principal:
-              Service:
-                - ec2.amazonaws.com
-        Version: 2012-10-17
-      Path: /
-      Policies:
-        - PolicyDocument:
-            Statement:
-              - Action: 'ec2:*'
-                Effect: Allow
-                Resource: '*'
-              # CLC
-              - Action: 'ec2:DescribeInstanceStatus'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'autoscaling:DescribeAutoScalingGroups'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'autoscaling:DescribeAutoScalingInstances'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'autoscaling:DescribeLoadBalancers'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'autoscaling:SetDesiredCapacity'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'elasticloadbalancing:DescribeInstanceHealth'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'autoscaling:TerminateInstanceInAutoScalingGroup'
-                Effect: Allow
-                Resource: '*'
-              # End CLC
-              - Action: 'elasticloadbalancing:*'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'kms:Decrypt'
-                Effect: Allow
-                Resource: '*'
-              - Action: 's3:GetObject'
-                Effect: Allow
-                Resource: 'arn:aws:s3:::*'
-              - Action:
-                  - 'ecr:BatchCheckLayerAvailability'
-                  - 'ecr:BatchGetImage'
-                  - 'ecr:GetDownloadUrlForLayer'
-                  - 'ecr:GetAuthorizationToken'
-                Effect: Allow
-                Resource: '*'
-              # allow connecting via Session Manager
-              - Action:
-                - "ssm:UpdateInstanceInformation"
-                - "ssmmessages:CreateControlChannel"
-                - "ssmmessages:CreateDataChannel"
-                - "ssmmessages:OpenControlChannel"
-                - "ssmmessages:OpenDataChannel"
-                Effect: Allow
-                Resource: "*"
-              - Action:
-                - "logs:CreateLogStream"
-                - "logs:PutLogEvents"
-                - "logs:DescribeLogGroups"
-                - "logs:DescribeLogStreams"
-                Effect: Allow
-                Resource: "*"
-            Version: 2012-10-17
-          PolicyName: root
-    Type: 'AWS::IAM::Role'
-{{- if ne .Cluster.Provider "zalando-eks" }}
-  CloudControllerManagerIAMRole:
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-          - Effect: Allow
-            Principal:
-              Federated: !Sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
-            Action:
-              - "sts:AssumeRoleWithWebIdentity"
-            Condition:
-              StringEquals:
-                "{{ .Cluster.LocalID }}.{{ .Values.hosted_zone }}:aud": "sts.amazonaws.com"
-                "{{ .Cluster.LocalID }}.{{ .Values.hosted_zone }}:sub": "system:serviceaccount:kube-system:cloud-controller-manager"
-        Version: 2012-10-17
-      Path: /
-      Policies:
-      # https://cloud-provider-aws.sigs.k8s.io/prerequisites/#iam-policies
-      - PolicyDocument:
-          Statement:
-          - Effect: Allow
-            Action:
-            - "autoscaling:DescribeAutoScalingGroups"
-            - "autoscaling:DescribeLaunchConfigurations"
-            - "autoscaling:DescribeTags"
-            - "ec2:DescribeInstances"
-            - "ec2:DescribeInstanceTopology"
-            - "ec2:DescribeRegions"
-            - "ec2:DescribeRouteTables"
-            - "ec2:DescribeSecurityGroups"
-            - "ec2:DescribeSubnets"
-            - "ec2:DescribeVolumes"
-            - "ec2:DescribeAvailabilityZones"
-            - "ec2:CreateSecurityGroup"
-            - "ec2:CreateTags"
-            - "ec2:CreateVolume"
-            - "ec2:ModifyInstanceAttribute"
-            - "ec2:ModifyVolume"
-            - "ec2:AttachVolume"
-            - "ec2:AuthorizeSecurityGroupIngress"
-            - "ec2:CreateRoute"
-            - "ec2:DeleteRoute"
-            - "ec2:DeleteSecurityGroup"
-            - "ec2:DeleteVolume"
-            - "ec2:DetachVolume"
-            - "ec2:RevokeSecurityGroupIngress"
-            - "ec2:DescribeVpcs"
-            - "elasticloadbalancing:AddTags"
-            - "elasticloadbalancing:AttachLoadBalancerToSubnets"
-            - "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer"
-            - "elasticloadbalancing:CreateLoadBalancer"
-            - "elasticloadbalancing:CreateLoadBalancerPolicy"
-            - "elasticloadbalancing:CreateLoadBalancerListeners"
-            - "elasticloadbalancing:ConfigureHealthCheck"
-            - "elasticloadbalancing:DeleteLoadBalancer"
-            - "elasticloadbalancing:DeleteLoadBalancerListeners"
-            - "elasticloadbalancing:DescribeLoadBalancers"
-            - "elasticloadbalancing:DescribeLoadBalancerAttributes"
-            - "elasticloadbalancing:DetachLoadBalancerFromSubnets"
-            - "elasticloadbalancing:DeregisterInstancesFromLoadBalancer"
-            - "elasticloadbalancing:ModifyLoadBalancerAttributes"
-            - "elasticloadbalancing:RegisterInstancesWithLoadBalancer"
-            - "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
-            - "elasticloadbalancing:AddTags"
-            - "elasticloadbalancing:CreateListener"
-            - "elasticloadbalancing:CreateTargetGroup"
-            - "elasticloadbalancing:DeleteListener"
-            - "elasticloadbalancing:DeleteTargetGroup"
-            - "elasticloadbalancing:DescribeListeners"
-            - "elasticloadbalancing:DescribeLoadBalancerPolicies"
-            - "elasticloadbalancing:DescribeTargetGroups"
-            - "elasticloadbalancing:DescribeTargetHealth"
-            - "elasticloadbalancing:ModifyListener"
-            - "elasticloadbalancing:ModifyTargetGroup"
-            - "elasticloadbalancing:RegisterTargets"
-            - "elasticloadbalancing:DeregisterTargets"
-            - "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
-            - "iam:CreateServiceLinkedRole"
-            - "kms:DescribeKey"
-            Resource:
-            - "*"
-          Version: 2012-10-17
-        PolicyName: root
-      RoleName: "{{.Cluster.LocalID}}-cloud-controller-manager"
-    Type: "AWS::IAM::Role"
-  ETCDS3BackupIAMRole:
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-          - Effect: Allow
-            Principal:
-              Federated: !Sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
-            Action:
-              - 'sts:AssumeRoleWithWebIdentity'
-            Condition:
-              StringEquals:
-                "{{ .Cluster.LocalID }}.{{ .Values.hosted_zone }}:sub": "system:serviceaccount:kube-system:etcd-backup"
-          - Action:
-              - 'sts:AssumeRole'
-            Effect: Allow
-            Principal:
-              AWS: !Join
-                - ''
-                - - !Sub 'arn:aws:iam::${AWS::AccountId}:role/'
-                  - !Ref MasterIAMRole
-        Version: 2012-10-17
-      Path: /
-      Policies:
-        - PolicyDocument:
-            Statement:
-              - Action:
-                  - 's3:ListBucket'
-                Effect: Allow
-                Resource:
-                  - >-
-                    arn:aws:s3:::{{.Cluster.ConfigItems.etcd_s3_backup_bucket}}
-              - Action:
-                  - 's3:PutObject'
-                  - 's3:GetObject'
-                  - 's3:DeleteObject'
-                Effect: Allow
-                Resource:
-                  - >-
-                    arn:aws:s3:::{{.Cluster.ConfigItems.etcd_s3_backup_bucket}}/*
-            Version: 2012-10-17
-          PolicyName: root
-      RoleName: "{{.Cluster.LocalID}}-etcd-backup"
-    Type: 'AWS::IAM::Role'
-{{- end }}
-  StaticEgressControllerIAMRole:
-    Properties:
-      AssumeRolePolicyDocument: !Sub
-        - |
+            }
+          ]
+        }
+  {{- if eq .Cluster.Provider "zalando-eks" }}
+- OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
+  {{- else }}
+- OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+  {{- end }}
+Path: /
+Policies:
+  - PolicyName: "KarpenterControllerPolicy-{{ .Cluster.ID | awsValidID }}"
+    # The PolicyDocument must be in JSON string format because we use a StringEquals condition that uses an interpolated
+    # value in one of its key parameters which isn't natively supported by CloudFormation
+    PolicyDocument: !Sub |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
           {
-            "Version": "2012-10-17",
-            "Statement": [
-              {
-                "Effect": "Allow",
-                "Principal": {
-                  "Federated": [
-                    "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
-                  ]
-                },
-                "Action": [
-                  "sts:AssumeRoleWithWebIdentity"
-                ],
-                "Condition": {
-                  "StringEquals": {
-                    "${OIDC}:sub": "system:serviceaccount:kube-system:kube-static-egress-controller"
-                  }
-                }
-              }
+            "Sid": "AllowScopedEC2InstanceAccessActions",
+            "Effect": "Allow",
+            "Resource": [
+              "arn:${AWS::Partition}:ec2:${AWS::Region}::image/*",
+              "arn:${AWS::Partition}:ec2:${AWS::Region}::snapshot/*",
+              "arn:${AWS::Partition}:ec2:${AWS::Region}:*:security-group/*",
+              "arn:${AWS::Partition}:ec2:${AWS::Region}:*:subnet/*",
+              "arn:${AWS::Partition}:ec2:${AWS::Region}:*:capacity-reservation/*"
+            ],
+            "Action": [
+              "ec2:RunInstances",
+              "ec2:CreateFleet"
             ]
-          }
-{{- if eq .Cluster.Provider "zalando-eks" }}
-        - OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
-{{- else }}
-        - OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
-{{- end }}
-      Path: /
-      Policies:
-        - PolicyDocument:
-            Statement:
-              - Action: 'cloudformation:*'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'ec2:AllocateAddress'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'ec2:AssociateRouteTable'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'ec2:DisassociateRouteTable'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'ec2:CreateRouteTable'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'ec2:CreateRoute'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'ec2:CreateNatGateway'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'ec2:CreateSubnet'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'ec2:CreateTags'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'ec2:DeleteTags'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'ec2:ReleaseAddress'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'ec2:DeleteRouteTable'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'ec2:DeleteRoute'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'ec2:DeleteNatGateway'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'ec2:DeleteSubnet'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'ec2:DescribeAddresses'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'ec2:DescribeInternetGateways'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'ec2:DescribeRouteTables'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'ec2:DescribeNatGateways'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'ec2:DescribeSubnets'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'ec2:DescribeVpcs'
-                Effect: Allow
-                Resource: '*'
-              - Action:
-                - "s3:PutObject"
-                - "s3:GetObject"
-                - "s3:GetObjectVersion"
-                Effect: Allow
-                Resource: "arn:aws:s3:::cluster-lifecycle-manager-{{.Cluster.InfrastructureAccountID}}-{{.Cluster.Region}}/*"
-            Version: 2012-10-17
-          PolicyName: root
-      RoleName: "{{.Cluster.LocalID}}-static-egress-controller"
-    Type: 'AWS::IAM::Role'
-  ZmonIAMRole:
-    Properties:
-      AssumeRolePolicyDocument: !Sub
-        - |
+          },
           {
-            "Version": "2012-10-17",
-            "Statement": [
-              {
-                "Action": [
-                  "sts:AssumeRole"
-                ],
-                "Effect": "Allow",
-                "Principal": {
-                  "Service": ["ec2.amazonaws.com"]
-                }
+            "Sid": "AllowScopedEC2LaunchTemplateAccessActions",
+            "Effect": "Allow",
+            "Resource": "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*",
+            "Action": [
+              "ec2:RunInstances",
+              "ec2:CreateFleet"
+            ],
+            "Condition": {
+              "StringEquals": {
+                "aws:ResourceTag/kubernetes.io/cluster/{{.Cluster.Name}}": "owned"
               },
-              {
-                "Action": [
-                  "sts:AssumeRole"
-                ],
-                "Effect": "Allow",
-                "Principal": {
-                  "AWS": "arn:aws:iam::${AWS::AccountId}:role/${WorkerIAMRole}"
-                }
-              },
-              {{/* TODO: Remove all of the above when ZMON is fully migrated to OIDC */}}
-              {
-                "Action": [
-                  "sts:AssumeRole"
-                ],
-                "Effect": "Allow",
-                "Principal": {
-                  "AWS": "{{.Cluster.ConfigItems.zmon_root_account_role}}"
-                }
-              },
-              {
-                "Effect": "Allow",
-                "Principal": {
-                  "Federated": [
-                    "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
-                  ]
-                },
-                "Action": [
-                  "sts:AssumeRoleWithWebIdentity"
-                ],
-                "Condition": {
-                  "StringEquals": {
-                    "${OIDC}:aud": "sts.amazonaws.com",
-                    "${OIDC}:sub": [
-                      "system:serviceaccount:visibility:zmon-appliance-scheduler",
-                      "system:serviceaccount:visibility:zmon-appliance-aws-agent",
-                      "system:serviceaccount:visibility:zmon"
-                    ]
-                  }
-                }
+              "StringLike": {
+                "aws:ResourceTag/karpenter.sh/nodepool": "*"
               }
-            ]
-          }
-{{- if eq .Cluster.Provider "zalando-eks" }}
-        - OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
-{{- else }}
-        - OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
-{{- end }}
-      Path: /
-      Policies:
-        - PolicyDocument:
-            Statement:
-              - Action: 'acm:DescribeCertificate'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'acm:ListCertificates'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'acm:ListTagsForCertificate'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'airflow:CreateCliToken'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'airflow:ListEnvironments'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'autoscaling:Describe*'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'cloudformation:Describe*'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'cloudformation:List*'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'cloudwatch:Describe*'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'cloudwatch:Get*'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'cloudwatch:List*'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'dax:DescribeClusters'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'ec2:Describe*'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'elasticache:Describe*'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'elasticloadbalancing:Describe*'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'iam:Get*'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'iam:List*'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'kinesis:Describe*'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'kinesisanalytics:List*'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'lambda:List*'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'opsworks:Describe*'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'rds:Describe*'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'rds:ListTagsForResource'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'route53:Get*'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'route53:List*'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'tag:Get*'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'dynamodb:ListTables'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'dynamodb:DescribeTable'
-                Effect: Allow
-                Resource: '*'
-              - Action: 's3:ListBucket'
-                Effect: Allow
-                Resource: '*'
-          {{if .Cluster.ConfigItems.zmon_accessible_s3_buckets}}
-              {{range $bucket := split .Cluster.ConfigItems.zmon_accessible_s3_buckets ","}}
-              - Action: 's3:GetObject'
-                Effect: Allow
-                Resource: 'arn:aws:s3:::{{ $bucket }}/*'
-              {{end}}
-          {{end}}
-              - Action: 'sqs:GetQueueAttributes'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'sqs:ListDeadLetterSourceQueues'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'sqs:ListQueues'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'servicequotas:ListServiceQuotas'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'sts:AssumeRole'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'sagemaker:DescribeEndpoint'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'sagemaker:ListEndpoints'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'states:ListStateMachines'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'states:ListExecutions'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'secretsmanager:GetSecretValue'
-                Effect: Allow
-                Resource: "arn:aws:secretsmanager:{{.Cluster.Region}}:{{.Cluster.InfrastructureAccountID}}:secret:*.zmon-db-user.credentials*"
-            Version: 2012-10-17
-          PolicyName: root
-      RoleName: "{{.Cluster.LocalID}}-app-zmon"
-    Type: 'AWS::IAM::Role'
-
-  LoggingAgentIAMRole:
-    Type: AWS::IAM::Role
-    Properties:
-      RoleName: "{{.Cluster.LocalID}}-app-logging-agent"
-      Path: /
-      AssumeRolePolicyDocument: !Sub
-        - |
+            }
+          },
           {
-            "Version": "2012-10-17",
-            "Statement": [
-              {
-                "Effect": "Allow",
-                "Action": [
-                  "sts:AssumeRole"
-                ],
-                "Principal": {
-                  "Service": [
-                    "ec2.amazonaws.com"
-                  ]
-                }
+            "Sid": "AllowScopedEC2InstanceActionsWithTags",
+            "Effect": "Allow",
+            "Resource": [
+              "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
+              "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+              "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
+              "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*",
+              "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*",
+              "arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*",
+              "arn:${AWS::Partition}:ec2:${AWS::Region}:*:capacity-reservation/*"
+            ],
+            "Action": [
+              "ec2:RunInstances",
+              "ec2:CreateFleet",
+              "ec2:CreateLaunchTemplate"
+            ],
+            "Condition": {
+              "StringEquals": {
+                "aws:RequestTag/kubernetes.io/cluster/{{.Cluster.Name}}": "owned",
+                "aws:RequestTag/eks:eks-cluster-name": "{{.Cluster.Name}}"
               },
-              {
-                "Effect": "Allow",
-                "Action": [
-                  "sts:AssumeRole"
-                ],
-                "Principal": {
-                  "AWS": "${WorkerIAMRole}"
-                }
-              },
-              {
-                "Effect": "Allow",
-                "Action": [
-                  "sts:AssumeRole"
-                ],
-                "Principal": {
-                  "AWS": "${MasterIAMRole}"
-                }
-              },
-              {
-                "Effect": "Allow",
-                "Principal": {
-                  "Federated": [
-                    "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
-                  ]
-                },
-                "Action": [
-                  "sts:AssumeRoleWithWebIdentity"
-                ],
-                "Condition": {
-                  "StringEquals": {
-                    "${OIDC}:sub": "system:serviceaccount:visibility:logging-agent"
-                  }
-                }
+              "StringLike": {
+                "aws:RequestTag/karpenter.sh/nodepool": "*"
               }
-            ]
-          }
-{{- if eq .Cluster.Provider "zalando-eks" }}
-        - OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
-{{- else }}
-        - OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
-{{- end }}
-          WorkerIAMRole: !Sub 'arn:aws:iam::${AWS::AccountId}:role/${WorkerIAMRole}'
-          MasterIAMRole: !Sub 'arn:aws:iam::${AWS::AccountId}:role/${MasterIAMRole}'
-      Policies:
-        - PolicyName: AllowS3BucketAccess
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-            - Action: ["s3:ListBucket"]
-              Effect: "Allow"
-              Resource: 'arn:aws:s3:::{{.Cluster.ConfigItems.logging_s3_bucket}}'
-            - Action: ["s3:GetObject"]
-              Effect: "Allow"
-              Resource: 'arn:aws:s3:::{{.Cluster.ConfigItems.logging_s3_bucket}}/*'
-            - Action: ["s3:PutObject"]
-              Effect: "Allow"
-              Resource: 'arn:aws:s3:::{{.Cluster.ConfigItems.logging_s3_bucket}}/*'
-{{- if .Cluster.ConfigItems.logging_infrastructure_s3_bucket }}
-        - PolicyName: AllowCentralTelemetryInfrastructureS3BucketAccess
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-            - Action: ["s3:ListBucket"]
-              Effect: "Allow"
-              Resource: 'arn:aws:s3:::{{.Cluster.ConfigItems.logging_infrastructure_s3_bucket}}'
-            - Action: ["s3:GetObject", "s3:PutObject", "s3:PutObjectAcl"]
-              Effect: "Allow"
-              Resource: 'arn:aws:s3:::{{.Cluster.ConfigItems.logging_infrastructure_s3_bucket}}/*'
-{{- end }}
-
-  KubeMetricsIAMRole:
-    Properties:
-      AssumeRolePolicyDocument: !Sub
-        - |
+            }
+          },
           {
-            "Version": "2012-10-17",
-            "Statement": [
-              {
-                "Effect": "Allow",
-                "Principal": {
-                  "Federated": [
-                    "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
-                  ]
-                },
-                "Action": [
-                  "sts:AssumeRoleWithWebIdentity"
-                ],
-                "Condition": {
-                  "StringEquals": {
-                    "${OIDC}:sub": "system:serviceaccount:kube-system:custom-metrics-apiserver"
-                  }
-                }
+            "Sid": "AllowScopedResourceCreationTagging",
+            "Effect": "Allow",
+            "Resource": [
+              "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
+              "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+              "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
+              "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*",
+              "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*",
+              "arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*"
+            ],
+            "Action": "ec2:CreateTags",
+            "Condition": {
+              "StringEquals": {
+                "aws:RequestTag/kubernetes.io/cluster/{{.Cluster.Name}}": "owned",
+                "ec2:CreateAction": [
+                  "RunInstances",
+                  "CreateFleet",
+                  "CreateLaunchTemplate"
+                ]
+              },
+              "StringLike": {
+                "aws:RequestTag/karpenter.sh/nodepool": "*"
               }
-            ]
-          }
-{{- if eq .Cluster.Provider "zalando-eks" }}
-        - OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
-{{- else }}
-        - OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
-{{- end }}
-      Path: /
-      Policies:
-        - PolicyDocument:
-            Statement:
-              - Action: 'sqs:GetQueueUrl'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'sqs:GetQueueAttributes'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'sqs:ListQueues'
-                Effect: Allow
-                Resource: '*'
-              - Action: 'sqs:ListQueueTags'
-                Effect: Allow
-                Resource: '*'
-            Version: 2012-10-17
-          PolicyName: root
-      RoleName: "{{.Cluster.LocalID}}-kube-metrics-adapter"
-    Type: 'AWS::IAM::Role'
-
-  EBSCSIControllerIAMRole:
-    Properties:
-      AssumeRolePolicyDocument: !Sub
-        - |
+            }
+          },
           {
-            "Version": "2012-10-17",
-            "Statement": [
-              {
-                "Effect": "Allow",
-                "Principal": {
-                  "Federated": [
-                    "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
-                  ]
-                },
-                "Action": [
-                  "sts:AssumeRoleWithWebIdentity"
-                ],
-                "Condition": {
-                  "StringEquals": {
-                    "${OIDC}:sub": "system:serviceaccount:kube-system:ebs-csi-controller-sa"
-                  }
-                }
+            "Sid": "AllowScopedResourceTagging",
+            "Effect": "Allow",
+            "Resource": "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+            "Action": "ec2:CreateTags",
+            "Condition": {
+              "StringEquals": {
+                "aws:ResourceTag/kubernetes.io/cluster/{{.Cluster.Name}}": "owned"
+              },
+              "StringLike": {
+                "aws:ResourceTag/karpenter.sh/nodepool": "*"
+              },
+              "StringEqualsIfExists": {
+                "aws:RequestTag/eks:eks-cluster-name": "{{.Cluster.Name}}"
+              },
+              "ForAllValues:StringEquals": {
+                "aws:TagKeys": [
+                  "eks:eks-cluster-name",
+                  "karpenter.sh/nodeclaim",
+                  "Name"
+                ]
               }
+            }
+          },
+          {
+            "Sid": "AllowScopedDeletion",
+            "Effect": "Allow",
+            "Resource": [
+              "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+              "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
+            ],
+            "Action": [
+              "ec2:TerminateInstances",
+              "ec2:DeleteLaunchTemplate"
+            ],
+            "Condition": {
+              "StringEquals": {
+                "aws:ResourceTag/kubernetes.io/cluster/{{.Cluster.Name}}": "owned"
+              },
+              "StringLike": {
+                "aws:ResourceTag/karpenter.sh/nodepool": "*"
+              }
+            }
+          },
+          {
+            "Sid": "AllowRegionalReadActions",
+            "Effect": "Allow",
+            "Resource": "*",
+            "Action": [
+              "ec2:DescribeCapacityReservations",
+              "ec2:DescribeImages",
+              "ec2:DescribeInstances",
+              "ec2:DescribeInstanceTypeOfferings",
+              "ec2:DescribeInstanceTypes",
+              "ec2:DescribeLaunchTemplates",
+              "ec2:DescribeSecurityGroups",
+              "ec2:DescribeSpotPriceHistory",
+              "ec2:DescribeSubnets"
+            ],
+            "Condition": {
+              "StringEquals": {
+                "aws:RequestedRegion": "${AWS::Region}"
+              }
+            }
+          },
+          {
+            "Sid": "AllowSSMReadActions",
+            "Effect": "Allow",
+            "Resource": "arn:${AWS::Partition}:ssm:${AWS::Region}::parameter/aws/service/*",
+            "Action": "ssm:GetParameter"
+          },
+          {
+            "Sid": "AllowPricingReadActions",
+            "Effect": "Allow",
+            "Resource": "*",
+            "Action": "pricing:GetProducts"
+          },
+          {
+            "Sid": "AllowInterruptionQueueActions",
+            "Effect": "Allow",
+            "Resource": "${KarpenterInterruptionQueue.Arn}",
+            "Action": [
+              "sqs:DeleteMessage",
+              "sqs:GetQueueUrl",
+              "sqs:ReceiveMessage"
             ]
+          },
+          {
+            "Sid": "AllowPassingInstanceRole",
+            "Effect": "Allow",
+            "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/{{.Cluster.LocalID}}-worker",
+            "Action": "iam:PassRole",
+            "Condition": {
+              "StringEquals": {
+                "iam:PassedToService": "ec2.amazonaws.com"
+              }
+            }
+          },
+          {
+            "Sid": "AllowScopedInstanceProfileCreationActions",
+            "Effect": "Allow",
+            "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
+            "Action": [
+              "iam:CreateInstanceProfile"
+            ],
+            "Condition": {
+              "StringEquals": {
+                "aws:RequestTag/kubernetes.io/cluster/{{.Cluster.Name}}": "owned",
+                "aws:RequestTag/eks:eks-cluster-name": "{{.Cluster.Name}}",
+                "aws:RequestTag/topology.kubernetes.io/region": "${AWS::Region}"
+              },
+              "StringLike": {
+                "aws:RequestTag/karpenter.k8s.aws/ec2nodeclass": "*"
+              }
+            }
+          },
+          {
+            "Sid": "AllowScopedInstanceProfileTagActions",
+            "Effect": "Allow",
+            "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
+            "Action": [
+              "iam:TagInstanceProfile"
+            ],
+            "Condition": {
+              "StringEquals": {
+                "aws:ResourceTag/kubernetes.io/cluster/{{.Cluster.Name}}": "owned",
+                "aws:ResourceTag/topology.kubernetes.io/region": "${AWS::Region}",
+                "aws:RequestTag/kubernetes.io/cluster/{{.Cluster.Name}}": "owned",
+                "aws:RequestTag/eks:eks-cluster-name": "{{.Cluster.Name}}",
+                "aws:RequestTag/topology.kubernetes.io/region": "${AWS::Region}"
+              },
+              "StringLike": {
+                "aws:ResourceTag/karpenter.k8s.aws/ec2nodeclass": "*",
+                "aws:RequestTag/karpenter.k8s.aws/ec2nodeclass": "*"
+              }
+            }
+          },
+          {
+            "Sid": "AllowScopedInstanceProfileActions",
+            "Effect": "Allow",
+            "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
+            "Action": [
+              "iam:AddRoleToInstanceProfile",
+              "iam:RemoveRoleFromInstanceProfile",
+              "iam:DeleteInstanceProfile"
+            ],
+            "Condition": {
+              "StringEquals": {
+                "aws:ResourceTag/kubernetes.io/cluster/{{.Cluster.Name}}": "owned",
+                "aws:ResourceTag/topology.kubernetes.io/region": "${AWS::Region}"
+              },
+              "StringLike": {
+                "aws:ResourceTag/karpenter.k8s.aws/ec2nodeclass": "*"
+              }
+            }
+          },
+          {
+            "Sid": "AllowInstanceProfileReadActions",
+            "Effect": "Allow",
+            "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
+            "Action": "iam:GetInstanceProfile"
+          },
+          {
+            "Sid": "AllowUnscopedInstanceProfileListAction",
+            "Effect": "Allow",
+            "Resource": "*",
+            "Action": "iam:ListInstanceProfiles"
+          },
+          {
+            "Sid": "AllowAPIServerEndpointDiscovery",
+            "Effect": "Allow",
+            "Resource": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/{{.Cluster.Name}}",
+            "Action": "eks:DescribeCluster"
           }
-{{- if eq .Cluster.Provider "zalando-eks" }}
-        - OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
-{{- else }}
-        - OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
-{{- end }}
-      Path: /
-      Policies:
-        - PolicyDocument:
-            Statement:
-              - Effect: Allow
-                Action:
-                - ec2:CreateSnapshot
-                - ec2:AttachVolume
-                - ec2:DetachVolume
-                - ec2:ModifyVolume
-                - ec2:DescribeAvailabilityZones
-                - ec2:DescribeInstances
-                - ec2:DescribeSnapshots
-                - ec2:DescribeTags
-                - ec2:DescribeVolumes
-                - ec2:DescribeVolumesModifications
-                Resource: "*"
-              - Effect: Allow
-                Action:
-                - ec2:CreateTags
-                Resource:
-                - arn:aws:ec2:*:*:volume/*
-                - arn:aws:ec2:*:*:snapshot/*
-                Condition:
-                  StringEquals:
-                    ec2:CreateAction:
-                    - CreateVolume
-                    - CreateSnapshot
-              - Effect: Allow
-                Action:
-                - ec2:DeleteTags
-                Resource:
-                - arn:aws:ec2:*:*:volume/*
-                - arn:aws:ec2:*:*:snapshot/*
-              - Effect: Allow
-                Action:
-                - ec2:CreateVolume
-                Resource: "*"
-                Condition:
-                  StringLike:
-                    aws:RequestTag/ebs.csi.aws.com/cluster: 'true'
-              - Effect: Allow
-                Action:
-                - ec2:CreateVolume
-                Resource: "*"
-                Condition:
-                  StringLike:
-                    aws:RequestTag/CSIVolumeName: "*"
-              - Effect: Allow
-                Action:
-                - ec2:DeleteVolume
-                Resource: "*"
-                Condition:
-                  StringLike:
-                    ec2:ResourceTag/ebs.csi.aws.com/cluster: 'true'
-              - Effect: Allow
-                Action:
-                - ec2:DeleteVolume
-                Resource: "*"
-                Condition:
-                  StringLike:
-                    ec2:ResourceTag/CSIVolumeName: "*"
-              - Effect: Allow
-                Action:
-                - ec2:DeleteVolume
-                Resource: "*"
-                Condition:
-                  StringLike:
-                    ec2:ResourceTag/kubernetes.io/created-for/pvc/name: "*"
-              - Effect: Allow
-                Action:
-                - ec2:DeleteSnapshot
-                Resource: "*"
-                Condition:
-                  StringLike:
-                    ec2:ResourceTag/CSIVolumeSnapshotName: "*"
-              - Effect: Allow
-                Action:
-                - ec2:DeleteSnapshot
-                Resource: "*"
-                Condition:
-                  StringLike:
-                    ec2:ResourceTag/ebs.csi.aws.com/cluster: 'true'
-            Version: 2012-10-17
-          PolicyName: root
-      RoleName: "{{.Cluster.LocalID}}-ebs-csi-controller"
-    Type: 'AWS::IAM::Role'
-
-  {{ if eq .Cluster.Environment "e2e" }}
-# This is a hack to easily create an aws iam role and s3 bucket for testing
-  # AWS IAM integration in e2e tests.
-  E2EAWSIAMTestRole:
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
+        ]
+      }
+RoleName: "{{.Cluster.LocalID}}-app-karpenter"
+Type: 'AWS::IAM::Role'
+KarpenterInterruptionQueue:
+  Type: AWS::SQS::Queue
+  Properties:
+    QueueName: !Sub "{{.Cluster.LocalID}}-karpenter-interruption-queue"
+    MessageRetentionPeriod: 300
+    SqsManagedSseEnabled: true
+KarpenterInterruptionQueuePolicy:
+  Type: AWS::SQS::QueuePolicy
+  Properties:
+    Queues:
+      - !Ref KarpenterInterruptionQueue
+    PolicyDocument:
+      Id: EC2InterruptionPolicy
+      Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+              - events.amazonaws.com
+              - sqs.amazonaws.com
+          Action: sqs:SendMessage
+          Resource: !GetAtt KarpenterInterruptionQueue.Arn
+ScheduledChangeRule:
+  Type: 'AWS::Events::Rule'
+  Properties:
+    EventPattern:
+      source:
+        - aws.health
+      detail-type:
+        - AWS Health Event
+    Targets:
+      - Id: KarpenterInterruptionQueueTarget
+        Arn: !GetAtt KarpenterInterruptionQueue.Arn
+SpotInterruptionRule:
+  Type: 'AWS::Events::Rule'
+  Properties:
+    EventPattern:
+      source:
+        - aws.ec2
+      detail-type:
+        - EC2 Spot Instance Interruption Warning
+    Targets:
+      - Id: KarpenterInterruptionQueueTarget
+        Arn: !GetAtt KarpenterInterruptionQueue.Arn
+RebalanceRule:
+  Type: 'AWS::Events::Rule'
+  Properties:
+    EventPattern:
+      source:
+        - aws.ec2
+      detail-type:
+        - EC2 Instance Rebalance Recommendation
+    Targets:
+      - Id: KarpenterInterruptionQueueTarget
+        Arn: !GetAtt KarpenterInterruptionQueue.Arn
+InstanceStateChangeRule:
+  Type: 'AWS::Events::Rule'
+  Properties:
+    EventPattern:
+      source:
+        - aws.ec2
+      detail-type:
+        - EC2 Instance State-change Notification
+    Targets:
+      - Id: KarpenterInterruptionQueueTarget
+        Arn: !GetAtt KarpenterInterruptionQueue.Arn
+DeploymentIAMRole:
+  Properties:
+    AssumeRolePolicyDocument:
+      Statement:
         - Action:
-          - 'sts:AssumeRole'
+            - 'sts:AssumeRole'
           Effect: Allow
           Principal:
             Service:
-            - ec2.amazonaws.com
+              - ec2.amazonaws.com
         - Action:
-          - 'sts:AssumeRole'
+            - 'sts:AssumeRole'
           Effect: Allow
           Principal:
             AWS: !Join
               - ''
               - - !Sub 'arn:aws:iam::${AWS::AccountId}:role/'
                 - !Ref WorkerIAMRole
-        Version: 2012-10-17
-      Path: /
-      Policies:
+      Version: 2012-10-17
+    Path: /
+    ManagedPolicyArns:
+      - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-DenyEc2UsApSa"
+      - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-DenyModifyShibboleth"
+      - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-DenyDefault"
+      - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-AllowPowerUser"
+      - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-AllowPowerUserCustom"
+      {{- if eq .Cluster.Name "playground" }}
+      - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-AllowPowerUser-Playground"
+      {{- end }}
+    RoleName: "{{.Cluster.LocalID}}-deployment"
+  Type: 'AWS::IAM::Role'
+DeploymentServiceBucket:
+  Type: AWS::S3::Bucket
+  DeletionPolicy: Delete
+  Properties:
+    BucketName: "{{ .Cluster.ConfigItems.deployment_service_bucket_name }}"
+    PublicAccessBlockConfiguration:
+      BlockPublicAcls: true
+      BlockPublicPolicy: true
+      IgnorePublicAcls: true
+      RestrictPublicBuckets: true
+    Tags:
+      - Key: component
+        Value: deployment-service
+    OwnershipControls:
+      Rules:
+        - ObjectOwnership: BucketOwnerPreferred
+DeploymentServiceBucketPolicy:
+  Type: AWS::S3::BucketPolicy
+  Properties:
+    Bucket: !Ref DeploymentServiceBucket
+    PolicyDocument:
+      Statement:
+        - NotAction:
+            - s3:GetObject
+            - s3:DeleteObject
+            - s3:ListBucket
+            - s3:PutObject
+          Effect: Deny
+          Resource:
+            - !Sub "arn:aws:s3:::${DeploymentServiceBucket}/*"
+            - !Sub "arn:aws:s3:::${DeploymentServiceBucket}"
+          Principal:
+            AWS:
+              - !GetAtt DeploymentControllerRole.Arn
+              - !GetAtt DeploymentStatusServiceRole.Arn
+  {{- if .Cluster.ConfigItems.deployment_service_api_role_arn }}
+- Action:
+    - s3:PutObject
+    - s3:PutObjectAcl
+  Effect: Allow
+  Resource:
+    - !Sub "arn:aws:s3:::${DeploymentServiceBucket}/manifests/*"
+  Principal:
+    AWS: "{{.Cluster.ConfigItems.deployment_service_api_role_arn}}"
+  {{- end }}
+- Action: "s3:*"
+  Effect: Deny
+  Resource:
+    - !Sub "arn:aws:s3:::${DeploymentServiceBucket}/*"
+    - !Sub "arn:aws:s3:::${DeploymentServiceBucket}"
+  Principal: "*"
+  Condition:
+    ArnNotEquals:
+      aws:PrincipalArn:
+        - !GetAtt DeploymentControllerRole.Arn
+        - !GetAtt DeploymentStatusServiceRole.Arn
+  {{- if .Cluster.ConfigItems.deployment_service_api_role_arn }}
+- "{{.Cluster.ConfigItems.deployment_service_api_role_arn}}"
+  {{- end }}
+- !Sub "arn:aws:iam::${AWS::AccountId}:role/cluster-lifecycle-manager-entrypoint"
+- !Sub "arn:aws:iam::${AWS::AccountId}:role/Shibboleth-Administrator"
+- !Sub "arn:aws:iam::${AWS::AccountId}:role/Administrator"
+  {{- if eq .Cluster.Name "playground" }}
+- !Sub "arn:aws:iam::${AWS::AccountId}:role/cluster-cleaner-nuke-entrypoint"
+  {{- end }}
+DeploymentControllerRole:
+  Type: AWS::IAM::Role
+  Properties:
+    RoleName: "{{.Cluster.ConfigItems.deployment_service_controller_role_name}}"
+    AssumeRolePolicyDocument: !Sub
+      - |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Federated": [
+                  "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
+                ]
+              },
+              "Action": [
+                "sts:AssumeRoleWithWebIdentity"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "${OIDC}:sub": "system:serviceaccount:kube-system:deployment-service-controller"
+                }
+              }
+            }
+          ]
+        }
+  {{- if eq .Cluster.Provider "zalando-eks" }}
+- OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
+  {{- else }}
+- OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+  {{- end }}
+Policies:
+  - PolicyName: ControllerPolicy
+    PolicyDocument:
+      Version: "2012-10-17"
+      Statement:
+        - Action:
+            - s3:DeleteObject
+          Resource:
+            - !Sub "arn:aws:s3:::${DeploymentServiceBucket}/*"
+          Effect: Allow
+        - Action:
+            - s3:GetObject
+          Resource:
+            - !Sub "arn:aws:s3:::${DeploymentServiceBucket}/manifests/*"
+          Effect: Allow
+        - Action:
+            - s3:PutObject
+          Resource:
+            - !Sub "arn:aws:s3:::${DeploymentServiceBucket}/final-task-statuses/*"
+          Effect: Allow
+        - Action:
+            - s3:ListBucket
+          Resource:
+            - !Sub "arn:aws:s3:::${DeploymentServiceBucket}"
+          Effect: Allow
+        - Action:
+            - kms:Decrypt
+          Effect: Allow
+          Resource: "*"
+          Condition:
+            StringLike:
+              "kms:RequestAlias": "alias/deployment-secret"
+        - Action:
+            - 'sts:AssumeRole'
+          Effect: Allow
+          Resource:
+            - !Sub "arn:aws:iam::${AWS::AccountId}:role/{{.Cluster.ConfigItems.deployment_service_deployment_role_name}}"
+DeploymentControllerDeploymentRole:
+  Type: AWS::IAM::Role
+  Properties:
+    RoleName: "{{.Cluster.ConfigItems.deployment_service_deployment_role_name}}"
+    AssumeRolePolicyDocument:
+      Version: "2012-10-17"
+      Statement:
+        - Effect: Allow
+          Principal:
+            AWS: !GetAtt DeploymentControllerRole.Arn
+          Action:
+            - sts:AssumeRole
+    ManagedPolicyArns:
+      - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-DenyEc2UsApSa"
+      - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-DenyModifyShibboleth"
+      - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-DenyDefault"
+      - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-AllowPowerUser"
+      - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-AllowPowerUserCustom"
+      {{- if eq .Cluster.Name "playground" }}
+      - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-AllowPowerUser-Playground"
+      {{- end }}
+  {{- if eq .Cluster.ConfigItems.deployment_service_ml_experiments_enabled "true"}}
+DeploymentControllerMLExperimentDeploymentRole:
+  Type: AWS::IAM::Role
+  Properties:
+    RoleName: "{{ .Cluster.ConfigItems.deployment_service_ml_experiments_role_name }}"
+    AssumeRolePolicyDocument:
+      Version: "2012-10-17"
+      Statement:
+        - Effect: Allow
+          Principal:
+            AWS: !GetAtt DeploymentControllerRole.Arn
+          Action:
+            - sts:AssumeRole
+    ManagedPolicyArns:
+      - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-mlbuilder-permission-boundary"
+  {{- end }}
+DeploymentStatusServiceRole:
+  Type: AWS::IAM::Role
+  Properties:
+    RoleName: "{{.Cluster.ConfigItems.deployment_service_status_service_role_name}}"
+    AssumeRolePolicyDocument: !Sub
+      - |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Federated": [
+                  "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
+                ]
+              },
+              "Action": [
+                "sts:AssumeRoleWithWebIdentity"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "${OIDC}:sub": "system:serviceaccount:kube-system:deployment-service-status-service"
+                }
+              }
+            }
+          ]
+        }
+  {{- if eq .Cluster.Provider "zalando-eks" }}
+- OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
+  {{- else }}
+- OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+  {{- end }}
+Policies:
+  - PolicyName: StatusServicePolicy
+    PolicyDocument:
+      Version: "2012-10-17"
+      Statement:
+        - Action:
+            - s3:GetObject
+          Resource:
+            - !Sub "arn:aws:s3:::${DeploymentServiceBucket}/final-task-statuses/*"
+          Effect: Allow
+        - Action:
+            - s3:GetObject
+            - s3:PutObject
+          Resource:
+            - !Sub "arn:aws:s3:::${DeploymentServiceBucket}/cached-probe-results/*"
+          Effect: Allow
+        - Action:
+            - s3:ListBucket
+          Resource:
+            - !Sub "arn:aws:s3:::${DeploymentServiceBucket}"
+          Effect: Allow
+        - Action:
+            - 'cloudformation:DescribeStackEvents'
+            - 'cloudformation:DescribeStackResources'
+            - 'cloudformation:DescribeStacks'
+            - 'cloudformation:GetTemplate'
+          Effect: Allow
+          Resource: '*'
+ExternalDNSIAMRole:
+  Properties:
+    AssumeRolePolicyDocument: !Sub
+      - |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Federated": [
+                  "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
+                ]
+              },
+              "Action": [
+                "sts:AssumeRoleWithWebIdentity"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "${OIDC}:sub": "system:serviceaccount:kube-system:external-dns"
+                }
+              }
+            }
+          ]
+        }
+  {{- if eq .Cluster.Provider "zalando-eks" }}
+- OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
+  {{- else }}
+- OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+  {{- end }}
+Path: /
+Policies:
+  - PolicyDocument:
+      Statement:
+        - Action: 'route53:*'
+          Effect: Allow
+          Resource: '*'
+      Version: 2012-10-17
+    PolicyName: root
+RoleName: "{{.Cluster.LocalID}}-app-external-dns"
+Type: 'AWS::IAM::Role'
+IngressControllerIAMRole:
+  Properties:
+    AssumeRolePolicyDocument: !Sub
+      - |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Federated": [
+                  "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
+                ]
+              },
+              "Action": [
+                "sts:AssumeRoleWithWebIdentity"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "${OIDC}:sub": "system:serviceaccount:kube-system:kube-ingress-aws-controller"
+                }
+              }
+            }
+          ]
+        }
+  {{- if eq .Cluster.Provider "zalando-eks" }}
+- OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
+  {{- else }}
+- OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+  {{- end }}
+Path: /
+Policies:
+  - PolicyDocument:
+      Statement:
+        - Action: 'acm:ListCertificates'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'acm:GetCertificate'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'acm:DescribeCertificate'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'acm:ListTagsForCertificate'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'autoscaling:DescribeAutoScalingGroups'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'autoscaling:AttachLoadBalancers'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'autoscaling:DetachLoadBalancers'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'autoscaling:DetachLoadBalancerTargetGroups'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'autoscaling:AttachLoadBalancerTargetGroups'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'autoscaling:DescribeLoadBalancerTargetGroups'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'cloudformation:*'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'elasticloadbalancing:*'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'elasticloadbalancingv2:*'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'ec2:DescribeAccountAttributes'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'ec2:DescribeInstances'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'ec2:DescribeInternetGateways'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'ec2:DescribeSubnets'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'ec2:DescribeSecurityGroups'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'ec2:DescribeRouteTables'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'ec2:DescribeVpcs'
+          Effect: Allow
+          Resource: '*'
+  {{- if eq .Cluster.Provider "zalando-eks" }}
+- Action: 'ec2:DescribeVpcPeeringConnections'
+  Effect: Allow
+  Resource: '*'
+  {{- end }}
+- Action: 'iam:CreateServiceLinkedRole'
+  Effect: Allow
+  Resource: '*'
+  Condition:
+    StringEquals:
+      "iam:AWSServiceName": "elasticloadbalancing.amazonaws.com"
+- Action: 'iam:GetServerCertificate'
+  Effect: Allow
+  Resource: '*'
+- Action: 'iam:ListServerCertificates'
+  Effect: Allow
+  Resource: '*'
+- Action: 'iam:ListServerCertificateTags'
+  Effect: Allow
+  Resource: '*'
+- Action: 'waf-regional:ListWebACLs'
+  Effect: Allow
+  Resource: '*'
+- Action: 'waf-regional:GetWebACL'
+  Effect: Allow
+  Resource: '*'
+- Action: 'waf-regional:GetWebACLForResource'
+  Effect: Allow
+  Resource: '*'
+- Action: 'waf-regional:AssociateWebACL'
+  Effect: Allow
+  Resource: '*'
+- Action: 'waf-regional:DisassociateWebACL'
+  Effect: Allow
+  Resource: '*'
+- Action: 'wafv2:ListWebACLs'
+  Effect: Allow
+  Resource: '*'
+- Action: 'wafv2:GetWebACL'
+  Effect: Allow
+  Resource: '*'
+- Action: 'wafv2:GetWebACLForResource'
+  Effect: Allow
+  Resource: '*'
+- Action: 'wafv2:AssociateWebACL'
+  Effect: Allow
+  Resource: '*'
+- Action: 'wafv2:DisassociateWebACL'
+  Effect: Allow
+  Resource: '*'
+Version: 2012-10-17
+PolicyName: root
+RoleName: "{{.Cluster.LocalID}}-app-ingr-ctrl"
+Type: 'AWS::IAM::Role'
+# Note: this is not strictly specific to Open Policy Agent and can be extend
+# if Skipper Ingress needs to access other AWS resources
+SkipperIngressIAMRole:
+  Properties:
+    AssumeRolePolicyDocument: !Sub
+      - |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Federated": [
+                  "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
+                ]
+              },
+              "Action": [
+                "sts:AssumeRoleWithWebIdentity"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "${OIDC}:sub": "system:serviceaccount:kube-system:skipper-ingress"
+                }
+              }
+            }
+          ]
+        }
+  {{- if eq .Cluster.Provider "zalando-eks" }}
+- OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
+  {{- else }}
+- OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+  {{- end }}
+Path: /
+Policies:
+  - PolicyDocument:
+      Statement:
+        - Effect: "Allow"
+          Action:
+            - "s3:GetObject"
+          Resource:
+            - "{{ .Cluster.ConfigItems.skipper_open_policy_agent_bucket_arn }}/*"
+      Version: 2012-10-17
+    PolicyName: read-opa-bundles
+RoleName: "{{.Cluster.LocalID}}-app-skipper-ingress"
+Type: 'AWS::IAM::Role'
+# Note: this is not strictly specific to Open Policy Agent and can be extend
+# if Skipper Validation Webhook needs to access other AWS resources
+SkipperWebhookIAMRole:
+  Properties:
+    AssumeRolePolicyDocument: !Sub
+      - |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Federated": [
+                  "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
+                ]
+              },
+              "Action": [
+                "sts:AssumeRoleWithWebIdentity"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "${OIDC}:sub": "system:serviceaccount:kube-system:skipper-validation-webhook"
+                }
+              }
+            }
+          ]
+        }
+  {{- if eq .Cluster.Provider "zalando-eks" }}
+- OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
+  {{- else }}
+- OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+  {{- end }}
+Path: /
+Policies:
+  - PolicyDocument:
+      Statement:
+        - Effect: "Allow"
+          Action:
+            - "s3:GetObject"
+          Resource:
+            - "{{ .Cluster.ConfigItems.skipper_open_policy_agent_bucket_arn }}/*"
+      Version: 2012-10-17
+    PolicyName: read-opa-bundles
+RoleName: "{{.Cluster.LocalID}}-app-skipper-validation-webhook"
+Type: 'AWS::IAM::Role'
+ClusterLifecycleControllerIAMRole:
+  Properties:
+    AssumeRolePolicyDocument: !Sub
+      - |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Federated": [
+                  "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
+                ]
+              },
+              "Action": [
+                "sts:AssumeRoleWithWebIdentity"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "${OIDC}:sub": "system:serviceaccount:kube-system:cluster-lifecycle-controller"
+                }
+              }
+            }
+          ]
+        }
+  {{- if eq .Cluster.Provider "zalando-eks" }}
+- OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
+  {{- else }}
+- OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+  {{- end }}
+Path: /
+Policies:
+  - PolicyDocument:
+      Statement:
+        - Action: 'ec2:DescribeInstanceStatus'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'ec2:TerminateInstances'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'autoscaling:DescribeAutoScalingGroups'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'autoscaling:DescribeAutoScalingInstances'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'autoscaling:DescribeLoadBalancers'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'autoscaling:DescribeLoadBalancerTargetGroups'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'autoscaling:DescribeTags'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'autoscaling:SetDesiredCapacity'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'elasticloadbalancing:DescribeInstanceHealth'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'elasticloadbalancing:DescribeTargetHealth'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'autoscaling:TerminateInstanceInAutoScalingGroup'
+          Effect: Allow
+          Resource: '*'
+      Version: 2012-10-17
+    PolicyName: root
+RoleName: "{{.Cluster.LocalID}}-cluster-lifecycle-controller"
+Type: 'AWS::IAM::Role'
+KubeReadyIAMRole:
+  Properties:
+    AssumeRolePolicyDocument: !Sub
+      - |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+  {{- if ne .Cluster.Provider "zalando-eks" }}
+  {
+    "Action": [
+      "sts:AssumeRole"
+    ],
+    "Effect": "Allow",
+    "Principal": {
+      "AWS": "${MasterIAMRole}"
+    }
+  },
+  {{- end }}
+  {
+    "Effect": "Allow",
+    "Principal": {
+      "Federated": [
+        "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
+      ]
+    },
+    "Action": [
+      "sts:AssumeRoleWithWebIdentity"
+    ],
+    "Condition": {
+      "StringEquals": {
+        "${OIDC}:sub": "system:serviceaccount:kube-system:kube-node-ready"
+      }
+    }
+  }
+]
+}
+  {{- if eq .Cluster.Provider "zalando-eks" }}
+- OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
+  {{- else }}
+- OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+  MasterIAMRole: !Join
+    - ''
+    - - !Sub 'arn:aws:iam::${AWS::AccountId}:role/'
+      - !Ref MasterIAMRole
+  {{- end }}
+Path: /
+Policies:
+  - PolicyDocument:
+      Statement:
+        - Action: 'autoscaling:Describe*'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'autoscaling:CompleteLifecycleAction'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'sts:AssumeRole'
+          Effect: Allow
+          Resource: '*'
+      Version: 2012-10-17
+    PolicyName: root
+RoleName: "{{.Cluster.LocalID}}-kube-node-ready"
+Type: 'AWS::IAM::Role'
+MasterIAMRole:
+  Properties:
+    AssumeRolePolicyDocument:
+      Statement:
+        - Action:
+            - 'sts:AssumeRole'
+          Effect: Allow
+          Principal:
+            Service:
+              - ec2.amazonaws.com
+      Version: 2012-10-17
+    Path: /
+    Policies:
       - PolicyDocument:
           Statement:
-          - Action:
-            - 's3:ListBucket'
-            Effect: Allow
-            Resource:
-            - >-
-              arn:aws:s3:::zalando-e2e-test-{{.Cluster.InfrastructureAccountID}}-{{.Cluster.LocalID}}
-          - Action:
-            - 's3:PutObject'
-            - 's3:GetObject'
-            - 's3:DeleteObject'
-            Effect: Allow
-            Resource:
-            - >-
-              arn:aws:s3:::zalando-e2e-test-{{.Cluster.InfrastructureAccountID}}-{{.Cluster.LocalID}}/*
+            - Action: 'ec2:*'
+              Effect: Allow
+              Resource: '*'
+            # CLC
+            - Action: 'ec2:DescribeInstanceStatus'
+              Effect: Allow
+              Resource: '*'
+            - Action: 'autoscaling:DescribeAutoScalingGroups'
+              Effect: Allow
+              Resource: '*'
+            - Action: 'autoscaling:DescribeAutoScalingInstances'
+              Effect: Allow
+              Resource: '*'
+            - Action: 'autoscaling:DescribeLoadBalancers'
+              Effect: Allow
+              Resource: '*'
+            - Action: 'autoscaling:SetDesiredCapacity'
+              Effect: Allow
+              Resource: '*'
+            - Action: 'elasticloadbalancing:DescribeInstanceHealth'
+              Effect: Allow
+              Resource: '*'
+            - Action: 'autoscaling:TerminateInstanceInAutoScalingGroup'
+              Effect: Allow
+              Resource: '*'
+            # End CLC
+            - Action: 'elasticloadbalancing:*'
+              Effect: Allow
+              Resource: '*'
+            - Action: 'kms:Decrypt'
+              Effect: Allow
+              Resource: '*'
+            - Action: 's3:GetObject'
+              Effect: Allow
+              Resource: 'arn:aws:s3:::*'
+            - Action:
+                - 'ecr:BatchCheckLayerAvailability'
+                - 'ecr:BatchGetImage'
+                - 'ecr:GetDownloadUrlForLayer'
+                - 'ecr:GetAuthorizationToken'
+              Effect: Allow
+              Resource: '*'
+            # allow connecting via Session Manager
+            - Action:
+                - "ssm:UpdateInstanceInformation"
+                - "ssmmessages:CreateControlChannel"
+                - "ssmmessages:CreateDataChannel"
+                - "ssmmessages:OpenControlChannel"
+                - "ssmmessages:OpenDataChannel"
+              Effect: Allow
+              Resource: "*"
+            - Action:
+                - "logs:CreateLogStream"
+                - "logs:PutLogEvents"
+                - "logs:DescribeLogGroups"
+                - "logs:DescribeLogStreams"
+              Effect: Allow
+              Resource: "*"
           Version: 2012-10-17
         PolicyName: root
-      RoleName: "{{.Cluster.LocalID}}-e2e-aws-iam-test"
-    Type: 'AWS::IAM::Role'
-  E2EAWSIAMTestBucket:
-    Type: AWS::S3::Bucket
-    DeletionPolicy: Delete
-    Properties:
-      BucketName: "zalando-e2e-test-{{.Cluster.InfrastructureAccountID}}-{{.Cluster.LocalID}}"
-      LifecycleConfiguration:
-        Rules:
+  Type: 'AWS::IAM::Role'
+  {{- if ne .Cluster.Provider "zalando-eks" }}
+CloudControllerManagerIAMRole:
+  Properties:
+    AssumeRolePolicyDocument:
+      Statement:
+        - Effect: Allow
+          Principal:
+            Federated: !Sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+          Action:
+            - "sts:AssumeRoleWithWebIdentity"
+          Condition:
+            StringEquals:
+              "{{ .Cluster.LocalID }}.{{ .Values.hosted_zone }}:aud": "sts.amazonaws.com"
+              "{{ .Cluster.LocalID }}.{{ .Values.hosted_zone }}:sub": "system:serviceaccount:kube-system:cloud-controller-manager"
+      Version: 2012-10-17
+    Path: /
+    Policies:
+      # https://cloud-provider-aws.sigs.k8s.io/prerequisites/#iam-policies
+      - PolicyDocument:
+          Statement:
+            - Effect: Allow
+              Action:
+                - "autoscaling:DescribeAutoScalingGroups"
+                - "autoscaling:DescribeLaunchConfigurations"
+                - "autoscaling:DescribeTags"
+                - "ec2:DescribeInstances"
+                - "ec2:DescribeInstanceTopology"
+                - "ec2:DescribeRegions"
+                - "ec2:DescribeRouteTables"
+                - "ec2:DescribeSecurityGroups"
+                - "ec2:DescribeSubnets"
+                - "ec2:DescribeVolumes"
+                - "ec2:DescribeAvailabilityZones"
+                - "ec2:CreateSecurityGroup"
+                - "ec2:CreateTags"
+                - "ec2:CreateVolume"
+                - "ec2:ModifyInstanceAttribute"
+                - "ec2:ModifyVolume"
+                - "ec2:AttachVolume"
+                - "ec2:AuthorizeSecurityGroupIngress"
+                - "ec2:CreateRoute"
+                - "ec2:DeleteRoute"
+                - "ec2:DeleteSecurityGroup"
+                - "ec2:DeleteVolume"
+                - "ec2:DetachVolume"
+                - "ec2:RevokeSecurityGroupIngress"
+                - "ec2:DescribeVpcs"
+                - "elasticloadbalancing:AddTags"
+                - "elasticloadbalancing:AttachLoadBalancerToSubnets"
+                - "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer"
+                - "elasticloadbalancing:CreateLoadBalancer"
+                - "elasticloadbalancing:CreateLoadBalancerPolicy"
+                - "elasticloadbalancing:CreateLoadBalancerListeners"
+                - "elasticloadbalancing:ConfigureHealthCheck"
+                - "elasticloadbalancing:DeleteLoadBalancer"
+                - "elasticloadbalancing:DeleteLoadBalancerListeners"
+                - "elasticloadbalancing:DescribeLoadBalancers"
+                - "elasticloadbalancing:DescribeLoadBalancerAttributes"
+                - "elasticloadbalancing:DetachLoadBalancerFromSubnets"
+                - "elasticloadbalancing:DeregisterInstancesFromLoadBalancer"
+                - "elasticloadbalancing:ModifyLoadBalancerAttributes"
+                - "elasticloadbalancing:RegisterInstancesWithLoadBalancer"
+                - "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
+                - "elasticloadbalancing:AddTags"
+                - "elasticloadbalancing:CreateListener"
+                - "elasticloadbalancing:CreateTargetGroup"
+                - "elasticloadbalancing:DeleteListener"
+                - "elasticloadbalancing:DeleteTargetGroup"
+                - "elasticloadbalancing:DescribeListeners"
+                - "elasticloadbalancing:DescribeLoadBalancerPolicies"
+                - "elasticloadbalancing:DescribeTargetGroups"
+                - "elasticloadbalancing:DescribeTargetHealth"
+                - "elasticloadbalancing:ModifyListener"
+                - "elasticloadbalancing:ModifyTargetGroup"
+                - "elasticloadbalancing:RegisterTargets"
+                - "elasticloadbalancing:DeregisterTargets"
+                - "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
+                - "iam:CreateServiceLinkedRole"
+                - "kms:DescribeKey"
+              Resource:
+                - "*"
+          Version: 2012-10-17
+        PolicyName: root
+    RoleName: "{{.Cluster.LocalID}}-cloud-controller-manager"
+  Type: "AWS::IAM::Role"
+ETCDS3BackupIAMRole:
+  Properties:
+    AssumeRolePolicyDocument:
+      Statement:
+        - Effect: Allow
+          Principal:
+            Federated: !Sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+          Action:
+            - 'sts:AssumeRoleWithWebIdentity'
+          Condition:
+            StringEquals:
+              "{{ .Cluster.LocalID }}.{{ .Values.hosted_zone }}:sub": "system:serviceaccount:kube-system:etcd-backup"
+        - Action:
+            - 'sts:AssumeRole'
+          Effect: Allow
+          Principal:
+            AWS: !Join
+              - ''
+              - - !Sub 'arn:aws:iam::${AWS::AccountId}:role/'
+                - !Ref MasterIAMRole
+      Version: 2012-10-17
+    Path: /
+    Policies:
+      - PolicyDocument:
+          Statement:
+            - Action:
+                - 's3:ListBucket'
+              Effect: Allow
+              Resource:
+                - >-
+                  arn:aws:s3:::{{.Cluster.ConfigItems.etcd_s3_backup_bucket}}
+            - Action:
+                - 's3:PutObject'
+                - 's3:GetObject'
+                - 's3:DeleteObject'
+              Effect: Allow
+              Resource:
+                - >-
+                  arn:aws:s3:::{{.Cluster.ConfigItems.etcd_s3_backup_bucket}}/*
+          Version: 2012-10-17
+        PolicyName: root
+    RoleName: "{{.Cluster.LocalID}}-etcd-backup"
+  Type: 'AWS::IAM::Role'
+  {{- end }}
+StaticEgressControllerIAMRole:
+  Properties:
+    AssumeRolePolicyDocument: !Sub
+      - |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Federated": [
+                  "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
+                ]
+              },
+              "Action": [
+                "sts:AssumeRoleWithWebIdentity"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "${OIDC}:sub": "system:serviceaccount:kube-system:kube-static-egress-controller"
+                }
+              }
+            }
+          ]
+        }
+  {{- if eq .Cluster.Provider "zalando-eks" }}
+- OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
+  {{- else }}
+- OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+  {{- end }}
+Path: /
+Policies:
+  - PolicyDocument:
+      Statement:
+        - Action: 'cloudformation:*'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'ec2:AllocateAddress'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'ec2:AssociateRouteTable'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'ec2:DisassociateRouteTable'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'ec2:CreateRouteTable'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'ec2:CreateRoute'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'ec2:CreateNatGateway'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'ec2:CreateSubnet'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'ec2:CreateTags'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'ec2:DeleteTags'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'ec2:ReleaseAddress'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'ec2:DeleteRouteTable'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'ec2:DeleteRoute'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'ec2:DeleteNatGateway'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'ec2:DeleteSubnet'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'ec2:DescribeAddresses'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'ec2:DescribeInternetGateways'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'ec2:DescribeRouteTables'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'ec2:DescribeNatGateways'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'ec2:DescribeSubnets'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'ec2:DescribeVpcs'
+          Effect: Allow
+          Resource: '*'
+        - Action:
+            - "s3:PutObject"
+            - "s3:GetObject"
+            - "s3:GetObjectVersion"
+          Effect: Allow
+          Resource: "arn:aws:s3:::cluster-lifecycle-manager-{{.Cluster.InfrastructureAccountID}}-{{.Cluster.Region}}/*"
+      Version: 2012-10-17
+    PolicyName: root
+RoleName: "{{.Cluster.LocalID}}-static-egress-controller"
+Type: 'AWS::IAM::Role'
+ZmonIAMRole:
+  Properties:
+    AssumeRolePolicyDocument: !Sub
+      - |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": ["ec2.amazonaws.com"]
+              }
+            },
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::${AWS::AccountId}:role/${WorkerIAMRole}"
+              }
+            },
+            {{/* TODO: Remove all of the above when ZMON is fully migrated to OIDC */}}
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "{{.Cluster.ConfigItems.zmon_root_account_role}}"
+              }
+            },
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Federated": [
+                  "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
+                ]
+              },
+              "Action": [
+                "sts:AssumeRoleWithWebIdentity"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "${OIDC}:aud": "sts.amazonaws.com",
+                  "${OIDC}:sub": [
+                    "system:serviceaccount:visibility:zmon-appliance-scheduler",
+                    "system:serviceaccount:visibility:zmon-appliance-aws-agent",
+                    "system:serviceaccount:visibility:zmon"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+  {{- if eq .Cluster.Provider "zalando-eks" }}
+- OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
+  {{- else }}
+- OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+  {{- end }}
+Path: /
+Policies:
+  - PolicyDocument:
+      Statement:
+        - Action: 'acm:DescribeCertificate'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'acm:ListCertificates'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'acm:ListTagsForCertificate'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'airflow:CreateCliToken'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'airflow:ListEnvironments'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'autoscaling:Describe*'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'cloudformation:Describe*'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'cloudformation:List*'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'cloudwatch:Describe*'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'cloudwatch:Get*'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'cloudwatch:List*'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'dax:DescribeClusters'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'ec2:Describe*'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'elasticache:Describe*'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'elasticloadbalancing:Describe*'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'iam:Get*'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'iam:List*'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'kinesis:Describe*'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'kinesisanalytics:List*'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'lambda:List*'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'opsworks:Describe*'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'rds:Describe*'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'rds:ListTagsForResource'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'route53:Get*'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'route53:List*'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'tag:Get*'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'dynamodb:ListTables'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'dynamodb:DescribeTable'
+          Effect: Allow
+          Resource: '*'
+        - Action: 's3:ListBucket'
+          Effect: Allow
+          Resource: '*'
+    {{if .Cluster.ConfigItems.zmon_accessible_s3_buckets}}
+    {{range $bucket := split .Cluster.ConfigItems.zmon_accessible_s3_buckets ","}}
+    - Action: 's3:GetObject'
+      Effect: Allow
+      Resource: 'arn:aws:s3:::{{ $bucket }}/*'
+    {{end}}
+    {{end}}
+    - Action: 'sqs:GetQueueAttributes'
+      Effect: Allow
+      Resource: '*'
+    - Action: 'sqs:ListDeadLetterSourceQueues'
+      Effect: Allow
+      Resource: '*'
+    - Action: 'sqs:ListQueues'
+      Effect: Allow
+      Resource: '*'
+    - Action: 'servicequotas:ListServiceQuotas'
+      Effect: Allow
+      Resource: '*'
+    - Action: 'sts:AssumeRole'
+      Effect: Allow
+      Resource: '*'
+    - Action: 'sagemaker:DescribeEndpoint'
+      Effect: Allow
+      Resource: '*'
+    - Action: 'sagemaker:ListEndpoints'
+      Effect: Allow
+      Resource: '*'
+    - Action: 'states:ListStateMachines'
+      Effect: Allow
+      Resource: '*'
+    - Action: 'states:ListExecutions'
+      Effect: Allow
+      Resource: '*'
+    - Action: 'secretsmanager:GetSecretValue'
+      Effect: Allow
+      Resource: "arn:aws:secretsmanager:{{.Cluster.Region}}:{{.Cluster.InfrastructureAccountID}}:secret:*.zmon-db-user.credentials*"
+    Version: 2012-10-17
+    PolicyName: root
+RoleName: "{{.Cluster.LocalID}}-app-zmon"
+Type: 'AWS::IAM::Role'
+
+LoggingAgentIAMRole:
+  Type: AWS::IAM::Role
+  Properties:
+    RoleName: "{{.Cluster.LocalID}}-app-logging-agent"
+    Path: /
+    AssumeRolePolicyDocument: !Sub
+      - |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Principal": {
+                "Service": [
+                  "ec2.amazonaws.com"
+                ]
+              }
+            },
+            {
+              "Effect": "Allow",
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Principal": {
+                "AWS": "${WorkerIAMRole}"
+              }
+            },
+            {
+              "Effect": "Allow",
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Principal": {
+                "AWS": "${MasterIAMRole}"
+              }
+            },
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Federated": [
+                  "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
+                ]
+              },
+              "Action": [
+                "sts:AssumeRoleWithWebIdentity"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "${OIDC}:sub": "system:serviceaccount:visibility:logging-agent"
+                }
+              }
+            }
+          ]
+        }
+  {{- if eq .Cluster.Provider "zalando-eks" }}
+- OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
+  {{- else }}
+- OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+  {{- end }}
+WorkerIAMRole: !Sub 'arn:aws:iam::${AWS::AccountId}:role/${WorkerIAMRole}'
+MasterIAMRole: !Sub 'arn:aws:iam::${AWS::AccountId}:role/${MasterIAMRole}'
+Policies:
+  - PolicyName: AllowS3BucketAccess
+    PolicyDocument:
+      Version: "2012-10-17"
+      Statement:
+        - Action: ["s3:ListBucket"]
+          Effect: "Allow"
+          Resource: 'arn:aws:s3:::{{.Cluster.ConfigItems.logging_s3_bucket}}'
+        - Action: ["s3:GetObject"]
+          Effect: "Allow"
+          Resource: 'arn:aws:s3:::{{.Cluster.ConfigItems.logging_s3_bucket}}/*'
+        - Action: ["s3:PutObject"]
+          Effect: "Allow"
+          Resource: 'arn:aws:s3:::{{.Cluster.ConfigItems.logging_s3_bucket}}/*'
+  {{- if .Cluster.ConfigItems.logging_infrastructure_s3_bucket }}
+- PolicyName: AllowCentralTelemetryInfrastructureS3BucketAccess
+  PolicyDocument:
+    Version: "2012-10-17"
+    Statement:
+      - Action: ["s3:ListBucket"]
+        Effect: "Allow"
+        Resource: 'arn:aws:s3:::{{.Cluster.ConfigItems.logging_infrastructure_s3_bucket}}'
+      - Action: ["s3:GetObject", "s3:PutObject", "s3:PutObjectAcl"]
+        Effect: "Allow"
+        Resource: 'arn:aws:s3:::{{.Cluster.ConfigItems.logging_infrastructure_s3_bucket}}/*'
+  {{- end }}
+
+KubeMetricsIAMRole:
+  Properties:
+    AssumeRolePolicyDocument: !Sub
+      - |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Federated": [
+                  "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
+                ]
+              },
+              "Action": [
+                "sts:AssumeRoleWithWebIdentity"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "${OIDC}:sub": "system:serviceaccount:kube-system:custom-metrics-apiserver"
+                }
+              }
+            }
+          ]
+        }
+  {{- if eq .Cluster.Provider "zalando-eks" }}
+- OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
+  {{- else }}
+- OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+  {{- end }}
+Path: /
+Policies:
+  - PolicyDocument:
+      Statement:
+        - Action: 'sqs:GetQueueUrl'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'sqs:GetQueueAttributes'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'sqs:ListQueues'
+          Effect: Allow
+          Resource: '*'
+        - Action: 'sqs:ListQueueTags'
+          Effect: Allow
+          Resource: '*'
+      Version: 2012-10-17
+    PolicyName: root
+RoleName: "{{.Cluster.LocalID}}-kube-metrics-adapter"
+Type: 'AWS::IAM::Role'
+
+EBSCSIControllerIAMRole:
+  Properties:
+    AssumeRolePolicyDocument: !Sub
+      - |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Federated": [
+                  "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
+                ]
+              },
+              "Action": [
+                "sts:AssumeRoleWithWebIdentity"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "${OIDC}:sub": "system:serviceaccount:kube-system:ebs-csi-controller-sa"
+                }
+              }
+            }
+          ]
+        }
+  {{- if eq .Cluster.Provider "zalando-eks" }}
+- OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
+  {{- else }}
+- OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+  {{- end }}
+Path: /
+Policies:
+  - PolicyDocument:
+      Statement:
+        - Effect: Allow
+          Action:
+            - ec2:CreateSnapshot
+            - ec2:AttachVolume
+            - ec2:DetachVolume
+            - ec2:ModifyVolume
+            - ec2:DescribeAvailabilityZones
+            - ec2:DescribeInstances
+            - ec2:DescribeSnapshots
+            - ec2:DescribeTags
+            - ec2:DescribeVolumes
+            - ec2:DescribeVolumesModifications
+          Resource: "*"
+        - Effect: Allow
+          Action:
+            - ec2:CreateTags
+          Resource:
+            - arn:aws:ec2:*:*:volume/*
+            - arn:aws:ec2:*:*:snapshot/*
+          Condition:
+            StringEquals:
+              ec2:CreateAction:
+                - CreateVolume
+                - CreateSnapshot
+        - Effect: Allow
+          Action:
+            - ec2:DeleteTags
+          Resource:
+            - arn:aws:ec2:*:*:volume/*
+            - arn:aws:ec2:*:*:snapshot/*
+        - Effect: Allow
+          Action:
+            - ec2:CreateVolume
+          Resource: "*"
+          Condition:
+            StringLike:
+              aws:RequestTag/ebs.csi.aws.com/cluster: 'true'
+        - Effect: Allow
+          Action:
+            - ec2:CreateVolume
+          Resource: "*"
+          Condition:
+            StringLike:
+              aws:RequestTag/CSIVolumeName: "*"
+        - Effect: Allow
+          Action:
+            - ec2:DeleteVolume
+          Resource: "*"
+          Condition:
+            StringLike:
+              ec2:ResourceTag/ebs.csi.aws.com/cluster: 'true'
+        - Effect: Allow
+          Action:
+            - ec2:DeleteVolume
+          Resource: "*"
+          Condition:
+            StringLike:
+              ec2:ResourceTag/CSIVolumeName: "*"
+        - Effect: Allow
+          Action:
+            - ec2:DeleteVolume
+          Resource: "*"
+          Condition:
+            StringLike:
+              ec2:ResourceTag/kubernetes.io/created-for/pvc/name: "*"
+        - Effect: Allow
+          Action:
+            - ec2:DeleteSnapshot
+          Resource: "*"
+          Condition:
+            StringLike:
+              ec2:ResourceTag/CSIVolumeSnapshotName: "*"
+        - Effect: Allow
+          Action:
+            - ec2:DeleteSnapshot
+          Resource: "*"
+          Condition:
+            StringLike:
+              ec2:ResourceTag/ebs.csi.aws.com/cluster: 'true'
+      Version: 2012-10-17
+    PolicyName: root
+RoleName: "{{.Cluster.LocalID}}-ebs-csi-controller"
+Type: 'AWS::IAM::Role'
+
+  {{ if eq .Cluster.Environment "e2e" }}
+# This is a hack to easily create an aws iam role and s3 bucket for testing
+# AWS IAM integration in e2e tests.
+E2EAWSIAMTestRole:
+  Properties:
+    AssumeRolePolicyDocument:
+      Statement:
+        - Action:
+            - 'sts:AssumeRole'
+          Effect: Allow
+          Principal:
+            Service:
+              - ec2.amazonaws.com
+        - Action:
+            - 'sts:AssumeRole'
+          Effect: Allow
+          Principal:
+            AWS: !Join
+              - ''
+              - - !Sub 'arn:aws:iam::${AWS::AccountId}:role/'
+                - !Ref WorkerIAMRole
+      Version: 2012-10-17
+    Path: /
+    Policies:
+      - PolicyDocument:
+          Statement:
+            - Action:
+                - 's3:ListBucket'
+              Effect: Allow
+              Resource:
+                - >-
+                  arn:aws:s3:::zalando-e2e-test-{{.Cluster.InfrastructureAccountID}}-{{.Cluster.LocalID}}
+            - Action:
+                - 's3:PutObject'
+                - 's3:GetObject'
+                - 's3:DeleteObject'
+              Effect: Allow
+              Resource:
+                - >-
+                  arn:aws:s3:::zalando-e2e-test-{{.Cluster.InfrastructureAccountID}}-{{.Cluster.LocalID}}/*
+          Version: 2012-10-17
+        PolicyName: root
+    RoleName: "{{.Cluster.LocalID}}-e2e-aws-iam-test"
+  Type: 'AWS::IAM::Role'
+E2EAWSIAMTestBucket:
+  Type: AWS::S3::Bucket
+  DeletionPolicy: Delete
+  Properties:
+    BucketName: "zalando-e2e-test-{{.Cluster.InfrastructureAccountID}}-{{.Cluster.LocalID}}"
+    LifecycleConfiguration:
+      Rules:
         - AbortIncompleteMultipartUpload:
             DaysAfterInitiation: 1
           ExpirationInDays: 7
           NoncurrentVersionExpirationInDays: 1
           Prefix: ""
           Status: Enabled
-      VersioningConfiguration:
-        Status: Suspended
-{{ end }}
+    VersioningConfiguration:
+      Status: Suspended
+  {{ end }}
 
-  AuditTrailBucket:
-    Type: AWS::S3::Bucket
-    DeletionPolicy: Delete
-    Properties:
-      BucketName: "{{ .Cluster.ConfigItems.audittrail_bucket_name }}"
-      LifecycleConfiguration:
-        Rules:
-          - AbortIncompleteMultipartUpload:
-              DaysAfterInitiation: 1
-            ExpirationInDays: 14
-            NoncurrentVersionExpirationInDays: 1
-            Prefix: ""
-            Status: Enabled
-      VersioningConfiguration:
-        Status: Suspended
-      Tags:
+AuditTrailBucket:
+  Type: AWS::S3::Bucket
+  DeletionPolicy: Delete
+  Properties:
+    BucketName: "{{ .Cluster.ConfigItems.audittrail_bucket_name }}"
+    LifecycleConfiguration:
+      Rules:
+        - AbortIncompleteMultipartUpload:
+            DaysAfterInitiation: 1
+          ExpirationInDays: 14
+          NoncurrentVersionExpirationInDays: 1
+          Prefix: ""
+          Status: Enabled
+    VersioningConfiguration:
+      Status: Suspended
+    Tags:
       - Key: component
         Value: audittrail-adapter
-  AuditTrailBucketPolicy:
-    Type: AWS::S3::BucketPolicy
-    Properties:
-      Bucket: !Ref AuditTrailBucket
-      PolicyDocument:
-        Statement:
-          # In-cluster access
-          - Action:
-              - s3:ListBucket
-            Effect: Allow
-            Principal:
-              AWS:
-                - !GetAtt EmergencyAccessServiceIAMRole.Arn
-                - !GetAtt AudittrailAdapterIAMRole.Arn
-            Resource:
-              - !GetAtt AuditTrailBucket.Arn
-
-          - Action:
-              - s3:PutObject
-            Effect: Allow
-            Principal:
-              AWS:
+AuditTrailBucketPolicy:
+  Type: AWS::S3::BucketPolicy
+  Properties:
+    Bucket: !Ref AuditTrailBucket
+    PolicyDocument:
+      Statement:
+        # In-cluster access
+        - Action:
+            - s3:ListBucket
+          Effect: Allow
+          Principal:
+            AWS:
               - !GetAtt EmergencyAccessServiceIAMRole.Arn
               - !GetAtt AudittrailAdapterIAMRole.Arn
-            Resource:
-              - !Sub
-                - "${BucketArn}/*"
-                - BucketArn: !GetAtt AuditTrailBucket.Arn
+          Resource:
+            - !GetAtt AuditTrailBucket.Arn
 
-{{- if .Cluster.ConfigItems.audittrail_root_account_role }}
-          # Central access
-          - Action:
-              - s3:ListBucket
-            Effect: Allow
-            Principal:
-              AWS:
-                - {{.Cluster.ConfigItems.audittrail_root_account_role}}
-            Resource:
-              - !GetAtt AuditTrailBucket.Arn
+        - Action:
+            - s3:PutObject
+          Effect: Allow
+          Principal:
+            AWS:
+              - !GetAtt EmergencyAccessServiceIAMRole.Arn
+              - !GetAtt AudittrailAdapterIAMRole.Arn
+          Resource:
+            - !Sub
+              - "${BucketArn}/*"
+              - BucketArn: !GetAtt AuditTrailBucket.Arn
 
-          - Action:
-              - s3:GetObject
-              - s3:DeleteObject
-            Effect: Allow
-            Principal:
-              AWS:
-                - {{.Cluster.ConfigItems.audittrail_root_account_role}}
-            Resource:
-              - !Sub
-                - "${BucketArn}/*"
-                - BucketArn: !GetAtt AuditTrailBucket.Arn
-{{- end }}
+  {{- if .Cluster.ConfigItems.audittrail_root_account_role }}
+# Central access
+- Action:
+    - s3:ListBucket
+  Effect: Allow
+  Principal:
+    AWS:
+      - {{.Cluster.ConfigItems.audittrail_root_account_role}}
+  Resource:
+    - !GetAtt AuditTrailBucket.Arn
 
-{{- if index .Cluster.ConfigItems "session_manager_destination_arn" }}
-  SessionManagerLogGroup:
-    Type: AWS::Logs::LogGroup
-    Properties:
-      LogGroupName: "SessionManager-{{.Cluster.Alias}}"
-      RetentionInDays: 30
+- Action:
+    - s3:GetObject
+    - s3:DeleteObject
+  Effect: Allow
+  Principal:
+    AWS:
+      - {{.Cluster.ConfigItems.audittrail_root_account_role}}
+  Resource:
+    - !Sub
+      - "${BucketArn}/*"
+      - BucketArn: !GetAtt AuditTrailBucket.Arn
+  {{- end }}
 
-  SessionManagerPreferencesDocument:
-    Type: AWS::SSM::Document
-    Properties:
-      UpdateMethod: NewVersion
-      Name: "SSM-SessionManager-{{.Cluster.Alias}}"
-      DocumentFormat: YAML
-      DocumentType: Session
-      Content:
-        schemaVersion: '1.0'
-        description: Document to hold settings for Kubernetes EC2 SSM sessions
-        sessionType: Standard_Stream
-        inputs:
-          cloudWatchLogGroupName: !Ref SessionManagerLogGroup
-          cloudWatchEncryptionEnabled: false
-          cloudWatchStreamingEnabled: true
-          runAsEnabled: false
-          idleSessionTimeout: '20'
-          shellProfile:
-            linux: 'bash'
+  {{- if index .Cluster.ConfigItems "session_manager_destination_arn" }}
+SessionManagerLogGroup:
+  Type: AWS::Logs::LogGroup
+  Properties:
+    LogGroupName: "SessionManager-{{.Cluster.Alias}}"
+    RetentionInDays: 30
 
-  SessionManagerSubscriptionFilter:
-    Type: AWS::Logs::SubscriptionFilter
-    Properties:
-      LogGroupName: !Ref SessionManagerLogGroup
-      RoleArn: !GetAtt SessionManagerSubscriptionFilterRole.Arn
-      FilterName: "SessionManager-{{.Cluster.Alias}}"
-      FilterPattern: ""
-      DestinationArn: "{{.Cluster.ConfigItems.session_manager_destination_arn}}"
+SessionManagerPreferencesDocument:
+  Type: AWS::SSM::Document
+  Properties:
+    UpdateMethod: NewVersion
+    Name: "SSM-SessionManager-{{.Cluster.Alias}}"
+    DocumentFormat: YAML
+    DocumentType: Session
+    Content:
+      schemaVersion: '1.0'
+      description: Document to hold settings for Kubernetes EC2 SSM sessions
+      sessionType: Standard_Stream
+      inputs:
+        cloudWatchLogGroupName: !Ref SessionManagerLogGroup
+        cloudWatchEncryptionEnabled: false
+        cloudWatchStreamingEnabled: true
+        runAsEnabled: false
+        idleSessionTimeout: '20'
+        shellProfile:
+          linux: 'bash'
 
-  SessionManagerSubscriptionFilterRole:
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service:
-                - logs.amazonaws.com
-            Action:
-              - "sts:AssumeRole"
-      Path: /
-      Policies:
-        - PolicyName: root
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: Allow
-                Action:
-                  - "logs:PutLogEvents"
-                Resource:
-                  - !GetAtt SessionManagerLogGroup.Arn
-      RoleName: "SessionManager-{{.Cluster.Alias}}"
-{{- end }}
+SessionManagerSubscriptionFilter:
+  Type: AWS::Logs::SubscriptionFilter
+  Properties:
+    LogGroupName: !Ref SessionManagerLogGroup
+    RoleArn: !GetAtt SessionManagerSubscriptionFilterRole.Arn
+    FilterName: "SessionManager-{{.Cluster.Alias}}"
+    FilterPattern: ""
+    DestinationArn: "{{.Cluster.ConfigItems.session_manager_destination_arn}}"
 
-  AWSNodeDecommissionerIAMRole:
-    Type: 'AWS::IAM::Role'
-    Properties:
-      RoleName: "{{.Cluster.LocalID}}-aws-node-decommissioner"
-      AssumeRolePolicyDocument: !Sub
-        - |
-          {
-            "Version": "2012-10-17",
-            "Statement": [
-              {
-                "Effect": "Allow",
-                "Principal": {
-                  "Federated": [
-                    "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
-                  ]
-                },
-                "Action": [
-                  "sts:AssumeRoleWithWebIdentity"
-                ],
-                "Condition": {
-                  "StringEquals": {
-                    "${OIDC}:sub": "system:serviceaccount:kube-system:aws-node-decommissioner"
-                  }
-                }
-              }
-            ]
-          }
-{{- if eq .Cluster.Provider "zalando-eks" }}
-        - OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
-{{- else }}
-        - OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
-{{- end }}
-      Path: /
-      Policies:
-        - PolicyDocument:
-            Version: 2012-10-17
-            Statement:
+SessionManagerSubscriptionFilterRole:
+  Type: AWS::IAM::Role
+  Properties:
+    AssumeRolePolicyDocument:
+      Version: "2012-10-17"
+      Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+              - logs.amazonaws.com
+          Action:
+            - "sts:AssumeRole"
+    Path: /
+    Policies:
+      - PolicyName: root
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
             - Effect: Allow
               Action:
-              - "ec2:DescribeInstances"
-              - "ec2:DescribeInstanceStatus"
-              Resource: "*"
-          PolicyName: root
-  EmergencyAccessServiceIAMRole:
-    Properties:
-      AssumeRolePolicyDocument: !Sub
-        - |
-          {
-            "Version": "2012-10-17",
-            "Statement": [
-              {
-                "Effect": "Allow",
-                "Principal": {
-                  "Federated": [
-                    "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
-                  ]
-                },
-                "Action": [
-                  "sts:AssumeRoleWithWebIdentity"
-                ],
-                "Condition": {
-                  "StringEquals": {
-                    "${OIDC}:sub": "system:serviceaccount:kube-system:emergency-access-service"
-                  }
+                - "logs:PutLogEvents"
+              Resource:
+                - !GetAtt SessionManagerLogGroup.Arn
+    RoleName: "SessionManager-{{.Cluster.Alias}}"
+  {{- end }}
+
+AWSNodeDecommissionerIAMRole:
+  Type: 'AWS::IAM::Role'
+  Properties:
+    RoleName: "{{.Cluster.LocalID}}-aws-node-decommissioner"
+    AssumeRolePolicyDocument: !Sub
+      - |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Federated": [
+                  "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
+                ]
+              },
+              "Action": [
+                "sts:AssumeRoleWithWebIdentity"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "${OIDC}:sub": "system:serviceaccount:kube-system:aws-node-decommissioner"
                 }
               }
-            ]
-          }
-{{- if eq .Cluster.Provider "zalando-eks" }}
-        - OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
-{{- else }}
-        - OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
-{{- end }}
-      Path: /
-      Policies:
-        - PolicyDocument:
-            Statement:
-              - Action:
-                  - s3:ListBucket
-                Effect: Allow
-                Resource:
-                  - !GetAtt AuditTrailBucket.Arn
-
-              - Action:
-                  - s3:PutObject
-                Effect: Allow
-                Resource:
-                  - !Sub
-                    - "${BucketArn}/*"
-                    - BucketArn: !GetAtt AuditTrailBucket.Arn
-            Version: 2012-10-17
-          PolicyName: root
-      RoleName: "{{.Cluster.LocalID}}-emergency-access-service"
-    Type: 'AWS::IAM::Role'
-  AudittrailAdapterIAMRole:
-    Properties:
-      AssumeRolePolicyDocument: !Sub
-        - |
-          {
-            "Version": "2012-10-17",
-            "Statement": [
-              {
-                "Effect": "Allow",
-                "Principal": {
-                  "Federated": [
-                    "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
-                  ]
-                },
-                "Action": [
-                  "sts:AssumeRoleWithWebIdentity"
-                ],
-                "Condition": {
-                  "StringEquals": {
-                    "${OIDC}:sub": "system:serviceaccount:kube-system:audittrail-adapter"
-                  }
+            }
+          ]
+        }
+  {{- if eq .Cluster.Provider "zalando-eks" }}
+- OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
+  {{- else }}
+- OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+  {{- end }}
+Path: /
+Policies:
+  - PolicyDocument:
+      Version: 2012-10-17
+      Statement:
+        - Effect: Allow
+          Action:
+            - "ec2:DescribeInstances"
+            - "ec2:DescribeInstanceStatus"
+          Resource: "*"
+    PolicyName: root
+EmergencyAccessServiceIAMRole:
+  Properties:
+    AssumeRolePolicyDocument: !Sub
+      - |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Federated": [
+                  "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
+                ]
+              },
+              "Action": [
+                "sts:AssumeRoleWithWebIdentity"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "${OIDC}:sub": "system:serviceaccount:kube-system:emergency-access-service"
                 }
               }
-            ]
-          }
-{{- if eq .Cluster.Provider "zalando-eks" }}
-        - OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
-{{- else }}
-        - OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
-{{- end }}
-      Path: /
-      Policies:
-        - PolicyDocument:
-            Statement:
-              - Action:
-                  - s3:ListBucket
-                Effect: Allow
-                Resource:
-                  - !GetAtt AuditTrailBucket.Arn
+            }
+          ]
+        }
+  {{- if eq .Cluster.Provider "zalando-eks" }}
+- OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
+  {{- else }}
+- OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+  {{- end }}
+Path: /
+Policies:
+  - PolicyDocument:
+      Statement:
+        - Action:
+            - s3:ListBucket
+          Effect: Allow
+          Resource:
+            - !GetAtt AuditTrailBucket.Arn
 
-              - Action:
-                  - s3:PutObject
-                Effect: Allow
-                Resource:
-                  - !Sub
-                    - "${BucketArn}/*"
-                    - BucketArn: !GetAtt AuditTrailBucket.Arn
-            Version: 2012-10-17
-          PolicyName: root
-      RoleName: "{{.Cluster.LocalID}}-audittrail-adapter"
-    Type: 'AWS::IAM::Role'
+        - Action:
+            - s3:PutObject
+          Effect: Allow
+          Resource:
+            - !Sub
+              - "${BucketArn}/*"
+              - BucketArn: !GetAtt AuditTrailBucket.Arn
+      Version: 2012-10-17
+    PolicyName: root
+RoleName: "{{.Cluster.LocalID}}-emergency-access-service"
+Type: 'AWS::IAM::Role'
+AudittrailAdapterIAMRole:
+  Properties:
+    AssumeRolePolicyDocument: !Sub
+      - |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Federated": [
+                  "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
+                ]
+              },
+              "Action": [
+                "sts:AssumeRoleWithWebIdentity"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "${OIDC}:sub": "system:serviceaccount:kube-system:audittrail-adapter"
+                }
+              }
+            }
+          ]
+        }
+  {{- if eq .Cluster.Provider "zalando-eks" }}
+- OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
+  {{- else }}
+- OIDC: "{{.Cluster.LocalID}}.{{.Values.hosted_zone}}"
+  {{- end }}
+Path: /
+Policies:
+  - PolicyDocument:
+      Statement:
+        - Action:
+            - s3:ListBucket
+          Effect: Allow
+          Resource:
+            - !GetAtt AuditTrailBucket.Arn
+
+        - Action:
+            - s3:PutObject
+          Effect: Allow
+          Resource:
+            - !Sub
+              - "${BucketArn}/*"
+              - BucketArn: !GetAtt AuditTrailBucket.Arn
+      Version: 2012-10-17
+    PolicyName: root
+RoleName: "{{.Cluster.LocalID}}-audittrail-adapter"
+Type: 'AWS::IAM::Role'
 # {{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6") }}
-  AWSLBControllerIAMRole:
-    Properties:
-      AssumeRolePolicyDocument: !Sub
-        - |
-          {
-            "Version": "2012-10-17",
-            "Statement": [
-              {
-                "Effect": "Allow",
-                "Principal": {
-                  "Federated": [
-                    "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
-                  ]
-                },
-                "Action": [
-                  "sts:AssumeRoleWithWebIdentity"
-                ],
-                "Condition": {
-                  "StringEquals": {
-                    "${OIDC}:sub": "system:serviceaccount:kube-system:aws-load-balancer-controller"
-                  }
+AWSLBControllerIAMRole:
+  Properties:
+    AssumeRolePolicyDocument: !Sub
+      - |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Federated": [
+                  "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDC}"
+                ]
+              },
+              "Action": [
+                "sts:AssumeRoleWithWebIdentity"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "${OIDC}:sub": "system:serviceaccount:kube-system:aws-load-balancer-controller"
                 }
               }
-            ]
-          }
-        - OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
-      Path: /
-      Policies:
-        - PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
+            }
+          ]
+        }
+      - OIDC: !Select [1, !Split ["//", !GetAtt EKSCluster.OpenIdConnectIssuerUrl]]
+    Path: /
+    Policies:
+      - PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
             - Effect: Allow
               Action:
-              - iam:CreateServiceLinkedRole
+                - iam:CreateServiceLinkedRole
               Resource: "*"
               Condition:
                 StringEquals:
                   iam:AWSServiceName: elasticloadbalancing.amazonaws.com
             - Effect: Allow
               Action:
-              - ec2:DescribeAccountAttributes
-              - ec2:DescribeAddresses
-              - ec2:DescribeAvailabilityZones
-              - ec2:DescribeInternetGateways
-              - ec2:DescribeVpcs
-              - ec2:DescribeVpcPeeringConnections
-              - ec2:DescribeSubnets
-              - ec2:DescribeSecurityGroups
-              - ec2:DescribeInstances
-              - ec2:DescribeNetworkInterfaces
-              - ec2:DescribeTags
-              - ec2:GetCoipPoolUsage
-              - ec2:DescribeCoipPools
-              - ec2:GetSecurityGroupsForVpc
-              - ec2:DescribeIpamPools
-              - elasticloadbalancing:DescribeLoadBalancers
-              - elasticloadbalancing:DescribeLoadBalancerAttributes
-              - elasticloadbalancing:DescribeListeners
-              - elasticloadbalancing:DescribeListenerCertificates
-              - elasticloadbalancing:DescribeSSLPolicies
-              - elasticloadbalancing:DescribeRules
-              - elasticloadbalancing:DescribeTargetGroups
-              - elasticloadbalancing:DescribeTargetGroupAttributes
-              - elasticloadbalancing:DescribeTargetHealth
-              - elasticloadbalancing:DescribeTags
-              - elasticloadbalancing:DescribeTrustStores
-              - elasticloadbalancing:DescribeListenerAttributes
-              - elasticloadbalancing:DescribeCapacityReservation
+                - ec2:DescribeAccountAttributes
+                - ec2:DescribeAddresses
+                - ec2:DescribeAvailabilityZones
+                - ec2:DescribeInternetGateways
+                - ec2:DescribeVpcs
+                - ec2:DescribeVpcPeeringConnections
+                - ec2:DescribeSubnets
+                - ec2:DescribeSecurityGroups
+                - ec2:DescribeInstances
+                - ec2:DescribeNetworkInterfaces
+                - ec2:DescribeTags
+                - ec2:GetCoipPoolUsage
+                - ec2:DescribeCoipPools
+                - ec2:GetSecurityGroupsForVpc
+                - ec2:DescribeIpamPools
+                - elasticloadbalancing:DescribeLoadBalancers
+                - elasticloadbalancing:DescribeLoadBalancerAttributes
+                - elasticloadbalancing:DescribeListeners
+                - elasticloadbalancing:DescribeListenerCertificates
+                - elasticloadbalancing:DescribeSSLPolicies
+                - elasticloadbalancing:DescribeRules
+                - elasticloadbalancing:DescribeTargetGroups
+                - elasticloadbalancing:DescribeTargetGroupAttributes
+                - elasticloadbalancing:DescribeTargetHealth
+                - elasticloadbalancing:DescribeTags
+                - elasticloadbalancing:DescribeTrustStores
+                - elasticloadbalancing:DescribeListenerAttributes
+                - elasticloadbalancing:DescribeCapacityReservation
               Resource: "*"
             - Effect: Allow
               Action:
-              - cognito-idp:DescribeUserPoolClient
-              - acm:ListCertificates
-              - acm:DescribeCertificate
-              - iam:ListServerCertificates
-              - iam:GetServerCertificate
-              - waf-regional:GetWebACL
-              - waf-regional:GetWebACLForResource
-              - waf-regional:AssociateWebACL
-              - waf-regional:DisassociateWebACL
-              - wafv2:GetWebACL
-              - wafv2:GetWebACLForResource
-              - wafv2:AssociateWebACL
-              - wafv2:DisassociateWebACL
-              - shield:GetSubscriptionState
-              - shield:DescribeProtection
-              - shield:CreateProtection
-              - shield:DeleteProtection
+                - cognito-idp:DescribeUserPoolClient
+                - acm:ListCertificates
+                - acm:DescribeCertificate
+                - iam:ListServerCertificates
+                - iam:GetServerCertificate
+                - waf-regional:GetWebACL
+                - waf-regional:GetWebACLForResource
+                - waf-regional:AssociateWebACL
+                - waf-regional:DisassociateWebACL
+                - wafv2:GetWebACL
+                - wafv2:GetWebACLForResource
+                - wafv2:AssociateWebACL
+                - wafv2:DisassociateWebACL
+                - shield:GetSubscriptionState
+                - shield:DescribeProtection
+                - shield:CreateProtection
+                - shield:DeleteProtection
               Resource: "*"
             - Effect: Allow
               Action:
-              - ec2:AuthorizeSecurityGroupIngress
-              - ec2:RevokeSecurityGroupIngress
+                - ec2:AuthorizeSecurityGroupIngress
+                - ec2:RevokeSecurityGroupIngress
               Resource: "*"
             - Effect: Allow
               Action:
-              - ec2:CreateSecurityGroup
+                - ec2:CreateSecurityGroup
               Resource: "*"
             - Effect: Allow
               Action:
-              - ec2:CreateTags
+                - ec2:CreateTags
               Resource: arn:aws:ec2:*:*:security-group/*
               Condition:
                 StringEquals:
@@ -3594,8 +3584,8 @@ Resources:
                   aws:RequestTag/elbv2.k8s.aws/cluster: 'false'
             - Effect: Allow
               Action:
-              - ec2:CreateTags
-              - ec2:DeleteTags
+                - ec2:CreateTags
+                - ec2:DeleteTags
               Resource: arn:aws:ec2:*:*:security-group/*
               Condition:
                 'Null':
@@ -3603,338 +3593,338 @@ Resources:
                   aws:ResourceTag/elbv2.k8s.aws/cluster: 'false'
             - Effect: Allow
               Action:
-              - ec2:AuthorizeSecurityGroupIngress
-              - ec2:RevokeSecurityGroupIngress
-              - ec2:DeleteSecurityGroup
+                - ec2:AuthorizeSecurityGroupIngress
+                - ec2:RevokeSecurityGroupIngress
+                - ec2:DeleteSecurityGroup
               Resource: "*"
               Condition:
                 'Null':
                   aws:ResourceTag/elbv2.k8s.aws/cluster: 'false'
             - Effect: Allow
               Action:
-              - elasticloadbalancing:CreateLoadBalancer
-              - elasticloadbalancing:CreateTargetGroup
+                - elasticloadbalancing:CreateLoadBalancer
+                - elasticloadbalancing:CreateTargetGroup
               Resource: "*"
               Condition:
                 'Null':
                   aws:RequestTag/elbv2.k8s.aws/cluster: 'false'
             - Effect: Allow
               Action:
-              - elasticloadbalancing:CreateListener
-              - elasticloadbalancing:DeleteListener
-              - elasticloadbalancing:CreateRule
-              - elasticloadbalancing:DeleteRule
+                - elasticloadbalancing:CreateListener
+                - elasticloadbalancing:DeleteListener
+                - elasticloadbalancing:CreateRule
+                - elasticloadbalancing:DeleteRule
               Resource: "*"
             - Effect: Allow
               Action:
-              - elasticloadbalancing:AddTags
-              - elasticloadbalancing:RemoveTags
+                - elasticloadbalancing:AddTags
+                - elasticloadbalancing:RemoveTags
               Resource:
-              - arn:aws:elasticloadbalancing:*:*:targetgroup/*/*
-              - arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*
-              - arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*
+                - arn:aws:elasticloadbalancing:*:*:targetgroup/*/*
+                - arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*
+                - arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*
               Condition:
                 'Null':
                   aws:RequestTag/elbv2.k8s.aws/cluster: 'true'
                   aws:ResourceTag/elbv2.k8s.aws/cluster: 'false'
             - Effect: Allow
               Action:
-              - elasticloadbalancing:AddTags
-              - elasticloadbalancing:RemoveTags
+                - elasticloadbalancing:AddTags
+                - elasticloadbalancing:RemoveTags
               Resource:
-              - arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*
-              - arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*
-              - arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*
-              - arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*
+                - arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*
+                - arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*
+                - arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*
+                - arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*
             - Effect: Allow
               Action:
-              - elasticloadbalancing:ModifyLoadBalancerAttributes
-              - elasticloadbalancing:SetIpAddressType
-              - elasticloadbalancing:SetSecurityGroups
-              - elasticloadbalancing:SetSubnets
-              - elasticloadbalancing:DeleteLoadBalancer
-              - elasticloadbalancing:ModifyTargetGroup
-              - elasticloadbalancing:ModifyTargetGroupAttributes
-              - elasticloadbalancing:DeleteTargetGroup
-              - elasticloadbalancing:ModifyListenerAttributes
-              - elasticloadbalancing:ModifyCapacityReservation
-              - elasticloadbalancing:ModifyIpPools
+                - elasticloadbalancing:ModifyLoadBalancerAttributes
+                - elasticloadbalancing:SetIpAddressType
+                - elasticloadbalancing:SetSecurityGroups
+                - elasticloadbalancing:SetSubnets
+                - elasticloadbalancing:DeleteLoadBalancer
+                - elasticloadbalancing:ModifyTargetGroup
+                - elasticloadbalancing:ModifyTargetGroupAttributes
+                - elasticloadbalancing:DeleteTargetGroup
+                - elasticloadbalancing:ModifyListenerAttributes
+                - elasticloadbalancing:ModifyCapacityReservation
+                - elasticloadbalancing:ModifyIpPools
               Resource: "*"
               Condition:
                 'Null':
                   aws:ResourceTag/elbv2.k8s.aws/cluster: 'false'
             - Effect: Allow
               Action:
-              - elasticloadbalancing:AddTags
+                - elasticloadbalancing:AddTags
               Resource:
-              - arn:aws:elasticloadbalancing:*:*:targetgroup/*/*
-              - arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*
-              - arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*
+                - arn:aws:elasticloadbalancing:*:*:targetgroup/*/*
+                - arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*
+                - arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*
               Condition:
                 StringEquals:
                   elasticloadbalancing:CreateAction:
-                  - CreateTargetGroup
-                  - CreateLoadBalancer
+                    - CreateTargetGroup
+                    - CreateLoadBalancer
                 'Null':
                   aws:RequestTag/elbv2.k8s.aws/cluster: 'false'
             - Effect: Allow
               Action:
-              - elasticloadbalancing:RegisterTargets
-              - elasticloadbalancing:DeregisterTargets
+                - elasticloadbalancing:RegisterTargets
+                - elasticloadbalancing:DeregisterTargets
               Resource: arn:aws:elasticloadbalancing:*:*:targetgroup/*/*
             - Effect: Allow
               Action:
-              - elasticloadbalancing:SetWebAcl
-              - elasticloadbalancing:ModifyListener
-              - elasticloadbalancing:AddListenerCertificates
-              - elasticloadbalancing:RemoveListenerCertificates
-              - elasticloadbalancing:ModifyRule
-              - elasticloadbalancing:SetRulePriorities
+                - elasticloadbalancing:SetWebAcl
+                - elasticloadbalancing:ModifyListener
+                - elasticloadbalancing:AddListenerCertificates
+                - elasticloadbalancing:RemoveListenerCertificates
+                - elasticloadbalancing:ModifyRule
+                - elasticloadbalancing:SetRulePriorities
               Resource: "*"
-          PolicyName: root
-      RoleName: "aws-lb-controller-{{.Cluster.LocalID}}"
-    Type: 'AWS::IAM::Role'
+        PolicyName: root
+    RoleName: "aws-lb-controller-{{.Cluster.LocalID}}"
+  Type: 'AWS::IAM::Role'
 # {{- end }}
-  RemoteFilesEncryptionKey:
-    Type: "AWS::KMS::Key"
-    Properties:
-      Description: The master key for encryption of remote files
-      EnableKeyRotation: true
-      KeyPolicy:
-        Version: "2012-10-17"
-        Id: "remote-files-encryption-key"
-        Statement:
-          - Sid: "Enable IAM User Permissions"
-            Effect: "Allow"
-            Principal:
-              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
-            Action:
+RemoteFilesEncryptionKey:
+  Type: "AWS::KMS::Key"
+  Properties:
+    Description: The master key for encryption of remote files
+    EnableKeyRotation: true
+    KeyPolicy:
+      Version: "2012-10-17"
+      Id: "remote-files-encryption-key"
+      Statement:
+        - Sid: "Enable IAM User Permissions"
+          Effect: "Allow"
+          Principal:
+            AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+          Action:
             - "kms:DescribeKey"
-            Resource: "*"
-          - Sid: "Allow administering the key"
-            Effect: "Allow"
-            Principal:
-              AWS:
-                - !Sub "arn:aws:iam::${AWS::AccountId}:role/cluster-lifecycle-manager-entrypoint"
-                - !Sub "arn:aws:iam::${AWS::AccountId}:role/Shibboleth-Administrator"
-                - !Sub "arn:aws:iam::${AWS::AccountId}:role/Administrator"
-            Action:
-            - "kms:*"
-            - "tag:TagResources"
-            Resource: "*"
-          - Sid: "Enable master and worker nodes to decrypt the remote files"
-            Effect: "Allow"
-            Principal:
-              AWS:
-                - "Fn::GetAtt":
-                  - "MasterIAMRole"
-                  - "Arn"
-                - "Fn::GetAtt":
-                  - "WorkerIAMRole"
-                  - "Arn"
-            Resource: "*"
-            Action:
-            - "kms:Decrypt"
-  EtcdEncryptionKey:
-    Type: "AWS::KMS::Key"
-    Properties:
-      Description: The KMS key for encryption of secrets in etcd
-      EnableKeyRotation: true
-      KeyPolicy:
-        Version: "2012-10-17"
-        Id: "etcd-key-policy"
-        Statement:
-          - Sid: "Allow CLM to manage this key"
-            Effect: "Allow"
-            Principal:
-              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:role/cluster-lifecycle-manager-entrypoint"
-            Action: "kms:*"
-            Resource: "*"
-          - Sid: "Allow Administrator to manage and use this key"
-            Effect: "Allow"
-            Principal:
-              AWS:
+          Resource: "*"
+        - Sid: "Allow administering the key"
+          Effect: "Allow"
+          Principal:
+            AWS:
+              - !Sub "arn:aws:iam::${AWS::AccountId}:role/cluster-lifecycle-manager-entrypoint"
               - !Sub "arn:aws:iam::${AWS::AccountId}:role/Shibboleth-Administrator"
               - !Sub "arn:aws:iam::${AWS::AccountId}:role/Administrator"
-            Action:
+          Action:
             - "kms:*"
             - "tag:TagResources"
-            Resource: "*"
-{{- if eq .Cluster.Provider "zalando-eks" }}
-          - Sid: "Allow EKSClusterRole access to describe the key"
-            Effect: "Allow"
-            Principal:
-              AWS:
-              - !GetAtt EKSClusterRole.Arn
-            Action:
-            - "kms:DescribeKey"
-            - "kms:CreateGrant"
-            Resource: "*"
-{{- else }}
-          - Sid: "Enable master nodes to encrypt and decrypt secrets in etcd"
-            Effect: "Allow"
-            Principal:
-              AWS:
-                - "Fn::GetAtt":
+          Resource: "*"
+        - Sid: "Enable master and worker nodes to decrypt the remote files"
+          Effect: "Allow"
+          Principal:
+            AWS:
+              - "Fn::GetAtt":
                   - "MasterIAMRole"
                   - "Arn"
-            Resource: "*"
-            Action:
-            - "kms:Encrypt"
-            - "kms:Decrypt"
-{{- end }}
-{{- if ne .Cluster.Provider "zalando-eks" }}
-  MasterFilesEncryptionKey:
-    Type: "AWS::KMS::Key"
-    Properties:
-      Description: The KMS key for encryption of remote files for master nodes
-      EnableKeyRotation: true
-      KeyPolicy:
-        Version: "2012-10-17"
-        Id: "master-key-policy"
-        Statement:
-          - Sid: "Enable IAM User Permissions"
-            Effect: "Allow"
-            Principal:
-              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
-            Action:
-            - "kms:DescribeKey"
-            Resource: "*"
-          - Sid: "Allow administering the key"
-            Effect: "Allow"
-            Principal:
-              AWS:
-                - !Sub "arn:aws:iam::${AWS::AccountId}:role/cluster-lifecycle-manager-entrypoint"
-                - !Sub "arn:aws:iam::${AWS::AccountId}:role/Shibboleth-Administrator"
-                - !Sub "arn:aws:iam::${AWS::AccountId}:role/Administrator"
-            Action:
-            - "kms:*"
-            - "tag:TagResources"
-            Resource: "*"
-          - Sid: "Enable master nodes to decrypt the remote files"
-            Effect: "Allow"
-            Principal:
-              AWS:
-                - "Fn::GetAtt":
-                  - "MasterIAMRole"
-                  - "Arn"
-            Resource: "*"
-            Action:
-            - "kms:Decrypt"
-{{- end}}
-  WorkerFilesEncryptionKey:
-    Type: "AWS::KMS::Key"
-    Properties:
-      Description: The KMS key for encryption of remote files for worker nodes
-      EnableKeyRotation: true
-      KeyPolicy:
-        Version: "2012-10-17"
-        Id: "worker-key-policy"
-        Statement:
-          - Sid: "Enable IAM User Permissions"
-            Effect: "Allow"
-            Principal:
-              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
-            Action:
-            - "kms:DescribeKey"
-            Resource: "*"
-          - Sid: "Allow administering the key"
-            Effect: "Allow"
-            Principal:
-              AWS:
-                - !Sub "arn:aws:iam::${AWS::AccountId}:role/cluster-lifecycle-manager-entrypoint"
-                - !Sub "arn:aws:iam::${AWS::AccountId}:role/Shibboleth-Administrator"
-                - !Sub "arn:aws:iam::${AWS::AccountId}:role/Administrator"
-            Action:
-            - "kms:*"
-            - "tag:TagResources"
-            Resource: "*"
-          - Sid: "Enable worker nodes to decrypt the remote files"
-            Effect: "Allow"
-            Principal:
-              AWS:
-                - "Fn::GetAtt":
+              - "Fn::GetAtt":
                   - "WorkerIAMRole"
                   - "Arn"
-            Resource: "*"
-            Action:
+          Resource: "*"
+          Action:
+            - "kms:Decrypt"
+EtcdEncryptionKey:
+  Type: "AWS::KMS::Key"
+  Properties:
+    Description: The KMS key for encryption of secrets in etcd
+    EnableKeyRotation: true
+    KeyPolicy:
+      Version: "2012-10-17"
+      Id: "etcd-key-policy"
+      Statement:
+        - Sid: "Allow CLM to manage this key"
+          Effect: "Allow"
+          Principal:
+            AWS: !Sub "arn:aws:iam::${AWS::AccountId}:role/cluster-lifecycle-manager-entrypoint"
+          Action: "kms:*"
+          Resource: "*"
+        - Sid: "Allow Administrator to manage and use this key"
+          Effect: "Allow"
+          Principal:
+            AWS:
+              - !Sub "arn:aws:iam::${AWS::AccountId}:role/Shibboleth-Administrator"
+              - !Sub "arn:aws:iam::${AWS::AccountId}:role/Administrator"
+          Action:
+            - "kms:*"
+            - "tag:TagResources"
+          Resource: "*"
+  {{- if eq .Cluster.Provider "zalando-eks" }}
+- Sid: "Allow EKSClusterRole access to describe the key"
+  Effect: "Allow"
+  Principal:
+    AWS:
+      - !GetAtt EKSClusterRole.Arn
+  Action:
+    - "kms:DescribeKey"
+    - "kms:CreateGrant"
+  Resource: "*"
+  {{- else }}
+- Sid: "Enable master nodes to encrypt and decrypt secrets in etcd"
+  Effect: "Allow"
+  Principal:
+    AWS:
+      - "Fn::GetAtt":
+          - "MasterIAMRole"
+          - "Arn"
+  Resource: "*"
+  Action:
+    - "kms:Encrypt"
+    - "kms:Decrypt"
+  {{- end }}
+  {{- if ne .Cluster.Provider "zalando-eks" }}
+MasterFilesEncryptionKey:
+  Type: "AWS::KMS::Key"
+  Properties:
+    Description: The KMS key for encryption of remote files for master nodes
+    EnableKeyRotation: true
+    KeyPolicy:
+      Version: "2012-10-17"
+      Id: "master-key-policy"
+      Statement:
+        - Sid: "Enable IAM User Permissions"
+          Effect: "Allow"
+          Principal:
+            AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+          Action:
+            - "kms:DescribeKey"
+          Resource: "*"
+        - Sid: "Allow administering the key"
+          Effect: "Allow"
+          Principal:
+            AWS:
+              - !Sub "arn:aws:iam::${AWS::AccountId}:role/cluster-lifecycle-manager-entrypoint"
+              - !Sub "arn:aws:iam::${AWS::AccountId}:role/Shibboleth-Administrator"
+              - !Sub "arn:aws:iam::${AWS::AccountId}:role/Administrator"
+          Action:
+            - "kms:*"
+            - "tag:TagResources"
+          Resource: "*"
+        - Sid: "Enable master nodes to decrypt the remote files"
+          Effect: "Allow"
+          Principal:
+            AWS:
+              - "Fn::GetAtt":
+                  - "MasterIAMRole"
+                  - "Arn"
+          Resource: "*"
+          Action:
+            - "kms:Decrypt"
+  {{- end}}
+WorkerFilesEncryptionKey:
+  Type: "AWS::KMS::Key"
+  Properties:
+    Description: The KMS key for encryption of remote files for worker nodes
+    EnableKeyRotation: true
+    KeyPolicy:
+      Version: "2012-10-17"
+      Id: "worker-key-policy"
+      Statement:
+        - Sid: "Enable IAM User Permissions"
+          Effect: "Allow"
+          Principal:
+            AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+          Action:
+            - "kms:DescribeKey"
+          Resource: "*"
+        - Sid: "Allow administering the key"
+          Effect: "Allow"
+          Principal:
+            AWS:
+              - !Sub "arn:aws:iam::${AWS::AccountId}:role/cluster-lifecycle-manager-entrypoint"
+              - !Sub "arn:aws:iam::${AWS::AccountId}:role/Shibboleth-Administrator"
+              - !Sub "arn:aws:iam::${AWS::AccountId}:role/Administrator"
+          Action:
+            - "kms:*"
+            - "tag:TagResources"
+          Resource: "*"
+        - Sid: "Enable worker nodes to decrypt the remote files"
+          Effect: "Allow"
+          Principal:
+            AWS:
+              - "Fn::GetAtt":
+                  - "WorkerIAMRole"
+                  - "Arn"
+          Resource: "*"
+          Action:
             - "kms:Decrypt"
 Outputs:
-{{- if eq .Cluster.Provider "zalando-eks" }}
-  EKSControlPlaneEndpoint:
-    Export:
-      Name: "{{.Cluster.ID}}:eks-control-plane-endpoint"
-    Value: !GetAtt EKSCluster.Endpoint
-  # EKSServiceIpv6Cidr:
-  #   Export:
-  #     Name: "{{.Cluster.ID}}:eks-service-cidr"
-  #   Value: !GetAtt EKSCluster.KubernetesNetworkConfig.ServiceIpv6Cidr
-  EKSOpenIdConnectIssuerUrl:
-    Export:
-      Name: "{{.Cluster.ID}}:eks-oidc-url"
-    Value: !GetAtt EKSCluster.OpenIdConnectIssuerUrl
-  EKSClusterSecurityGroupId:
-    Export:
-      Name: "{{.Cluster.ID}}:eks-security-group-id"
-    Value: !GetAtt EKSCluster.ClusterSecurityGroupId
-  EKSWorkerSecurityGroup:
-    Export:
-      Name: "{{.Cluster.ID}}:worker-security-group"
-    Value: !Ref EKSWorkerSecurityGroup
-  # Too big for Cloudformation output?
-  # EKSCertificateAuthorityData:
-  #   Export:
-  #     Name: "{{.Cluster.ID}}:eks-certificate-authority-data"
-  #   Value: !GetAtt EKSCluster.CertificateAuthorityData
+  {{- if eq .Cluster.Provider "zalando-eks" }}
+EKSControlPlaneEndpoint:
+  Export:
+    Name: "{{.Cluster.ID}}:eks-control-plane-endpoint"
+  Value: !GetAtt EKSCluster.Endpoint
+# EKSServiceIpv6Cidr:
+#   Export:
+#     Name: "{{.Cluster.ID}}:eks-service-cidr"
+#   Value: !GetAtt EKSCluster.KubernetesNetworkConfig.ServiceIpv6Cidr
+EKSOpenIdConnectIssuerUrl:
+  Export:
+    Name: "{{.Cluster.ID}}:eks-oidc-url"
+  Value: !GetAtt EKSCluster.OpenIdConnectIssuerUrl
+EKSClusterSecurityGroupId:
+  Export:
+    Name: "{{.Cluster.ID}}:eks-security-group-id"
+  Value: !GetAtt EKSCluster.ClusterSecurityGroupId
+EKSWorkerSecurityGroup:
+  Export:
+    Name: "{{.Cluster.ID}}:worker-security-group"
+  Value: !Ref EKSWorkerSecurityGroup
+# Too big for Cloudformation output?
+# EKSCertificateAuthorityData:
+#   Export:
+#     Name: "{{.Cluster.ID}}:eks-certificate-authority-data"
+#   Value: !GetAtt EKSCluster.CertificateAuthorityData
   {{- if eq .Cluster.ConfigItems.eks_efs_csi_support_enabled "true" }}
-  EFSFileSystemID:
-    Export:
-      Name: '{{ .Cluster.ID}}:efs-filesystem-id'
-    Value: !Ref EFSFileSystem
+EFSFileSystemID:
+  Export:
+    Name: '{{ .Cluster.ID}}:efs-filesystem-id'
+  Value: !Ref EFSFileSystem
   {{- end}}
-{{- else }}
-  MasterIAMRole:
-    Export:
-      Name: '{{.Cluster.ID}}:master-iam-role'
-    Value: !Ref MasterIAMRole
-  MasterFilesEncryptionKey:
-    Export:
-      Name: '{{ .Cluster.ID}}:master-files-encryption-key'
-    Value: !Ref MasterFilesEncryptionKey
-{{- if ne .Cluster.ConfigItems.delete_vpc_resources "true" }}
-  MasterLoadBalancerNLBTargetGroup:
-    Export:
-      Name: '{{.Cluster.ID}}:master-load-balancer-nlb-target-group'
-    Value: !Ref MasterLoadBalancerNLBTargetGroup
-{{- if or (eq .Cluster.ConfigItems.control_plane_load_balancer_internal "pre") (eq .Cluster.ConfigItems.control_plane_load_balancer_internal "serving") (eq .Cluster.ConfigItems.control_plane_load_balancer_internal "active") }}
-  ControlPlaneInternalLBTargetGroup:
-    Export:
-      Name: '{{.Cluster.ID}}:control-plane-internal-lb-target-group'
-    Value: !Ref ControlPlaneInternalLBTargetGroup
-{{- end }}
-  MasterSecurityGroup:
-    Export:
-      Name: '{{.Cluster.ID}}:master-security-group'
-    Value: !Ref MasterSecurityGroup
-  WorkerSecurityGroup:
-    Export:
-      Name: '{{.Cluster.ID}}:worker-security-group'
-    Value: !Ref WorkerSecurityGroup
-{{- end }}
-  EtcdEncryptionKey:
-    Export:
-      Name: '{{ .Cluster.ID}}:etcd-encryption-key'
-    Value: !Ref EtcdEncryptionKey
-{{- end}}
-  WorkerIAMRole:
-    Export:
-      Name: '{{.Cluster.ID}}:worker-iam-role'
-    Value: !Ref WorkerIAMRole
-  RemoteFilesEncryptionKey:
-    Export:
-      Name: '{{ .Cluster.ID}}:remote-files-encryption-key'
-    Value: !Ref RemoteFilesEncryptionKey
-  WorkerFilesEncryptionKey:
-    Export:
-      Name: '{{ .Cluster.ID}}:worker-files-encryption-key'
-    Value: !Ref WorkerFilesEncryptionKey
+  {{- else }}
+MasterIAMRole:
+  Export:
+    Name: '{{.Cluster.ID}}:master-iam-role'
+  Value: !Ref MasterIAMRole
+MasterFilesEncryptionKey:
+  Export:
+    Name: '{{ .Cluster.ID}}:master-files-encryption-key'
+  Value: !Ref MasterFilesEncryptionKey
+  {{- if ne .Cluster.ConfigItems.delete_vpc_resources "true" }}
+MasterLoadBalancerNLBTargetGroup:
+  Export:
+    Name: '{{.Cluster.ID}}:master-load-balancer-nlb-target-group'
+  Value: !Ref MasterLoadBalancerNLBTargetGroup
+  {{- if or (eq .Cluster.ConfigItems.control_plane_load_balancer_internal "pre") (eq .Cluster.ConfigItems.control_plane_load_balancer_internal "serving") (eq .Cluster.ConfigItems.control_plane_load_balancer_internal "active") }}
+ControlPlaneInternalLBTargetGroup:
+  Export:
+    Name: '{{.Cluster.ID}}:control-plane-internal-lb-target-group'
+  Value: !Ref ControlPlaneInternalLBTargetGroup
+  {{- end }}
+MasterSecurityGroup:
+  Export:
+    Name: '{{.Cluster.ID}}:master-security-group'
+  Value: !Ref MasterSecurityGroup
+WorkerSecurityGroup:
+  Export:
+    Name: '{{.Cluster.ID}}:worker-security-group'
+  Value: !Ref WorkerSecurityGroup
+  {{- end }}
+EtcdEncryptionKey:
+  Export:
+    Name: '{{ .Cluster.ID}}:etcd-encryption-key'
+  Value: !Ref EtcdEncryptionKey
+  {{- end}}
+WorkerIAMRole:
+  Export:
+    Name: '{{.Cluster.ID}}:worker-iam-role'
+  Value: !Ref WorkerIAMRole
+RemoteFilesEncryptionKey:
+  Export:
+    Name: '{{ .Cluster.ID}}:remote-files-encryption-key'
+  Value: !Ref RemoteFilesEncryptionKey
+WorkerFilesEncryptionKey:
+  Export:
+    Name: '{{ .Cluster.ID}}:worker-files-encryption-key'
+  Value: !Ref WorkerFilesEncryptionKey

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -435,7 +435,7 @@ skipper_open_policy_agent_preloading_enabled: "false"
 skipper_open_policy_agent_decision_log_export_enabled: "false"
 skipper_open_policy_agent_console_logs_enabled: "false"
 skipper_open_policy_agent_decision_log_s3_endpoint: ""
-skipper_open_policy_agent_decision_log_s3_region: ""
+skipper_open_policy_agent_decision_log_s3_region: "eu-central-1"
 skipper_open_policy_agent_decision_log_bucket_arn: ""
 
 # Default timeout value in seconds for outgoing http calls from Open Policy Agent in a skipper filter

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -436,6 +436,7 @@ skipper_open_policy_agent_decision_log_export_enabled: "false"
 skipper_open_policy_agent_console_logs_enabled: "false"
 skipper_open_policy_agent_decision_log_s3_endpoint: ""
 skipper_open_policy_agent_decision_log_s3_region: ""
+skipper_open_policy_agent_decision_log_bucket_arn: ""
 
 # Default timeout value in seconds for outgoing http calls from Open Policy Agent in a skipper filter
 skipper_open_policy_agent_styra_response_header_timeout: "2"


### PR DESCRIPTION
Opa decision logs from the skipper ingress can be directed to a given S3 bucket by default. 

This PR adds the role policies so that skipper-ingress and skipper-validation-webhook will have necessary write access to the bucket