### PR TITLE
Update etcd AMI

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -868,8 +868,8 @@ etcd_instance_type: "t3.medium"
 
 etcd_scalyr_key: ""
 
-etcd_ami_amd64: {{ amiID "zalando-ubuntu-etcd-production-v3.5.22-amd64-main-38" "861068367966"}}
-etcd_ami_arm64: {{ amiID "zalando-ubuntu-etcd-production-v3.5.22-arm64-main-38" "861068367966"}}
+etcd_ami_amd64: {{ amiID "zalando-ubuntu-etcd-production-v3.5.30-amd64-main-40" "861068367966"}}
+etcd_ami_arm64: {{ amiID "zalando-ubuntu-etcd-production-v3.5.30-arm64-main-40" "861068367966"}}
 
 cluster_dns: "coredns"
 coredns_log_svc_names: "true"


### PR DESCRIPTION
This update drops the snapd package manager from the AMI that has vulnerabilities. This is required for vulnerability resolution.

Also updates to etcd `v3.5.30`