### PR TITLE
change all VPAs mode from Recreate to InPlaceOrRecreate

### DIFF
--- a/cluster/manifests/03-kube-aws-iam-controller/vpa.yaml
+++ b/cluster/manifests/03-kube-aws-iam-controller/vpa.yaml
@@ -12,7 +12,7 @@ spec:
     kind: Deployment
     name: kube-aws-iam-controller
   updatePolicy:
-    updateMode: Recreate
+    updateMode: InPlaceOrRecreate
   resourcePolicy:
     containerPolicies:
     - containerName: kube-aws-iam-controller

--- a/cluster/manifests/03-skipper-validation-webhook/vpa.yaml
+++ b/cluster/manifests/03-skipper-validation-webhook/vpa.yaml
@@ -12,7 +12,7 @@ spec:
     kind: Deployment
     name: skipper-validation-webhook
   updatePolicy:
-    updateMode: Recreate
+    updateMode: InPlaceOrRecreate
   resourcePolicy:
     containerPolicies:
     - containerName: skipper-admission-webhook

--- a/cluster/manifests/04-ebs-csi/vpa.yaml
+++ b/cluster/manifests/04-ebs-csi/vpa.yaml
@@ -12,7 +12,7 @@ spec:
     kind: Deployment
     name: ebs-csi-controller
   updatePolicy:
-    updateMode: Recreate
+    updateMode: InPlaceOrRecreate
   resourcePolicy:
     containerPolicies:
     - containerName: ebs-plugin

--- a/cluster/manifests/aws-load-balancer-controller/vpa.yaml
+++ b/cluster/manifests/aws-load-balancer-controller/vpa.yaml
@@ -13,7 +13,7 @@ spec:
     kind: Deployment
     name: aws-load-balancer-controller
   updatePolicy:
-    updateMode: Recreate
+    updateMode: InPlaceOrRecreate
   resourcePolicy:
     containerPolicies:
     - containerName: controller

--- a/cluster/manifests/cluster-lifecycle-controller/vpa.yaml
+++ b/cluster/manifests/cluster-lifecycle-controller/vpa.yaml
@@ -12,7 +12,7 @@ spec:
     kind: Deployment
     name: "cluster-lifecycle-controller"
   updatePolicy:
-    updateMode: Recreate
+    updateMode: InPlaceOrRecreate
   resourcePolicy:
     containerPolicies:
     - containerName: "cluster-lifecycle-controller"

--- a/cluster/manifests/cronjob-fixer/vpa.yaml
+++ b/cluster/manifests/cronjob-fixer/vpa.yaml
@@ -12,7 +12,7 @@ spec:
     kind: Deployment
     name: cronjob-fixer
   updatePolicy:
-    updateMode: Recreate
+    updateMode: InPlaceOrRecreate
   resourcePolicy:
     containerPolicies:
     - containerName: cronjob-fixer

--- a/cluster/manifests/efs-provisioner/vpa.yaml
+++ b/cluster/manifests/efs-provisioner/vpa.yaml
@@ -13,7 +13,7 @@ spec:
     kind: Deployment
     name: efs-provisioner
   updatePolicy:
-    updateMode: Recreate
+    updateMode: InPlaceOrRecreate
   resourcePolicy:
     containerPolicies:
     - containerName: efs-provisioner

--- a/cluster/manifests/event-logger/vpa.yaml
+++ b/cluster/manifests/event-logger/vpa.yaml
@@ -12,7 +12,7 @@ spec:
     kind: StatefulSet
     name: kubernetes-event-logger
   updatePolicy:
-    updateMode: Recreate
+    updateMode: InPlaceOrRecreate
   resourcePolicy:
     containerPolicies:
     - containerName: logger

--- a/cluster/manifests/external-dns/vpa.yaml
+++ b/cluster/manifests/external-dns/vpa.yaml
@@ -12,7 +12,7 @@ spec:
     kind: Deployment
     name: external-dns
   updatePolicy:
-    updateMode: Recreate
+    updateMode: InPlaceOrRecreate
   resourcePolicy:
     containerPolicies:
     - containerName: external-dns

--- a/cluster/manifests/ingress-controller/vpa.yaml
+++ b/cluster/manifests/ingress-controller/vpa.yaml
@@ -11,7 +11,7 @@ spec:
     kind: Deployment
     name: kube-ingress-aws-controller
   updatePolicy:
-    updateMode: Recreate
+    updateMode: InPlaceOrRecreate
   resourcePolicy:
     containerPolicies:
     - containerName: kube-ingress-aws-controller

--- a/cluster/manifests/kube-downscaler/vpa.yaml
+++ b/cluster/manifests/kube-downscaler/vpa.yaml
@@ -13,7 +13,7 @@ spec:
     kind: Deployment
     name: kube-downscaler
   updatePolicy:
-    updateMode: Recreate
+    updateMode: InPlaceOrRecreate
   resourcePolicy:
     containerPolicies:
     - containerName: downscaler

--- a/cluster/manifests/kube-janitor/vpa.yaml
+++ b/cluster/manifests/kube-janitor/vpa.yaml
@@ -13,7 +13,7 @@ spec:
     kind: Deployment
     name: kube-janitor
   updatePolicy:
-    updateMode: Recreate
+    updateMode: InPlaceOrRecreate
   resourcePolicy:
     containerPolicies:
     - containerName: janitor

--- a/cluster/manifests/kube-metrics-adapter/vpa.yaml
+++ b/cluster/manifests/kube-metrics-adapter/vpa.yaml
@@ -12,7 +12,7 @@ spec:
     kind: Deployment
     name: kube-metrics-adapter
   updatePolicy:
-    updateMode: Recreate
+    updateMode: InPlaceOrRecreate
   resourcePolicy:
     containerPolicies:
     - containerName: kube-metrics-adapter

--- a/cluster/manifests/kube-node-ready-controller/vpa.yaml
+++ b/cluster/manifests/kube-node-ready-controller/vpa.yaml
@@ -13,7 +13,7 @@ spec:
     kind: Deployment
     name: kube-node-ready-controller
   updatePolicy:
-    updateMode: Recreate
+    updateMode: InPlaceOrRecreate
   resourcePolicy:
     containerPolicies:
     - containerName: controller

--- a/cluster/manifests/kube-state-metrics/vpa.yaml
+++ b/cluster/manifests/kube-state-metrics/vpa.yaml
@@ -12,7 +12,7 @@ spec:
     kind: Deployment
     name: kube-state-metrics
   updatePolicy:
-    updateMode: Recreate
+    updateMode: InPlaceOrRecreate
   resourcePolicy:
     containerPolicies:
     - containerName: kube-state-metrics

--- a/cluster/manifests/kube-static-egress-controller/vpa.yaml
+++ b/cluster/manifests/kube-static-egress-controller/vpa.yaml
@@ -12,7 +12,7 @@ spec:
     kind: Deployment
     name: "kube-static-egress-controller"
   updatePolicy:
-    updateMode: Recreate
+    updateMode: InPlaceOrRecreate
   resourcePolicy:
     containerPolicies:
     - containerName: "controller"

--- a/cluster/manifests/kubernetes-lifecycle-metrics/vpa.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/vpa.yaml
@@ -12,7 +12,7 @@ spec:
     kind: Deployment
     name: kubernetes-lifecycle-metrics
   updatePolicy:
-    updateMode: Recreate
+    updateMode: InPlaceOrRecreate
   resourcePolicy:
     containerPolicies:
     - containerName: kubernetes-lifecycle-metrics

--- a/cluster/manifests/metrics-server/metrics-server-vpa.yaml
+++ b/cluster/manifests/metrics-server/metrics-server-vpa.yaml
@@ -12,7 +12,7 @@ spec:
     kind: Deployment
     name: metrics-server
   updatePolicy:
-    updateMode: Recreate
+    updateMode: InPlaceOrRecreate
   resourcePolicy:
     containerPolicies:
     - containerName: metrics-server

--- a/cluster/manifests/pdb-controller/vpa.yaml
+++ b/cluster/manifests/pdb-controller/vpa.yaml
@@ -12,7 +12,7 @@ spec:
     kind: Deployment
     name: pdb-controller
   updatePolicy:
-    updateMode: Recreate
+    updateMode: InPlaceOrRecreate
   resourcePolicy:
     containerPolicies:
     - containerName: pdb-controller

--- a/cluster/manifests/prometheus/prometheus-vpa.yaml
+++ b/cluster/manifests/prometheus/prometheus-vpa.yaml
@@ -16,7 +16,7 @@ spec:
     kind: StatefulSet
     name: prometheus
   updatePolicy:
-    updateMode: Recreate
+    updateMode: InPlaceOrRecreate
   resourcePolicy:
     containerPolicies:
     - containerName: prometheus

--- a/cluster/manifests/skipper/pod-deletion-cost-controller-vpa.yaml
+++ b/cluster/manifests/skipper/pod-deletion-cost-controller-vpa.yaml
@@ -12,7 +12,7 @@ spec:
     kind: Deployment
     name: pod-deletion-cost-controller
   updatePolicy:
-    updateMode: Recreate
+    updateMode: InPlaceOrRecreate
   resourcePolicy:
     containerPolicies:
     - containerName: pod-deletion-cost-controller

--- a/cluster/manifests/stackset-controller/vpa.yaml
+++ b/cluster/manifests/stackset-controller/vpa.yaml
@@ -12,7 +12,7 @@ spec:
     kind: Deployment
     name: stackset-controller
   updatePolicy:
-    updateMode: Recreate
+    updateMode: InPlaceOrRecreate
   resourcePolicy:
     containerPolicies:
     - containerName: stackset-controller

--- a/cluster/manifests/z-karpenter/vpa.yaml
+++ b/cluster/manifests/z-karpenter/vpa.yaml
@@ -13,7 +13,7 @@ spec:
     kind: Deployment
     name: karpenter
   updatePolicy:
-    updateMode: Recreate
+    updateMode: InPlaceOrRecreate
   resourcePolicy:
     containerPolicies:
       - containerName: controller


### PR DESCRIPTION
change all VPAs mode from Recreate to InPlaceOrRecreate

The validation was done already in https://github.com/zalando-incubator/kubernetes-on-aws/pull/10959 and most of the cases were done with a `InPlace` Update without any eviction.