### PR TITLE
fluent-bit for journald logging

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -617,7 +617,8 @@ static_egress_controller_enabled: "false"
 static_egress_controller_memory_min: "10Mi"
 
 # journald reader settings
-journald_reader_enabled: "true"
+journald_reader_enabled: "false"
+journald_reader_fluentbit_enabled: "true"
 journald_reader_cpu: "1m"
 journald_reader_memory: "30Mi"
 

--- a/cluster/manifests/02-admission-control/config.yaml
+++ b/cluster/manifests/02-admission-control/config.yaml
@@ -94,7 +94,7 @@ data:
   pod.image-check.namespaces: "^(image-policy-test-enabled-.*|kube-system|visibility)$"
 
   # Always allow certain container images regardless of namespace, defaults to none if not configured
-  pod.image-check.ignored-images: "^k8s.gcr.io/pause:.+$"
+  pod.image-check.ignored-images: "^(k8s.gcr.io/pause|906394416424.dkr.ecr.{{.Cluster.Region}}.amazonaws.com/aws-for-fluent-bit):.+$"
 {{- end }}
 
   # This setting enables and disables replacement of vanity images with ECR images during pod admission (during create and update)

--- a/cluster/manifests/node-monitor/daemonset.yaml
+++ b/cluster/manifests/node-monitor/daemonset.yaml
@@ -89,6 +89,74 @@ spec:
               name: usr
               readOnly: true
 {{- end }}
+{{- if eq .Cluster.ConfigItems.journald_reader_fluentbit_enabled "true" }}
+        - image: 906394416424.dkr.ecr.{{.Cluster.Region}}.amazonaws.com/aws-for-fluent-bit:3.4.9
+          name: fluent-bit-journald-reader
+          command:
+            - /fluent-bit/bin/fluent-bit
+          args:
+            - -q
+            - -i
+            - systemd
+            - -p
+            - Path=/var/log/journal
+            - -p
+            - DB=/fluent-bit-state/fluent-bit.db
+            - -p
+            - Read_From_Tail=false
+            - -p
+            - Tag=host.journald
+            - -F
+            - record_modifier
+            - -m
+            - host.journald
+            - -p
+            - Allowlist_key=MESSAGE
+            - -p
+            - Allowlist_key=_SYSTEMD_UNIT
+            - -p
+            - Allowlist_key=_BOOT_ID
+            - -p
+            - Allowlist_key=_MACHINE_ID
+            - -p
+            - Allowlist_key=_PID
+            - -F
+            - modify
+            - -m
+            - host.journald
+            - -p
+            - Rename=MESSAGE message
+            - -p
+            - Rename=_SYSTEMD_UNIT unit
+            - -p
+            - Rename=_BOOT_ID boot_id
+            - -p
+            - Rename=_MACHINE_ID machine_id
+            - -p
+            - Rename=_PID pid
+            - -o
+            - stdout
+            - -p
+            - format=json_lines
+            - -p
+            - json_date_format=iso8601
+            - -f
+            - "1"
+          resources:
+            requests:
+              cpu: {{.Cluster.ConfigItems.journald_reader_cpu}}
+              memory: {{.Cluster.ConfigItems.journald_reader_memory}}
+              ephemeral-storage: 256Mi
+            limits:
+              cpu: {{.Cluster.ConfigItems.journald_reader_cpu}}
+              memory: {{.Cluster.ConfigItems.journald_reader_memory}}
+          volumeMounts:
+            - mountPath: /var/log/journal
+              name: journald-logs
+              readOnly: true
+            - mountPath: /fluent-bit-state
+              name: journald-reader-state
+{{- end }}
       automountServiceAccountToken: false
       terminationGracePeriodSeconds: 30
       volumes:
@@ -110,7 +178,7 @@ spec:
         - name: kmsg
           hostPath:
             path: /dev/kmsg
-{{- if eq .Cluster.ConfigItems.journald_reader_enabled "true" }}
+{{- if or (eq .Cluster.ConfigItems.journald_reader_enabled "true") (eq .Cluster.ConfigItems.journald_reader_fluentbit_enabled "true") }}
         - name: journald-logs
           hostPath:
             path: /var/log/journal


### PR DESCRIPTION
This introduces `fluent-bit` as a replacement for the current custom `journald-reader` container in the `node-monitor` daemonset.

The purpose is to parse systemd logs and write to stdout such that logging-agent can ship them to our logging provider. This is the same the custom `journald-reader` does today but it has the problem that it can't run on bottlerocket:

```
/usr/bin/env: error while loading shared libraries: libselinux.so.1: cannot open shared object file: No such file or directory
```

It uses the AWS provided private ECR image: `906394416424.dkr.ecr.{{.Cluster.Region}}.amazonaws.com/aws-for-fluent-bit` such that we don't need to build and maintain our own, this is equivalent to the images we get from other EKS Addons and provides the same availability guarantee as our own ECR repo (ECR availability).

The original `journald_reader` is still kept, but disabled by default, this is just so we can roll back if we see any issues during the rollout, eventually it can be removed completely.

The fluent-bit logging is done so it mimics the same format as we currently have a log looks like this:

```
{"date":"2026-07-24T12:04:24.900163Z","boot_id":"9a5ba04b94d94b9389e8e15ee67bbfab","machine_id":"ec25fedf6751e2511d6ab3b5dd893396","unit":"kubelet.service","pid":"1751","message":"I0724 12:04:24.900108    1751 pod_startup_latency_tracker.go:148] \"Observed pod startup duration\" pod=\"kube-system/node-monitor-5xjtw\" podStartSLOduration=1.285153213 podStartE2EDuration=\"3.900093797s\" totalImagesPullingTime=\"2.614940584s\" totalInitContainerRuntime=\"0s\" isStatefulPod=true podCreationTimestamp=\"2026-07-24 12:04:21 +0000 UTC\" imagePullSessionsCount=1 imagePullSessionsStartsCount=0 observedRunningTime=\"2026-07-24 12:04:24.899075653 +0000 UTC m=+3887.939149474\" watchObservedRunningTime=\"2026-07-24 12:04:24.900093797 +0000 UTC m=+3887.940167605\""}
```