### PR TITLE
Add toggle to turn off skipper-ingress eastwest topology-mode

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -356,6 +356,9 @@ skipper_eastwest_dns_log_enabled: "false"
 # if enabled adds port 8080 as svc port to eastwest svc
 skipper_ingress_eastwest_additional_port: "false"
 
+# if enabled adds service.kubernetes.io/topology-mode: auto to the eastwest service
+skipper_ingress_eastwest_topology_mode_auto: "true"
+
 # skipper tcp lifo
 # See: https://opensource.zalando.com/skipper/operation/operation/#tcp-lifo
 skipper_enable_tcp_queue: "true"                    # TODO(sszuecs): cleanup candidate to reduce amount of branches in deployment

--- a/cluster/manifests/skipper/service-internal.yaml
+++ b/cluster/manifests/skipper/service-internal.yaml
@@ -1,8 +1,10 @@
 kind: Service
 apiVersion: v1
 metadata:
+{{- if eq .Cluster.ConfigItems.skipper_ingress_eastwest_topology_mode_auto "true" }}
   annotations:
     service.kubernetes.io/topology-mode: auto
+{{- end}}
   name: skipper-internal
   namespace: kube-system
   labels:


### PR DESCRIPTION
This adds a config-item that allows turning off the `service.kubernetes.io/topology-mode: auto` setting on the skipper-ingress internal (eastwest) service.

This is done as we see a correlation with issues and this feature in at least a subset of clusters. This allows to easily turn it off to check the effect.