### PR TITLE
ingress-controller: Avoid access to metadata endpoint

### DIFF
--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -37,6 +37,8 @@ spec:
         - name: controller
           image: "{{ $image }}"
           args:
+            - "--cluster-id={{.Cluster.ID}}"
+            - "--vpc-id={{.Cluster.ConfigItems.vpc_id}}"
             - --ip-addr-type={{ .Cluster.ConfigItems.kube_aws_ingress_controller_lb_ip_addr_type }}
             - --target-group-ip-addr-type={{ .Cluster.ConfigItems.kube_aws_ingress_controller_target_group_ip_addr_type }}
 {{- if eq .Cluster.ConfigItems.kube_aws_ingress_controller_nlb_preserve_client_ip "false" }}


### PR DESCRIPTION
From a security perspective we want to run the instances without pods having access to the EC2 metadata endpoint. Currently the ingress-controller depends on the metadata for vpc-id and cluster-id discovery. By passing it as flags that dependency is no longer needed.

This contributes to running bottlerocket AMIs where kube2iam won't work, which is currently providing safe access to ec2 metadata endpoint.

ref: #11643 