### PR TITLE
Use shorter cluster hostnames

### DIFF
--- a/cluster/manifests/prometheus/ingress.yaml
+++ b/cluster/manifests/prometheus/ingress.yaml
@@ -10,6 +10,7 @@ spec:
   hosts:
     - system-prometheus.{{ .Values.hosted_zone }}
     - system-prometheus-{{ .Cluster.Alias }}.{{ .Values.hosted_zone }}
+    - sys-prom-{{ .Cluster.Alias }}.{{ .Values.hosted_zone }}
   backends:
     - name: prometheus
       type: service

--- a/cluster/manifests/skipper/routegroup-probe.yaml
+++ b/cluster/manifests/skipper/routegroup-probe.yaml
@@ -14,6 +14,7 @@ spec:
   - backendName: simulation
   hosts:
   - cluster-health-{{ .Cluster.Alias }}.{{ .Values.hosted_zone }}
+  - c-health-{{ .Cluster.Alias }}.{{ .Values.hosted_zone }}
   routes:
   - pathSubtree: /
     filters:


### PR DESCRIPTION
For the EKS migration we established a max length for alias of 45 chars. This was based on the fact that we construct hostnames like: `system-prometheus-{{ .Cluster.Alias }}` which in DNS has a limit 63.

We missed one aspect which is external-dns creates records with `cname-` prefix which eats up 6 chars of the 63 limit.

To stay within the `45` char limit the calculation becomes:

```
[cname-]     +     [host-prefix]     +     [alias] = 63
6 chars               12 chars             45 chars
```

Right now:

* `system-prometheus-` (18 chars)
* `cluster-health-` (15 chars)

are more than the 12 chars limit.

This adds additional hostnames for these two cases with abbreviated names to make it within the limit. These hosts are used by a small subset of central tooling, so it's relatively easy to first enable the new names, switch all clients/use cases, and then remove the longer names after checking they are not being called by actual clients.