### PR TITLE
Add k8s.pod.name and cloud.availability_zone tags to skipper tracing

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -165,6 +165,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.labels['topology.kubernetes.io/zone']
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: LIGHTSTEP_TOKEN
           valueFrom:
             secretKeyRef:
@@ -301,6 +305,8 @@ spec:
             tag=cluster={{ .Cluster.Alias }}
             tag=k8s.cluster.name={{ .Cluster.Alias }}
             tag=artifact={{ .image }}
+            tag=k8s.pod.name=$(POD_NAME)
+            tag=cloud.availability_zone=$(KUBE_NODE_ZONE)
             max-buffered-spans={{ .Cluster.ConfigItems.skipper_ingress_tracing_buffer }}
             grpc-max-msg-size={{ .Cluster.ConfigItems.skipper_ingress_lightstep_grpc_max_msg_size }}
             max-period={{ .Cluster.ConfigItems.skipper_ingress_lightstep_max_period }}


### PR DESCRIPTION
## Summary

Add Kubernetes pod name and cloud availability zone as tracing tags to skipper ingress controller for better observability and trace correlation in Lightstep, following OpenTelemetry semantic conventions.

## Details

- Added POD_NAME environment variable from pod metadata via downward API
- Added k8s.pod.name tag to skipper lightstep configuration
- Added cloud.availability_zone tag to skipper lightstep configuration (uses existing KUBE_NODE_ZONE env var)
- Tags follow OpenTelemetry semantic conventions as documented at https://opentelemetry.io/docs/specs/semconv/registry/attributes/cloud/#cloud-availability-zone
- This enables better trace aggregation and debugging by identifying which pod and availability zone handled each request

## Test Plan

- [ ] Verify skipper pods start successfully with new tracing tags
- [ ] Confirm traces in Lightstep include k8s.pod.name and cloud.availability_zone tags
- [ ] Check that tracing continues to work correctly for all requests