### PR TITLE
karpenter: remove CLUSTER_ENDPOINT setting

### DIFF
--- a/cluster/manifests/z-karpenter/deployment.yaml
+++ b/cluster/manifests/z-karpenter/deployment.yaml
@@ -58,8 +58,10 @@ spec:
               value: "1.19.0-0"
             - name: AWS_REGION
               value: "{{ .Cluster.Region }}"
+{{- if eq .Cluster.Provider "zalando-aws"}}
             - name: CLUSTER_ENDPOINT
-              value: https://kubernetes.default.svc.cluster.local.
+              value: https://kubernetes.default.svc.cluster.local
+{{- end }}
             - name: ENABLE_PROFILING
               value: 'false'
             - name: INTERRUPTION_QUEUE


### PR DESCRIPTION
This removes the `CLUSTER_ENDPOINT` setting on karpenter deployment. The setting is used by Karpenter when creating node pools for known AMIs e.g. Amazon Linux 2023. The kubelet kubeconfig is configured with that value. Setting `https://kubernetes.default.svc.cluster.local.` doesn't make sense in that case as this DNS name requires kube-proxy which in turns require kubelet ♻️.

If the value is not set it will just default to the EKS endpoint which is the right behavior. ~For custom AMI as we use now this is not used and thus has no effect when being dropped.~ If the value is not set it defaults to look up the EKS endpoint. For now keep the CLUSTER_ENDPOINT setting for non-EKS clusters or Karpenter fails to run.