### PR TITLE
fix: canary opt-out non zone aware routes

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -223,7 +223,7 @@ spec:
           - "-validate-query={{ .Cluster.ConfigItems.skipper_validate_query }}"
           - "-validate-query-log={{ .Cluster.ConfigItems.skipper_validate_query_log }}"
 {{ if eq .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
-{{ if ne {{ .name }} "skipper-ingress-canary" }}
+{{ if ne .name "skipper-ingress-canary" }}
           - "-routes-urls=http://skipper-ingress-routesrv.kube-system.svc.cluster.local/routes"
 {{ end }}
           - "-normalize-host"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -223,7 +223,7 @@ spec:
           - "-validate-query={{ .Cluster.ConfigItems.skipper_validate_query }}"
           - "-validate-query-log={{ .Cluster.ConfigItems.skipper_validate_query_log }}"
 {{ if eq .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
-{{ if ne "{{ .name }}" "skipper-ingress-canary" }}
+{{ if ne {{ .name }} "skipper-ingress-canary" }}
           - "-routes-urls=http://skipper-ingress-routesrv.kube-system.svc.cluster.local/routes"
 {{ end }}
           - "-normalize-host"


### PR DESCRIPTION
fix: canary opt-out non zone aware routes

We saw that we get both args in canary and somehow it uses the non zone aware routes.