### PR TITLE
Skip deletion of AWSIAMRole CRD until it's supported

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -410,8 +410,9 @@ post_apply:
 # - name: kube-aws-iam-controller
 #   namespace: kube-system
 #   kind: ServiceAccount
-- name: awsiamroles.zalando.org
-  kind: CustomResourceDefinition
+# Deletion of CRDs isn't supported right now, see https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/961
+# - name: awsiamroles.zalando.org
+#   kind: CustomResourceDefinition
 {{- end }}
 {{- if ne .Cluster.ConfigItems.kube2iam_enabled "true" }}
 - name: kube2iam


### PR DESCRIPTION
We need a fix in CLM to make this work.