### PR TITLE
Run node DNS with static interface [3/4]

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1085,7 +1085,7 @@ dns_coredns_mem: "195Mi"
 #  kubelet - kubelet configures static dns IP address - worker node rotation!
 #  only_interface - dns cache listens _only_ on the static interface
 #
-dns_static_interface: "listening"
+dns_static_interface: "kubelet"
 
 # special roles for test/pet clusters
 {{if eq .Cluster.Environment "e2e"}}


### PR DESCRIPTION
This is the third phase of the roll out described in #11216 

* [x] Depends on https://github.com/zalando-incubator/kubernetes-on-aws/pull/11217 in stable