### PR TITLE
Revert "ACK needs to be able to tag EKS resources"

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -439,7 +439,6 @@ Resources:
             Action:
               - 'sts:AssumeRole'
               - 'sts:TagSession'
-              - 'eks:TagResource'
       ManagedPolicyArns:
       - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-DenyEc2UsApSa"
       - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-DenyModifyShibboleth"


### PR DESCRIPTION
Reverts zalando-incubator/kubernetes-on-aws#11659

The action was added under assumerole policy which is invalid. Needs to be an actual inline policy permission