### PR TITLE
feat: allow mutatingwebhookconfigurations for poweruser role

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1340,6 +1340,8 @@ role_sync_controller_enabled: "true"
 role_sync_controller_enabled: "false"
 {{ end }}
 
+role_grant_mutatingwebhookconfigurations_permission: "false"
+
 # Access control configs
 # Enable users with the poweruser role to modify EndpointSlices.
 access_control_poweruser_modify_endpointslices: "false"

--- a/cluster/manifests/roles/poweruser-role.yaml
+++ b/cluster/manifests/roles/poweruser-role.yaml
@@ -94,6 +94,9 @@ rules:
   - admissionregistration.k8s.io
   resources:
   - validatingwebhookconfigurations
+{{- if eq .Cluster.ConfigItems.role_grant_mutatingwebhookconfigurations_permission "true" }}
+  - mutatingwebhookconfigurations
+{{- end }}
   verbs:
   - create
   - delete


### PR DESCRIPTION
This is needed for the Dash0 operator. It's hidden behind a feature flag as Dash0 is for a PoC.