### PR TITLE
skipper-ingress: removes b3multi from otel propagators list

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -302,7 +302,7 @@ spec:
               k8s.pod.name: $(POD_NAME)
               cloud.availability_zone: $(KUBE_NODE_ZONE)
               otel-exporter: true
-            propagators: [tracecontext, ottrace, b3multi, baggage]
+            propagators: [tracecontext, ottrace, baggage]
             sampler: always_on
             batchSpanProcessor:
               maxQueueSize: {{ .Cluster.ConfigItems.skipper_ingress_open_telemetry_bsp_max_queue_size }}
@@ -700,7 +700,7 @@ spec:
               k8s.pod.name: $(POD_NAME)
               cloud.availability_zone: $(KUBE_NODE_ZONE)
               otel-exporter: true
-            propagators: [tracecontext, ottrace, b3multi, baggage]
+            propagators: [tracecontext, ottrace, baggage]
             sampler: always_on
             batchSpanProcessor:
               maxQueueSize: {{ .Cluster.ConfigItems.skipper_ingress_open_telemetry_bsp_max_queue_size }}


### PR DESCRIPTION
As explained in the test cases in PR [[1]](https://github.com/zalando/skipper/pull/4247), having b3 propagator results in disconnected traces.

With opentracing this was not supported. With opentracing we only use the lightstep propagator and it is as same as the ottrace propagator.

Therefore removing the b3 propagator restores the trace behaviour closer to the previous behaviour.

