### PR TITLE
Allow polarsignals to run on more dedicated workloads

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -331,8 +331,24 @@ skipper_pod_deletion_cost_controller_resync_enable: "true"
 skipper_pod_deletion_cost_controller_resync_interval: "1h"
 
 # polarsignals - only enabled for some clusters
-# right now only installed on skipper-ingress nodes
 polarsignals_enabled: "false"
+# Comma separated list of workloads for which polarsignals is enabled, only used
+# if polarsignals_enabled is true, right now only skipper-ingress is configured
+# by default
+#
+# Note:
+#   skipper-ingress is treated as a special case assuming a _dedicated_ node
+#   pool
+#   For all other workloads it's assumed they use scheduling annotations
+#   abstraction which sets:
+#
+#   nodeSelector:
+#     zalando.org/dedicated: <workload>
+#   tolerations:
+#     - effect: NoSchedule
+#       key: zalando.org/dedicated
+#       operator: Exists
+polarsignals_workloads: "skipper-ingress"
 polarsignals_oom_prof_enable: "false"
 polarsignals_oom_prof_allocs_enable: "false"
 polarsignals_apikey: ""

--- a/cluster/manifests/polarsignals/daemonset.yaml
+++ b/cluster/manifests/polarsignals/daemonset.yaml
@@ -1,4 +1,5 @@
 {{ if eq .Cluster.ConfigItems.polarsignals_enabled "true" }}
+{{- range $workload := split .Cluster.ConfigItems.polarsignals_workloads "," }}
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -6,7 +7,11 @@ metadata:
   labels:
     component: agent
     application: polarsignals
+  {{- if eq $workload "skipper-ingress" }}
   name: polarsignals-agent
+  {{- else }}
+  name: polarsignals-agent-{{ $workload }}
+  {{- end }}
   namespace: polarsignals
   annotations:
     node-ready.cluster.zalando.org/exclude: "true"
@@ -93,11 +98,19 @@ spec:
       serviceAccountName: polarsignals-agent
       nodeSelector:
         kubernetes.io/os: linux
+  {{- if eq $workload "skipper-ingress" }}
         dedicated: skipper-ingress
       tolerations:
         - effect: NoSchedule
           key: dedicated
           value: skipper-ingress
+  {{- else }}
+        zalando.org/dedicated: {{ $workload }}
+      tolerations:
+      - effect: NoSchedule
+        key: zalando.org/dedicated
+        operator: Exists
+  {{- end }}
       volumes:
         - name: parca-config-volume
           configMap:
@@ -129,4 +142,5 @@ spec:
         - secret:
             secretName: polarsignals-agent
           name: token
+{{- end }}
 {{ end }}


### PR DESCRIPTION
This is a more complex version of #10784

It introduces the config-item: `polarsignals_workloads` which is a comma-separated list of "workload" names mapping to dedicated node names.

For each workload defined in the list it will create a daemonset with the right nodeSelector and tolerations for that to only run next to the workloads with that same dedicated node name.

* [ ] This does NOT handle cleanup of daemonsets if the workload value is removed from the list, right now a manual delete of the daemonset in the cluster would be needed.