### PR TITLE
cleanup: routesrv deployment with suffix "2"

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -4,15 +4,6 @@ pre_apply:
 - name: deployment-service-controller
   kind: StatefulSet
   namespace: kube-system
-- kind: StatefulSet
-  name: skipper-ingress-redis
-  namespace: kube-system
-- kind: HorizontalPodAutoscaler
-  name: skipper-ingress-redis
-  namespace: kube-system
-- kind: Service
-  name: skipper-ingress-redis
-  namespace: kube-system
 
 # everything defined under here will be deleted after applying the manifests
 post_apply:
@@ -20,12 +11,12 @@ post_apply:
 # routesrv deployment in order to change the spec.selector. In a
 # second step we will rename it back to without 2, deleting the
 # deployments with "2"
-# - name: skipper-ingress-routesrv2
-#   namespace: kube-system
-#   kind: Deployment
-# - name: skipper-ingress-canary-routesrv2
-#   namespace: kube-system
-#   kind: Deployment
+- name: skipper-ingress-routesrv2
+  namespace: kube-system
+  kind: Deployment
+- name: skipper-ingress-canary-routesrv2
+  namespace: kube-system
+  kind: Deployment
 {{- if eq .Cluster.Provider "zalando-eks"}}
 - name: coredns
   kind: Deployment

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -526,7 +526,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "{{ .name }}-routesrv2"
+  name: "{{ .name }}-routesrv"
   namespace: kube-system
   labels:
     application: skipper-ingress
@@ -542,11 +542,11 @@ spec:
       maxUnavailable: 0
   selector:
     matchLabels:
-      deployment: "{{ .name }}-routesrv2"
+      deployment: "{{ .name }}-routesrv"
   template:
     metadata:
       labels:
-        deployment: "{{ .name }}-routesrv2"
+        deployment: "{{ .name }}-routesrv"
         application: skipper-ingress
         version: "{{ .routesrv_version }}"
         component: routesrv
@@ -569,7 +569,7 @@ spec:
           whenUnsatisfiable: DoNotSchedule
           labelSelector:
             matchLabels:
-              deployment: "{{ .name }}-routesrv2"
+              deployment: "{{ .name }}-routesrv"
 {{- end }}
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       serviceAccountName: skipper-ingress-routesrv

--- a/cluster/manifests/skipper/hpa-routesrv.yaml
+++ b/cluster/manifests/skipper/hpa-routesrv.yaml
@@ -10,7 +10,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: skipper-ingress-routesrv2
+    name: skipper-ingress-routesrv
   minReplicas: {{ .Cluster.ConfigItems.skipper_routesrv_min_replicas }}
   maxReplicas: {{ .Cluster.ConfigItems.skipper_routesrv_max_replicas }}
   metrics:

--- a/cluster/manifests/skipper/routesrv-canary-service.yaml
+++ b/cluster/manifests/skipper/routesrv-canary-service.yaml
@@ -14,4 +14,4 @@ spec:
       targetPort: 9990
       protocol: TCP
   selector:
-    deployment: skipper-ingress-canary-routesrv2
+    deployment: skipper-ingress-canary-routesrv

--- a/cluster/manifests/skipper/routesrv-service.yaml
+++ b/cluster/manifests/skipper/routesrv-service.yaml
@@ -14,4 +14,4 @@ spec:
       targetPort: 9990
       protocol: TCP
   selector:
-    deployment: skipper-ingress-routesrv2
+    deployment: skipper-ingress-routesrv


### PR DESCRIPTION
This pr is "step2" of https://github.com/zalando-incubator/kubernetes-on-aws/pull/11195 and should be not merged at the same time as the mentioned one and https://github.com/zalando-incubator/kubernetes-on-aws/pull/11307.
