### PR TITLE
Inject default do-not-disrupt grace-period in pods

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -802,6 +802,11 @@ teapot_admission_controller_runtime_policy_spot_hard_assignment: "false"
 
 # Enable and configure prevent scale down annotation
 teapot_admission_controller_prevent_scale_down_enabled: "true"
+{{if eq .Cluster.Environment "production"}}
+teapot_admission_controller_prevent_scale_down_grace_period_default: "30m"
+{{else}}
+teapot_admission_controller_prevent_scale_down_grace_period_default: "15m"
+{{end}}
 {{if or (eq .Cluster.Environment "production") (eq .Cluster.Environment "e2e")}}
 teapot_admission_controller_prevent_scale_down_allowed: "true"
 {{else}}

--- a/cluster/manifests/02-admission-control/config.yaml
+++ b/cluster/manifests/02-admission-control/config.yaml
@@ -223,4 +223,6 @@ data:
   pod.prevent-scale-down.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_prevent_scale_down_enabled }}"
   pod.prevent-scale-down.allowed: "{{ .Cluster.ConfigItems.teapot_admission_controller_prevent_scale_down_allowed }}"
 
+  pod.prevent-scale-down.grace-period-default: "{{ .Cluster.ConfigItems.teapot_admission_controller_prevent_scale_down_grace_period_default }}"
+
   pod.graceful-termination.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_graceful_termination }}"

--- a/cluster/manifests/02-admission-control/deployment.yaml
+++ b/cluster/manifests/02-admission-control/deployment.yaml
@@ -49,7 +49,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
       - name: admission-controller
-        image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-309
+        image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-310
         lifecycle:
           preStop:
             sleep:

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -216,7 +216,7 @@ write_files:
             limits:
               memory: {{ .Values.InstanceInfo.MemoryFraction (parseInt64 .Cluster.ConfigItems.apiserver_memory_limit_percent)}}
 {{- end }}
-        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-309
+        - image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/admission-controller:master-310
           name: admission-controller
           lifecycle:
             preStop:


### PR DESCRIPTION
### Description

<!-- Describe the purpose and goal of this pull request, as well as the set of changes
     (supported by examples and images) in a few sentences or bullet points to guide the
     reviewer. If this section becomes to long consider splitting the pull request. -->

This implement automatic injection of an annotation `karpenter.sh/do-not-disrupt: "30m"` when `pod.prevent-scale-down.grace-period-default: 30m` is set and none of the following conditions are true:

* Pod is a CronJob pod (gets `karpenter.sh/do-not-disrupt: "true"`)
* Pod is orphaned (gets `karpenter.sh/do-not-disrupt: "true"`)
* Pod has `zalando.org/prevent-scale-down: "true"` set (gets `karpenter.sh/do-not-disrupt: "true"`)
* Target node pools are not Karpenter (currently only implemented for this)

The idea is that all pods get this by default which essentially ensures a minimum runtime of that grace-period before they can be disrupted.
This uses a feature introduced in [Karpenter v1.12.0](https://github.com/kubernetes-sigs/karpenter/releases/tag/v1.12.0)

If users attempt to set a custom value of e.g `karpenter.sh/do-not-disrupt: "1h"` it will be rejected as we don't allow users to set a value themselves.

The value is set to 30m in production and 15m in test for now.
