### PR TITLE
skipper-main: Update to version v0.27.25-1479

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -394,6 +394,9 @@ skipper_combined_response_metrics: "false"
 # skipper_backend_host_metrics sets the flag -backend-host-metrics.
 # It enables reporting total serve time metrics for backend
 skipper_backend_host_metrics: "false"
+# skipper_backend_zone_metrics sets the flag -backend-zone-metrics.
+# It enables reporting total serve time metrics for backend by zone
+skipper_backend_zone_metrics: "true"
 
 #
 # skipper-ingress validation webhook

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,6 +1,6 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.27.18-1472" }}
+{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.27.25-1479" }}
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.27.25-1479" }}
 
 {{/* Allow to override manually canary image by config item */}}


### PR DESCRIPTION
Update skipper main fleet to v0.27.25-1479
changes: https://github.com/zalando/skipper/compare/v0.27.18...v0.27.25

Enabling config item to track latency by zone from skipper-ingress to backend

ref: 
https://github.com/zalando-incubator/kubernetes-on-aws/pull/11590
https://github.com/zalando-incubator/kubernetes-on-aws/pull/11578