### PR TITLE
update to latest EKS addon versions

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -399,7 +399,7 @@ Resources:
     Type: AWS::EKS::Addon
     Properties:
       AddonName: vpc-cni
-      AddonVersion: "v1.21.1-eksbuild.3"
+      AddonVersion: "v1.21.1-eksbuild.7"
       ClusterName: !Ref EKSCluster
       ConfigurationValues: !Sub |
 {{- if eq .Cluster.ConfigItems.aws_vpc_cni_custom_networking "true" }}
@@ -434,7 +434,7 @@ Resources:
     Type: AWS::EKS::Addon
     Properties:
       AddonName: eks-pod-identity-agent
-      AddonVersion: "v1.3.10-eksbuild.2"
+      AddonVersion: "v1.3.10-eksbuild.3"
       ClusterName: !Ref EKSCluster
       ConfigurationValues: |
         {
@@ -447,7 +447,7 @@ Resources:
     Type: AWS::EKS::Addon
     Properties:
       AddonName: kube-proxy
-      AddonVersion: "v1.35.0-eksbuild.2"
+      AddonVersion: "v1.35.3-eksbuild.5"
       ClusterName: !Ref EKSCluster
       ConfigurationValues: |
         {
@@ -461,7 +461,7 @@ Resources:
     Type: AWS::EKS::Addon
     Properties:
       AddonName: eks-node-monitoring-agent
-      AddonVersion: "v1.6.1-eksbuild.1"
+      AddonVersion: "v1.6.3-eksbuild.1"
       ClusterName: !Ref EKSCluster
       ConfigurationValues: |
         {


### PR DESCRIPTION
Update to latest EKS addon versions.

Got the versions via a script like this:

```bash
#!/usr/bin/env bash


CLUSTER=<cluster>
K8S_VERSION=$(aws eks describe-cluster --name $CLUSTER --query 'cluster.version' --output text)

for addon in $(aws eks list-addons --cluster-name $CLUSTER --query 'addons[]' --output text); do
  LATEST=$(aws eks describe-addon-versions \
    --addon-name $addon \
    --kubernetes-version $K8S_VERSION \
    --query 'addons[0].addonVersions[0].addonVersion' \
    --output text)
  CURRENT=$(aws eks describe-addon --cluster-name $CLUSTER --addon-name $addon \
    --query 'addon.addonVersion' --output text)
  echo "$addon | current: $CURRENT | latest: $LATEST"
done
```