### PR TITLE
admission-controller: Wire Skipper application-label checks

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -306,6 +306,15 @@ skipper_pod_deletion_cost_controller_poll_timeout: "60s"
 skipper_pod_deletion_cost_controller_resync_enable: "true"
 skipper_pod_deletion_cost_controller_resync_interval: "1h"
 
+{{if eq .Cluster.Environment "production"}}
+skipper_resources_validate_application_label: "true"
+skipper_resources_application_label_in_scope_resources: "ingresses,routegroups,fabricgateways"
+{{else}}
+skipper_resources_validate_application_label: "false"
+skipper_resources_application_label_in_scope_resources: "ingresses,routegroups,fabricgateways"
+{{end}}
+skipper_resources_application_label_min_creation_time: "2026-07-22T10:00:00Z"
+
 # polarsignals - only enabled for some clusters
 polarsignals_enabled: "false"
 # Comma separated list of workloads for which polarsignals is enabled, only used

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -308,11 +308,10 @@ skipper_pod_deletion_cost_controller_resync_interval: "1h"
 
 {{if eq .Cluster.Environment "production"}}
 skipper_resources_validate_application_label: "true"
-skipper_resources_application_label_in_scope_resources: "ingresses,routegroups,fabricgateways"
 {{else}}
 skipper_resources_validate_application_label: "false"
-skipper_resources_application_label_in_scope_resources: "ingresses,routegroups,fabricgateways"
 {{end}}
+skipper_resources_application_label_in_scope_resources: "ingresses,routegroups,fabricgateways"
 skipper_resources_application_label_min_creation_time: "2026-07-22T10:00:00Z"
 
 # polarsignals - only enabled for some clusters

--- a/cluster/manifests/02-admission-control/config.yaml
+++ b/cluster/manifests/02-admission-control/config.yaml
@@ -68,6 +68,10 @@ data:
   podfactory.application-label-check.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_validate_application_label }}"
   podfactory.application-label-check.minimum-creation-time: "{{ .Cluster.ConfigItems.teapot_admission_controller_application_min_creation_time }}"
 
+  applicationlabel.check.enable: "{{ .Cluster.ConfigItems.skipper_resources_validate_application_label }}"
+  applicationlabel.check.in-scope-resources: "{{ .Cluster.ConfigItems.skipper_resources_application_label_in_scope_resources }}"
+  applicationlabel.check.minimum-creation-time: "{{ .Cluster.ConfigItems.skipper_resources_application_label_min_creation_time }}"
+
   podfactory.base-image-check.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_validate_base_images }}"
 {{- if index .Cluster.ConfigItems "teapot_admission_controller_validate_base_images_namespaces" }}
   podfactory.base-image-check.namespaces: "{{ .Cluster.ConfigItems.teapot_admission_controller_validate_base_images_namespaces }}"


### PR DESCRIPTION
### Description

Wire the admission-controller application-label validation ConfigMap values for Skipper resources.

- Add ConfigItems for the validation flag, in-scope resources, and the RFC3339 grandfathering cutoff.
- Enable the defaults for production clusters and disable them for non-production clusters.
- Render the ConfigItems as `applicationlabel.check.*` values in the admission-controller ConfigMap.

The Teapot Cluster Config Manager rollout configuration keeps validation disabled per channel until it is enabled progressively.

### Related Issue(s)

https://github.com/zalando-build/pg9-issues/issues/466

### Testing

- `git diff --check`
- Verified the ConfigMap uses the expected `applicationlabel.check.*` configuration keys.

### Checklist

- [x] I have reviewed and tested the changes thoroughly with definition of done in mind.
- [x] I have added appropriate comments (and documentation) to the code for clarity.
- [ ] I have communicated updates to customers (e.g., feature changes, expected downtimes, etc.)