### PR TITLE
feature: ingress alpn policy

### DIFF
--- a/cluster/config-defaults.yaml
+++ b/cluster/config-defaults.yaml
@@ -92,6 +92,7 @@ cluster_lifecycle_controller_memory_min: "10Mi"
 
 # ALB config created by kube-aws-ingress-controller
 kube_aws_ingress_controller_ssl_policy: "ELBSecurityPolicy-TLS13-1-2-Res-2021-06"
+kube_aws_ingress_controller_alpn_policy: "None"
 kube_aws_ingress_controller_idle_timeout: "1m"
 kube_aws_ingress_controller_deregistration_delay_timeout: "10s"
 # allow using NLBs for ingress

--- a/cluster/manifests/ingress-controller/deployment.yaml
+++ b/cluster/manifests/ingress-controller/deployment.yaml
@@ -56,6 +56,7 @@ spec:
 {{- end }}
             - --stack-termination-protection
             - --ssl-policy={{ .Cluster.ConfigItems.kube_aws_ingress_controller_ssl_policy }}
+            - --nlb-alpn-policy={{ .Cluster.ConfigItems.kube_aws_ingress_controller_alpn_policy }}
             - --idle-connection-timeout={{ .Cluster.ConfigItems.kube_aws_ingress_controller_idle_timeout }}
             - --deregistration-delay-timeout={{ .Cluster.ConfigItems.kube_aws_ingress_controller_deregistration_delay_timeout }}
             # {{ if eq .Cluster.ConfigItems.kube_aws_ingress_controller_nlb_cross_zone "true" }}


### PR DESCRIPTION
feature: ingress alpn policy

no default change, so minor to deploy.

requires the version update which was already merged: https://github.com/zalando-incubator/kubernetes-on-aws/pull/12203