### PR TITLE
update: skipper-ingress to v0.27.43-1495

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,6 +1,6 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.27.39-1491" }}
+{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.27.43-1495" }}
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.27.50-1502" }}
 
 {{/* Allow to override manually canary image by config item */}}


### PR DESCRIPTION
- dependency updates
- fix: correctly set "allow" value for OTel spans if client canceled in redis/valkey based rate limits

ref: https://github.com/zalando-incubator/kubernetes-on-aws/pull/11889
ref: https://github.com/zalando/skipper/compare/v0.27.39...v0.27.43