### PR TITLE
feature: inject "zalando.org/topology-spread: true" into the pod template annotation in stacksets

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -766,6 +766,7 @@ teapot_admission_controller_deployment_default_max_surge: "5%"
 teapot_admission_controller_deployment_default_max_unavailable: "1"
 teapot_admission_controller_inject_aws_waiter: "true"
 teapot_admission_controller_parent_resource_hash: "true"
+teapot_admission_controller_stackset_inject_topology_spread_enable: "false"
 
 ## Defaults are set per-cluster
 teapot_admission_controller_check_daemonset_resources: "true"

--- a/cluster/manifests/02-admission-control/config.yaml
+++ b/cluster/manifests/02-admission-control/config.yaml
@@ -234,3 +234,4 @@ data:
   pod.sandbox-egress.skipper-image: "container-registry.zalando.net/teapot/skipper-internal:v0.27.57-1508"
   pod.sandbox-egress.nftables-image: "container-registry.zalando.net/gwproxy/nftables:main-111"
 {{ end }}
+  stackset.inject-topology-spread.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_stackset_inject_topology_spread_enable }}"


### PR DESCRIPTION
feature: inject "zalando.org/topology-spread: true" into the pod template annotation in stacksets

off by default, rolling out via ccm

ref: https://github.com/zalando-incubator/kubernetes-on-aws/pull/11996 should be deployed, before we enable this