### PR TITLE
Allow AWS fluent-bit image in production

### DIFF
--- a/cluster/manifests/02-admission-control/config.yaml
+++ b/cluster/manifests/02-admission-control/config.yaml
@@ -95,6 +95,8 @@ data:
 
   # Always allow certain container images regardless of namespace, defaults to none if not configured
   pod.image-check.ignored-images: "^(k8s.gcr.io/pause|906394416424.dkr.ecr.{{.Cluster.Region}}.amazonaws.com/aws-for-fluent-bit):.+$"
+{{- else }}
+  pod.image-check.ignored-images: "^906394416424.dkr.ecr.{{.Cluster.Region}}.amazonaws.com/aws-for-fluent-bit:.+$"
 {{- end }}
 
   # This setting enables and disables replacement of vanity images with ECR images during pod admission (during create and update)


### PR DESCRIPTION
Follow up to #11770 

Allow the AWS fluent-bit image in production by ignoring the image check in admission-controller. This was missed and only done in e2e in #11770

The motivation for doing this is to avoid re-hosting the AWS provided image on ECR. This is similar to EKS addons where we also rely on and trust the AWS provided images.