### PR TITLE
Add support for skipper route metrics flag

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -347,6 +347,9 @@ spec:
           - "-max-tcp-listener-concurrency={{ .Cluster.ConfigItems.skipper_max_tcp_listener_concurrency }}"
           - "-max-tcp-listener-queue={{ .Cluster.ConfigItems.skipper_max_tcp_listener_queue }}"
 {{ end }}
+{{ if eq .Cluster.ConfigItems.skipper_enable_route_metrics "true" }}
+          - "-serve-route-metrics"
+{{ end }}
 {{ if eq .Cluster.ConfigItems.skipper_enable_proxy_protocol "true" }}
           - "-enable-proxy-protocol"
           - "-proxy-allow-cidrs={{ .Cluster.ConfigItems.skipper_proxy_allow_cidrs }}"


### PR DESCRIPTION
I'd like to enable `skipper_serve_route_duration_seconds` skipper metric in some clusters because it would ease us monitoring during EKS migration 