### PR TITLE
skipper-ingress: update main to v0.26.19-1449

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,6 +1,6 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.26.10-1440" }}
+{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.26.19-1449" }}
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.26.19-1449" }}
 
 {{/* Allow to override manually canary image by config item */}}


### PR DESCRIPTION
ref: https://github.com/zalando/skipper/compare/v0.26.10...v0.26.19

- fix: introduce timeout for decicion log task
- fix: wait for cipher refresher goroutine to exit on Close
- fix: eliminate race in TestCacheFilter_ColdMissCoalescing 
- feature: proxy mTLS support
- fix: Fix oidcClaimsQuery example
- go: update to 1.26.4