### PR TITLE
add vpa for cluster lifecycle controller

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -70,6 +70,9 @@ karpenter_flex_types_enabled: "true"
 # configure whether spot instances should be enabled in Karpenter's capacity-types
 karpenter_enable_spot: "true"
 
+# cluster lifecycle controller
+cluster_lifecycle_controller_memory_min: "10Mi"
+
 # ALB config created by kube-aws-ingress-controller
 kube_aws_ingress_controller_ssl_policy: "ELBSecurityPolicy-TLS13-1-2-Res-2021-06"
 kube_aws_ingress_controller_idle_timeout: "1m"

--- a/cluster/manifests/cluster-lifecycle-controller/vpa.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/vpa.yaml
@@ -1,0 +1,20 @@
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: "cluster-lifecycle-controller"
+  namespace: "kube-system"
+  labels:
+    application: kubernetes
+    component: cluster-lifecycle-controller
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: "cluster-lifecycle-controller"
+  updatePolicy:
+    updateMode: Recreate
+  resourcePolicy:
+    containerPolicies:
+    - containerName: "cluster-lifecycle-controller"
+      minAllowed:
+        memory: "{{.Cluster.ConfigItems.cluster_lifecycle_controller_memory_min}}"


### PR DESCRIPTION
add vpa for cluster lifecycle controller

Most clusters don't need more than 10/20 Mi of memory, so this should save at least 50Gi across all clusters.