### PR TITLE
skipper-ingress: upgrade main image to v0.27.69

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,6 +1,6 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.27.60-1511" }}
+{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.27.69-1519" }}
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.27.71-1521" }}
 
 {{/* Allow to override manually canary image by config item */}}
@@ -302,6 +302,7 @@ spec:
               cloud.availability_zone: $(KUBE_NODE_ZONE)
               otel-exporter: true
             propagators: [tracecontext, ottrace, b3multi, baggage]
+            sampler: always_on
             batchSpanProcessor:
               maxQueueSize: {{ .Cluster.ConfigItems.skipper_ingress_open_telemetry_bsp_max_queue_size }}
               maxExportBatchSize: {{ .Cluster.ConfigItems.skipper_ingress_open_telemetry_bsp_max_export_batch_size }}
@@ -699,6 +700,7 @@ spec:
               cloud.availability_zone: $(KUBE_NODE_ZONE)
               otel-exporter: true
             propagators: [tracecontext, ottrace, b3multi, baggage]
+            sampler: always_on
             batchSpanProcessor:
               maxQueueSize: {{ .Cluster.ConfigItems.skipper_ingress_open_telemetry_bsp_max_queue_size }}
               maxExportBatchSize: {{ .Cluster.ConfigItems.skipper_ingress_open_telemetry_bsp_max_export_batch_size }}


### PR DESCRIPTION
## Overview

This image has the [capability to configure the otel sampler mode](https://github.com/zalando/skipper/pull/4208). The default mode is parentbased_always_on. We want to change it to always_on as we want to propagate sampled=1 always from skipper-ingress.

This make sure that even after a upstream service decides to change the sampled=0, after skipper-ingress it will be overridden to sampled=1. As http traffic almost always goes through skipper-ingress before they reach the application in Zalando, it avoids cascading of trace  sampling decisions that individual application make to other applications.

## All Changes

Since the last version in production was v0.27.60, other than the above described changes, the image bring all https://github.com/zalando/skipper/compare/v0.27.60...v0.27.69 changes to be effective in the main fleet.