### PR TITLE
Feature: routesrv canary

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -130,8 +130,8 @@ skipper_ingress_canary_image: ""
 skipper_ingress_test_single_pod: "false"
 skipper_canary_controller_enabled: "false"
 
-skipper_ingress_canary_routes_urls: "http://skipper-ingress-routesrv-canary.kube-system.svc.cluster.local/routes"
-skipper_ingress_routes_urls: "http://skipper-ingress-routesrv.kube-system.svc.cluster.local/routes"
+skipper_ingress_canary_routes_urls: http://skipper-ingress-routesrv-canary.kube-system.svc.cluster.local/routes
+skipper_ingress_routes_urls: http://skipper-ingress-routesrv.kube-system.svc.cluster.local/routes
 
 
 # When set to true (and dedicated node pool for skipper is also true) the
@@ -269,9 +269,6 @@ skipper_routesrv_target_average_utilization_cpu: "80"
 skipper_routesrv_target_average_utilization_memory: "80"
 skipper_ingress_routesrv_scaling_schedules: ""
 skipper_routesrv_log_level: "INFO"
-
-skipper_routes_url: "http://skipper-ingress-routesrv.kube-system.svc.cluster.local/routes"
-skipper_canary_routes_url: ""
 
 # skipper-ingress component pod-deletion-cost-controller
 skipper_pod_deletion_cost_controller_memory: 200Mi

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -100,6 +100,7 @@ skipper_ingress_target_average_utilization_cpu: "60"
 skipper_ingress_target_average_utilization_memory: "80"
 skipper_ingress_hpa_scale_down_wait: "600"
 skipper_ingress_hpa_scale_up_max_perc: "100"
+skipper_ingress_routes_url: "http://skipper-ingress-routesrv.kube-system.svc.cluster.local/routes"
 {{if eq .Cluster.Environment "production"}}
 skipper_ingress_min_replicas: "3"
 skipper_ingress_max_replicas: "300"
@@ -251,11 +252,6 @@ skipper_ingress_request_size_buckets: ""
 #
 # skipper routesrv settings
 #
-# skipper_routesrv_enabled is a three state switch:
-# - "false" - routesrv deployment is removed, skipper uses own k8s dataclient
-# - "pre" - routesrv is deployed, skipper uses own k8s dataclient
-# - "exec" - routesrv is deployed, skipper uses routesrv
-skipper_routesrv_enabled: "exec"
 skipper_routesrv_memory: "1Gi"
 skipper_routesrv_min_replicas: 2
 {{if eq .Cluster.Environment "production"}}

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -130,7 +130,7 @@ skipper_ingress_canary_image: ""
 skipper_ingress_test_single_pod: "false"
 skipper_canary_controller_enabled: "false"
 
-skipper_ingress_canary_routes_urls: http://skipper-ingress-routesrv-canary.kube-system.svc.cluster.local/routes
+skipper_ingress_canary_routes_urls: http://skipper-ingress-canary-routesrv.kube-system.svc.cluster.local/routes
 skipper_ingress_routes_urls: http://skipper-ingress-routesrv.kube-system.svc.cluster.local/routes
 
 

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -100,7 +100,6 @@ skipper_ingress_target_average_utilization_cpu: "60"
 skipper_ingress_target_average_utilization_memory: "80"
 skipper_ingress_hpa_scale_down_wait: "600"
 skipper_ingress_hpa_scale_up_max_perc: "100"
-skipper_ingress_routes_url: "http://skipper-ingress-routesrv.kube-system.svc.cluster.local/routes"
 {{if eq .Cluster.Environment "production"}}
 skipper_ingress_min_replicas: "3"
 skipper_ingress_max_replicas: "300"
@@ -130,6 +129,10 @@ skipper_ingress_canary_enabled: "true"
 skipper_ingress_canary_image: ""
 skipper_ingress_test_single_pod: "false"
 skipper_canary_controller_enabled: "false"
+
+skipper_ingress_canary_routes_urls: "http://skipper-ingress-routesrv-canary.kube-system.svc.cluster.local/routes"
+skipper_ingress_routes_urls: "http://skipper-ingress-routesrv.kube-system.svc.cluster.local/routes"
+
 
 # When set to true (and dedicated node pool for skipper is also true) the
 # daemonset overhead will be subtracted from the cpu settings such

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -86,15 +86,6 @@ post_apply:
   kind: Deployment
 {{ end }}
 
-{{ if eq .Cluster.ConfigItems.skipper_routesrv_enabled "false" }}
-- name: skipper-ingress-routesrv
-  namespace: kube-system
-  kind: Deployment
-- name: skipper-ingress-routesrv
-  namespace: kube-system
-  kind: Service
-{{ end }}
-
 {{- if ne .Cluster.ConfigItems.skipper_oauth2_ui_login "true" }}
 - kind: CronJob
   name: hostname-credentials-controller

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -4,6 +4,10 @@ pre_apply:
 - name: deployment-service-controller
   kind: StatefulSet
   namespace: kube-system
+# we need to do this in order to re-create the deployment with different spec.selector
+- name: skipper-ingress-routesrv
+  namespace: kube-system
+  kind: Deployment
 {{- if eq .Cluster.ConfigItems.skipper_redis_cleanup_enabled "true" }}
 - kind: StatefulSet
   name: skipper-ingress-redis

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -4,10 +4,6 @@ pre_apply:
 - name: deployment-service-controller
   kind: StatefulSet
   namespace: kube-system
-# we need to do this in order to re-create the deployment with different spec.selector
-- name: skipper-ingress-routesrv
-  namespace: kube-system
-  kind: Deployment
 {{- if eq .Cluster.ConfigItems.skipper_redis_cleanup_enabled "true" }}
 - kind: StatefulSet
   name: skipper-ingress-redis
@@ -19,6 +15,19 @@ pre_apply:
 
 # everything defined under here will be deleted after applying the manifests
 post_apply:
+# we deploy skipper-ingress-routesrv2 and need to delete the old
+# routesrv deployment in order to change the spec.selector. In a
+# second step we will rename it back to without 2, deleting the
+# deployments with "2"
+- name: skipper-ingress-routesrv
+  namespace: kube-system
+  kind: Deployment
+# - name: skipper-ingress-routesrv2
+#   namespace: kube-system
+#   kind: Deployment
+# - name: skipper-ingress-canary-routesrv2
+#   namespace: kube-system
+#   kind: Deployment
 {{- if eq .Cluster.Provider "zalando-eks"}}
 - name: coredns
   kind: Deployment

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -611,7 +611,7 @@ spec:
           - "-address=:9990"
           - "-wait-for-healthcheck-interval={{ .Cluster.ConfigItems.skipper_wait_for_healthcheck_interval }}"
           - "-kubernetes-east-west-range-domains=ingress.cluster.local"
-          - '-kubernetes-east-west-range-predicates=ClientIP("{{ $cluster_internal_cidrs | join `","` }}")'
+          - '-kubernetes-east-west-range-predicates=ClientIP("{{ .cluster_internal_cidrs | join `","` }}")'
           - '-kubernetes-annotation-predicates={{ .Cluster.ConfigItems.skipper_kubernetes_annotation_predicates }}'
           - '-kubernetes-annotation-filters-append={{ .Cluster.ConfigItems.skipper_kubernetes_annotation_filters_append }}'
           - '-kubernetes-east-west-range-annotation-predicates={{ .Cluster.ConfigItems.skipper_kubernetes_east_west_range_annotation_predicates }}'
@@ -635,7 +635,7 @@ spec:
 {{ end }}
 {{ if or (eq .Cluster.ConfigItems.nlb_switch "pre") (eq .Cluster.ConfigItems.nlb_switch "exec") }}
           - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
-          - '-forwarded-headers-exclude-cidrs={{ $cluster_internal_cidrs | join "," }}'
+          - '-forwarded-headers-exclude-cidrs={{ .cluster_internal_cidrs | join "," }}'
 {{ end }}
           - >-
             -opentracing=lightstep

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -3,14 +3,14 @@
 {{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.24.86-1417" }}
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.24.86-1417" }}
 
-{{ $routesrv_main_version := index (split (index (split $main_image_updated_manually ":") 1) "-") 0 }}
-{{ $routesrv_canary_version := index (split (index (split $canary_image ":") 1) "-") 0 }}
-{{ $routesrv_image_without_tag := "container-registry.zalando.net/teapot/skipper" }}
-
 {{/* Allow to override manually canary image by config item */}}
 {{ if ne .Cluster.ConfigItems.skipper_ingress_canary_image "" }}
 {{ $canary_image = .Cluster.ConfigItems.skipper_ingress_canary_image }}
 {{ end }}
+
+{{ $routesrv_main_version := index (split (index (split $main_image_updated_manually ":") 1) "-") 0 }}
+{{ $routesrv_canary_version := index (split (index (split $canary_image ":") 1) "-") 0 }}
+{{ $routesrv_image_without_tag := "container-registry.zalando.net/teapot/skipper" }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}
 {{ $canary_args := "" }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -233,7 +233,7 @@ spec:
           - "-enable-copy-stream-pool={{ .Cluster.ConfigItems.skipper_copy_stream_pool_enabled }}"
           - "-validate-query={{ .Cluster.ConfigItems.skipper_validate_query }}"
           - "-validate-query-log={{ .Cluster.ConfigItems.skipper_validate_query_log }}"
-          - '-routes-urls="{{ .routes_urls }}"'
+          - "-routes-urls={{ .routes_urls }}"
           - "-normalize-host"
           - "-address=:9999"
           - "-wait-first-route-load"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -3,6 +3,9 @@
 {{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.24.86-1417" }}
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.24.86-1417" }}
 
+{{ $routesrv_main_version := index (split (index (split $main_image_updated_manually ":") 1) "-") 0 }}
+{{ $routesrv_canary_version := index (split (index (split $canary_image ":") 1) "-") 0 }}
+
 {{/* Allow to override manually canary image by config item */}}
 {{ if ne .Cluster.ConfigItems.skipper_ingress_canary_image "" }}
 {{ $canary_image = .Cluster.ConfigItems.skipper_ingress_canary_image }}
@@ -23,6 +26,7 @@
 {{ template "skipper-ingress" dict
   "name" "skipper-ingress"
   "image" $main_image_updated_manually
+  "routesrv_image": $routesrv_main_version
   "routes_urls" .Cluster.ConfigItems.skipper_ingress_routes_urls
 
   "Cluster" .Cluster
@@ -35,6 +39,7 @@
 {{ template "skipper-ingress" dict
   "name" "skipper-ingress-canary"
   "image" $canary_image
+  "routesrv_image": $routesrv_canary_version
   "replicas" 1
   "args" $canary_args
   "routes_urls" .Cluster.ConfigItems.skipper_ingress_canary_routes_urls
@@ -583,7 +588,7 @@ spec:
 {{- end }}
       containers:
       - name: routesrv
-        image: {{ .image }}
+        image: {{ .routesrv_image }}
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - name: ingress-port
@@ -648,9 +653,9 @@ spec:
             tag=account={{ .Cluster.Alias }}
             tag=cluster={{ .Cluster.Alias }}
             tag=k8s.cluster.name={{ .Cluster.Alias }}
-            tag=artifact={{ .image }}
-            tag=container.image.name={{ index (split .image ":") 0 }}
-            tag=container.image.tags={{ index (split .image ":") 1 }}
+            tag=artifact={{ .routesrv_image }}
+            tag=container.image.name={{ index (split .routesrv_image ":") 0 }}
+            tag=container.image.tags={{ index (split .routesrv_image ":") 1 }}
             tag=k8s.pod.name=$(POD_NAME)
             tag=cloud.availability_zone=$(KUBE_NODE_ZONE)
             max-buffered-spans={{ .Cluster.ConfigItems.skipper_ingress_tracing_buffer }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,6 +5,7 @@
 
 {{ $routesrv_main_version := index (split (index (split $main_image_updated_manually ":") 1) "-") 0 }}
 {{ $routesrv_canary_version := index (split (index (split $canary_image ":") 1) "-") 0 }}
+{{ $routesrv_image_without_tag := "container-registry.zalando.net/teapot/skipper:" }}
 
 {{/* Allow to override manually canary image by config item */}}
 {{ if ne .Cluster.ConfigItems.skipper_ingress_canary_image "" }}
@@ -26,7 +27,8 @@
 {{ template "skipper-ingress" dict
   "name" "skipper-ingress"
   "image" $main_image_updated_manually
-  "routesrv_image" $routesrv_main_version
+  "routesrv_image" $routesrv_image_without_tag
+  "routesrv_version" $routesrv_main_version
   "routes_urls" .Cluster.ConfigItems.skipper_ingress_routes_urls
 
   "Cluster" .Cluster
@@ -39,7 +41,8 @@
 {{ template "skipper-ingress" dict
   "name" "skipper-ingress-canary"
   "image" $canary_image
-  "routesrv_image" $routesrv_canary_version
+  "routesrv_image" $routesrv_image_without_tag
+  "routesrv_version" $routesrv_canary_version
   "replicas" 1
   "args" $canary_args
   "routes_urls" .Cluster.ConfigItems.skipper_ingress_canary_routes_urls
@@ -588,7 +591,7 @@ spec:
 {{- end }}
       containers:
       - name: routesrv
-        image: {{ .routesrv_image }}
+        image: {{ print .routesrv_image ":" .routesrv_version }}
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - name: ingress-port
@@ -653,9 +656,9 @@ spec:
             tag=account={{ .Cluster.Alias }}
             tag=cluster={{ .Cluster.Alias }}
             tag=k8s.cluster.name={{ .Cluster.Alias }}
-            tag=artifact={{ .routesrv_image }}
-            tag=container.image.name={{ index (split .routesrv_image ":") 0 }}
-            tag=container.image.tags={{ index (split .routesrv_image ":") 1 }}
+            tag=artifact={{ print .routesrv_image ":" .routesrv_version }}
+            tag=container.image.name={{ .routesrv_image }}
+            tag=container.image.tags={{ .routesrv_version }}
             tag=k8s.pod.name=$(POD_NAME)
             tag=cloud.availability_zone=$(KUBE_NODE_ZONE)
             max-buffered-spans={{ .Cluster.ConfigItems.skipper_ingress_tracing_buffer }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -26,7 +26,7 @@
 {{ template "skipper-ingress" dict
   "name" "skipper-ingress"
   "image" $main_image_updated_manually
-  "routesrv_image": $routesrv_main_version
+  "routesrv_image" $routesrv_main_version
   "routes_urls" .Cluster.ConfigItems.skipper_ingress_routes_urls
 
   "Cluster" .Cluster
@@ -39,7 +39,7 @@
 {{ template "skipper-ingress" dict
   "name" "skipper-ingress-canary"
   "image" $canary_image
-  "routesrv_image": $routesrv_canary_version
+  "routesrv_image" $routesrv_canary_version
   "replicas" 1
   "args" $canary_args
   "routes_urls" .Cluster.ConfigItems.skipper_ingress_canary_routes_urls

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -532,14 +532,16 @@ metadata:
     version: "{{ .routesrv_version }}"
     component: routesrv
 spec:
+{{ if index . "replicas" }}
+  replicas: {{ .replicas }}
+{{ end }}
   strategy:
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 0
   selector:
     matchLabels:
-      application: skipper-ingress
-      component: routesrv
+      deployment: "{{ .name }}-routesrv"
   template:
     metadata:
       labels:

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -525,7 +525,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "{{ .name }}-routesrv"
+  name: "{{ .name }}-routesrv2"
   namespace: kube-system
   labels:
     application: skipper-ingress
@@ -541,11 +541,11 @@ spec:
       maxUnavailable: 0
   selector:
     matchLabels:
-      deployment: "{{ .name }}-routesrv"
+      deployment: "{{ .name }}-routesrv2"
   template:
     metadata:
       labels:
-        deployment: "{{ .name }}-routesrv"
+        deployment: "{{ .name }}-routesrv2"
         application: skipper-ingress
         version: "{{ .routesrv_version }}"
         component: routesrv
@@ -568,7 +568,7 @@ spec:
           whenUnsatisfiable: DoNotSchedule
           labelSelector:
             matchLabels:
-              deployment: "{{ .name }}-routesrv"
+              deployment: "{{ .name }}-routesrv2"
 {{- end }}
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       serviceAccountName: skipper-ingress-routesrv

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -34,7 +34,6 @@
   "Cluster" .Cluster
   "Values" .Values
   "cluster_internal_cidrs" $cluster_internal_cidrs
-  "local_routes_url" $main_routes_url
 }}
 
 {{ if eq .Cluster.ConfigItems.skipper_ingress_canary_enabled "true" }}
@@ -50,7 +49,6 @@
   "Cluster" .Cluster
   "Values" .Values
   "cluster_internal_cidrs" $cluster_internal_cidrs
-  "local_routes_url" $canary_routes_url
 }}
 {{ end }}
 

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,7 +5,7 @@
 
 {{ $routesrv_main_version := index (split (index (split $main_image_updated_manually ":") 1) "-") 0 }}
 {{ $routesrv_canary_version := index (split (index (split $canary_image ":") 1) "-") 0 }}
-{{ $routesrv_image_without_tag := "container-registry.zalando.net/teapot/skipper:" }}
+{{ $routesrv_image_without_tag := "container-registry.zalando.net/teapot/skipper" }}
 
 {{/* Allow to override manually canary image by config item */}}
 {{ if ne .Cluster.ConfigItems.skipper_ingress_canary_image "" }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -10,7 +10,6 @@
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}
 {{ $canary_args := "" }}
-{{ end }}
 
 {{ $cluster_internal_cidrs := list "10.2.0.0/15" .Values.vpc_ipv4_cidr }}
 {{ if eq .Cluster.Provider "zalando-eks" }}
@@ -24,6 +23,7 @@
 {{ template "skipper-ingress" dict
   "name" "skipper-ingress"
   "image" $main_image_updated_manually
+  "routes_urls" .Cluster.ConfigItems.skipper_ingress_routes_urls
 
   "Cluster" .Cluster
   "Values" .Values
@@ -37,6 +37,7 @@
   "image" $canary_image
   "replicas" 1
   "args" $canary_args
+  "routes_urls" .Cluster.ConfigItems.skipper_ingress_canary_routes_urls
 
   "Cluster" .Cluster
   "Values" .Values
@@ -226,7 +227,7 @@ spec:
           - "-enable-copy-stream-pool={{ .Cluster.ConfigItems.skipper_copy_stream_pool_enabled }}"
           - "-validate-query={{ .Cluster.ConfigItems.skipper_validate_query }}"
           - "-validate-query-log={{ .Cluster.ConfigItems.skipper_validate_query_log }}"
-          - "-routes-urls={{ .Cluster.ConfigItems.skipper_ingress_routes_url }}"
+          - '-routes-urls="{{ .routes_urls }}"'
           - "-normalize-host"
           - "-address=:9999"
           - "-wait-first-route-load"

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -10,11 +10,6 @@
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}
 {{ $canary_args := "" }}
-
-{{ $main_routes_url := .Cluster.ConfigItems.skipper_routes_url }}
-{{ $canary_routes_url := .Cluster.ConfigItems.skipper_routes_url }}
-{{ if ne .Cluster.ConfigItems.skipper_canary_routes_url "" }}
-{{ $canary_routes_url = .Cluster.ConfigItems.skipper_canary_routes_url }}
 {{ end }}
 
 {{ $cluster_internal_cidrs := list "10.2.0.0/15" .Values.vpc_ipv4_cidr }}
@@ -231,30 +226,11 @@ spec:
           - "-enable-copy-stream-pool={{ .Cluster.ConfigItems.skipper_copy_stream_pool_enabled }}"
           - "-validate-query={{ .Cluster.ConfigItems.skipper_validate_query }}"
           - "-validate-query-log={{ .Cluster.ConfigItems.skipper_validate_query_log }}"
-{{ if eq .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
-          - "-routes-urls={{ .local_routes_url }}"
+          - "-routes-urls={{ .Cluster.ConfigItems.skipper_ingress_routes_url }}"
           - "-normalize-host"
-{{ else }}
-          - "-kubernetes"
-          - "-kubernetes-in-cluster"
-          - "-kubernetes-healthcheck=false" # see -inline-routes
-          - "-kubernetes-path-mode=path-prefix"
-          - "-kubernetes-backend-traffic-algorithm={{ .Cluster.ConfigItems.skipper_ingress_backend_traffic_algorithm }}"
-          - "-kubernetes-default-lb-algorithm={{ .Cluster.ConfigItems.skipper_ingress_default_lb_algorithm }}"
-          - "-kubernetes-disable-catchall-routes={{ .Cluster.ConfigItems.skipper_ingress_disable_catchall_routes }}"
-          - "-enable-kubernetes-endpointslices={{ .Cluster.ConfigItems.skipper_endpointslices_enabled }}"
-{{ end }}
           - "-address=:9999"
           - "-wait-first-route-load"
           - "-wait-for-healthcheck-interval={{ .Cluster.ConfigItems.skipper_wait_for_healthcheck_interval }}"
-{{ if ne .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
-          - "-kubernetes-east-west-range-domains=ingress.cluster.local"
-          - '-kubernetes-east-west-range-predicates=ClientIP("{{ .cluster_internal_cidrs | join `","` }}")'
-          - '-kubernetes-annotation-predicates={{ .Cluster.ConfigItems.skipper_kubernetes_annotation_predicates }}'
-          - '-kubernetes-annotation-filters-append={{ .Cluster.ConfigItems.skipper_kubernetes_annotation_filters_append }}'
-          - '-kubernetes-east-west-range-annotation-predicates={{ .Cluster.ConfigItems.skipper_kubernetes_east_west_range_annotation_predicates }}'
-          - '-kubernetes-east-west-range-annotation-filters-append={{ .Cluster.ConfigItems.skipper_kubernetes_east_west_range_annotation_filters_append }}'
-{{ end }}
           - "-enable-kubernetes-external-names={{ .Cluster.ConfigItems.skipper_externalname_service_enabled }}"
           - "-proxy-preserve-host"
           - "-compress-encodings={{ .Cluster.ConfigItems.skipper_compress_encodings }}"
@@ -282,9 +258,6 @@ spec:
           - "-enable-api-usage-monitoring"
           - "-api-usage-monitoring-realm-keys=https://identity.zalando.com/realm"
           - "-api-usage-monitoring-client-keys=https://identity.zalando.com/managed-id,sub"
-{{ if ne .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
-          - "-default-filters-dir=/etc/config/default-filters"
-{{ end }}
           - "-max-audit-body=0"
           - "-enable-swarm"
           - "-cluster-ratelimit-max-group-shards={{ .Cluster.ConfigItems.skipper_cluster_ratelimit_max_group_shards }}"
@@ -344,16 +317,6 @@ spec:
           - "-enable-lua={{ .Cluster.ConfigItems.skipper_lua_scripts_enabled }}"
           - "-lua-sources={{ .Cluster.ConfigItems.skipper_lua_sources }}"
           - "-disabled-filters={{ .Cluster.ConfigItems.skipper_disabled_filters }}"
-{{ if ne .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
-          - '-default-filters-prepend={{ .Cluster.ConfigItems.skipper_default_filters }}'
-          - '-default-filters-append={{ .Cluster.ConfigItems.skipper_default_filters_authentication }}'
-          - '-default-filters-append={{ .Cluster.ConfigItems.skipper_default_filters_append }}'
-  {{ if .Cluster.ConfigItems.skipper_edit_route_placeholders }}
-          {{ range $placeholder := split .Cluster.ConfigItems.skipper_edit_route_placeholders "[cf724afc]" }}
-          - '-edit-route={{ $placeholder }}'
-          {{ end }}
-  {{ end }}
-{{ end }}
           - "-suppress-route-update-logs={{ .Cluster.ConfigItems.skipper_suppress_route_update_logs }}"
 {{ if eq .Cluster.ConfigItems.skipper_enable_tcp_queue "true" }}
           - "-enable-tcp-queue"
@@ -494,10 +457,6 @@ spec:
           - name: routes
             mountPath: /etc/routes
 {{ end }}
-{{ if ne .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
-          - name: filters
-            mountPath: /etc/config/default-filters
-{{ end }}
 {{ if eq .Cluster.ConfigItems.skipper_lua_scripts_enabled "true" }}
           - name: lua
             mountPath: /etc/skipper/lua
@@ -523,12 +482,6 @@ spec:
         - name: routes
           configMap:
             name: sandbox-tokeninfo-bridge-conf
-{{ end }}
-{{ if ne .Cluster.ConfigItems.skipper_routesrv_enabled "exec" }}
-        - name: filters
-          configMap:
-            name: skipper-default-filters
-            optional: true
 {{ end }}
 {{ if eq .Cluster.ConfigItems.skipper_lua_scripts_enabled "true" }}
         - name: lua
@@ -560,19 +513,16 @@ spec:
         key: dedicated
         value: skipper-ingress
 {{ end }}
-{{ end }}
 
-{{ if ne .Cluster.ConfigItems.skipper_routesrv_enabled "false" }}
-{{ $main_version := index (split (index (split $main_image_updated_manually ":") 1) "-") 0 }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: skipper-ingress-routesrv
+  name: "{{ .name }}-routesrv"
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: "{{ $main_version }}"
+    version: "{{ $version }}"
     component: routesrv
 spec:
   strategy:
@@ -586,9 +536,9 @@ spec:
   template:
     metadata:
       labels:
-        deployment: skipper-ingress-routesrv
+        deployment: "{{ .name }}-routesrv"
         application: skipper-ingress
-        version: "{{ $main_version }}"
+        version: "{{ $version }}"
         component: routesrv
       annotations:
         config/hash: {{"secret.yaml" | manifestHash}}
@@ -609,7 +559,7 @@ spec:
           whenUnsatisfiable: DoNotSchedule
           labelSelector:
             matchLabels:
-              deployment: skipper-ingress-routesrv
+              deployment: "{{ .name }}-routesrv"
 {{- end }}
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       serviceAccountName: skipper-ingress-routesrv
@@ -632,7 +582,7 @@ spec:
 {{- end }}
       containers:
       - name: routesrv
-        image: container-registry.zalando.net/teapot/skipper:{{ $main_version }}
+        image: {{ .image }}
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - name: ingress-port
@@ -696,7 +646,12 @@ spec:
             tag=component=routesrv
             tag=account={{ .Cluster.Alias }}
             tag=cluster={{ .Cluster.Alias }}
-            tag=artifact=container-registry.zalando.net/teapot/skipper:{{ $main_version }}
+            tag=k8s.cluster.name={{ .Cluster.Alias }}
+            tag=artifact={{ .image }}
+            tag=container.image.name={{ index (split .image ":") 0 }}
+            tag=container.image.tags={{ index (split .image ":") 1 }}
+            tag=k8s.pod.name=$(POD_NAME)
+            tag=cloud.availability_zone=$(KUBE_NODE_ZONE)
             max-buffered-spans={{ .Cluster.ConfigItems.skipper_ingress_tracing_buffer }}
             grpc-max-msg-size={{ .Cluster.ConfigItems.skipper_ingress_lightstep_grpc_max_msg_size }}
             max-period=2500ms
@@ -707,6 +662,14 @@ spec:
             propagators={{ .Cluster.ConfigItems.skipper_ingress_lightstep_propagators }}
             {{ .Cluster.ConfigItems.skipper_ingress_lightstep_log_events }}
         env:
+        - name: KUBE_NODE_ZONE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['topology.kubernetes.io/zone']
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: LIGHTSTEP_TOKEN
           valueFrom:
             secretKeyRef:

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -529,7 +529,7 @@ metadata:
   namespace: kube-system
   labels:
     application: skipper-ingress
-    version: "{{ $version }}"
+    version: "{{ .routesrv_version }}"
     component: routesrv
 spec:
   strategy:
@@ -545,7 +545,7 @@ spec:
       labels:
         deployment: "{{ .name }}-routesrv"
         application: skipper-ingress
-        version: "{{ $version }}"
+        version: "{{ .routesrv_version }}"
         component: routesrv
       annotations:
         config/hash: {{"secret.yaml" | manifestHash}}

--- a/cluster/manifests/skipper/routesrv-canary-service.yaml
+++ b/cluster/manifests/skipper/routesrv-canary-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: skipper-ingress-routesrv
+  name: skipper-ingress-canary-routesrv
   namespace: kube-system
   labels:
     application: skipper-ingress
@@ -14,4 +14,4 @@ spec:
       targetPort: 9990
       protocol: TCP
   selector:
-    deployment: skipper-ingress-routesrv
+    deployment: skipper-ingress-canary-routesrv

--- a/cluster/manifests/skipper/routesrv-canary-service.yaml
+++ b/cluster/manifests/skipper/routesrv-canary-service.yaml
@@ -14,4 +14,4 @@ spec:
       targetPort: 9990
       protocol: TCP
   selector:
-    deployment: skipper-ingress-canary-routesrv
+    deployment: skipper-ingress-canary-routesrv2

--- a/cluster/manifests/skipper/routesrv-service.yaml
+++ b/cluster/manifests/skipper/routesrv-service.yaml
@@ -14,4 +14,4 @@ spec:
       targetPort: 9990
       protocol: TCP
   selector:
-    deployment: skipper-ingress-routesrv
+    deployment: skipper-ingress-routesrv2


### PR DESCRIPTION
feature: routes-urls parameter can simply change for skipper-ingress and skipper-ingress-canary
feature: add routesrv canary to serve only skipper-ingress-canary
fix: version miss match between data-plane and control-plane
feature: copy OTel tags from data-plane to control-plane
refactor: drop the routesrv enable/disable flags to reduce complexity
    
