### PR TITLE
bugfix: canary deployment no route-url

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -9,7 +9,7 @@
 {{ end }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}
-{{ $canary_args = "-routes-urls=http://skipper-ingress-routesrv.kube-system.svc.cluster.local/routes" }}
+{{ $canary_args := "-routes-urls=http://skipper-ingress-routesrv.kube-system.svc.cluster.local/routes" }}
 {{ if eq .Cluster.ConfigItems.skipper_ingress_zone_aware_routing_enabled "true" }}
 {{ $canary_args = "-routes-urls=http://skipper-ingress-routesrv.kube-system.svc.cluster.local/routes/$(KUBE_NODE_ZONE)" }}
 {{ end }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -9,11 +9,9 @@
 {{ end }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}
-{{ $canary_args := "" }}
+{{ $canary_args = "-routes-urls=http://skipper-ingress-routesrv.kube-system.svc.cluster.local/routes" }}
 {{ if eq .Cluster.ConfigItems.skipper_ingress_zone_aware_routing_enabled "true" }}
 {{ $canary_args = "-routes-urls=http://skipper-ingress-routesrv.kube-system.svc.cluster.local/routes/$(KUBE_NODE_ZONE)" }}
-{{else}}
-{{ $canary_args = "-routes-urls=http://skipper-ingress-routesrv.kube-system.svc.cluster.local/routes" }}
 {{ end }}
 
 {{ $cluster_internal_cidrs := list "10.2.0.0/15" .Values.vpc_ipv4_cidr }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -12,6 +12,8 @@
 {{ $canary_args := "" }}
 {{ if eq .Cluster.ConfigItems.skipper_ingress_zone_aware_routing_enabled "true" }}
 {{ $canary_args = "-routes-urls=http://skipper-ingress-routesrv.kube-system.svc.cluster.local/routes/$(KUBE_NODE_ZONE)" }}
+{{else}}
+{{ $canary_args = "-routes-urls=http://skipper-ingress-routesrv.kube-system.svc.cluster.local/routes" }}
 {{ end }}
 
 {{ $cluster_internal_cidrs := list "10.2.0.0/15" .Values.vpc_ipv4_cidr }}


### PR DESCRIPTION
Canary deployment doesn't get any `routes-url` if `skipper_ingress_zone_aware_routing_enabled` is set to false.