### PR TITLE
Disable poweruser networkpolicy access by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1328,6 +1328,10 @@ role_sync_controller_enabled: "false"
 # Enable users with the poweruser role to modify EndpointSlices.
 access_control_poweruser_modify_endpointslices: "false"
 
+# Enable users with the poweruser role to modify NetworkPolicies. This is a
+# potentially dangerous permission, so it is disabled by default.
+access_control_poweruser_modify_networkpolicies: "false"
+
 #Wiz Configs
 # When wiz_enable_runtime_sensor and wiz_enable_runtime_connector are set to true,
 # this enables WIZ runtime monitoring. A DaemonSet called Sensor and a Deployment

--- a/cluster/manifests/roles/poweruser-role.yaml
+++ b/cluster/manifests/roles/poweruser-role.yaml
@@ -174,7 +174,9 @@ rules:
   - networking.k8s.io
   resources:
   - ingresses
+{{- if eq .Cluster.ConfigItems.access_control_poweruser_modify_networkpolicies "true" }}
   - networkpolicies
+{{- end }}
   verbs:
   - create
   - delete


### PR DESCRIPTION
By default PowerUsers should not have access to crea/temodify networkpolicies. Put it behind a config-item to allow us to enable it per cluster e.g. in some test clusters where users want to explore the feature.

This is only relevant for EKS and only when: `aws_vpc_cni_enable_network_policy: true`