### PR TITLE
Karpenter: Add missing permissions

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -1557,7 +1557,8 @@ Resources:
                     "arn:${AWS::Partition}:ec2:${AWS::Region}::snapshot/*",
                     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:security-group/*",
                     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:subnet/*",
-                    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:capacity-reservation/*"
+                    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:capacity-reservation/*",
+                    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:placement-group/*"
                   ],
                   "Action": [
                     "ec2:RunInstances",
@@ -1590,8 +1591,7 @@ Resources:
                     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
                     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*",
                     "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*",
-                    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*",
-                    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:capacity-reservation/*"
+                    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*"
                   ],
                   "Action": [
                     "ec2:RunInstances",
@@ -1686,9 +1686,11 @@ Resources:
                     "ec2:DescribeCapacityReservations",
                     "ec2:DescribeImages",
                     "ec2:DescribeInstances",
+                    "ec2:DescribeInstanceStatus",
                     "ec2:DescribeInstanceTypeOfferings",
                     "ec2:DescribeInstanceTypes",
                     "ec2:DescribeLaunchTemplates",
+                    "ec2:DescribePlacementGroups",
                     "ec2:DescribeSecurityGroups",
                     "ec2:DescribeSpotPriceHistory",
                     "ec2:DescribeSubnets"


### PR DESCRIPTION
Observed in e2e that Karpenter tries to do `DescribeInstanceStatus` and failing. Add missing permissions from upstream.