### PR TITLE
Revert "kube-metrics-adapter: Update to version v0.2.8-14-gd0dbe73"

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: container-registry.zalando.net/teapot/kube-metrics-adapter:v0.2.8-14-gd0dbe73
+        image: container-registry.zalando.net/teapot/kube-metrics-adapter:v0.2.8
         env:
         - name: AWS_REGION
           value: {{ .Cluster.Region }}


### PR DESCRIPTION
Reverts zalando-incubator/kubernetes-on-aws#10977

This introduced some regression with kube-metrics-adapter, reverting for now and we will check in a separated PR

```
Summarizing 1 Failure:
  [FAIL] [zalando] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from kube-metrics-adapter) [It] should scale down with Custom Metric of type Pod from kube-metrics-adapter [CustomMetricsAutoscaling] [Zalando]
  /workspace/test/e2e/util.go:710
```