### PR TITLE
skipper: otel attribute add k8s.cluster.name to replace "cluster" attribute by otel convention

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -296,6 +296,7 @@ spec:
             tag=application=skipper-ingress
             tag=account={{ .Cluster.Alias }}
             tag=cluster={{ .Cluster.Alias }}
+            tag=k8s.cluster.name={{ .Cluster.Alias }}
             tag=artifact={{ .image }}
             max-buffered-spans={{ .Cluster.ConfigItems.skipper_ingress_tracing_buffer }}
             grpc-max-msg-size={{ .Cluster.ConfigItems.skipper_ingress_lightstep_grpc_max_msg_size }}


### PR DESCRIPTION
skipper: otel attribute add k8s.cluster.name to replace "cluster" attribute by otel convention