### PR TITLE
removes unused and deleted wiz secrets from deletions.yaml

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -314,13 +314,6 @@ post_apply:
   kind : ClusterRoleBinding
   namespace: wiz
 {{- end }}
-# cleanup unused wiz secrets, regardless of sensor/connector status
-- name: wiz-sensor-apikey
-  kind: Secret
-  namespace: wiz
-- name: custom-wiz-sensor-api-token
-  kind: Secret
-  namespace: wiz
 {{- if and (ne .Cluster.ConfigItems.wiz_enable_runtime_connector_broker "true") (ne .Cluster.ConfigItems.wiz_enable_runtime_sensor "true") }}
 - name: wiz
   kind: Namespace


### PR DESCRIPTION
`wiz-sensor-apikey` and `custom-wiz-sensor-api-token` were renamed and the old copies had to be deleted. This was done with #11106 which is merged to stable. This PR cleans up the explicit deletions.