### PR TITLE
feature: allow override skipper-ingress-canary image for hotfix purposes for example

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -151,6 +151,7 @@ skipper_ingress_health_check_options: "period=10s,min-requests=10,min-drop-proba
 
 # Enables deployment of canary version
 skipper_ingress_canary_enabled: "true"
+skipper_ingress_canary_image: ""
 skipper_ingress_test_single_pod: "false"
 skipper_canary_controller_enabled: "false"
 

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -3,6 +3,11 @@
 {{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.24.48-1378" }}
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.24.52-1381" }}
 
+{{/* Allow to override manually canary image by config item */}}
+{{ if ne .Cluster.ConfigItems.skipper_ingress_canary_image "" }}
+{{ $canary_image := .Cluster.ConfigItems.skipper_ingress_canary_image }}
+{{ end }}
+
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}
 {{ $canary_args := "" }}
 


### PR DESCRIPTION
feature: allow override skipper-ingress-canary image for hotfix purposes for example