### PR TITLE
ingr-ctrl: Use Cluster.Name instead of ID

### DIFF
--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -37,7 +37,7 @@ spec:
         - name: controller
           image: "{{ $image }}"
           args:
-            - "--cluster-id={{.Cluster.ID}}"
+            - "--cluster-id={{.Cluster.Name}}"
             - "--vpc-id={{.Cluster.ConfigItems.vpc_id}}"
             - --ip-addr-type={{ .Cluster.ConfigItems.kube_aws_ingress_controller_lb_ip_addr_type }}
             - --target-group-ip-addr-type={{ .Cluster.ConfigItems.kube_aws_ingress_controller_target_group_ip_addr_type }}


### PR DESCRIPTION
Follow up to #11673

Use `Cluster.Name` instead of `Cluster.ID` to use the correct value for EKS clusters.