### PR TITLE
skipper-ingress: update to v0.27.7-1461

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,6 +1,6 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.26.19-1449" }}
+{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.27.7-1461" }}
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.27.7-1461" }}
 
 {{/* Allow to override manually canary image by config item */}}


### PR DESCRIPTION
ref canary: https://github.com/zalando-incubator/kubernetes-on-aws/pull/11456
ref changeset: https://github.com/zalando/skipper/compare/v0.26.19...v0.27.7

- optimization: brotli compression
- fix: Host metrics corrected for HostAny() predicate
- feature: opt-out zone aware traffic by ingress/routegroup via annotation
- feature: mTLS filters https://opensource.zalando.com/skipper/reference/filters/#tls (requires CA integration, which is not yet done in this deployment)