### PR TITLE
ShadowTraffic: adds both read write access to status

### DIFF
--- a/cluster/manifests/shadow-traffic-controller/20-rbac.yaml
+++ b/cluster/manifests/shadow-traffic-controller/20-rbac.yaml
@@ -20,6 +20,7 @@ rules:
       - zalando.org
     resources:
       - shadowtraffics
+      - shadowtraffics/status
     verbs:
       - get
       - list


### PR DESCRIPTION
Fixes the following error;

failed to update status for ShadowTraffic shadow-traffic-controller... is forbidden: User system:serviceaccount:kube-system:shadow-traffic-controller