### PR TITLE
Excluding feedback checklist  and adding more context to reviewer.

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -472,4 +472,4 @@ pipeline:
   commands:
     - desc: "LLM Review"
       cmd: |
-        llm-code-review -read-from-github -write-to-github
+        llm-code-review -read-from-github -write-to-github -no-feedback-checklist -C 20


### PR DESCRIPTION
With default 5 lines context llm reviewer doesn't see the problems in https://github.com/zalando-incubator/kubernetes-on-aws/pull/10824

Also the feedback checklist consumes too much space in the PR

https://linear.app/zalando/issue/ZAL-96/enable-code-review-for-kubernetes-on-aws