### PR TITLE
Add missing RBAC rules for latest EBS CSI driver

### DIFF
--- a/cluster/manifests/04-ebs-csi/clusterrole-provisioner.yaml
+++ b/cluster/manifests/04-ebs-csi/clusterrole-provisioner.yaml
@@ -33,3 +33,6 @@ rules:
   - apiGroups: [ "storage.k8s.io" ]
     resources: [ "volumeattachments" ]
     verbs: [ "get", "list", "watch" ]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattributesclasses"]
+    verbs: ["get"]

--- a/cluster/manifests/04-ebs-csi/clusterrole-resizer.yaml
+++ b/cluster/manifests/04-ebs-csi/clusterrole-resizer.yaml
@@ -24,3 +24,6 @@ rules:
   - apiGroups: [ "" ]
     resources: [ "pods" ]
     verbs: [ "get", "list", "watch" ]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattributesclasses"]
+    verbs: ["get", "list", "watch"]


### PR DESCRIPTION
Latest version introduced a new resource for which we need to add permissions.

```bash
csi-resizer E0420 16:51:36.671276       1 reflector.go:204] "Failed to watch" err="failed to list *v1.VolumeAttributesClass: volumeattributesclasses.storage.k8s.io is forbidden: User \"system:serviceaccount:kube-system:ebs-csi-controller-sa\" cannot list resource \"volumeattributesclasses\" in API group \"storage.k8s.io\" at the cluster scope"
```