### PR TITLE
Optionally Give poweruser role access to modify endpointslices

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1377,6 +1377,10 @@ role_sync_controller_enabled: "true"
 role_sync_controller_enabled: "false"
 {{ end }}
 
+# Access control configs
+# Enable users with the poweruser role to modify EndpointSlices.
+access_control_poweruser_modify_endpointslices: "false"
+
 #Wiz Configs
 # When wiz_enable_runtime_sensor and wiz_enable_runtime_connector are set to true,
 # this enables WIZ runtime monitoring. A DaemonSet called Sensor and a Deployment

--- a/cluster/manifests/roles/poweruser-role.yaml
+++ b/cluster/manifests/roles/poweruser-role.yaml
@@ -181,6 +181,18 @@ rules:
   - deletecollection
   - patch
   - update
+# {{ if eq .Cluster.ConfigItems.access_control_poweruser_modify_endpointslices "true" }}
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+# {{ end }}
 - apiGroups:
   - metacontroller.k8s.io
   resources:


### PR DESCRIPTION
Add the possibility to manage endpointslices similar to how it's possible with endpoints.

This is requested by one team with a special use case where they manage endpoints directly and they want to migrate to endpointslices.

Keep it behind a flag, disabled by default, to gauge the need for this in general as it can be quite powerful.