### PR TITLE
Exclude 5th gen AMD instances in prod

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -57,6 +57,17 @@ karpenter_instance_family_t_enabled: "false"
 # scheduling issues, we need to properly test and support it later if needed
 karpenter_instance_family_g6f_enabled: "false"
 
+
+# List of instance families to exclude from Karpenter node pools. This is a
+# comma separated list of instance family names, e.g. "c5a,m5a,r5a". By default,
+# we exclude 5th gen AMD-based instance families in production clusters due to
+# their lower performance compared to Intel-based instances.
+{{if eq .Cluster.Environment "production"}}
+karpenter_excluded_instance_families: "c5a,m5a,r5a,c5ad,m5ad,r5ad"
+{{else}}
+karpenter_excluded_instance_families: ""
+{{end}}
+
 # configure whether we allow flex instance types for Karpenter nodes
 # flex instance types have a baseline CPU performance with burst capability.
 # This provides an unpredictable performance, hence we want to avoid running

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -242,6 +242,14 @@ spec:
             - "c5d.large"
             - "m5d.large"
             - "r5d.large"
+        # {{ if ne .NodePool.ConfigItems.karpenter_excluded_instance_families ""}}
+        - key: "karpenter.k8s.aws/instance-family"
+          operator: "NotIn"
+          values:
+#         {{ range $family = split .NodePool.ConfigItems.karpenter_excluded_instance_families "," }}
+          - "{{ $family }}"
+#         {{ end }}
+        # {{ end }}
         # {{ if ne .NodePool.ConfigItems.karpenter_flex_types_enabled "true" }}
         - key: "karpenter.k8s.aws/instance-capability-flex"
           operator: "NotIn"


### PR DESCRIPTION
Similar to #10725 exclude 5th gen AMD instances in production as we historically had reports of low performance which we want to introduce when disabling the more restricted `default-karpenter` pool.

#10710 aimed to disable _all_ amd instances but this doesn't work for several reasons:

* Some users explicitly request AMD instance types of newer generations
* GPU types like g6 which are regularly used are amd instances, those we definitely want to allow.