### PR TITLE
Grant ACK EKS capability role EKS Access Entry permissions

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -445,9 +445,32 @@ Resources:
       - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-DenyDefault"
       - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-AllowPowerUser"
       - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-AllowPowerUserCustom"
+      - !Ref EKSCapabilityACKAccessEntryPolicy
       {{- if eq .Cluster.Name "playground" }}
       - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-AllowPowerUser-Playground"
       {{- end }}
+  # ZalandoCloud-AllowPowerUser restricts the capability role's eks:* actions to
+  # AccessKubernetesApi/*PodIdentityAssociation/Describe*/List*, which excludes the
+  # EKS Access Entry API. Grant exactly the Access Entry + Access Policy actions the
+  # ACK EKS controller needs to reconcile AccessEntry resources (create/read/update/
+  # delete and access-policy association), scoped narrowly rather than via eks:*.
+  EKSCapabilityACKAccessEntryPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+        - Effect: Allow
+          Action:
+          - "eks:CreateAccessEntry"
+          - "eks:DescribeAccessEntry"
+          - "eks:UpdateAccessEntry"
+          - "eks:DeleteAccessEntry"
+          - "eks:ListAccessEntries"
+          - "eks:AssociateAccessPolicy"
+          - "eks:DisassociateAccessPolicy"
+          - "eks:ListAssociatedAccessPolicies"
+          Resource: "*"
   EKSCapabilityACK:
     Type: 'AWS::EKS::Capability'
     Properties:


### PR DESCRIPTION
## What

Adds a narrowly-scoped IAM managed policy (`EKSCapabilityACKAccessEntryPolicy`) granting the ACK EKS capability role the EKS **Access Entry** and **Access Policy** API permissions, and attaches it to `EKSCapabilityACKRole`.

## Why

The ACK EKS capability role (`<cluster>-ACK-CapabilityRole`) inherits its EKS permissions from `ZalandoCloud-AllowPowerUser`, which restricts `eks:*` to `AccessKubernetesApi`, `*PodIdentityAssociation`, `Describe*` and `List*`. This **excludes the EKS Access Entry API**.

As a result, the ACK EKS controller cannot reconcile `eks.services.k8s.aws/AccessEntry` resources and fails with:

```
<cluster>-ACK-CapabilityRole is not authorized to perform: eks:CreateAccessEntry
on resource: arn:aws:eks:<region>:<acct>:cluster/<cluster>
because no identity-based policy allows the eks:CreateAccessEntry action
```

This blocks any KRO/ACK-based abstraction that provisions namespace-scoped `AccessEntry` resources to grant teams access to their own namespace.

## What changed

- New `AWS::IAM::ManagedPolicy` `EKSCapabilityACKAccessEntryPolicy` granting exactly:
  - `eks:CreateAccessEntry`, `eks:DescribeAccessEntry`, `eks:UpdateAccessEntry`, `eks:DeleteAccessEntry`, `eks:ListAccessEntries`
  - `eks:AssociateAccessPolicy`, `eks:DisassociateAccessPolicy`, `eks:ListAssociatedAccessPolicies`
- Attached to `EKSCapabilityACKRole` via `ManagedPolicyArns`.
- Both live inside the existing `{{- if eq .Cluster.ConfigItems.capability_ack_enabled "true" }}` block, so nothing is created when ACK is disabled.

## Notes / design choices

- **Scoped to the specific actions, not `eks:*`.** The upstream ACK EKS controller's recommended policy uses `eks:*`, but that would defeat the least-privilege model this role already follows via `AllowPowerUser`. Only the Access Entry + Access Policy actions are added.
- `Resource: "*"` — the EKS Access Entry / Access Policy APIs are cluster-scoped; the access an entry can grant is already constrained by the `accessScope` on each `AccessEntry` and by the association policy ARN.
- No behavioural change for clusters without `capability_ack_enabled`.

## Testing

CloudFormation YAML for the added resource validated locally; Go-template `if`/`range`/`end` counts unchanged vs `dev`. Requires the `ready-to-test` label to run e2e.
