### PR TITLE
e2e: Only set efs_id in non-EKS

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -371,9 +371,6 @@ post_apply:
 - name: efs-provisioner
   kind: ConfigMap
   namespace: kube-system
-- name: efs-provisioner
-  kind: ServiceAccount
-  namespace: kube-system
 - name: efs-provisioner-runner
   kind: ClusterRole
 - name: leader-locking-efs-provisioner
@@ -387,6 +384,9 @@ post_apply:
   namespace: kube-system
 - name: aws-efs
   kind: StorageClass
+- name: efs-provisioner
+  kind: ServiceAccount
+  namespace: kube-system
 {{ end }}
 {{- if ne .Cluster.ConfigItems.capability_kro_enabled "true"}}
 - name: kro-poweruser

--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -29,7 +29,7 @@ clusters:
     zmon_scheduler_replicas: '0'
     zmon_worker_replicas: '0'
     skipper_ingress_refuse_payload: "refused-pattern-1[cf724afc]refused-pattern-2"
-    efs_id: ${EFS_ID}
+    $(if [ "${CLUSTER_PROVIDER}" == "zalando-aws" ]; then echo -n "efs_id: ${EFS_ID}"; else echo -n ""; fi)
     webhook_id: ${INFRASTRUCTURE_ACCOUNT}:${REGION}:kube-aws-test
     nlb_switch: "pre"
     vm_dirty_bytes: 134217728


### PR DESCRIPTION
Bottlerocket is not compatible with the legacy EFS provisioner as it requires nfs tools on the instance (#11643)

Since we don't use this feature in any EKS cluster, simply disable it from e2e test in EKS clusters as well.