### PR TITLE
Explicitly set external-dns annotation prefix

### DIFF
--- a/cluster/manifests/external-dns/deployment.yaml
+++ b/cluster/manifests/external-dns/deployment.yaml
@@ -42,6 +42,7 @@ spec:
         - --source=service
         - --source=ingress
         - --source=skipper-routegroup
+        - --annotation-prefix=external-dns.alpha.kubernetes.io/
 {{- range split .Cluster.ConfigItems.external_dns_domain_filter "," }}
         - --domain-filter={{ . }}
 {{- end }}


### PR DESCRIPTION
The default changes in external-dns v0.22.0 with no migration path: https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.22.0

Ensure we don't upgrade and have the default used across the platform change.