### PR TITLE
Allow PowerUser create tokenreviews permissions at cluster level

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1365,6 +1365,10 @@ access_control_poweruser_modify_networkpolicies: "false"
 # This is a potentially dangerous permission, so it is disabled by default.
 access_control_poweruser_modify_validatingadmissionpolicies: "false"
 
+# Enable users with the poweruser role to create TokenReviews. This is a
+# potentially dangerous permission, so it is disabled by default.
+access_control_poweruser_create_tokenreviews: "false"
+
 #Wiz Configs
 # When wiz_enable_runtime_sensor and wiz_enable_runtime_connector are set to true,
 # this enables WIZ runtime monitoring. A DaemonSet called Sensor and a Deployment

--- a/cluster/manifests/roles/poweruser-role.yaml
+++ b/cluster/manifests/roles/poweruser-role.yaml
@@ -107,6 +107,14 @@ rules:
   - deletecollection
   - patch
   - update
+{{- if eq .Cluster.ConfigItems.access_control_poweruser_create_tokenreviews "true" }}
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+{{- end }}
 - apiGroups:
   - apiextensions.k8s.io
   resources:


### PR DESCRIPTION
This adds a config-item to enable tokenreviews create permissions to PowerUser/CDP by cluster. It's disabled by default.

This is done to enable ZAP where the AgentGateway depends on it.