### PR TITLE
Provide cluster IPv4 CIDR in deploy config

### DIFF
--- a/cluster/manifests/deployment-service/01-config.yaml
+++ b/cluster/manifests/deployment-service/01-config.yaml
@@ -10,6 +10,7 @@ data:
   cluster-provider: "{{.Cluster.Provider}}"
   cluster-channel: "{{.Cluster.Channel}}"
   cluster-vpc-id: "{{.Cluster.ConfigItems.vpc_id}}"
+  cluster-vpc-ipv4-cidr: "{{.Values.vpc_ipv4_cidr}}"
   scalyr-team-token: "{{.Cluster.ConfigItems.scalyr_team_token}}"
   create-namespaces: "true"
   aws-available: "true"


### PR DESCRIPTION
Utilize deployment config to make the IPv4 CIDR easily discoverable.

The current use case is that postgres-migrator needs this in order to set up the right LB SG rules. Having it available in the cluster makes it simpler to discover.