### PR TITLE
Add skipper-version tag for ingress tracing

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -248,6 +248,8 @@ kasada_api_key: ""
 skipper_ingress_response_size_buckets: ""
 skipper_ingress_request_size_buckets: ""
 
+skipper_ingress_version_tag_enabled: "false"
+
 #
 # skipper routesrv settings
 #

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -301,6 +301,9 @@ spec:
             tag=cluster={{ .Cluster.Alias }}
             tag=k8s.cluster.name={{ .Cluster.Alias }}
             tag=artifact={{ .image }}
+{{ if eq .Cluster.ConfigItems.skipper_ingress_version_tag_enabled "true" }}
+            tag=skipper_version={{ index (split .image ":") 1 }}
+{{ end }}
             max-buffered-spans={{ .Cluster.ConfigItems.skipper_ingress_tracing_buffer }}
             grpc-max-msg-size={{ .Cluster.ConfigItems.skipper_ingress_lightstep_grpc_max_msg_size }}
             max-period={{ .Cluster.ConfigItems.skipper_ingress_lightstep_max_period }}


### PR DESCRIPTION
## Changes

- Added skipper_ingress_version_tag_enabled configuration flag
- Extracts skipper version from container image tag for tracing

## Testing

- [ ] Verify tracing includes skipper-version tag when flag is enabled
- [ ] Verify no impact when flag is disabled (default)