### PR TITLE
Revert fluent bit

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -617,8 +617,7 @@ static_egress_controller_enabled: "false"
 static_egress_controller_memory_min: "10Mi"
 
 # journald reader settings
-journald_reader_enabled: "false"
-journald_reader_fluentbit_enabled: "true"
+journald_reader_enabled: "true"
 journald_reader_cpu: "1m"
 journald_reader_memory: "30Mi"
 

--- a/cluster/manifests/02-admission-control/config.yaml
+++ b/cluster/manifests/02-admission-control/config.yaml
@@ -95,8 +95,6 @@ data:
 
   # Always allow certain container images regardless of namespace, defaults to none if not configured
   pod.image-check.ignored-images: "^(k8s.gcr.io/pause|906394416424.dkr.ecr.{{.Cluster.Region}}.amazonaws.com/aws-for-fluent-bit):.+$"
-{{- else }}
-  pod.image-check.ignored-images: "^906394416424.dkr.ecr.{{.Cluster.Region}}.amazonaws.com/aws-for-fluent-bit:.+$"
 {{- end }}
 
   # This setting enables and disables replacement of vanity images with ECR images during pod admission (during create and update)

--- a/cluster/manifests/02-admission-control/config.yaml
+++ b/cluster/manifests/02-admission-control/config.yaml
@@ -94,7 +94,7 @@ data:
   pod.image-check.namespaces: "^(image-policy-test-enabled-.*|kube-system|visibility)$"
 
   # Always allow certain container images regardless of namespace, defaults to none if not configured
-  pod.image-check.ignored-images: "^(k8s.gcr.io/pause|906394416424.dkr.ecr.{{.Cluster.Region}}.amazonaws.com/aws-for-fluent-bit):.+$"
+  pod.image-check.ignored-images: "^k8s.gcr.io/pause:.+$"
 {{- end }}
 
   # This setting enables and disables replacement of vanity images with ECR images during pod admission (during create and update)

--- a/cluster/manifests/node-monitor/daemonset.yaml
+++ b/cluster/manifests/node-monitor/daemonset.yaml
@@ -89,74 +89,6 @@ spec:
               name: usr
               readOnly: true
 {{- end }}
-{{- if eq .Cluster.ConfigItems.journald_reader_fluentbit_enabled "true" }}
-        - image: 906394416424.dkr.ecr.{{.Cluster.Region}}.amazonaws.com/aws-for-fluent-bit:3.4.9
-          name: fluent-bit-journald-reader
-          command:
-            - /fluent-bit/bin/fluent-bit
-          args:
-            - -q
-            - -i
-            - systemd
-            - -p
-            - Path=/var/log/journal
-            - -p
-            - DB=/fluent-bit-state/fluent-bit.db
-            - -p
-            - Read_From_Tail=false
-            - -p
-            - Tag=host.journald
-            - -F
-            - record_modifier
-            - -m
-            - host.journald
-            - -p
-            - Allowlist_key=MESSAGE
-            - -p
-            - Allowlist_key=_SYSTEMD_UNIT
-            - -p
-            - Allowlist_key=_BOOT_ID
-            - -p
-            - Allowlist_key=_MACHINE_ID
-            - -p
-            - Allowlist_key=_PID
-            - -F
-            - modify
-            - -m
-            - host.journald
-            - -p
-            - Rename=MESSAGE message
-            - -p
-            - Rename=_SYSTEMD_UNIT unit
-            - -p
-            - Rename=_BOOT_ID boot_id
-            - -p
-            - Rename=_MACHINE_ID machine_id
-            - -p
-            - Rename=_PID pid
-            - -o
-            - stdout
-            - -p
-            - format=json_lines
-            - -p
-            - json_date_format=iso8601
-            - -f
-            - "1"
-          resources:
-            requests:
-              cpu: {{.Cluster.ConfigItems.journald_reader_cpu}}
-              memory: {{.Cluster.ConfigItems.journald_reader_memory}}
-              ephemeral-storage: 256Mi
-            limits:
-              cpu: {{.Cluster.ConfigItems.journald_reader_cpu}}
-              memory: {{.Cluster.ConfigItems.journald_reader_memory}}
-          volumeMounts:
-            - mountPath: /var/log/journal
-              name: journald-logs
-              readOnly: true
-            - mountPath: /fluent-bit-state
-              name: journald-reader-state
-{{- end }}
       automountServiceAccountToken: false
       terminationGracePeriodSeconds: 30
       volumes:
@@ -178,7 +110,7 @@ spec:
         - name: kmsg
           hostPath:
             path: /dev/kmsg
-{{- if or (eq .Cluster.ConfigItems.journald_reader_enabled "true") (eq .Cluster.ConfigItems.journald_reader_fluentbit_enabled "true") }}
+{{- if eq .Cluster.ConfigItems.journald_reader_enabled "true" }}
         - name: journald-logs
           hostPath:
             path: /var/log/journal


### PR DESCRIPTION
Revert the fluent-bit journald-reader setup introduced in #11770 and #11883 

This setup only works on bottlerocket making it not attractive to run on the short term. The assumed reason is the version of systemd in the fluent-bit image is only compatible with the systemd on bottlerocket and not on Ubuntu AMI. The result is no logs (and no errors) on Ubuntu.