### PR TITLE
Run node DNS with static interface [1/4]

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1062,12 +1062,23 @@ external_dns_mem: "4Gi"
 expirimental_dns_unbound_liveness_probe: "true"
 
 # DNS container resources
-dns_unbound_cpu: "100m"
-dns_unbound_mem: "50Mi"
-dns_unbound_exporter_cpu: "10m"
-dns_unbound_exporter_mem: "45Mi"
-dns_coredns_cpu: "50m"
-dns_coredns_mem: "100Mi"
+dns_coredns_cpu: "160m"
+dns_coredns_mem: "195Mi"
+
+# Roll out of static dns interface
+#
+# The rollout needs to be in multiple stages to avoid disruption of node local
+# DNS. Each stage must fully complete i.e. all CoreDNS pods must rotate (thus
+# all nodes must rotate) before going to the next stage.
+#
+# stages:
+#
+#  interface - static interface container runs
+#  listening - dns cache listens to static interface
+#  kubelet - kubelet configures static dns IP address - worker node rotation!
+#  only_interface - dns cache listens _only_ on the static interface
+#
+dns_static_interface: "interface"
 
 # special roles for test/pet clusters
 {{if eq .Cluster.Environment "e2e"}}

--- a/cluster/manifests/01-coredns-local/configmap-local.yaml
+++ b/cluster/manifests/01-coredns-local/configmap-local.yaml
@@ -11,11 +11,23 @@ data:
     server:
       directory: "/etc/unbound/"
 {{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6") }}
+{{- if ne .Cluster.ConfigItems.dns_static_interface "only_interface" }}
       interface: "::0"
+{{- end }}
+{{- if ne .Cluster.ConfigItems.dns_static_interface "interface" }}
+      interface: "fd00:1:2:3::5"
+{{- end }}
 {{- else }}
+{{- if ne .Cluster.ConfigItems.dns_static_interface "only_interface" }}
       interface: 0.0.0.0
 {{- end }}
+{{- if ne .Cluster.ConfigItems.dns_static_interface "interface" }}
+      interface: 169.254.20.10
+{{- end }}
+{{- end }}
+{{- if ne .Cluster.ConfigItems.dns_static_interface "only_interface" }}
       interface-automatic: yes
+{{- end }}
       # Drop user privileges after binding the port.
       username: "_unbound"
       # Prevent the unbound server from forking into the background as a daemon
@@ -25,6 +37,8 @@ data:
       log-servfail: yes
       # allow query localhost (coredns at 127.0.0.1:9254)
       do-not-query-localhost: no
+      so-sndbuf: 0
+      so-rcvbuf: 0
 {{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6") }}
       access-control: ::/0 allow
 {{- else }}

--- a/cluster/manifests/01-coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/01-coredns-local/daemonset-coredns.yaml
@@ -25,18 +25,38 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9153"
     spec:
+      resources:
+        limits:
+          cpu: {{.Cluster.ConfigItems.dns_coredns_cpu}}
+          memory: {{.Cluster.ConfigItems.dns_coredns_mem}}
       terminationGracePeriodSeconds: 40
       initContainers:
       - name: ensure-apiserver
         image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/ensure-apiserver:master-6
         resources:
           requests:
-            cpu: 1m
-            memory: 50Mi
             ephemeral-storage: 256Mi
-          limits:
-            cpu: 1m
-            memory: 50Mi
+{{- if ne .Cluster.ConfigItems.dns_static_interface "" }}
+      - name: static-interface
+        image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/cloud-platform/dnscache-interface:main-1
+        restartPolicy: Always
+        args:
+        - --local-ip
+{{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6") }}
+        - "fd00:1:2:3::5"
+{{- else }}
+        - "169.254.20.10"
+{{- end }}
+        - --local-port
+        - "53"
+        resources:
+          requests:
+            ephemeral-storage: 256Mi
+        securityContext:
+          capabilities:
+            add:
+              - NET_ADMIN
+{{- end }}
       containers:
       - name: unbound
         image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/teapot/unbound:1.25.1-master-19
@@ -58,9 +78,17 @@ spec:
             - dig
             - "+short"
 {{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6") }}
+{{- if ne .Cluster.ConfigItems.dns_static_interface "interface" }}
+            - "@fd00:1:2:3::5"
+{{- else }}
             - "@::1"
+{{- end }}
+{{- else }}
+{{- if ne .Cluster.ConfigItems.dns_static_interface "interface" }}
+            - "@169.254.20.10"
 {{- else }}
             - "@127.0.0.1"
+{{- end }}
 {{- end }}
             - "kubernetes.default.svc.cluster.local"
           initialDelaySeconds: 60
@@ -74,9 +102,6 @@ spec:
         resources:
           requests:
             ephemeral-storage: 256Mi
-          limits:
-            cpu: {{.Cluster.ConfigItems.dns_unbound_cpu}}
-            memory: {{.Cluster.ConfigItems.dns_unbound_mem}}
         volumeMounts:
         - mountPath: /etc/unbound/unbound.conf
           name: config-volume
@@ -103,9 +128,6 @@ spec:
         resources:
           requests:
             ephemeral-storage: 256Mi
-          limits:
-            cpu: {{.Cluster.ConfigItems.dns_unbound_exporter_cpu}}
-            memory: {{.Cluster.ConfigItems.dns_unbound_exporter_mem}}
         volumeMounts:
         - mountPath: /run/unbound
           name: unbound-socket
@@ -149,9 +171,6 @@ spec:
         resources:
           requests:
             ephemeral-storage: 256Mi
-          limits:
-            cpu: {{.Cluster.ConfigItems.dns_coredns_cpu}}
-            memory: {{.Cluster.ConfigItems.dns_coredns_mem}}
         lifecycle:
           preStop:
             sleep:

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -37,6 +37,8 @@ spec:
         - name: controller
           image: "{{ $image }}"
           args:
+            - "--cluster-id={{.Cluster.ID}}"
+            - "--vpc-id={{.Cluster.ConfigItems.vpc_id}}"
             - --ip-addr-type={{ .Cluster.ConfigItems.kube_aws_ingress_controller_lb_ip_addr_type }}
             - --target-group-ip-addr-type={{ .Cluster.ConfigItems.kube_aws_ingress_controller_target_group_ip_addr_type }}
 {{- if eq .Cluster.ConfigItems.kube_aws_ingress_controller_nlb_preserve_client_ip "false" }}

--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -71,7 +71,11 @@ write_files:
 {{- end }}
       # variables are replaced on instance start-up.
       providerID: __PROVIDER_ID__
+{{- if or (eq .Cluster.ConfigItems.dns_static_interface "kubelet") (eq .Cluster.ConfigItems.dns_static_interface "only_interface") }}
+      clusterDNS: ["169.254.20.10"]
+{{- else }}
       clusterDNS: [__CLUSTER_DNS__]
+{{- end }}
       registerWithTaints:
         - key: node.kubernetes.io/role
           value: master

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -46,7 +46,11 @@ spec:
   # Karpenter provides the ability to specify a few additional Kubelet args.
   # These are all optional and provide support for additional customization and use cases.
   kubelet:
-    clusterDNS: [ "10.0.1.100" ]
+    # {{ if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6") }}
+    clusterDNS: ["fd00:1:2:3::5"]
+    # {{ else }}
+    clusterDNS: ["169.254.20.10"]
+    # {{ end }}
     cpuCFSQuota: false
 #{{ if ne .Cluster.Provider "zalando-eks" }}
 # {{ if ne .Cluster.ConfigItems.karpenter_max_pods_per_node "" }}

--- a/cluster/node-pools/worker-splitaz/userdata.yaml
+++ b/cluster/node-pools/worker-splitaz/userdata.yaml
@@ -132,7 +132,15 @@ write_files:
       protectKernelDefaults: true
       # variables are replaced on instance start-up.
       providerID: __PROVIDER_ID__
+{{- if or (eq .Cluster.ConfigItems.dns_static_interface "kubelet") (eq .Cluster.ConfigItems.dns_static_interface "only_interface") }}
+{{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6") }}
+      clusterDNS: ["fd00:1:2:3::5"]
+{{- else }}
+      clusterDNS: ["169.254.20.10"]
+{{- end }}
+{{- else }}
       clusterDNS: [__CLUSTER_DNS__]
+{{- end }}
 {{- if or (.NodePool.Taints) (eq .NodePool.Profile "worker-karpenter") }}
       registerWithTaints:
 {{- range $taint := .NodePool.Taints }}


### PR DESCRIPTION
## Problem

Today the per node DNScache+CoreDNS listens on 0.0.0.0/::0 and kubelet is dynamically configured to map the private IP of the node to the clusterDNS. This means the `/etc/resolve.conf` of the pods will point to the IP of the local node.

This dynamic setup puts a requirement of dynamically configuring kubelet on startup which is currently encoded in the custom AMI. This makes it more complicated to switch to another AMI without carrying over this complexity.

## Solution

Instead of using the _dynamic_ node IP we can simple define a static IP in the 'link-local' range '169.254.0.0/16' for IPv4 or from the 'Unique Local Address' range in IPv6 'fd00::/8'. This is inspired by how the [NodeLocal DNScache](https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/) is configured.
That way we can configure a static clusterDNS address for every AMI which is supported out of the box e.g. in EKS optimized AMIs/Karpenter.

To solve this, this PR introduces a sidecar container `dnscache-interface` to the CoreDNS daemonset pods. The purpose of this container is to setup a dummy interface and map a static IP to it which is then used for DNS.

Essentially the container does the equivalent of:

```bash
IFACE="dnscache"
IP="169.254.20.10"

ip link add ""$IFACE" type dummy
# Bring it up
ip link set "$IFACE" up
# Assign IP
ip addr add "$IP" dev "$IFACE"
```

Additionally the resources are changed from being per container in the daemonset pods, to be [at the pod level](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#pod-level-resource-specification) (Feature since Kubernetes v1.34). This simplifies the resource settings as the containers can just share the resources and we don't need to tweak per container. Likely we can reduce the default resources this way. For now the resources are just the sum of the previous per container resources, with the assumption that the new container, `dnscache-interface`, can simply use the spare resources already allocated, it does so little that it should not affect anything.

### Roll out

The CoreDNS daemonset pods are tied to the lifecycle of a node, because we can't just restart the pods without downtime of DNS. The implication of this design is that we need to roll the nodes in multiple stages in order to ensure a zero downtime roll out.

The roll out stages are as follows:

1. The new dnscache-interface container is enabled in the daemonset, this will setup the static interface on all new pods/nodes
2. The unbound (dnscache) config is changed to listen on both 0.0.0.0/::0 and the static ipaddress/interface. This ensures that kubelet still can connect to 0.0.0.0 which is required until the AMI/kubelet config is changed.
3. The AMI/Kubelet is updated to use the static ipaddress meaning DNS traffic will stop going over 0.0.0.0
4. 0.0.0.0/::0 is removed from the unbound (dnscache) config as it's no longer needed


### FAQ

#### Why not just use upstream NodeLocal DNScache?

The current DNS cache setup is based on extensive performance testing also comparing NodeLocal DNS cache where unbound + CoreDNS was the best performing setup in terms of latency and resource usage