### PR TITLE
Remove wrongly configured SG for internal service

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -152,7 +152,6 @@ skipper_eks_migration_enabled: "false"
 # If not set, falls back to the default "http://skipper-ingress-eks.<hosted_zone>
 skipper_ingress_migration_forward_backend_url_custom: ""
 skipper_eks_migration_svc_enabled: "false"
-worker_sg_legacy_cluster: ""
 
 # skipper node-pool
 enable_dedicate_nodepool_skipper: "true"

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -394,3 +394,8 @@ post_apply:
 - name: kro-poweruser-secret-read
   kind: ClusterRoleBinding
 {{- end }}
+{{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.SiblingCluster nil) }}
+- name: skipper-internal-eks
+  namespace: kube-system
+  kind: Service
+{{- end }}

--- a/cluster/manifests/skipper/service-eks-internal.yaml
+++ b/cluster/manifests/skipper/service-eks-internal.yaml
@@ -7,8 +7,6 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: application=skipper-ingress,component=ingress
     service.beta.kubernetes.io/aws-load-balancer-attributes: dns_record.client_routing_policy=availability_zone_affinity,load_balancing.cross_zone.enabled=false
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
-    # SG of the old cluster worker nodes
-    service.beta.kubernetes.io/aws-load-balancer-security-groups: {{ .Cluster.ConfigItems.worker_sg_legacy_cluster }}
     service.beta.kubernetes.io/aws-load-balancer-healthcheck-path: /kube-system/healthz
     service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol: http
     service.beta.kubernetes.io/aws-load-balancer-scheme: internal
@@ -30,4 +28,6 @@ spec:
     application: skipper-ingress
     component: ingress
   type: LoadBalancer
+  loadBalancerSourceRanges:
+  - "{{ .Values.vpc_ipv4_cidr }}"
 # {{ end }}

--- a/cluster/manifests/skipper/service-eks-internal.yaml
+++ b/cluster/manifests/skipper/service-eks-internal.yaml
@@ -1,4 +1,4 @@
-# {{ if eq .Cluster.ConfigItems.skipper_eks_migration_svc_enabled "true" }}
+# {{ if eq .Cluster.Provider "zalando-eks" }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/cluster/manifests/skipper/service-eks-internal.yaml
+++ b/cluster/manifests/skipper/service-eks-internal.yaml
@@ -1,4 +1,4 @@
-# {{ if eq .Cluster.Provider "zalando-eks" }}
+# {{ if and (eq .Cluster.Provider "zalando-eks") (ne .Cluster.SiblingCluster nil) }}
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
Following up on https://github.com/zalando-incubator/kubernetes-on-aws/pull/11315.

The change in the PR prevents connection from the legacy app to the EKS cluster's proxy service.

Turns out the annotation is wrongly used. Configuring the SG doesn't mean the LB is accessible from nodes having that SG. It means the LB is configured with the LB. In our case it would give the LB the worker SG which is not what we want. We want to access the LB _from_ the worker which is not the same.

Let's just specify no SG which allows traffic from everywhere. Since it's an internal LB it's fine. However, as additional precaution, we're setting the IPv4 CIDR (legacy cluster nodes) which adds it as the only inbound rule.