### PR TITLE
expose vpa target cpu percentile to test being less conservative for test clusters

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -592,6 +592,8 @@ logging_infrastructure_s3_bucket: ""
 
 vpa_cpu: "200m"
 vpa_mem: "500Mi"
+# Default value for vpa cpu target recommendations
+vpa_target_cpu_percentile: 0.9
 
 prometheus_cpu: "1000m"
 prometheus_mem: "4Gi"

--- a/cluster/manifests/02-vertical-pod-autoscaler/recommender-deployment.yaml
+++ b/cluster/manifests/02-vertical-pod-autoscaler/recommender-deployment.yaml
@@ -33,6 +33,7 @@ spec:
         - --v=1
         - --memory-saver
         - --pod-recommendation-min-memory-mb=50
+        - --target-cpu-percentile="{{.Cluster.ConfigItems.vpa_target_cpu_percentile}}"
         command:
         - "/recommender"
         resources:


### PR DESCRIPTION
Most of the test clusters still have pods with a good amount of waisted cpu resources for long periods when using VPA.
This allow us to test if being less conservative with CPU would still keep the same stability while reducing costs.

NOTE: still need to validate if we are not using already the minimum for most cases