### PR TITLE
Enable AAAA record creation in external-dns for IPv6 DNS support

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -52,6 +52,7 @@ spec:
         - --aws-zones-cache-duration={{ .Cluster.ConfigItems.external_dns_zones_cache_duration }}
         - --annotation-filter=external-dns.alpha.kubernetes.io/exclude notin (true)
         - --policy={{ .Cluster.ConfigItems.external_dns_policy }}
+        - --aws-prefer-cname
         resources:
           requests:
             cpu: 50m


### PR DESCRIPTION
## Summary
- Enable external-dns to create AAAA (IPv6) DNS records for dualstack ingress
- Allows IPv6 clients to discover and connect to services via native IPv6
- Fixes client IP preservation for IPv6 client connections

## Test plan
- Verify DNS resolves to AAAA records: `dig test-predicates.pg9-test.zalan.do AAAA`
- Test IPv6 curl: `curl -6 https://test-predicates.pg9-test.zalan.do/test-client-ip-ipv6`
- Confirm ClientIP predicates match actual IPv6 client address
- Validate both A and AAAA records exist for ingress domains