### PR TITLE
chore: update wiz-kubernetes-integration chart to v0.3.32

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -304,7 +304,7 @@ post_apply:
 - name: wiz-sensor
   kind: ServiceAccount
   namespace: wiz
-- name: wiz-sensor-apikey
+- name: wiz-sensor-api-token
   kind: Secret
   namespace: wiz
 - name: wiz-sensor
@@ -314,6 +314,13 @@ post_apply:
   kind : ClusterRoleBinding
   namespace: wiz
 {{- end }}
+# cleanup unused wiz secrets, regardless of sensor/connector status
+- name: wiz-sensor-apikey
+  kind: Secret
+  namespace: wiz
+- name: custom-wiz-sensor-api-token
+  kind: Secret
+  namespace: wiz
 {{- if and (ne .Cluster.ConfigItems.wiz_enable_runtime_connector_broker "true") (ne .Cluster.ConfigItems.wiz_enable_runtime_sensor "true") }}
 - name: wiz
   kind: Namespace

--- a/cluster/manifests/wiz/002-connector-broker-serviceaccount.yaml
+++ b/cluster/manifests/wiz/002-connector-broker-serviceaccount.yaml
@@ -19,7 +19,7 @@ metadata:
   name: wiz-cluster-reader
   namespace: "wiz"
   labels:
-    helm.sh/chart: wiz-kubernetes-connector-4.0.3
+    helm.sh/chart: wiz-kubernetes-connector-4.0.4
     application: "wiz"
     component: "connector"
 {{end}}

--- a/cluster/manifests/wiz/002-connector-job-serviceaccount.yaml
+++ b/cluster/manifests/wiz/002-connector-job-serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: wiz-auto-modify-connector
   namespace: "wiz"
   labels:
-    helm.sh/chart: wiz-kubernetes-connector-4.0.3
+    helm.sh/chart: wiz-kubernetes-connector-4.0.4
     application: "wiz"
     component: "connector"
 {{ end }}

--- a/cluster/manifests/wiz/002-sensor-serviceaccount.yaml
+++ b/cluster/manifests/wiz/002-sensor-serviceaccount.yaml
@@ -1,13 +1,13 @@
 {{ if eq .Cluster.ConfigItems.wiz_enable_runtime_sensor "true"}}
 ---
-# Source: wiz-sensor/templates/serviceaccount.yaml
+# Source: wiz-kubernetes-integration/charts/wiz-sensor/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: wiz-sensor
   namespace: wiz
   labels:
-    helm.sh/chart: wiz-sensor-1.0.8831
+    helm.sh/chart: wiz-sensor-1.0.10341
     application: "wiz"
     component: "sensor"
 {{end}}

--- a/cluster/manifests/wiz/003-connector-broker-clusterrole.yaml
+++ b/cluster/manifests/wiz/003-connector-broker-clusterrole.yaml
@@ -8,7 +8,7 @@ kind: ClusterRoleBinding
 metadata:
   name: wiz-cluster-reader
   labels:
-    helm.sh/chart: wiz-kubernetes-connector-4.0.3
+    helm.sh/chart: wiz-kubernetes-connector-4.0.4
     application: "wiz"
     component: "connector"
 roleRef:

--- a/cluster/manifests/wiz/003-connector-job-role.yaml
+++ b/cluster/manifests/wiz/003-connector-job-role.yaml
@@ -7,7 +7,7 @@ metadata:
   name: wiz-auto-modify-connector
   namespace: "wiz"
   labels:
-    helm.sh/chart: wiz-kubernetes-connector-4.0.3
+    helm.sh/chart: wiz-kubernetes-connector-4.0.4
     application: "wiz"
     component: "connector"
 rules:
@@ -29,7 +29,7 @@ metadata:
   name: wiz-auto-modify-connector
   namespace: "wiz"
   labels:
-    helm.sh/chart: wiz-kubernetes-connector-4.0.3
+    helm.sh/chart: wiz-kubernetes-connector-4.0.4
     application: "wiz"
     component: "connector"
 roleRef:

--- a/cluster/manifests/wiz/003-sensor-clusterrole.yaml
+++ b/cluster/manifests/wiz/003-sensor-clusterrole.yaml
@@ -1,12 +1,12 @@
 {{ if eq .Cluster.ConfigItems.wiz_enable_runtime_sensor "true"}}
 ---
-# Source: wiz-sensor/templates/clusterrole.yaml
+# Source: wiz-kubernetes-integration/charts/wiz-sensor/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: wiz-sensor
   labels:
-    helm.sh/chart: wiz-sensor-1.0.8831
+    helm.sh/chart: wiz-sensor-1.0.10341
     application: "wiz"
     component: "sensor"
 rules:
@@ -17,18 +17,17 @@ rules:
   - apiGroups: ["", "apps", "batch"]
     resources: [
       "namespaces", "nodes", "daemonsets", "replicasets", "deployments",
-      "jobs", "cronjobs", "statefulsets", "replicationcontrollers", "serviceaccounts",
-      "nodes/proxy"
+      "jobs", "cronjobs", "statefulsets", "replicationcontrollers", "serviceaccounts"
     ]
     verbs: ["get", "list", "watch"]
 ---
-# Source: wiz-sensor/templates/clusterrolebinding.yaml
+# Source: wiz-kubernetes-integration/charts/wiz-kubernetes-connector/templates/service-account-cluster-reader.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: wiz-sensor
   labels:
-    helm.sh/chart: wiz-sensor-1.0.8831
+    helm.sh/chart: wiz-sensor-1.0.10341
     application: "wiz"
     component: "sensor"
 subjects:

--- a/cluster/manifests/wiz/004-connector-broker-secrets.yaml
+++ b/cluster/manifests/wiz/004-connector-broker-secrets.yaml
@@ -9,7 +9,7 @@ metadata:
   name: wiz-connector-connector
   namespace: "wiz"
   labels:
-    helm.sh/chart: wiz-kubernetes-connector-4.0.3
+    helm.sh/chart: wiz-kubernetes-connector-4.0.4
     application: "wiz"
     component: "connector"
 type: Opaque
@@ -25,21 +25,21 @@ metadata:
   name: wiz-cluster-reader-token
   namespace: "wiz"
   labels:
-    helm.sh/chart: wiz-kubernetes-connector-4.0.3
+    helm.sh/chart: wiz-kubernetes-connector-4.0.4
     application: "wiz"
     component: "connector"
   annotations:
     kubernetes.io/service-account.name: wiz-cluster-reader
 type: kubernetes.io/service-account-token
 ---
-# Source: wiz-sensor/templates/secrets-wiz-api-token.yaml
+# Source: wiz-kubernetes-integration/templates/secrets-wiz-api-token.yaml
 apiVersion: v1
 kind: Secret
 metadata:
   name: wiz-api-token
   namespace: wiz
   labels:
-    helm.sh/chart: wiz-kubernetes-integration-0.3.6
+    helm.sh/chart: wiz-kubernetes-integration-0.3.32
     application: "wiz"
     component: "connector"
 type: Opaque

--- a/cluster/manifests/wiz/004-sensor-secrets.yaml
+++ b/cluster/manifests/wiz/004-sensor-secrets.yaml
@@ -1,13 +1,14 @@
 {{ if eq .Cluster.ConfigItems.wiz_enable_runtime_sensor "true"}}
 ---
-# Source: wiz-sensor/templates/secrets-wiz-api-token.yaml
+# Source: wiz-kubernetes-integration/templates/secrets-wiz-api-token.yaml
 apiVersion: v1
 kind: Secret
 metadata:
-  name: custom-wiz-sensor-api-token
+  # custom name to allow sensor and connector to deploy separately
+  name: wiz-sensor-api-token
   namespace: wiz
   labels:
-    helm.sh/chart: wiz-kubernetes-integration-0.3.6
+    helm.sh/chart: wiz-kubernetes-integration-0.3.32
     application: "wiz"
     component: "sensor"
 type: Opaque

--- a/cluster/manifests/wiz/005-connector-job.yaml
+++ b/cluster/manifests/wiz/005-connector-job.yaml
@@ -7,7 +7,7 @@ metadata:
   name: wiz-kubernetes-connector-create-connector
   namespace: "wiz"
   labels:
-    helm.sh/chart: wiz-kubernetes-connector-4.0.3
+    helm.sh/chart: wiz-kubernetes-connector-4.0.4
     application: "wiz"
     component: "connector"
     job: "wiz-connector-agent"
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       labels: 
-        helm.sh/chart: wiz-kubernetes-connector-4.0.3
+        helm.sh/chart: wiz-kubernetes-connector-4.0.4
         application: "wiz"
         component: "connector"
         job: "wiz-connector-agent"
@@ -30,7 +30,7 @@ spec:
       restartPolicy: "Never"
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
+        runAsUser: 10000
       volumes:
       - name: api-client
         secret:
@@ -46,7 +46,7 @@ spec:
             runAsGroup: 10000
             runAsNonRoot: true
             runAsUser: 10000
-          image: "container-registry.zalando.net/secops-systems/wiz-broker:3.0.3-main-8"
+          image: "container-registry.zalando.net/secops-systems/wiz-broker:3.0.9-main-9"
           imagePullPolicy: IfNotPresent
           command:
             - "wiz-broker"

--- a/cluster/manifests/wiz/connector-deployment.yaml
+++ b/cluster/manifests/wiz/connector-deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: wiz-broker
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
+        runAsUser: 10000
       volumes:
         - name: api-client
           secret:
@@ -49,7 +49,7 @@ spec:
             runAsGroup: 10000
             runAsNonRoot: true
             runAsUser: 10000
-          image: "container-registry.zalando.net/secops-systems/wiz-broker:3.0.3-main-8"
+          image: "container-registry.zalando.net/secops-systems/wiz-broker:3.0.9-main-9"
           imagePullPolicy: IfNotPresent
           volumeMounts:
           - name: api-client
@@ -89,7 +89,7 @@ spec:
           - name: WIZ_CHART_VERSION
             value: "3.0.3"
           - name: WIZ_IMAGE_REF
-            value: "container-registry.zalando.net/secops-systems/wiz-broker:3.0.3-main-8"
+            value: "container-registry.zalando.net/secops-systems/wiz-broker:3.0.9-main-9"
           - name: WIZ_USE_HATUNNEL # toggle WebSocket usage on
             value: "1"
           - name: WIZ_BROKER_HEARTBEAT_DISABLE_CLUSTER_ID

--- a/cluster/manifests/wiz/sensor-daemonset.yaml
+++ b/cluster/manifests/wiz/sensor-daemonset.yaml
@@ -1,13 +1,14 @@
 {{ if eq .Cluster.ConfigItems.wiz_enable_runtime_sensor "true"}}
 ---
-# Source: wiz-sensor/templates/daemonset.yaml
+# Source: wiz-kubernetes-integration/charts/wiz-sensor/templates/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: wiz-sensor
   labels:
-    helm.sh/chart: wiz-sensor-1.0.8831
+    helm.sh/chart: wiz-sensor-1.0.10341
     image/tag: v1
+    dsimage/tag: v1
     application: "wiz"
     component: "sensor"
     daemonset: "wiz-sensor"
@@ -23,7 +24,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: wiz-sensor-1.0.8831
+        helm.sh/chart: wiz-sensor-1.0.10341
         image/tag: v1
         application: "wiz"
         component: "sensor"
@@ -50,7 +51,7 @@ spec:
       restartPolicy: Always
       containers:
       - name: wiz-sensor
-        image: container-registry.zalando.net/secops-systems/wiz-sensor:1.0.8831-main-8
+        image: container-registry.zalando.net/secops-systems/wiz-sensor:1.0.10314-main-9
         imagePullPolicy: IfNotPresent
         securityContext:
           capabilities:
@@ -161,7 +162,7 @@ spec:
           value: "true"
           {{- end }}
         - name: HELM_CHART_VERSION
-          value: 1.0.8831
+          value: 1.0.10341
         - name: ALLOW_KUBELET_COMMUNICATION
           value: "false"
         - name: FORCE_KUBELET_COMMUNICATION
@@ -192,7 +193,7 @@ spec:
           type: DirectoryOrCreate
       - name: api-client-secret
         secret:
-          secretName: custom-wiz-sensor-api-token
+          secretName: wiz-sensor-api-token
           items:
             - key: clientId
               path: clientId
@@ -200,7 +201,7 @@ spec:
               path: clientToken
       - name: api-endpoint-name-secret
         secret:
-          secretName: custom-wiz-sensor-api-token
+          secretName: wiz-sensor-api-token
           optional: true
           items:
             - key: clientEndpoint


### PR DESCRIPTION
bumps the manifests to the new version to deploy updated images