### PR TITLE
Use config-item to control eks internal migration service

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -147,11 +147,19 @@ skipper_ingress_binpack: "false"
 {{end}}
 
 # skipper EKS migration support
+{{- if and (eq .Cluster.Provider "zalando-aws") (ne .Cluster.SiblingCluster nil) }}
+skipper_eks_migration_enabled: "true"
+{{- else }}
 skipper_eks_migration_enabled: "false"
+{{- end }}
 # allow setting a custom forward-backend-url
 # If not set, falls back to the default "http://skipper-ingress-eks.<hosted_zone>
 skipper_ingress_migration_forward_backend_url_custom: ""
+{{- if and (eq .Cluster.Provider "zalando-eks") (ne .Cluster.SiblingCluster nil) }}
+skipper_eks_migration_svc_enabled: "true"
+{{- else }}
 skipper_eks_migration_svc_enabled: "false"
+{{- end }}
 
 # skipper node-pool
 enable_dedicate_nodepool_skipper: "true"

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -394,7 +394,7 @@ post_apply:
 - name: kro-poweruser-secret-read
   kind: ClusterRoleBinding
 {{- end }}
-{{- if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.SiblingCluster nil) }}
+{{- if ne .Cluster.ConfigItems.skipper_eks_migration_svc_enabled "true" }}
 - name: skipper-internal-eks
   namespace: kube-system
   kind: Service

--- a/cluster/manifests/skipper/service-eks-internal.yaml
+++ b/cluster/manifests/skipper/service-eks-internal.yaml
@@ -1,4 +1,4 @@
-# {{ if and (eq .Cluster.Provider "zalando-eks") (ne .Cluster.SiblingCluster nil) }}
+# {{ if eq .Cluster.ConfigItems.skipper_eks_migration_svc_enabled "true" }}
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
Follow up to #11442

This re-introduces the use of the config-item: `skipper_eks_migration_svc_enabled` to enable/disable the EKS internal migration service.

The config-item is true by default if cluster is `zalando-eks` and has a SiblingCluster, like before.

The benefit of the config-item is that it allows to set it for other use cases. Currently we have a use case where the feature is used for cross account migration via Private link, in this setup `SiblingCluster` is `nil` and thus it would be disabled without the config-item.

Addtionally this introduces similar condition for `skipper_eks_migration_enabled` which is the source side of the migration. This way the feature is automatically enabled for clusters pairs set up for EKS migration.