### PR TITLE
skipper canary: update to have zone aware opt-out annotation

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,7 +1,7 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
 {{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.26.19-1449" }}
-{{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.26.19-1449" }}
+{{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.27.7-1461" }}
 
 {{/* Allow to override manually canary image by config item */}}
 {{ if ne .Cluster.ConfigItems.skipper_ingress_canary_image "" }}


### PR DESCRIPTION
https://github.com/zalando/skipper/compare/v0.26.19...v0.27.7

- optimization: brotli compression
- fix: Host metrics corrected for HostAny() predicate
- feature: opt-out zone aware traffic by ingress/routegroup via annotation
- feature: mTLS filters https://opensource.zalando.com/skipper/reference/filters/#tls (requires CA integration, which is not yet done in this deployment)