### PR TITLE
feat: Adds shadow-traffic-controller deployment configuration

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1446,5 +1446,8 @@ aws_load_balancer_controller_default_target_type: "instance"
 # configure if sandbox-controller should be deployed
 sandbox_controller_enabled: "true"
 
-# configure if shadow-traffic-controller should be deployed
+# shadow-traffic-controller configuration
 shadow_traffic_controller_enabled: "true"
+shadow_traffic_controller_log_level: "info"
+shadow_traffic_controller_cpu: "100m"
+shadow_traffic_controller_memory: "300Mi"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1445,3 +1445,6 @@ aws_load_balancer_controller_default_target_type: "instance"
 
 # configure if sandbox-controller should be deployed
 sandbox_controller_enabled: "true"
+
+# configure if shadow-traffic-controller should be deployed
+shadow_traffic_controller_enabled: "true"

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -328,6 +328,11 @@ post_apply:
   namespace: kube-system
   kind: Deployment
 {{ end }}
+{{ if ne .Cluster.ConfigItems.shadow_traffic_controller_enabled "true" }}
+- name: shadow-traffic-controller
+  namespace: kube-system
+  kind: Deployment
+{{ end }}
 {{- if and (ne .Cluster.ConfigItems.wiz_enable_runtime_connector_broker "true") (ne .Cluster.ConfigItems.wiz_enable_runtime_connector "true") }}
 - name: wiz-connector-connector
   kind : Secret

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -332,6 +332,13 @@ post_apply:
 - name: shadow-traffic-controller
   namespace: kube-system
   kind: Deployment
+- name: shadow-traffic-controller
+  kind: ServiceAccount
+  namespace: kube-system
+- name: shadow-traffic-controller
+  kind : ClusterRole
+- name: shadow-traffic-controller
+  kind : ClusterRoleBinding
 {{ end }}
 {{- if and (ne .Cluster.ConfigItems.wiz_enable_runtime_connector_broker "true") (ne .Cluster.ConfigItems.wiz_enable_runtime_connector "true") }}
 - name: wiz-connector-connector

--- a/cluster/manifests/shadow-traffic-controller/10-shadow_traffic_crd.yaml
+++ b/cluster/manifests/shadow-traffic-controller/10-shadow_traffic_crd.yaml
@@ -1,0 +1,207 @@
+# {{ if eq .Cluster.ConfigItems.shadow_traffic_controller_enabled "true" }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  name: shadowtraffics.zalando.org
+spec:
+  group: zalando.org
+  names:
+    categories:
+      - all
+    kind: ShadowTraffic
+    listKind: ShadowTrafficList
+    plural: shadowtraffics
+    shortNames:
+      - st
+    singular: shadowtraffic
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec describes the desired behavior of the ShadowTraffic
+              properties:
+                routeMatchers:
+                  description: |-
+                    RouteMatchers defines the criteria for selecting routes for shadowing. If not specified,
+                    all the routes in the reference route object will be selected for shadowing.
+                  items:
+                    description: |-
+                      RouteMatcher defines the criteria for selecting routes for shadowing. It supports matching routes based on
+                      their path, HTTP method, and Header predicates. At least one of Path or Headers must be specified.
+                      Methods can optionally be used alongside Path or Headers for further filtering.
+                    properties:
+                      headers:
+                        description: |-
+                          Headers should match with the route's Header predicates to select the route for shadowing.
+                          If specified, all the headers should match to be an eligible route for shadowing.
+                          If not specified, routes will be selected regardless of their headers.
+                        items:
+                          description: |-
+                            Header represents a Skipper Header Predicate. It should be in the format Header("key", "value")
+                            or HeaderRegexp("key", "regex").
+                          pattern: ^Header\((.+)\)$|^HeaderRegexp\((.+)\)$
+                          type: string
+                        type: array
+                      methods:
+                        description: |-
+                          Methods should match with the route's Method/Methods predicate values to select the route for shadowing.
+                          If specified, all the methods should match to be an eligible route for shadowing.
+                          If not specified, routes will be selected regardless of their method.
+                        items:
+                          description: HTTPMethod represents an HTTP method in uppercase
+                          enum:
+                            - GET
+                            - POST
+                            - PUT
+                            - DELETE
+                            - PATCH
+                            - HEAD
+                            - OPTIONS
+                            - CONNECT
+                            - TRACE
+                          type: string
+                        type: array
+                      path:
+                        description:
+                          Path should match with the route's path predicate
+                          value to select the route for shadowing
+                        properties:
+                          type:
+                            description:
+                              Type is the type of the Skipper path Predicate.
+                              It can be Path or PathSubtree.
+                            enum:
+                              - Path
+                              - PathSubtree
+                            type: string
+                          value:
+                            description:
+                              Value is the path value of the above mentioned
+                              Skipper Predicate type
+                            type: string
+                        required:
+                          - type
+                          - value
+                        type: object
+                    type: object
+                    x-kubernetes-validations:
+                      - message:
+                          at least one of path or headers must be specified in
+                          a route matcher
+                        rule:
+                          (has(self.path) && has(self.path.type)) || (has(self.headers)
+                          && size(self.headers) > 0)
+                  minItems: 1
+                  type: array
+                shadowBackend:
+                  description:
+                    ShadowBackend is the backend that the shadow traffic
+                    should be proxied to
+                  properties:
+                    address:
+                      description: Address is required for type "network"
+                      type: string
+                    name:
+                      description: Name is the name of the shadow backend
+                      type: string
+                    serviceName:
+                      description: ServiceName is required for type "service"
+                      type: string
+                    servicePort:
+                      description: ServicePort is required for type "service"
+                      type: integer
+                    type:
+                      description: Type is the backend type (network or service)
+                      enum:
+                        - network
+                        - service
+                      type: string
+                  required:
+                    - name
+                    - type
+                  type: object
+                sourceObjectReferences:
+                  description:
+                    SourceObjectReferences describes the reference route
+                    objects
+                  items:
+                    description:
+                      SourceObjectReference references a Kubernetes route
+                      object
+                    properties:
+                      kind:
+                        description:
+                          Kind is the Kubernetes resource kind of the reference
+                          route object
+                        enum:
+                          - RouteGroup
+                          - FabricGateway
+                          - StackSet
+                        type: string
+                      name:
+                        description: Name is the name of the reference route object
+                        type: string
+                      namespace:
+                        description:
+                          Namespace is the namespace of the reference route
+                          object
+                        type: string
+                    required:
+                      - kind
+                      - name
+                      - namespace
+                    type: object
+                  type: array
+                trafficShare:
+                  description:
+                    TrafficShare is the percentage (0 - 1] of traffic that
+                    should be shadowed
+                  pattern: ^0(\.[0-9]+)?$|^1(\.0+)?$
+                  type: string
+              required:
+                - shadowBackend
+                - sourceObjectReferences
+                - trafficShare
+              type: object
+            status:
+              description: Status describes the current state of the ShadowTraffic
+              properties:
+                problems:
+                  description: |-
+                    Problems are errors encountered while processing the ShadowTraffic object
+                    or reference route object
+                  items:
+                    type: string
+                  type: array
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+# {{ end }}

--- a/cluster/manifests/shadow-traffic-controller/20-rbac.yaml
+++ b/cluster/manifests/shadow-traffic-controller/20-rbac.yaml
@@ -1,0 +1,78 @@
+# {{ if eq .Cluster.ConfigItems.shadow_traffic_controller_enabled "true" }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: shadow-traffic-controller
+  namespace: kube-system
+  labels:
+    application: shadow-traffic-controller
+    component: shadow-traffic-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: shadow-traffic-controller
+  labels:
+    application: shadow-traffic-controller
+    component: shadow-traffic-controller
+rules:
+  - apiGroups:
+      - zalando.org
+    resources:
+      - shadowtraffics
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+  - apiGroups:
+      - zalando.org
+    resources:
+      - routegroups
+    verbs:
+      - list
+      - watch
+      - get
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - zalando.org
+    resources:
+      - stacks
+    verbs:
+      - list
+      - get
+  - apiGroups:
+      - zalando.org
+    resources:
+      - stacksets
+    verbs:
+      - list
+      - get
+  - apiGroups:
+      - zalando.org
+    resources:
+      - fabricgateways
+    verbs:
+      - list
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: shadow-traffic-controller
+  labels:
+    application: shadow-traffic-controller
+    component: shadow-traffic-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: shadow-traffic-controller
+subjects:
+  - kind: ServiceAccount
+    name: shadow-traffic-controller
+    namespace: kube-system
+# {{ end }}

--- a/cluster/manifests/shadow-traffic-controller/30-deployment.yaml
+++ b/cluster/manifests/shadow-traffic-controller/30-deployment.yaml
@@ -1,4 +1,4 @@
-# {{ $image := "container-registry-test.zalando.net/gwproxy/shadow-traffic-controller:main-10" }}
+# {{ $image := "container-registry-test.zalando.net/gwproxy/shadow-traffic-controller:main-12" }}
 # {{ $version := index (split $image ":") 1 }}
 # {{ if eq .Cluster.ConfigItems.shadow_traffic_controller_enabled "true" }}
 apiVersion: apps/v1

--- a/cluster/manifests/shadow-traffic-controller/30-deployment.yaml
+++ b/cluster/manifests/shadow-traffic-controller/30-deployment.yaml
@@ -23,20 +23,34 @@ spec:
         kubernetes-log-watcher/scalyr-parser: |
           [{"container": "controller", "parser": "keyValue"}]
         logging/destination: "{{ .Cluster.ConfigItems.log_destination_both }}"
-        prometheus.io/path: /metrics
-        prometheus.io/port: "7979"
-        prometheus.io/scrape: "true"
     spec:
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       serviceAccountName: shadow-traffic-controller
       containers:
         - name: controller
           image: "{{ $image }}"
+          args:
+            - "--log-level={{ .Cluster.ConfigItems.shadow_traffic_controller_log_level }}"
+            - "--address=:8080"
+          ports:
+            - name: server
+              containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: server
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            successThreshold: 1
+            failureThreshold: 3
           resources:
-            limits:
-              cpu: 50m
-              memory: 300Mi
             requests:
-              cpu: 50m
-              memory: 300Mi
+              cpu: "{{ .Cluster.ConfigItems.shadow_traffic_controller_cpu }}"
+              memory: "{{ .Cluster.ConfigItems.shadow_traffic_controller_memory }}"
+            limits:
+              cpu: "{{ .Cluster.ConfigItems.shadow_traffic_controller_cpu }}"
+              memory: "{{ .Cluster.ConfigItems.shadow_traffic_controller_memory }}"
 # {{ end }}

--- a/cluster/manifests/shadow-traffic-controller/30-deployment.yaml
+++ b/cluster/manifests/shadow-traffic-controller/30-deployment.yaml
@@ -1,0 +1,42 @@
+# {{ $image := "container-registry-test.zalando.net/gwproxy/shadow-traffic-controller:main-10" }}
+# {{ $version := index (split $image ":") 1 }}
+# {{ if eq .Cluster.ConfigItems.shadow_traffic_controller_enabled "true" }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: shadow-traffic-controller
+  namespace: kube-system
+  labels:
+    application: shadow-traffic-controller
+    version: "{{ $version }}"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      application: shadow-traffic-controller
+  template:
+    metadata:
+      labels:
+        application: shadow-traffic-controller
+        version: "{{ $version }}"
+      annotations:
+        kubernetes-log-watcher/scalyr-parser: |
+          [{"container": "controller", "parser": "keyValue"}]
+        logging/destination: "{{ .Cluster.ConfigItems.log_destination_both }}"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "7979"
+        prometheus.io/scrape: "true"
+    spec:
+      priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
+      serviceAccountName: shadow-traffic-controller
+      containers:
+        - name: controller
+          image: "{{ $image }}"
+          resources:
+            limits:
+              cpu: 50m
+              memory: 300Mi
+            requests:
+              cpu: 50m
+              memory: 300Mi
+# {{ end }}


### PR DESCRIPTION
Adds the deployment manifest for the shadow-traffic-controller.

A new cluster configuration item, shadow_traffic_controller_enabled, has been introduced to control it deployment. The controller is enabled by default for the e2e tests.

The config item is set to false by default in teapot-cluster-config-manager [1]. Setting this config item to "true" is required to enable its deployment in clusters.

A conditional deletion rule was added to ensure the deployment is removed when the configuration item is not set to "true".

Also parameterised cpu, memory, and log-level configs for ease of operations.

References:
  [1] https://github.com/zalando-build/teapot-cluster-config-manager/pull/1421