### PR TITLE
expand skipper validation webhook vpa to all clusters

### DIFF
--- a/cluster/manifests/03-skipper-validation-webhook/vpa.yaml
+++ b/cluster/manifests/03-skipper-validation-webhook/vpa.yaml
@@ -1,4 +1,3 @@
-# {{- if eq .Cluster.Provider "zalando-eks"}}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
@@ -19,4 +18,3 @@ spec:
     - containerName: skipper-admission-webhook
       minAllowed:
         memory: "{{.Cluster.ConfigItems.skipper_webhook_memory_min}}"
-# {{- end }}


### PR DESCRIPTION
expand skipper validation webhook vpa to all clusters

The initial values are configured here for a week while the VPA collect data for accurate recommendations
https://github.com/zalando-build/teapot-cluster-config-manager/pull/1425