### PR TITLE
fix: Add http redirect proxy protocol env for skipper

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -183,6 +183,10 @@ spec:
 {{ if or (eq .Cluster.ConfigItems.nlb_switch "pre") (eq .Cluster.ConfigItems.nlb_switch "exec") }}
         - name: HTTP_REDIRECT
           value: "true"
+{{ if eq .Cluster.ConfigItems.skipper_enable_proxy_protocol "true" }}
+        - name: ENABLE_PROXY_PROTOCOL_REDIRECT
+          value: "true"
+{{ end }}
 {{ end }}
 {{ if eq .Cluster.ConfigItems.skipper_lua_scripts_enabled "true" }}
         - name: LUA_PATH


### PR DESCRIPTION
Add environment variable to control or enable proxy protocol for the http redirect skipper process