### PR TITLE
Update OPA bundle path to refer v2

### DIFF
--- a/cluster/manifests/skipper/02-configmap-open-policy-agent.yaml
+++ b/cluster/manifests/skipper/02-configmap-open-policy-agent.yaml
@@ -11,7 +11,7 @@ data:
   opaconfig.yaml: |-
     discovery:
       name: discovery
-      resource: v1/bundles/zalando-apps/{{ `{{ .bundlename }}` }}/discovery.tgz
+      resource: v2/bundles/zalando-apps/{{ `{{ .bundlename }}` }}/discovery.tgz
       service: styra-bundles
     labels:
       environment: {{ .Cluster.Environment }}


### PR DESCRIPTION
Direct OPA agents to retrieve bundles from v2

Rollback plan would be to switch back to V1.
Currently Skipper is running on V1, but the content is V2 and this is making it transparent.