### PR TITLE
Run node DNS with static interface [2/4]

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1078,7 +1078,7 @@ dns_coredns_mem: "195Mi"
 #  kubelet - kubelet configures static dns IP address - worker node rotation!
 #  only_interface - dns cache listens _only_ on the static interface
 #
-dns_static_interface: "interface"
+dns_static_interface: "listening"
 
 # special roles for test/pet clusters
 {{if eq .Cluster.Environment "e2e"}}


### PR DESCRIPTION
This is the second phase of the roll out described in #11216 

All clusters have the stage defined at cluster level so this will only affect e2e (and new clusters).