### PR TITLE
EBS CSI Plugin: Set memory through variable

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -962,9 +962,10 @@ cpu_manager_policy: "none"
 # sysctl names allowed to be used in security policies, comma-separated
 allowed_unsafe_sysctls: "net.ipv4.tcp_keepalive_time,net.ipv4.tcp_keepalive_intvl,net.ipv4.tcp_keepalive_probes,net.ipv4.tcp_syn_retries,net.ipv4.tcp_retries2"
 
-# the maximum amount of memory for EBS CSI controller's sidecars
+# the maximum amount of resources for EBS CSI
 ebs_csi_controller_sidecar_memory: "80Mi"
 ebs_csi_controller_sidecar_cpu: "10m"
+ebs_csi_plugin_memory: "40Mi"
 
 # pull images in parallel
 serialize_image_pulls: "false"

--- a/cluster/manifests/04-ebs-csi/controller.yaml
+++ b/cluster/manifests/04-ebs-csi/controller.yaml
@@ -60,10 +60,10 @@ spec:
           resources:
             requests:
               cpu: 10m
-              memory: {{ .Cluster.ConfigItems.ebs_csi_controller_sidecar_memory }}
+              memory: {{ .Cluster.ConfigItems.ebs_csi_plugin_memory }}
             limits:
               cpu: 10m
-              memory: {{ .Cluster.ConfigItems.ebs_csi_controller_sidecar_memory }}
+              memory: {{ .Cluster.ConfigItems.ebs_csi_plugin_memory }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/

--- a/cluster/manifests/04-ebs-csi/controller.yaml
+++ b/cluster/manifests/04-ebs-csi/controller.yaml
@@ -60,10 +60,10 @@ spec:
           resources:
             requests:
               cpu: 10m
-              memory: 40Mi
+              memory: {{ .Cluster.ConfigItems.ebs_csi_controller_sidecar_memory }}
             limits:
               cpu: 10m
-              memory: 40Mi
+              memory: {{ .Cluster.ConfigItems.ebs_csi_controller_sidecar_memory }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/


### PR DESCRIPTION
Replace hardcoded 40Mi memory requests/limits with configurable template variable via `ebs_csi_plugin_memory` config item, allowing cluster-specific memory tuning without manifest modification.