### PR TITLE
feat: Enable Runtime Response Capabilties for Wiz Sensor

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1362,7 +1362,7 @@ wiz_priority: "true"
 wiz_node_feature_rollout : "false"
 
 # Enable runtime sensor response capabilities such as KILL
-wiz_enable_runtime_sensor_response_capabilities: "false"
+wiz_enable_runtime_sensor_response_capabilities: "true"
 
 # Configure legacy EFS connectivity from the entire VPC. This allows EKS clusters to connect to the legacy EFS file system.
 efs_allow_vpc_connection: "false"


### PR DESCRIPTION
- Enable Runtime Response Capability for Wiz Sensor on all clusters.
- We have tested the Runtime Response Capability with wiz sensor on test cluster and as runtime response policies need to be rolled out across all cluster for threat prevention this need to enabled by default on all projects.