### PR TITLE
update: skipper-ingress main v0.27.85 and l2 cache

### DIFF
--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -408,10 +408,12 @@ spec:
           - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
           - '-forwarded-headers-exclude-cidrs={{ .cluster_internal_cidrs | join "," }}'
 {{ end }}
-{{ if not (index .Cluster.ConfigItems.skipper_disabled_filters "cache") }}
+{{- $filters := split .Cluster.ConfigItems.skipper_disabled_filters ","}}
+  {{ if not (index $filters "cache") }}
           - "-cache-l1-ttl=60s"
           - "-enable-l2-cache"
-{{ end }}
+  {{ end }}
+{{- end}}
           - "-inline-routes"
           - |
             kube__healthz_down: Path("/kube-system/healthz") && Shutdown()

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -408,8 +408,8 @@ spec:
           - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
           - '-forwarded-headers-exclude-cidrs={{ .cluster_internal_cidrs | join "," }}'
 {{ end }}
-{{- $filters := split .Cluster.ConfigItems.skipper_disabled_filters ","}}
-{{ if not (index $filters "cache") }}
+{{- $filters := split .Cluster.ConfigItems.skipper_disabled_filters "cache" | join "" }}
+{{ if eq $filters .Cluster.ConfigItems.skipper_disabled_filters }}
           - "-cache-l1-ttl=60s"
           - "-enable-l2-cache"
 {{ end }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -408,7 +408,7 @@ spec:
           - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
           - '-forwarded-headers-exclude-cidrs={{ .cluster_internal_cidrs | join "," }}'
 {{ end }}
-{{ if not (contains .Cluster.ConfigItems.skipper_disabled_filters "cache") }}
+{{ if not (index .Cluster.ConfigItems.skipper_disabled_filters "cache") }}
           - "-cache-l1-ttl=60s"
           - "-enable-l2-cache"
 {{ end }}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -1,6 +1,6 @@
 {{/* image-updater-bot detects *image variables so use name with suffix to disable it for the main image */}}
 
-{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.27.71-1521" }}
+{{ $main_image_updated_manually := "container-registry.zalando.net/teapot/skipper-internal:v0.27.85-1535" }}
 {{ $canary_image := "container-registry.zalando.net/teapot/skipper-internal:v0.27.92-1542" }}
 
 {{/* Allow to override manually canary image by config item */}}

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -409,11 +409,10 @@ spec:
           - '-forwarded-headers-exclude-cidrs={{ .cluster_internal_cidrs | join "," }}'
 {{ end }}
 {{- $filters := split .Cluster.ConfigItems.skipper_disabled_filters ","}}
-  {{ if not (index $filters "cache") }}
+{{ if not (index $filters "cache") }}
           - "-cache-l1-ttl=60s"
           - "-enable-l2-cache"
-  {{ end }}
-{{- end}}
+{{ end }}
           - "-inline-routes"
           - |
             kube__healthz_down: Path("/kube-system/healthz") && Shutdown()

--- a/cluster/manifests/skipper/deployment.yaml
+++ b/cluster/manifests/skipper/deployment.yaml
@@ -408,6 +408,10 @@ spec:
           - "-forwarded-headers=X-Forwarded-For,X-Forwarded-Proto=https,X-Forwarded-Port=443"
           - '-forwarded-headers-exclude-cidrs={{ .cluster_internal_cidrs | join "," }}'
 {{ end }}
+{{ if not (contains .Cluster.ConfigItems.skipper_disabled_filters "cache") }}
+          - "-cache-l1-ttl=60s"
+          - "-enable-l2-cache"
+{{ end }}
           - "-inline-routes"
           - |
             kube__healthz_down: Path("/kube-system/healthz") && Shutdown()


### PR DESCRIPTION
feature: setup l2 cache infrastructure in skipper and enable/disable via skipper_disabled_filters contains "cache"
update: skipper main to v0.27.85

ref: https://github.com/zalando/skipper/compare/v0.27.71...v0.27.85
