### PR TITLE
fix: skipper spp issues

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,6 +1,6 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.24.48-1378" }}
+{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.24.53-1382" }}
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.24.53-1382" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}


### PR DESCRIPTION
optimize lb algorithm consistentHash to perform well with more than 400 backend pods

ref: https://github.com/zalando-incubator/kubernetes-on-aws/pull/10821