### PR TITLE
adjust min memory for event-logs the same as minimum VPA memory

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1110,7 +1110,7 @@ pdb_controller_max_unavailable: "1%"
 
 # Log Kubernetes events to Scalyr
 kubernetes_event_logger_enabled: "true"
-event_logger_mem_min: "100Mi"
+event_logger_mem_min: "50Mi"
 event_logger_cpu_min: "10m"
 
 # enable/disable routegroup support for stackset


### PR DESCRIPTION
adjust min memory for event-logs the same as minimum VPA memory.
Even 50Mi is more than enough for all cluster, and at least we keep the minimum possible value that is enforced by VPA.