### PR TITLE
hotfix: skipper-ingress-canary consistentHash

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,7 +1,7 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
 {{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.24.48-1378" }}
-{{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.24.48-1378" }}
+{{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.24.53-1382" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}
 {{ $canary_args := "" }}


### PR DESCRIPTION
hotfix: skipper-ingress-canary consistentHash lb optimized for more than 300 pods