### PR TITLE
karpenter: Allow enabling NodeRepair

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -9,6 +9,13 @@ karpenter_log_level: "error"
 # reservation is then only usable if a NodeClass selects it explicitly. Set false to let open ODCRs be
 # consumed automatically, as they are for any other EC2 instance.
 karpenter_feature_reserved_capacity: "true"
+
+# enable Karpenter's node repair feature. When true, Karpenter will attempt to
+# repair nodes that are unhealthy.
+# Only works in EKS where we have eks-node-monitoring-agent running.
+# https://karpenter.sh/docs/concepts/disruption/#node-auto-repair
+karpenter_feature_node_repair: "false"
+
 # restrict the maximum number of pods for karpenter nodes
 karpenter_max_pods_per_node: "32"
 

--- a/cluster/manifests/z-karpenter/deployment.yaml
+++ b/cluster/manifests/z-karpenter/deployment.yaml
@@ -101,7 +101,7 @@ spec:
             # every OPEN capacity reservation (upstream pkg/providers/launchtemplate/types.go). Cluster
             # operators who just want an open ODCR consumed turn it off.
             - name: FEATURE_GATES
-              value: "ReservedCapacity={{ .Cluster.ConfigItems.karpenter_feature_reserved_capacity }},SpotToSpotConsolidation=true,NodeRepair=false,NodeOverlay=false,StaticCapacity=false"
+              value: "ReservedCapacity={{ .Cluster.ConfigItems.karpenter_feature_reserved_capacity }},SpotToSpotConsolidation=true,NodeRepair={{ .Cluster.ConfigItems.karpenter_feature_node_repair }},NodeOverlay=false,StaticCapacity=false"
             - name: BATCH_MAX_DURATION
               value: "10s"
             - name: BATCH_IDLE_DURATION


### PR DESCRIPTION
Allow enabling NodeRepair feature gate via a config-item.

This would allow Karpenter to perform automatic node repair actions as outlined in https://karpenter.sh/docs/concepts/disruption/#node-auto-repair

This feature will only work in EKS as it needs to be paired with e.g. eks-node-monitoring-agent which can indicate "broken" nodes.