### PR TITLE
ebs-csi controller must not run on cluster-seed node

### DIFF
--- a/cluster/manifests/04-ebs-csi/controller.yaml
+++ b/cluster/manifests/04-ebs-csi/controller.yaml
@@ -23,8 +23,6 @@ spec:
       serviceAccountName: ebs-csi-controller-sa
       priorityClassName: system-cluster-critical
 {{- if eq .Cluster.Provider "zalando-eks"}}
-      nodeSelector:
-        dedicated: cluster-seed
       tolerations:
       - key: dedicated
         value: cluster-seed


### PR DESCRIPTION
Change the ebs-csi controller to not require running on the cluster-seed node. It still can run there, but doesn't have to. This allows it to run _somewhere_ even if the cluster-seed is rotating.