### PR TITLE
Configure lifecycle-metrics with statefile

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -630,6 +630,7 @@ kube_state_metrics_vpa_update_mode: "InPlaceOrRecreate"
 
 kubernetes_lifecycle_metrics_mem_max: "4Gi"
 kubernetes_lifecycle_metrics_mem_min: "120Mi"
+kubernetes_lifecycle_metrics_state_file: "true"
 
 kube_node_ready_controller_cpu: "50m"
 kube_node_ready_controller_memory: "200Mi"

--- a/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/deployment.yaml
@@ -18,7 +18,9 @@ spec:
         application: kubernetes
         component: lifecycle-metrics
       annotations:
+{{- if ne .Cluster.ConfigItems.kubernetes_lifecycle_metrics_state_file "true" }}
         karpenter.sh/do-not-disrupt: "true"
+{{- end }}
         prometheus.io/path: /metrics
         prometheus.io/port: "9090"
         prometheus.io/scrape: "true"
@@ -32,7 +34,11 @@ spec:
       serviceAccountName: kubernetes-lifecycle-metrics
       containers:
         - name: kubernetes-lifecycle-metrics
-          image: "container-registry.zalando.net/teapot/kubernetes-lifecycle-metrics:master-49"
+          image: "container-registry.zalando.net/teapot/kubernetes-lifecycle-metrics:master-50"
+{{- if eq .Cluster.ConfigItems.kubernetes_lifecycle_metrics_state_file "true" }}
+          args:
+            - --state-file=/state/state.json
+{{- end }}
           ports:
             - containerPort: 9090
               protocol: TCP
@@ -48,3 +54,12 @@ spec:
               path: /healthz
               port: 9090
               scheme: HTTP
+{{- if eq .Cluster.ConfigItems.kubernetes_lifecycle_metrics_state_file "true" }}
+          volumeMounts:
+          - mountPath: /state
+            name: state
+      volumes:
+      - name: state
+        persistentVolumeClaim:
+          claimName: kubernetes-lifecycle-metrics
+{{- end }}

--- a/cluster/manifests/kubernetes-lifecycle-metrics/pvc.yaml
+++ b/cluster/manifests/kubernetes-lifecycle-metrics/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if eq .Cluster.ConfigItems.kubernetes_lifecycle_metrics_state_file "true" }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kubernetes-lifecycle-metrics
+  namespace: kube-system
+  labels:
+    application: kubernetes
+    component: lifecycle-metrics
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: standard
+  resources:
+    requests:
+      storage: 1Gi
+{{- end }}


### PR DESCRIPTION
This updates the kubernetes-lifecycle-metrics component to a version that supports storing it's state in a statefile on a PVC.

The purpose of this feature is to persist state across rescheduling of the `kubernetes-lifecycle-metrics` pods and thereby get rid of the usage of `karpenter.sh/do-not-disrupt: "true"` which was introduced to avoid the pod from being re-scheduled too often.

Before the component would replay some events if it was rescheduled leading to multi-counting of the same pod scheduling events impacting the SLO metrics for Pod Scheduling SLO. With the state file the replay of events is avoided.