### PR TITLE
AMI: neigh-gc fix

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -947,8 +947,13 @@ tracing_coredns_local_zone_traces_endpoint: ""
 # AMI id given the image name and the Image AWS account owner.
 #
 # [0]: https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/8a9bd1cb2d094038a9e23e646421f8146b48886a/provisioner/template.go#L116
+{{if eq .Cluster.Provider "zalando-eks"}}
+kuberuntu_image_v1_35_new_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.35.7-amd64-master-436" "861068367966" }}
+kuberuntu_image_v1_35_new_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.35.7-arm64-master-436" "861068367966" }}
+{{else}}
 kuberuntu_image_v1_35_new_amd64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.35.7-amd64-master-435" "861068367966" }}
 kuberuntu_image_v1_35_new_arm64: {{ amiID "zalando-ubuntu-jammy-22.04-kubernetes-production-v1.35.7-arm64-master-435" "861068367966" }}
+{{end}}
 
 # This is used to determine which AMI to use for the cluster or individual node
 # pools. Possible values are 'new' or 'old'


### PR DESCRIPTION
This updates the AMI to a version that increases the IPv6 Neightbor Discovery limits similar to how it's done for IPv4 (the ARP equivalent)

Without this EKS IPv6 clusters can reach table limits and drop connections:

    [Fri Aug  7 12:57:04 2026] neighbour: ndisc_cache: neighbor table overflow!
    
The AMI update is scoped to EKS clusters only as this is the only place where the setting matters. We want to avoid rolling the nodes in non-EKS when it's not needed (this change will be anyway in all Kubernetes v1.36 AMI #11918)