### PR TITLE
[STABLE: cherry-pick] exclude S3 CSI Driver Addon components from being processed by admission-controller

### DIFF
--- a/cluster/manifests/02-admission-control/teapot.yaml
+++ b/cluster/manifests/02-admission-control/teapot.yaml
@@ -28,6 +28,7 @@ webhooks:
             - "eks-pod-identity-agent"
             - "aws-efs-csi-driver"
             - "eks-node-monitoring-agent"
+            - "aws-mountpoint-s3-csi-driver"
         - key: application
           operator: NotIn
           values: ["kube-ingress-aws-controller"]
@@ -359,6 +360,7 @@ webhooks:
           values:
             - "aws-efs-csi-driver"
             - "eks-node-monitoring-agent"
+            - "aws-mountpoint-s3-csi-driver"
 {{- end }}
     clientConfig:
       {{- if eq .Cluster.Provider "zalando-eks"}}
@@ -397,6 +399,7 @@ webhooks:
             - "eks-pod-identity-agent"
             - "aws-efs-csi-driver"
             - "eks-node-monitoring-agent"
+            - "aws-mountpoint-s3-csi-driver"
 {{- end }}
     clientConfig:
       {{- if eq .Cluster.Provider "zalando-eks"}}


### PR DESCRIPTION
This cherry-picks #10685 to stable such that it's not part of #10670

This is to make sure e2e can pass for #10670 which otherwise fails because #10685 and #10664 are combined there which was not intended.