### PR TITLE
shadow-traffic-controller: gives watch permission for stacksets, stacks, and fabricgateways

### DIFF
--- a/cluster/manifests/shadow-traffic-controller/20-rbac.yaml
+++ b/cluster/manifests/shadow-traffic-controller/20-rbac.yaml
@@ -46,6 +46,7 @@ rules:
     verbs:
       - list
       - get
+      - watch
   - apiGroups:
       - zalando.org
     resources:
@@ -53,6 +54,7 @@ rules:
     verbs:
       - list
       - get
+      - watch
   - apiGroups:
       - zalando.org
     resources:
@@ -60,6 +62,7 @@ rules:
     verbs:
       - list
       - get
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
see $title