### PR TITLE
external-dns: Disable creation of AAAA records

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -1107,6 +1107,10 @@ external_dns_mem: "4Gi"
 # - stable
 external_dns_version: "new"
 
+# enable creation of AAAA records for IPv6 support along with A records.
+# This should only be enabled if the cluster is fully IPv6 capable.
+external_dns_aaaa_records_enabled: "false"
+
 expirimental_dns_unbound_liveness_probe: "true"
 
 # DNS container resources

--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -56,6 +56,9 @@ spec:
         - --aws-zones-cache-duration={{ .Cluster.ConfigItems.external_dns_zones_cache_duration }}
         - --annotation-filter=external-dns.alpha.kubernetes.io/exclude notin (true)
         - --policy={{ .Cluster.ConfigItems.external_dns_policy }}
+{{- if ne .Cluster.ConfigItems.external_dns_aaaa_records_enabled "true" }}
+        - --exclude-record-types=AAAA
+{{- end }}
         resources:
           requests:
             cpu: 50m


### PR DESCRIPTION
Upgrading external-dns in #11984 implicitly enabled creation of AAAA records. This uncovered that our platform is not 100% IPv6 capable on the related paths and caused an incident.

To allow updating external-dns without this side-effect, disable AAAA records by default.

This also lets us enable them per cluster once we are ready to test and support it properly.