### PR TITLE
allow to configure per cluster the min sync for iptables and ipvs

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -527,6 +527,8 @@ kube_proxy_cpu: "50m"
 kube_proxy_memory_request: "200Mi"
 kube_proxy_memory_limit: "200Mi"
 kube_proxy_sync_period: "15m0s"
+kube_proxy_iptables_min_sync_period: "0s"
+kube_proxy_ipvs_min_sync_period: "0s"
 kube_proxy_verbose_level: "1"
 
 # kube-node-decommissioner

--- a/cluster/manifests/kube-proxy/configmap.yaml
+++ b/cluster/manifests/kube-proxy/configmap.yaml
@@ -27,10 +27,10 @@ data:
     iptables:
       masqueradeAll: false
       masqueradeBit: 14
-      minSyncPeriod: 0s
+      minSyncPeriod: "{{ .Cluster.ConfigItems.kube_proxy_iptables_min_sync_period }}"
       syncPeriod: 30s
     ipvs:
-      minSyncPeriod: 0s
+      minSyncPeriod: "{{ .Cluster.ConfigItems.kube_proxy_ipvs_min_sync_period }}"
       scheduler: ""
       syncPeriod: 30s
     kind: KubeProxyConfiguration


### PR DESCRIPTION
This allows to configure per cluster the minSync period for iptables and ipvs.

There is one cluster with a Client Side Load Balancer accessing directly the pods and when we have cases of syncronized node boots is causes issues with packet delays. If we configure a value of `20s` for this cluster it should at least to help spread across a wider window.

https://github.com/zalando-build/zooport/issues/7288