### PR TITLE
Allow access to ValidatingAdmissionPolicies

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1361,6 +1361,10 @@ access_control_poweruser_modify_endpointslices: "false"
 # potentially dangerous permission, so it is disabled by default.
 access_control_poweruser_modify_networkpolicies: "false"
 
+# Enable users with the poweruser role to modify ValidatingAdmissionPolicies.
+# This is a potentially dangerous permission, so it is disabled by default.
+access_control_poweruser_modify_validatingadmissionpolicies: "false"
+
 #Wiz Configs
 # When wiz_enable_runtime_sensor and wiz_enable_runtime_connector are set to true,
 # this enables WIZ runtime monitoring. A DaemonSet called Sensor and a Deployment

--- a/cluster/manifests/roles/poweruser-role.yaml
+++ b/cluster/manifests/roles/poweruser-role.yaml
@@ -97,6 +97,10 @@ rules:
 {{- if eq .Cluster.ConfigItems.role_grant_mutatingwebhookconfigurations_permission "true" }}
   - mutatingwebhookconfigurations
 {{- end }}
+{{- if eq .Cluster.ConfigItems.access_control_poweruser_modify_validatingadmissionpolicies "true" }}
+  - validatingadmissionpolicies
+  - validatingadmissionpolicybindings
+{{- end }}
   verbs:
   - create
   - delete

--- a/cluster/manifests/roles/readonly-role.yaml
+++ b/cluster/manifests/roles/readonly-role.yaml
@@ -81,6 +81,8 @@ rules:
   resources:
   - mutatingwebhookconfigurations
   - validatingwebhookconfigurations
+  - validatingadmissionpolicies
+  - validatingadmissionpolicybindings
   verbs:
   - get
   - list


### PR DESCRIPTION
Allow conditional access to ValidatingAdmissionPolicies for the poweruser/cdp role per cluster

This is done to enable it for special cases i.e. ZAP

ref: https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/