### PR TITLE
ShadowTraffic: set annotations required to make system-prometheus scrape the metrics

### DIFF
--- a/cluster/manifests/shadow-traffic-controller/30-deployment.yaml
+++ b/cluster/manifests/shadow-traffic-controller/30-deployment.yaml
@@ -23,6 +23,9 @@ spec:
         kubernetes-log-watcher/scalyr-parser: |
           [{"container": "controller", "parser": "keyValue"}]
         logging/destination: "{{ .Cluster.ConfigItems.log_destination_both }}"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scrape: "true"
     spec:
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       serviceAccountName: shadow-traffic-controller


### PR DESCRIPTION
Prometheus that scrape endpoints that expose metrics in Prometheus format only scrapes pods with these annotations. With [this PR](https://github.com/zalando-incubator/kubernetes-on-aws/pull/11406) shadow-traffic-controller too exposes a prometheus metric endpoint.  