### PR TITLE
kube-aws-iam-controller must not run on cluster-seed node

### DIFF
--- a/cluster/manifests/03-kube-aws-iam-controller/deployment.yaml
+++ b/cluster/manifests/03-kube-aws-iam-controller/deployment.yaml
@@ -45,8 +45,6 @@ spec:
             cpu: "{{.Cluster.ConfigItems.kube_aws_iam_controller_cpu}}"
             memory: "{{.Cluster.ConfigItems.kube_aws_iam_controller_mem}}"
 {{- if eq .Cluster.Provider "zalando-eks"}}
-      nodeSelector:
-        dedicated: cluster-seed
       tolerations:
       - key: dedicated
         value: cluster-seed


### PR DESCRIPTION
Similar to #11961

Change the kube-aws-iam-controller to not require running on the cluster-seed node. It still can run there, but doesn't have to. This allows it to run somewhere even if the cluster-seed is rotating.