### PR TITLE
Enable node-exporter ENA metrics

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -527,7 +527,7 @@ kubelet_cadvisor_enabled: "true"
 # node exporter settings
 node_exporter_cpu: "20m"
 node_exporter_memory: "75Mi"
-node_exporter_experimental_metrics: "false"
+node_exporter_experimental_metrics: "true"
 
 # kube-proxy settings
 kube_proxy_cpu: "50m"


### PR DESCRIPTION
This enables the node exporter experimental metrics which includes ENA metrics (e.g. packet drops on EC2 Network interfaces).

This was previously set in 173 clusters per cluster, but newer clusters didn't have it enabled. Since we ran it in so many clusters already it's safe to enable by default.