### PR TITLE
Add pod.image-check.ignore-namespaces config item

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -795,10 +795,10 @@ teapot_admission_controller_validate_pod_images: "true"
 # if docker-meta is down, do not reject container images running in `kube-system`
 # teapot_admission_controller_validate_pod_images_soft_fail_namespaces: "^kube-system$"
 
-# As a temporary escape hatch during incidents, you can limit the namespaces where container image
-# checks are required (defaults to all namespaces) and/or always allow certain container images
-# regardless of namespace (defaults to none), e.g.:
-# teapot_admission_controller_validate_pod_images_namespaces: "^visibility$"
+# As a temporary escape hatch during incidents, you can exclude certain namespaces from the
+# checks (defaults to none) and/or always allow certain container images regardless of namespace
+# (defaults to none), e.g.:
+# teapot_admission_controller_validate_pod_images_ignore_namespaces: "^kube-system$"
 # teapot_admission_controller_validate_pod_images_ignored_images: "^k8s.gcr.io/external-dns:.+$"
 
 teapot_admission_controller_validate_pod_template_resources: "true"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -798,7 +798,7 @@ teapot_admission_controller_validate_pod_images: "true"
 # As a temporary escape hatch during incidents, you can exclude certain namespaces from the
 # checks (defaults to none) and/or always allow certain container images regardless of namespace
 # (defaults to none), e.g.:
-# teapot_admission_controller_validate_pod_images_ignore_namespaces: "^kube-system$"
+# teapot_admission_controller_validate_pod_images_ignored_namespaces: "^kube-system$"
 # teapot_admission_controller_validate_pod_images_ignored_images: "^k8s.gcr.io/external-dns:.+$"
 
 teapot_admission_controller_validate_pod_template_resources: "true"

--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -810,18 +810,13 @@ teapot_admission_controller_postgresql_owning_application_check_enabled: "true"
 teapot_admission_controller_validate_application_label: "false"
 teapot_admission_controller_validate_base_images: "false"
 
-# Check container image compliance in e2e clusters. There are some exceptions to allow the e2e test suite to run.
+# Check container image compliance in e2e clusters. There are some exceptions to allow the e2e test suite to run,
+# see the "e2e" special-case block in cluster/manifests/02-admission-control/config.yaml.
 teapot_admission_controller_validate_pod_images: "true"
 
 # The upstream e2e test suite runs test cases using the pause image in kube-system, which is
 # otherwise subject to image compliance checks, so it needs to be allowed explicitly.
 teapot_admission_controller_validate_pod_images_ignored_images: "^k8s.gcr.io/pause:.+$"
-
-# The e2e test suite runs arbitrary, non-compliant test case images across namespaces, so only
-# enforce compliance where it can be checked reliably: kube-system and visibility (to catch
-# regressions there) and the image-policy-test-enabled-* namespaces, which are deliberately set up
-# for reliable image policy tests.
-teapot_admission_controller_validate_pod_images_namespaces: "^(image-policy-test-enabled-.*|kube-system|visibility)$"
 
 teapot_admission_controller_validate_pod_template_resources: "false"
 teapot_admission_controller_preemption_enabled: "true"

--- a/cluster/manifests/02-admission-control/config.yaml
+++ b/cluster/manifests/02-admission-control/config.yaml
@@ -95,9 +95,10 @@ data:
   pod.image-check.namespaces: "{{ .Cluster.ConfigItems.teapot_admission_controller_validate_pod_images_namespaces }}"
 {{- end }}
 
-{{- if index .Cluster.ConfigItems "teapot_admission_controller_validate_pod_images_ignore_namespaces" }}
+{{- if index .Cluster.ConfigItems "teapot_admission_controller_validate_pod_images_ignored_namespaces" }}
   # Exclude the namespaces matching this regular expression from container image checks, defaults to none.
-  pod.image-check.ignore-namespaces: "{{ .Cluster.ConfigItems.teapot_admission_controller_validate_pod_images_ignore_namespaces }}"
+  # Note: the admission-controller flag itself is "ignore-namespaces" (no "d"), unlike our config item name.
+  pod.image-check.ignore-namespaces: "{{ .Cluster.ConfigItems.teapot_admission_controller_validate_pod_images_ignored_namespaces }}"
 {{- end }}
 
 {{- if index .Cluster.ConfigItems "teapot_admission_controller_validate_pod_images_ignored_images" }}

--- a/cluster/manifests/02-admission-control/config.yaml
+++ b/cluster/manifests/02-admission-control/config.yaml
@@ -90,11 +90,6 @@ data:
   pod.image-check.soft-fail-namespaces: "{{ .Cluster.ConfigItems.teapot_admission_controller_validate_pod_images_soft_fail_namespaces }}"
 {{- end }}
 
-{{- if index .Cluster.ConfigItems "teapot_admission_controller_validate_pod_images_namespaces" }}
-  # Limit the namespaces where container image checks are required, defaults to all namespaces.
-  pod.image-check.namespaces: "{{ .Cluster.ConfigItems.teapot_admission_controller_validate_pod_images_namespaces }}"
-{{- end }}
-
 {{- if index .Cluster.ConfigItems "teapot_admission_controller_validate_pod_images_ignored_namespaces" }}
   # Exclude the namespaces matching this regular expression from container image checks, defaults to none.
   # Note: the admission-controller flag itself is "ignore-namespaces" (no "d"), unlike our config item name.
@@ -104,6 +99,18 @@ data:
 {{- if index .Cluster.ConfigItems "teapot_admission_controller_validate_pod_images_ignored_images" }}
   # Always allow certain container images regardless of namespace, defaults to none.
   pod.image-check.ignored-images: "{{ .Cluster.ConfigItems.teapot_admission_controller_validate_pod_images_ignored_images }}"
+{{- end }}
+
+{{- if eq .Cluster.Environment "e2e" }}
+  # Special setting only configured for e2e clusters
+  #
+  # DO NOT USE THIS IN PRODUCTION CLUSTERS
+
+  # The e2e test suite runs arbitrary, non-compliant test case images across namespaces, so only
+  # enforce compliance where it can be checked reliably: kube-system and visibility (to catch
+  # regressions there) and the image-policy-test-enabled-* namespaces, which are deliberately set up
+  # for reliable image policy tests.
+  pod.image-check.namespaces: "^(image-policy-test-enabled-.*|kube-system|visibility)$"
 {{- end }}
 
   # This setting enables and disables replacement of vanity images with ECR images during pod admission (during create and update)

--- a/cluster/manifests/02-admission-control/config.yaml
+++ b/cluster/manifests/02-admission-control/config.yaml
@@ -95,6 +95,11 @@ data:
   pod.image-check.namespaces: "{{ .Cluster.ConfigItems.teapot_admission_controller_validate_pod_images_namespaces }}"
 {{- end }}
 
+{{- if index .Cluster.ConfigItems "teapot_admission_controller_validate_pod_images_ignore_namespaces" }}
+  # Exclude the namespaces matching this regular expression from container image checks, defaults to none.
+  pod.image-check.ignore-namespaces: "{{ .Cluster.ConfigItems.teapot_admission_controller_validate_pod_images_ignore_namespaces }}"
+{{- end }}
+
 {{- if index .Cluster.ConfigItems "teapot_admission_controller_validate_pod_images_ignored_images" }}
   # Always allow certain container images regardless of namespace, defaults to none.
   pod.image-check.ignored-images: "{{ .Cluster.ConfigItems.teapot_admission_controller_validate_pod_images_ignored_images }}"


### PR DESCRIPTION
## Summary
- Follows up on #12160: admission-controller also supports `pod.image-check.ignore-namespaces` to exclude namespaces from container image compliance checks (complementing the existing `pod.image-check.namespaces` allow-list).
- Wires this up as `teapot_admission_controller_validate_pod_images_ignored_namespaces` in `cluster/manifests/02-admission-control/config.yaml`, matching the "ignored" naming used by the sibling `..._ignored_images` config item.
- Note: admission-controller's own flag is `pod.image-check.ignore-namespaces` (no "d"), so there's a small naming mismatch between our config item and the underlying flag — called out with a comment since we can't change admission-controller's flag name here.
- Documents the new escape-hatch config item in `cluster/config-defaults.yaml`.

## Test plan
- [ ] Verify rendered admission-controller configmap includes `pod.image-check.ignore-namespaces` when the config item is set