### PR TITLE
Fix X-Forwarded-Proto header handling when Proxy Protocol v2 is enabled

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -225,7 +225,6 @@ spec:
           - "-enable-kubernetes-endpointslices={{ .Cluster.ConfigItems.skipper_endpointslices_enabled }}"
 {{ end }}
           - "-address=:9999"
-          - "-insecure-address=:9998"
           - "-wait-first-route-load"
           - "-wait-for-healthcheck-interval={{ .Cluster.ConfigItems.skipper_wait_for_healthcheck_interval }}"
 {{ if ne .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,7 +1,7 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-21-pr-56-13" }}
-{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-21-pr-56-13" }}
+{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-22-pr-56-14" }}
+{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-22-pr-56-14" }}
 
 {{/* Allow to override manually canary image by config item */}}
 {{ if ne .Cluster.ConfigItems.skipper_ingress_canary_image "" }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -225,6 +225,7 @@ spec:
           - "-enable-kubernetes-endpointslices={{ .Cluster.ConfigItems.skipper_endpointslices_enabled }}"
 {{ end }}
           - "-address=:9999"
+          - "-insecure-address=:9998"
           - "-wait-first-route-load"
           - "-wait-for-healthcheck-interval={{ .Cluster.ConfigItems.skipper_wait_for_healthcheck_interval }}"
 {{ if ne .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,7 +1,7 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-8-pr-56-2" }}
-{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-8-pr-56-2" }}
+{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-9-pr-56-3" }}
+{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-9-pr-56-3" }}
 
 {{/* Allow to override manually canary image by config item */}}
 {{ if ne .Cluster.ConfigItems.skipper_ingress_canary_image "" }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -383,7 +383,7 @@ spec:
           - "-enable-open-policy-agent-preloading={{ .Cluster.ConfigItems.skipper_open_policy_agent_preloading_enabled }}"
 {{ end }}
 {{ if or (eq .Cluster.ConfigItems.nlb_switch "pre") (eq .Cluster.ConfigItems.nlb_switch "exec") }}
-          - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=auto,X-Forwarded-Port=443"
+          - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
           - '-forwarded-headers-exclude-cidrs={{ .cluster_internal_cidrs | join "," }}'
 {{ end }}
           - "-inline-routes"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,7 +1,7 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-13-pr-56-7" }}
-{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-13-pr-56-7" }}
+{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-14-pr-56-8" }}
+{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-14-pr-56-8" }}
 
 {{/* Allow to override manually canary image by config item */}}
 {{ if ne .Cluster.ConfigItems.skipper_ingress_canary_image "" }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -383,8 +383,13 @@ spec:
           - "-enable-open-policy-agent-preloading={{ .Cluster.ConfigItems.skipper_open_policy_agent_preloading_enabled }}"
 {{ end }}
 {{ if or (eq .Cluster.ConfigItems.nlb_switch "pre") (eq .Cluster.ConfigItems.nlb_switch "exec") }}
+{{- if eq .Cluster.ConfigItems.skipper_enable_proxy_protocol "true" }}
+          - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Port=443"
+          - '-forwarded-headers-exclude-cidrs={{ .cluster_internal_cidrs | join "," }}'
+{{- else }}
           - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
           - '-forwarded-headers-exclude-cidrs={{ .cluster_internal_cidrs | join "," }}'
+{{- end }}
 {{ end }}
           - "-inline-routes"
           - |

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -353,11 +353,6 @@ spec:
           - "-proxy-deny-cidrs={{ .Cluster.ConfigItems.skipper_proxy_deny_cidrs }}"
           - "-proxy-skip-cidrs={{ .Cluster.ConfigItems.skipper_proxy_skip_cidrs }}"
 {{ end }}
-{{ if or (eq .Cluster.ConfigItems.nlb_switch "pre") (eq .Cluster.ConfigItems.nlb_switch "exec") }}
-{{ if eq .Cluster.ConfigItems.skipper_enable_proxy_protocol "true" }}
-          - "-insecure-address=:9998"
-{{ end }}
-{{ end }}
 {{ if eq .Cluster.ConfigItems.skipper_local_tokeninfo "bridge" }}
           - "-oauth2-tokeninfo-url=http://127.0.0.1:9000/oauth2/tokeninfo"
           - "-status-checks=http://127.0.0.1:9021/health,http://127.0.0.1:9121/health,http://127.0.0.1:9000/healthz"
@@ -389,7 +384,7 @@ spec:
 {{ end }}
 {{ if or (eq .Cluster.ConfigItems.nlb_switch "pre") (eq .Cluster.ConfigItems.nlb_switch "exec") }}
 {{ if eq .Cluster.ConfigItems.skipper_enable_proxy_protocol "true" }}
-          - "-forwarded-headers=X-Forwarded-Proto=auto,X-Forwarded-Port=443"
+          - "-forwarded-headers=X-Forwarded-Proto=https,X-Forwarded-Port=443"
 {{ else }}
           - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
           - '-forwarded-headers-exclude-cidrs={{ .cluster_internal_cidrs | join "," }}'

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -383,13 +383,8 @@ spec:
           - "-enable-open-policy-agent-preloading={{ .Cluster.ConfigItems.skipper_open_policy_agent_preloading_enabled }}"
 {{ end }}
 {{ if or (eq .Cluster.ConfigItems.nlb_switch "pre") (eq .Cluster.ConfigItems.nlb_switch "exec") }}
-{{- if eq .Cluster.ConfigItems.skipper_enable_proxy_protocol "true" }}
-          - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Port=443"
+          - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=auto,X-Forwarded-Port=443"
           - '-forwarded-headers-exclude-cidrs={{ .cluster_internal_cidrs | join "," }}'
-{{- else }}
-          - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
-          - '-forwarded-headers-exclude-cidrs={{ .cluster_internal_cidrs | join "," }}'
-{{- end }}
 {{ end }}
           - "-inline-routes"
           - |

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -383,12 +383,8 @@ spec:
           - "-enable-open-policy-agent-preloading={{ .Cluster.ConfigItems.skipper_open_policy_agent_preloading_enabled }}"
 {{ end }}
 {{ if or (eq .Cluster.ConfigItems.nlb_switch "pre") (eq .Cluster.ConfigItems.nlb_switch "exec") }}
-{{ if eq .Cluster.ConfigItems.skipper_enable_proxy_protocol "true" }}
-          - "-forwarded-headers=X-Forwarded-Proto=https,X-Forwarded-Port=443"
-{{ else }}
           - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
           - '-forwarded-headers-exclude-cidrs={{ .cluster_internal_cidrs | join "," }}'
-{{ end }}
 {{ end }}
           - "-inline-routes"
           - |

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,7 +1,7 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-15-pr-56-9" }}
-{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-15-pr-56-9" }}
+{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-18-pr-56-10" }}
+{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-18-pr-56-10" }}
 
 {{/* Allow to override manually canary image by config item */}}
 {{ if ne .Cluster.ConfigItems.skipper_ingress_canary_image "" }}
@@ -225,7 +225,6 @@ spec:
           - "-enable-kubernetes-endpointslices={{ .Cluster.ConfigItems.skipper_endpointslices_enabled }}"
 {{ end }}
           - "-address=:9999"
-          - "-insecure-address=:9998"
           - "-wait-first-route-load"
           - "-wait-for-healthcheck-interval={{ .Cluster.ConfigItems.skipper_wait_for_healthcheck_interval }}"
 {{ if ne .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
@@ -353,6 +352,7 @@ spec:
           - "-proxy-allow-cidrs={{ .Cluster.ConfigItems.skipper_proxy_allow_cidrs }}"
           - "-proxy-deny-cidrs={{ .Cluster.ConfigItems.skipper_proxy_deny_cidrs }}"
           - "-proxy-skip-cidrs={{ .Cluster.ConfigItems.skipper_proxy_skip_cidrs }}"
+          - "-insecure-address=:9998"
 {{ end }}
 {{ if eq .Cluster.ConfigItems.skipper_local_tokeninfo "bridge" }}
           - "-oauth2-tokeninfo-url=http://127.0.0.1:9000/oauth2/tokeninfo"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -352,7 +352,6 @@ spec:
           - "-proxy-allow-cidrs={{ .Cluster.ConfigItems.skipper_proxy_allow_cidrs }}"
           - "-proxy-deny-cidrs={{ .Cluster.ConfigItems.skipper_proxy_deny_cidrs }}"
           - "-proxy-skip-cidrs={{ .Cluster.ConfigItems.skipper_proxy_skip_cidrs }}"
-          - "-insecure-address=:9998"
 {{ end }}
 {{ if eq .Cluster.ConfigItems.skipper_local_tokeninfo "bridge" }}
           - "-oauth2-tokeninfo-url=http://127.0.0.1:9000/oauth2/tokeninfo"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,7 +1,7 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-10-pr-56-4" }}
-{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-10-pr-56-4" }}
+{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-11-pr-56-5" }}
+{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-11-pr-56-5" }}
 
 {{/* Allow to override manually canary image by config item */}}
 {{ if ne .Cluster.ConfigItems.skipper_ingress_canary_image "" }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -352,6 +352,7 @@ spec:
           - "-proxy-allow-cidrs={{ .Cluster.ConfigItems.skipper_proxy_allow_cidrs }}"
           - "-proxy-deny-cidrs={{ .Cluster.ConfigItems.skipper_proxy_deny_cidrs }}"
           - "-proxy-skip-cidrs={{ .Cluster.ConfigItems.skipper_proxy_skip_cidrs }}"
+          - "-insecure-address=:9998"
 {{ end }}
 {{ if eq .Cluster.ConfigItems.skipper_local_tokeninfo "bridge" }}
           - "-oauth2-tokeninfo-url=http://127.0.0.1:9000/oauth2/tokeninfo"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,7 +1,7 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-15-pr-56-9" }}
-{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-15-pr-56-9" }}
+{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.24.64-1393" }}
+{{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.24.64-1393" }}
 
 {{/* Allow to override manually canary image by config item */}}
 {{ if ne .Cluster.ConfigItems.skipper_ingress_canary_image "" }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -383,7 +383,7 @@ spec:
           - "-enable-open-policy-agent-preloading={{ .Cluster.ConfigItems.skipper_open_policy_agent_preloading_enabled }}"
 {{ end }}
 {{ if or (eq .Cluster.ConfigItems.nlb_switch "pre") (eq .Cluster.ConfigItems.nlb_switch "exec") }}
-          - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
+          - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=auto,X-Forwarded-Port=443"
           - '-forwarded-headers-exclude-cidrs={{ .cluster_internal_cidrs | join "," }}'
 {{ end }}
           - "-inline-routes"
@@ -668,7 +668,7 @@ spec:
           {{ end }}
 {{ end }}
 {{ if or (eq .Cluster.ConfigItems.nlb_switch "pre") (eq .Cluster.ConfigItems.nlb_switch "exec") }}
-          - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
+          - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=auto,X-Forwarded-Port=443"
           - '-forwarded-headers-exclude-cidrs={{ $cluster_internal_cidrs | join "," }}'
 {{ end }}
           - >-

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,7 +1,7 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-12-pr-56-6" }}
-{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-12-pr-56-6" }}
+{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-13-pr-56-7" }}
+{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-13-pr-56-7" }}
 
 {{/* Allow to override manually canary image by config item */}}
 {{ if ne .Cluster.ConfigItems.skipper_ingress_canary_image "" }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,7 +1,7 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-19-pr-56-11" }}
-{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-19-pr-56-11" }}
+{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-20-pr-56-12" }}
+{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-20-pr-56-12" }}
 
 {{/* Allow to override manually canary image by config item */}}
 {{ if ne .Cluster.ConfigItems.skipper_ingress_canary_image "" }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,7 +1,7 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-14-pr-56-8" }}
-{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-14-pr-56-8" }}
+{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-15-pr-56-9" }}
+{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-15-pr-56-9" }}
 
 {{/* Allow to override manually canary image by config item */}}
 {{ if ne .Cluster.ConfigItems.skipper_ingress_canary_image "" }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,7 +1,7 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-23-pr-56-15" }}
-{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-23-pr-56-15" }}
+{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-23-pr-56-16" }}
+{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-23-pr-56-16" }}
 
 {{/* Allow to override manually canary image by config item */}}
 {{ if ne .Cluster.ConfigItems.skipper_ingress_canary_image "" }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,7 +1,7 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-9-pr-56-3" }}
-{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-9-pr-56-3" }}
+{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-10-pr-56-4" }}
+{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-10-pr-56-4" }}
 
 {{/* Allow to override manually canary image by config item */}}
 {{ if ne .Cluster.ConfigItems.skipper_ingress_canary_image "" }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,7 +1,7 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.24.58-1387" }}
-{{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.24.64-1393" }}
+{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-15-pr-56-9" }}
+{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-15-pr-56-9" }}
 
 {{/* Allow to override manually canary image by config item */}}
 {{ if ne .Cluster.ConfigItems.skipper_ingress_canary_image "" }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,7 +1,7 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-18-pr-56-10" }}
-{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-18-pr-56-10" }}
+{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-19-pr-56-11" }}
+{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-19-pr-56-11" }}
 
 {{/* Allow to override manually canary image by config item */}}
 {{ if ne .Cluster.ConfigItems.skipper_ingress_canary_image "" }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,7 +1,7 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-22-pr-56-14" }}
-{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-22-pr-56-14" }}
+{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-23-pr-56-15" }}
+{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-23-pr-56-15" }}
 
 {{/* Allow to override manually canary image by config item */}}
 {{ if ne .Cluster.ConfigItems.skipper_ingress_canary_image "" }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -668,7 +668,7 @@ spec:
           {{ end }}
 {{ end }}
 {{ if or (eq .Cluster.ConfigItems.nlb_switch "pre") (eq .Cluster.ConfigItems.nlb_switch "exec") }}
-          - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=auto,X-Forwarded-Port=443"
+          - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
           - '-forwarded-headers-exclude-cidrs={{ $cluster_internal_cidrs | join "," }}'
 {{ end }}
           - >-

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,7 +1,7 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.24.58-1387" }}
-{{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.24.64-1393" }}
+{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-internal-test:v0.24.70-pr-56-17" }}
+{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-internal-test:v0.24.70-pr-56-17" }}
 
 {{/* Allow to override manually canary image by config item */}}
 {{ if ne .Cluster.ConfigItems.skipper_ingress_canary_image "" }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -352,7 +352,11 @@ spec:
           - "-proxy-allow-cidrs={{ .Cluster.ConfigItems.skipper_proxy_allow_cidrs }}"
           - "-proxy-deny-cidrs={{ .Cluster.ConfigItems.skipper_proxy_deny_cidrs }}"
           - "-proxy-skip-cidrs={{ .Cluster.ConfigItems.skipper_proxy_skip_cidrs }}"
+{{ end }}
+{{ if or (eq .Cluster.ConfigItems.nlb_switch "pre") (eq .Cluster.ConfigItems.nlb_switch "exec") }}
+{{ if eq .Cluster.ConfigItems.skipper_enable_proxy_protocol "true" }}
           - "-insecure-address=:9998"
+{{ end }}
 {{ end }}
 {{ if eq .Cluster.ConfigItems.skipper_local_tokeninfo "bridge" }}
           - "-oauth2-tokeninfo-url=http://127.0.0.1:9000/oauth2/tokeninfo"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,7 +1,7 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-20-pr-56-12" }}
-{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-20-pr-56-12" }}
+{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-21-pr-56-13" }}
+{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-21-pr-56-13" }}
 
 {{/* Allow to override manually canary image by config item */}}
 {{ if ne .Cluster.ConfigItems.skipper_ingress_canary_image "" }}
@@ -384,21 +384,24 @@ spec:
           - "-enable-open-policy-agent-preloading={{ .Cluster.ConfigItems.skipper_open_policy_agent_preloading_enabled }}"
 {{ end }}
 {{ if or (eq .Cluster.ConfigItems.nlb_switch "pre") (eq .Cluster.ConfigItems.nlb_switch "exec") }}
+{{ if eq .Cluster.ConfigItems.skipper_enable_proxy_protocol "true" }}
+          - "-forwarded-headers=X-Forwarded-Proto=auto,X-Forwarded-Port=443"
+{{ else }}
           - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
           - '-forwarded-headers-exclude-cidrs={{ .cluster_internal_cidrs | join "," }}'
+{{ end }}
 {{ end }}
           - "-inline-routes"
           - |
             kube__healthz_down: Path("/kube-system/healthz") && Shutdown()
               && SourceFromLast("{{ .cluster_internal_cidrs | join `","` }}", "10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8", "fd00::/8", "::1/128")
               -> annotate("iam.zalando.org/public", "Healthcheck route access is restricted by IP")
-              -> disableAccessLog()
               -> status(503)
               -> <shunt>;
             kube__healthz_up: Path("/kube-system/healthz")
               && SourceFromLast("{{ .cluster_internal_cidrs | join `","` }}", "10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12", "127.0.0.1/8", "fd00::/8", "::1/128")
               -> annotate("iam.zalando.org/public", "Healthcheck route access is restricted by IP")
-              -> disableAccessLog()
+              -> disableAccessLog(2)
               -> status(200)
               -> <shunt>;
             {{ .Cluster.ConfigItems.skipper_ingress_inline_routes }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,7 +1,7 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-2-pr-56-1" }}
-{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-2-pr-56-1" }}
+{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-8-pr-56-2" }}
+{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-8-pr-56-2" }}
 
 {{/* Allow to override manually canary image by config item */}}
 {{ if ne .Cluster.ConfigItems.skipper_ingress_canary_image "" }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,7 +1,7 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-11-pr-56-5" }}
-{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-11-pr-56-5" }}
+{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-12-pr-56-6" }}
+{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-12-pr-56-6" }}
 
 {{/* Allow to override manually canary image by config item */}}
 {{ if ne .Cluster.ConfigItems.skipper_ingress_canary_image "" }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,6 +1,6 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.24.64-1393" }}
+{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.24.58-1387" }}
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.24.64-1393" }}
 
 {{/* Allow to override manually canary image by config item */}}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,7 +1,7 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-23-pr-56-16" }}
-{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-23-pr-56-16" }}
+{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.24.58-1387" }}
+{{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.24.64-1393" }}
 
 {{/* Allow to override manually canary image by config item */}}
 {{ if ne .Cluster.ConfigItems.skipper_ingress_canary_image "" }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,7 +1,7 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.24.58-1387" }}
-{{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.24.64-1393" }}
+{{ $main_image_updated_manually := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-2-pr-56-1" }}
+{{ $canary_image := "container-registry-test.zalando.net/teapot/skipper-internal-test:pr-3945-2-pr-56-1" }}
 
 {{/* Allow to override manually canary image by config item */}}
 {{ if ne .Cluster.ConfigItems.skipper_ingress_canary_image "" }}

--- a/cluster/manifests/skipper/routegroup-probe.yaml
+++ b/cluster/manifests/skipper/routegroup-probe.yaml
@@ -17,5 +17,5 @@ spec:
   routes:
   - pathSubtree: /
     filters:
-    - disableAccessLog()
+    - disableAccessLog(2)
     - inlineContent("OK")


### PR DESCRIPTION
## Summary
Use Proto=auto in forwarded-headers for NLB with Proxy Protocol v2 support.

This change requires Skipper PR https://github.com/zalando/skipper/pull/3945 which extracts TLS information from PROXY protocol v2 TLV data to properly set X-Forwarded-Proto header.

## Details
With Proto=auto and proper PROXY v2 TLV parsing, Skipper correctly sets X-Forwarded-Proto header:
- HTTPS clients → TLV SSL detected → X-Forwarded-Proto=https  
- HTTP clients → No TLV SSL → X-Forwarded-Proto=http

This fixes HTTP to HTTPS redirect routes when Proxy Protocol v2 is enabled on NLB.

## Prerequisites
- Skipper version must include fix from PR #3945 (PROXY v2 TLV SSL extraction)
- NLB must have Proxy Protocol v2 enabled (via `kube_aws_ingress_controller_nlb_proxy_protocol_v2`)
- Skipper must have `-enable-proxy-protocol` flag enabled