### PR TITLE
Enable Scheduling Controls by default

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1385,7 +1385,7 @@ kube_janitor_enabled: "true"
 {{end}}
 
 # scheduling_controls
-teapot_admission_controller_scheduling_controls_enabled: "false"
+teapot_admission_controller_scheduling_controls_enabled: "true"
 teapot_admission_controller_scheduling_controls_default_architecture: "amd64"
 
 # master-node-autoscaler configuration


### PR DESCRIPTION
It's set as default in all environments via CCM, simply set it as default here so it also applies to pet clusters.