### PR TITLE
new vpa version with config-item

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -666,10 +666,10 @@ horizontal_pod_downscale_stabilization: "5m0s"
 # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#tolerance
 horizontal_pod_autoscaler_configurable_tolerance: "false"
 
-# Vertical pod autoscaler version for controlling roll-out, can be "current" or "legacy"
-# current => v1.0.0-internal.20
-# legacy => v0.12.0-internal.19
-vertical_pod_autoscaler_version: "current"
+# Vertical pod autoscaler version for controlling roll-out, can be "new" or "stable"
+# new => v1.6.0-main-13-custom
+# stable => v1.6.0-main-12-custom
+vertical_pod_autoscaler_version: "stable"
 
 # Cluster update settings
 {{if eq .Cluster.Environment "production"}}

--- a/cluster/manifests/02-vertical-pod-autoscaler/admission-controller-deployment.yaml
+++ b/cluster/manifests/02-vertical-pod-autoscaler/admission-controller-deployment.yaml
@@ -25,10 +25,10 @@ spec:
       serviceAccountName: vpa-admission-controller
       containers:
       - name: admission-controller
-        {{if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "current"}}
+        {{if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "new"}}
+        image: container-registry.zalando.net/teapot/vpa-admission-controller:v1.6.0-main-13-custom
+        {{else if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "stable"}}
         image: container-registry.zalando.net/teapot/vpa-admission-controller:v1.6.0-main-12-custom
-        {{else if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "legacy"}}
-        image: container-registry.zalando.net/teapot/vpa-admission-controller:v1.5.1-main-11-custom
         {{end}}
         command:
           - /admission-controller

--- a/cluster/manifests/02-vertical-pod-autoscaler/recommender-deployment.yaml
+++ b/cluster/manifests/02-vertical-pod-autoscaler/recommender-deployment.yaml
@@ -23,10 +23,10 @@ spec:
       serviceAccountName: vpa-recommender
       containers:
       - name: recommender
-        {{if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "current"}}
+        {{if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "new"}}
+        image: container-registry.zalando.net/teapot/vpa-recommender:v1.6.0-main-13-custom
+        {{else if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "stable"}}
         image: container-registry.zalando.net/teapot/vpa-recommender:v1.6.0-main-12-custom
-        {{else if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "legacy"}}
-        image: container-registry.zalando.net/teapot/vpa-recommender:v1.5.1-main-11-custom
         {{end}}
         args:
         - --logtostderr

--- a/cluster/manifests/02-vertical-pod-autoscaler/updater-deployment.yaml
+++ b/cluster/manifests/02-vertical-pod-autoscaler/updater-deployment.yaml
@@ -27,10 +27,10 @@ spec:
       serviceAccountName: vpa-updater
       containers:
       - name: updater
-        {{if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "current"}}
+        {{if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "new"}}
+        image: container-registry.zalando.net/teapot/vpa-updater:v1.6.0-main-13-custom
+        {{else if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "stable"}}
         image: container-registry.zalando.net/teapot/vpa-updater:v1.6.0-main-12-custom
-        {{else if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "legacy"}}
-        image: container-registry.zalando.net/teapot/vpa-updater:v1.5.1-main-11-custom
         {{end}}
         command:
           - ./updater


### PR DESCRIPTION
new vpa version with patch to restart pod on OOM with `InPlaceOrReplace`.
This is a temporary patch while kubernetes fixes the issue in one of the next releases.
I'm using a config-item to be easily/fast to rollout and rollback if needed.
I reused the existing `vertical_pod_autoscaler_version` since I did not find it used anywhere, probably this was never cleaned.