### PR TITLE
Add servicequotas:GetServiceQuota to zmon permissions

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -3054,6 +3054,9 @@ Resources:
               - Action: 'servicequotas:ListServiceQuotas'
                 Effect: Allow
                 Resource: '*'
+              - Action: 'servicequotas:GetServiceQuota'
+                Effect: Allow
+                Resource: '*'
               - Action: 'sts:AssumeRole'
                 Effect: Allow
                 Resource: '*'


### PR DESCRIPTION
Extend zmon permissions for ServiceQuotas by `GetServiceQuota`, with this we can query single quotas instead 

ref: https://linear.app/zalando/issue/OBS-1692/limit-aws-servicequota-detection-to-the-ones-that-are-actually-used-by