### PR TITLE
Remove `/parca` binary arg from scraper manifest

### DIFF
--- a/cluster/manifests/polarsignals/10-scraper.yaml
+++ b/cluster/manifests/polarsignals/10-scraper.yaml
@@ -123,7 +123,6 @@ spec:
       serviceAccountName: polarsignals-scraper
       containers:
         - args:
-            - /parca
             - --config-path=/var/polarsignals-scraper/polarsignals-scraper.yaml
             - --store-address=grpc.polarsignals.com:443
             - --bearer-token-file=/var/polarsignals-secret/token


### PR DESCRIPTION
the binary name is already in CMD in dockerfile