### PR TITLE
Set backend-zone-metrics in skipper-ingress deployment

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -250,6 +250,7 @@ spec:
           - "-serve-host-counter"
           - "-combined-response-metrics={{ .Cluster.ConfigItems.skipper_combined_response_metrics }}"
           - "-backend-host-metrics={{ .Cluster.ConfigItems.skipper_backend_host_metrics }}"
+          - "-backend-zone-metrics={{ .Cluster.ConfigItems.skipper_backend_zone_metrics }}"
           - "-disable-metrics-compat"
           - "-disable-metrics-compression"
           - "-enable-profile"


### PR DESCRIPTION
Add config item backend-zone-metrics to skipper-ingress deployment