### PR TITLE
Fix: Add proper target-access-mode configuration for CNI and non-CNI modes

### DIFF
--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -37,15 +37,14 @@ spec:
         - name: controller
           image: "{{ $image }}"
           args:
-            - --target-access-mode=HostPort
-{{- if eq .Cluster.Provider "zalando-eks" }}
             - --ip-addr-type={{ .Cluster.ConfigItems.kube_aws_ingress_controller_lb_ip_addr_type }}
             - --target-group-ip-addr-type={{ .Cluster.ConfigItems.kube_aws_ingress_controller_target_group_ip_addr_type }}
 {{- if eq .Cluster.ConfigItems.kube_aws_ingress_controller_enable_cni_mode "true" }}
             - --target-access-mode=AWSCNI
             - --target-cni-namespace=kube-system
             - --target-cni-pod-labelselector=application=skipper-ingress,component=ingress
-{{- end }}
+{{- else }}
+            - --target-access-mode=HostPort
 {{- end }}
             - --stack-termination-protection
             - --ssl-policy={{ .Cluster.ConfigItems.kube_aws_ingress_controller_ssl_policy }}


### PR DESCRIPTION
## Summary
This fix simplifies the target-access-mode configuration for EKS clusters by always using the CNI configuration logic:

- When CNI mode enabled: Use AWSCNI with pod targeting
- When CNI mode disabled: Use HostPort mode with instance targeting

This addresses the issue where non-CNI mode on EKS clusters was not properly configuring the target-access-mode, causing ingress controller to fail to connect to targets.

## Changes
- Removed provider-specific logic (zalando-aws vs zalando-eks check)
- Simplified to always apply CNI configuration logic
- Always set --target-access-mode based on CNI enablement

## Test plan
- [x] Verify changes work for EKS clusters with CNI enabled
- [x] Verify changes work for EKS clusters with CNI disabled  
- [x] Confirm ingress controller can reach targets correctly
- [x] Validate simplified approach is cleaner and maintainable

## Related
- Fixes IPv6 target groups issue with missing client IP preservation
- Relates to PR #10647
