### PR TITLE
Make pod image-check namespaces and ignored-images configurable

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -795,6 +795,12 @@ teapot_admission_controller_validate_pod_images: "true"
 # if docker-meta is down, do not reject container images running in `kube-system`
 # teapot_admission_controller_validate_pod_images_soft_fail_namespaces: "^kube-system$"
 
+# As a temporary escape hatch during incidents, you can limit the namespaces where container image
+# checks are required (defaults to all namespaces) and/or always allow certain container images
+# regardless of namespace (defaults to none), e.g.:
+# teapot_admission_controller_validate_pod_images_namespaces: "^visibility$"
+# teapot_admission_controller_validate_pod_images_ignored_images: "^k8s.gcr.io/external-dns:.+$"
+
 teapot_admission_controller_validate_pod_template_resources: "true"
 teapot_admission_controller_preemption_enabled: "true"
 teapot_admission_controller_postgresql_delete_protection_enabled: "true"
@@ -806,6 +812,16 @@ teapot_admission_controller_validate_base_images: "false"
 
 # Check container image compliance in e2e clusters. There are some exceptions to allow the e2e test suite to run.
 teapot_admission_controller_validate_pod_images: "true"
+
+# The upstream e2e test suite runs test cases using the pause image in kube-system, which is
+# otherwise subject to image compliance checks, so it needs to be allowed explicitly.
+teapot_admission_controller_validate_pod_images_ignored_images: "^k8s.gcr.io/pause:.+$"
+
+# The e2e test suite runs arbitrary, non-compliant test case images across namespaces, so only
+# enforce compliance where it can be checked reliably: kube-system and visibility (to catch
+# regressions there) and the image-policy-test-enabled-* namespaces, which are deliberately set up
+# for reliable image policy tests.
+teapot_admission_controller_validate_pod_images_namespaces: "^(image-policy-test-enabled-.*|kube-system|visibility)$"
 
 teapot_admission_controller_validate_pod_template_resources: "false"
 teapot_admission_controller_preemption_enabled: "true"

--- a/cluster/manifests/02-admission-control/config.yaml
+++ b/cluster/manifests/02-admission-control/config.yaml
@@ -90,16 +90,14 @@ data:
   pod.image-check.soft-fail-namespaces: "{{ .Cluster.ConfigItems.teapot_admission_controller_validate_pod_images_soft_fail_namespaces }}"
 {{- end }}
 
-{{- if eq .Cluster.Environment "e2e" }}
-  # Special settings only configured for e2e clusters
-  #
-  # DO NOT USE THESE IN PRODUCTION CLUSTERS
+{{- if index .Cluster.ConfigItems "teapot_admission_controller_validate_pod_images_namespaces" }}
+  # Limit the namespaces where container image checks are required, defaults to all namespaces.
+  pod.image-check.namespaces: "{{ .Cluster.ConfigItems.teapot_admission_controller_validate_pod_images_namespaces }}"
+{{- end }}
 
-  # Limit the namespaces where container image checks are required, defaults to all if not configured
-  pod.image-check.namespaces: "^(image-policy-test-enabled-.*|kube-system|visibility)$"
-
-  # Always allow certain container images regardless of namespace, defaults to none if not configured
-  pod.image-check.ignored-images: "^k8s.gcr.io/pause:.+$"
+{{- if index .Cluster.ConfigItems "teapot_admission_controller_validate_pod_images_ignored_images" }}
+  # Always allow certain container images regardless of namespace, defaults to none.
+  pod.image-check.ignored-images: "{{ .Cluster.ConfigItems.teapot_admission_controller_validate_pod_images_ignored_images }}"
 {{- end }}
 
   # This setting enables and disables replacement of vanity images with ECR images during pod admission (during create and update)


### PR DESCRIPTION
## Summary
- Extract the previously hardcoded, e2e-only values for `pod.image-check.namespaces` and `pod.image-check.ignored-images` into config items: `teapot_admission_controller_validate_pod_images_namespaces` and `teapot_admission_controller_validate_pod_images_ignored_images`.
- These config items are only set for e2e clusters, matching the previous hardcoded behavior. For other environments they are left unset.
- `cluster/manifests/02-admission-control/config.yaml` guards both settings the same way as the existing `teapot_admission_controller_validate_pod_images_soft_fail_namespaces` config item, so they are simply omitted from the rendered ConfigMap (falling back to the admission controller's own defaults: match everything / match nothing) when not configured.
- Added commented-out examples in the production branch of `config-defaults.yaml`, next to the existing soft-fail-namespaces hint, documenting these as a temporary escape hatch during incidents.

## Test plan
- [x] Verified `config-defaults.yaml` only defines the two config items in the e2e branch (no duplicate definitions).
- [x] Verified `config.yaml` renders `pod.image-check.namespaces`/`pod.image-check.ignored-images` only when the corresponding config item is set.