### PR TITLE
Change Karpenter VPA updateMode to 'Recreate'

### DIFF
--- a/cluster/manifests/z-karpenter/vpa.yaml
+++ b/cluster/manifests/z-karpenter/vpa.yaml
@@ -13,7 +13,7 @@ spec:
     kind: Deployment
     name: karpenter
   updatePolicy:
-    updateMode: InPlaceOrRecreate
+    updateMode: Recreate
   resourcePolicy:
     containerPolicies:
       - containerName: controller


### PR DESCRIPTION
Currently we observe Karpenter ending up in an unhealthy state (OOMing), especially during node rotations. The `InPlace` update functionality doesn't appear to be stable in our setup at the moment so try reverting it back to only `Recreate`.