### PR TITLE
add vpa for efs provisioner

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1400,6 +1400,7 @@ eks_efs_csi_support_enabled: "false"
 eks_s3_csi_support_enabled: "false"
 eks_node_monitoring_enabled: "false"
 {{ end }}
+efs_provisioner_memory_min: "10Mi"
 
 # prefix delegation can only be configured for ipv4. For ipv6 it can only be true.
 aws_vpc_cni_prefix_delegation: "false"

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -413,6 +413,9 @@ post_apply:
 {{- end}}
 {{ if not (index .Cluster.ConfigItems "efs_id") }}
 - name: efs-provisioner
+  kind: VerticalPodAutoscaler
+  namespace: kube-system
+- name: efs-provisioner
   kind: Deployment
   namespace: kube-system
 - name: efs-provisioner

--- a/cluster/manifests/efs-provisioner/depl-efs-provisioner.yaml
+++ b/cluster/manifests/efs-provisioner/depl-efs-provisioner.yaml
@@ -50,6 +50,9 @@ spec:
           limits:
             cpu: 25m
             memory: 100Mi
+          requests:
+            cpu: 25m
+            memory: 100Mi
         volumeMounts:
         - name: pv-volume
           mountPath: /persistentvolumes

--- a/cluster/manifests/efs-provisioner/vpa.yaml
+++ b/cluster/manifests/efs-provisioner/vpa.yaml
@@ -1,0 +1,22 @@
+{{ if index .Cluster.ConfigItems "efs_id" }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: efs-provisioner
+  namespace: kube-system
+  labels:
+    application: kubernetes
+    component: efs-provisioner
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: efs-provisioner
+  updatePolicy:
+    updateMode: Recreate
+  resourcePolicy:
+    containerPolicies:
+    - containerName: efs-provisioner
+      minAllowed:
+        memory: {{.Cluster.ConfigItems.efs_provisioner_memory_min}}
+{{ end }}


### PR DESCRIPTION
add vpa for efs provisioner
This not only helps to reduce a bit the costs but it also allow to automatically scale up if needed.
Since we don't define the requests (only limits) some internal tools have some issues, so I'm defining the request equal to the limits.