### PR TITLE
fix: switch zone aware *.ingress.cluster.local ClusterIP AZ aware config

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -356,8 +356,10 @@ skipper_eastwest_dns_log_enabled: "false"
 # if enabled adds port 8080 as svc port to eastwest svc
 skipper_ingress_eastwest_additional_port: "false"
 
-# if enabled adds service.kubernetes.io/topology-mode: auto to the eastwest service
-skipper_ingress_eastwest_topology_mode_auto: "true"
+# if enabled adds service.kubernetes.io/topology-mode: auto to the eastwest service, tries to add safety automatically by enabling/disabling zone awareness
+skipper_ingress_eastwest_topology_mode_auto: "false"
+# if enabled adds trafficDistribution: PreferSameZone, ignore all magic just make it zone aware
+skipper_ingress_eastwest_zone_aware_clusterip: "true"
 
 # skipper tcp lifo
 # See: https://opensource.zalando.com/skipper/operation/operation/#tcp-lifo

--- a/cluster/manifests/skipper/service-internal.yaml
+++ b/cluster/manifests/skipper/service-internal.yaml
@@ -12,6 +12,9 @@ metadata:
     component: ingress
 spec:
   type: ClusterIP
+{{- if eq .Cluster.ConfigItems.skipper_ingress_eastwest_zone_aware_clusterip "true" }}
+  trafficDistribution: PreferSameZone
+{{- end}}
 {{- if eq .Cluster.Provider "zalando-eks" }}
   clusterIP: {{ nthAddressFromCIDR .Cluster.ConfigItems.service_cidr 50 }}
 {{- else}}


### PR DESCRIPTION
fix: switch zone aware *.ingress.cluster.local ClusterIP to be zone aware without automatic guardrails

My assumption is that it either flaps all the time or is enabled all the time. In both cases it would be a fix not a feature.
If it's disable and now enabled it should not matter either because skipper-ingress will handle the load anyways.