### PR TITLE
Allow ZMON readaccess from outside

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -429,3 +429,7 @@ post_apply:
   namespace: kube-system
   kind: RoleBinding
 {{- end }}
+- name: zmon-external-check
+  kind: ClusterRole
+- name: zmon-external-check
+  kind: ClusterRoleBinding

--- a/cluster/manifests/roles/zmon-external-check-rbac.yaml
+++ b/cluster/manifests/roles/zmon-external-check-rbac.yaml
@@ -1,28 +1,19 @@
-# This role is used to check coredns endpoints of a cluster from the outside.
+# This gives zmon read access to clusters from the outside. This allows checking
+# various core functionality like coredns availability and Karpenter
+# availability from a zmon-worker in another cluster.
+#
 # The intention is to monitor a cluster from the outside in case DNS is broken
 # and ZMON inside the cluster would not work.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: zmon-external-check
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - endpoints
-  resourceNames:
-  - coredns
-  verbs:
-  - get
----
+# Or Karpenter is not working and can't scale up nodes, so ZMON inside the
+# cluster would not work.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: zmon-external-check
+  name: zmon-external-reader
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: zmon-external-check
+  name: readonly
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User


### PR DESCRIPTION
Extend the zmon external access to readonly permissions. This allows making ZMON checks that run from a zmon-worker in a different cluster to monitor core functionality that could prevent zmon _inside_ the cluster from working in case there are issues.

This allows us to work around the current issue where the local zmon is used to monitor the local cluster and if some part of the local cluster is broken, we won't get notified.

Concrete examples to monitor:

* Monitor DNS from the outside as the local zmon depends on it to work
* Monitor Karpenter from the outside and local zmon depends on it to scale and work.