### PR TITLE
Add container.image.name and container.image.tags to skipper tracing

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -305,6 +305,8 @@ spec:
             tag=cluster={{ .Cluster.Alias }}
             tag=k8s.cluster.name={{ .Cluster.Alias }}
             tag=artifact={{ .image }}
+            tag=container.image.name={{ index (split .image ":") 0 }}
+            tag=container.image.tags={{ index (split .image ":") 1 }}
             tag=k8s.pod.name=$(POD_NAME)
             tag=cloud.availability_zone=$(KUBE_NODE_ZONE)
             max-buffered-spans={{ .Cluster.ConfigItems.skipper_ingress_tracing_buffer }}


### PR DESCRIPTION
Add OpenTelemetry semantic convention attributes for container image information to skipper ingress controller tracing.

Tags follow OpenTelemetry semantic conventions as documented at https://opentelemetry.io/docs/specs/semconv/registry/entities/container/#container-image

Changes:
- Added container.image.name tag (registry + repository path without tag)
- Added container.image.tags tag (the version/tag portion)
- The artifact tag is kept for now and can be removed once Lightstep is fully migrated