### PR TITLE
add vpa for skipper admission webhook for eks clusters

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -386,6 +386,7 @@ skipper_backend_host_metrics: "false"
 #
 skipper_webhook_cpu: 100m
 skipper_webhook_memory: 500Mi
+skipper_webhook_memory_min: 100Mi
 
 # disabled|provisioned|enabled routegroup validation via skipper webhook
 # can be one of disabled|provisioned|enabled

--- a/cluster/manifests/02-skipper-validation-webhook/vpa.yaml
+++ b/cluster/manifests/02-skipper-validation-webhook/vpa.yaml
@@ -1,0 +1,22 @@
+# {{- if eq .Cluster.Provider "zalando-eks"}}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: skipper-validation-webhook
+  namespace: kube-system
+  labels:
+    application: skipper-ingress
+    component: webhook
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: skipper-validation-webhook
+  updatePolicy:
+    updateMode: Recreate
+  resourcePolicy:
+    containerPolicies:
+    - containerName: skipper-admission-webhook
+      minAllowed:
+        memory: "{{.Cluster.ConfigItems.skipper_webhook_memory_min}}"
+# {{- end }}


### PR DESCRIPTION
add vpa for skipper admission webhook for eks clusters
The current static defined memory of 512Mi is requesting 20% of the seed node memory, but checking all cluster it usually only needs around 128Mi (4 times less).
This should free memory (also a bit of cpu) to add other pods or even to reduce the seed worker node size (e.g. test clusters). This also reduce the risk of ending up now having enough memory for the seed worker node in the future if when we add more daemonsets or deployments.

NOTE: to avoid some concerns we can set the `skipper_webhook_memory_min` to 500Mi in the config-manager for one week (eks provider) while the VPA gets more data to provide more accurated recommendations.