### PR TITLE
Bump parca scrapper image to v0.28.0-main-10

### DIFF
--- a/cluster/manifests/polarsignals/10-scraper.yaml
+++ b/cluster/manifests/polarsignals/10-scraper.yaml
@@ -127,7 +127,7 @@ spec:
             - --store-address=grpc.polarsignals.com:443
             - --bearer-token-file=/var/polarsignals-secret/token
             - --mode=scraper-only
-          image: container-registry.zalando.net/gwproxy/parca:v0.28.0-main-9
+          image: container-registry.zalando.net/gwproxy/parca:v0.28.0-main-10
           name: polarsignals-scraper
           ports:
             - containerPort: 7070


### PR DESCRIPTION
the new one is based on the static image, required for system certs