### PR TITLE
Configure HPAScaleToZero feature gate on kube-controller-manager

### DIFF
--- a/cluster/node-pools/master-default/userdata.yaml
+++ b/cluster/node-pools/master-default/userdata.yaml
@@ -589,7 +589,7 @@ write_files:
           - --root-ca-file=/etc/kubernetes/ssl/ca.pem
           - --cloud-provider=external
           - --cloud-config=/etc/kubernetes/cloud-config.ini
-          - --feature-gates=MaxUnavailableStatefulSet={{.Cluster.ConfigItems.max_unavailable_statefulset_enabled}}{{if eq .Cluster.ConfigItems.horizontal_pod_autoscaler_configurable_tolerance "true"}},HPAConfigurableTolerance=true{{end}}
+          - --feature-gates=MaxUnavailableStatefulSet={{.Cluster.ConfigItems.max_unavailable_statefulset_enabled}}{{if eq .Cluster.ConfigItems.horizontal_pod_autoscaler_configurable_tolerance "true"}},HPAConfigurableTolerance=true{{end}},HPAScaleToZero={{ .Cluster.ConfigItems.enable_hpa_scale_to_zero }}
           - --use-service-account-credentials=true
           - --configure-cloud-routes=false
           - --allocate-node-cidrs=true


### PR DESCRIPTION
This configures the HPAScaleToZero feature gate on the kube-controller-manager. This is needed since Kubernetes v1.36 where the HPA controller is checking for this feature gate to decide on the ScaledToZero feature introduced in https://github.com/kubernetes/kubernetes/pull/135118

Before it was enough to set HPAScaleToZero feature gate on the kube-apiserver.