### PR TITLE
allow to exclude instance size by node pool to experiment

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -40,6 +40,11 @@ karpenter_excluded_instance_families: "c5a,m5a,r5a,c5ad,m5ad,r5ad,c6a,m6a,r6a,c6
 karpenter_excluded_instance_families: ""
 {{end}}
 
+# List of instance sizes to exclude from Karptenter node pools.
+# This is a comma seprated list of instance sizes, e.g. "large,xlarge"
+# By default we don't exclude any instance size.
+karpenter_excluded_instance_sizes: ""
+
 # configure whether we allow flex instance types for Karpenter nodes
 # flex instance types have a baseline CPU performance with burst capability.
 # This provides an unpredictable performance, hence we want to avoid running

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -234,6 +234,11 @@ spec:
           operator: "NotIn"
           values:
             - "metal"
+            # {{ if ne .NodePool.ConfigItems.karpenter_excluded_instance_sizes ""}}
+            # {{ range $size := split .NodePool.ConfigItems.karpenter_excluded_instance_sizes "," }}
+            - "{{ $size }}"
+            # {{ end }}
+            # {{ end }}
         # exclude instance-types with slow SSD
         - key: "node.kubernetes.io/instance-type"
           operator: "NotIn"


### PR DESCRIPTION
Allow to exclude instance size by node pool to experiment and see the cost impact.
The main goal is to validate the cost impact if we exclude the `large` instance from test clusters.
The goal would be to reduce the overhead cost from daemonsets that use a significant part of the `large` instance nodes.