### PR TITLE
set karpenter maxPods for EKS clusters

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -17,7 +17,14 @@ karpenter_feature_reserved_capacity: "true"
 karpenter_feature_node_repair: "false"
 
 # restrict the maximum number of pods for karpenter nodes
+{{ if eq .Cluster.Provider "zalando-aws" }}
 karpenter_max_pods_per_node: "32"
+
+{{ else if eq .Cluster.Provider "zalando-eks" }}
+# number of Pods must not exceed the maximum number of Pods per node supported by Kubernetes
+karpenter_max_pods_per_node: "110"
+
+{{ end }}
 
 # configure whether karpenter should assume instances with local storage use
 # RAID0 for ephemeral pod storage.

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -53,11 +53,13 @@ spec:
     # {{ end }}
     cpuCFSQuota: false
 #{{ if ne .Cluster.Provider "zalando-eks" }}
-# {{ if ne .Cluster.ConfigItems.karpenter_max_pods_per_node "" }}
+#   {{ if ne .Cluster.ConfigItems.karpenter_max_pods_per_node "" }}
     maxPods: {{ .Cluster.ConfigItems.karpenter_max_pods_per_node }}
-# {{ else }}
+#   {{ else }}
     maxPods: {{ nodeCIDRMaxPods (parseInt64 .Cluster.ConfigItems.node_cidr_mask_size) (parseInt64 .Cluster.ConfigItems.node_max_pods_extra_capacity) }}
-# {{ end }}
+#   {{ end }}
+#{{ else }}
+    maxPods: {{ .Cluster.ConfigItems.karpenter_max_pods_per_node }}
 #{{ end }}
     systemReserved:
       cpu: "{{ .Cluster.ConfigItems.kubelet_system_reserved_cpu }}"

--- a/cluster/node-pools/worker-karpenter/provisioners.yaml
+++ b/cluster/node-pools/worker-karpenter/provisioners.yaml
@@ -52,15 +52,11 @@ spec:
     clusterDNS: ["169.254.20.10"]
     # {{ end }}
     cpuCFSQuota: false
-#{{ if ne .Cluster.Provider "zalando-eks" }}
-#   {{ if ne .Cluster.ConfigItems.karpenter_max_pods_per_node "" }}
+# {{ if ne .Cluster.ConfigItems.karpenter_max_pods_per_node "" }}
     maxPods: {{ .Cluster.ConfigItems.karpenter_max_pods_per_node }}
-#   {{ else }}
+# {{ else }}
     maxPods: {{ nodeCIDRMaxPods (parseInt64 .Cluster.ConfigItems.node_cidr_mask_size) (parseInt64 .Cluster.ConfigItems.node_max_pods_extra_capacity) }}
-#   {{ end }}
-#{{ else }}
-    maxPods: {{ .Cluster.ConfigItems.karpenter_max_pods_per_node }}
-#{{ end }}
+# {{ end }}
     systemReserved:
       cpu: "{{ .Cluster.ConfigItems.kubelet_system_reserved_cpu }}"
       memory: "{{ .Cluster.ConfigItems.kubelet_system_reserved_memory }}"


### PR DESCRIPTION
Currently, there is no limit set for `maxPods` per node in the kubelet configuraiton for Karpenter nodes. This results in some larger instance sizes (e.g `96xlarge`) to schedule 100s of Pods. This results in unpredictable behavior and is not supported.

This change limits the `maxPods` for EKS clusters to `110`, which is the maximum supported by Kubernetes: https://kubernetes.io/docs/setup/best-practices/cluster-large/