### PR TITLE
add config-item to inject AWS_REGION and AWS_DEFAULT_REGION to pods

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -757,6 +757,7 @@ teapot_admission_controller_max_ephemeral_storage_request: "5Gi"
 teapot_admission_controller_application_min_creation_time: "2019-06-03T12:00:00Z"
 teapot_admission_controller_ndots: "2"
 teapot_admission_controller_inject_environment_variables: "true"
+teapot_admission_controller_inject_pod_aws_region: "false"
 {{ if eq .Cluster.Environment "test" }}
 teapot_admission_controller_inject_node_options_environment_variable: "true"
 {{ else }}

--- a/cluster/manifests/02-admission-control/config.yaml
+++ b/cluster/manifests/02-admission-control/config.yaml
@@ -60,6 +60,11 @@ data:
   pod.env-inject.variable.LOG4J_FORMAT_MSG_NO_LOOKUPS: "true"
 {{- end}}
 
+{{- if eq .Cluster.ConfigItems.teapot_admission_controller_inject_pod_aws_region "true" }}
+  pod.env-inject.variable.AWS_REGION: "{{ .Cluster.Region }}"
+  pod.env-inject.variable.AWS_DEFAULT_REGION: "{{ .Cluster.Region }}"
+{{- end}}
+
   pod.env-inject.node-options.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_inject_node_options_environment_variable }}"
   pod.scheduling-controls.enable: "{{ .Cluster.ConfigItems.teapot_admission_controller_scheduling_controls_enabled }}"
   pod.scheduling-controls.default-architecture: "{{ .Cluster.ConfigItems.teapot_admission_controller_scheduling_controls_default_architecture }}"


### PR DESCRIPTION
add option to inject AWS_REGION to pods with config-item, so we can gradually rollout to clusters.
The default is set to false and we using the config-item rollout to a set of cluster at the time.

This ensure that region is set for the IRSA, and avoid to use the metadata api through the kube2iam proxy to get that information.