### PR TITLE
stackset: Allow per stack public hostname in EKS

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1113,6 +1113,16 @@ stackset_controller_sync_interval: "10s"
 stackset_controller_mem_min: "120Mi"
 stackset_controller_mem_max: "4Gi"
 
+# Stackset controller per-stack public hostname
+# This feature enables automatic injection of per stack public hostnames
+# It's disabled in EKS clusters by default as it's not compatible in both
+# non-EKS and EKS during migration.
+{{- if eq .Cluster.Provider "zalando-aws" }}
+stackset_per_stack_public_hostname_enabled: "true"
+{{- else }}
+stackset_per_stack_public_hostname_enabled: "false"
+{{- end }}
+
 # EBS settings for the root volume
 ebs_master_root_volume_size: "50"
 ebs_root_volume_size: "100"

--- a/cluster/manifests/stackset-controller/deployment.yaml
+++ b/cluster/manifests/stackset-controller/deployment.yaml
@@ -59,7 +59,7 @@ spec:
         - "--sync-ingress-annotation=kubernetes.io/ingress.class"
 {{ end}}
         - "--cluster-domain=ingress.cluster.local"
-{{- if eq .Cluster.Provider "zalando-aws" }}
+{{- if eq .Cluster.ConfigItems.stackset_per_stack_public_hostname_enabled "true" }}
         - "--cluster-domain={{ .Values.hosted_zone }}"
 {{- end }}
         resources:


### PR DESCRIPTION
Introduce a config-item that allows the automatic public hostname per Stack for StackSets.

It was previously disable for any EKS cluster to facility EKS migration as it can't be enabled in two clusters of the same account, however, there is no way for users to get the feature in EKS now.

Moving it to a config-item makes it still disabled by default in EKS, but can optionally be enabled for valid use cases, when there is no non-EKS cluster in the account.

Ideally we make the feature opt-in per StackSet and disable it by default, but this is a temporary solution.