### PR TITLE
canary: image variable

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -5,7 +5,7 @@
 
 {{/* Allow to override manually canary image by config item */}}
 {{ if ne .Cluster.ConfigItems.skipper_ingress_canary_image "" }}
-{{ $canary_image := .Cluster.ConfigItems.skipper_ingress_canary_image }}
+{{ $canary_image = .Cluster.ConfigItems.skipper_ingress_canary_image }}
 {{ end }}
 
 {{/* Optional canary arguments separated by "[cf724afc]" to allow whitespaces, e.g. "-foo=has a whitespace[cf724afc]-baz=qux" */}}


### PR DESCRIPTION
tested with the local `render-with-aws-stups` cmd from CLM from https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/925

```sh
//before
➜ ./build/clm render-with-aws-stup --directory="./../kubernetes-on-aws" --configs-file="./../cluster-config-manager/clusters/pg9-euc1-test.yaml" --cluster-alias="pg9-euc1-test" | grep "image"
// no output means no file was changed

//after
➜ ./build/clm render-with-aws-stup --directory="./../kubernetes-on-aws" --configs-file="./../cluster-config-manager/clusters/pg9-euc1-test.yaml" --cluster-alias="pg9-euc1-test" | grep "image"
        image: my-image:latest
        image: container-registry.zalando.net/teapot/skipper:v0.24.80
```