### PR TITLE
Add kube-state-metrics CustomResourceState config for StackSet metrics

### DIFF
--- a/cluster/manifests/kube-state-metrics/deployment.yaml
+++ b/cluster/manifests/kube-state-metrics/deployment.yaml
@@ -32,6 +32,7 @@ spec:
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         - --metric-labels-allowlist=pods=[{{.Cluster.ConfigItems.observability_metrics_pods_labels}}],ingresses=[{{.Cluster.ConfigItems.observability_metrics_ingresses_labels}}],nodes=[topology.kubernetes.io/zone,node.kubernetes.io/instance-type,node.kubernetes.io/node-pool,node.kubernetes.io/role,node.kubernetes.io/profile,dedicated]
         - --metric-annotations-allowlist=pods=[{{.Cluster.ConfigItems.observability_metrics_pods_annotations}}]
+        - --custom-resource-state-config-file=/etc/config/stackset-metrics-config.yaml
         ports:
         - containerPort: 8080
           name: http-metrics
@@ -52,9 +53,16 @@ spec:
           requests:
             cpu: "{{.Cluster.ConfigItems.kube_state_metrics_cpu}}"
             memory: "{{.Cluster.ConfigItems.kube_state_metrics_mem_max}}"
+        volumeMounts:
+        - name: stackset-metrics-config
+          mountPath: /etc/config
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 65534
           capabilities:
             drop: ["ALL"]
+      volumes:
+      - name: stackset-metrics-config
+        configMap:
+          name: stackset-metrics-config

--- a/cluster/manifests/kube-state-metrics/rbac.yaml
+++ b/cluster/manifests/kube-state-metrics/rbac.yaml
@@ -137,3 +137,20 @@ rules:
   verbs:
   - list
   - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - zalando.org
+  resources:
+  - stacks
+  - stacksets
+  verbs:
+  - get
+  - list
+  - watch

--- a/cluster/manifests/kube-state-metrics/stackset-metrics-config.yaml
+++ b/cluster/manifests/kube-state-metrics/stackset-metrics-config.yaml
@@ -7,7 +7,7 @@ metadata:
     application: kubernetes
     component: kube-state-metrics
 data:
-  config.yaml: |
+  stackset-metrics-config.yaml: |
     kind: CustomResourceStateMetrics
     spec:
       resources:

--- a/cluster/manifests/kube-state-metrics/stackset-metrics-config.yaml
+++ b/cluster/manifests/kube-state-metrics/stackset-metrics-config.yaml
@@ -1,0 +1,65 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stackset-metrics-config
+  namespace: kube-system
+  labels:
+    application: kubernetes
+    component: kube-state-metrics
+data:
+  config.yaml: |
+    kind: CustomResourceStateMetrics
+    spec:
+      resources:
+      - groupVersionKind:
+          group: zalando.org
+          version: "v1"
+          kind: StackSet
+        metrics:
+        - name: stackset_labels
+          help: "Kubernetes labels converted to Prometheus labels for StackSet"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                "label_*": [metadata, labels]
+        - name: stackset_info
+          help: "StackSet identity and version"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                stackset: [metadata, name]
+                namespace: [metadata, namespace]
+                version: [spec, stackTemplate, spec, version]
+      - groupVersionKind:
+          group: zalando.org
+          version: "v1"
+          kind: Stack
+        metrics:
+        - name: stack_labels
+          help: "Kubernetes labels converted to Prometheus labels for Stack"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                "label_*": [metadata, labels]
+        - name: stack_info
+          help: "Stack identity and version"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                stack: [metadata, name]
+                namespace: [metadata, namespace]
+                version: [metadata, labels, "stack-version"]
+        - name: stack_owner
+          help: "Information about Stackset that owns Stack"
+          each:
+            type: Info
+            info:
+              path: [metadata, ownerReferences]
+              labelsFromPath:
+                owner_kind: [kind]
+                owner_name: [name]
+                owner_uid: [uid]


### PR DESCRIPTION
Enable resource attribution for StackSet-managed workloads by exposing ownership and metadata metrics via kube-state-metrics `CustomResourceState` feature.

Exposes 5 Info metrics:
- `kube_customresource_stackset_labels`: StackSet labels
- `kube_customresource_stackset_info`: StackSet identity and version
- `kube_customresource_stack_labels`: Stack labels
- `kube_customresource_stack_info`: Stack identity and version
- `kube_customresource_stack_owner`: Stack-to-StackSet ownership link (key for resource attribution chain)

This enables Prometheus queries to attribute Pod resource consumption through Deployment → Stack → StackSet hierarchy for capacity planning and cost attribution.

Configuration added as ConfigMap in kube-state-metrics manifests. KSM deployment updated to mount and use the configuration file.

Implementation follows [kube-state-metrics CustomResourceState documentation](https://github.com/kubernetes/kube-state-metrics/blob/main/docs/metrics/extend/customresourcestate-metrics.md).

Ref.: [cloud-platform:7835](https://github.com/zalando-build/cloud-platform/issues/7835)