### PR TITLE
Remove ExecProbe feature gate logic

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1154,10 +1154,6 @@ deploy_allow_ram: "false"
 
 experimental_nlb_alpn_h2_enabled: "true"
 
-# Enable/Disable ExecProbeTimeout (default in v1.20)
-# Can be disabled in case some workloads depends on the old behavior.
-exec_probe_timeout_enabled: "true"
-
 # Settings for the deployment service
 deployment_service_controller_memory_min: "50Mi"
 deployment_service_api_role_arn: ""

--- a/cluster/node-pools/worker-splitaz/userdata.yaml
+++ b/cluster/node-pools/worker-splitaz/userdata.yaml
@@ -77,9 +77,6 @@ write_files:
       hairpinMode: hairpin-veth
 {{- end }}
       featureGates:
-{{- if eq .NodePool.ConfigItems.exec_probe_timeout_enabled "false" }}
-        ExecProbeTimeout: false
-{{- end }}
 {{- if eq .Cluster.Provider "zalando-eks"}}
         RotateKubeletServerCertificate: true
 {{- end }}


### PR DESCRIPTION
Remove ExecProbe feature gate logic, it can't be configured since Kubernetes v1.35 (default enabled only) so we don't need the feature flag logic anymore. 