### PR TITLE
increase kubelet_summary_metrics_hpa_max_replicas to 20

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -517,7 +517,7 @@ event_rate_limit_config_burst: "1000"
 kubelet_summary_metrics_enabled: "true"
 kubelet_summary_metrics_cpu: "100m"
 kubelet_summary_metrics_memory: "256Mi"
-kubelet_summary_metrics_hpa_max_replicas: "10"
+kubelet_summary_metrics_hpa_max_replicas: "20"
 kubelet_summary_metrics_hpa_cpu_target: "80"
 kubelet_summary_metrics_hpa_memory_target: "80"
 


### PR DESCRIPTION
We suffered OOMkills on some `kubelet-summary-metrics` Pods last evening because the HPA had maxed out to `10` replicas and the deployment couldn't scale further. Increasing this for all clusters to avoid this in the future.