### PR TITLE
bug-fix: update valkey url

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -133,6 +133,9 @@ skipper_canary_controller_enabled: "false"
 skipper_ingress_canary_routes_urls: http://skipper-ingress-canary-routesrv.kube-system.svc.cluster.local/routes
 skipper_ingress_routes_urls: http://skipper-ingress-routesrv.kube-system.svc.cluster.local/routes
 
+skipper_ingress_canary_swarm_valkey_remote: http://skipper-ingress-canary-routesrv.kube-system.svc.cluster.local/swarm/valkey/shards
+skipper_ingress_swarm_valkey_remote: http://skipper-ingress-routesrv.kube-system.svc.cluster.local/swarm/valkey/shards
+
 
 # When set to true (and dedicated node pool for skipper is also true) the
 # daemonset overhead will be subtracted from the cpu settings such

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -30,6 +30,7 @@
   "routesrv_image" $routesrv_image_without_tag
   "routesrv_version" $routesrv_main_version
   "routes_urls" .Cluster.ConfigItems.skipper_ingress_routes_urls
+  "valkey_remote" .Cluster.ConfigItems.skipper_ingress_swarm_valkey_remote
 
   "Cluster" .Cluster
   "Values" .Values
@@ -45,6 +46,7 @@
   "replicas" 1
   "args" $canary_args
   "routes_urls" .Cluster.ConfigItems.skipper_ingress_canary_routes_urls
+  "valkey_remote" .Cluster.ConfigItems.skipper_ingress_canary_swarm_valkey_remote
 
   "Cluster" .Cluster
   "Values" .Values
@@ -270,7 +272,7 @@ spec:
           - "-enable-swarm"
           - "-cluster-ratelimit-max-group-shards={{ .Cluster.ConfigItems.skipper_cluster_ratelimit_max_group_shards }}"
           - "-swarm-valkey-conn-timeout={{ .Cluster.ConfigItems.skipper_valkey_conn_timeout }}"
-          - "-swarm-valkey-remote=http://skipper-ingress-routesrv.kube-system.svc.cluster.local/swarm/valkey/shards"
+          - "-swarm-valkey-remote={{ .valkey_remote }}"
           - "-histogram-metric-buckets=.0001,.00025,.0005,.00075,.001,.0025,.005,.0075,.01,.025,.05,.075,.1,.2,.3,.4,.5,.75,1,2,3,4,5,7,10,15,20,30,60,120,300,600"
 {{if ne .Cluster.ConfigItems.skipper_ingress_response_size_buckets ""}}
           - "-response-size-buckets={{ .Cluster.ConfigItems.skipper_ingress_response_size_buckets }}"


### PR DESCRIPTION
After the separation of the two deployments, i.e skipper-ingress and skipper-ingress-canary we did not update valkey to point to the right instance of RouteSRV. This PR addresses this issue.