### PR TITLE
Revert "aws-credentials-waiter: Update to version master-311"

### DIFF
--- a/cluster/manifests/02-admission-control/config.yaml
+++ b/cluster/manifests/02-admission-control/config.yaml
@@ -32,7 +32,7 @@ data:
   pod.service-account-iam.enable: "true"
   pod.service-account-iam.base-aws-account-id: "{{ .Cluster.InfrastructureAccountID }}"
 {{- if eq .Cluster.ConfigItems.teapot_admission_controller_inject_aws_waiter "true" }}
-  pod.aws-waiter.image: "926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/automata/aws-credentials-waiter:master-311"
+  pod.aws-waiter.image: "926694233939.dkr.ecr.eu-central-1.amazonaws.com/production_namespace/automata/aws-credentials-waiter:master-306"
 {{- end }}
   pod.env-inject.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_inject_environment_variables }}"
   pod.env-inject.variable._PLATFORM_ACCOUNT: "{{ .Cluster.Alias }}"


### PR DESCRIPTION
Reverts zalando-incubator/kubernetes-on-aws#11744

latest image is not multi-arch, revert until image build is fixed!