### PR TITLE
Fix e2e aws iam test bucket policy

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -3429,18 +3429,7 @@ Resources:
       PolicyDocument:
         Statement:
           - Action:
-              - s3:ListBucket
               - s3:PutObject
-              - s3:GetObject
-              - s3:DeleteObject
-            Effect: Allow
-            Resource:
-              - !Sub "arn:aws:s3:::${E2EAWSIAMTestBucket}"
-              - !Sub "arn:aws:s3:::${E2EAWSIAMTestBucket}/*"
-            Principal:
-              AWS:
-                - !GetAtt E2EAWSIAMTestRole.Arn
-          - Action: "s3:*"
             Effect: Deny
             Resource:
               - !Sub "arn:aws:s3:::${E2EAWSIAMTestBucket}"


### PR DESCRIPTION
The bucket policy introduced in https://github.com/zalando-incubator/kubernetes-on-aws/pull/11665 was so strict we can't cleanup the bucket after the e2e is run.

Change the policy to allow any action except for `s3:PutObject` for all roles in the account like before. We only allow `s3:PutObject` for the e2eawsiamrole to validate that only this can put objects which are part of the e2e test.