### PR TITLE
skipper-ingress: use configItem for route

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -271,6 +271,9 @@ skipper_routesrv_target_average_utilization_memory: "80"
 skipper_ingress_routesrv_scaling_schedules: ""
 skipper_routesrv_log_level: "INFO"
 
+skipper_routes_url: "http://skipper-ingress-routesrv.kube-system.svc.cluster.local/routes"
+skipper_canary_routes_url: ""
+
 # skipper-ingress component pod-deletion-cost-controller
 skipper_pod_deletion_cost_controller_memory: 200Mi
 skipper_pod_deletion_cost_controller_cpu: 50m

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -232,7 +232,7 @@ spec:
           - "-validate-query={{ .Cluster.ConfigItems.skipper_validate_query }}"
           - "-validate-query-log={{ .Cluster.ConfigItems.skipper_validate_query_log }}"
 {{ if eq .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
-          - '-routes-urls= "{{ .local_routes_url }}"'
+          - "-routes-urls={{ .local_routes_url }}"
           - "-normalize-host"
 {{ else }}
           - "-kubernetes"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -9,9 +9,12 @@
 {{ end }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}
-{{ $canary_args := "-routes-urls=http://skipper-ingress-routesrv.kube-system.svc.cluster.local/routes" }}
-{{ if eq .Cluster.ConfigItems.skipper_ingress_zone_aware_routing_enabled "true" }}
-{{ $canary_args = "-routes-urls=http://skipper-ingress-routesrv.kube-system.svc.cluster.local/routes/$(KUBE_NODE_ZONE)" }}
+{{ $canary_args := "" }}
+
+{{ $main_routes_url := .Cluster.ConfigItems.skipper_routes_url }}
+{{ $canary_routes_url := .Cluster.ConfigItems.skipper_routes_url }}
+{{ if ne .Cluster.ConfigItems.skipper_canary_routes_url "" }}
+{{ $canary_routes_url = .Cluster.ConfigItems.skipper_canary_routes_url }}
 {{ end }}
 
 {{ $cluster_internal_cidrs := list "10.2.0.0/15" .Values.vpc_ipv4_cidr }}
@@ -30,6 +33,7 @@
   "Cluster" .Cluster
   "Values" .Values
   "cluster_internal_cidrs" $cluster_internal_cidrs
+  "local_routes_url" $main_routes_url
 }}
 
 {{ if eq .Cluster.ConfigItems.skipper_ingress_canary_enabled "true" }}
@@ -42,6 +46,7 @@
   "Cluster" .Cluster
   "Values" .Values
   "cluster_internal_cidrs" $cluster_internal_cidrs
+  "local_routes_url" $canary_routes_url
 }}
 {{ end }}
 
@@ -227,9 +232,7 @@ spec:
           - "-validate-query={{ .Cluster.ConfigItems.skipper_validate_query }}"
           - "-validate-query-log={{ .Cluster.ConfigItems.skipper_validate_query_log }}"
 {{ if eq .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
-{{ if ne .name "skipper-ingress-canary" }}
-          - "-routes-urls=http://skipper-ingress-routesrv.kube-system.svc.cluster.local/routes"
-{{ end }}
+          - '-routes-urls= "{{ .local_routes_url }}"'
           - "-normalize-host"
 {{ else }}
           - "-kubernetes"


### PR DESCRIPTION
Pass `routes-url` as configItem and reset zone aware url to enable canary

next step should be make a canary for routeSRV

rendering files locally shows

## Only canary change
```
        - -enable-copy-stream-pool=true
        - -validate-query=true
        - -validate-query-log=false
        - -routes-urls= "http://skipper-ingress-routesrv.kube-system.svc.cluster.local/routes"
        - -normalize-host
        - -address=:9999
        - -wait-first-route-load
--
        - -enable-copy-stream-pool=true
        - -validate-query=true
        - -validate-query-log=false
        - -routes-urls= "http://canary-url.example.org"
        - -normalize-host
        - -address=:9999
        - -wait-first-route-load
```

## Both URL changes

```
        - -enable-copy-stream-pool=true
        - -validate-query=true
        - -validate-query-log=false
        - -routes-urls= "http://main-url.example.org"
        - -normalize-host
        - -address=:9999
        - -wait-first-route-load
--
        - -enable-copy-stream-pool=true
        - -validate-query=true
        - -validate-query-log=false
        - -routes-urls= "http://canary-url.example.org"
        - -normalize-host
        - -address=:9999
        - -wait-first-route-load
```

## No URL change

```
        - -enable-copy-stream-pool=true
        - -validate-query=true
        - -validate-query-log=false
        - -routes-urls= "http://skipper-ingress-routesrv.kube-system.svc.cluster.local/routes"
        - -normalize-host
        - -address=:9999
        - -wait-first-route-load
--
        - -enable-copy-stream-pool=true
        - -validate-query=true
        - -validate-query-log=false
        - -routes-urls= "http://skipper-ingress-routesrv.kube-system.svc.cluster.local/routes"
        - -normalize-host
        - -address=:9999
        - -wait-first-route-load
```