### PR TITLE
skipper-ingress: set otel sampling to always_on

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -303,6 +303,7 @@ spec:
               cloud.availability_zone: $(KUBE_NODE_ZONE)
               otel-exporter: true
             propagators: [tracecontext, ottrace, b3multi, baggage]
+            sampler: always_on
             batchSpanProcessor:
               maxQueueSize: {{ .Cluster.ConfigItems.skipper_ingress_open_telemetry_bsp_max_queue_size }}
               maxExportBatchSize: {{ .Cluster.ConfigItems.skipper_ingress_open_telemetry_bsp_max_export_batch_size }}
@@ -700,6 +701,7 @@ spec:
               cloud.availability_zone: $(KUBE_NODE_ZONE)
               otel-exporter: true
             propagators: [tracecontext, ottrace, b3multi, baggage]
+            sampler: always_on
             batchSpanProcessor:
               maxQueueSize: {{ .Cluster.ConfigItems.skipper_ingress_open_telemetry_bsp_max_queue_size }}
               maxExportBatchSize: {{ .Cluster.ConfigItems.skipper_ingress_open_telemetry_bsp_max_export_batch_size }}


### PR DESCRIPTION
From v0.27.69 [1] onwards skipper has the capability to configure the otel sampler mode. The default mode is parentbased_always_on. We want to change it to always_on as we want to propagate sampled=1 always from skipper-ingress.

This make sure that even after a upstream service decides to change the sampled=0, after skipper-ingress it will be overridden to sampled=1. As http traffic almost always goes through skipper-ingress before they reach the application in Zalando, it avoids cascading of trace sampling decisions that individual application make to other applications.

References:
  [1] https://github.com/zalando/skipper/releases/tag/v0.27.69