### PR TITLE
skipper-ingress: update skipper version

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,6 +1,6 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.24.86-1417" }}
+{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.26.5-1434" }}
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.26.8-1437" }}
 
 {{/* Allow to override manually canary image by config item */}}


### PR DESCRIPTION
ref: https://github.com/zalando/skipper/compare/v0.24.86...v0.26.5

- fix: error handling in valkey ring updater loop
- fix: zone aware route filtering in routesrv
- fix: always extract baggage header
- fix: auth OpenID filter config lookup adding timeouts
- feature: support for https://opensource.zalando.com/skipper/reference/filters/#clusterleakybucketratelimit
- feature: async decision logging for OPA

canary update ref: https://github.com/zalando-incubator/kubernetes-on-aws/pull/11309