### PR TITLE
kube-node-ready: 1 replica with vpa and rollingUpdate

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -625,6 +625,7 @@ kubernetes_lifecycle_metrics_mem_min: "120Mi"
 
 kube_node_ready_controller_cpu: "50m"
 kube_node_ready_controller_memory: "200Mi"
+kube_node_ready_controller_memory_min: "50Mi"
 
 # Enable deployment of aws-cloud-controller-manager
 aws_cloud_controller_manager_enabled: "true"

--- a/cluster/manifests/kube-node-ready-controller/daemonset.yaml
+++ b/cluster/manifests/kube-node-ready-controller/daemonset.yaml
@@ -14,11 +14,8 @@ spec:
   selector:
     matchLabels:
       daemonset: kube-node-ready-controller
-{{- if ne .Cluster.Provider "zalando-eks"}}
-  updateStrategy:
-    type: RollingUpdate
-{{- else }}
-  replicas: 2
+{{- if eq .Cluster.Provider "zalando-eks"}}
+  replicas: 1
 {{- end}}
   template:
     metadata:
@@ -47,22 +44,6 @@ spec:
             cpu: {{.Cluster.ConfigItems.kube_node_ready_controller_cpu}}
             memory: {{.Cluster.ConfigItems.kube_node_ready_controller_memory}}
 {{- if eq .Cluster.Provider "zalando-eks"}}
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                daemonset: kube-node-ready-controller
-            topologyKey: kubernetes.io/hostname
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              preference:
-                matchExpressions:
-                - key: dedicated
-                  operator: In
-                  values:
-                  - cluster-seed
       tolerations:
       - key: dedicated
         value: cluster-seed

--- a/cluster/manifests/kube-node-ready-controller/vpa.yaml
+++ b/cluster/manifests/kube-node-ready-controller/vpa.yaml
@@ -1,0 +1,22 @@
+{{- if eq .Cluster.Provider "zalando-eks"}}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: kube-node-ready-controller
+  namespace: kube-system
+  labels:
+    application: kubernetes
+    component: kube-node-ready-controller
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: kube-node-ready-controller
+  updatePolicy:
+    updateMode: Recreate
+  resourcePolicy:
+    containerPolicies:
+    - containerName: controller
+      minAllowed:
+        memory: "{{.Cluster.ConfigItems.kube_node_ready_controller_memory_min}}"
+{{- end}}


### PR DESCRIPTION
kube-node-ready: 1 replica with vpa and rollingUpdate

NOTE: we could replace the daemonset by a deployment in the legacy cluster to simplify, but it would not bring any cost savings. We can always do it in a separated PR later if we prefer.