### PR TITLE
shadow-traffic-controller: use production docker registry instead of test registry

### DIFF
--- a/cluster/manifests/shadow-traffic-controller/30-deployment.yaml
+++ b/cluster/manifests/shadow-traffic-controller/30-deployment.yaml
@@ -1,4 +1,4 @@
-# {{ $image := "container-registry-test.zalando.net/gwproxy/shadow-traffic-controller:main-12" }}
+# {{ $image := "container-registry.zalando.net/gwproxy/shadow-traffic-controller:main-12" }}
 # {{ $version := index (split $image ":") 1 }}
 # {{ if eq .Cluster.ConfigItems.shadow_traffic_controller_enabled "true" }}
 apiVersion: apps/v1


### PR DESCRIPTION
see $title