### PR TITLE
e2e: Only allow IAM test role access to test bucket

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -3423,6 +3423,34 @@ Resources:
           Status: Enabled
       VersioningConfiguration:
         Status: Suspended
+  E2EAWSIAMTestBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref E2EAWSIAMTestBucket
+      PolicyDocument:
+        Statement:
+          - Action:
+              - s3:ListBucket
+              - s3:PutObject
+              - s3:GetObject
+              - s3:DeleteObject
+            Effect: Allow
+            Resource:
+              - !Sub "arn:aws:s3:::${E2EAWSIAMTestBucket}"
+              - !Sub "arn:aws:s3:::${E2EAWSIAMTestBucket}/*"
+            Principal:
+              AWS:
+                - !GetAtt E2EAWSIAMTestRole.Arn
+          - Action: "s3:*"
+            Effect: Deny
+            Resource:
+              - !Sub "arn:aws:s3:::${E2EAWSIAMTestBucket}"
+              - !Sub "arn:aws:s3:::${E2EAWSIAMTestBucket}/*"
+            Principal: "*"
+            Condition:
+              ArnNotEquals:
+                aws:PrincipalArn:
+                  - !GetAtt E2EAWSIAMTestRole.Arn
 {{ end }}
 
   AuditTrailBucket:


### PR DESCRIPTION
Fixes a bug in the e2e test where getting the worker role credentials would also pass the test. We explicitly want to catch such issues and fail the tests.