### PR TITLE
skipper-canary: enable zone aware routing

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -162,6 +162,7 @@ skipper_edit_route_placeholders: ""
 skipper_ingress_inline_routes: ""
 skipper_ingress_refuse_payload: ""
 skipper_endpointslices_enabled: "true"
+skipper_ingress_zone_aware_routing_enabled: "true"
 skipper_externalname_service_enabled: "true"
 
 skipper_kubernetes_annotation_predicates: ''

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -9,7 +9,10 @@
 {{ end }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}
-{{ $canary_args := "-routes-urls=http://skipper-ingress-routesrv.kube-system.svc.cluster.local/routes/$(KUBE_NODE_ZONE)" }}
+{{ $canary_args := "" }}
+{{ if eq .Cluster.ConfigItems.skipper_ingress_zone_aware_routing_enabled "true" }}
+{{ $canary_args = "-routes-urls=http://skipper-ingress-routesrv.kube-system.svc.cluster.local/routes/$(KUBE_NODE_ZONE)" }}
+{{ end }}
 
 {{ $cluster_internal_cidrs := list "10.2.0.0/15" .Values.vpc_ipv4_cidr }}
 {{ if eq .Cluster.Provider "zalando-eks" }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -9,7 +9,7 @@
 {{ end }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}
-{{ $canary_args := "" }}
+{{ $canary_args := "-routes-urls=http://skipper-ingress-routesrv.kube-system.svc.cluster.local/routes/$(KUBE_NODE_ZONE)" }}
 
 {{ $cluster_internal_cidrs := list "10.2.0.0/15" .Values.vpc_ipv4_cidr }}
 {{ if eq .Cluster.Provider "zalando-eks" }}
@@ -158,6 +158,10 @@ spec:
           protocol: TCP
 {{ end }}
         env:
+        - name: KUBE_NODE_ZONE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['topology.kubernetes.io/zone']
         - name: LIGHTSTEP_TOKEN
           valueFrom:
             secretKeyRef:
@@ -212,7 +216,9 @@ spec:
           - "-validate-query={{ .Cluster.ConfigItems.skipper_validate_query }}"
           - "-validate-query-log={{ .Cluster.ConfigItems.skipper_validate_query_log }}"
 {{ if eq .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
+{{ if ne "{{ .name }}" "skipper-ingress-canary" }}
           - "-routes-urls=http://skipper-ingress-routesrv.kube-system.svc.cluster.local/routes"
+{{ end }}
           - "-normalize-host"
 {{ else }}
           - "-kubernetes"


### PR DESCRIPTION
Enable zone aware routing only for canary if flag skipper_ingress_zone_aware_routing_enabled is set to true. Currently it is disabled in Tier 1 & Tier 2 clusters.
