### PR TITLE
Add Proxy Protocol v2 and preserve client IP support for NLB

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -105,6 +105,10 @@ kube_aws_ingress_controller_lb_ip_addr_type: "ipv4"
 kube_aws_ingress_controller_target_group_ip_addr_type: "ipv4"
 # when enabled, the ingress controller will use AWS CNI to attach ENIs to the ingress controller pods and use pod IPs as targets in the target group.
 kube_aws_ingress_controller_enable_cni_mode: "false"
+# preserve client ip address
+kube_aws_ingress_controller_nlb_preserve_client_ip: "true"
+# enable proxy protocol v2
+kube_aws_ingress_controller_nlb_proxy_protocol_v2: "false"
 # ALB to NLB switch
 # "pre":
 # - kube-ingress-aws-controller will configure NLB to forward HTTPS requests

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -39,6 +39,12 @@ spec:
           args:
             - --ip-addr-type={{ .Cluster.ConfigItems.kube_aws_ingress_controller_lb_ip_addr_type }}
             - --target-group-ip-addr-type={{ .Cluster.ConfigItems.kube_aws_ingress_controller_target_group_ip_addr_type }}
+{{- if eq .Cluster.ConfigItems.kube_aws_ingress_controller_nlb_preserve_client_ip "false" }}
+            - --nlb-preserve-client-ip-disabled
+{{- end }}
+{{- if eq .Cluster.ConfigItems.kube_aws_ingress_controller_nlb_proxy_protocol_v2 "true" }}
+            - --nlb-proxy-protocol-v2-enabled
+{{- end }}
 {{- if eq .Cluster.ConfigItems.kube_aws_ingress_controller_enable_cni_mode "true" }}
             - --target-access-mode=AWSCNI
             - --target-cni-namespace=kube-system


### PR DESCRIPTION
## Summary
- Add configuration support for Proxy Protocol v2 on NLB target groups
- Add configuration support for preserving client IP on NLB target groups

the ingress controller support was added in here https://github.com/zalando-incubator/kubernetes-on-aws/pull/10778