### PR TITLE
Add cluster label to Prometheus service manifest

### DIFF
--- a/cluster/manifests/prometheus/service.yaml
+++ b/cluster/manifests/prometheus/service.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     application: kubernetes
     component: prometheus
+    cluster: "{{ .Cluster.Alias }}"
 spec:
   type: ClusterIP
   ports:


### PR DESCRIPTION
it's impossible to filter by cluster in internal tool right now because service doesn't have a label. because of that internal tool can't execute dry run 