### PR TITLE
Restrict LLM code review to pull requests aiming `dev`

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -462,6 +462,7 @@ pipeline:
 - id: llm-code-review
   depends_on: []
   when:
+    target_branch: dev
     event: pull_request
   type: script
   vm_config:


### PR DESCRIPTION
having it for other branches doesn't make sence