### PR TITLE
Grant ACK capability role Bedrock inference profile permissions

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -470,6 +470,10 @@ Resources:
           - "eks:AssociateAccessPolicy"
           - "eks:DisassociateAccessPolicy"
           - "eks:ListAssociatedAccessPolicies"
+          - "bedrock:CreateInferenceProfile"
+          - "bedrock:GetInferenceProfile"
+          - "bedrock:DeleteInferenceProfile"
+          - "bedrock:ListInferenceProfiles"
           Resource: "*"
   EKSCapabilityACK:
     Type: 'AWS::EKS::Capability'


### PR DESCRIPTION
## What
Adds `bedrock:CreateInferenceProfile`, `bedrock:GetInferenceProfile`, `bedrock:DeleteInferenceProfile`, and `bedrock:ListInferenceProfiles` to the `EKSCapabilityACKAccessEntryPolicy` managed policy used by the EKS ACK capability role.

## Why
For the ZAP project, we're prototyping an `llmproxy` resource that abstracts an OpenAI-compatible proxy with baked-in cost control and other requirements. The ACK Bedrock controller needs these permissions to reconcile `InferenceProfile` resources on behalf of that abstraction.

## Notes
- Scoped narrowly to the specific Bedrock inference-profile actions needed, following the same pattern as the existing EKS access-entry permissions in this policy.
- No node roll required; this only changes IAM permissions on the ACK capability role.
- Not user-exposed: the PowerUser role does not grant direct create access to resources in the ACK API group, so this does not let end users create Bedrock inference profiles themselves — only the ACK controller (via the capability role) can act on this permission.