### PR TITLE
Remove misleading annotations from EKS migration service

### DIFF
--- a/cluster/manifests/skipper/service-eks-internal.yaml
+++ b/cluster/manifests/skipper/service-eks-internal.yaml
@@ -8,13 +8,10 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-attributes: dns_record.client_routing_policy=availability_zone_affinity,load_balancing.cross_zone.enabled=false
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
     # SG of the old cluster worker nodes
-    service.beta.kubernetes.io/aws-load-balancer-extra-security-groups: {{ .Cluster.ConfigItems.worker_sg_legacy_cluster }}
     service.beta.kubernetes.io/aws-load-balancer-healthcheck-path: /kube-system/healthz
     service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol: http
-    service.beta.kubernetes.io/aws-load-balancer-internal: "true"
-    service.beta.kubernetes.io/aws-load-balancer-ip-address-type: dualstack
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internal
     service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: preserve_client_ip.enabled=true
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   labels:
     application: skipper-ingress
     component: ingress

--- a/cluster/manifests/skipper/service-eks-internal.yaml
+++ b/cluster/manifests/skipper/service-eks-internal.yaml
@@ -8,6 +8,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-attributes: dns_record.client_routing_policy=availability_zone_affinity,load_balancing.cross_zone.enabled=false
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
     # SG of the old cluster worker nodes
+    service.beta.kubernetes.io/aws-load-balancer-security-groups: {{ .Cluster.ConfigItems.worker_sg_legacy_cluster }}
     service.beta.kubernetes.io/aws-load-balancer-healthcheck-path: /kube-system/healthz
     service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol: http
     service.beta.kubernetes.io/aws-load-balancer-scheme: internal


### PR DESCRIPTION
Based on our docs https://cloud.docs.zalando.net/reference/kubernetes-infrastructure/eks-migration/howtos/loadbalancer-service/#noteworthy-annotations-on-load-balancer-services this removes annotations that don't work anymore or that are already on the default.

Main driver was the removal of `service.beta.kubernetes.io/aws-load-balancer-extra-security-groups` which doesn't have any effect and could lead to people having a false sense of security. This spec was also used for a Service on a legacy cluster where it fails with: `error: BYO extra security group annotation "service.beta.kubernetes.io/aws-load-balancer-extra-security-groups" is not supported by NLB` in the latest Kubernetes version.

The other annotations are changed from their deprecated version or are dropped because they are the default value (on EKS). None of these changes here should have any effect on the final load balancer setup. 

EDIT: it will tighten the SG to only be accessible from the defined SG, not from everywhere. Not so relevant for internal load balancers but more accurate overall this way.

---

Note, I assume this service is only relevant on EKS clusters. If not, please let me know.