### PR TITLE
Make the skipper-forward-backend-url configurable

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -141,6 +141,9 @@ skipper_ingress_binpack: "false"
 
 # skipper EKS migration support
 skipper_eks_migration_enabled: "false"
+# allow setting a custom forward-backend-url
+# If not set, falls back to the default "http://skipper-ingress-eks.<hosted_zone>
+skipper_ingress_migration_forward_backend_url_custom: ""
 skipper_eks_migration_svc_enabled: "false"
 worker_sg_legacy_cluster: ""
 

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -633,7 +633,11 @@ spec:
         args:
           - "routesrv"
 {{ if eq .Cluster.ConfigItems.skipper_eks_migration_enabled "true" }}
+{{- if ne .Cluster.ConfigItems.skipper_ingress_migration_forward_backend_url_custom "" }}
+          - "-forward-backend-url={{ .Cluster.ConfigItems.skipper_ingress_migration_forward_backend_url }}"
+{{- else }}
           - "-forward-backend-url=http://skipper-ingress-eks.{{ .Values.hosted_zone }}"
+{{- end }}
 {{ end }}
           - "-application-log-level={{ .Cluster.ConfigItems.skipper_routesrv_log_level }}"
           - "-enable-profile"


### PR DESCRIPTION
Make the `skipper_ingress_migration_forward_backend_url` configurable via a config-item. The default is what it was before.

Only relevant if `skipper_eks_migration_enabled: true`

The reason for this is in special cross account migration setups we can't use the predefined URL pattern as it assumes same account migration.