### PR TITLE
skipper-ingress: update main to v0.26.10-1440

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -166,7 +166,7 @@ skipper_default_filters: 'disableAccessLog(2,3,404,429) -> fifo(2000,20,"1s")'
 # skipper_default_filters_authentication defines filters that implement default request authentication
 skipper_default_filters_authentication: ''
 skipper_default_filters_append: 'stateBagToTag("auth-user", "client.uid")'
-skipper_disabled_filters: "clusterLeakyBucketRatelimit,static,bearerinjector,setRequestHeaderFromSecret,basicAuth,setDynamicBackendUrlFromHeader"
+skipper_disabled_filters: "static,bearerinjector,setRequestHeaderFromSecret,basicAuth,setDynamicBackendUrlFromHeader"
 skipper_lua_sources: "file"
 skipper_edit_route_placeholders: ""
 skipper_ingress_inline_routes: ""

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,6 +1,6 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.26.5-1434" }}
+{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.26.10-1440" }}
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.26.19-1449" }}
 
 {{/* Allow to override manually canary image by config item */}}


### PR DESCRIPTION
highlights:

- feature: valkey based leaky bucket rate limit support (drop disabled filter)
- feature: cache() filter with in-memory cache implementation
- security fix: OPA authz bypass https://github.com/zalando/skipper/security/advisories/GHSA-659f-rgp5-w4wf
- fix: valkey ring update
- fix: OpenID config lookup timeout

ref: https://github.com/zalando/skipper/compare/v0.25.5...v0.26.10