### PR TITLE
Updates skipper-ingress main image to v0.24.86

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,6 +1,6 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.24.80-1412" }}
+{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.24.86-1417" }}
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.24.86-1417" }}
 
 {{/* Allow to override manually canary image by config item */}}


### PR DESCRIPTION
This image has the fix for the valkey timeout issue that the gift-cards cluster keep reporting few times.

 See https://github.com/zalando/skipper/compare/v0.24.80...v0.24.86 for all the changes that this image includes compared to the last main version.