### PR TITLE
Add nodes read privileges

### DIFF
--- a/cluster/manifests/roles/build-scaling-console.yaml
+++ b/cluster/manifests/roles/build-scaling-console.yaml
@@ -49,10 +49,9 @@ rules:
   - list
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get", "list"]
-- apiGroups: [""]
-  resources: ["statefulsets"]
-  verbs: ["get", "list"]
+  verbs:
+  - get
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/cluster/manifests/roles/build-scaling-console.yaml
+++ b/cluster/manifests/roles/build-scaling-console.yaml
@@ -47,6 +47,12 @@ rules:
   verbs:
   - get
   - list
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["statefulsets"]
+  verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Add read nodes privileges for the Scaling Console to improve node level reporting.