### PR TITLE
Remove prometheus hostname

### DIFF
--- a/cluster/manifests/prometheus/ingress.yaml
+++ b/cluster/manifests/prometheus/ingress.yaml
@@ -8,7 +8,6 @@ metadata:
     component: prometheus
 spec:
   hosts:
-    - system-prometheus.{{ .Values.hosted_zone }}
     - sys-prom-{{ .Cluster.Alias }}.{{ .Values.hosted_zone }}
   backends:
     - name: prometheus

--- a/cluster/manifests/prometheus/ingress.yaml
+++ b/cluster/manifests/prometheus/ingress.yaml
@@ -9,7 +9,6 @@ metadata:
 spec:
   hosts:
     - system-prometheus.{{ .Values.hosted_zone }}
-    - system-prometheus-{{ .Cluster.Alias }}.{{ .Values.hosted_zone }}
     - sys-prom-{{ .Cluster.Alias }}.{{ .Values.hosted_zone }}
   backends:
     - name: prometheus

--- a/cluster/manifests/skipper/routegroup-probe.yaml
+++ b/cluster/manifests/skipper/routegroup-probe.yaml
@@ -13,7 +13,6 @@ spec:
   defaultBackends:
   - backendName: simulation
   hosts:
-  - cluster-health-{{ .Cluster.Alias }}.{{ .Values.hosted_zone }}
   - c-health-{{ .Cluster.Alias }}.{{ .Values.hosted_zone }}
   routes:
   - pathSubtree: /


### PR DESCRIPTION
This removes the prometheus long hostname after the migration to the new records.
This is a follow up on https://github.com/zalando-incubator/kubernetes-on-aws/pull/12208 