### PR TITLE
skipper-ingress: Configure Opentelemetry with a flag

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -410,7 +410,15 @@ skipper_ingress_lightstep_propagators: "lightstep"
 # set to "log-events" to enable
 skipper_ingress_lightstep_log_events: ""
 lightstep_token: ""
+# otel collector endpoint
 tracing_collector_host: "tracing.platform-infrastructure.zalan.do"
+tracing_collector_port: "8443"
+# OpenTelemetry
+skipper_ingress_open_telemetry_enabled: "true"
+skipper_ingress_open_telemetry_bsp_max_queue_size: 2048
+skipper_ingress_open_telemetry_bsp_max_export_batch_size: 512
+skipper_ingress_open_telemetry_bsp_schedule_delay: "5s"
+skipper_ingress_open_telemetry_bsp_export_timeout: "5s"
 
 # skipper_serve_method_metric sets the flag -serve-method-metric. It
 # defines if the http method is included in the dimension

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -281,11 +281,38 @@ spec:
 {{if ne .Cluster.ConfigItems.skipper_ingress_request_size_buckets ""}}
           - "-request-size-buckets={{ .Cluster.ConfigItems.skipper_ingress_request_size_buckets }}"
 {{ end }}
+{{ if eq .Cluster.ConfigItems.skipper_ingress_open_telemetry_enabled "true" }}
+          - -open-telemetry
+          - |
+            tracesExporter: otlp
+            exporterOtlp:
+              protocol: http/protobuf
+              endpoint: "https://{{ .Cluster.ConfigItems.tracing_collector_host }}:{{ .Cluster.ConfigItems.tracing_collector_port }}"
+            resourceAttributes:
+              service.name: skipper-ingress
+              application: skipper-ingress
+              component: ingress
+              account: {{ .Cluster.Alias }}
+              cluster: {{ .Cluster.Alias }}
+              k8s.cluster.name: {{ .Cluster.Alias }}
+              artifact: {{ .image }}
+              container.image.name: {{ index (split .image ":") 0 }}
+              container.image.tags: {{ index (split .image ":") 1 }}
+              k8s.pod.name: $(POD_NAME)
+              cloud.availability_zone: $(KUBE_NODE_ZONE)
+              otel-exporter: true
+            propagators: [tracecontext, ottrace, b3multi, baggage]
+            batchSpanProcessor:
+              maxQueueSize: {{ .Cluster.ConfigItems.skipper_ingress_open_telemetry_bsp_max_queue_size }}
+              maxExportBatchSize: {{ .Cluster.ConfigItems.skipper_ingress_open_telemetry_bsp_max_export_batch_size }}
+              scheduleDelay: {{ .Cluster.ConfigItems.skipper_ingress_open_telemetry_bsp_schedule_delay }}
+              exportTimeout: {{ .Cluster.ConfigItems.skipper_ingress_open_telemetry_bsp_export_timeout }}
+{{ else }}
           - >-
             -opentracing=lightstep
             component-name=skipper-ingress
             token=$(LIGHTSTEP_TOKEN)
-            collector={{ .Cluster.ConfigItems.tracing_collector_host }}:8444
+            collector={{ .Cluster.ConfigItems.tracing_collector_host }}:{{ .Cluster.ConfigItems.tracing_collector_port }}
             cmd-line=skipper-ingress
             tag=application=skipper-ingress
             tag=account={{ .Cluster.Alias }}
@@ -305,6 +332,7 @@ spec:
             max-logs-per-span={{ .Cluster.ConfigItems.skipper_ingress_lightstep_max_logs_per_span }}
             propagators={{ .Cluster.ConfigItems.skipper_ingress_lightstep_propagators }}
             {{ .Cluster.ConfigItems.skipper_ingress_lightstep_log_events }}
+{{ end }}
           - "-opentracing-excluded-proxy-tags={{ .Cluster.ConfigItems.skipper_ingress_opentracing_excluded_proxy_tags }}"
 {{ if eq .Cluster.ConfigItems.skipper_ingress_opentracing_client_trace_by_tag "true" }}
           - "-opentracing-client-trace-by-tag"
@@ -650,11 +678,38 @@ spec:
           - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
           - '-forwarded-headers-exclude-cidrs={{ .cluster_internal_cidrs | join "," }}'
 {{ end }}
+{{ if eq .Cluster.ConfigItems.skipper_ingress_open_telemetry_enabled "true" }}
+          - -open-telemetry
+          - |
+            tracesExporter: otlp
+            exporterOtlp:
+              protocol: http/protobuf
+              endpoint: "https://{{ .Cluster.ConfigItems.tracing_collector_host }}:{{ .Cluster.ConfigItems.tracing_collector_port }}"
+            resourceAttributes:
+              service.name: routesrv
+              application: skipper-ingress
+              component: routesrv
+              account: {{ .Cluster.Alias }}
+              cluster: {{ .Cluster.Alias }}
+              k8s.cluster.name: {{ .Cluster.Alias }}
+              artifact: {{ print .routesrv_image ":" .routesrv_version }}
+              container.image.name: {{ .routesrv_image }}
+              container.image.tags: {{ .routesrv_version }}
+              k8s.pod.name: $(POD_NAME)
+              cloud.availability_zone: $(KUBE_NODE_ZONE)
+              otel-exporter: true
+            propagators: [tracecontext, ottrace, b3multi, baggage]
+            batchSpanProcessor:
+              maxQueueSize: {{ .Cluster.ConfigItems.skipper_ingress_open_telemetry_bsp_max_queue_size }}
+              maxExportBatchSize: {{ .Cluster.ConfigItems.skipper_ingress_open_telemetry_bsp_max_export_batch_size }}
+              scheduleDelay: {{ .Cluster.ConfigItems.skipper_ingress_open_telemetry_bsp_schedule_delay }}
+              exportTimeout: {{ .Cluster.ConfigItems.skipper_ingress_open_telemetry_bsp_export_timeout }}
+{{ else }}
           - >-
             -opentracing=lightstep
             component-name=routesrv
             token=$(LIGHTSTEP_TOKEN)
-            collector={{ .Cluster.ConfigItems.tracing_collector_host }}:8444
+            collector={{ .Cluster.ConfigItems.tracing_collector_host }}:{{ .Cluster.ConfigItems.tracing_collector_port }}
             cmd-line=routesrv
             tag=application=skipper-ingress
             tag=component=routesrv
@@ -675,6 +730,7 @@ spec:
             max-logs-per-span={{ .Cluster.ConfigItems.skipper_ingress_lightstep_max_logs_per_span }}
             propagators={{ .Cluster.ConfigItems.skipper_ingress_lightstep_propagators }}
             {{ .Cluster.ConfigItems.skipper_ingress_lightstep_log_events }}
+{{ end }}
         env:
         - name: KUBE_NODE_ZONE
           valueFrom:


### PR DESCRIPTION
Skipper has the support for Otel after (zalando/skipper#3627, zalando/skipper#3657) PRs. This changes configure Otel and enable Otel Exporters ship trace spans in the skipper-ingress deployment.

### Testing

Tested the changes in a test-cluster. The exporting of spans to the observability backend works fine with the Otel Exporter. The `resource attributes` are same for all the skipper-ingress span types (`ingress`, `proxy`, serve_route`, and etc) as it is with the opentracing configs.

The `ot-tracer-traceid`, `ot-tracer-spanid`, `ot-tracer-sampled` and `traceparent` headers are passed to the backend application as expected. See the following logs of the request and response headers of the backend application.

```
[APP]time="2026-08-11T13:17:39Z" level=info msg="GET / HTTP/1.1\r\nHost: foo-bar-service.example.test\r\nAccept-Encoding: gzip, deflate\r\nX-B3-Sampled: 1\r\nUser-Agent: python-requests/2.33.0\r\nAccept: */*\r\nConnection: keep-alive\r\nOt-Tracer-Sampled: true\r\nOt-Tracer-Spanid: e6ef603d5192e6c4\r\nTraceparent: 00-74b59b72dbef74c9da7bfdfa479a3a9a-e6ef603d5192e6c4-01\r\nX-B3-Spanid: e6ef603d5192e6c4\r\nAuthorization: TRUNCATED\r\nOt-Tracer-Traceid: da7bfdfa479a3a9a\r\nX-B3-Traceid: 74b59b72dbef74c9da7bfdfa479a3a9a\r\nX-Forwarded-For: 185.85.220.51\r\nX-Forwarded-Port: 443\r\nX-Forwarded-Proto: https\r\n\r\n"
[APP]time="2026-08-11T13:17:39Z" level=info msg="Response for GET / HTTP/1.1\r\n\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: 25\r\nServer: Skipper\r\n\r\n"
185.85.220.51 - - [11/Aug/2026:13:17:39 +0000] "GET / HTTP/1.1" 200 25 "-" "python-requests/2.33.0" 0 foo-bar-service.example.test - -
[APP]time="2026-08-11T13:17:39Z" level=info msg="GET / HTTP/1.1\r\nHost: foo-bar-service.example.test\r\nAuthorization: TRUNCATED\r\nX-B3-Spanid: ad9332c80633f5b5\r\nX-B3-Traceid: 430c8fbaf7b6c417bce04d2ff7b114de\r\nX-Forwarded-Port: 443\r\nConnection: keep-alive\r\nOt-Tracer-Sampled: true\r\nX-Forwarded-For: 185.85.220.51\r\nX-Forwarded-Proto: https\r\nAccept: */*\r\nAccept-Encoding: gzip, deflate\r\nTraceparent: 00-430c8fbaf7b6c417bce04d2ff7b114de-ad9332c80633f5b5-01\r\nX-B3-Sampled: 1\r\nUser-Agent: python-requests/2.33.0\r\nOt-Tracer-Spanid: ad9332c80633f5b5\r\nOt-Tracer-Traceid: bce04d2ff7b114de\r\n\r\n"
[APP]time="2026-08-11T13:17:39Z" level=info msg="Response for GET / HTTP/1.1\r\n\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: 25\r\nServer: Skipper\r\n\r\n"
185.85.220.51 - - [11/Aug/2026:13:17:39 +0000] "GET / HTTP/1.1" 200 25 "-" "python-requests/2.33.0" 0 foo-bar-service.example.test - -
```