### PR TITLE
Upgrade EKS Node Monitoring agent version to v1.5.2

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -404,7 +404,7 @@ Resources:
     Type: AWS::EKS::Addon
     Properties:
       AddonName: eks-node-monitoring-agent
-      AddonVersion: "v1.4.3-eksbuild.2"
+      AddonVersion: "v1.5.2-eksbuild.1"
       ClusterName: !Ref EKSCluster
   {{ end }}
 


### PR DESCRIPTION
Bump the EKS Node Monitoring Agent version to `v1.5.2-eksbuild.1`.

According to the docs, Addons can only be updated by a single minor version at a time:

> You can only update one minor version at a time. For example, if your current version is 1.28.x-eksbuild.y and you want to update to 1.30.x-eksbuild.y, then you must update your current version to 1.29.x-eksbuild.y and then update it again to 1.30.x-eksbuild.y.

The update to `v1.6.0-eksbuild.1`, which allows setting Pod Labels will follow afterwards.