### PR TITLE
e2e: Give EKS seed node high priority for rotation

### DIFF
--- a/test/e2e/cluster_config.sh
+++ b/test/e2e/cluster_config.sh
@@ -63,7 +63,7 @@ clusters:
   $(if [ "${CLUSTER_PROVIDER}" == "zalando-eks" ]; then
 cat <<EOFF
 - config_items:
-      labels: dedicated=cluster-seed
+      labels: dedicated=cluster-seed,cluster-lifecycle-controller.zalan.do/decommission-priority=999
       taints: dedicated=cluster-seed:NoSchedule
     discount_strategy: none
     instance_types:

--- a/test/e2e/daemonset-updated/main.go
+++ b/test/e2e/daemonset-updated/main.go
@@ -214,7 +214,7 @@ func onDeleteDaemonsets(ctx context.Context, client kubernetes.Interface) (map[d
 func decommissionNode(ctx context.Context, client kubernetes.Interface, node *Node) error {
 	taint := v1.Taint{
 		Key:    "decommission-pending",
-		Value:  "spot-replacement",
+		Value:  "daemonset-update",
 		Effect: v1.TaintEffectNoSchedule,
 	}
 


### PR DESCRIPTION
Observed in e2e that the cluster-seed node has same priority as other nodes meaning other nodes can be rotated first and let the seed node unscheduled for a long time. This is not desired.

Additionally change the taint value set by the daemonset updater as it was a non-nonsensical taint value in the context.