### PR TITLE
Default kube_aws_iam_controller_enabled to false

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -676,7 +676,7 @@ metrics_server_metric_resolution: "15s"
 
 kube_aws_iam_controller_cpu: "5m"
 kube_aws_iam_controller_mem: "50Mi"
-kube_aws_iam_controller_enabled: "true"
+kube_aws_iam_controller_enabled: "false"
 
 kube_state_metrics_cpu: "100m"
 kube_state_metrics_mem_max: "4Gi"

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -409,10 +409,8 @@ post_apply:
 - name: kube-aws-iam-controller
   namespace: kube-system
   kind: ServiceAccount
-# TODO: Since this removes resources deployed by the users,
-# let's play it safe and uncomment this at a later time.
-# - name: awsiamroles.zalando.org
-#   kind: CustomResourceDefinition
+- name: awsiamroles.zalando.org
+  kind: CustomResourceDefinition
 {{- end }}
 {{- if ne .Cluster.ConfigItems.kube2iam_enabled "true" }}
 - name: kube2iam

--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -406,9 +406,10 @@ post_apply:
 - name: kube-aws-iam-controller-privileged-psp
   namespace: kube-system
   kind: RoleBinding
-- name: kube-aws-iam-controller
-  namespace: kube-system
-  kind: ServiceAccount
+# For now we keep the ServiceAccount to ease the rollout.
+# - name: kube-aws-iam-controller
+#   namespace: kube-system
+#   kind: ServiceAccount
 - name: awsiamroles.zalando.org
   kind: CustomResourceDefinition
 {{- end }}

--- a/test/e2e/aws_iam.go
+++ b/test/e2e/aws_iam.go
@@ -20,7 +20,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	awsiamrole "github.com/zalando-incubator/kube-aws-iam-controller/pkg/client/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -28,11 +27,10 @@ import (
 	admissionapi "k8s.io/pod-security-admission/api"
 )
 
-var _ = describe("AWS IAM Integration (kube2iam + kube-aws-iam-controller)", func() {
+var _ = describe("AWS IAM Integration (kube2iam)", func() {
 	f := framework.NewDefaultFramework("aws-iam")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelBaseline
 	var cs kubernetes.Interface
-	var zcs awsiamrole.Interface
 
 	BeforeEach(func() {
 		cs = f.ClientSet
@@ -45,32 +43,6 @@ var _ = describe("AWS IAM Integration (kube2iam + kube-aws-iam-controller)", fun
 		if f.Options.GroupVersion != nil {
 			config.GroupVersion = f.Options.GroupVersion
 		}
-		zcs, err = awsiamrole.NewForConfig(config)
-		framework.ExpectNoError(err)
-	})
-
-	It("Should get AWS IAM credentials (kube-aws-iam-controller) [AWS-IAM] [Zalando]", func() {
-		awsIAMRoleRS := "aws-iam-test"
-		ns := f.Namespace.Name
-
-		By("Creating a awscli POD in namespace " + ns)
-		pod := createAWSIAMPod("aws-iam-", ns, E2ES3AWSIAMBucket())
-		_, err := cs.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
-
-		// AWSIAMRole
-		By("Creating AWSIAMRole " + awsIAMRoleRS + " in namespace " + ns)
-		rs := createAWSIAMRole(awsIAMRoleRS, ns, E2EAWSIAMRole())
-		defer func() {
-			By("deleting the AWSIAMRole")
-			defer GinkgoRecover()
-			err2 := zcs.ZalandoV1().AWSIAMRoles(ns).Delete(context.TODO(), rs.Name, metav1.DeleteOptions{})
-			Expect(err2).NotTo(HaveOccurred())
-		}()
-		_, err = zcs.ZalandoV1().AWSIAMRoles(ns).Create(context.TODO(), rs, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
-
-		framework.ExpectNoError(e2epod.WaitForPodSuccessInNamespace(context.TODO(), f.ClientSet, pod.Name, pod.Namespace))
 	})
 
 	It("Should get AWS IAM credentials (kube2iam) [AWS-IAM] [Zalando]", func() {


### PR DESCRIPTION
## Summary
- kube-aws-iam-controller / AWSIAMRole is deprecated in favor of OIDC-based IAM roles.
- Flip the default of `kube_aws_iam_controller_enabled` from `"true"` to `"false"` in `cluster/config-defaults.yaml`.
- Clusters still relying on AWSIAMRole CRDs have been switched to explicit opt-in (`kube_aws_iam_controller_enabled: true`) in zalando-build/teapot-cluster-config-manager#1874, so no existing cluster loses the controller as a result of this change.

## Test plan
- [x] Confirm zalando-build/teapot-cluster-config-manager#1874 merges (or has merged) before/alongside this, so opted-in clusters keep the controller running
- [x] Verify no other cluster still depends on kube-aws-iam-controller without an explicit override