### PR TITLE
Exclude 6a family intance types

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -63,9 +63,9 @@ karpenter_instance_family_g6f_enabled: "false"
 # we exclude 5th gen AMD-based instance families in production clusters due to
 # their lower performance compared to Intel-based instances.
 {{if eq .Cluster.Environment "production"}}
-karpenter_excluded_instance_families: "c5a,m5a,r5a,c5ad,m5ad,r5ad"
+karpenter_excluded_instance_families: "c5a,m5a,r5a,c5ad,m5ad,r5ad,c6a,m6a,r6a,c6ad,m6ad,r6ad"
 {{ else if eq .Cluster.Environment "e2e" }}
-karpenter_excluded_instance_families: "c5a,m5a,r5a,c5ad,m5ad,r5ad"
+karpenter_excluded_instance_families: "c5a,m5a,r5a,c5ad,m5ad,r5ad,c6a,m6a,r6a,c6ad,m6ad,r6ad"
 {{else}}
 karpenter_excluded_instance_families: ""
 {{end}}


### PR DESCRIPTION
Similar to #10730 also include standard 6a instance family types

We do this to reduce the risk of introducing "worse performing" instances

There are a small subset of workloads requesting these types explicitly, will filter those clusters out of this change for now and work with the teams to update.