### PR TITLE
kubelet-summary-summary: adjust ration memory to cpu

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -503,7 +503,7 @@ event_rate_limit_config_burst: "1000"
 # collection.
 kubelet_summary_metrics_enabled: "true"
 kubelet_summary_metrics_cpu: "100m"
-kubelet_summary_metrics_memory: "512Mi"
+kubelet_summary_metrics_memory: "256Mi"
 kubelet_summary_metrics_hpa_max_replicas: "10"
 kubelet_summary_metrics_hpa_cpu_target: "80"
 kubelet_summary_metrics_hpa_memory_target: "80"


### PR DESCRIPTION
adjust ration memory to cpu from current metrics
After checking the previous 7 days from several clusters (including the ones with more load) it's clear the HPA is always scaling based on CPU and we are waisting around 256Mi per pod.
The initial idea was to introduce VPA with 2 replicas but the gains should be similar with less risk and disruption.
Some clusters frequently scale up and down during the days, so probably HPA is better for this use-case