### PR TITLE
 Grant ACK capability role for S3 buckets

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -470,6 +470,10 @@ Resources:
           - "eks:AssociateAccessPolicy"
           - "eks:DisassociateAccessPolicy"
           - "eks:ListAssociatedAccessPolicies"
+          - "s3:CreateBucket"
+          - "s3:PutBucket*"
+          - "s3:ListBuckets"
+          - "s3:DeleteBucket*"
           Resource: "*"
   EKSCapabilityACK:
     Type: 'AWS::EKS::Capability'

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -446,6 +446,7 @@ Resources:
       - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-AllowPowerUser"
       - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-AllowPowerUserCustom"
       - !Ref EKSCapabilityACKAccessEntryPolicy
+      - !Ref EKSCapabilityACKS3Policy
       {{- if eq .Cluster.Name "playground" }}
       - !Sub "arn:aws:iam::${AWS::AccountId}:policy/ZalandoCloud-AllowPowerUser-Playground"
       {{- end }}
@@ -470,11 +471,22 @@ Resources:
           - "eks:AssociateAccessPolicy"
           - "eks:DisassociateAccessPolicy"
           - "eks:ListAssociatedAccessPolicies"
-          - "s3:CreateBucket"
-          - "s3:PutBucket*"
-          - "s3:ListBuckets"
-          - "s3:DeleteBucket*"
           Resource: "*"
+  # Temporary PoC permissions for ACK S3 controller.
+  # Revisit scope after PoC is complete; remove or tighten before GA.
+  EKSCapabilityACKS3Policy:
+  Type: AWS::IAM::ManagedPolicy
+  Properties:
+    PolicyDocument:
+      Version: "2012-10-17"
+      Statement:
+      - Effect: Allow
+        Action:
+        - "s3:CreateBucket"
+        - "s3:PutBucket*"
+        - "s3:ListBuckets"
+        - "s3:DeleteBucket*"
+        Resource: "*"
   EKSCapabilityACK:
     Type: 'AWS::EKS::Capability'
     Properties:


### PR DESCRIPTION
Add a set of permissions to test the (ACK) S3 controller. I may miss some actions which will be caught during the PoC. After the PoC, we can revisit it again. 