### PR TITLE
allow vpa-updater to patch event resource

### DIFF
--- a/cluster/manifests/02-vertical-pod-autoscaler/rbac.yaml
+++ b/cluster/manifests/02-vertical-pod-autoscaler/rbac.yaml
@@ -42,6 +42,7 @@ rules:
       - list
       - watch
       - create
+      - patch
   - apiGroups:
       - "poc.autoscaling.k8s.io"
     resources:


### PR DESCRIPTION
We have an error in reported by the VPA that it cannot patch the `events`, this extends the RBAC to allow that:

```golang
E0505 06:11:35.249053       1 event.go:359] "Server rejected event (will not retry!)" err="events \"external-dns-5b77d57b56-p8hln.18ac1b735f362e8b\" is forbidden: User \"system:serviceaccount:kube-system:vpa-updater\" cannot patch resource \"events\" in API group \"\" in the namespace \"kube-system\": access undecided system:serviceaccount:kube-system:vpa-updater/[system:serviceaccounts system:serviceaccounts:kube-system system:authenticated]" event="&Event{ObjectMeta:{external-dns-5b77d57b56-p8hln.18ac1b735f362e8b  kube-system   665190071 0 0001-01-01 00:00:00 +0000 UTC <nil> <nil> map[] map[] [] [] []},InvolvedObject:ObjectReference{Kind:Pod,Namespace:kube-system,Name:external-dns-5b77d57b56-p8hln,UID:630e6563-d2e5-4b5b-a0e9-3b147305fcfe,APIVersion:v1,ResourceVersion:667563618,FieldPath:,},Reason:InPlaceResizedByVPA,Message:Pod was resized in place by VPA Updater.,Source:EventSource{Component:vpa-updater,Host:,},FirstTimestamp:2026-05-03 16:35:35 +0000 UTC,LastTimestamp:2026-05-05 06:11:35.246995671 +0000 UTC m=+577680.658021441,Count:4,Type:Normal,EventTime:0001-01-01 00:00:00 +0000 UTC,Series:nil,Action:,Related:nil,ReportingController:vpa-updater,ReportingInstance:,}"
```