### PR TITLE
Update to VPA v1.7.0

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -667,9 +667,9 @@ horizontal_pod_downscale_stabilization: "5m0s"
 horizontal_pod_autoscaler_configurable_tolerance: "false"
 
 # Vertical pod autoscaler version for controlling roll-out, can be "new" or "stable"
-# new => v1.6.0-main-13-custom
-# stable => v1.6.0-main-12-custom
-vertical_pod_autoscaler_version: "stable"
+# new => v1.7.0-main-14-custom
+# stable => v1.6.0-main-13-custom
+vertical_pod_autoscaler_version: "new"
 
 # Cluster update settings
 {{if eq .Cluster.Environment "production"}}

--- a/cluster/manifests/02-vertical-pod-autoscaler/01-crd.yaml
+++ b/cluster/manifests/02-vertical-pod-autoscaler/01-crd.yaml
@@ -254,6 +254,14 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .spec.updatePolicy.minReplicas
+      name: MinReplicas
+      priority: 1
+      type: integer
+    - jsonPath: .spec.updatePolicy.evictAfterOOMSeconds
+      name: OOMSeconds
+      priority: 1
+      type: integer
     name: v1
     schema:
       openAPIV3Schema:
@@ -354,6 +362,25 @@ spec:
                             Specifies the maximum amount of resources that will be recommended
                             for the container. The default is no maximum.
                           type: object
+                        memoryAggregationIntervalCount:
+                          description: |-
+                            memoryAggregationIntervalCount is the number of consecutive
+                            memoryAggregationIntervals which make up the memory aggregation window.
+                            The total window length is:
+                            MemoryAggregationIntervalSeconds * MemoryAggregationIntervalCount.
+                          format: int64
+                          minimum: 1
+                          type: integer
+                        memoryAggregationIntervalSeconds:
+                          description: |-
+                            memoryAggregationIntervalSeconds is the length of a single interval
+                            (in seconds) for which the peak memory usage is computed.
+                            Memory usage peaks are aggregated in multiples of this interval.
+                            In other words, there is one memory usage sample per interval
+                            (the maximum usage over that interval).
+                          format: int32
+                          minimum: 1
+                          type: integer
                         minAllowed:
                           additionalProperties:
                             anyOf:
@@ -388,8 +415,113 @@ spec:
                             when OOM is detected.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
+                        startupBoost:
+                          description: |-
+                            startupBoost specifies the startup boost policy for the container.
+                            This overrides any pod-level startup boost policy.
+                            The startup boost policy takes precedence over the rest of the fields in
+                            this struct, except for ContainerName and ControlledValues.
+                          properties:
+                            cpu:
+                              description: |-
+                                cpu specifies the CPU startup boost policy.
+                                If this field is not set, no startup boost is applied.
+                              properties:
+                                durationSeconds:
+                                  description: |-
+                                    durationSeconds indicates for how long to keep the pod boosted after it goes to Ready.
+                                    Defaults to 0.
+                                  format: int32
+                                  type: integer
+                                factor:
+                                  description: |-
+                                    factor specifies the factor to apply to the resource request.
+                                    This field is required when Type is "Factor".
+                                  format: int32
+                                  type: integer
+                                quantity:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    quantity specifies the absolute resource quantity to be used as the
+                                    resource request and limit during the boost phase.
+                                    This field is required when Type is "Quantity".
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type:
+                                  description: |-
+                                    type specifies the kind of boost to apply.
+                                    Supported values are: "Factor", "Quantity".
+                                    No startupboost will be applied for unrecognized values.
+                                  enum:
+                                  - Factor
+                                  - Quantity
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                              x-kubernetes-validations:
+                              - message: factor is required when type is Factor and
+                                  forbidden otherwise
+                                rule: (self.type == 'Factor') == has(self.factor)
+                              - message: quantity is required when type is Quantity
+                                  and forbidden otherwise
+                                rule: (self.type == 'Quantity') == has(self.quantity)
+                          type: object
                       type: object
                     type: array
+                type: object
+              startupBoost:
+                description: startupBoost specifies the startup boost policy for the
+                  pod.
+                properties:
+                  cpu:
+                    description: |-
+                      cpu specifies the CPU startup boost policy.
+                      If this field is not set, no startup boost is applied.
+                    properties:
+                      durationSeconds:
+                        description: |-
+                          durationSeconds indicates for how long to keep the pod boosted after it goes to Ready.
+                          Defaults to 0.
+                        format: int32
+                        type: integer
+                      factor:
+                        description: |-
+                          factor specifies the factor to apply to the resource request.
+                          This field is required when Type is "Factor".
+                        format: int32
+                        type: integer
+                      quantity:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          quantity specifies the absolute resource quantity to be used as the
+                          resource request and limit during the boost phase.
+                          This field is required when Type is "Quantity".
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      type:
+                        description: |-
+                          type specifies the kind of boost to apply.
+                          Supported values are: "Factor", "Quantity".
+                          No startupboost will be applied for unrecognized values.
+                        enum:
+                        - Factor
+                        - Quantity
+                        type: string
+                    required:
+                    - type
+                    type: object
+                    x-kubernetes-validations:
+                    - message: factor is required when type is Factor and forbidden
+                        otherwise
+                      rule: (self.type == 'Factor') == has(self.factor)
+                    - message: quantity is required when type is Quantity and forbidden
+                        otherwise
+                      rule: (self.type == 'Quantity') == has(self.quantity)
                 type: object
               targetRef:
                 description: |-
@@ -425,6 +557,14 @@ spec:
                   If not specified, all fields in the `PodUpdatePolicy` are set to their
                   default values.
                 properties:
+                  evictAfterOOMSeconds:
+                    description: |-
+                      evictAfterOOMSeconds specifies the time in seconds to wait after an OOM event before
+                      considering the pod for eviction. Pods that have OOMed in less than this time
+                      since start will be evicted.
+                    format: int32
+                    minimum: 1
+                    type: integer
                   evictionRequirements:
                     description: |-
                       EvictionRequirements is a list of EvictionRequirements that need to
@@ -475,6 +615,7 @@ spec:
                     - Initial
                     - Recreate
                     - InPlaceOrRecreate
+                    - InPlace
                     - Auto
                     type: string
                 type: object
@@ -504,6 +645,14 @@ spec:
                         message is a human-readable explanation containing details about
                         the transition
                       type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
                     reason:
                       description: reason is the reason for the condition's last transition.
                       type: string
@@ -519,6 +668,12 @@ spec:
                   - type
                   type: object
                 type: array
+              observedGeneration:
+                description: observedGeneration is the most recent generation observed
+                  by this autoscaler.
+                format: int64
+                minimum: 0
+                type: integer
               recommendation:
                 description: |-
                   The most recently computed amount of resources recommended by the

--- a/cluster/manifests/02-vertical-pod-autoscaler/admission-controller-deployment.yaml
+++ b/cluster/manifests/02-vertical-pod-autoscaler/admission-controller-deployment.yaml
@@ -26,9 +26,9 @@ spec:
       containers:
       - name: admission-controller
         {{if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "new"}}
-        image: container-registry.zalando.net/teapot/vpa-admission-controller:v1.6.0-main-13-custom
+        image: container-registry.zalando.net/teapot/vpa-admission-controller:v1.7.0-main-14-custom
         {{else if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "stable"}}
-        image: container-registry.zalando.net/teapot/vpa-admission-controller:v1.6.0-main-12-custom
+        image: container-registry.zalando.net/teapot/vpa-admission-controller:v1.6.0-main-13-custom
         {{end}}
         command:
           - /admission-controller

--- a/cluster/manifests/02-vertical-pod-autoscaler/recommender-deployment.yaml
+++ b/cluster/manifests/02-vertical-pod-autoscaler/recommender-deployment.yaml
@@ -24,9 +24,9 @@ spec:
       containers:
       - name: recommender
         {{if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "new"}}
-        image: container-registry.zalando.net/teapot/vpa-recommender:v1.6.0-main-13-custom
+        image: container-registry.zalando.net/teapot/vpa-recommender:v1.7.0-main-14-custom
         {{else if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "stable"}}
-        image: container-registry.zalando.net/teapot/vpa-recommender:v1.6.0-main-12-custom
+        image: container-registry.zalando.net/teapot/vpa-recommender:v1.6.0-main-13-custom
         {{end}}
         args:
         - --logtostderr

--- a/cluster/manifests/02-vertical-pod-autoscaler/updater-deployment.yaml
+++ b/cluster/manifests/02-vertical-pod-autoscaler/updater-deployment.yaml
@@ -28,9 +28,9 @@ spec:
       containers:
       - name: updater
         {{if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "new"}}
-        image: container-registry.zalando.net/teapot/vpa-updater:v1.6.0-main-13-custom
+        image: container-registry.zalando.net/teapot/vpa-updater:v1.7.0-main-14-custom
         {{else if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "stable"}}
-        image: container-registry.zalando.net/teapot/vpa-updater:v1.6.0-main-12-custom
+        image: container-registry.zalando.net/teapot/vpa-updater:v1.6.0-main-13-custom
         {{end}}
         command:
           - ./updater


### PR DESCRIPTION
Updates VPA to the latest stable version v1.7.0

`vertical_pod_autoscaler_version` is changed to `new` by default, with the ability to switch back to "stable" the previous version if there are any issues observed.

https://github.com/kubernetes/autoscaler/releases/tag/vertical-pod-autoscaler-1.7.0