### PR TITLE
Karpenter: don't bind mount /var/log/pods

### DIFF
--- a/cluster/manifests/z-karpenter/deployment.yaml
+++ b/cluster/manifests/z-karpenter/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             capabilities:
               drop:
                 - ALL
-          image: container-registry.zalando.net/teapot/karpenter:1.14.0-main-56.patched
+          image: container-registry.zalando.net/teapot/karpenter:1.14.0-main-57.patched
           imagePullPolicy: IfNotPresent
           env:
             - name: KUBERNETES_MIN_VERSION


### PR DESCRIPTION
This updates Karpenter to a version with a patch to not put the `/var/log/pods` directory on a local SSD if the instance is an instance type with local SSD.

This is done to avoid a problem where logging-agent tries to hard link across devices which it normally doesn't have to do as folders are on the same device on non-SSD instances or on Ubuntu AMI.

We use by default a 100Gi root EBS volume, so it's not a problem to keep the pod logs there.

It basically removes the `/var/log/pods` entry from [here](https://github.com/aws/karpenter-provider-aws/blob/5e28effa4ddfd6cb21e370400e02159ad574d0ca/pkg/providers/amifamily/bootstrap/bottlerocket.go#L105).