### PR TITLE
add vpa for fabric-gateways-controller

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -482,8 +482,7 @@ skipper_open_policy_agent_jwt_cache_max_num_entries: "1000"
 #   - true: runs the controller
 #
 fabric_gateway_controller_enabled: "true"
-fabric_gateway_controller_cpu: "50m"
-fabric_gateway_controller_memory: "150Mi"
+fabric_gateway_controller_memory_min: "10Mi"
 fabric_gateway_controller_allow_all_filters: "false"
 fabric_gateway_controller_ssl_policy: ""
 fabric_gateway_controller_log_level: "INFO"

--- a/cluster/manifests/fabric-gateway/deployment.yaml
+++ b/cluster/manifests/fabric-gateway/deployment.yaml
@@ -50,8 +50,9 @@ spec:
             {{ end }}
           resources:
             requests:
-              cpu: {{ .Cluster.ConfigItems.fabric_gateway_controller_cpu }}
-              memory: {{ .Cluster.ConfigItems.fabric_gateway_controller_memory }}
+              cpu: "50m"
+              memory: "150Mi"
             limits:
-              cpu: {{ .Cluster.ConfigItems.fabric_gateway_controller_cpu }}
-              memory: {{ .Cluster.ConfigItems.fabric_gateway_controller_memory }}
+              cpu: "50m"
+              memory: "150Mi"
+

--- a/cluster/manifests/fabric-gateway/vpa.yaml
+++ b/cluster/manifests/fabric-gateway/vpa.yaml
@@ -1,0 +1,20 @@
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: fabric-gateway-controller
+  namespace: kube-system
+  labels:
+    application: gateway-operator
+    component: fabric-gateway-controller
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: fabric-gateway-controller
+  updatePolicy:
+    updateMode: Recreate
+  resourcePolicy:
+    containerPolicies:
+    - containerName: controller
+      minAllowed:
+        memory: {{.Cluster.ConfigItems.fabric_gateway_controller_memory_min}}


### PR DESCRIPTION
add vpa for fabric-gateways-controller.
This allow both to reduce cost adjusting resources, but also scale up automatically in case it's needed.
- Removed config items with memory and cpu only used now on the first deployment
- Added config-item for minAllowed memory in case we need to manually increase at some point