### PR TITLE
Limits the max pods per node in kubelet config

### DIFF
--- a/cluster/node-pools/worker-splitaz/userdata.yaml
+++ b/cluster/node-pools/worker-splitaz/userdata.yaml
@@ -85,7 +85,11 @@ write_files:
 {{- if eq .Cluster.Provider "zalando-eks" }}
       # replaced with dynamic value based on instance type during instance
       # start-up.
+{{- if or (eq .Cluster.ConfigItems.eks_ip_family "ipv6") (eq .Cluster.ConfigItems.aws_vpc_cni_prefix_delegation "true") }}
+      maxPods: {{ .Cluster.ConfigItems.karpenter_max_pods_per_node }}
+{{- else }}
       maxPods: __MAX_PODS__
+{{- end }}
 {{- else }}
       maxPods: {{ nodeCIDRMaxPods (parseInt64 .Cluster.ConfigItems.node_cidr_mask_size) (parseInt64 .Cluster.ConfigItems.node_max_pods_extra_capacity) }}
 {{- end }}


### PR DESCRIPTION
This is an addition to #11852

It configures the maxPods config in the kubelet config in userdata.yaml.

It does so only for the case of `eks_ip_family "ipv6"` or `aws_vpc_cni_prefix_delegation "true"`. The reason is that those cases allow up to 250 pods per node based on a dynamic script on the Ubuntu AMI. We want to limit this down to `karpenter_max_pods_per_node` (without having to also change the AMI script for the short term).

For other case of `eks_ip_family "ipv4"` and `aws_vpc_cni_prefix_delegation "false"` we fall back to the previous logic. This is because the limit will be much lower for small instances so we need the fall back. We currently don't run any clusters with setup so it's only kept to not break those should we ever want to create them. Can be completely removed in the future.