### PR TITLE
Revert "skipper-internal: Update to version v0.24.53-1382"

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,7 +1,7 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
 {{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.24.48-1378" }}
-{{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.24.53-1382" }}
+{{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.24.52-1381" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}
 {{ $canary_args := "" }}


### PR DESCRIPTION
Reverts zalando-incubator/kubernetes-on-aws#10821

Roll back due to high CPU usage opserved in SPP