### PR TITLE
Annotate DNS pods to track progress

### DIFF
--- a/cluster/manifests/01-coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/01-coredns-local/daemonset-coredns.yaml
@@ -24,6 +24,7 @@ spec:
         prometheus.io/path: /metrics
         prometheus.io/scrape: "true"
         prometheus.io/port: "9153"
+        dns-static-interface: "{{.Cluster.ConfigItems.dns_static_interface}}"
     spec:
       resources:
         limits:


### PR DESCRIPTION
For the rollout of #11216 we need a way to track if a cluster is fully rolled out for a stage before proceeding to the next stage. To simplify this, simply annotate the CoreDNS pods such that we know if the given stage was applied or not and can count how many pods/nodes are missing per cluster.