### PR TITLE
karpenter: Fix don't bind var logs pods to ssd

### DIFF
--- a/cluster/manifests/z-karpenter/deployment.yaml
+++ b/cluster/manifests/z-karpenter/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             capabilities:
               drop:
                 - ALL
-          image: container-registry.zalando.net/teapot/karpenter:1.14.0-main-57.patched
+          image: container-registry.zalando.net/teapot/karpenter:1.14.0-main-58.patched
           imagePullPolicy: IfNotPresent
           env:
             - name: KUBERNETES_MIN_VERSION


### PR DESCRIPTION
Follow up to #11976 fixing the Karpenter patch to not bind mount `/var/log/pods` on local SSD instance types.