### PR TITLE
Give Karpenter more options to run

### DIFF
--- a/cluster/manifests/z-karpenter/deployment.yaml
+++ b/cluster/manifests/z-karpenter/deployment.yaml
@@ -159,6 +159,10 @@ spec:
                 matchExpressions:
                 - key: karpenter.sh/nodepool
                   operator: DoesNotExist
+                - key: lifecycle-status
+                  operator: In
+                  values:
+                  - ready
 {{- if eq .Cluster.Provider "zalando-eks"}}
             - weight: 100
               preference:
@@ -187,6 +191,9 @@ spec:
           operator: Exists
         - key: node.kubernetes.io/role
           value: master
+          effect: NoSchedule
+        - key: decommission-pending
+          operator: Exists
           effect: NoSchedule
 {{- if eq .Cluster.Provider "zalando-eks"}}
         - key: dedicated


### PR DESCRIPTION
When a cluster is rotating nodes it does so by marking all old nodes to be decommissioned with a taint:

```yaml
taints:
  - effect: NoSchedule
    key: decommission-pending
    value: rolling-upgrade
```

If Karpenter crashes at the same time and is too big to land on the cluster-seed node (that may also be marked for replacement) then it has nowhere to land and Karpenter itself can't spin up new nodes.

To reduce the risk of Karpenter not running, this adds two changes:

1. Allow Karpenter to run on nodes that are prepared to being decommissioned. This has the risk that karpenter will land on old nodes and have to be moved multiple times during a node rotation.
2. To minimize the risk of 1, prefer that karpenter runs on nodes with `lifecycle-status=ready` over those that are decomissioning (they have `lifecycle-status=decommission-pending`)

This is not 100% preventing Karpenter from getting in a situation where it can't run but it reduces the chance as it now can run on any of the `decomission-pending` nodes which was otherwise not possible before.