### PR TITLE
Set default routes-url for canary to the zone aware endpoint

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -135,7 +135,7 @@ skipper_ingress_canary_image: ""
 skipper_ingress_test_single_pod: "false"
 skipper_canary_controller_enabled: "false"
 
-skipper_ingress_canary_routes_urls: http://skipper-ingress-canary-routesrv.kube-system.svc.cluster.local/routes
+skipper_ingress_canary_routes_urls: http://skipper-ingress-canary-routesrv.kube-system.svc.cluster.local/routes/$(KUBE_NODE_ZONE)
 skipper_ingress_routes_urls: http://skipper-ingress-routesrv.kube-system.svc.cluster.local/routes
 
 skipper_ingress_canary_swarm_valkey_remote: http://skipper-ingress-canary-routesrv.kube-system.svc.cluster.local/swarm/valkey/shards


### PR DESCRIPTION
The config-item `skipper_ingress_canary_routes_urls` is set to the zone aware endpoint in all clusters, this PR cleans up the config-item and makes it the default endpoint.