### PR TITLE
Support running EKS AMIs

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -67,6 +67,16 @@ karpenter_flex_types_enabled: "false"
 karpenter_flex_types_enabled: "true"
 {{end}}
 
+# Define Karpenter AMI family alias. This is used to determine the AMI used for
+# Karpenter nodes.
+#
+# The default is custom which is the Zalando Kubernetes on Ubuntu AMI.
+#
+# alternatives:
+#  - al2023@latest
+#  - bottlerocket@latest
+karpenter_ami_family_alias: "custom"
+
 # configure whether spot instances should be enabled in Karpenter's capacity-types
 karpenter_enable_spot: "true"
 

--- a/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
+++ b/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
@@ -45,9 +45,17 @@ spec:
                 operator: In
                 values:
                 - nvidia
+              - key: ami-family
+                operator: NotIn
+                values:
+                - bottlerocket
             - matchExpressions:
               - key: zalando.org/nvidia-gpu
                 operator: Exists
+              - key: ami-family
+                operator: NotIn
+                values:
+                - bottlerocket
       priorityClassName: system-node-critical
       volumes:
       - name: device-plugin

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -4,11 +4,16 @@ kind: EC2NodeClass
 metadata:
   name: "{{ .NodePool.Name }}"
 spec:
+  # {{ if eq .NodePool.ConfigItems.karpenter_ami_family_alias "custom" }}
   amiFamily: Custom
   amiSelectorTerms:
     # Select on any AMI that has any of the following IDs
     - id: {{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_35_" .NodePool.ConfigItems.kuberuntu_ami_version "_amd64") }}
     - id: {{ index .NodePool.ConfigItems (print "kuberuntu_image_v1_35_" .NodePool.ConfigItems.kuberuntu_ami_version "_arm64") }}
+  # {{ else }}
+  amiSelectorTerms:
+    - alias: "{{ .NodePool.ConfigItems.karpenter_ami_family_alias }}"
+  # {{ end }}
   metadataOptions:
     httpEndpoint: enabled
     # {{ if and (eq .Cluster.Provider "zalando-eks") (eq .Cluster.ConfigItems.eks_ip_family "ipv6") }}
@@ -96,8 +101,24 @@ spec:
 #    {{ end}}
 #  {{ end}}
 #{{ end}}
+{{- if eq .NodePool.ConfigItems.karpenter_ami_family_alias "custom" }}
   userData: |
 {{ .Values.UserData | indent 4 }}
+{{- else if hasPrefix .NodePool.ConfigItems.karpenter_ami_family_alias "al2023" }}
+  userData: |
+    ---
+    apiVersion: node.eks.aws/v1alpha1
+    kind: NodeConfig
+    spec:
+      kubelet:
+        flags:
+          # hack to pass admission-controller requirements
+          - "--node-labels=node.kubernetes.io/role=worker"
+{{- else if hasPrefix .NodePool.ConfigItems.karpenter_ami_family_alias "bottlerocket" }}
+  userData: |
+      [settings.kubernetes]
+      node-labels = {"node.kubernetes.io/role" = "worker"}
+{{- end }}
 ---
 apiVersion: karpenter.sh/v1
 kind: NodePool

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -21,8 +21,13 @@ spec:
     # {{ else }}
     httpProtocolIPv6: disabled
     # {{ end }}
+    # {{ if or (hasPrefix .NodePool.ConfigItems.karpenter_ami_family_alias "bottlerocket") (hasPrefix .NodePool.ConfigItems.karpenter_ami_family_alias "al2023") }}
+    httpPutResponseHopLimit: 1
+    httpTokens: required
+    # {{ else }}
     httpPutResponseHopLimit: 2
     httpTokens: optional
+    # {{ end }}
   subnetSelectorTerms:
     - tags:
         # {{ if eq .NodePool.ConfigItems.internal_node_subnets_enabled "true" }}

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -133,6 +133,9 @@ spec:
     metadata:
       # Labels are arbitrary key-values that are applied to all nodes
       labels:
+# {{ if hasPrefix .NodePool.ConfigItems.karpenter_ami_family_alias "bottlerocket" }}
+        ami-family: "bottlerocket"
+# {{ end }}
         lifecycle-status: ready
         node.kubernetes.io/node-pool: "{{ .NodePool.Name }}"
         node.kubernetes.io/role: worker


### PR DESCRIPTION
Enable support for running EKS AMIs as alternative to the Custom Ubuntu AMI.

This puts it behind a config-item such that it can be enabled per cluster or even node pool. The default is still Ubuntu AMI (`custom`).

This is e2e tested with bottlerocket in #11838 