### PR TITLE
Make kube2iam conditional on enablement config

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -966,6 +966,7 @@ audit_webhook_batch_max_size: "250"
 
 kube2iam_cpu: "25m"
 kube2iam_memory: "100Mi"
+kube2iam_enabled: "true"
 
 # configure whether kube2iam should only run on worker nodes.
 kube2iam_worker_only: "true"

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -414,3 +414,18 @@ post_apply:
 # - name: awsiamroles.zalando.org
 #   kind: CustomResourceDefinition
 {{- end }}
+{{- if ne .Cluster.ConfigItems.kube2iam_enabled "true" }}
+- name: kube2iam
+  namespace: kube-system
+  kind: DaemonSet
+- name: kube2iam
+  namespace: kube-system
+  kind: ServiceAccount
+- name: kube2iam
+  kind: ClusterRole
+- name: kube2iam
+  kind: ClusterRoleBinding
+- name: kube2iam-privileged-psp
+  namespace: kube-system
+  kind: RoleBinding
+{{- end }}

--- a/cluster/manifests/kube2iam/daemonset.yaml
+++ b/cluster/manifests/kube2iam/daemonset.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Cluster.ConfigItems.kube2iam_enabled "true"}}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -71,3 +72,4 @@ spec:
           limits:
             cpu: {{ .Cluster.ConfigItems.kube2iam_cpu }}
             memory: {{ .Cluster.ConfigItems.kube2iam_memory }}
+{{- end}}

--- a/cluster/manifests/kube2iam/rbac.yaml
+++ b/cluster/manifests/kube2iam/rbac.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Cluster.ConfigItems.kube2iam_enabled "true"}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -39,3 +40,4 @@ subjects:
 - kind: ServiceAccount
   name: kube2iam
   namespace: kube-system
+{{- end}}


### PR DESCRIPTION
In preparation for the decommissioning of `kube2iam`, set flag to make it optionally opt-out, allowing clusters to disable it before complete removal.

Ref.: https://github.com/zalando-build/cloud-platform/issues/7877