### PR TITLE
patched karpenter 1.9.0 with option to select min for spot to spot consolidation

### DIFF
--- a/cluster/manifests/z-karpenter/09-karpenter.sh_nodepools.yaml
+++ b/cluster/manifests/z-karpenter/09-karpenter.sh_nodepools.yaml
@@ -158,6 +158,11 @@ spec:
                         - WhenEmpty
                         - WhenEmptyOrUnderutilized
                       type: string
+                    minInstanceTypesForSpotToSpotConsolidation:
+                      description: Minimum number of instance types for spot-to-spot consolidation
+                      format: int32
+                      minimum: 1
+                      type: integer
                   required:
                     - consolidateAfter
                   type: object

--- a/cluster/manifests/z-karpenter/deployment.yaml
+++ b/cluster/manifests/z-karpenter/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             capabilities:
               drop:
                 - ALL
-          image: "container-registry.zalando.net/teapot/karpenter:1.9.0-main-49.patched"
+          image: "container-registry-test.zalando.net/teapot/karpenter:1.9.0-pr-52-2.patched"
           imagePullPolicy: IfNotPresent
           env:
             - name: KUBERNETES_MIN_VERSION

--- a/cluster/manifests/z-karpenter/deployment.yaml
+++ b/cluster/manifests/z-karpenter/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             capabilities:
               drop:
                 - ALL
-          image: "container-registry-test.zalando.net/teapot/karpenter:1.9.0-pr-52-2.patched"
+          image: "container-registry.zalando.net/teapot/karpenter:1.9.0-main-50.patched"
           imagePullPolicy: IfNotPresent
           env:
             - name: KUBERNETES_MIN_VERSION

--- a/cluster/manifests/z-karpenter/deployment.yaml
+++ b/cluster/manifests/z-karpenter/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             capabilities:
               drop:
                 - ALL
-          image: "container-registry.zalando.net/teapot/karpenter:1.8.2-main-48.patched"
+          image: "container-registry-test.zalando.net/teapot/karpenter:1.9.0-pr-52-2.patched"
           imagePullPolicy: IfNotPresent
           env:
             - name: KUBERNETES_MIN_VERSION

--- a/cluster/manifests/z-karpenter/deployment.yaml
+++ b/cluster/manifests/z-karpenter/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             capabilities:
               drop:
                 - ALL
-          image: "container-registry.zalando.net/teapot/karpenter:1.9.0-main-50.patched"
+          image: container-registry.zalando.net/teapot/karpenter:1.9.0-main-{{if eq .Cluster.Environment "production"}}49{{else}}50{{end}}.patched
           imagePullPolicy: IfNotPresent
           env:
             - name: KUBERNETES_MIN_VERSION

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -322,7 +322,7 @@ spec:
 #{{  end }}
     # Minimum number of instance types for spot-to-spot consolidation
 #{{ if index .NodePool.ConfigItems "minInstanceTypesForSpotToSpotConsolidation"}}
-    minInstanceTypesForSpotToSpotConsolidation: {{.NodePool.ConfigItems.minInstanceTypesForSpotToSpotConsolidation}}
+    minInstanceTypesForSpotToSpotConsolidation: {{.NodePool.ConfigItems.min_instance_types_for_spot_to_spot_consolidation}}
 #{{  end }}
   # Priority given to the NodePool when the scheduler considers which NodePool
   # to select. Higher weights indicate higher priority when comparing NodePools.

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -320,6 +320,10 @@ spec:
     consolidationPolicy: WhenEmptyOrUnderutilized
     consolidateAfter: {{ or (index .NodePool.ConfigItems "consolidate_after") "0s" }}
 #{{  end }}
+    # Minimum number of instance types for spot-to-spot consolidation
+#{{ if index .NodePool.ConfigItems "minInstanceTypesForSpotToSpotConsolidation"}}
+    minInstanceTypesForSpotToSpotConsolidation: {{.NodePool.ConfigItems.minInstanceTypesForSpotToSpotConsolidation}}
+#{{  end }}
   # Priority given to the NodePool when the scheduler considers which NodePool
   # to select. Higher weights indicate higher priority when comparing NodePools.
   # Specifying no weight is equivalent to specifying a weight of 0.

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -321,7 +321,7 @@ spec:
     consolidateAfter: {{ or (index .NodePool.ConfigItems "consolidate_after") "0s" }}
 #{{  end }}
     # Minimum number of instance types for spot-to-spot consolidation
-#{{ if index .NodePool.ConfigItems "minInstanceTypesForSpotToSpotConsolidation"}}
+#{{ if index .NodePool.ConfigItems "min_instance_types_for_spot_to_spot_consolidation"}}
     minInstanceTypesForSpotToSpotConsolidation: {{.NodePool.ConfigItems.min_instance_types_for_spot_to_spot_consolidation}}
 #{{  end }}
   # Priority given to the NodePool when the scheduler considers which NodePool


### PR DESCRIPTION
patched karpenter 1.9.0 with option to select min for spot to spot consolidation

To be on the safe side I decided to run the new patched image only for non production environment for 1/2 weeks, just in case we have any issue in this critical component.
I'm already updating the CRDs since it's an optional field that we set the value under a config item, so we only create it for node pools in the test environment