### PR TITLE
Remove cluster-health hostname

### DIFF
--- a/cluster/manifests/skipper/routegroup-probe.yaml
+++ b/cluster/manifests/skipper/routegroup-probe.yaml
@@ -13,7 +13,6 @@ spec:
   defaultBackends:
   - backendName: simulation
   hosts:
-  - cluster-health-{{ .Cluster.Alias }}.{{ .Values.hosted_zone }}
   - c-health-{{ .Cluster.Alias }}.{{ .Values.hosted_zone }}
   routes:
   - pathSubtree: /


### PR DESCRIPTION
As a follow up to https://github.com/zalando-incubator/kubernetes-on-aws/pull/12208, remove the longer hostname with `cluster-health-` prefix.