### PR TITLE
Register application label validation webhook

### DIFF
--- a/cluster/manifests/02-admission-control/teapot.yaml
+++ b/cluster/manifests/02-admission-control/teapot.yaml
@@ -551,6 +551,33 @@ webhooks:
         apiVersions: ["v1"]
         resources: ["routegroups"]
 
+{{- if eq .Cluster.ConfigItems.skipper_resources_validate_application_label "true" }}
+  - name: applicationlabel-validation-admitter.teapot.zalan.do
+    clientConfig:
+      {{- if eq .Cluster.Provider "zalando-eks"}}
+      service:
+        name: "admission-controller"
+        namespace: "kube-system"
+        path: "/applicationlabel_validation"
+      {{- else }}
+      url: "https://localhost:8085/applicationlabel_validation"
+      {{- end }}
+      caBundle: "{{ .Cluster.ConfigItems.ca_cert_decompressed }}"
+    admissionReviewVersions: ["v1beta1"]
+    failurePolicy: Fail
+    sideEffects: "NoneOnDryRun"
+    matchPolicy: Equivalent
+    rules:
+      - operations: [ "CREATE", "UPDATE" ]
+        apiGroups: ["networking.k8s.io"]
+        apiVersions: ["v1"]
+        resources: ["ingresses"]
+      - operations: [ "CREATE", "UPDATE" ]
+        apiGroups: ["zalando.org"]
+        apiVersions: ["v1"]
+        resources: ["routegroups", "fabricgateways"]
+{{- end }}
+
 {{- if eq .Cluster.ConfigItems.teapot_admission_controller_enable_rolebinding_webhook "true" }}
   - name: rolebinding-admitter.teapot.zalan.do
 {{- if eq .Cluster.Provider "zalando-eks"}}


### PR DESCRIPTION
## Summary

Register the admission-controller `applicationlabel_validation` endpoint as a validating webhook for Ingress, RouteGroup, and FabricGateway resources.

The controller image and configuration were already rolled out, but no webhook targeted this endpoint, so application-label validation was never invoked.

## Validation

- Confirmed `pg9-euc1-test` runs `admission-controller:master-329` with application-label validation enabled and all three resources in scope.
- Confirmed no live validating webhook targeted `/applicationlabel_validation`.
- Confirmed the resource names against the test cluster API.
- `git diff --check`

## References

- https://github.com/zalando-build/admission-controller/pull/400
- https://github.com/zalando-incubator/kubernetes-on-aws/pull/11748
- https://github.com/zalando-incubator/kubernetes-on-aws/pull/11761
- https://github.com/zalando-incubator/kubernetes-on-aws/pull/11763