### PR TITLE
Enable deletion of awsiamroles CRD

### DIFF
--- a/cluster/manifests/deletions.yaml
+++ b/cluster/manifests/deletions.yaml
@@ -427,9 +427,8 @@ post_apply:
 # - name: kube-aws-iam-controller
 #   namespace: kube-system
 #   kind: ServiceAccount
-# Deletion of CRDs isn't supported right now, see https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/961
-# - name: awsiamroles.zalando.org
-#   kind: CustomResourceDefinition
+- name: awsiamroles.zalando.org
+  kind: CustomResourceDefinition
 {{- end }}
 {{- if ne .Cluster.ConfigItems.kube2iam_enabled "true" }}
 - name: kube2iam


### PR DESCRIPTION
## Summary
- Deletion of CRDs is now supported by cluster-lifecycle-manager (previously blocked, see zalando-incubator/cluster-lifecycle-manager#961).
- Re-enable the previously commented-out deletion of the `awsiamroles.zalando.org` CustomResourceDefinition in `cluster/manifests/deletions.yaml`, guarded the same way as the rest of the `kube-aws-iam-controller` cleanup block (only when `kube_aws_iam_controller_enabled` is not `"true"`).

## Test plan
- [x] Verified the entry is still nested under the existing `{{- if ne .Cluster.ConfigItems.kube_aws_iam_controller_enabled "true" }}` guard.