### PR TITLE
[TEST] IPv6 Proxy Protocol v2 and Client IP Preservation - Validation Run

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -105,6 +105,10 @@ kube_aws_ingress_controller_lb_ip_addr_type: "ipv4"
 kube_aws_ingress_controller_target_group_ip_addr_type: "ipv4"
 # when enabled, the ingress controller will use AWS CNI to attach ENIs to the ingress controller pods and use pod IPs as targets in the target group.
 kube_aws_ingress_controller_enable_cni_mode: "false"
+# preserve client ip address
+kube_aws_ingress_controller_nlb_preserve_client_ip: "true"
+# enable proxy protocol v2
+kube_aws_ingress_controller_nlb_proxy_protocol_v2: "false"
 # ALB to NLB switch
 # "pre":
 # - kube-ingress-aws-controller will configure NLB to forward HTTPS requests

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -39,6 +39,12 @@ spec:
           args:
             - --ip-addr-type={{ .Cluster.ConfigItems.kube_aws_ingress_controller_lb_ip_addr_type }}
             - --target-group-ip-addr-type={{ .Cluster.ConfigItems.kube_aws_ingress_controller_target_group_ip_addr_type }}
+{{- if eq .Cluster.ConfigItems.kube_aws_ingress_controller_nlb_preserve_client_ip "false" }}
+            - --nlb-preserve-client-ip-disabled
+{{- end }}
+{{- if eq .Cluster.ConfigItems.kube_aws_ingress_controller_nlb_proxy_protocol_v2 "true" }}
+            - --nlb-proxy-protocol-v2-enabled
+{{- end }}
 {{- if eq .Cluster.ConfigItems.kube_aws_ingress_controller_enable_cni_mode "true" }}
             - --target-access-mode=AWSCNI
             - --target-cni-namespace=kube-system


### PR DESCRIPTION
## Summary
**TEST PR** - Validates IPv6 target groups fix with controller from https://github.com/zalando-incubator/kube-ingress-aws-controller/pull/783

Includes config items for NLB target group attributes (preserve_client_ip, proxy_protocol_v2) and uses test controller image.

## Test Plan
- Deploy to test cluster
- Enable dualstack nlb `kube_aws_ingress_controller_lb_ip_addr_type: "ipv6"`
- Enable IPv6 targets: `kube_aws_ingress_controller_target_group_ip_addr_type: "ipv6"`
- Set `kube_aws_ingress_controller_nlb_proxy_protocol_v2: "true"`
- Verify ClientIP and SourceFromLast predicates work
- Test with IPv4 and IPv6 clients

## Related
- https://github.com/zalando-incubator/kube-ingress-aws-controller/pull/783
- includes fixes from https://github.com/zalando-incubator/kubernetes-on-aws/pull/10751
- IPv6 target groups client IP preservation, proxy protocol v2
