### PR TITLE
Set dns_static_interface to the final stage

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1078,7 +1078,7 @@ dns_coredns_mem: "195Mi"
 #  kubelet - kubelet configures static dns IP address - worker node rotation!
 #  only_interface - dns cache listens _only_ on the static interface
 #
-dns_static_interface: "interface"
+dns_static_interface: "only_interface"
 
 # special roles for test/pet clusters
 {{if eq .Cluster.Environment "e2e"}}


### PR DESCRIPTION
This configures the default value for `dns_static_interface` to the final stage. The purpose of this is that the default is final so new clusters created are automatically starting from the final stage and don't need migration.

related PR describing the rollout https://github.com/zalando-incubator/kubernetes-on-aws/pull/11216

* [ ] The prerequisite is that all clusters, not yet migrated, has the stage set explicitly per cluster.