### PR TITLE
add toggle to drop lightstep envar injection in admission-controller

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -707,6 +707,7 @@ teapot_admission_controller_max_ephemeral_storage_request: "5Gi"
 teapot_admission_controller_application_min_creation_time: "2019-06-03T12:00:00Z"
 teapot_admission_controller_ndots: "2"
 teapot_admission_controller_inject_environment_variables: "true"
+teapot_admission_controller_inject_lightstep_variables: "true"
 {{ if eq .Cluster.Environment "test" }}
 teapot_admission_controller_inject_node_options_environment_variable: "true"
 {{ else }}

--- a/cluster/manifests/02-admission-control/config.yaml
+++ b/cluster/manifests/02-admission-control/config.yaml
@@ -38,9 +38,11 @@ data:
   pod.env-inject.variable._PLATFORM_ACCOUNT: "{{ .Cluster.Alias }}"
   pod.env-inject.variable._PLATFORM_CLUSTER_ID: "{{ .Cluster.ID }}"
   pod.env-inject.variable._PLATFORM_OPENTRACING_TAG_ACCOUNT: "{{ .Cluster.Alias }}"
+{{- if eq .Cluster.ConfigItems.teapot_admission_controller_inject_lightstep_variables "true" }}
   pod.env-inject.variable._PLATFORM_OPENTRACING_LIGHTSTEP_COLLECTOR_PORT: "8443"
   pod.env-inject.variable._PLATFORM_OPENTRACING_LIGHTSTEP_COLLECTOR_HOST: "{{ .Cluster.ConfigItems.tracing_collector_host }}"
   pod.env-inject.variable._PLATFORM_OPENTRACING_LIGHTSTEP_ACCESS_TOKEN: "{{ .Cluster.ConfigItems.lightstep_token }}"
+{{- end }}
   pod.env-inject.variable._PLATFORM_OBSERVABILITY_COLLECTOR_ENDPOINT: "{{ .Cluster.ConfigItems.observability_collector_endpoint }}"
   pod.env-inject.variable._PLATFORM_OBSERVABILITY_COLLECTOR_PORT: "{{ .Cluster.ConfigItems.observability_collector_port }}"
   pod.env-inject.variable._PLATFORM_OBSERVABILITY_COLLECTOR_SCHEME: "{{ .Cluster.ConfigItems.observability_collector_scheme }}"


### PR DESCRIPTION
As we are decommissioning lightstep, we need to drop this environment variable injection in the admission-controller. 

This PR introduces a toggle with the default behavior of injection allowed. In a follow-up, we can adjust the e2e tests to drop checking for injection of these variables.