### PR TITLE
feat(karpenter): make reserved capacity feature gate configurable

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -4,6 +4,11 @@ karpenter_controller_cpu: "25m"
 karpenter_controller_memory: "256Mi"
 # set log level of karpenter: error|debug
 karpenter_log_level: "error"
+# enable Karpenter's native capacity-reservation support. When true, Karpenter launches every node with
+# CapacityReservationPreference=none, which opts it OUT of open EC2 On-Demand Capacity Reservations; a
+# reservation is then only usable if a NodeClass selects it explicitly. Set false to let open ODCRs be
+# consumed automatically, as they are for any other EC2 instance.
+karpenter_feature_reserved_capacity: "true"
 # restrict the maximum number of pods for karpenter nodes
 karpenter_max_pods_per_node: "32"
 

--- a/cluster/manifests/z-karpenter/deployment.yaml
+++ b/cluster/manifests/z-karpenter/deployment.yaml
@@ -96,8 +96,12 @@ spec:
                   containerName: controller
                   divisor: "0"
                   resource: limits.memory
+            # ReservedCapacity flips Karpenter to LaunchModeTargeted, which writes
+            # CapacityReservationPreference=none into every launch template and so opts the node out of
+            # every OPEN capacity reservation (upstream pkg/providers/launchtemplate/types.go). Cluster
+            # operators who just want an open ODCR consumed turn it off.
             - name: FEATURE_GATES
-              value: "ReservedCapacity=true,SpotToSpotConsolidation=true,NodeRepair=false,NodeOverlay=false,StaticCapacity=false"
+              value: "ReservedCapacity={{ .Cluster.ConfigItems.karpenter_feature_reserved_capacity }},SpotToSpotConsolidation=true,NodeRepair=false,NodeOverlay=false,StaticCapacity=false"
             - name: BATCH_MAX_DURATION
               value: "10s"
             - name: BATCH_IDLE_DURATION


### PR DESCRIPTION
Copy of #11607 to run e2e

---

## Make Karpenter's `ReservedCapacity` feature gate a per-cluster config item

### Issue

Karpenter nodes never consume an *open* EC2 On-Demand Capacity Reservation. Every launch template Karpenter creates carries `CapacityReservationPreference: none`, which opts the instance out of every open reservation:

```console
$ LT=$(aws ec2 describe-launch-templates --filters 'Name=launch-template-name,Values=karpenter.k8s.aws/*' \
    --query 'LaunchTemplates[0].LaunchTemplateId' --output text)
$ aws ec2 describe-launch-template-versions --launch-template-id "$LT" --versions '$Latest' \
    --query 'LaunchTemplateVersions[0].LaunchTemplateData.CapacityReservationSpecification'
{ "CapacityReservationPreference": "none" }
```

This is not an AWS default. Upstream writes it only in `LaunchModeTargeted`, and [`LaunchMode()`](https://github.com/aws/karpenter-provider-aws/blob/2be95547983a8948b7172aa66bf92c905fbbf001/pkg/providers/launchtemplate/types.go#L64-L69) returns that mode exactly when the `ReservedCapacity` feature gate is on. Upstream flags the consequence in a comment right above
[the write](https://github.com/aws/karpenter-provider-aws/blob/2be95547983a8948b7172aa66bf92c905fbbf001/pkg/providers/launchtemplate/types.go#L148-L156):

> Gate this specifically since the update to CapacityReservationPreference will opt od / spot launches out
> of open ODCRs, which is a breaking change from the pre-native ODCR support behavior.

### When it was introduced

[`90b72cf`](https://github.com/zalando-incubator/kubernetes-on-aws/commit/90b72cf405e171077c7c6a05fd57662353bd3cf0) (2025-10-09, "Update to Karpenter v1.8.0") flipped the gate `false` -> `true` fleet-wide as part of the version bump: [`deployment.yaml#L97-L98`](https://github.com/zalando-incubator/kubernetes-on-aws/blob/90b72cf405e171077c7c6a05fd57662353bd3cf0/cluster/manifests/z-karpenter/deployment.yaml#L97-L98).

Nothing uses what it unlocks: no NodePool selects `karpenter.sh/capacity-type: reserved`, no EC2NodeClass declares `capacityReservationSelectorTerms`, and no live node is on reserved capacity. So the bump silently ended open-ODCR consumption for the whole fleet, with nothing gained.

### Fix

Template the gate from a new cluster config item `karpenter_feature_reserved_capacity`, defaulting to `"true"` so no cluster changes behavior:

- [`cluster/config-defaults.yaml#L6`](https://github.com/zalando-incubator/kubernetes-on-aws/blob/a10c60010140dd960200d84e6d5bc85931680724/cluster/config-defaults.yaml#L6): new default beside `karpenter_log_level`
- [`cluster/manifests/z-karpenter/deployment.yaml#L99-L100`](https://github.com/zalando-incubator/kubernetes-on-aws/blob/a10c60010140dd960200d84e6d5bc85931680724/cluster/manifests/z-karpenter/deployment.yaml#L99-L100): `ReservedCapacity={{ .Cluster.ConfigItems.karpenter_feature_reserved_capacity }}`

Set it `false` on a cluster and Karpenter returns to `LaunchModeOpen`: an open reservation is consumed automatically by any matching instance, as it is for a hand-started one.

Companion PR in `teapot-cluster-config-manager` declares the item next to [`karpenter_in_transit_support_required`](https://github.com/zalando-build/teapot-cluster-config-manager/blob/50dd55f9fc1decebbdb8580d379d22c33c2a202e/schema.yaml#L567-L568) and sets it `false` for `deepthought-euc1-test`, which has a g6.4xlarge reservation for GPU serving.
