### PR TITLE
Revert "platform-iam-tokeninfo: Update to version master-204"

### DIFF
--- a/cluster/manifests/zalando-iam-aws-proxy/deployment.yaml
+++ b/cluster/manifests/zalando-iam-aws-proxy/deployment.yaml
@@ -49,7 +49,7 @@ spec:
             sleep:
               seconds: 20
       - name: tokeninfo
-        image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/foundation/platform-iam-tokeninfo:master-204
+        image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/foundation/platform-iam-tokeninfo:master-201
         env:
         - name: OPENID_PROVIDER_CONFIGURATION_URL
           value: https://identity.zalando.com/.well-known/openid-configuration
@@ -82,7 +82,7 @@ spec:
             memory: 100Mi
       # {{- if ne .Cluster.Environment "production"}}
       - name: tokeninfo-sandbox
-        image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/foundation/platform-iam-tokeninfo:master-204
+        image: 926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/foundation/platform-iam-tokeninfo:master-201
         env:
         - name: OPENID_PROVIDER_CONFIGURATION_URL
           value: https://sandbox.identity.zalando.com/.well-known/openid-configuration


### PR DESCRIPTION
This reverts image update in https://github.com/zalando-incubator/kubernetes-on-aws/pull/11670

This new version is causing Pods to constantly crash loop, due to the image not being multi-arch